### PR TITLE
[RFC] Add ordering shipment state

### DIFF
--- a/src/Sylius/Bundle/ShippingBundle/Model/ShipmentInterface.php
+++ b/src/Sylius/Bundle/ShippingBundle/Model/ShipmentInterface.php
@@ -19,6 +19,7 @@ namespace Sylius\Bundle\ShippingBundle\Model;
 interface ShipmentInterface extends ShippingSubjectInterface
 {
     // Shipment default states.
+    const STATE_ORDERING = 'ordering';
     const STATE_READY    = 'ready';
     const STATE_PENDING  = 'pending';
     const STATE_SHIPPED  = 'shipped';


### PR DESCRIPTION
Hi guys,

Currently shipments are created in the database at the `ShippingStep`, with the state `ready`. This is not good because it's impossible to filter out shipments that haven't been paid for.

I propose to introduce a `ordering` (best name I've found)  This is the default state for shipment linked to an order that is not yet confirmed (= paid). We then need to update the state to `ready` (or `pending`) when the order is actually confirmed.

About the difference beween the states `ready` and `pending`. For me this is according to how shipments are handled by the company. It could send automatic shipment as soon as orders are confirmed, in this case state goes from `ordering` to `ready` directly. Or it could wait for something (administrative check or whatever) before actually prepare and send the shipment, in this case state goes from `ordering` to `pending` to finaly `ready`. Did I understand well?

Any thoughts?
