### PR TITLE
Display Product Variant consistently in cart, checkout, order receipt.

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
@@ -16,7 +16,7 @@
     <table id="items" class="table table-striped">
         <thead>
         <tr>
-            <th colspan="2">{{ 'sylius.order_item.sellable'|trans }}</th>
+            <th>{{ 'sylius.order_item.sellable'|trans }}</th>
             <th>{{ 'sylius.order_item.quantity'|trans }}</th>
             <th>{{ 'sylius.order_item.unit_price'|trans }}</th>
             <th>{{ 'sylius.order_item.total'|trans }}</th>
@@ -24,22 +24,10 @@
         </thead>
         <tbody>
         {% for item in order.items %}
-            {% set variant = item.variant %}
             {% set product = item.product %}
             <tr>
                 <td>
-                    {% if product.images|length > 0 %}
-                        <div id="gallery">
-                            {% for image in product.images %}
-                                <a href="{{ image.path|imagine_filter('sylius_gallery') }}" title="{{ product.name }}">
-                                    <img class="img-polaroid" src="{{ image.path|imagine_filter('sylius_90x60') }}" alt="{{ product.name }}" />
-                                </a>
-                            {% endfor %}
-                        </div>
-                    {% endif %}
-                </td>
-                <td>
-                    <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}">{{ product.name }}</a>
+                    {{ include('SyliusWebBundle:Frontend/Product:_variant.html.twig', {'variant': item.variant}) }}
                 </td>
                 <td>{{ item.quantity }}</td>
                 <td>{{ item.unitPrice|sylius_money }}</td>
@@ -49,7 +37,7 @@
         </tbody>
         <tfoot>
             <tr>
-                <th colspan="4">
+                <th colspan="3">
                     <span class="pull-right">
                         {{ 'sylius.order.items_total'|trans }}
                     </span>
@@ -57,7 +45,7 @@
                 <th>{{ order.itemsTotal|sylius_money }}</th>
             </tr>
             <tr>
-                <td colspan="4">
+                <td colspan="3">
                     <span class="pull-right">
                         {{ 'sylius.order.tax_total'|trans }}
                     </span>
@@ -65,7 +53,7 @@
                 <td>{{ order.taxTotal|sylius_money }}</td>
             </tr>
             <tr>
-                <td colspan="4">
+                <td colspan="3">
                     <span class="pull-right">
                         {{ 'sylius.order.shipping_total'|trans }}
                     </span>
@@ -73,7 +61,7 @@
                 <td>{{ order.shippingTotal|sylius_money }}</td>
             </tr>
             <tr>
-                <td colspan="4">
+                <td colspan="3">
                     <span class="pull-right">
                         {{ 'sylius.order.promotion_total'|trans }}
                     </span>
@@ -81,7 +69,7 @@
                 <td>{{ order.promotionTotal|sylius_money }}</td>
             </tr>
             <tr>
-                <th colspan="4">
+                <th colspan="3">
                     <span class="pull-right">
                         {{ 'sylius.order.total'|trans }}
                     </span>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/_item.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/_item.html.twig
@@ -1,20 +1,8 @@
 {% set product = item.variant.product %}
 <tr>
     <td class="col-md-1">{{ loop.index }}</td>
-    <td class="col-md-1">
-        <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}" class="thumbnail" style="width: 90px;">
-            <img src="{{ product.image ? product.image.path|imagine_filter('sylius_90x60') : 'http://placehold.it/90x60' }}" alt="" />
-        </a>
-    </td>
     <td>
-        <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}">
-            <strong>{{ product.name }}</strong>
-        </a>
-        <br>
-
-        {% for option in item.variant.options %}
-        <span class="label label-info">{{ option.presentation }}: {{ option.value }}</span>
-        {% endfor %}
+        {{ include('SyliusWebBundle:Frontend/Product:_variant.html.twig', {'variant': item.variant}) }}
     </td>
     <td class="col-md-2">
         {{ form_row(form.items[loop.index0].quantity, {'label': false}) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
@@ -17,7 +17,6 @@
     <thead>
         <tr>
             <th>#</th>
-            <th></th>
             <th>{{ 'sylius.cart.summary.product'|trans }}</th>
             <th>{{ 'sylius.cart.summary.quantity'|trans }}</th>
             <th></th>
@@ -33,18 +32,18 @@
     <tfoot>
         {% if cart.promotionTotal %}
         <tr>
-            <td colspan="7" style="text-align: right;">
+            <td colspan="6" style="text-align: right;">
                 <strong>{{ 'sylius.order.promotion_total'|trans }}</strong>: {{ cart.promotionTotal|sylius_price }}
             </td>
         </tr>
         {% endif %}
         <tr>
-            <td colspan="7" style="text-align: right;">
+            <td colspan="6" style="text-align: right;">
                 <strong>{{ 'sylius.order.shipping_total'|trans }}</strong>: {{ cart.shippingTotal|sylius_price }}
             </td>
         </tr>
         <tr>
-            <td colspan="5">
+            <td colspan="4">
                 <p><strong>{{ 'sylius.order.taxes'|trans }}</strong></p>
                 <ul>
                 {% for taxAdjustment in cart.taxAdjustments %}
@@ -59,7 +58,7 @@
             </td>
         </tr>
         <tr>
-            <td colspan="7" style="text-align: right;">
+            <td colspan="6" style="text-align: right;">
                 <strong>{{ 'sylius.cart.summary.grand_total'|trans }}</strong>: {{ cart.total|sylius_price }}
             </td>
         </tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/Finalize/_item.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/Finalize/_item.html.twig
@@ -1,23 +1,8 @@
-{% set variant = item.variant %}
 {% set product = item.product %}
 <tr>
     <td>{{ loop.index }}</td>
     <td>
-        <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}" class="thumbnail pull-left" style="width: 90px; margin-right: 15px;">
-            <img src="{{ product.image ? product.image.path|imagine_filter('sylius_90x60') : 'http://placehold.it/90x60' }}" alt="" />
-        </a>
-        <div>
-            <p>
-                <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}">{{ product.name }}</a>
-            </p>
-            {% if product.hasOptions %}
-            <ul class="unstyled">
-                {% for option in variant.options %}
-                <li><strong>{{ option.presentation }}</strong>: {{ option.value }}</li>
-                {% endfor %}
-            </ul>
-            {% endif %}
-        </div>
+        {{ include('SyliusWebBundle:Frontend/Product:_variant.html.twig', {'variant': item.variant}) }}
     </td>
     <td>{{ item.quantity }}</td>
     <td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_variant.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_variant.html.twig
@@ -1,0 +1,16 @@
+{% set product = variant.product %}
+<a href="{{ path('sylius_product_show', {'slug': product.slug}) }}" class="thumbnail pull-left" style="margin-right: 15px;">
+    <img src="{{ product.image ? product.image.path|imagine_filter('sylius_90x60') : 'http://placehold.it/90x60' }}" alt="{{ product.name }}" />
+</a>
+<div>
+    <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}"><strong>{{ product.name }}</strong></a>
+    {% if variant.presentation is not empty %}
+        <strong>{{ variant.presentation }}</strong>
+    {% elseif product.hasOptions %}
+        <ul class="list-unstyled">
+            {% for option in variant.options %}
+                <li><strong>{{ option.presentation }}</strong>: {{ option.value }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+</div>


### PR DESCRIPTION
Currently there are 3 frontend areas where a product variant is displayed in 3 slightly different ways.
This PR centralizes display logic into one template and simplifies the other templates.

This is what this looks like everywhere now:
![sylius_variant](https://f.cloud.github.com/assets/624921/1451845/eac6b3d8-42ae-11e3-8668-90e6879a03f4.JPG)
