### PR TITLE
Loading DoctrineFixturesBundle in dev enveroment

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -52,7 +52,6 @@ class AppKernel extends Kernel
 
             // Core bundles.
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
-            new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
             new Symfony\Bundle\AsseticBundle\AsseticBundle(),
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new Symfony\Bundle\MonologBundle\MonologBundle(),
@@ -78,6 +77,10 @@ class AppKernel extends Kernel
 
         if (in_array($this->environment, array('dev'))) {
             $bundles[] = new \Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
+        }
+        
+        if (in_array($this->environment, array('dev','test'))) {
+            $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
         }
 
         return $bundles;


### PR DESCRIPTION
Now DoctrineFixturesBundle installs only in dev.
It in exists require-dev section composer.json file.
If we run `composer.phar install --no-dev`, we will get error:
PHP Fatal error:  Class 'Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle' not found in ...app/AppKernel.php
