### PR TITLE
[ResourceBundle] Proper handling of null values

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/EntityRepository.php
+++ b/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/EntityRepository.php
@@ -115,7 +115,10 @@ class EntityRepository extends BaseEntityRepository implements RepositoryInterfa
         }
 
         foreach ($criteria as $property => $value) {
-            if (!is_array($value)) {
+            if (null === $value) {
+                $queryBuilder
+                    ->andWhere($queryBuilder->expr()->isNull($this->getPropertyName($property)));
+            } elseif (!is_array($value)) {
                 $queryBuilder
                     ->andWhere($queryBuilder->expr()->eq($this->getPropertyName($property), ':' . $property))
                     ->setParameter($property, $value);


### PR DESCRIPTION
Internally doctrine findBy will change to IS NULL. Setting o.property = null does not work. This adds another if statement to check if the value is null and builds the QueryBuilder accordingly
