### PR TITLE
Increase order number max length

### DIFF
--- a/src/Sylius/Bundle/SalesBundle/Generator/OrderNumberGenerator.php
+++ b/src/Sylius/Bundle/SalesBundle/Generator/OrderNumberGenerator.php
@@ -41,7 +41,7 @@ class OrderNumberGenerator implements OrderNumberGeneratorInterface
      * @param OrderRepositoryInterface $repository
      * @param integer                  $numberLength
      */
-    public function __construct(OrderRepositoryInterface $repository, $numberLength = 6)
+    public function __construct(OrderRepositoryInterface $repository, $numberLength = 9)
     {
         $this->repository = $repository;
         $this->numberLength = $numberLength;


### PR DESCRIPTION
6 numbers is too short length for order number. For example we have more than 15 millions orders in database.
