### PR TITLE
Bugfix "different address" toggle

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/assets/js/province-choices.js
+++ b/src/Sylius/Bundle/WebBundle/Resources/assets/js/province-choices.js
@@ -42,8 +42,9 @@
         }
 
         var billingAddressCheckbox = $('input[type="checkbox"][name$="[differentBillingAddress]"]');
+        var billingAddressContainer = $('#sylius-billing-address-container');
         var toggleBillingAddress = function() {
-            $('#sylius-billing-address-container').toggle('checked' === billingAddressCheckbox.attr('checked'));
+            billingAddressContainer.toggle(billingAddressCheckbox.prop('checked'));
         };
         toggleBillingAddress();
         billingAddressCheckbox.on('change', toggleBillingAddress);


### PR DESCRIPTION
The recent update to jQuery 1.10 seems to have broken this functionality, as checkbox checked state needs to be tested for with `prop()` instead of `attr()`.

As a sidenote, currently the Sylius Demo site still works, because apparently the assets have not been dumped since the jQuery update. The demo still runs jQuery 1.8.
