### PR TITLE
Fix translation & make it more consistent

### DIFF
--- a/src/Sylius/Bundle/CartBundle/Resources/translations/flashes.en.xlf
+++ b/src/Sylius/Bundle/CartBundle/Resources/translations/flashes.en.xlf
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="1">
                 <source>sylius.cart.cart_save_completed</source>
-                <target>The cart have been updated correctly.</target>
+                <target>The cart has been successfully updated.</target>
             </trans-unit>
             <trans-unit id="2">
                 <source>sylius.cart.cart_clear_completed</source>

--- a/src/Sylius/Bundle/CartBundle/spec/Sylius/Bundle/CartBundle/EventListener/FlashListenerSpec.php
+++ b/src/Sylius/Bundle/CartBundle/spec/Sylius/Bundle/CartBundle/EventListener/FlashListenerSpec.php
@@ -148,7 +148,7 @@ class FlashListenerSpec extends ObjectBehavior
      */
     function it_should_have_a_default_success_flash_message_for_event_name($session, $translator, $event, $flashBag, $cartEvents)
     {
-        $messages = array(SyliusCartEvents::ITEM_ADD_COMPLETED => 'The cart have been updated correctly.');
+        $messages = array(SyliusCartEvents::ITEM_ADD_COMPLETED => 'The cart has been successfully updated.');
         $this->messages = $messages;
 
         $event


### PR DESCRIPTION
Carts should be singular, and wording is now more consistent throughout site.
