### PR TITLE
Enhance main app menus to make them more consistent

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
@@ -57,6 +57,13 @@ class FrontendMenuBuilder extends MenuBuilder
     protected $moneyExtension;
 
     /**
+     * Request.
+     *
+     * @var Request
+     */
+    protected $request;
+
+    /**
      * Constructor.
      *
      * @param FactoryInterface         $factory
@@ -83,6 +90,16 @@ class FrontendMenuBuilder extends MenuBuilder
         $this->taxonomyRepository = $taxonomyRepository;
         $this->cartProvider = $cartProvider;
         $this->moneyExtension = $moneyExtension;
+    }
+
+    /**
+     * Sets the request the service
+     *
+     * @param Request $request
+     */
+    public function setRequest(Request $request = null)
+    {
+        $this->request = $request;
     }
 
     /**
@@ -117,11 +134,23 @@ class FrontendMenuBuilder extends MenuBuilder
         )));
 
         if ($this->securityContext->isGranted('ROLE_USER')) {
-            $menu->addChild('account', array(
-                'route' => 'sylius_account_homepage',
-                'linkAttributes' => array('title' => $this->translate('sylius.frontend.menu.main.account')),
-                'labelAttributes' => array('icon' => 'icon-user icon-large', 'iconOnly' => false)
-            ))->setLabel($this->translate('sylius.frontend.menu.main.account'));
+
+            $route = $this->request === null ? '' : $this->request->get('_route');
+
+            if (1 === preg_match('/^(sylius_account)|(fos_user)/', $route)) {
+                $menu->addChild('shop', array(
+                    'route' => 'sylius_homepage',
+                    'linkAttributes' => array('title' => $this->translate('sylius.frontend.menu.account.shop')),
+                    'labelAttributes' => array('icon' => 'icon-th icon-large', 'iconOnly' => false)
+                ))->setLabel($this->translate('sylius.frontend.menu.account.shop'));
+            }
+            else {
+                $menu->addChild('account', array(
+                    'route' => 'sylius_account_homepage',
+                    'linkAttributes' => array('title' => $this->translate('sylius.frontend.menu.main.account')),
+                    'labelAttributes' => array('icon' => 'icon-user icon-large', 'iconOnly' => false)
+                ))->setLabel($this->translate('sylius.frontend.menu.main.account'));
+            }
             $menu->addChild('logout', array(
                 'route' => 'fos_user_security_logout',
                 'linkAttributes' => array('title' => $this->translate('sylius.frontend.menu.main.logout')),
@@ -309,12 +338,6 @@ class FrontendMenuBuilder extends MenuBuilder
             'linkAttributes' => array('title' => $this->translate('sylius.frontend.menu.account.orders')),
             'labelAttributes' => array('icon' => 'icon-briefcase', 'iconOnly' => false)
         ))->setLabel($this->translate('sylius.frontend.menu.account.orders'));
-
-        $child->addChild('shop', array(
-            'route' => 'sylius_homepage',
-            'linkAttributes' => array('title' => $this->translate('sylius.frontend.menu.account.shop')),
-            'labelAttributes' => array('icon' => 'icon-shopping-cart', 'iconOnly' => false)
-        ))->setLabel($this->translate('sylius.frontend.menu.account.shop'));
 
         return $menu;
     }

--- a/src/Sylius/Bundle/WebBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/services.xml
@@ -48,6 +48,9 @@
             <argument type="service" id="sylius.repository.taxonomy" />
             <argument type="service" id="sylius.cart_provider" />
             <argument type="service" id="sylius.twig.money" />
+            <call method="setRequest">
+                <argument type="service" id="request" on-invalid="null" strict="false" />
+            </call>
         </service>
         <service id="sylius.menu_builder.backend" class="%sylius.menu_builder.backend.class%">
             <argument type="service" id="knp_menu.factory" />


### PR DESCRIPTION
Remove "Back to the shop" from the my account menu. 
Switch between "My account" and "Back to the shop" on the main menu.
