### PR TITLE
Updated macros.html.twig to not show hardcoded information but actual table data

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/macros.html.twig
@@ -27,8 +27,14 @@
                 <strong>#{{ order.number }}</strong>
                 </a>
             </td>
-            <td><span class="label label-important">{{ 'sylius.order.payment_states.balance_due'|trans }}</span></td>
-            <td><span class="label label-warning">{{ 'sylius.order.shipment_states.pending'|trans }}</span></td>
+            <td>
+                {% if order.payment %}
+                    <span class="label label-important">{{ order.payment.balance }}</span>
+                {% endif %}
+            </td>
+            <td>
+                <span class="label label-warning">{{ order.state }}</span>
+            </td>
             <td><a href="mailto:{{ order.user.email|default('john@example.com') }}" class="btn btn-link">{{ order.user.email|default('john@example.com') }}</a></td>
             <td>{{ order.total|sylius_price(order.currency) }}</td>
             <td>


### PR DESCRIPTION
It was pretty confusing to see the "shipment state" in the "Orders" menu and the shipment state under the "Shipments" menu was different. What is actually the state showed in the "Orders" menu, is it the state of the order itself or of the shipment it has? (Even though an order can have several shipments)

I changed the twig template to show the "state" value being in the sylius_order table, without knowing what it actually means. I also searched for a constant which defines it, without any success.

I hope that's what you want and maybe you can give me feedback to fix it further!
