### PR TITLE
Add Cascade to Payment mapping

### DIFF
--- a/src/Sylius/Bundle/PaymentsBundle/Model/Payment.php
+++ b/src/Sylius/Bundle/PaymentsBundle/Model/Payment.php
@@ -231,6 +231,7 @@ class Payment implements PaymentInterface
     {
         if (!$this->hasLog($log)) {
             $this->logs->add($log);
+            $log->setPayment($this);
         }
 
         return $this;
@@ -243,6 +244,7 @@ class Payment implements PaymentInterface
     {
         if ($this->hasLog($log)) {
             $this->logs->removeElement($log);
+            $log->setPayment(null);
         }
 
         return $this;
@@ -285,15 +287,17 @@ class Payment implements PaymentInterface
     }
 
     /**
-     * @param array $details
+     * {@inheritdoc}
      */
     public function setDetails(array $details)
     {
         $this->details = $details;
+
+        return $this;
     }
 
     /**
-     * @return array
+     * {@inheritdoc}
      */
     public function getDetails()
     {

--- a/src/Sylius/Bundle/PaymentsBundle/Model/PaymentInterface.php
+++ b/src/Sylius/Bundle/PaymentsBundle/Model/PaymentInterface.php
@@ -41,6 +41,8 @@ interface PaymentInterface extends TimestampableInterface
      * Set payment method.
      *
      * @param null|PaymentMethodInterface $method
+     *
+     * @return PaymentInterface
      */
     public function setMethod(PaymentMethodInterface $method = null);
 
@@ -55,6 +57,8 @@ interface PaymentInterface extends TimestampableInterface
      * Set payment source.
      *
      * @param null|PaymentSourceInterface $source
+     *
+     * @return PaymentInterface
      */
     public function setSource(PaymentSourceInterface $source = null);
 
@@ -69,6 +73,8 @@ interface PaymentInterface extends TimestampableInterface
      * Set state.
      *
      * @param string $state
+     *
+     * @return PaymentInterface
      */
     public function setState($state);
 
@@ -83,6 +89,8 @@ interface PaymentInterface extends TimestampableInterface
      * Set currency.
      *
      * @param string
+     *
+     * @return PaymentInterface
      */
     public function setCurrency($currency);
 
@@ -97,6 +105,8 @@ interface PaymentInterface extends TimestampableInterface
      * Set amount.
      *
      * @param integer $amount
+     *
+     * @return PaymentInterface
      */
     public function setAmount($amount);
 
@@ -120,6 +130,8 @@ interface PaymentInterface extends TimestampableInterface
      * Add payment processing log.
      *
      * @param PaymentLogInterface $log
+     *
+     * @return PaymentInterface
      */
     public function addLog(PaymentLogInterface $log);
 
@@ -127,11 +139,15 @@ interface PaymentInterface extends TimestampableInterface
      * Remove payment processing log.
      *
      * @param PaymentLogInterface $log
+     *
+     * @return PaymentInterface
      */
     public function removeLog(PaymentLogInterface $log);
 
     /**
      * @param array $details
+     *
+     * @return PaymentInterface
      */
     public function setDetails(array $details);
 

--- a/src/Sylius/Bundle/PaymentsBundle/Resources/config/doctrine/model/Payment.orm.xml
+++ b/src/Sylius/Bundle/PaymentsBundle/Resources/config/doctrine/model/Payment.orm.xml
@@ -29,10 +29,17 @@
         <field name="details" column="details" type="json_array" />
 
         <many-to-one field="creditCard" target-entity="Sylius\Bundle\PaymentsBundle\Model\CreditCardInterface">
+            <cascade>
+                <cascade-all/>
+            </cascade>
             <join-column name="credit_card_id" referenced-column-name="id" nullable="true" on-delete="SET NULL" />
         </many-to-one>
 
-        <one-to-many field="logs" target-entity="Sylius\Bundle\PaymentsBundle\Model\PaymentLogInterface" mapped-by="payment" />
+        <one-to-many field="logs" target-entity="Sylius\Bundle\PaymentsBundle\Model\PaymentLogInterface" mapped-by="payment">
+            <cascade>
+                <cascade-all/>
+            </cascade>
+        </one-to-many>
 
         <field name="createdAt" column="created_at" type="datetime">
             <gedmo:timestampable on="create"/>

--- a/src/Sylius/Bundle/PaymentsBundle/spec/Sylius/Bundle/PaymentsBundle/Model/PaymentSpec.php
+++ b/src/Sylius/Bundle/PaymentsBundle/spec/Sylius/Bundle/PaymentsBundle/Model/PaymentSpec.php
@@ -116,6 +116,7 @@ class PaymentSpec extends ObjectBehavior
     function it_adds_logs($log)
     {
         $this->hasLog($log)->shouldReturn(false);
+        $log->setPayment($this)->shouldBeCalled();
         $this->addLog($log);
         $this->hasLog($log)->shouldReturn(true);
     }
@@ -126,6 +127,7 @@ class PaymentSpec extends ObjectBehavior
     function it_removes_logs($log)
     {
         $this->addLog($log);
+        $log->setPayment(null)->shouldBeCalled();
         $this->removeLog($log);
         $this->hasLog($log)->shouldReturn(false);
     }


### PR DESCRIPTION
Currently Payment Log and Credit Card are not cascading from Payment persistence. This PR fixed this.

Also fixes proper bi-directional relation between Payments and Logs. Lastly, updates PaymentInterface docblocks with proper return type.
