### PR TITLE
[Core] Consider Shipment State "ready" in StateResolver

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OrderProcessing/StateResolver.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderProcessing/StateResolver.php
@@ -64,6 +64,10 @@ class StateResolver implements StateResolverInterface
             return OrderShippingStates::RETURNED;
         }
 
+        if (array(ShipmentInterface::STATE_READY) === $states) {
+            return OrderShippingStates::READY;
+        }
+
         return OrderShippingStates::PARTIALLY_SHIPPED;
     }
 }


### PR DESCRIPTION
fixes #735

Shipping state "ready" was not handled in Sylius\Bundle\CoreBundle\OrderProcessing\StateResolver::getShippingState
