### PR TITLE
[CoreBundle] Replace controller rendering with Twig extension

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -80,6 +80,7 @@
 
         <parameter key="sylius.oauth.user_provider.class">Sylius\Bundle\CoreBundle\OAuth\UserProvider</parameter>
 
+        <parameter key="sylius.twig.product.class">Sylius\Bundle\CoreBundle\Twig\SyliusProductExtension</parameter>
         <parameter key="sylius.twig.restricted_zone_extension.class">Sylius\Bundle\CoreBundle\Twig\SyliusRestrictedZoneExtension</parameter>
     </parameters>
 
@@ -403,6 +404,11 @@
             </argument>
         </service>
 
+        <!-- Twig extensions -->
+        <service id="sylius.twig.product" class="%sylius.twig.product.class%">
+            <argument type="service" id="sylius.repository.product" />
+            <tag name="twig.extension" />
+        </service>
         <service id="sylius.twig.restricted_zone_extension" class="%sylius.twig.restricted_zone_extension.class%">
             <argument type="service" id="sylius.checker.restricted_zone" />
             <tag name="twig.extension" />

--- a/src/Sylius/Bundle/CoreBundle/Twig/SyliusProductExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/SyliusProductExtension.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Twig;
+
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+
+/**
+ * Sylius product twig helper.
+ *
+ * @author Joseph Bielawski <stloyd@gmail.com>
+ */
+class SyliusProductExtension extends \Twig_Extension
+{
+    /**
+     * @var EntityRepository
+     */
+    private $repository;
+
+    /**
+     * Constructor.
+     *
+     * @param EntityRepository $repository
+     */
+    public function __construct(EntityRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return array(
+             new \Twig_SimpleFunction('sylius_product_latest', array($this, 'fetchLatest')),
+        );
+    }
+
+    /**
+     * @param integer $limit
+     *
+     * @return array
+     */
+    public function fetchLatest($limit = 10)
+    {
+        return $this->repository->findLatest($limit);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sylius_product';
+    }
+}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Homepage/main.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Homepage/main.html.twig
@@ -6,6 +6,6 @@
     <p class="lead">{{ 'sylius.homepage.splash.subheadline'|trans }}</p>
 </div>
 
-{{ render(url('sylius_partial_product_latest', {'limit': 9, 'template': 'SyliusWebBundle:Frontend/Product:latest.html.twig'})) }}
+{% include 'SyliusWebBundle:Frontend/Product:latest.html.twig' with {'products': sylius_product_latest(9)} %}
 
 {% endblock %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/layout.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/layout.html.twig
@@ -59,9 +59,11 @@
             <div class="col-md-3" id="sidebar">
                 {% block sidebar %}
                 <h4>{{ 'sylius.shop_by'|trans }}</h4><br>
-                {{ knp_menu_render('sylius.frontend.taxonomies', {'template': 'SyliusWebBundle:Frontend:menu.html.twig'}) }}
-                {{ render(url('sylius_partial_product_latest', {'limit': 5, 'template': 'SyliusWebBundle:Frontend/Product:latestSidebar.html.twig'})) }}
-                {{ sonata_block_render({'name': '/cms/blocks/contact'}) }}
+                    {{ knp_menu_render('sylius.frontend.taxonomies', {'template': 'SyliusWebBundle:Frontend:menu.html.twig'}) }}
+
+                    {% include 'SyliusWebBundle:Frontend/Product:latestSidebar.html.twig' with {'products': sylius_product_latest(5)} %}
+
+                    {{ sonata_block_render({'name': '/cms/blocks/contact'}) }}
 
                     <h2>Links</h2>
                     <ul>


### PR DESCRIPTION
Memory footprint reduced from **~44MB** to **~37,5MB** while rendering homepage at my local machine!
