### PR TITLE
Add description to promotion adjustments

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Promotion/Action/FixedDiscountAction.php
+++ b/src/Sylius/Bundle/CoreBundle/Promotion/Action/FixedDiscountAction.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\CoreBundle\Promotion\Action;
 
 use Sylius\Bundle\CoreBundle\Model\OrderInterface;
 use Sylius\Bundle\PromotionsBundle\Action\PromotionActionInterface;
+use Sylius\Bundle\PromotionsBundle\Model\PromotionInterface;
 use Sylius\Bundle\PromotionsBundle\Model\PromotionSubjectInterface;
 use Sylius\Bundle\ResourceBundle\Model\RepositoryInterface;
 
@@ -43,12 +44,13 @@ class FixedDiscountAction implements PromotionActionInterface
     /**
      * {@inheritdoc}
      */
-    public function execute(PromotionSubjectInterface $subject, array $configuration)
+    public function execute(PromotionSubjectInterface $subject, array $configuration, PromotionInterface $promotion)
     {
         $adjustment = $this->repository->createNew();
 
         $adjustment->setAmount(-$configuration['amount']);
         $adjustment->setLabel(OrderInterface::PROMOTION_ADJUSTMENT);
+        $adjustment->setDescription($promotion->getDescription());
 
         $subject->addAdjustment($adjustment);
     }

--- a/src/Sylius/Bundle/CoreBundle/Promotion/Action/PercentageDiscountAction.php
+++ b/src/Sylius/Bundle/CoreBundle/Promotion/Action/PercentageDiscountAction.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\CoreBundle\Promotion\Action;
 
 use Sylius\Bundle\CoreBundle\Model\OrderInterface;
 use Sylius\Bundle\PromotionsBundle\Action\PromotionActionInterface;
+use Sylius\Bundle\PromotionsBundle\Model\PromotionInterface;
 use Sylius\Bundle\PromotionsBundle\Model\PromotionSubjectInterface;
 use Sylius\Bundle\ResourceBundle\Model\RepositoryInterface;
 
@@ -43,12 +44,13 @@ class PercentageDiscountAction implements PromotionActionInterface
     /**
      * {@inheritdoc}
      */
-    public function execute(PromotionSubjectInterface $subject, array $configuration)
+    public function execute(PromotionSubjectInterface $subject, array $configuration, PromotionInterface $promotion)
     {
         $adjustment = $this->repository->createNew();
 
         $adjustment->setAmount(- $subject->getPromotionSubjectItemTotal() * ($configuration['percentage']));
         $adjustment->setLabel(OrderInterface::PROMOTION_ADJUSTMENT);
+        $adjustment->setDescription($promotion->getDescription());
 
         $subject->addAdjustment($adjustment);
     }

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Promotion/Action/FixedDiscountActionSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Promotion/Action/FixedDiscountActionSpec.php
@@ -38,19 +38,22 @@ class FixedDiscountActionSpec extends ObjectBehavior
     }
 
     /**
-     * @param Sylius\Bundle\CoreBundle\Model\OrderInterface       $order
-     * @param Sylius\Bundle\OrderBundle\Model\AdjustmentInterface $adjustment
+     * @param Sylius\Bundle\CoreBundle\Model\OrderInterface          $order
+     * @param Sylius\Bundle\OrderBundle\Model\AdjustmentInterface    $adjustment
+     * @param Sylius\Bundle\PromotionsBundle\Model\PromotionInterface $promotion
      */
-    function it_applies_fixed_discount_as_promotion_adjustment($adjustmentRepository, $order, $adjustment)
+    function it_applies_fixed_discount_as_promotion_adjustment($adjustmentRepository, $order, $adjustment, $promotion)
     {
         $adjustmentRepository->createNew()->willReturn($adjustment);
+        $promotion->getDescription()->willReturn('promotion description');
 
         $adjustment->setAmount(-500)->shouldBeCalled();
         $adjustment->setLabel(OrderInterface::PROMOTION_ADJUSTMENT)->shouldBeCalled();
+        $adjustment->setDescription('promotion description')->shouldBeCalled();
 
         $order->addAdjustment($adjustment)->shouldBeCalled();
         $configuration = array('amount' => 500);
 
-        $this->execute($order, $configuration);
+        $this->execute($order, $configuration, $promotion);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Promotion/Action/PercentageDiscountActionSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Promotion/Action/PercentageDiscountActionSpec.php
@@ -38,18 +38,21 @@ class PercentageDiscountActionSpec extends ObjectBehavior
     }
 
     /**
-     * @param Sylius\Bundle\CoreBundle\Model\OrderInterface       $order
-     * @param Sylius\Bundle\OrderBundle\Model\AdjustmentInterface $adjustment
+     * @param Sylius\Bundle\CoreBundle\Model\OrderInterface           $order
+     * @param Sylius\Bundle\OrderBundle\Model\AdjustmentInterface     $adjustment
+     * @param Sylius\Bundle\PromotionsBundle\Model\PromotionInterface $promotion
      */
-    function it_applies_percentage_discount_as_promotion_adjustment($adjustmentRepository, $order, $adjustment)
+    function it_applies_percentage_discount_as_promotion_adjustment($adjustmentRepository, $order, $adjustment, $promotion)
     {
         $order->getPromotionSubjectItemTotal()->willReturn(10000);
         $adjustmentRepository->createNew()->willReturn($adjustment);
+        $promotion->getDescription()->willReturn('promotion description');
 
         $adjustment->setAmount(-2500)->shouldBeCalled();
         $adjustment->setLabel(OrderInterface::PROMOTION_ADJUSTMENT)->shouldBeCalled();
-
+        $adjustment->setDescription('promotion description')->shouldBeCalled();
         $order->addAdjustment($adjustment)->shouldBeCalled();
+
         $configuration = array('percentage' => 0.25);
 
         $this->execute($order, $configuration);

--- a/src/Sylius/Bundle/PromotionsBundle/Action/PromotionActionInterface.php
+++ b/src/Sylius/Bundle/PromotionsBundle/Action/PromotionActionInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\PromotionsBundle\Action;
 
+use Sylius\Bundle\PromotionsBundle\Model\PromotionInterface;
 use Sylius\Bundle\PromotionsBundle\Model\PromotionSubjectInterface;
 
 /**
@@ -27,7 +28,7 @@ interface PromotionActionInterface
      * @param array $configuration
      * @return mixed
      */
-    public function execute(PromotionSubjectInterface $subject, array $configuration);
+    public function execute(PromotionSubjectInterface $subject, array $configuration, PromotionInterface $promotion);
 
     /**
      * Returns the form name related to this action.

--- a/src/Sylius/Bundle/PromotionsBundle/Action/PromotionApplicator.php
+++ b/src/Sylius/Bundle/PromotionsBundle/Action/PromotionApplicator.php
@@ -34,7 +34,7 @@ class PromotionApplicator implements PromotionApplicatorInterface
         foreach ($promotion->getActions() as $action) {
             $this->registry
                 ->getAction($action->getType())
-                ->execute($subject, $action->getConfiguration())
+                ->execute($subject, $action->getConfiguration(), $promotion)
             ;
         }
     }

--- a/src/Sylius/Bundle/PromotionsBundle/spec/Sylius/Bundle/PromotionsBundle/Action/PromotionApplicatorSpec.php
+++ b/src/Sylius/Bundle/PromotionsBundle/spec/Sylius/Bundle/PromotionsBundle/Action/PromotionApplicatorSpec.php
@@ -52,7 +52,7 @@ class PromotionApplicatorSpec extends ObjectBehavior
         $actionModel->getType()->shouldBeCalled()->willReturn(ActionInterface::TYPE_FIXED_DISCOUNT);
         $actionModel->getConfiguration()->shouldBeCalled()->willReturn($configuration);
 
-        $action->execute($subject, $configuration)->shouldBeCalled();
+        $action->execute($subject, $configuration, $promotion)->shouldBeCalled();
 
         $this->apply($subject, $promotion);
     }


### PR DESCRIPTION
Currently promotion adjustments don't have a description.
This PR makes it possible to pass Promotion descriptions to these adjustments.
