### PR TITLE
Add HWIOauthBundle to CoreBundle deps

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -43,7 +43,8 @@
         "jms/serializer-bundle":          "0.12.*",
         "knplabs/knp-gaufrette-bundle":   "0.2.*@dev",
         "mathiasverraes/money":           "*@dev",
-        "omnipay/omnipay":                "1.0.*@dev"
+        "omnipay/omnipay":                "1.0.*@dev",
+        "hwi/oauth-bundle":               "0.3.*"
     },
     "require-dev": {
         "fzaninotto/faker": "1.2.*",


### PR DESCRIPTION
Sorry guys I did it a bit too fast yesterday.

@cordoval I've put `0.3.*` just to be consistent with the main app `composer.json`. If we want to use a better version pattern it's a wider change.
