### PR TITLE
[ResourceBundle] Small fix on configuration

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
@@ -148,7 +148,7 @@ class Configuration
     {
         $limit = $this->get('limit', 10);
 
-        if (null === $limit) {
+        if (false === $limit) {
             return null;
         }
 
@@ -216,6 +216,6 @@ class Configuration
 
     protected function get($parameter, $default = null)
     {
-        return array_key_exists($parameter, $this->parameters) ? $this->parameters[$parameter] : $default;
+        return isset($this->parameters[$parameter]) ? $this->parameters[$parameter] : $default;
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ConfigurationSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ConfigurationSpec.php
@@ -100,18 +100,18 @@ class ConfigurationSpec extends ObjectBehavior
         $this->getLimit()->shouldReturn(10);
     }
 
-    function it_has_limit_equal_to_null_if_limit_is_null($request)
-    {
-        $request->attributes->set('_sylius', array('limit' => null));
-        $this->load($request);
-
-        $this->getLimit()->shouldReturn(null);
-    }
-
     function its_paginated_by_default($request)
     {
         $this->load($request);
         $this->isPaginated()->shouldReturn(true);
+    }
+
+    function it_has_limit_equal_to_null_if_limit_is_set_to_false($request)
+    {
+        $request->attributes->set('_sylius', array('limit' => false));
+        $this->load($request);
+
+        $this->getLimit()->shouldReturn(null);
     }
 
     function its_pagination_max_per_page_is_equal_to_10_by_default($request)


### PR DESCRIPTION
If you have a route configured like that (a var with a $) :

```
route_index:
    pattern:  /route
    defaults:
        _controller: sylius.controller.route:indexAction
        _sylius:
            paginate: $limit
```

The method get of the Configuration class will not return the default value

``` php
$this->get('paginate', 10); // return null if paginate is not defined instead of 10
```
