### PR TITLE
Allowing translations to be easily extracted

### DIFF
--- a/app/autoload.php
+++ b/app/autoload.php
@@ -10,6 +10,7 @@
  */
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\Common\Annotations\AnnotationReader;
 
 $loader = require __DIR__.'/../vendor/autoload.php';
 
@@ -19,5 +20,12 @@ if (!function_exists('intl_get_error_code')) {
 }
 
 AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
+
+AnnotationReader::addGlobalIgnoredName('BeforeScenario');
+AnnotationReader::addGlobalIgnoredName('Given');
+AnnotationReader::addGlobalIgnoredName('When');
+AnnotationReader::addGlobalIgnoredName('Then');
+AnnotationReader::addGlobalIgnoredName('BeforeSuite');
+AnnotationReader::addGlobalIgnoredName('AfterScenario');
 
 return $loader;

--- a/src/Sylius/Bundle/WebBundle/Controller/Backend/DashboardController.php
+++ b/src/Sylius/Bundle/WebBundle/Controller/Backend/DashboardController.php
@@ -43,7 +43,7 @@ class DashboardController extends Controller
             'users' => $this->get('sylius.repository.user')->findBy(array(), array('id' => 'desc'), 5),
             'charts' => array(
                 'chart_order_total' => array(
-                    'label' => $this->container->get('translator')->trans('sylius.backend.dashboard.chart_order_total'),
+                    'label' => /** @Ignore */ $this->container->get('translator')->trans('sylius.backend.dashboard.chart_order_total'),
                     'type' => 'Line',
                     'data' => array(
                         'labels' => $months,
@@ -57,7 +57,7 @@ class DashboardController extends Controller
                     )
                 ),
                 'chart_order_count' => array(
-                    'label' => $this->container->get('translator')->trans('sylius.backend.dashboard.chart_order_count'),
+                    'label' => /** @Ignore */ $this->container->get('translator')->trans('sylius.backend.dashboard.chart_order_count'),
                     'type' => 'Line',
                     'data' => array(
                         'labels' => $months,


### PR DESCRIPTION
When extracting Core or Web bundles translations, we always face this exception : 

```
   [Doctrine\Common\Annotations\AnnotationException]                                                                                                        
   [Semantical Error] The annotation "@Given" in method Behat\MinkExtension\Context \MinkContext::iAmOnHomepage() was never imported. Did you maybe forget to add a "use" statement for this annotation? 
```

As explained by everzet himself here  https://github.com/Behat/MinkBundle/issues/29 this PR resolves, the problem.
