### PR TITLE
Fix incorrect date field input format in order filter form.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Filter/OrderFilterType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Filter/OrderFilterType.php
@@ -43,6 +43,7 @@ class OrderFilterType extends AbstractType
             ->add('createdAtFrom', 'date', array(
                 'required' => false,
                 'widget'   => 'single_text',
+                'input'    => 'string',
                 'label'    => 'sylius.form.order_filter.created_at_from',
                 'attr'     => array(
                     'placeholder' => 'sylius.form.order_filter.created_at_from'
@@ -51,6 +52,7 @@ class OrderFilterType extends AbstractType
             ->add('createdAtTo', 'date', array(
                 'required' => false,
                 'widget'   => 'single_text',
+                'input'    => 'string',
                 'label'    => 'sylius.form.order_filter.created_at_to',
                 'attr'     => array(
                     'placeholder' => 'sylius.form.order_filter.created_at_to'


### PR DESCRIPTION
The default input format for date type is `datetime` but we are expecting a `string`.
