### PR TITLE
Change PurchaseListener properties' visibility to protected.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/PurchaseListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/PurchaseListener.php
@@ -21,10 +21,10 @@ use Sylius\Bundle\PaymentsBundle\Model\PaymentInterface;
 
 class PurchaseListener
 {
-    private $cartProvider;
-    private $router;
-    private $session;
-    private $translator;
+    protected $cartProvider;
+    protected $router;
+    protected $session;
+    protected $translator;
 
     public function __construct(CartProviderInterface $cartProvider, UrlGeneratorInterface $router, SessionInterface $session, TranslatorInterface $translator)
     {


### PR DESCRIPTION
As a developer I extend this class and I want to reuse parent's properties like UrlGenerator.
