### PR TITLE
[payum] add execute same request with payment details action.

### DIFF
--- a/app/config/payum.yml
+++ b/app/config/payum.yml
@@ -17,6 +17,7 @@ payum:
                 actions:
                     - sylius.payum.paypal.action.capture_order_using_express_checkout
                     - sylius.payum.action.order_status
+                    - sylius.payum.action.execute_same_request_with_payment_details
 
             storages:
                 Sylius\Bundle\CoreBundle\Model\Order:
@@ -36,6 +37,7 @@ payum:
                     - sylius.payum.stripe.action.capture_order_using_credit_card
                     - sylius.payum.action.obtain_credit_card
                     - sylius.payum.action.order_status
+                    - sylius.payum.action.execute_same_request_with_payment_details
 
             storages:
                 Sylius\Bundle\CoreBundle\Model\Order:

--- a/src/Sylius/Bundle/PayumBundle/Payum/Action/ExecuteSameRequestWithPaymentDetailsAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Payum/Action/ExecuteSameRequestWithPaymentDetailsAction.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+* This file is part of the Sylius package.
+*
+* (c) Paweł Jędrzejewski
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Sylius\Bundle\PayumBundle\Payum\Action;
+
+use Payum\Action\PaymentAwareAction;
+use Payum\Bridge\Spl\ArrayObject;
+use Payum\Exception\RequestNotSupportedException;
+use Payum\Request\ModelRequestInterface;
+use Sylius\Bundle\PaymentsBundle\Model\PaymentInterface;
+
+class ExecuteSameRequestWithPaymentDetailsAction extends PaymentAwareAction
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function execute($request)
+    {
+        /** @var $request ModelRequestInterface */
+        if (!$this->supports($request)) {
+            throw RequestNotSupportedException::createActionNotSupported($this, $request);
+        }
+
+        /** @var PaymentInterface $payment */
+        $payment = $request->getModel();
+        $details = ArrayObject::ensureArrayObject($payment->getDetails());
+
+        try {
+            $request->setModel($details);
+
+            $this->payment->execute($request);
+
+            $payment->setDetails((array) $details);
+        } catch (\Exception $e) {
+            $payment->setDetails((array) $details);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($request)
+    {
+        return
+            $request instanceof ModelRequestInterface &&
+            $request->getModel() instanceof PaymentInterface &&
+            $request->getModel()->getDetails()
+        ;
+    }
+}

--- a/src/Sylius/Bundle/PayumBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/config/services.xml
@@ -24,6 +24,7 @@
         <parameter key="sylius.payum.dummy.action.order_status.class">Sylius\Bundle\PayumBundle\Payum\Dummy\Action\OrderStatusAction</parameter>
         <parameter key="sylius.payum.action.order_status.class">Sylius\Bundle\PayumBundle\Payum\Action\OrderStatusAction</parameter>
         <parameter key="sylius.payum.action.obtain_credit_card.class">Sylius\Bundle\PayumBundle\Payum\Action\ObtainCreditCardAction</parameter>
+        <parameter key="sylius.payum.action.execute_same_request_with_payment_details.class">Sylius\Bundle\PayumBundle\Payum\Action\ExecuteSameRequestWithPaymentDetailsAction</parameter>
     </parameters>
 
     <services>
@@ -36,6 +37,7 @@
         <service id="sylius.payum.paypal.action.capture_order_using_express_checkout" class="%sylius.payum.paypal.action.capture_order_using_express_checkout.class%" />
         <service id="sylius.payum.stripe.action.capture_order_using_credit_card" class="%sylius.payum.stripe.action.capture_order_using_credit_card.class%" />
         <service id="sylius.payum.action.order_status" class="%sylius.payum.action.order_status.class%" />
+        <service id="sylius.payum.action.execute_same_request_with_payment_details" class="%sylius.payum.action.execute_same_request_with_payment_details.class%" />
         <service id="sylius.payum.action.obtain_credit_card" class="%sylius.payum.action.obtain_credit_card.class%" >
             <argument type="service" id="form.factory" />
             <argument type="service" id="templating" />

--- a/src/Sylius/Bundle/PayumBundle/spec/Sylius/Bundle/PayumBundle/Payum/Action/ExecuteSameRequestWithPaymentDetailsActionSpec.php
+++ b/src/Sylius/Bundle/PayumBundle/spec/Sylius/Bundle/PayumBundle/Payum/Action/ExecuteSameRequestWithPaymentDetailsActionSpec.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+* This file is part of the Sylius package.
+*
+* (c) Paweł Jędrzejewski
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace spec\Sylius\Bundle\PayumBundle\Payum\Action;
+
+use Payum\Request\ModelRequestInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\PaymentsBundle\Model\PaymentInterface;
+use Payum\PaymentInterface as PayumPaymentInterface;
+
+class ExecuteSameRequestWithPaymentDetailsActionSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\PayumBundle\Payum\Action\ExecuteSameRequestWithPaymentDetailsAction');
+    }
+
+    function it_extends_payum_payment_aware_action()
+    {
+        $this->shouldHaveType('Payum\Action\PaymentAwareAction');
+    }
+
+    function it_should_support_model_request_with_payment_model_and_not_empty_details(
+        ModelRequestInterface $request,
+        PaymentInterface $payment
+    ) {
+        $request->getModel()->willReturn($payment);
+        $payment->getDetails()->willReturn(array('foo' => 'foo'));
+
+        $this->supports($request)->shouldReturn(true);
+    }
+
+    function it_should_not_support_model_request_with_payment_model_and_empty_details(
+        ModelRequestInterface $request,
+        PaymentInterface $payment
+    ) {
+        $request->getModel()->willReturn($payment);
+        $payment->getDetails()->willReturn(array());
+
+        $this->supports($request)->shouldReturn(false);
+    }
+
+    function it_should_not_support_model_request_with_not_payment_model(ModelRequestInterface $request)
+    {
+        $request->getModel()->willReturn(new \stdClass);
+
+        $this->supports($request)->shouldReturn(false);
+    }
+
+    function it_should_not_support_anything_not_model_request()
+    {
+        $this->supports(new \stdClass)->shouldReturn(false);
+    }
+
+    function it_throws_exception_if_executing_not_supported_request()
+    {
+        $this
+            ->shouldThrow('Payum\Exception\RequestNotSupportedException')
+            ->duringExecute($notSupportedRequest = 'foo')
+        ;
+    }
+
+    function it_should_execute_same_request_with_details_wrapped_by_array_object(
+        ModelRequestInterface $request,
+        PaymentInterface $payment,
+        PayumPaymentInterface $payumPayment
+    ) {
+        $this->setPayment($payumPayment);
+
+        $request->getModel()->willReturn($payment);
+        $payment->getDetails()->willReturn(array('foo' => 'fooValue'));
+
+        $request
+            ->setModel(Argument::type('Payum\Bridge\Spl\ArrayObject'))
+            ->shouldBeCalled()
+            ->will(function ($args) use ($request) {
+                $request->getModel()->willReturn($args[0]);
+            })
+        ;
+        $request->getModel()->willReturn($payment);
+
+        $payumPayment
+            ->execute($request)
+            ->shouldBeCalled()
+            ->will(function ($args) {
+                $details = $args[0]->getModel();
+                $details['bar'] = 'barValue';
+            })
+        ;
+
+        $payment->setDetails(array('foo' => 'fooValue', 'bar' => 'barValue'))->shouldBeCalled();
+
+        $this->execute($request);
+    }
+}


### PR DESCRIPTION
This action contains some code that all capture might duplicate. Also it allows to hook between order and payment object execution with payum extension.
