### PR TITLE
Fix CreditCardType to work with Symfony's Luhn Validator

### DIFF
--- a/src/Sylius/Bundle/PaymentsBundle/Form/Type/CreditCardType.php
+++ b/src/Sylius/Bundle/PaymentsBundle/Form/Type/CreditCardType.php
@@ -44,10 +44,10 @@ class CreditCardType extends AbstractType
               ->add('cardholderName', 'text', array(
                 'label' => 'sylius.form.credit_card.cardholder_name',
               ))
-              ->add('number', 'number', array(
+              ->add('number', 'text', array(
                   'label' => 'sylius.form.credit_card.number',
               ))
-              ->add('securityCode', 'number', array(
+              ->add('securityCode', 'text', array(
                   'label' => 'sylius.form.credit_card.security_code',
               ))
               ->add('expiryMonth', 'choice', array(

--- a/src/Sylius/Bundle/PaymentsBundle/spec/Sylius/Bundle/PaymentsBundle/Form/Type/CreditCardTypeSpec.php
+++ b/src/Sylius/Bundle/PaymentsBundle/spec/Sylius/Bundle/PaymentsBundle/Form/Type/CreditCardTypeSpec.php
@@ -47,13 +47,13 @@ class CreditCardTypeSpec extends ObjectBehavior
         ;
 
         $builder
-            ->add('number', 'number', Argument::any())
+            ->add('number', 'text', Argument::any())
             ->shouldBeCalled()
             ->willReturn($builder)
         ;
 
         $builder
-            ->add('securityCode', 'number', Argument::any())
+            ->add('securityCode', 'text', Argument::any())
             ->shouldBeCalled()
             ->willReturn($builder)
         ;


### PR DESCRIPTION
Currently the number field is of type number, but Symfony's Luhn validator only works with strings.
Consequently this field fails to validate. This commit changes the type to text.
(Also fixes CS, there were some tabs in there..)
