### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php":                                  ">=5.3.3",
 
-        "doctrine/doctrine-bundle":             "1.2.*@dev",
+        "doctrine/doctrine-bundle":             "dev-master",
         "doctrine/orm":                         "~2.3",
         "friendsofsymfony/rest-bundle":         "~1.0",
         "friendsofsymfony/user-bundle":         "2.0.*@dev",


### PR DESCRIPTION
In doctrine/doctrine-bundle 1.2.*@dev the file DoctrineOrmMappingPass is missing and an initial composer.phar update, fails after downloading all the bundles. Changing it to dev-master has resolved the problem to me.
