### PR TITLE
Fix product options page spacing bug.

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Option/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Option/macros.html.twig
@@ -22,7 +22,7 @@
                 <td>{{ option.name }}</td>
                 <td>{{ option.presentation }}</td>
                 <td>
-                    <ul>
+                    <ul class="list-unstyled">
                         {% for value in option.values %}
                         <span class="label label-primary">{{ value }}</span>
                         {% endfor %}


### PR DESCRIPTION
Before: The "value" column was a bit off.

![screen shot 2013-11-30 at 9 33 33 am](https://f.cloud.github.com/assets/193112/1647963/e80d143a-595f-11e3-8f4c-978bc2cb8975.png)

After:

![screen shot 2013-11-30 at 9 36 21 am](https://f.cloud.github.com/assets/193112/1647964/ef2a7e2e-595f-11e3-80d5-5afd0fac8960.png)
