### PR TITLE
fix doctrine-bundle deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php":                                  ">=5.3.3",
 
-        "doctrine/doctrine-bundle":             "1.2.*@dev",
+        "doctrine/doctrine-bundle":             "~1.3@dev",
         "doctrine/orm":                         "~2.3",
         "friendsofsymfony/rest-bundle":         "~1.0",
         "friendsofsymfony/user-bundle":         "2.0.*@dev",


### PR DESCRIPTION
doctrine-bundle @ 1.2 is not the correct version since the orm mappings pass is introduced in version 1.3 @beta.
This pr uses 1.3 version.
