### PR TITLE
Redirect to specific URL after add to cart.

### DIFF
--- a/src/Sylius/Bundle/CartBundle/Controller/CartItemController.php
+++ b/src/Sylius/Bundle/CartBundle/Controller/CartItemController.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\CartBundle\Controller;
 
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -59,7 +60,7 @@ class CartItemController extends Controller
             // Write flash message
             $this->dispatchEvent(SyliusCartEvents::ITEM_ADD_ERROR, new FlashEvent($exception->getMessage()));
 
-            return $this->redirectToCartSummary();
+            return $this->redirectAfterAdd($request);
         }
 
         $event = new CartItemEvent($cart, $item);
@@ -74,9 +75,25 @@ class CartItemController extends Controller
         // Write flash message
         $this->dispatchEvent(SyliusCartEvents::ITEM_ADD_COMPLETED, new FlashEvent());
 
+        return $this->redirectAfterAdd($request);
+    }
+    
+    /**
+     * Redirect to specific URL or to cart.
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    private function redirectAfterAdd(Request $request)
+    {
+        if ($request->query->has('_redirect_to')) {
+            return $this->redirect($request->query->get('_redirect_to'));
+        }
+
         return $this->redirectToCartSummary();
     }
-
+    
     /**
      * Removes item from cart.
      * It takes an item id as an argument.


### PR DESCRIPTION
As a developer, I would like have the option to redirect customer to any page I want after add item to cart.
#### Usage:

``` jinja
{# Product/show.html.twig #}

<form action="{{ path('sylius_cart_item_add', {
    'id': product.id, 
    '_redirect_to': url(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')) 
}) }}" method="post">

   {# ... rest of the add to cart form #}

</form>
```
