### PR TITLE
Add easy way to disable inventory tracking.

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -38,3 +38,4 @@ parameters:
     sylius.oauth.google.clientsecret:   <google_client_secret>
 
     sylius.inventory.backorders_enabled: true
+    sylius.inventory.tracking_enabled: true

--- a/app/config/sylius.yml
+++ b/app/config/sylius.yml
@@ -65,6 +65,7 @@ sylius_promotions: ~
 
 sylius_inventory:
     backorders: %sylius.inventory.backorders_enabled%
+    track_inventory: %sylius.inventory.tracking_enabled%
     classes:
         unit:
             model: Sylius\Bundle\CoreBundle\Model\InventoryUnit

--- a/src/Sylius/Bundle/InventoryBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/InventoryBundle/DependencyInjection/Configuration.php
@@ -39,10 +39,21 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('driver')->isRequired()->cannotBeEmpty()->end()
                 ->booleanNode('backorders')->defaultTrue()->end()
+                ->booleanNode('track_inventory')->defaultTrue()->end()
                 ->scalarNode('checker')->defaultValue('sylius.availability_checker.default')->cannotBeEmpty()->end()
-                ->scalarNode('operator')->defaultValue('sylius.inventory_operator.default')->cannotBeEmpty()->end()
+                ->scalarNode('operator')->cannotBeEmpty()->end()
                 ->arrayNode('events')->prototype('scalar')->end()
-            ->end();
+            ->end()
+        ->end()
+        ->validate()
+            ->ifTrue(function($array){
+                return !isset($array['operator']);
+            })
+            ->then(function($array){
+                $array['operator'] = 'sylius.inventory_operator.'.($array['track_inventory'] ? 'default' : 'noop');
+                return $array;
+            })
+        ->end();
 
         $this->addClassesSection($rootNode);
 

--- a/src/Sylius/Bundle/InventoryBundle/Operator/NoopInventoryOperator.php
+++ b/src/Sylius/Bundle/InventoryBundle/Operator/NoopInventoryOperator.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\InventoryBundle\Operator;
+
+use Sylius\Bundle\InventoryBundle\Model\StockableInterface;
+
+/**
+ * Inventory operator which does not adjust inventory
+ *
+ * @author Daniel Richter <nexyz9@gmail.com>
+ */
+class NoopInventoryOperator implements InventoryOperatorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function increase(StockableInterface $stockable, $quantity)
+    {
+        // nothing happens.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function decrease($inventoryUnits)
+    {
+        // nothing happens.
+    }
+}

--- a/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
@@ -19,6 +19,7 @@
 
     <parameters>
         <parameter key="sylius.availability_checker.default.class">Sylius\Bundle\InventoryBundle\Checker\AvailabilityChecker</parameter>
+        <parameter key="sylius.inventory_operator.noop.class">Sylius\Bundle\InventoryBundle\Operator\NoopInventoryOperator</parameter>
         <parameter key="sylius.inventory_operator.default.class">Sylius\Bundle\InventoryBundle\Operator\InventoryOperator</parameter>
         <parameter key="sylius.backorders_handler.class">Sylius\Bundle\InventoryBundle\Operator\BackordersHandler</parameter>
         <parameter key="sylius.inventory_unit_factory.class">Sylius\Bundle\InventoryBundle\Factory\InventoryUnitFactory</parameter>
@@ -40,6 +41,8 @@
             <argument type="service" id="sylius.backorders_handler" />
             <argument type="service" id="sylius.availability_checker" />
         </service>
+
+        <service id="sylius.inventory_operator.noop" class="%sylius.inventory_operator.noop.class%" />
 
         <service id="sylius.availability_checker.default" class="%sylius.availability_checker.default.class%">
             <argument>%sylius.backorders%</argument>


### PR DESCRIPTION
Currently inventory is always being tracked (resulting in backorders if not replenished).
This PR adds a simple NoopInventoryOperator and a configuration switch.
