### PR TITLE
Fix Shipping Adjustment application

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OrderProcessing/ShippingChargesProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderProcessing/ShippingChargesProcessor.php
@@ -53,6 +53,8 @@ class ShippingChargesProcessor implements ShippingChargesProcessorInterface
      */
     public function applyShippingCharges(OrderInterface $order)
     {
+        $order->removeShippingAdjustments(); // Remove all shipping adjustments, we recalculate everything from scratch.
+
         foreach ($order->getShipments() as $shipment) {
             $shippingCharge = $this->calculator->calculate($shipment);
 

--- a/src/Sylius/Bundle/CoreBundle/OrderProcessing/TaxationProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderProcessing/TaxationProcessor.php
@@ -90,11 +90,12 @@ class TaxationProcessor implements TaxationProcessorInterface
      */
     public function applyTaxes(OrderInterface $order)
     {
+        $order->removeTaxAdjustments(); // Remove all tax adjustments, we recalculate everything from scratch.
+
         if (0 === count($order->getItems())) {
             return;
         }
 
-        $order->removeTaxAdjustments(); // Remove all tax adjustments, we recalculate everything from scratch.
         $zone = null;
 
         if (null !== $order->getShippingAddress()) {

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Model/OrderSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Model/OrderSpec.php
@@ -12,6 +12,7 @@
 namespace spec\Sylius\Bundle\CoreBundle\Model;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\CoreBundle\Model\OrderInterface;
 
 /**
 *
@@ -134,6 +135,88 @@ class OrderSpec extends ObjectBehavior
         $this->removeShipment($shipment);
 
         $this->hasShipment($shipment)->shouldReturn(false);
+    }
+
+    /**
+     * helper method
+     *
+     * @param Sylius\Bundle\CoreBundle\Model\OrderInterface $order
+     * @param Sylius\Bundle\SalesBundle\Model\AdjustmentInterface $shippingAdjustment
+     * @param Sylius\Bundle\SalesBundle\Model\AdjustmentInterface $taxAdjustment
+     */
+    protected function addShippingAndTaxAdjustments($order, $shippingAdjustment, $taxAdjustment)
+    {
+        $shippingAdjustment->getLabel()->willReturn(OrderInterface::SHIPPING_ADJUSTMENT);
+        $shippingAdjustment->setAdjustable($order)->shouldBeCalled();
+        $taxAdjustment->getLabel()->willReturn(OrderInterface::TAX_ADJUSTMENT);
+        $taxAdjustment->setAdjustable($order)->shouldBeCalled();
+
+        $order->addAdjustment($shippingAdjustment);
+        $order->addAdjustment($taxAdjustment);
+    }
+
+    /**
+     * @param Sylius\Bundle\SalesBundle\Model\AdjustmentInterface $shippingAdjustment
+     * @param Sylius\Bundle\SalesBundle\Model\AdjustmentInterface $taxAdjustment
+     */
+    function it_should_return_shipping_adjustments($shippingAdjustment, $taxAdjustment)
+    {
+        $this->addShippingAndTaxAdjustments($this, $shippingAdjustment, $taxAdjustment);
+
+        $this->getAdjustments()->count()->shouldReturn(2); //both adjustments have been added
+
+        $shippingAdjustments = $this->getShippingAdjustments();
+        $shippingAdjustments->count()->shouldReturn(1); //but here we only get shipping
+        $shippingAdjustments->first()->shouldReturn($shippingAdjustment);
+    }
+
+    /**
+     * @param Sylius\Bundle\SalesBundle\Model\AdjustmentInterface $shippingAdjustment
+     * @param Sylius\Bundle\SalesBundle\Model\AdjustmentInterface $taxAdjustment
+     */
+    function it_should_remove_shipping_adjustments($shippingAdjustment, $taxAdjustment)
+    {
+        $this->addShippingAndTaxAdjustments($this, $shippingAdjustment, $taxAdjustment);
+
+        $this->getAdjustments()->count()->shouldReturn(2); //both adjustments have been added
+
+        $shippingAdjustment->setAdjustable(null)->shouldBeCalled();
+        $this->removeShippingAdjustments();
+
+        $this->getAdjustments()->count()->shouldReturn(1); //one has been removed
+        $this->getShippingAdjustments()->count()->shouldReturn(0); //shipping adjustment has been removed
+    }
+
+    /**
+     * @param Sylius\Bundle\SalesBundle\Model\AdjustmentInterface $shippingAdjustment
+     * @param Sylius\Bundle\SalesBundle\Model\AdjustmentInterface $taxAdjustment
+     */
+    function it_should_return_tax_adjustments($shippingAdjustment, $taxAdjustment)
+    {
+        $this->addShippingAndTaxAdjustments($this, $shippingAdjustment, $taxAdjustment);
+
+        $this->getAdjustments()->count()->shouldReturn(2); //both adjustments have been added
+
+        $taxAdjustments = $this->getTaxAdjustments();
+        $taxAdjustments->count()->shouldReturn(1); //but here we only get tax
+        $taxAdjustments->first()->shouldReturn($taxAdjustment);
+    }
+
+    /**
+     * @param Sylius\Bundle\SalesBundle\Model\AdjustmentInterface $shippingAdjustment
+     * @param Sylius\Bundle\SalesBundle\Model\AdjustmentInterface $taxAdjustment
+     */
+    function it_should_remove_tax_adjustments($shippingAdjustment, $taxAdjustment)
+    {
+        $this->addShippingAndTaxAdjustments($this, $shippingAdjustment, $taxAdjustment);
+
+        $this->getAdjustments()->count()->shouldReturn(2); //both adjustments have been added
+
+        $taxAdjustment->setAdjustable(null)->shouldBeCalled();
+        $this->removeTaxAdjustments();
+
+        $this->getAdjustments()->count()->shouldReturn(1); //one has been removed
+        $this->getTaxAdjustments()->count()->shouldReturn(0); //tax adjustment has been removed
     }
 
     /*

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/OrderProcessing/ShippingChargesProcessorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/OrderProcessing/ShippingChargesProcessorSpec.php
@@ -42,8 +42,20 @@ class ShippingChargesProcessorSpec extends ObjectBehavior
     /**
      * @param Sylius\Bundle\CoreBundle\Model\OrderInterface $order
      */
+    function it_removes_existing_shipping_adjustments($order)
+    {
+        $order->getShipments()->shouldBeCalled()->willReturn(array());
+        $order->removeShippingAdjustments()->shouldBeCalled();
+
+        $this->applyShippingCharges($order);
+    }
+
+    /**
+     * @param Sylius\Bundle\CoreBundle\Model\OrderInterface $order
+     */
     function it_doesnt_apply_any_shipping_charge_if_order_has_no_shipments($order)
     {
+        $order->removeShippingAdjustments()->shouldBeCalled();
         $order->getShipments()->shouldBeCalled()->willReturn(array());
         $order->addAdjustment(Argument::any())->shouldNotBeCalled();
 
@@ -72,6 +84,7 @@ class ShippingChargesProcessorSpec extends ObjectBehavior
         $adjustment->setLabel(Order::SHIPPING_ADJUSTMENT)->shouldBeCalled();
         $adjustment->setDescription('FedEx')->shouldBeCalled();
 
+        $order->removeShippingAdjustments()->shouldBeCalled();
         $order->addAdjustment($adjustment)->shouldBeCalled();
 
         $this->applyShippingCharges($order);

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/OrderProcessing/TaxationProcessorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/OrderProcessing/TaxationProcessorSpec.php
@@ -48,7 +48,19 @@ class TaxationProcessorSpec extends ObjectBehavior
     function it_doesnt_apply_any_taxes_if_order_has_no_items($order)
     {
         $order->getItems()->willReturn(array());
+        $order->removeTaxAdjustments()->shouldBeCalled();
         $order->addAdjustment(Argument::any())->shouldNotBeCalled();
+
+        $this->applyTaxes($order);
+    }
+
+    /**
+     * @param Sylius\Bundle\CoreBundle\Model\OrderInterface $order
+     */
+    function it_removes_existing_tax_adjustments($order)
+    {
+        $order->getItems()->willReturn(array());
+        $order->removeTaxAdjustments()->shouldBeCalled();
 
         $this->applyTaxes($order);
     }


### PR DESCRIPTION
Currently ShippingChargesProcessor only adds shipping adjustments. This commit makes it remove already applied adjustments before applying new ones. Also adds to the spec tests.
