### PR TITLE
Use configurable secret for remember_me cookie.

### DIFF
--- a/sylius/config/container/security.yml
+++ b/sylius/config/container/security.yml
@@ -15,7 +15,7 @@ security:
                 check_path: /login
                 use_referer: true
             remember_me:
-                key: eUodAjYEzDza72
+                key: %sylius.secret%
                 name: APP_REMEMBER_ME
                 lifetime: 31536000
                 always_remember_me: true


### PR DESCRIPTION
It's a recommendet practice to use the configurable secret from the parameters.yml for any kind of "secret". See http://symfony.com/doc/master/cookbook/security/remember_me.html as reference. Also, it would be too bad if any Sylius installation has the same remember me cookie secret! ;-)
