### PR TITLE
Implement fluid interface in all entities

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Model/Province.php
+++ b/src/Sylius/Bundle/AddressingBundle/Model/Province.php
@@ -66,6 +66,8 @@ class Province implements ProvinceInterface
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -82,5 +84,7 @@ class Province implements ProvinceInterface
     public function setCountry(CountryInterface $country = null)
     {
         $this->country = $country;
+
+        return $this;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Model/Image.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/Image.php
@@ -13,10 +13,39 @@ namespace Sylius\Bundle\CoreBundle\Model;
 
 class Image implements ImageInterface
 {
+    /**
+     * Id
+     *
+     * @var integer
+     */
     protected $id;
+
+    /**
+     * File
+     *
+     * @var \SplFileInfo
+     */
     protected $file;
+
+    /**
+     * Path to file
+     *
+     * @var string
+     */
     protected $path;
+
+    /**
+     * Creation date
+     *
+     * @var \DateTime
+     */
     protected $createdAt;
+
+    /**
+     * Update date
+     *
+     * @var \DateTime
+     */
     protected $updatedAt;
 
     public function __construct()
@@ -24,6 +53,11 @@ class Image implements ImageInterface
         $this->createdAt = new \DateTime();
     }
 
+    /**
+     * Get id
+     *
+     * @return integer
+     */
     public function getId()
     {
         return $this->id;
@@ -51,6 +85,8 @@ class Image implements ImageInterface
     public function setFile(\SplFileInfo $file)
     {
         $this->file = $file;
+
+        return $this;
     }
 
     /**
@@ -75,6 +111,8 @@ class Image implements ImageInterface
     public function setPath($path)
     {
         $this->path = $path;
+
+        return $this;
     }
 
     /**
@@ -91,6 +129,8 @@ class Image implements ImageInterface
     public function setCreatedAt(\DateTime $createdAt)
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     /**
@@ -107,5 +147,7 @@ class Image implements ImageInterface
     public function setUpdatedAt(\DateTime $updatedAt)
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Model/Order.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/Order.php
@@ -126,6 +126,8 @@ class Order extends Cart implements OrderInterface
     public function setShippingAddress(AddressInterface $address)
     {
         $this->shippingAddress = $address;
+
+        return $this;
     }
 
     /**
@@ -142,6 +144,8 @@ class Order extends Cart implements OrderInterface
     public function setBillingAddress(AddressInterface $address)
     {
         $this->billingAddress = $address;
+
+        return $this;
     }
 
     /**
@@ -382,6 +386,8 @@ class Order extends Cart implements OrderInterface
     public function setPromotionCoupon(CouponInterface $coupon = null)
     {
         $this->promotionCoupon = $coupon;
+
+        return $this;
     }
 
     /**
@@ -424,6 +430,8 @@ class Order extends Cart implements OrderInterface
     public function setCreatedAt(\DateTime $createdAt)
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Model/Shipment.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/Shipment.php
@@ -41,5 +41,7 @@ class Shipment extends BaseShipment implements ShipmentInterface
     public function setOrder(OrderInterface $order = null)
     {
         $this->order = $order;
+
+        return $this;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Model/Taxon.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/Taxon.php
@@ -64,6 +64,8 @@ class Taxon extends BaseTaxon implements ImageInterface
     public function setFile(\SplFileInfo $file)
     {
         $this->file = $file;
+
+        return $this;
     }
 
     /**
@@ -88,6 +90,8 @@ class Taxon extends BaseTaxon implements ImageInterface
     public function setPath($path)
     {
         $this->path = $path;
+
+        return $this;
     }
 
     /**
@@ -104,6 +108,8 @@ class Taxon extends BaseTaxon implements ImageInterface
     public function setCreatedAt(\DateTime $createdAt)
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     /**
@@ -120,5 +126,7 @@ class Taxon extends BaseTaxon implements ImageInterface
     public function setUpdatedAt(\DateTime $updatedAt)
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Model/User.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/User.php
@@ -52,6 +52,8 @@ class User extends BaseUser implements UserInterface
     public function setCurrency($currency)
     {
         $this->currency = $currency;
+
+        return $this;
     }
 
     /**
@@ -213,6 +215,8 @@ class User extends BaseUser implements UserInterface
     public function removeAddress(AddressInterface $address)
     {
         $this->addresses->removeElement($address);
+
+        return $this;
     }
 
     /**
@@ -241,21 +245,37 @@ class User extends BaseUser implements UserInterface
         return $this->firstName.' '.$this->lastName;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setFirstName($firstName)
     {
         $this->firstName = $firstName;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getFirstName()
     {
         return $this->firstName;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setLastName($lastName)
     {
         $this->lastName = $lastName;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getLastName()
     {
         return $this->lastName;
@@ -275,6 +295,8 @@ class User extends BaseUser implements UserInterface
     public function setCreatedAt(\DateTime $createdAt)
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     /**
@@ -291,6 +313,8 @@ class User extends BaseUser implements UserInterface
     public function setUpdatedAt(\DateTime $updatedAt)
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Model/UserInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/UserInterface.php
@@ -23,19 +23,42 @@ use Sylius\Bundle\ResourceBundle\Model\TimestampableInterface;
  */
 interface UserInterface extends BaseUserInterface, TimestampableInterface
 {
+    /**
+     * Get first name
+     */
     public function getFirstName();
 
     /**
-     * Set firstname.
+     * Set first name
      *
      * @param string $firstName
      */
     public function setFirstName($firstName);
 
+    /**
+     * Get last name
+     */
     public function getLastName();
+
+    /**
+     * Set last name
+     *
+     * @param string $lastName
+     */
     public function setLastName($lastName);
 
+    /**
+     * Get currency
+     *
+     * @return string
+     */
     public function getCurrency();
+
+    /**
+     * Set currency
+     *
+     * @param string $currency
+     */
     public function setCurrency($currency);
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Model/VariantImage.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/VariantImage.php
@@ -13,6 +13,11 @@ namespace Sylius\Bundle\CoreBundle\Model;
 
 class VariantImage extends Image implements VariantImageInterface
 {
+    /**
+     * The associated variant
+     *
+     * @var VariantInterface
+     */
     protected $variant;
 
     /**
@@ -29,5 +34,7 @@ class VariantImage extends Image implements VariantImageInterface
     public function setVariant(VariantInterface $variant = null)
     {
         $this->variant = $variant;
+
+        return $this;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Model/VariantInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/VariantInterface.php
@@ -66,6 +66,9 @@ interface VariantInterface extends BaseVariantInterface, ShippableInterface, Sto
      */
     public function removeImage(VariantImageInterface $image);
 
+    /**
+     * @return integer
+     */
     public function getWeight();
     public function setWeight($weight);
 

--- a/src/Sylius/Bundle/MoneyBundle/Model/ExchangeRate.php
+++ b/src/Sylius/Bundle/MoneyBundle/Model/ExchangeRate.php
@@ -67,6 +67,8 @@ class ExchangeRate implements ExchangeRateInterface
     public function setCurrency($currency)
     {
         $this->currency = $currency;
+
+        return $this;
     }
 
     /**
@@ -83,6 +85,8 @@ class ExchangeRate implements ExchangeRateInterface
     public function setRate($rate)
     {
         $this->rate = $rate;
+
+        return $this;
     }
 
     /**
@@ -99,6 +103,8 @@ class ExchangeRate implements ExchangeRateInterface
     public function setCreatedAt(\DateTime $createdAt)
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     /**
@@ -115,5 +121,7 @@ class ExchangeRate implements ExchangeRateInterface
     public function setUpdatedAt(\DateTime $updatedAt)
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 }

--- a/src/Sylius/Bundle/OrderBundle/Model/Adjustment.php
+++ b/src/Sylius/Bundle/OrderBundle/Model/Adjustment.php
@@ -236,6 +236,8 @@ class Adjustment implements AdjustmentInterface
     public function setCreatedAt(\DateTime $createdAt)
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     /**
@@ -252,5 +254,7 @@ class Adjustment implements AdjustmentInterface
     public function setUpdatedAt(\DateTime $updatedAt)
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 }

--- a/src/Sylius/Bundle/OrderBundle/Model/Order.php
+++ b/src/Sylius/Bundle/OrderBundle/Model/Order.php
@@ -452,6 +452,8 @@ class Order implements OrderInterface, TimestampableInterface
     public function setCreatedAt(\DateTime $createdAt)
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     /**
@@ -468,6 +470,8 @@ class Order implements OrderInterface, TimestampableInterface
     public function setUpdatedAt(\DateTime $updatedAt)
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 
     /**
@@ -476,6 +480,8 @@ class Order implements OrderInterface, TimestampableInterface
     public function setState($state)
     {
         $this->state = $state;
+
+        return $this;
     }
 
     /**

--- a/src/Sylius/Bundle/OrderBundle/Model/OrderItem.php
+++ b/src/Sylius/Bundle/OrderBundle/Model/OrderItem.php
@@ -123,6 +123,8 @@ class OrderItem implements OrderItemInterface
     public function setOrder(OrderInterface $order = null)
     {
         $this->order = $order;
+
+        return $this;
     }
 
     /**
@@ -139,6 +141,8 @@ class OrderItem implements OrderItemInterface
     public function setUnitPrice($unitPrice)
     {
         $this->unitPrice = $unitPrice;
+
+        return $this;
     }
 
     /**

--- a/src/Sylius/Bundle/PaymentsBundle/Model/PaymentMethod.php
+++ b/src/Sylius/Bundle/PaymentsBundle/Model/PaymentMethod.php
@@ -113,6 +113,8 @@ class PaymentMethod implements PaymentMethodInterface
     public function setEnabled($enabled)
     {
         $this->enabled = (Boolean) $enabled;
+
+        return $this;
     }
 
     /**
@@ -129,6 +131,8 @@ class PaymentMethod implements PaymentMethodInterface
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -145,6 +149,8 @@ class PaymentMethod implements PaymentMethodInterface
     public function setDescription($description)
     {
         $this->description = $description;
+
+        return $this;
     }
 
     /**
@@ -161,6 +167,8 @@ class PaymentMethod implements PaymentMethodInterface
     public function setGateway($gateway)
     {
         $this->gateway = $gateway;
+
+        return $this;
     }
 
     /**
@@ -177,6 +185,8 @@ class PaymentMethod implements PaymentMethodInterface
     public function setEnvironment($environment)
     {
         $this->environment = $environment;
+
+        return $this;
     }
 
     /**

--- a/src/Sylius/Bundle/PromotionsBundle/Model/Action.php
+++ b/src/Sylius/Bundle/PromotionsBundle/Model/Action.php
@@ -18,48 +18,103 @@ namespace Sylius\Bundle\PromotionsBundle\Model;
  */
 class Action implements ActionInterface
 {
+    /**
+     * The id of this action
+     *
+     * @var integer
+     */
     protected $id;
+
+    /**
+     * The type of this action
+     *
+     * @var string
+     */
     protected $type;
+
+    /**
+     * The configuration of this action
+     *
+     * @var array
+     */
     protected $configuration;
+
+    /**
+     * The promotion associated with this action
+     *
+     * @var PromotionInterface
+     */
     protected $promotion;
 
+    /**
+     * Constructor
+     */
     public function __construct()
     {
         $this->configuration = array();
     }
 
+    /**
+     * Get id
+     *
+     * @return int
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getType()
     {
         return $this->type;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setType($type)
     {
         $this->type = $type;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getConfiguration()
     {
         return $this->configuration;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setConfiguration(array $configuration)
     {
         $this->configuration = $configuration;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getPromotion()
     {
         return $this->promotion;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setPromotion(PromotionInterface $promotion = null)
     {
         $this->promotion = $promotion;
+
+        return $this;
     }
 }

--- a/src/Sylius/Bundle/PromotionsBundle/Model/ActionInterface.php
+++ b/src/Sylius/Bundle/PromotionsBundle/Model/ActionInterface.php
@@ -21,10 +21,45 @@ interface ActionInterface
     const TYPE_FIXED_DISCOUNT      = 'fixed_discount';
     const TYPE_PERCENTAGE_DISCOUNT = 'percentage_discount';
 
+    /**
+     * Get type
+     *
+     * @return string
+     */
     public function getType();
+
+    /**
+     * Set type
+     *
+     * @param $type
+     */
     public function setType($type);
+
+    /**
+     * Get configuration
+     *
+     * @return array
+     */
     public function getConfiguration();
+
+    /**
+     * Set configuration
+     *
+     * @param array $configuration
+     */
     public function setConfiguration(array $configuration);
+
+    /**
+     * Get promotion
+     *
+     * @return PromotionInterface
+     */
     public function getPromotion();
+
+    /**
+     * Set promotion
+     *
+     * @param PromotionInterface $promotion
+     */
     public function setPromotion(PromotionInterface $promotion = null);
 }

--- a/src/Sylius/Bundle/PromotionsBundle/Model/Coupon.php
+++ b/src/Sylius/Bundle/PromotionsBundle/Model/Coupon.php
@@ -18,48 +18,113 @@ namespace Sylius\Bundle\PromotionsBundle\Model;
  */
 class Coupon implements CouponInterface
 {
+    /**
+     * Id
+     *
+     * @var integer
+     */
     protected $id;
+
+    /**
+     * Coupon code
+     *
+     * @var string
+     */
     protected $code;
+
+    /**
+     * Usage limit
+     *
+     * @var integer
+     */
     protected $usageLimit;
+
+    /**
+     * Number of times used
+     *
+     * @var integer
+     */
     protected $used;
+
+    /**
+     * Associated promotion
+     *
+     * @var PromotionInterface
+     */
     protected $promotion;
+
+    /**
+     * Expiration date
+     *
+     * @var \DateTime
+     */
     protected $expiresAt;
 
+    /**
+     * Constructor
+     */
     public function __construct()
     {
         $this->used = 0;
     }
 
+    /**
+     * Get id
+     *
+     * @return integer
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getCode()
     {
         return $this->code;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setCode($code)
     {
         $this->code = $code;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getUsageLimit()
     {
         return $this->usageLimit;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setUsageLimit($usageLimit)
     {
         $this->usageLimit = $usageLimit;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getUsed()
     {
         return $this->used;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setUsed($used)
     {
         $this->used = $used;
@@ -67,26 +132,45 @@ class Coupon implements CouponInterface
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function incrementUsed()
     {
         $this->used++;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getPromotion()
     {
         return $this->promotion;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setPromotion(PromotionInterface $promotion = null)
     {
         $this->promotion = $promotion;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getExpiresAt()
     {
         return $this->expiresAt;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setExpiresAt(\DateTime $expiresAt = null)
     {
         $this->expiresAt = $expiresAt;
@@ -94,6 +178,9 @@ class Coupon implements CouponInterface
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isValid()
     {
         if (null !== $this->usageLimit && $this->used >= $this->usageLimit) {

--- a/src/Sylius/Bundle/PromotionsBundle/Model/CouponInterface.php
+++ b/src/Sylius/Bundle/PromotionsBundle/Model/CouponInterface.php
@@ -18,16 +18,85 @@ namespace Sylius\Bundle\PromotionsBundle\Model;
  */
 interface CouponInterface
 {
+    /**
+     * Get code
+     *
+     * @return string
+     */
     public function getCode();
+
+    /**
+     * Set code
+     *
+     * @param string $code
+     */
     public function setCode($code);
+
+    /**
+     * Get usage limit
+     *
+     * @return integer
+     */
     public function getUsageLimit();
+
+    /**
+     * Set usage limit
+     *
+     * @param integer $usageLimit
+     */
     public function setUsageLimit($usageLimit);
+
+    /**
+     * Get number of times this coupon has been used
+     *
+     * @return integer
+     */
     public function getUsed();
+
+    /**
+     * Set number of times this coupon has been used
+     *
+     * @param integer $used
+     */
     public function setUsed($used);
+
+    /**
+     * Increment usage
+     */
     public function incrementUsed();
+
+    /**
+     * Get associated promotion
+     *
+     * @return PromotionInterface
+     */
     public function getPromotion();
+
+    /**
+     * Set the associated promotion
+     *
+     * @param PromotionInterface $promotion
+     */
     public function setPromotion(PromotionInterface $promotion = null);
+
+    /**
+     * Get the expiration date
+     *
+     * @return \DateTime
+     */
     public function getExpiresAt();
+
+    /**
+     * Set the expiration date
+     *
+     * @param \DateTime $expiresAt
+     */
     public function setExpiresAt(\DateTime $expiresAt = null);
+
+    /**
+     * Is this coupon valid?
+     *
+     * @return Boolean
+     */
     public function isValid();
 }

--- a/src/Sylius/Bundle/PromotionsBundle/Model/Promotion.php
+++ b/src/Sylius/Bundle/PromotionsBundle/Model/Promotion.php
@@ -20,20 +20,100 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 class Promotion implements PromotionInterface
 {
+    /**
+     * Id
+     *
+     * @var integer
+     */
     protected $id;
+
+    /**
+     * Name
+     *
+     * @var string
+     */
     protected $name;
+
+    /**
+     * Description
+     *
+     * @var string
+     */
     protected $description;
+
+    /**
+     * Usage limit
+     *
+     * @var integer
+     */
     protected $usageLimit;
+
+    /**
+     * Number of times this coupon has been used
+     *
+     * @var integer
+     */
     protected $used;
+
+    /**
+     * Start date
+     *
+     * @var \DateTime
+     */
     protected $startsAt;
+
+    /**
+     * End date
+     *
+     * @var \DateTime
+     */
     protected $endsAt;
+
+    /**
+     * Whether this promotion is triggered by a coupon
+     *
+     * @var Boolean
+     */
     protected $couponBased;
+
+    /**
+     * Associated coupons
+     *
+     * @var CouponInterface[]
+     */
     protected $coupons;
+
+    /**
+     * Associated rules
+     *
+     * @var RuleInterface[]
+     */
     protected $rules;
+
+    /**
+     * Associated actions
+     *
+     * @var ActionInterface[]
+     */
     protected $actions;
+
+    /**
+     * Last time updated
+     *
+     * @var \DateTime
+     */
     protected $updatedAt;
+
+    /**
+     * Creation date
+     *
+     * @var \DateTime
+     */
     protected $createdAt;
 
+    /**
+     * Constructor
+     */
     public function __construct()
     {
         $this->used = 0;
@@ -43,46 +123,79 @@ class Promotion implements PromotionInterface
         $this->actions = new ArrayCollection();
     }
 
+    /**
+     * @return int
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return $this->name;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getDescription()
     {
         return $this->description;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setDescription($description)
     {
         $this->description = $description;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getUsageLimit()
     {
         return $this->usageLimit;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setUsageLimit($usageLimit)
     {
         $this->usageLimit = $usageLimit;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getUsed()
     {
         return $this->used;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setUsed($used)
     {
         $this->used = $used;
@@ -90,145 +203,247 @@ class Promotion implements PromotionInterface
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function incrementUsed()
     {
         $this->used++;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getStartsAt()
     {
         return $this->startsAt;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setStartsAt(\DateTime $startsAt = null)
     {
         $this->startsAt = $startsAt;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getEndsAt()
     {
         return $this->endsAt;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setEndsAt(\DateTime $endsAt = null)
     {
         $this->endsAt = $endsAt;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function isCouponBased()
     {
         return $this->couponBased;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setCouponBased($couponBased)
     {
         $this->couponBased = (Boolean) $couponBased;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getCoupons()
     {
         return $this->coupons;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function hasCoupons()
     {
         return !$this->coupons->isEmpty();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function hasCoupon(CouponInterface $coupon)
     {
         return $this->coupons->contains($coupon);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function addCoupon(CouponInterface $coupon)
     {
         if (!$this->hasCoupon($coupon)) {
             $coupon->setPromotion($this);
             $this->coupons->add($coupon);
         }
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function removeCoupon(CouponInterface $coupon)
     {
         $coupon->setPromotion(null);
         $this->coupons->removeElement($coupon);
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function hasRules()
     {
         return !$this->rules->isEmpty();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getRules()
     {
         return $this->rules;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function hasRule(RuleInterface $rule)
     {
         return $this->rules->contains($rule);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function addRule(RuleInterface $rule)
     {
         if (!$this->hasRule($rule)) {
             $rule->setPromotion($this);
             $this->rules->add($rule);
         }
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function removeRule(RuleInterface $rule)
     {
         $rule->setPromotion(null);
         $this->rules->removeElement($rule);
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function hasActions()
     {
         return !$this->actions->isEmpty();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getActions()
     {
         return $this->actions;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function hasAction(ActionInterface $action)
     {
         return $this->actions->contains($action);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function addAction(ActionInterface $action)
     {
         if (!$this->hasAction($action)) {
             $action->setPromotion($this);
             $this->actions->add($action);
         }
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function removeAction(ActionInterface $action)
     {
         $action->setPromotion(null);
         $this->actions->removeElement($action);
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getUpdatedAt()
     {
         return $this->updatedAt;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setUpdatedAt(\DateTime $updatedAt)
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getCreatedAt()
     {
         return $this->createdAt;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setCreatedAt(\DateTime $createdAt)
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 }

--- a/src/Sylius/Bundle/PromotionsBundle/Model/PromotionInterface.php
+++ b/src/Sylius/Bundle/PromotionsBundle/Model/PromotionInterface.php
@@ -20,18 +20,93 @@ use Sylius\Bundle\ResourceBundle\Model\TimestampableInterface;
  */
 interface PromotionInterface extends TimestampableInterface
 {
+    /**
+     * Get name
+     *
+     * @return string
+     */
     public function getName();
+
+    /**
+     * Set name
+     *
+     * @param string $name
+     */
     public function setName($name);
+
+    /**
+     * Get description
+     *
+     * @return string
+     */
     public function getDescription();
+
+    /**
+     * Set description
+     *
+     * @param string $description
+     */
     public function setDescription($description);
+
+    /**
+     * Get usage limit
+     *
+     * @return integer
+     */
     public function getUsageLimit();
+
+    /**
+     * Set usage limit
+     *
+     * @param integer $usageLimit
+     */
     public function setUsageLimit($usageLimit);
+
+    /**
+     * Get usage
+     *
+     * @return integer
+     */
     public function getUsed();
+
+    /**
+     * Set usage
+     *
+     * @param integer $used
+     */
     public function setUsed($used);
+
+    /**
+     * Increment usage
+     */
     public function incrementUsed();
+
+    /**
+     * Get start date
+     *
+     * @return \DateTime
+     */
     public function getStartsAt();
+
+    /**
+     * Set start date
+     *
+     * @param \DateTime $startsAt
+     */
     public function setStartsAt(\DateTime $startsAt = null);
+
+    /**
+     * Get end date
+     *
+     * @return \DateTime
+     */
     public function getEndsAt();
+
+    /**
+     * Set end date
+     *
+     * @param \DateTime $endsAt
+     */
     public function setEndsAt(\DateTime $endsAt = null);
 
     /**

--- a/src/Sylius/Bundle/PromotionsBundle/Model/PromotionSubjectInterface.php
+++ b/src/Sylius/Bundle/PromotionsBundle/Model/PromotionSubjectInterface.php
@@ -20,16 +20,22 @@ namespace Sylius\Bundle\PromotionsBundle\Model;
 interface PromotionSubjectInterface
 {
     /**
+     * Get associated coupon
+     *
      * @return null|CouponInterface
      */
     public function getPromotionCoupon();
 
     /**
+     * Get number of promotion subjects
+     *
      * @return integer
      */
     public function getPromotionSubjectItemCount();
 
     /**
+     * Get total of promotion subjects
+     *
      * @return integer
      */
     public function getPromotionSubjectItemTotal();

--- a/src/Sylius/Bundle/PromotionsBundle/Model/Rule.php
+++ b/src/Sylius/Bundle/PromotionsBundle/Model/Rule.php
@@ -18,48 +18,103 @@ namespace Sylius\Bundle\PromotionsBundle\Model;
  */
 class Rule implements RuleInterface
 {
+    /**
+     * Id
+     *
+     * @var integer
+     */
     protected $id;
+
+    /**
+     * Type
+     *
+     * @var string
+     */
     protected $type;
+
+    /**
+     * Configuration
+     *
+     * @var array
+     */
     protected $configuration;
+
+    /**
+     * Associated promotion
+     *
+     * @var PromotionInterface
+     */
     protected $promotion;
 
+    /**
+     * Constructor
+     */
     public function __construct()
     {
         $this->configuration = array();
     }
 
+    /**
+     * Get id
+     *
+     * @return integer
+     */
     public function getId()
     {
         return $this->id;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getType()
     {
         return $this->type;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setType($type)
     {
         $this->type = $type;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getConfiguration()
     {
         return $this->configuration;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setConfiguration(array $configuration)
     {
         $this->configuration = $configuration;
+
+        return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getPromotion()
     {
         return $this->promotion;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setPromotion(PromotionInterface $promotion = null)
     {
         $this->promotion = $promotion;
+
+        return $this;
     }
 }

--- a/src/Sylius/Bundle/PromotionsBundle/Model/RuleInterface.php
+++ b/src/Sylius/Bundle/PromotionsBundle/Model/RuleInterface.php
@@ -21,10 +21,45 @@ interface RuleInterface
     const TYPE_ITEM_TOTAL = 'item_total';
     const TYPE_ITEM_COUNT = 'item_count';
 
+    /**
+     * Get type
+     *
+     * @return string
+     */
     public function getType();
+
+    /**
+     * Set type
+     *
+     * @param string $type
+     */
     public function setType($type);
+
+    /**
+     * Get configuration
+     *
+     * @return array
+     */
     public function getConfiguration();
+
+    /**
+     * Set configuration
+     *
+     * @param array $configuration
+     */
     public function setConfiguration(array $configuration);
+
+    /**
+     * Get associated promotion
+     *
+     * @return PromotionInterface
+     */
     public function getPromotion();
+
+    /**
+     * Set associated promotion
+     *
+     * @param PromotionInterface $promotion
+     */
     public function setPromotion(PromotionInterface $promotion = null);
 }

--- a/src/Sylius/Bundle/ShippingBundle/Model/Rule.php
+++ b/src/Sylius/Bundle/ShippingBundle/Model/Rule.php
@@ -68,6 +68,8 @@ class Rule implements RuleInterface
     public function setType($type)
     {
         $this->type = $type;
+
+        return $this;
     }
 
     /**
@@ -84,6 +86,8 @@ class Rule implements RuleInterface
     public function setConfiguration(array $configuration)
     {
         $this->configuration = $configuration;
+
+        return $this;
     }
 
     /**
@@ -100,5 +104,7 @@ class Rule implements RuleInterface
     public function setMethod(ShippingMethodInterface $method = null)
     {
         $this->method = $method;
+
+        return $this;
     }
 }

--- a/src/Sylius/Bundle/ShippingBundle/Model/Shipment.php
+++ b/src/Sylius/Bundle/ShippingBundle/Model/Shipment.php
@@ -110,6 +110,8 @@ class Shipment implements ShipmentInterface, TimestampableInterface
     public function setState($state)
     {
         $this->state = $state;
+
+        return $this;
     }
 
     /**
@@ -126,6 +128,8 @@ class Shipment implements ShipmentInterface, TimestampableInterface
     public function setMethod(ShippingMethodInterface $method)
     {
         $this->method = $method;
+
+        return $this;
     }
 
     /**
@@ -153,6 +157,8 @@ class Shipment implements ShipmentInterface, TimestampableInterface
             $item->setShipment($this);
             $this->items->add($item);
         }
+
+        return $this;
     }
 
     /**
@@ -164,6 +170,8 @@ class Shipment implements ShipmentInterface, TimestampableInterface
             $item->setShipment(null);
             $this->items->removeElement($item);
         }
+
+        return $this;
     }
 
     /**
@@ -197,6 +205,8 @@ class Shipment implements ShipmentInterface, TimestampableInterface
     public function setTracking($tracking)
     {
         $this->tracking = $tracking;
+
+        return $this;
     }
 
     /**
@@ -221,6 +231,8 @@ class Shipment implements ShipmentInterface, TimestampableInterface
     public function setCreatedAt(\DateTime $createdAt)
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     /**
@@ -237,6 +249,8 @@ class Shipment implements ShipmentInterface, TimestampableInterface
     public function setUpdatedAt(\DateTime $updatedAt)
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 
     public function getShippingWeight()
@@ -246,6 +260,8 @@ class Shipment implements ShipmentInterface, TimestampableInterface
         foreach ($this->items as $item) {
             $weight += $item->getShippable()->getShippingWeigth();
         }
+
+        return $weight;
     }
 
     public function getShippingItemCount()

--- a/src/Sylius/Bundle/ShippingBundle/Model/ShipmentItem.php
+++ b/src/Sylius/Bundle/ShippingBundle/Model/ShipmentItem.php
@@ -99,6 +99,8 @@ class ShipmentItem implements ShipmentItemInterface
     public function setShipment(ShipmentInterface $shipment = null)
     {
         $this->shipment = $shipment;
+
+        return $this;
     }
 
     /**
@@ -115,6 +117,8 @@ class ShipmentItem implements ShipmentItemInterface
     public function setShippable(ShippableInterface $shippable)
     {
         $this->shippable = $shippable;
+
+        return $this;
     }
 
     /**
@@ -131,6 +135,8 @@ class ShipmentItem implements ShipmentItemInterface
     public function setShippingState($state)
     {
         $this->shippingState = $state;
+
+        return $this;
     }
 
     /**
@@ -147,6 +153,8 @@ class ShipmentItem implements ShipmentItemInterface
     public function setCreatedAt(\DateTime $createdAt)
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     /**
@@ -163,5 +171,7 @@ class ShipmentItem implements ShipmentItemInterface
     public function setUpdatedAt(\DateTime $updatedAt)
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 }

--- a/src/Sylius/Bundle/ShippingBundle/Model/ShippingCategory.php
+++ b/src/Sylius/Bundle/ShippingBundle/Model/ShippingCategory.php
@@ -91,6 +91,8 @@ class ShippingCategory implements ShippingCategoryInterface
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -107,6 +109,8 @@ class ShippingCategory implements ShippingCategoryInterface
     public function setDescription($description)
     {
         $this->description = $description;
+
+        return $this;
     }
 
     /**
@@ -123,6 +127,8 @@ class ShippingCategory implements ShippingCategoryInterface
     public function setCreatedAt(\DateTime $createdAt)
     {
         $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     /**
@@ -139,5 +145,7 @@ class ShippingCategory implements ShippingCategoryInterface
     public function setUpdatedAt(\DateTime $updatedAt)
     {
         $this->updatedAt = $updatedAt;
+
+        return $this;
     }
 }

--- a/src/Sylius/Bundle/TaxationBundle/Model/TaxCategory.php
+++ b/src/Sylius/Bundle/TaxationBundle/Model/TaxCategory.php
@@ -104,6 +104,8 @@ class TaxCategory implements TaxCategoryInterface
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -120,6 +122,8 @@ class TaxCategory implements TaxCategoryInterface
     public function setDescription($description)
     {
         $this->description = $description;
+
+        return $this;
     }
 
     /**
@@ -139,6 +143,8 @@ class TaxCategory implements TaxCategoryInterface
             $rate->setCategory($this);
             $this->rates->add($rate);
         }
+
+        return $this;
     }
 
     /**
@@ -150,6 +156,8 @@ class TaxCategory implements TaxCategoryInterface
             $rate->setCategory(null);
             $this->rates->removeElement($rate);
         }
+
+        return $this;
     }
 
     /**

--- a/src/Sylius/Bundle/TaxationBundle/Model/TaxRate.php
+++ b/src/Sylius/Bundle/TaxationBundle/Model/TaxRate.php
@@ -108,6 +108,8 @@ class TaxRate implements TaxRateInterface
     public function setCategory(TaxCategoryInterface $category = null)
     {
         $this->category = $category;
+
+        return $this;
     }
 
     /**
@@ -124,6 +126,8 @@ class TaxRate implements TaxRateInterface
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -164,6 +168,8 @@ class TaxRate implements TaxRateInterface
     public function setIncludedInPrice($includedInPrice)
     {
         $this->includedInPrice = (Boolean) $includedInPrice;
+
+        return $this;
     }
 
     /**
@@ -180,6 +186,8 @@ class TaxRate implements TaxRateInterface
     public function setCalculator($calculator)
     {
         $this->calculator = $calculator;
+
+        return $this;
     }
 
     /**

--- a/src/Sylius/Bundle/TaxonomiesBundle/Model/Taxon.php
+++ b/src/Sylius/Bundle/TaxonomiesBundle/Model/Taxon.php
@@ -136,6 +136,8 @@ class Taxon implements TaxonInterface
     public function setTaxonomy(TaxonomyInterface $taxonomy = null)
     {
         $this->taxonomy = $taxonomy;
+
+        return $this;
     }
 
     /**
@@ -160,6 +162,8 @@ class Taxon implements TaxonInterface
     public function setParent(TaxonInterface $parent = null)
     {
         $this->parent = $parent;
+
+        return $this;
     }
 
     /**
@@ -222,6 +226,8 @@ class Taxon implements TaxonInterface
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -238,6 +244,8 @@ class Taxon implements TaxonInterface
     public function setSlug($slug)
     {
         $this->slug = $slug;
+
+        return $this;
     }
 
     /**
@@ -262,6 +270,8 @@ class Taxon implements TaxonInterface
     public function setPermalink($permalink)
     {
         $this->permalink = $permalink;
+
+        return $this;
     }
 
     /**
@@ -278,6 +288,8 @@ class Taxon implements TaxonInterface
     public function setDescription($description)
     {
         $this->description = $description;
+
+        return $this;
     }
 
     /**
@@ -330,5 +342,7 @@ class Taxon implements TaxonInterface
     public function setLevel($level)
     {
         $this->level = $level;
+
+        return $this;
     }
 }

--- a/src/Sylius/Bundle/VariableProductBundle/Model/VariableProduct.php
+++ b/src/Sylius/Bundle/VariableProductBundle/Model/VariableProduct.php
@@ -78,6 +78,8 @@ class VariableProduct extends Product implements VariableProductInterface
             ->getMasterVariant()
             ->setAvailableOn($availableOn)
         ;
+
+        return $this;
     }
 
     /**
@@ -98,13 +100,15 @@ class VariableProduct extends Product implements VariableProductInterface
     public function setMasterVariant(VariantInterface $masterVariant)
     {
         if ($this->variants->contains($masterVariant)) {
-            return;
+            return $this;
         }
 
         $masterVariant->setProduct($this);
         $masterVariant->setMaster(true);
 
         $this->variants->add($masterVariant);
+
+        return $this;
     }
 
     /**
@@ -145,6 +149,8 @@ class VariableProduct extends Product implements VariableProductInterface
         foreach ($variants as $variant) {
             $this->addVariant($variant);
         }
+
+        return $this;
     }
 
     /**
@@ -156,6 +162,8 @@ class VariableProduct extends Product implements VariableProductInterface
             $variant->setProduct($this);
             $this->variants->add($variant);
         }
+
+        return $this;
     }
 
     /**
@@ -167,6 +175,8 @@ class VariableProduct extends Product implements VariableProductInterface
             $variant->setProduct(null);
             $this->variants->removeElement($variant);
         }
+
+        return $this;
     }
 
     /**
@@ -199,6 +209,8 @@ class VariableProduct extends Product implements VariableProductInterface
     public function setOptions(Collection $options)
     {
         $this->options = $options;
+
+        return $this;
     }
 
     /**
@@ -209,6 +221,8 @@ class VariableProduct extends Product implements VariableProductInterface
         if (!$this->hasOption($option)) {
             $this->options->add($option);
         }
+
+        return $this;
     }
 
     /**
@@ -219,6 +233,8 @@ class VariableProduct extends Product implements VariableProductInterface
         if ($this->hasOption($option)) {
             $this->options->removeElement($option);
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Currently the fluid interface of entities is inconsistent. This PR fixes this and adds missing phpdocs as well.

(Also fixes a little bug where total shipping weight is not returned properly.)
