### PR TITLE
Moved debug toggle from AppKernel to web/app_dev.php

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -9,10 +9,7 @@
  * file that was distributed with this source code.
  */
 
-use Symfony\Component\ClassLoader\DebugUniversalClassLoader;
 use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\HttpKernel\Debug\ErrorHandler;
-use Symfony\Component\HttpKernel\Debug\ExceptionHandler;
 use Symfony\Component\HttpKernel\Kernel;
 
 /**
@@ -82,27 +79,6 @@ class AppKernel extends Kernel
         $bundles = $this->addFixturesBundle($bundles);
 
         return $bundles;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function init()
-    {
-        if ($this->debug) {
-            ini_set('display_errors', 1);
-            error_reporting(-1);
-
-            DebugUniversalClassLoader::enable();
-            ErrorHandler::register();
-            if ('cli' !== php_sapi_name()) {
-                ExceptionHandler::register();
-            }
-        } else {
-            ini_set('display_errors', 0);
-        }
-
-        ini_set('date.timezone', 'UTC');
     }
 
     /**

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
  */
 
+use Symfony\Component\Debug\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
 /*
@@ -27,6 +28,9 @@ if (!in_array(@$_SERVER['REMOTE_ADDR'], array(
 }
 
 require_once __DIR__.'/../app/bootstrap.php.cache';
+
+Debug::enable();
+
 require_once __DIR__.'/../app/AppKernel.php';
 
 // Initialize kernel and run the application.


### PR DESCRIPTION
`AppKernel->init()` was using deprecated classes and was duplicating code and is deprecated itself altogether. So moved code to where it belongs - app_dev.php.

https://github.com/symfony/symfony-standard/blob/master/app/AppKernel.php
https://github.com/symfony/symfony-standard/blob/master/web/app_dev.php

Also removed `ini_set('date.time', 'UTC');` as should be already set in php.ini depending on server location (plus we have that set in puppet script):

https://github.com/Im0rtality/Sylius/blob/master/vagrant/manifests/default.pp#L118

Solves some SensioInsight major warnings.

This partially overlaps with #513, but last commit was 3 months ago.
