### PR TITLE
[WIP] Add ability to sort shipping methods and add price to shipping method choice list view data

### DIFF
--- a/src/Sylius/Bundle/ShippingBundle/Form/ChoiceList/ShippingMethodChoiceList.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/ChoiceList/ShippingMethodChoiceList.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ShippingBundle\Form\ChoiceList;
+
+use Sylius\Bundle\ShippingBundle\Form\View\ShippingMethodChoiceViewEnhancerInterface;
+use Sylius\Bundle\ShippingBundle\Model\ShippingSubjectInterface;
+use Symfony\Component\Form\Extension\Core\ChoiceList\LazyChoiceList;
+use Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceList;
+
+/**
+ * Choice List which enhances Choice Views
+ */
+class ShippingMethodChoiceList extends LazyChoiceList
+{
+    protected $methods;
+    protected $shippingSubject;
+    protected $enhancer;
+
+    public function __construct(ChoiceList $methods, ShippingSubjectInterface $shippingSubject, ShippingMethodChoiceViewEnhancerInterface $enhancer)
+    {
+        $this->methods = $methods;
+        $this->shippingSubject = $shippingSubject;
+        $this->enhancer = $enhancer;
+    }
+
+    protected function enhanceViews($views)
+    {
+        $enhancedViews = array();
+
+        foreach ($views as $view) {
+            $enhancedViews[] = $this->enhancer->enhanceChoiceView($view, $this->shippingSubject);
+        }
+
+        return $enhancedViews;
+    }
+
+    public function getRemainingViews()
+    {
+        $views = parent::getRemainingViews();
+
+        return $this->enhanceViews($views);
+    }
+
+    public function getPreferredViews()
+    {
+        $views = parent::getPreferredViews();
+
+        return $this->enhanceViews($views);
+    }
+
+    /**
+     * Loads the choice list
+     *
+     * Should be implemented by child classes.
+     *
+     * @return ChoiceListInterface The loaded choice list
+     */
+    protected function loadChoiceList()
+    {
+        return $this->methods;
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/Form/ChoiceList/ShippingMethodChoiceListFactory.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/ChoiceList/ShippingMethodChoiceListFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ShippingBundle\Form\ChoiceList;
+
+use Sylius\Bundle\ShippingBundle\Form\View\ShippingMethodChoiceViewEnhancerInterface;
+use Sylius\Bundle\ShippingBundle\Model\ShippingSubjectInterface;
+use Sylius\Bundle\ShippingBundle\Sorter\ShippingMethodSorterInterface;
+use Symfony\Component\Form\Extension\Core\ChoiceList\ObjectChoiceList;
+
+/**
+ * Creates a shipping choice list that is sorted and enhanced with extra view data
+ *
+ * @author Daniel Richter <nexyz9@gmail.com>
+ */
+class ShippingMethodChoiceListFactory implements ShippingMethodChoiceListFactoryInterface
+{
+    protected $enhancer;
+    protected $sorter;
+
+    public function __construct(ShippingMethodChoiceViewEnhancerInterface $enhancer, ShippingMethodSorterInterface $sorter = null)
+    {
+        $this->enhancer = $enhancer;
+        $this->sorter = $sorter;
+    }
+
+    /**
+     * @param ShippingSubjectInterface $subject
+     * @param \Sylius\Bundle\ShippingBundle\Model\ShippingMethodInterface[] $methods
+     * @return ShippingMethodChoiceList|\Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceList
+     */
+    function createChoiceList(ShippingSubjectInterface $subject, $methods)
+    {
+        if ($this->sorter) {
+            $methods = $this->sorter->sort($methods, $subject);
+        }
+
+        return new ShippingMethodChoiceList(new ObjectChoiceList($methods), $subject, $this->enhancer);
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/Form/ChoiceList/ShippingMethodChoiceListFactoryInterface.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/ChoiceList/ShippingMethodChoiceListFactoryInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by JetBrains PhpStorm.
+ * User: Richtermeister
+ * Date: 9/27/13
+ * Time: 5:19 PM
+ * To change this template use File | Settings | File Templates.
+ */
+
+namespace Sylius\Bundle\ShippingBundle\Form\ChoiceList;
+
+
+use Sylius\Bundle\ShippingBundle\Model\ShippingSubjectInterface;
+use Sylius\Bundle\ShippingBundle\Model\ShippingMethodInterface;
+use Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceList;
+
+/**
+ * Creates a choice list to select a shipping method
+ *
+ * @author Daniel Richter <nexyz9@gmail.com>
+ */
+interface ShippingMethodChoiceListFactoryInterface
+{
+    /**
+     * Returns choice list based on passed shipping subject and methods
+     *
+     * @param ShippingSubjectInterface $subject
+     * @param ShippingMethodInterface[] $methods
+     * @return ChoiceList
+     */
+    function createChoiceList(ShippingSubjectInterface $subject, $methods);
+}

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\ShippingBundle\Form\Type;
 
+use Sylius\Bundle\ShippingBundle\Form\ChoiceList\ShippingMethodChoiceListFactoryInterface;
 use Sylius\Bundle\ShippingBundle\Resolver\MethodsResolverInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\ChoiceList\ObjectChoiceList;
@@ -33,13 +34,22 @@ class ShippingMethodChoiceType extends AbstractType
     protected $resolver;
 
     /**
+     * Shipping Method Choice List Factory
+     *
+     * @var ShippingMethodChoiceListFactoryInterface
+     */
+    protected $choiceFactory;
+
+    /**
      * Constructor.
      *
      * @param MethodsResolverInterface $resolver
+     * @param ShippingMethodChoiceListFactoryInterface $choiceFactory
      */
-    public function __construct(MethodsResolverInterface $resolver)
+    public function __construct(MethodsResolverInterface $resolver, ShippingMethodChoiceListFactoryInterface $choiceFactory = null)
     {
         $this->resolver = $resolver;
+        $this->choiceFactory = $choiceFactory;
     }
 
     /**
@@ -48,11 +58,12 @@ class ShippingMethodChoiceType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $methodsResolver = $this->resolver;
+        $choiceFactory = $this->choiceFactory;
 
-        $choiceList = function (Options $options) use ($methodsResolver) {
+        $choiceList = function (Options $options) use ($methodsResolver, $choiceFactory) {
             $methods = $methodsResolver->getSupportedMethods($options['subject'], $options['criteria']);
 
-            return new ObjectChoiceList($methods);
+            return $choiceFactory ? $choiceFactory->createChoiceList($options['subject'], $methods) : new ObjectChoiceList($methods);
         };
 
         $resolver

--- a/src/Sylius/Bundle/ShippingBundle/Form/View/PricedShippingMethodChoiceView.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/View/PricedShippingMethodChoiceView.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ShippingBundle\Form\View;
+
+use Symfony\Component\Form\Extension\Core\View\ChoiceView;
+
+/**
+ * Represents a Shipping Method choice in templates.
+ * Makes the calculated price for the choice available to the template.
+ *
+ * @author Daniel Richter <nexyz9@gmail.com>
+ */
+class PricedShippingMethodChoiceView extends ChoiceView
+{
+    /**
+     * The price of this shipping method choice
+     *
+     * @var float
+     */
+    public $price;
+
+    public function __construct($data, $value, $label, $price)
+    {
+        $this->price = $price;
+
+        parent::__construct($data, $value, $label);
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/Form/View/PricedShippingMethodChoiceViewEnhancer.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/View/PricedShippingMethodChoiceViewEnhancer.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ShippingBundle\Form\View;
+
+use Sylius\Bundle\ShippingBundle\Calculator\Registry\CalculatorRegistryInterface;
+use Sylius\Bundle\ShippingBundle\Model\ShippingMethodInterface;
+use Sylius\Bundle\ShippingBundle\Model\ShippingSubjectInterface;
+use Symfony\Component\Form\Extension\Core\View\ChoiceView;
+
+/**
+ * Enhances ChoiceView by adding shipping price
+ *
+ * @author Daniel Richter <nexyz9@gmail.com>
+ */
+class PricedShippingMethodChoiceViewEnhancer implements ShippingMethodChoiceViewEnhancerInterface
+{
+    protected $calculators;
+
+    public function __construct(CalculatorRegistryInterface $calculators)
+    {
+        $this->calculators = $calculators;
+    }
+
+    /**
+     * Turns ChoiceView into PricedShippingMethodChoiceView and adds calculated price data
+     *
+     * @param ChoiceView $view
+     * @param ShippingSubjectInterface $subject
+     * @return PricedShippingMethodChoiceView
+     * @throws \InvalidArgumentException
+     */
+    public function enhanceChoiceView(ChoiceView $view, ShippingSubjectInterface $subject)
+    {
+        if ($view instanceof PricedShippingMethodChoiceView) {
+            return $view;
+        }
+
+        $method = $view->data; /* @var $method ShippingMethodInterface */
+
+        if (!$method instanceof ShippingMethodInterface) {
+            throw new \InvalidArgumentException('ShippingMethodInterface expected');
+        }
+
+        $calculator = $this->calculators->getCalculator($method->getCalculator());
+        $price = $calculator->calculate($subject, $method->getConfiguration());
+
+        return new PricedShippingMethodChoiceView($view->data, $view->value, $view->label, $price);
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/Form/View/ShippingMethodChoiceViewEnhancerInterface.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/View/ShippingMethodChoiceViewEnhancerInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ShippingBundle\Form\View;
+
+use Sylius\Bundle\ShippingBundle\Model\ShippingSubjectInterface;
+use Symfony\Component\Form\Extension\Core\View\ChoiceView;
+
+/**
+ * Applies enhancements to ChoiceView instances
+ *
+ * @author Daniel Richter <nexyz9@gmail.com>
+ */
+interface ShippingMethodChoiceViewEnhancerInterface
+{
+    /**
+     * Enhances the passed choice view according to the passed shipping subject
+     *
+     * @param ChoiceView $view
+     * @param ShippingSubjectInterface $subject
+     * @return mixed
+     */
+    function enhanceChoiceView(ChoiceView $view, ShippingSubjectInterface $subject);
+}

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
@@ -40,6 +40,10 @@
 
         <parameter key="sylius.shipping_calculator.flexible_rate.class">Sylius\Bundle\ShippingBundle\Calculator\FlexibleRateCalculator</parameter>
         <parameter key="sylius.form.type.shipping_calculator.flexible_rate_configuration.class">Sylius\Bundle\ShippingBundle\Form\Type\Calculator\FlexibleRateConfigurationType</parameter>
+
+        <parameter key="sylius.form.shipping_method_choice_list_factory.class">Sylius\Bundle\ShippingBundle\Form\ChoiceList\ShippingMethodChoiceListFactory</parameter>
+        <parameter key="sylius.form.shipping_method_choice_view_enhancer.class">Sylius\Bundle\ShippingBundle\Form\View\PricedShippingMethodChoiceViewEnhancer</parameter>
+        <parameter key="sylius.shipping_method_sorter.price.class">Sylius\Bundle\ShippingBundle\Sorter\PricedShippingMethodSorter</parameter>
     </parameters>
 
     <services>
@@ -103,8 +107,23 @@
             <argument type="service" id="sylius.repository.shipping_method" />
             <argument type="service" id="sylius.shipping_eligibility_checker" />
         </service>
+
+        <service id="sylius.shipping_method_sorter.price" class="%sylius.shipping_method_sorter.price.class%">
+            <argument type="service" id="sylius.shipping_calculator_registry" />
+        </service>
+
+        <service id="sylius.form.shipping_method_choice_view_enhancer" class="%sylius.form.shipping_method_choice_view_enhancer.class%">
+            <argument type="service" id="sylius.shipping_calculator_registry" />
+        </service>
+
+        <service id="sylius.form.shipping_method_choice_list_factory" class="%sylius.form.shipping_method_choice_list_factory.class%">
+            <argument type="service" id="sylius.form.shipping_method_choice_view_enhancer" />
+            <argument type="service" id="sylius.shipping_method_sorter.price" />
+        </service>
+
         <service id="sylius.form.type.shipping_method_choice" class="%sylius.form.type.shipping_method_choice.class%">
             <argument type="service" id="sylius.shipping_methods_resolver" />
+            <argument type="service" id="sylius.form.shipping_method_choice_list_factory" />
             <tag name="form.type" alias="sylius_shipping_method_choice" />
         </service>
 
@@ -114,6 +133,7 @@
         </service>
 
         <service id="sylius.shipping_calculator_registry" class="%sylius.shipping_calculator_registry.class%" />
+
         <service id="sylius.shipping_calculator" class="%sylius.shipping_calculator.class%">
             <argument type="service" id="sylius.shipping_calculator_registry" />
         </service>
@@ -121,6 +141,7 @@
         <service id="sylius.shipping_shipping_calculator.flat_rate" class="%sylius.shipping_calculator.flat_rate.class%">
             <tag name="sylius.shipping_calculator" calculator="flat_rate" label="Flat rate per shipment" />
         </service>
+
         <service id="sylius.form.type.shipping_calculator.flat_rate_configuration" class="%sylius.form.type.shipping_calculator.flat_rate_configuration.class%">
             <argument>%sylius.validation_group.shipping_calculator_flat_rate_configuration%</argument>
             <tag name="form.type" alias="sylius_shipping_calculator_flat_rate_configuration" />
@@ -129,6 +150,7 @@
         <service id="sylius.shipping_calculator.per_item_rate" class="%sylius.shipping_calculator.per_item_rate.class%">
             <tag name="sylius.shipping_calculator" calculator="per_item_rate" label="Flat rate per item" />
         </service>
+
         <service id="sylius.form.type.shipping_calculator.per_item_rate_configuration" class="%sylius.form.type.shipping_calculator.per_item_rate_configuration.class%">
             <argument>%sylius.validation_group.shipping_calculator_per_item_rate_configuration%</argument>
             <tag name="form.type" alias="sylius_shipping_calculator_per_item_rate_configuration" />
@@ -137,6 +159,7 @@
         <service id="sylius.shipping_calculator.flexible_rate" class="%sylius.shipping_calculator.flexible_rate.class%">
             <tag name="sylius.shipping_calculator" calculator="flexible_rate" label="Flexible rate" />
         </service>
+
         <service id="sylius.form.type.shipping_calculator.flexible_rate_configuration" class="%sylius.form.type.shipping_calculator.flexible_rate_configuration.class%">
             <argument>%sylius.validation_group.shipping_calculator_flexible_rate_configuration%</argument>
             <tag name="form.type" alias="sylius_shipping_calculator_flexible_rate_configuration" />

--- a/src/Sylius/Bundle/ShippingBundle/Sorter/PricedShippingMethodSorter.php
+++ b/src/Sylius/Bundle/ShippingBundle/Sorter/PricedShippingMethodSorter.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ShippingBundle\Sorter;
+
+
+use Sylius\Bundle\ShippingBundle\Calculator\Registry\CalculatorRegistryInterface;
+use Sylius\Bundle\ShippingBundle\Model\ShippingMethodInterface;
+use Sylius\Bundle\ShippingBundle\Model\ShippingSubjectInterface;
+
+/**
+ * Sorts shipping methods based on their price
+ *
+ * @author Daniel Richter <nexyz9@gmail.com>
+ */
+class PricedShippingMethodSorter implements ShippingMethodSorterInterface
+{
+    protected $calculators;
+    protected $shippingSubject;
+
+    public function __construct(CalculatorRegistryInterface $calculators)
+    {
+        $this->calculators = $calculators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sort(array $methods, ShippingSubjectInterface $subject)
+    {
+        $sorter = $this;
+
+        usort($methods, function (ShippingMethodInterface $methodA, ShippingMethodInterface $methodB) use ($subject, $sorter) {
+
+            $priceA = $sorter->getPrice($subject, $methodA);
+            $priceB = $sorter->getPrice($subject, $methodB);
+
+            if ($priceA === $priceB) {
+                return 0;
+            }
+
+            return $priceA > $priceB ? 1 : -1;
+        });
+
+        return $methods;
+    }
+
+    public function getPrice(ShippingSubjectInterface $subject, ShippingMethodInterface $method)
+    {
+        $calculator = $this->calculators->getCalculator($method->getCalculator());
+
+        return $calculator->calculate($subject, $method->getConfiguration());
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/Sorter/ShippingMethodSorterInterface.php
+++ b/src/Sylius/Bundle/ShippingBundle/Sorter/ShippingMethodSorterInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ShippingBundle\Sorter;
+
+
+use Sylius\Bundle\ShippingBundle\Model\ShippingSubjectInterface;
+use Sylius\Bundle\ShippingBundle\Model\ShippingMethodInterface;
+
+/**
+ * Applies a sort order to an array of ShippingMethod objects
+ */
+interface ShippingMethodSorterInterface
+{
+    /**
+     * Sorts shipping methods
+     *
+     * @param ShippingMethodInterface[] $methods
+     * @param ShippingSubjectInterface $subject
+     * @return ShippingMethodInterface[]
+     */
+    function sort(array $methods, ShippingSubjectInterface $subject);
+}


### PR DESCRIPTION
This commit delegates the creation of the ChoiceList for shipping methods to a factory.

Benefits:
- enhance choice views with additional data for the respective method (currently price, could be extended for estimated delivery date, etc).
- (optionally) sort methods (currently by price, could be extended for estimated delivery date, etc).
