### PR TITLE
Abandon cart on cart clean

### DIFF
--- a/src/Sylius/Bundle/CartBundle/EventListener/CartListener.php
+++ b/src/Sylius/Bundle/CartBundle/EventListener/CartListener.php
@@ -95,6 +95,7 @@ class CartListener implements EventSubscriberInterface
     {
         $this->cartManager->remove($event->getCart());
         $this->cartManager->flush();
+        $this->cartProvider->abandonCart();
     }
 
     public function saveCart(CartEvent $event)


### PR DESCRIPTION
I may have missed something, but actually when clearing a cart it's deleted from the database, but not from the session (cartProvider using SessionStorage). So on the next page, CartProvider will do `$this->repository->find($identifier);` leading to a NotFoundException because the cart has been deleted.

This PR delete the cart identifier from the session. That way, on the next page CartProvider will create a new cart instead of trying to use an unexisting one.

The weird thing is that it's currently working well on the demo, but how? Can't find, even with a grep, where the `abandonCart` method is called.
