### PR TITLE
Fix Process to keep step sequence after removing step

### DIFF
--- a/src/Sylius/Bundle/FlowBundle/Process/Process.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Process.php
@@ -188,6 +188,7 @@ class Process implements ProcessInterface
 
         unset($this->steps[$name]);
         unset($this->orderedSteps[$index]);
+        $this->orderedSteps = array_values($this->orderedSteps); //keep sequential index intact
     }
 
     /**

--- a/src/Sylius/Bundle/FlowBundle/Tests/Process/ProcessTest.php
+++ b/src/Sylius/Bundle/FlowBundle/Tests/Process/ProcessTest.php
@@ -73,6 +73,33 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function shouldKeepStepsInSequentialOrderAfterRemoveStep()
+    {
+        $process = new Process();
+
+        $process->setSteps(array(
+            'foo' => new TestStep(),
+            'bar' => new TestStep(),
+            'foobar' => new TestStep()
+        ));
+
+        $process->removeStep('bar');
+        $process->addStep('bar', new TestStep());
+
+        $correctOrder = array('foo', 'foobar', 'bar');
+
+        foreach ($process->getOrderedSteps() as $i => $step) {
+            $this->assertSame($correctOrder[$i], $step->getName());
+        }
+
+        foreach ($correctOrder as $i => $name) {
+            $this->assertSame($name, $process->getStepByIndex($i)->getName());
+        }
+    }
+
+    /**
+     * @test
+     */
     public function shouldAddStep()
     {
         $process = new Process();


### PR DESCRIPTION
Currently removing a step from the process leaves gaps in the step sequence and a process is considered closed at the breakpoint, even though there are more steps thereafter. This commmit ensures that proper index sequence is maintained throughout step removal/additions.
