### PR TITLE
Optimize cart totals retrieving from menu builder

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
@@ -101,18 +101,23 @@ class FrontendMenuBuilder extends MenuBuilder
             )
         ));
 
-        $cart = $this->cartProvider->getCart();
+        if ($this->cartProvider->hasCart()) {
+            $cart = $this->cartProvider->getCart();
+            $cartTotals = array('items' => $cart->getTotalItems(), 'total' => $cart->getTotal());
+        } else {
+            $cartTotals = array('items' => 0, 'total' => 0);
+        }
 
         $menu->addChild('cart', array(
             'route' => 'sylius_cart_summary',
             'linkAttributes' => array('title' => $this->translate('sylius.frontend.menu.main.cart', array(
-                '%items%' => $cart->getTotalItems(),
-                '%total%' => $this->moneyExtension->formatPrice($cart->getTotal())
+                '%items%' => $cartTotals['items'],
+                '%total%' => $this->moneyExtension->formatPrice($cartTotals['total'])
             ))),
             'labelAttributes' => array('icon' => 'icon-shopping-cart icon-large')
         ))->setLabel($this->translate('sylius.frontend.menu.main.cart', array(
-            '%items%' => $cart->getTotalItems(),
-            '%total%' => $this->moneyExtension->formatPrice($cart->getTotal())
+            '%items%' => $cartTotals['items'],
+            '%total%' => $this->moneyExtension->formatPrice($cartTotals['total'])
         )));
 
         if ($this->securityContext->isGranted('ROLE_USER')) {


### PR DESCRIPTION
As part of our ongoing process of optimization.
`$cartProvider->getCart()` is actually creating the cart if not exist. That's a long process, and useless as we just want some figures from it. If the cart doesn't exist, then it's `0`.
