### PR TITLE
[CoreBundle] Add missing declaration of Locale controller

### DIFF
--- a/app/config/sylius.yml
+++ b/app/config/sylius.yml
@@ -110,3 +110,4 @@ sylius_resource:
             driver: doctrine/orm
             classes:
                 model: Sylius\Bundle\CoreBundle\Model\Locale
+                controller: Sylius\Bundle\ResourceBundle\Controller\ResourceController


### PR DESCRIPTION
Without this, current code leads to 500 error.

> **/administration/locales/**
> You have requested a non-existent service "sylius.controller.locale". Did you mean this: "sylius.listener.locale"? 
