### PR TITLE
Updated deprecated field_row block

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/forms.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/forms.html.twig
@@ -8,7 +8,7 @@
 {% endspaceless %}
 {% endblock form_widget_simple %}
 
-{% block field_row %}
+{% block form_row %}
 {% spaceless %}
     <div class="control-group{% if errors|length > 0 %} error{% endif %}">
         {{ form_label(form, label|default(null)) }}


### PR DESCRIPTION
Currently the forms fields aren't properly rendered because in symfony 2.3 all the `field_*` blocks are deprecated... the new name are `form_*`.
