### PR TITLE
Reduce Travis-CI build on main repository to only master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
+    - 5.3
+    - 5.4
+    - 5.5
+
+branches:
+    only:
+        - master
 
 services: mongodb
 


### PR DESCRIPTION
Without this change every push done by @pjedrzejewski into branches at main repository (how many times I told you to use fork =P) forces Travis-CI to call builds twice for same change:
1. For commit into branch on main repository,
2. For pull request update to which that commit belongs.
