### PR TITLE
Add Shipping Category to Product mapping/form/templates

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/ProductType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/ProductType.php
@@ -39,6 +39,11 @@ class ProductType extends BaseProductType
                 'empty_value' => '---',
                 'label'       => 'sylius.form.product.tax_category'
             ))
+            ->add('shippingCategory', 'sylius_shipping_category_choice', array(
+                'required'    => false,
+                'empty_value' => '---',
+                'label'       => 'sylius.form.product.shipping_category'
+            ))
             ->add('taxons', 'sylius_taxon_selection')
             ->add('variantSelectionMethod', 'choice', array(
                 'label'   => 'sylius.form.product.variant_selection_method',

--- a/src/Sylius/Bundle/CoreBundle/Model/Product.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/Product.php
@@ -156,6 +156,8 @@ class Product extends BaseProduct implements ProductInterface
     public function setTaxons(Collection $taxons)
     {
         $this->taxons = $taxons;
+
+        return $this;
     }
 
     /**
@@ -208,6 +210,8 @@ class Product extends BaseProduct implements ProductInterface
     public function setTaxCategory(TaxCategoryInterface $category = null)
     {
         $this->taxCategory = $category;
+
+        return $this;
     }
 
     /**
@@ -224,6 +228,8 @@ class Product extends BaseProduct implements ProductInterface
     public function setShippingCategory(ShippingCategoryInterface $category = null)
     {
         $this->shippingCategory = $category;
+
+        return $this;
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Model/Variant.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/Variant.php
@@ -159,6 +159,8 @@ class Variant extends BaseVariant implements VariantInterface
         if (0 > $this->onHand) {
             $this->onHand = 0;
         }
+
+        return $this;
     }
 
     /**
@@ -183,6 +185,8 @@ class Variant extends BaseVariant implements VariantInterface
     public function setAvailableOnDemand($availableOnDemand)
     {
         $this->availableOnDemand = (Boolean) $availableOnDemand;
+
+        return $this;
     }
 
     /**
@@ -193,6 +197,8 @@ class Variant extends BaseVariant implements VariantInterface
         parent::setDefaults($masterVariant);
 
         $this->setPrice($masterVariant->getPrice());
+
+        return $this;
     }
 
     /**
@@ -228,6 +234,8 @@ class Variant extends BaseVariant implements VariantInterface
             $image->setVariant($this);
             $this->images->add($image);
         }
+
+        return $this;
     }
 
     /**
@@ -237,6 +245,8 @@ class Variant extends BaseVariant implements VariantInterface
     {
         $image->setVariant(null);
         $this->images->removeElement($image);
+
+        return $this;
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Product.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Product.orm.xml
@@ -24,6 +24,10 @@
             <join-column name="tax_category_id" referenced-column-name="id" nullable="true" />
         </many-to-one>
 
+        <many-to-one field="shippingCategory" target-entity="Sylius\Bundle\ShippingBundle\Model\ShippingCategoryInterface">
+            <join-column name="shipping_category_id" referenced-column-name="id" nullable="true" />
+        </many-to-one>
+
         <many-to-many field="taxons" target-entity="Sylius\Bundle\TaxonomiesBundle\Model\TaxonInterface">
             <join-table name="sylius_product_taxon">
                 <join-columns>

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.xlf
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.xlf
@@ -54,6 +54,10 @@
         <source>sylius.form.product.tax_category</source>
         <target>Tax category</target>
       </trans-unit>
+      <trans-unit id="737416fcfe721dea8cfc1247ec9e2c3b" resname="sylius.form.product.shipping_category">
+        <source>sylius.form.product.shipping_category</source>
+        <target>Shipping category</target>
+      </trans-unit>
       <trans-unit id="39ab32ec4aed4889c6d8ca2e8075b4cc" resname="sylius.form.product.variant_selection_method">
         <source>sylius.form.product.variant_selection_method</source>
         <target>Variant selection method</target>

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.xlf
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.xlf
@@ -1222,6 +1222,10 @@
         <source>sylius.product.no_tax_category</source>
         <target>No tax category</target>
       </trans-unit>
+      <trans-unit id="8be7a394aa4d7e59b74a86eb06832c12" resname="sylius.product.no_shipping_category">
+        <source>sylius.product.no_shipping_category</source>
+        <target>No shipping category</target>
+      </trans-unit>
       <trans-unit id="54cc7ecdb027bf1a8a7acd6c474a1fe0" resname="sylius.product.no_taxons">
         <source>sylius.product.no_taxons</source>
         <target>There are no taxons for this product</target>
@@ -1281,6 +1285,10 @@
       <trans-unit id="ef63be619b3f38199c730b04fe6df3a9" resname="sylius.product.tax_category">
         <source>sylius.product.tax_category</source>
         <target>Tax category</target>
+      </trans-unit>
+      <trans-unit id="3b63c6858f4e05f2bdad30801fa12a21" resname="sylius.product.shipping_category">
+        <source>sylius.product.shipping_category</source>
+        <target>Shipping category</target>
       </trans-unit>
       <trans-unit id="11c4582757733cff795bf9cf6f77b1f4" resname="sylius.product.update_header">
         <source>sylius.product.update_header</source>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_main.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_main.html.twig
@@ -10,5 +10,6 @@
     {{ form_row(form.masterVariant.onHand) }}
     <hr />
     {{ form_row(form.taxCategory) }}
+    {{ form_row(form.shippingCategory) }}
     {{ form_row(form.variantSelectionMethod) }}
 </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
@@ -98,6 +98,10 @@
                     <td>{{ product.taxCategory|default('sylius.product.no_tax_category'|trans) }}</td>
                 </tr>
                 <tr>
+                    <td>{{ 'sylius.product.shipping_category'|trans }}</td>
+                    <td>{{ product.shippingCategory|default('sylius.product.no_shipping_category'|trans) }}</td>
+                </tr>
+                <tr>
                     <td>{{ 'sylius.product.available_on_demand'|trans }}</td>
                     <td>
                         <span class="label label-{{ product.masterVariant.availableOnDemand ? 'success' : 'warning'}}">


### PR DESCRIPTION
Currently shipping category is not mapped or displayed in forms or templates. This PR fixes that.
Also fixes fluid interface issues with Product/Variant entities.
