### PR TITLE
FIX-472 broken product form for cyrillic taxonomy

### DIFF
--- a/src/Sylius/Bundle/TaxonomiesBundle/Form/DataTransformer/TaxonSelectionToCollectionTransformer.php
+++ b/src/Sylius/Bundle/TaxonomiesBundle/Form/DataTransformer/TaxonSelectionToCollectionTransformer.php
@@ -46,7 +46,7 @@ class TaxonSelectionToCollectionTransformer implements DataTransformerInterface
         $taxons = array();
 
         foreach ($this->taxonomies as $taxonomy) {
-            $taxons[strtolower($taxonomy->getName())] = array();
+            $taxons[$taxonomy->getId()] = array();
         }
 
         if (null === $value) {
@@ -58,7 +58,7 @@ class TaxonSelectionToCollectionTransformer implements DataTransformerInterface
         }
 
         foreach ($value as $taxon) {
-            $taxons[strtolower($taxon->getTaxonomy())][] = $taxon;
+            $taxons[$taxon->getTaxonomy()->getId()][] = $taxon;
         }
 
         return $taxons;

--- a/src/Sylius/Bundle/TaxonomiesBundle/Form/Type/TaxonSelectionType.php
+++ b/src/Sylius/Bundle/TaxonomiesBundle/Form/Type/TaxonSelectionType.php
@@ -11,9 +11,9 @@
 
 namespace Sylius\Bundle\TaxonomiesBundle\Form\Type;
 
-use Gedmo\Sluggable\Util\Urlizer;
 use Sylius\Bundle\ResourceBundle\Model\RepositoryInterface;
 use Sylius\Bundle\TaxonomiesBundle\Form\DataTransformer\TaxonSelectionToCollectionTransformer;
+use Sylius\Bundle\TaxonomiesBundle\Model\Taxonomy;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\ChoiceList\ObjectChoiceList;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -56,7 +56,8 @@ class TaxonSelectionType extends AbstractType
         $builder->addModelTransformer(new TaxonSelectionToCollectionTransformer($taxonomies));
 
         foreach ($taxonomies as $taxonomy) {
-            $builder->add(Urlizer::urlize($taxonomy->getName()), 'choice', array(
+            /* @var $taxonomy Taxonomy*/
+            $builder->add($taxonomy->getId(), 'choice', array(
                 'choice_list' => new ObjectChoiceList($taxonomy->getTaxonsAsList()),
                 'multiple'    => $options['multiple'],
                 'label'       => /** @Ignore */ $taxonomy->getName()


### PR DESCRIPTION
I replaced name to id, this is much more safe, because name could have non-latin character. 

See https://github.com/Sylius/Sylius/issues/472
