### PR TITLE
Test security token before retrieving user

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/CheckoutStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/CheckoutStep.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\CoreBundle\Checkout\Step;
 
 use Sylius\Bundle\FlowBundle\Process\Step\ControllerStep;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
 /**
  * Base class for checkout steps.
@@ -67,7 +68,10 @@ abstract class CheckoutStep extends ControllerStep
      */
     protected function isUserLoggedIn()
     {
-        $token = $this->get('security.context')->getToken();
-        return $token !== null AND is_object($token->getUser());
+        try {
+            return $this->get('security.context')->isGranted('IS_AUTHENTICATED_REMEMBERED');
+        } catch(AuthenticationCredentialsNotFoundException $e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
If security layer is disabled for this URL, the security token is null: we need to test it.
