### PR TITLE
Add ability for admins to log in as other users.

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -26,7 +26,7 @@ security:
             anonymous: true
 
         main:
-            switch_user: false
+            switch_user: { role: ROLE_SYLIUS_ADMIN }
             context:     user
             pattern:     /.*
             form_login:

--- a/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
@@ -151,11 +151,24 @@ class FrontendMenuBuilder extends MenuBuilder
         }
 
         if ($this->securityContext->isGranted('ROLE_SYLIUS_ADMIN')) {
-            $menu->addChild('administration', array(
+
+            $routeParams = array(
                 'route' => 'sylius_backend_dashboard',
                 'linkAttributes' => array('title' => $this->translate('sylius.frontend.menu.main.administration')),
                 'labelAttributes' => array('icon' => 'icon-briefcase icon-large', 'iconOnly' => false)
-            ))->setLabel($this->translate('sylius.frontend.menu.main.administration'));
+            );
+
+            if ($this->securityContext->isGranted('ROLE_PREVIOUS_ADMIN')) {
+                $routeParams = array_merge($routeParams, array(
+                    'route' => 'sylius_switch_user_return',
+                    'routeParameters' => array(
+                        'username' => $this->securityContext->getToken()->getUsername(),
+                        '_switch_user' => '_exit'
+                    )
+                ));
+            }
+
+            $menu->addChild('administration', $routeParams)->setLabel($this->translate('sylius.frontend.menu.main.administration'));
         }
 
         return $menu;

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/frontend/account.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/frontend/account.yml
@@ -10,3 +10,7 @@ sylius_account_order:
 
 sylius_account_address:
     resource: @SyliusWebBundle/Resources/config/routing/frontend/account/address.yml
+
+sylius_switch_user_return:
+    pattern: /switch/{username}/exit
+    defaults: { _controller: sylius.controller.backend.security:exitUserSwitchAction }

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.xlf
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.xlf
@@ -2266,6 +2266,10 @@
         <source>sylius.user.last_name</source>
         <target>Last name</target>
       </trans-unit>
+      <trans-unit id="35a2e8d0fe7103442cd041fc024a4e86" resname="sylius.user.impersonate">
+        <source>sylius.user.impersonate</source>
+        <target>Log in as this user</target>
+      </trans-unit>
       <trans-unit id="35a2e8d0fe7103442cd041fc024a4e86" resname="sylius.user.manage">
         <source>sylius.user.manage</source>
         <target>manage users</target>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/User/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/User/show.html.twig
@@ -13,6 +13,7 @@
 {% block content %}
 <div class="page-header">
     <div class="actions-menu">
+        {{ buttons.generic(path('sylius_account_homepage', { '_switch_user': user.username }), 'sylius.user.impersonate'|trans) }}
         {{ buttons.manage(path('sylius_backend_user_index'), 'sylius.user.manage'|trans) }}
         {% if not user.deleted %}
         {{ buttons.edit(path('sylius_backend_user_update', {'id': user.id})) }}


### PR DESCRIPTION
This PR adds a "Log in as this user" button to the backend user screen which allows you to impersonate any user.
The idea is to enable customer service users to use the frontend on customer's behalf (update addresses, place orders, etc).

When you click the Administration link while you are impersonating, you will be returned to the user you started with.
