### PR TITLE
Added input options to support --no-interaction flag for sylius:install

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Command/InstallCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/InstallCommand.php
@@ -94,9 +94,9 @@ class InstallCommand extends ContainerAwareCommand
         $output->writeln('<info>Setting up database.</info>');
 
         $this
-            ->runCommand('doctrine:database:create', new ArrayInput(['--no-interaction']), $output)
-            ->runCommand('doctrine:schema:create', new ArrayInput([['--no-interaction']]), $output)
-            ->runCommand('assetic:dump', new ArrayInput(['--no-interaction']), $output);
+            ->runCommand('doctrine:database:create', new ArrayInput(array('--no-interaction')), $output)
+            ->runCommand('doctrine:schema:create', new ArrayInput(array('--no-interaction')), $output)
+            ->runCommand('assetic:dump', new ArrayInput(array('--no-interaction')), $output);
 
         $output->writeln('');
 
@@ -168,7 +168,7 @@ class InstallCommand extends ContainerAwareCommand
         $output->writeln('<info>Loading sample data.</info>');
         $this->runCommand(
             'doctrine:fixtures:load',
-            new ArrayInput(['--no-interaction']),
+            new ArrayInput(array('--no-interaction')),
             $output
         );
 


### PR DESCRIPTION
Fixes https://github.com/Sylius/Sylius/issues/841
- Logic of `sylius:install` remained mostly same except for removed second dialog when installing fixtures.
- Added checking of command return value (throw exception if not 0)
- Missing `--admin-*="..."` yields error, but message is quite descriptive. Probably could be checked to print user friendly message or something.
- Probably could add `doctrine:database:drop --force`, but somewhy could not pass params to command.

Feedback for last 2 points would be appreciated.
