### PR TITLE
[Core] Handle better inventory units on cart change

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Model/VariantInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/VariantInterface.php
@@ -23,6 +23,11 @@ use Sylius\Bundle\ShippingBundle\Model\ShippableInterface;
 interface VariantInterface extends BaseVariantInterface, ShippableInterface, StockableInterface
 {
     /**
+     * Return variant id
+     */
+    public function getId();
+
+    /**
      * Get variant price.
      *
      * @return integer

--- a/src/Sylius/Bundle/CoreBundle/OrderProcessing/InventoryHandler.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderProcessing/InventoryHandler.php
@@ -62,25 +62,26 @@ class InventoryHandler implements InventoryHandlerInterface
         $variants = array();
 
         // We first iterate over cart items, counting items in positive
-        // and inventory units already existing in negative
         foreach ($order->getItems() as $item) {
             $variant = $item->getVariant();
 
             if (!isset($units[$variant->getId()])) {
-                $quantities[$variant->getId()] = $item->getQuantity() - count($order->getInventoryUnitsByVariant($variant));
+                $quantities[$variant->getId()] = $item->getQuantity();
                 $variants[$variant->getId()] = $variant;
             } else {
                 $quantities[$variant->getId()] += $item->getQuantity();
             }
         }
 
-        // We then iterate over inventory units to count those not matching any item
+        // We then iterate over inventory units to count them in negative
         foreach ($order->getInventoryUnits() as $unit) {
             $variant = $unit->getStockable();
 
             if (!isset($quantities[$variant->getId()])) {
-                $quantities[$variant->getId()] = -count($order->getInventoryUnitsByVariant($variant));
+                $quantities[$variant->getId()] = -1;
                 $variants[$variant->getId()] = $variant;
+            } else {
+            	$quantities[$variant->getId()]--;
             }
         }
 

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/OrderProcessing/InventoryHandlerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/OrderProcessing/InventoryHandlerSpec.php
@@ -11,6 +11,7 @@
 
 namespace spec\Sylius\Bundle\CoreBundle\OrderProcessing;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\InventoryBundle\Model\InventoryUnitInterface;
@@ -45,6 +46,7 @@ class InventoryHandlerSpec extends ObjectBehavior
     function it_does_not_create_any_inventory_units_if_order_has_no_items($order)
     {
         $order->getItems()->willReturn(array());
+        $order->getInventoryUnits()->willReturn(array());
         $order->addInventoryUnit(Argument::any())->shouldNotBeCalled();
 
         $this->processInventoryUnits($order);
@@ -64,7 +66,7 @@ class InventoryHandlerSpec extends ObjectBehavior
         $item->getVariant()->willReturn($variant);
         $item->getQuantity()->willReturn(2);
 
-        $order->getInventoryUnitsByVariant($variant)->shouldBeCalled()->willReturn(array());
+        $order->getInventoryUnits()->willReturn(array());
 
         $inventoryUnitFactory->create($variant, 2, InventoryUnitInterface::STATE_CHECKOUT)->shouldBeCalled()->willReturn(array($unit1, $unit2));
 
@@ -88,7 +90,13 @@ class InventoryHandlerSpec extends ObjectBehavior
         $item->getVariant()->willReturn($variant);
         $item->getQuantity()->willReturn(2);
 
-        $order->getInventoryUnitsByVariant($variant)->shouldBeCalled()->willReturn(array($unit1));
+        //$variant->getId()->willReturn(1);
+
+        $unit1->getStockable()->willReturn($variant);
+        $unit2->getStockable()->willReturn($variant);
+
+        $order->getInventoryUnitsByVariant($variant)->willReturn(array($unit1));
+        $order->getInventoryUnits()->willReturn(array($unit1));
 
         $inventoryUnitFactory->create($variant, 1, InventoryUnitInterface::STATE_CHECKOUT)->shouldBeCalled()->willReturn(array($unit2));
 
@@ -107,12 +115,18 @@ class InventoryHandlerSpec extends ObjectBehavior
      */
     function it_removes_extra_inventory_units($inventoryUnitFactory, $order, $item, $variant, $unit1, $unit2)
     {
-        $order->getItems()->willReturn(array($item));
+    	$order->getItems()->willReturn(array($item));
 
         $item->getVariant()->willReturn($variant);
         $item->getQuantity()->willReturn(1);
 
-        $order->getInventoryUnitsByVariant($variant)->shouldBeCalled()->willReturn(array($unit1, $unit2));
+        $unit1->getStockable()->willReturn($variant);
+        $unit2->getStockable()->willReturn($variant);
+
+        $variant->getId()->willReturn(1);
+
+        $order->getInventoryUnitsByVariant($variant)->shouldBeCalled()->willReturn(new ArrayCollection(array($unit1, $unit2)));
+        $order->getInventoryUnits()->willReturn(new ArrayCollection(array($unit1, $unit2)));
 
         $inventoryUnitFactory->create(Argument::any())->shouldNotBeCalled();
 


### PR DESCRIPTION
This PR fixes 3 issues:
- First, inventory units weren't deleted when deleting an item from the cart.
- Second, there was the assumption that each CartItem have different variants attached. But this depends on how you implement the `CartItem::equals` method (in my project I can have 2 items with same variant).
- Third in `removeInventoryUnits`, you cannot walk over a collection that way, indexes are not always contiguous.

I'm not that happy with my implementation with 2 array $quantities and $variants, but I had no choice as I can't put a Variant object in array index. If you have any better idea...
