### PR TITLE
Update OrderProcessor to leave existing payment alone

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OrderProcessing/PaymentProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderProcessing/PaymentProcessor.php
@@ -43,11 +43,17 @@ class PaymentProcessor implements PaymentProcessorInterface
      */
     public function createPayment(OrderInterface $order)
     {
+        if ($order->getPayment()) {
+            return;
+        }
+
         $payment = $this->paymentRepository->createNew();
 
-        $payment->setCurrency($order->getCurrency());
-        $order->setPayment($payment);
+        $payment
+            ->setCurrency($order->getCurrency())
+            ->setAmount($order->getTotal())
+        ;
 
-        return $payment;
+        $order->setPayment($payment);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/OrderProcessing/PaymentProcessorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/OrderProcessing/PaymentProcessorSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\CoreBundle\OrderProcessing;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\CoreBundle\Model\OrderInterface;
+use Sylius\Bundle\PaymentsBundle\Model\PaymentInterface;
+use Sylius\Bundle\ResourceBundle\Model\RepositoryInterface;
+
+/**
+ * @author Daniel Richter <nexyz9@gmail.com>
+ */
+class PaymentProcessorSpec extends ObjectBehavior
+{
+    function let(RepositoryInterface $repository)
+    {
+        $this->beConstructedWith($repository);
+    }
+
+    function it_sets_payment_to_orders_without_payment(OrderInterface $order, $repository, PaymentInterface $payment)
+    {
+        $payment->setCurrency(Argument::any())->willReturn($payment);
+        $payment->setAmount(Argument::any())->willReturn($payment);
+
+        $repository->createNew()->shouldBeCalled()->willReturn($payment);
+
+        $order->getPayment()->shouldBeCalled()->willReturn(null);
+        $order->getCurrency()->shouldBeCalled();
+
+        $order->getTotal()->shouldBeCalled();
+        $order->setPayment($payment)->shouldBeCalled();
+        $this->createPayment($order);
+    }
+
+    function it_leaves_existing_payment_alone(OrderInterface $order, $repository, PaymentInterface $payment)
+    {
+        $order->getPayment()->willReturn($payment);
+
+        $repository->createNew()->shouldNotBeCalled();
+        $order->setPayment(Argument::any())->shouldNotBeCalled();
+
+        $this->createPayment($order);
+    }
+}


### PR DESCRIPTION
Currently the OrderProcessor creates new Payments, even if an order already has an associated Payment.
This PR causes it to check for existing payment first, and do nothing if found. It also sets the Amount on Payment.
