### PR TITLE
Execute Behat scenarios by tag groups on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,23 @@ before_script:
 #   - sleep 5
 
 script:
-    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose -p frontend
-    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose -p backend
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@cart'
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@taxation'
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@shipping'
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@addressing'
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@promotions'
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@inventory'
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@taxonomies'
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@settings'
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@payments'
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@currencies'
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@account'
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@checkout'
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@homepage'
+    - php -d memory_limit=4096M bin/behat --no-snippets --no-paths --verbose --tags '@products'
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@users'
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@dashboard'
+    - php -d memory_limit=2048M bin/behat --no-snippets --no-paths --verbose --tags '@orders'
     - cd src/Sylius/Bundle/CoreBundle; ../../../../bin/phpspec run -fpretty --verbose
 
 notifications:


### PR DESCRIPTION
@pjedrzejewski I noticed that you introduced tags for the Behat features and I assume you execute them tag group by tag group in order to avoid the PHP memory issue on Travis CI (eg. https://travis-ci.org/Sylius/Sylius/jobs/10005147#L586). Thus I changed Sylius' `.travis.yml` to do exactly that by default (see https://travis-ci.org/headrevision/Sylius/jobs/10026602).
