### PR TITLE
Set max per page before current page.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Controller/ProductController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/ProductController.php
@@ -46,8 +46,8 @@ class ProductController extends ResourceController
             ->createByTaxonPaginator($taxon)
         ;
 
-        $paginator->setCurrentPage($request->query->get('page', 1));
         $paginator->setMaxPerPage($this->getConfiguration()->getPaginationMaxPerPage());
+        $paginator->setCurrentPage($request->query->get('page', 1));
 
         return $this->renderResponse('SyliusWebBundle:Frontend/Product:indexByTaxon.html.twig', array(
             'taxon'    => $taxon,


### PR DESCRIPTION
Pagerfanta will have an incorrect number of page if we don't set max per page before current page.
