### PR TITLE
Move from private to protected in checkout steps

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
@@ -63,7 +63,7 @@ class AddressingStep extends CheckoutStep
         return $this->renderStep($context, $order, $form);
     }
 
-    private function renderStep(ProcessContextInterface $context, OrderInterface $order, FormInterface $form)
+    protected function renderStep(ProcessContextInterface $context, OrderInterface $order, FormInterface $form)
     {
         return $this->render('SyliusWebBundle:Frontend/Checkout/Step:addressing.html.twig', array(
             'order'   => $order,
@@ -73,7 +73,7 @@ class AddressingStep extends CheckoutStep
 
     }
 
-    private function createCheckoutAddressingForm(OrderInterface $order)
+    protected function createCheckoutAddressingForm(OrderInterface $order)
     {
         return $this->createForm('sylius_checkout_addressing', $order);
     }

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/FinalizeStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/FinalizeStep.php
@@ -50,7 +50,7 @@ class FinalizeStep extends CheckoutStep
         return $this->complete();
     }
 
-    private function renderStep(ProcessContextInterface $context, OrderInterface $order)
+    protected function renderStep(ProcessContextInterface $context, OrderInterface $order)
     {
         return $this->render('SyliusWebBundle:Frontend/Checkout/Step:finalize.html.twig', array(
             'context' => $context,

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
@@ -63,7 +63,7 @@ class PaymentStep extends CheckoutStep
         return $this->renderStep($context, $order, $form);
     }
 
-    private function renderStep(ProcessContextInterface $context, OrderInterface $order, FormInterface $form)
+    protected function renderStep(ProcessContextInterface $context, OrderInterface $order, FormInterface $form)
     {
       return $this->render('SyliusWebBundle:Frontend/Checkout/Step:payment.html.twig', array(
             'order'   => $order,
@@ -72,7 +72,7 @@ class PaymentStep extends CheckoutStep
         ));
     }
 
-    private function createCheckoutPaymentForm(OrderInterface $order)
+    protected function createCheckoutPaymentForm(OrderInterface $order)
     {
         return $this->createForm('sylius_checkout_payment', $order);
     }

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
@@ -81,7 +81,7 @@ class SecurityStep extends CheckoutStep
      * @param ProcessContextInterface $context
      * @param FormInterface           $registrationForm
      */
-    private function renderStep(ProcessContextInterface $context, FormInterface $registrationForm)
+    protected function renderStep(ProcessContextInterface $context, FormInterface $registrationForm)
     {
         return $this->render('SyliusWebBundle:Frontend/Checkout/Step:security.html.twig', array(
             'context'           => $context,
@@ -94,7 +94,7 @@ class SecurityStep extends CheckoutStep
      *
      * @return FormInterface
      */
-    private function getRegistrationForm()
+    protected function getRegistrationForm()
     {
         return $this->get('fos_user.registration.form.factory')->createForm();
     }
@@ -102,7 +102,7 @@ class SecurityStep extends CheckoutStep
     /**
      * Override security target path, it will redirect user to checkout after login.
      */
-    private function overrideSecurityTargetPath()
+    protected function overrideSecurityTargetPath()
     {
         $url = $this->generateUrl('sylius_checkout_security', array(), true);
         $providerKey = $this->container->getParameter('fos_user.firewall_name');

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
@@ -65,7 +65,7 @@ class ShippingStep extends CheckoutStep
         return $this->renderStep($context, $order, $form);
     }
 
-    private function renderStep(ProcessContextInterface $context, OrderInterface $order, FormInterface $form)
+    protected function renderStep(ProcessContextInterface $context, OrderInterface $order, FormInterface $form)
     {
         return $this->render('SyliusWebBundle:Frontend/Checkout/Step:shipping.html.twig', array(
             'order'   => $order,
@@ -74,7 +74,7 @@ class ShippingStep extends CheckoutStep
         ));
     }
 
-    private function createCheckoutShippingForm(OrderInterface $order)
+    protected function createCheckoutShippingForm(OrderInterface $order)
     {
         $zone = $this->getZoneMatcher()->match($order->getShippingAddress());
 


### PR DESCRIPTION
To ease the customization of checkout steps.
(As a developer, by overriding one method I want to be able to use other methods (form creation, etc.))
