### PR TITLE
Taxonomy images link is not correct

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/macros.html.twig
@@ -34,7 +34,7 @@
     <td>
         {% if taxon.path|length > 0 %}
             <div data-toggle="modal-gallery" data-target="#modal-gallery">
-                <a href="{{ taxon.path|imagine_filter('sylius_gallery') }}" title="{{ taxon.name }}" class="thumbnail thumbnail-image">
+                <a href="{{ taxon.path|imagine_filter('sylius_gallery') }}" data-gallery="gallery" title="{{ taxon.name }}" class="thumbnail thumbnail-image">
                     <img src="{{ taxon.path|imagine_filter('sylius_50x40') }}" alt="" />
                 </a>
             </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxonomy/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxonomy/macros.html.twig
@@ -20,7 +20,7 @@
                 {% if taxonomy.root is not null %}
                     {% if taxonomy.root.path|length > 0 %}
                         <div data-toggle="modal-gallery" data-target="#modal-gallery">
-                            <a href="{{ taxonomy.root.path|imagine_filter('sylius_gallery') }}" title="{{ taxonomy.name }}" class="thumbnail thumbnail-image">
+                            <a href="{{ taxonomy.root.path|imagine_filter('sylius_gallery') }}"  data-gallery="gallery" title="{{ taxonomy.name }}" class="thumbnail thumbnail-image">
                                 <img src="{{ taxonomy.root.path|imagine_filter('sylius_50x40') }}" alt="" />
                             </a>
                         </div>


### PR DESCRIPTION
When you want to see the taxonomy images (bigger size), you get a 404 error like this : No route found for "GET /administration/taxonomies/7a/ca/6d4e51fa34ad8e17b2e6887cf2cb.jpeg. There is not imagine_filter apply to them.
