### PR TITLE
Add canaling of given query string on history rewind

### DIFF
--- a/src/Sylius/Bundle/FlowBundle/Controller/ProcessController.php
+++ b/src/Sylius/Bundle/FlowBundle/Controller/ProcessController.php
@@ -27,15 +27,16 @@ class ProcessController extends ContainerAware
      * Build and start process for given scenario.
      * This action usually redirects to first step.
      *
-     * @param string $scenarioAlias
+     * @param Request $request
+     * @param string  $scenarioAlias
      *
      * @return Response
      */
-    public function startAction($scenarioAlias)
+    public function startAction(Request $request, $scenarioAlias)
     {
         $coordinator = $this->container->get('sylius.process.coordinator');
 
-        return $coordinator->start($scenarioAlias);
+        return $coordinator->start($scenarioAlias, $request->query);
     }
 
     /**
@@ -54,7 +55,7 @@ class ProcessController extends ContainerAware
         $coordinator = $this->container->get('sylius.process.coordinator');
 
         try {
-            return $coordinator->display($scenarioAlias, $stepName);
+            return $coordinator->display($scenarioAlias, $stepName, $request->query);
         } catch (\InvalidArgumentException $e) {
             throw new NotFoundHttpException('The step you are looking for is not found.', $e);
         }

--- a/src/Sylius/Bundle/FlowBundle/Process/Coordinator/Coordinator.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Coordinator/Coordinator.php
@@ -17,6 +17,7 @@ use Sylius\Bundle\FlowBundle\Process\ProcessInterface;
 use Sylius\Bundle\FlowBundle\Process\Scenario\ProcessScenarioInterface;
 use Sylius\Bundle\FlowBundle\Process\Step\ActionResult;
 use Sylius\Bundle\FlowBundle\Process\Step\StepInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -77,7 +78,7 @@ class Coordinator implements CoordinatorInterface
     /**
      * {@inheritdoc}
      */
-    public function start($scenarioAlias)
+    public function start($scenarioAlias, ParameterBag $queryParameters = null)
     {
         $process = $this->buildProcess($scenarioAlias);
         $step = $process->getFirstStep();
@@ -89,13 +90,13 @@ class Coordinator implements CoordinatorInterface
             return $validator->getResponse($step);
         }
 
-        return $this->redirectToStepDisplayAction($process, $step);
+        return $this->redirectToStepDisplayAction($process, $step, $queryParameters);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function display($scenarioAlias, $stepName)
+    public function display($scenarioAlias, $stepName, ParameterBag $queryParameters = null)
     {
         $process = $this->buildProcess($scenarioAlias);
         $step = $process->getStepByName($stepName);
@@ -108,7 +109,7 @@ class Coordinator implements CoordinatorInterface
             //the step we are supposed to display was not found in the history.
             if (null === $this->context->getPreviousStep()) {
                 //there is no previous step go to start
-                return $this->start($scenarioAlias);
+                return $this->start($scenarioAlias, $queryParameters);
             }
 
             //we will go back to previous step...
@@ -212,10 +213,11 @@ class Coordinator implements CoordinatorInterface
      *
      * @param ProcessInterface $process
      * @param StepInterface    $step
+     * @param ParameterBag     $queryParameters
      *
      * @return RedirectResponse
      */
-    protected function redirectToStepDisplayAction(ProcessInterface $process, StepInterface $step)
+    protected function redirectToStepDisplayAction(ProcessInterface $process, StepInterface $step, ParameterBag $queryParameters = null)
     {
         $this->context->addStepToHistory($step->getName());
 
@@ -227,10 +229,17 @@ class Coordinator implements CoordinatorInterface
             return new RedirectResponse($url);
         }
 
-        $url = $this->router->generate('sylius_flow_display', array(
-            'scenarioAlias' => $process->getScenarioAlias(),
-            'stepName'      => $step->getName()
-        ));
+        // Default parameters for display route
+        $routeParameters = array(
+                'scenarioAlias' => $process->getScenarioAlias(),
+                'stepName'      => $step->getName(),
+        );
+
+        if (null !== $queryParameters) {
+            $routeParameters = array_merge($queryParameters->all(), $routeParameters);
+        }
+
+        $url = $this->router->generate('sylius_flow_display', $routeParameters);
 
         return new RedirectResponse($url);
     }

--- a/src/Sylius/Bundle/FlowBundle/Process/Coordinator/CoordinatorInterface.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Coordinator/CoordinatorInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\FlowBundle\Process\Coordinator;
 
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -27,21 +28,23 @@ interface CoordinatorInterface
     /**
      * Start scenario, should redirect to first step.
      *
-     * @param string $scenarioAlias
+     * @param string       $scenarioAlias
+     * @param ParameterBag $queryParameters
      *
      * @return RedirectResponse
      */
-    public function start($scenarioAlias);
+    public function start($scenarioAlias, ParameterBag $queryParameters = null);
 
     /**
      * Display step.
      *
-     * @param string $scenarioAlias
-     * @param string $stepName
+     * @param string       $scenarioAlias
+     * @param string       $stepName
+     * @param ParameterBag $queryParameters
      *
      * @return Response
      */
-    public function display($scenarioAlias, $stepName);
+    public function display($scenarioAlias, $stepName, ParameterBag $queryParameters = null);
 
     /**
      * Move forward.


### PR DESCRIPTION
When starting the flow or requesting the first step with a query string, it got lost. (E.g. `/flow/firstStep?foo=bar` redirected to `/flow/firstStep` _without_ the query string). The losing of the query string was caused by a redirect without any parameters. Now added canaling of the query string into the redirect, e.g. `/flow?foo=bar redirects` to `/flow/firstStep?foo=bar` as well as `/flow/firstStep?foo=bar` to `/flow/firstStep?foo=bar`.

This is a port of the pull request originally made here: https://github.com/Sylius/SyliusFlowBundle/pull/26
