### PR TITLE
Moved backorders enabled to parameters.yml

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -36,3 +36,5 @@ parameters:
     sylius.oauth.facebook.clientsecret: <facebook_client_secret>
     sylius.oauth.google.clientid:       <google_client_id>
     sylius.oauth.google.clientsecret:   <google_client_secret>
+
+    sylius.inventory.backorders_enabled: true

--- a/app/config/sylius.yml
+++ b/app/config/sylius.yml
@@ -64,7 +64,7 @@ sylius_shipping:
 sylius_promotions: ~
 
 sylius_inventory:
-    backorders: true
+    backorders: %sylius.inventory.backorders_enabled%
     classes:
         unit:
             model: Sylius\Bundle\CoreBundle\Model\InventoryUnit


### PR DESCRIPTION
Maybe it should even be configurable on `/administration/settings/general` page...
