### PR TITLE
remove sylius from psr-0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         ]
     },
     "autoload": {
-        "psr-0": { "Sylius\\": "src/" }
+        "psr-0": { "": "src/" }
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
This commit removes explicit mapping of the Sylius namespace to the src directory. This will avoid developers running into class not found errors when they put their own code into the src directory.
