### PR TITLE
Add doctrine/doctrine-bundle as dependency.

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -23,6 +23,7 @@
         "php": ">=5.3.3",
 
         "symfony/framework-bundle":        "~2.3",
+        "doctrine/doctrine-bundle":        "~1.3",
         "sylius/resource-bundle":          "1.0.*@dev",
         "stof/doctrine-extensions-bundle": "1.1.*"
     },

--- a/src/Sylius/Bundle/CartBundle/composer.json
+++ b/src/Sylius/Bundle/CartBundle/composer.json
@@ -23,6 +23,7 @@
         "php": ">=5.3.3",
 
         "symfony/framework-bundle": "~2.3",
+        "doctrine/doctrine-bundle": "~1.3",
         "sylius/money-bundle":      "1.0.*@dev",
         "sylius/order-bundle":      "1.0.*@dev",
         "sylius/resource-bundle":   "1.0.*@dev"

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -23,6 +23,7 @@
         "php":                            ">=5.3.3",
 
         "symfony/framework-bundle":       "~2.3",
+        "doctrine/doctrine-bundle":       "~1.3",
         "sylius/product-bundle":          "1.0.*@dev",
         "sylius/variable-product-bundle": "1.0.*@dev",
         "sylius/cart-bundle":             "1.0.*@dev",

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -24,6 +24,7 @@
 
         "symfony/framework-bundle": "~2.3",
         "symfony/intl":             "~2.3",
+        "doctrine/doctrine-bundle": "~1.3",
         "sylius/resource-bundle":   "1.0.*@dev",
         "mathiasverraes/money":     "*@dev"
     },

--- a/src/Sylius/Bundle/OrderBundle/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/composer.json
@@ -23,6 +23,7 @@
         "php": ">=5.3.3",
 
         "symfony/framework-bundle":        "~2.3",
+        "doctrine/doctrine-bundle":        "~1.3",
         "sylius/resource-bundle":          "1.0.*@dev",
         "sylius/money-bundle":             "1.0.*@dev",
         "stof/doctrine-extensions-bundle": "1.1.*"

--- a/src/Sylius/Bundle/PaymentsBundle/composer.json
+++ b/src/Sylius/Bundle/PaymentsBundle/composer.json
@@ -23,6 +23,7 @@
         "php":                             ">=5.3.3",
 
         "symfony/framework-bundle":        "~2.3",
+        "doctrine/doctrine-bundle":        "~1.3",
         "sylius/resource-bundle":          "1.0.*@dev",
         "stof/doctrine-extensions-bundle": "1.1.*"
     },

--- a/src/Sylius/Bundle/PayumBundle/composer.json
+++ b/src/Sylius/Bundle/PayumBundle/composer.json
@@ -26,12 +26,13 @@
     "require": {
         "php":                    ">=5.3.3",
 
-        "sylius/order-bundle":    "1.0.*@dev",
-        "sylius/core-bundle":     "1.0.*@dev",
-        "sylius/payments-bundle": "1.0.*@dev",
-        "sylius/resource-bundle": "1.0.*@dev",
-        "payum/payum-bundle":     "~0.7.3@dev",
-        "payum/payum":            "~0.7.2@dev"
+        "doctrine/doctrine-bundle": "~1.3",
+        "sylius/order-bundle":      "1.0.*@dev",
+        "sylius/core-bundle":       "1.0.*@dev",
+        "sylius/payments-bundle":   "1.0.*@dev",
+        "sylius/resource-bundle":   "1.0.*@dev",
+        "payum/payum-bundle":       "~0.7.3@dev",
+        "payum/payum":              "~0.7.2@dev"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Sylius/Bundle/ProductBundle/composer.json
+++ b/src/Sylius/Bundle/ProductBundle/composer.json
@@ -23,6 +23,7 @@
         "php": ">=5.3.3",
 
         "symfony/framework-bundle":        "~2.3",
+        "doctrine/doctrine-bundle":        "~1.3",
         "sylius/resource-bundle":          "1.0.*@dev",
         "stof/doctrine-extensions-bundle": "1.1.*"
     },

--- a/src/Sylius/Bundle/PromotionsBundle/composer.json
+++ b/src/Sylius/Bundle/PromotionsBundle/composer.json
@@ -23,6 +23,7 @@
         "php": ">=5.3.3",
 
         "symfony/framework-bundle":        "~2.3",
+        "doctrine/doctrine-bundle":        "~1.3",
         "sylius/resource-bundle":          "1.0.*@dev",
         "stof/doctrine-extensions-bundle": "1.1.*"
     },

--- a/src/Sylius/Bundle/SettingsBundle/composer.json
+++ b/src/Sylius/Bundle/SettingsBundle/composer.json
@@ -23,6 +23,7 @@
         "php":                             ">=5.3.3",
 
         "symfony/framework-bundle":        "~2.3",
+        "doctrine/doctrine-bundle":        "~1.3",
         "sylius/resource-bundle":          "1.0.*@dev",
         "stof/doctrine-extensions-bundle": "1.1.*",
         "liip/doctrine-cache-bundle":      "*"

--- a/src/Sylius/Bundle/ShippingBundle/composer.json
+++ b/src/Sylius/Bundle/ShippingBundle/composer.json
@@ -23,6 +23,7 @@
         "php":                             ">=5.3.3",
 
         "symfony/framework-bundle":        "2.3.*",
+        "doctrine/doctrine-bundle":        "~1.3",
         "sylius/resource-bundle":          "1.0.*@dev",
         "sylius/money-bundle":             "1.0.*@dev",
         "stof/doctrine-extensions-bundle": "1.1.*"

--- a/src/Sylius/Bundle/TaxationBundle/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/composer.json
@@ -23,6 +23,7 @@
         "php":                             ">=5.3.3",
 
         "symfony/framework-bundle":        "~2.3",
+        "doctrine/doctrine-bundle":        "~1.3",
         "sylius/resource-bundle":          "1.0.*@dev",
         "stof/doctrine-extensions-bundle": "1.1.*"
     },

--- a/src/Sylius/Bundle/TaxonomiesBundle/composer.json
+++ b/src/Sylius/Bundle/TaxonomiesBundle/composer.json
@@ -23,6 +23,7 @@
         "php":                             ">=5.3.3",
 
         "symfony/framework-bundle":        "~2.3",
+        "doctrine/doctrine-bundle":        "~1.3",
         "sylius/resource-bundle":          "1.0.*@dev",
         "stof/doctrine-extensions-bundle": "1.1.*"
     },

--- a/src/Sylius/Bundle/VariableProductBundle/composer.json
+++ b/src/Sylius/Bundle/VariableProductBundle/composer.json
@@ -23,6 +23,7 @@
         "php":                             ">=5.3.3",
 
         "symfony/framework-bundle":        "~2.3",
+        "doctrine/doctrine-bundle":        "~1.3",
         "sylius/product-bundle":           "1.0.*@dev",
         "sylius/resource-bundle":          "1.0.*@dev",
         "stof/doctrine-extensions-bundle": "1.1.*"


### PR DESCRIPTION
The `DoctrineOrmMappingPass` are only available `>=1.3.0` (currently available as `1.3.x-dev`/`dev-master`). This bundles take use of them, so they should declare `~1.3` as a dependency.

Also it's needed to change the root `composer.json` to `~1.3@dev` or `/1.3.*@dev` match the new branch alias doctrine/DoctrineBundle#253, @stloyd said he will do this (ref #930)
