### PR TITLE
Administration is broken

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Menu/BackendMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/BackendMenuBuilder.php
@@ -38,7 +38,7 @@ class BackendMenuBuilder extends MenuBuilder
             )
         ));
 
-        $menu->setCurrentUri($request->getRequestUri());
+        $menu->setCurrent($request->getRequestUri());
 
         $childOptions = array(
             'attributes'         => array('class' => 'dropdown'),
@@ -80,7 +80,7 @@ class BackendMenuBuilder extends MenuBuilder
             )
         ));
 
-        $menu->setCurrentUri($request->getRequestUri());
+        $menu->setCurrent($request->getRequestUri());
 
         $childOptions = array(
             'childrenAttributes' => array('class' => 'nav'),


### PR DESCRIPTION
Might be linked with migration to Knp Menu Bundle 2.0. alpha version, the method setCurrentUri doesn't exist anymore, just change it to setCurrent as explained in KnpMenu, but I didn't have a deeper look to that issue yet, so waiting for your comments.
