### PR TITLE
Allow Variant selection for Products without Options

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Cart/ItemResolver.php
+++ b/src/Sylius/Bundle/CoreBundle/Cart/ItemResolver.php
@@ -97,7 +97,7 @@ class ItemResolver implements ItemResolverInterface
         $item = $form->getData(); // Item instance, cool.
 
         // If our product has no variants, we simply set the master variant of it.
-        if (!$product->hasOptions()) {
+        if (!$product->hasVariants()) {
             $item->setVariant($product->getMasterVariant());
         }
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/CartItemType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/CartItemType.php
@@ -34,7 +34,7 @@ class CartItemType extends BaseCartItemType
     {
         parent::buildForm($builder, $options);
 
-        if (isset($options['product']) && $options['product']->hasOptions()) {
+        if (isset($options['product']) && $options['product']->hasVariants()) {
             $type = Product::VARIANT_SELECTION_CHOICE === $options['product']->getVariantSelectionMethod() ? 'sylius_variant_choice' : 'sylius_variant_match';
 
             $builder->add('variant', $type, array(

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
@@ -53,7 +53,7 @@
 <hr>
 <div class="row">
     <form action="{{ path('sylius_cart_item_add', {'id': product.id}) }}" method="post" class="clearfix">
-    {% if product.hasOptions %}
+    {% if product.hasVariants %}
         <div class="col-md-6">
             {% if product.isVariantSelectionMethodChoice %}
             <table class="table table-condensed">
@@ -100,7 +100,7 @@
         </div>
     {% endif %}
     <div class="col-md-6 pull-right">
-        {% if not product.hasOptions and not sylius_inventory_is_available(product.masterVariant) %}
+        {% if not product.hasVariants and not sylius_inventory_is_available(product.masterVariant) %}
             <span class="label label-important">{{ 'sylius.out_of_stock'|trans }}</span>
         {% else %}
             {{ form_row(form.quantity, {'attr': {'class': 'center-text'}, 'empty_value': '1'}) }}


### PR DESCRIPTION
Currently Sylius assumes that a product only has variants if it has options, even though what really matters is whether there are variants. In my app I am creating variants directly without options (works great, except for the areas in this PR). This PR checks for the presence of variants instead of options.
