### PR TITLE
Fix Image placeholders

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/macros.html.twig
@@ -26,7 +26,7 @@
             </td>
             <td>
                 <a href="{{ path('sylius_backend_product_show', {'id': product.id}) }}" class="thumbnail thumbnail-image">
-                    <img src="{{ product.image.path|default('http://placehold.it/50x40')|imagine_filter('sylius_50x40') }}" alt="" />
+                    <img src="{{ product.image ? product.image.path|imagine_filter('sylius_50x40') : 'http://placehold.it/50x40' }}" alt="" />
                 </a>
             </td>
             <td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/_item.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/_item.html.twig
@@ -3,7 +3,7 @@
     <td>{{ loop.index }}</td>
     <td>
         <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}" class="thumbnail" style="width: 90px;">
-            <img src="{{ product.image.path|default('http://placehold.it/90x60')|imagine_filter('sylius_90x60') }}" alt="" />
+            <img src="{{ product.image ? product.image.path|imagine_filter('sylius_90x60') : 'http://placehold.it/90x60' }}" alt="" />
         </a>
     </td>
     <td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/Finalize/_item.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/Finalize/_item.html.twig
@@ -4,7 +4,7 @@
     <td>{{ loop.index }}</td>
     <td>
         <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}" class="thumbnail pull-left" style="width: 90px; margin-right: 15px;">
-            <img src="{{ product.image.path|default('http://placehold.it/90x60')|imagine_filter('sylius_90x60') }}" alt="" />
+            <img src="{{ product.image ? product.image.path|imagine_filter('sylius_90x60') : 'http://placehold.it/90x60' }}" alt="" />
         </a>
         <div>
             <p>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_single.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_single.html.twig
@@ -1,7 +1,7 @@
 <div class="row-fluid product">
     <div class="span3">
         <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}" class="thumbnail">
-            <img src="{{ product.image.path|default('http://placehold.it/200x200')|imagine_filter('sylius_200x200') }}" alt="" />
+            <img src="{{ product.image ? product.image.path|imagine_filter('sylius_200x200') : 'http://placehold.it/200x200' }}" alt="{{ product.name }}" />
         </a>
     </div>
     <div class="span9">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_singleBox.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_singleBox.html.twig
@@ -1,7 +1,7 @@
 <div class="product-box">
     <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}"><h3>{{ product.name|truncate(18) }}</h3></a>
     <a class="thumbnail" href="{{ path('sylius_product_show', {'slug': product.slug}) }}">
-        <img  src="{{ product.image.path|default('http://placehold.it/250x250')|imagine_filter('sylius_262x255') }}" alt="{{ product.name }}" />
+        <img  src="{{ product.image ? product.image.path|imagine_filter('sylius_262x255') : 'http://placehold.it/262x255' }}" alt="{{ product.name }}" />
         <span class="label">{{ product.price|sylius_price }}</span>
         <button class="btn btn-success"><i class="icon-shopping-cart icon-white"></i> {{ 'sylius.add_to_cart'|trans }}</button>
     </a>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/latestSidebar.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/latestSidebar.html.twig
@@ -4,7 +4,7 @@
     {% for product in products %}
         <li>
             <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}" class="btn btn-link">
-                <img class="thumbnail" src="{{ product.image.path|default('http://placehold.it/50x40')|imagine_filter('sylius_50x40') }}" alt="{{ product.name }}" />
+                <img class="thumbnail" src="{{ product.image ? product.image.path|imagine_filter('sylius_50x40') : 'http://placehold.it/50x40' }}" alt="{{ product.name }}" />
                 <h4>{{ product.name }}</h4>
             </a>
         </li>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
@@ -6,7 +6,7 @@
 <div class="row-fluid">
     <div class="span3">
         <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}" class="thumbnail">
-            <img src="{{ product.image.path|default('http://placehold.it/200x200')|imagine_filter('sylius_200x200') }}" alt="" />
+            <img src="{{ product.image ? product.image.path|imagine_filter('sylius_200x200') : 'http://placehold.it/200x200' }}" alt="{{ product.name }}" />
         </a>
     </div>
     <div class="span9">


### PR DESCRIPTION
- avoid usage of placehold.it images together with image filter,
  because image filter does not (currently) work with remote URLs.
- ensure placeholders have proper size.
- add missing alt tag content on images.
