### PR TITLE
Removed KnpMenu from WebBundle to be compatible to SymfonyCMF

### DIFF
--- a/src/Sylius/Bundle/WebBundle/composer.json
+++ b/src/Sylius/Bundle/WebBundle/composer.json
@@ -24,8 +24,6 @@
 
         "symfony/framework-bundle":  "~2.3",
         "sylius/core-bundle":        "1.0.*@dev",
-        "knplabs/knp-menu":          "1.1.*",
-        "knplabs/knp-menu-bundle":   "1.1.*",
         "liip/imagine-bundle":       "~0.9",
         "knplabs/knp-snappy-bundle": "*@dev"
     },


### PR DESCRIPTION
Was left untouched during recent fix
