### PR TITLE
Moved HTML5shim js call after CSS

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/layout.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/layout.html.twig
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-
 <html>
     <head>
         <title>
@@ -8,11 +7,6 @@
             {% endblock %}
         </title>
         <meta charset="UTF-8">
-
-        <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-        <!--[if lt IE 9]>
-            <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-        <![endif]-->
 
         <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Open+Sans:300italic,400,300,700' rel='stylesheet' type='text/css'>
 
@@ -26,6 +20,11 @@
                 <link rel="stylesheet" href="{{ asset_url }}" type="text/css" />
             {% endstylesheets %}
         {% endblock %}
+
+        <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
+        <!--[if lt IE 9]>
+        <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+        <![endif]-->
     </head>
     <body>
         {% include 'SyliusWebBundle:Backend:_navbar.html.twig' %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/layout.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/layout.html.twig
@@ -1,7 +1,5 @@
 <!DOCTYPE html>
-
 {% set settings = sylius_settings_all('general') %}
-
 <html>
     <head>
         <title>
@@ -12,11 +10,6 @@
         <meta charset="UTF-8">
         <meta name="description" content="{{ settings.meta_description|default('sylius.meta.frontend_description'|trans) }}">
         <meta name="keywords" content="{{ settings.meta_keywords|default('sylius.meta.frontend_keywords'|trans) }}">
-
-        <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
-        <!--[if lt IE 9]>
-          <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-        <![endif]-->
 
         <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Open+Sans:300italic,400,300,700' rel='stylesheet' type='text/css'>
 
@@ -31,6 +24,11 @@
             <link rel="stylesheet" href="{{ asset_url }}" type="text/css" />
         {% endstylesheets %}
         {% endblock %}
+
+        <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
+        <!--[if lt IE 9]>
+        <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
+        <![endif]-->
     </head>
     <body>
         <div class="container">


### PR DESCRIPTION
quote from https://code.google.com/p/html5shiv/

> It must be included before the `<body>` element (i.e. in the `<head>`) but doesn't matter if it appears before or after the CSS - **but for the sake of performance, it would make better sense to include the CSS first then this script.**
