### PR TITLE
Fix orders fixtures

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/DataFixtures/ORM/LoadOrdersData.php
+++ b/src/Sylius/Bundle/CoreBundle/DataFixtures/ORM/LoadOrdersData.php
@@ -71,15 +71,7 @@ class LoadOrdersData extends DataFixture
         } while ('UK' === $isoName);
 
         $country = $this->getReference('Sylius.Country.'.$isoName);
-        $province = null;
-
-        if ($country->hasProvinces()) {
-            $provinceKey = $this->faker->randomNumber(
-                0,
-                $country->getProvinces()->count()
-            );
-            $province = $country->getProvinces()->get($provinceKey);
-        };
+        $province = $country->hasProvinces() ? $this->faker->randomElement($country->getProvinces()->toArray()) : null;
 
         $address->setCountry($country);
         $address->setProvince($province);


### PR DESCRIPTION
The method randomElement was updated in version 1.2. See the issue https://github.com/Sylius/Sylius/issues/189. This pull could fix the issue
