### PR TITLE
Use right form types and default data for the "add production promotion action"

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Action/AddProductConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Action/AddProductConfigurationType.php
@@ -60,15 +60,15 @@ class AddProductConfigurationType extends AbstractType
             ))
             ->add('quantity', 'integer', array(
                 'label' => 'sylius.form.action.add_product_configuration.quantity',
-                'data'  => 1,
+                'empty_data'  => 1,
                 'constraints' => array(
                     new NotBlank(),
                     new Type(array('type' => 'numeric')),
                 )
             ))
-            ->add('price', 'integer', array(
+            ->add('price', 'sylius_money', array(
                 'label' => 'sylius.form.action.add_product_configuration.price',
-                'data'  => 0,
+                'empty_data'  => 0,
                 'constraints' => array(
                     new NotBlank(),
                     new Type(array('type' => 'numeric')),


### PR DESCRIPTION
/cc @winzou 

Previous the `data` option was preventing the new configuration from saving. Also the user had to enter the price in the smallest units, now it uses the money field.
