### PR TITLE
Fixing standalone bundles requirements

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/composer.json
+++ b/src/Sylius/Bundle/ResourceBundle/composer.json
@@ -26,7 +26,8 @@
         "symfony/twig-bundle":             "~2.3",
         "friendsofsymfony/rest-bundle":    "~1.0",
         "jms/serializer-bundle":           "0.12.*",
-        "white-october/pagerfanta-bundle": "1.0.*"
+        "white-october/pagerfanta-bundle": "1.0.*",
+        "doctrine/doctrine-bundle":        "1.2.*@dev"
     },
     "require-dev": {
         "phpspec/phpspec":      "2.0.*@dev",


### PR DESCRIPTION
When you try to install a bundle standalone (v1.0.*@dev), you get 

```
PHP Fatal error:  Class 'Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass' not found in /home/jago/testtoto/vendor/sylius/cart-bundle/Sylius/Bundle/CartBundle/SyliusCartBundle.php on line 55
```
