### PR TITLE
Refresh cart right after cart_change event (fix #716)

### DIFF
--- a/src/Sylius/Bundle/CartBundle/EventListener/RefreshCartListener.php
+++ b/src/Sylius/Bundle/CartBundle/EventListener/RefreshCartListener.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CartBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * Ensure that the cart is refreshed before other listeners.
+ */
+class RefreshCartListener
+{
+    public function onCartChange(GenericEvent $event)
+    {
+        $event->getSubject()->calculateTotal();
+    }
+}

--- a/src/Sylius/Bundle/CartBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CartBundle/Resources/config/services.xml
@@ -25,6 +25,7 @@
 
         <parameter key="sylius.cart_listener.class">Sylius\Bundle\CartBundle\EventListener\CartListener</parameter>
         <parameter key="sylius.cart_flash_listener.class">Sylius\Bundle\CartBundle\EventListener\FlashListener</parameter>
+        <parameter key="sylius.refresh_cart_listener.class">Sylius\Bundle\CartBundle\EventListener\RefreshCartListener</parameter>
 
         <parameter key="sylius.cart.purger.class">Sylius\Bundle\CartBundle\Purger\ExpiredCartsPurger</parameter>
     </parameters>
@@ -88,6 +89,10 @@
             <argument type="service" id="session" />
             <argument type="service" id="translator" />
             <call method="setMessages"/>
+        </service>
+        
+        <service id="sylius.refresh_cart_listener" class="%sylius.refresh_cart_listener.class%">
+            <tag name="kernel.event_listener" event="sylius.cart_change" method="onCartChange" priority="255" />
         </service>
 
         <service id="sylius.cart.purger" class="%sylius.cart.purger.class%">


### PR DESCRIPTION
Refresh the cart with high priority after CART_CHANGE event, so that other listeners are dealing with an updated cart. Fix #716.
