### PR TITLE
Classes for KnpMenu root node should not be hardcoded. #745

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
@@ -97,7 +97,7 @@ class FrontendMenuBuilder extends MenuBuilder
     {
         $menu = $this->factory->createItem('root', array(
             'childrenAttributes' => array(
-                'class' => 'nav nav-pills'
+                'class' => $this->elementClasses['mainMenu']
             )
         ));
 
@@ -170,7 +170,7 @@ class FrontendMenuBuilder extends MenuBuilder
     {
         $menu = $this->factory->createItem('root', array(
             'childrenAttributes' => array(
-                'class' => 'nav nav-pills'
+                'class' => $this->elementClasses['currencyMenu']
             )
         ));
 
@@ -196,7 +196,7 @@ class FrontendMenuBuilder extends MenuBuilder
     {
         $menu = $this->factory->createItem('root', array(
             'childrenAttributes' => array(
-                'class' => 'nav'
+                'class' => $this->elementClasses['taxonomiesMenu']
             )
         ));
 
@@ -247,7 +247,7 @@ class FrontendMenuBuilder extends MenuBuilder
     {
         $menu = $this->factory->createItem('root', array(
             'childrenAttributes' => array(
-                'class' => 'nav nav-pills pull-right'
+                'class' => $this->elementClasses['socialMenu']
             )
         ));
 
@@ -281,7 +281,7 @@ class FrontendMenuBuilder extends MenuBuilder
     {
         $menu = $this->factory->createItem('root', array(
             'childrenAttributes' => array(
-                'class' => 'nav'
+                'class' => $this->elementClasses['accountMenu']
             )
         ));
 

--- a/src/Sylius/Bundle/WebBundle/Menu/MenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/MenuBuilder.php
@@ -53,6 +53,13 @@ abstract class MenuBuilder
     protected $request;
 
     /**
+     * Element classes
+     *
+     * @var string
+     */
+    protected $elementClasses;
+
+    /**
      * Constructor.
      *
      * @param FactoryInterface         $factory
@@ -74,6 +81,15 @@ abstract class MenuBuilder
     public function setRequest(Request $request = null)
     {
         $this->request = $request;
+    }
+
+    /**
+     * Sets the element classes
+     *
+     * @param $elementClasses
+     */
+    public function setElementClasses($elementClasses) {
+        $this->elementClasses = $elementClasses;
     }
 
     /**

--- a/src/Sylius/Bundle/WebBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/services.xml
@@ -19,6 +19,14 @@
         <parameter key="sylius.form.frontend.registration.type.class">Sylius\Bundle\CoreBundle\Form\Type\RegistrationFormType</parameter>
 
         <parameter key="sylius.listener.frontend.address.class">Sylius\Bundle\WebBundle\EventListener\Account\AddressListener</parameter>
+
+        <parameter key="sylius.menu_builder.frontend.element_classes" type="collection">
+            <parameter key="mainMenu" type="string">nav nav-pills</parameter>
+            <parameter key="currencyMenu" type="string">nav nav-pills</parameter>
+            <parameter key="taxonomiesMenu" type="string">nav</parameter>
+            <parameter key="socialMenu" type="string">nav nav-pills pull-right</parameter>
+            <parameter key="accountMenu" type="string">nav</parameter>
+        </parameter>
     </parameters>
 
     <services>
@@ -53,6 +61,9 @@
             <argument type="service" id="sylius.twig.money" />
             <call method="setRequest">
                 <argument type="service" id="request" on-invalid="null" strict="false" />
+            </call>
+            <call method="setElementClasses">
+                <argument>%sylius.menu_builder.frontend.element_classes%</argument>
             </call>
         </service>
         <service id="sylius.menu_builder.backend" class="%sylius.menu_builder.backend.class%">


### PR DESCRIPTION
https://github.com/Sylius/SyliusWebBundle/pull/37

Cleaned up, so compared to linked PR composer mess is not there anymore
