### PR TITLE
Fix security step redirection

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
@@ -76,7 +76,7 @@ class SecurityStep extends CheckoutStep
      */
     private function overrideSecurityTargetPath()
     {
-        $url = $this->generateUrl('sylius_checkout_start', array(), true);
+        $url = $this->generateUrl('sylius_checkout_security', array(), true);
         $providerKey = $this->container->getParameter('fos_user.firewall_name');
 
         $this->get('session')->set('_security.'.$providerKey.'.target_path', $url);


### PR DESCRIPTION
Why redirecting to the first step of checkout flow? Let's redirect to the security step, and we can even go further and redirect directly to the next step (addressing). What do you think?
