### PR TITLE
Fix order sorting to mitigate incorrect order number generation.

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
@@ -33,7 +33,7 @@ class OrderRepository extends EntityRepository implements OrderRepositoryInterfa
         return $queryBuilder
             ->andWhere($queryBuilder->expr()->isNotNull('o.completedAt'))
             ->setMaxResults($amount)
-            ->orderBy('o.id', 'desc')
+            ->orderBy('o.completedAt', 'desc')
             ->getQuery()
             ->getResult()
         ;


### PR DESCRIPTION
See https://github.com/Sylius/Sylius/pull/631

The issue @jeremyFreeAgent discovered is very real and will affect production sites. This PR here helps, but only to the extent that conflicting orders would have to be placed in the same second to cause a collision (which is still quite possible for high-volume sites). Better ideas are very welcome..

Also, there is still the issue of a race-condition with more than one user checking out at the same time. We will need a way to issue a table lock.
