### PR TITLE
Make province-choices.js more flexible by not relying on .well class

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/assets/js/province-choices.js
+++ b/src/Sylius/Bundle/WebBundle/Resources/assets/js/province-choices.js
@@ -12,7 +12,7 @@
 
     $(document).ready(function() {
         $('select[name$="[country]"]').on('change', function() {
-            var provinceContainer = $(this).parents('div.well').find('div.province-container');
+            var provinceContainer = $(this).parents('div.address-container').find('div.province-container');
             var provinceName = $(this).attr('name').replace('country', 'province');
 
             if (null === $(this).val()) {


### PR DESCRIPTION
Currently the province-choices.js relies on a parent container for an address to have a .well class,
even though there already is an .address-container class. This PR makes it use the latter.
