### PR TITLE
Allow limit to null to get the entire list of resource.

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
@@ -146,7 +146,13 @@ class Configuration
 
     public function getLimit()
     {
-        return (int) $this->get('limit', 10);
+        $limit = $this->get('limit', 10);
+
+        if (null === $limit) {
+            return null;
+        }
+
+        return (int) $limit;
     }
 
     public function isPaginated()

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ConfigurationSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ConfigurationSpec.php
@@ -100,6 +100,14 @@ class ConfigurationSpec extends ObjectBehavior
         $this->getLimit()->shouldReturn(10);
     }
 
+    function it_has_limit_equal_to_null_if_limit_is_null($request)
+    {
+        $request->attributes->set('_sylius', array('limit' => null));
+        $this->load($request);
+
+        $this->getLimit()->shouldReturn(null);
+    }
+
     function its_paginated_by_default($request)
     {
         $this->load($request);


### PR DESCRIPTION
Here is my use case :

I have about 20 to 30 products, and i want all of my product on a single
page without pager or limit.

My config is

``` yml
_sylius:
    paginate: false
    limit: null
    sorting: { releasedAt: desc }
```

Without my change i got 0 product because of the int cast inside
getLimit method
