### PR TITLE
Make cart save redirect to cart summary

### DIFF
--- a/src/Sylius/Bundle/CartBundle/Controller/CartController.php
+++ b/src/Sylius/Bundle/CartBundle/Controller/CartController.php
@@ -75,6 +75,8 @@ class CartController extends Controller
 
             // Write flash message
             $this->dispatchEvent(SyliusCartEvents::CART_SAVE_COMPLETED, new FlashEvent());
+
+            return $this->redirectToCartSummary();
         }
 
         return $this->renderResponse('summary.html', array(


### PR DESCRIPTION
Currently the cart save action doesn't follow the POST/redirect pattern. Tiny detail, but this fixes it.
