### PR TITLE
Make default currency from config actually work

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -59,6 +59,10 @@
     <services>
         <!-- settings schemas -->
         <service id="sylius.settings_schema.general" class="%sylius.settings_schema.general.class%">
+            <argument type="collection">
+                <argument key="currency">%sylius.money.currency%</argument>
+                <argument key="locale">%sylius.locale%</argument>
+            </argument>
             <tag name="sylius.settings_schema" namespace="general" />
         </service>
         <service id="sylius.settings_schema.taxation" class="%sylius.settings_schema.taxation.class%">

--- a/src/Sylius/Bundle/CoreBundle/Settings/GeneralSettingsSchema.php
+++ b/src/Sylius/Bundle/CoreBundle/Settings/GeneralSettingsSchema.php
@@ -16,6 +16,7 @@ use Sylius\Bundle\SettingsBundle\Schema\SettingsBuilderInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Locale;
+use Symfony\Component\Validator\Constraints\Currency;
 
 /**
  * General settings schema.
@@ -25,18 +26,31 @@ use Symfony\Component\Validator\Constraints\Locale;
 class GeneralSettingsSchema implements SchemaInterface
 {
     /**
+     * @var array
+     */
+    protected $defaults;
+
+    /**
+     * @param array $defaults
+     */
+    public function __construct(array $defaults = array())
+    {
+        $this->defaults = $defaults;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function buildSettings(SettingsBuilderInterface $builder)
     {
         $builder
-            ->setDefaults(array(
+            ->setDefaults(array_merge(array(
                 'title'            => 'Sylius - Modern ecommerce for Symfony2',
                 'meta_keywords'    => 'symfony, sylius, ecommerce, webshop, shopping cart',
                 'meta_description' => 'Sylius is modern ecommerce solution for PHP. Based on the Symfony2 framework.',
                 'locale'           => 'en',
-                'currency'         => 'EUR',
-            ))
+                'currency'         => 'USD',
+            ), $this->defaults))
             ->setAllowedTypes(array(
                 'title'            => array('string'),
                 'meta_keywords'    => array('string'),
@@ -78,10 +92,11 @@ class GeneralSettingsSchema implements SchemaInterface
                     new Locale(),
                 )
             ))
-            ->add('currency', 'text', array( // TODO: use currency type when we upgrade to 2.3
+            ->add('currency', 'currency', array(
                 'label'       => 'sylius.form.settings.general.currency',
                 'constraints' => array(
-                    new NotBlank()
+                    new NotBlank(),
+                    new Currency(),
                 )
             ))
         ;


### PR DESCRIPTION
Currently the default currency is specified via parameters.yml, but the general settings override it with EUR.
This PR passes the configuration through to the settings schema. Also switches to currency form type.
