### PR TITLE
 [Flow] Add own InvalidException (fix #655)

### DIFF
--- a/src/Sylius/Bundle/FlowBundle/Controller/ProcessController.php
+++ b/src/Sylius/Bundle/FlowBundle/Controller/ProcessController.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\FlowBundle\Controller;
 
+use Sylius\Bundle\FlowBundle\Process\Coordinator\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -46,6 +47,8 @@ class ProcessController extends ContainerAware
      * @param string  $scenarioAlias
      * @param string  $stepName
      *
+     * @throws NotFoundHttpException
+     *
      * @return Response
      */
     public function displayAction(Request $request, $scenarioAlias, $stepName)
@@ -56,7 +59,7 @@ class ProcessController extends ContainerAware
 
         try {
             return $coordinator->display($scenarioAlias, $stepName, $request->query);
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             throw new NotFoundHttpException('The step you are looking for is not found.', $e);
         }
     }

--- a/src/Sylius/Bundle/FlowBundle/Process/Coordinator/Coordinator.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Coordinator/Coordinator.php
@@ -190,7 +190,7 @@ class Coordinator implements CoordinatorInterface
     public function registerScenario($alias, ProcessScenarioInterface $scenario)
     {
         if (isset($this->scenarios[$alias])) {
-            throw new \InvalidArgumentException(sprintf('Process scenario with alias "%s" is already registered', $alias));
+            throw new InvalidArgumentException(sprintf('Process scenario with alias "%s" is already registered', $alias));
         }
 
         $this->scenarios[$alias] = $scenario;
@@ -202,7 +202,7 @@ class Coordinator implements CoordinatorInterface
     public function loadScenario($alias)
     {
         if (!isset($this->scenarios[$alias])) {
-            throw new \InvalidArgumentException(sprintf('Process scenario with alias "%s" is not registered', $alias));
+            throw new InvalidArgumentException(sprintf('Process scenario with alias "%s" is not registered', $alias));
         }
 
         return $this->scenarios[$alias];

--- a/src/Sylius/Bundle/FlowBundle/Process/Coordinator/InvalidArgumentException.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Coordinator/InvalidArgumentException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\FlowBundle\Process\Coordinator;
+
+class InvalidArgumentException extends \Exception
+{
+}


### PR DESCRIPTION
Fix wtf exception #655.

Btw I haven't seen this before, but FlowBundle is using PHPUnit instead of phpspec, weird.
