### PR TITLE
Error in getChildTaxon

### DIFF
--- a/src/Sylius/Bundle/TaxonomiesBundle/Model/Taxonomy.php
+++ b/src/Sylius/Bundle/TaxonomiesBundle/Model/Taxonomy.php
@@ -151,10 +151,11 @@ class Taxonomy implements TaxonomyInterface
 
     private function getChildTaxons(TaxonInterface $taxon, Collection $taxons)
     {
-        foreach ($taxon->getChildren() as $child) {
-            $taxons[] = $child;
+       if($taxon->getChildren())
+         foreach ($taxon->getChildren() as $child) {
+             $taxons[] = $child;
 
-            $this->getChildTaxons($child, $taxons);
-        }
+             $this->getChildTaxons($child, $taxons);
+         }
     }
 }


### PR DESCRIPTION
When override Taxon, there's a error 
ContextErrorException: Warning: Invalid argument supplied for foreach() in src/Sylius/Bundle/TaxonomiesBundle/Model/Taxonomy.php line 154
