### PR TITLE
[WIP] Split OrderInterface (one from CoreBundle) into several

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Payum/Action/OrderStatusAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Payum/Action/OrderStatusAction.php
@@ -14,7 +14,8 @@ namespace Sylius\Bundle\PayumBundle\Payum\Action;
 use Payum\Core\Action\PaymentAwareAction;
 use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Request\StatusRequestInterface;
-use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Payment\Model\PaymentAwareInterface;
 
 class OrderStatusAction extends PaymentAwareAction
 {
@@ -28,7 +29,7 @@ class OrderStatusAction extends PaymentAwareAction
             throw RequestNotSupportedException::createActionNotSupported($this, $request);
         }
 
-        /** @var OrderInterface $order */
+        /** @var OrderInterface|PaymentAwareInterface $order */
         $order = $request->getModel();
 
         if ($order->getPayment()->getDetails()) {
@@ -49,7 +50,8 @@ class OrderStatusAction extends PaymentAwareAction
     {
         return
             $request instanceof StatusRequestInterface &&
-            $request->getModel() instanceof OrderInterface
+            $request->getModel() instanceof OrderInterface &&
+            $request->getModel() instanceof PaymentAwareInterface
         ;
     }
 }

--- a/src/Sylius/Bundle/PayumBundle/Payum/Be2bill/Action/NotifyAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Payum/Be2bill/Action/NotifyAction.php
@@ -55,6 +55,13 @@ class NotifyAction extends PaymentAwareAction
      */
     protected $identifier;
 
+    /**
+     * @param Api                      $api
+     * @param OrderRepositoryInterface $orderRepository
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param ObjectManager            $objectManager
+     * @param string                   $identifier
+     */
     public function __construct(Api $api, OrderRepositoryInterface $orderRepository, EventDispatcherInterface $eventDispatcher, ObjectManager $objectManager, $identifier)
     {
         $this->api             = $api;

--- a/src/Sylius/Bundle/PayumBundle/Payum/Dummy/Action/CaptureOrderAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Payum/Dummy/Action/CaptureOrderAction.php
@@ -14,7 +14,8 @@ namespace Sylius\Bundle\PayumBundle\Payum\Dummy\Action;
 use Payum\Core\Action\PaymentAwareAction;
 use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Request\CaptureRequest;
-use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Payment\Model\PaymentAwareInterface;
 
 class CaptureOrderAction extends PaymentAwareAction
 {
@@ -28,7 +29,7 @@ class CaptureOrderAction extends PaymentAwareAction
             throw RequestNotSupportedException::createActionNotSupported($this, $request);
         }
 
-        /** @var OrderInterface $order */
+        /** @var OrderInterface|PaymentAwareInterface $order */
         $order = $request->getModel();
         $payment = $order->getPayment();
         $payment->setAmount($order->getTotal());
@@ -36,6 +37,7 @@ class CaptureOrderAction extends PaymentAwareAction
         $paymentDetails = $payment->getDetails();
         if (empty($paymentDetails)) {
             $payment->setDetails(array(
+                'description' => 'The payment is done by dummy payum extension.',
                 'captured' => true,
             ));
         }
@@ -48,7 +50,8 @@ class CaptureOrderAction extends PaymentAwareAction
     {
         return
             $request instanceof CaptureRequest &&
-            $request->getModel() instanceof OrderInterface
+            $request->getModel() instanceof OrderInterface &&
+            $request->getModel() instanceof PaymentAwareInterface
         ;
     }
 }

--- a/src/Sylius/Bundle/PayumBundle/Payum/Dummy/Action/OrderStatusAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Payum/Dummy/Action/OrderStatusAction.php
@@ -14,7 +14,8 @@ namespace Sylius\Bundle\PayumBundle\Payum\Dummy\Action;
 use Payum\Core\Action\PaymentAwareAction;
 use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Request\StatusRequestInterface;
-use Sylius\Component\Core\Model\Order;
+use Sylius\Component\Payment\Model\PaymentAwareInterface;
+use Sylius\Component\Order\Model\OrderInterface;
 
 class OrderStatusAction extends PaymentAwareAction
 {
@@ -28,7 +29,7 @@ class OrderStatusAction extends PaymentAwareAction
             throw RequestNotSupportedException::createActionNotSupported($this, $request);
         }
 
-        /** @var Order $order */
+        /** @var OrderInterface|PaymentAwareInterface $order */
         $order = $request->getModel();
 
         $paymentDetails = $order->getPayment()->getDetails();
@@ -54,7 +55,8 @@ class OrderStatusAction extends PaymentAwareAction
     {
         return
             $request instanceof StatusRequestInterface &&
-            $request->getModel() instanceof Order
+            $request->getModel() instanceof OrderInterface &&
+            $request->getModel() instanceof PaymentAwareInterface
         ;
     }
 }

--- a/src/Sylius/Bundle/PayumBundle/Payum/Paypal/Action/NotifyOrderAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Payum/Paypal/Action/NotifyOrderAction.php
@@ -17,7 +17,8 @@ use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Request\SecuredNotifyRequest;
 use Payum\Core\Request\SyncRequest;
 use Sylius\Bundle\PayumBundle\Payum\Request\StatusRequest;
-use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Payment\Model\PaymentAwareInterface;
 use Sylius\Component\Payment\SyliusPaymentEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -54,7 +55,7 @@ class NotifyOrderAction extends PaymentAwareAction
             throw RequestNotSupportedException::createActionNotSupported($this, $request);
         }
 
-        /** @var OrderInterface $order */
+        /** @var OrderInterface|PaymentAwareInterface $order */
         $order = $request->getModel();
         $payment = $order->getPayment();
         $previousState = $payment->getState();
@@ -87,7 +88,8 @@ class NotifyOrderAction extends PaymentAwareAction
     {
         return
             $request instanceof SecuredNotifyRequest &&
-            $request->getModel() instanceof OrderInterface
+            $request->getModel() instanceof OrderInterface &&
+            $request->getModel() instanceof PaymentAwareInterface
         ;
     }
 }

--- a/src/Sylius/Bundle/PayumBundle/composer.json
+++ b/src/Sylius/Bundle/PayumBundle/composer.json
@@ -32,6 +32,12 @@
         "payum/payum-bundle":     "0.8.*",
         "payum/payum":            "0.8.*"
     },
+    "suggest": {
+        "sylius/core-bundle":    "If you want to integrate payum's purchase step to checkout process",
+        "sylius/taxonomies-bundle": "If you want to add tax details to payment",
+        "sylius/addressing-bundle": "If you want to add billing or shipping details to payment",
+        "sylius/promotions-bundle": "If you want to add promotion details to payment"
+    },
     "config": {
         "bin-dir": "bin"
     },

--- a/src/Sylius/Component/Addressing/Model/AddressAwareInterface.php
+++ b/src/Sylius/Component/Addressing/Model/AddressAwareInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+* This file is part of the Sylius package.
+*
+* (c) Paweł Jędrzejewski
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Sylius\Component\Addressing\Model;
+
+interface AddressAwareInterface
+{
+    /**
+     * Add address.
+     *
+     * @param AddressInterface $address
+     */
+    public function addAddress(AddressInterface $address);
+
+    /**
+     * Remove address.
+     *
+     * @param AddressInterface $address
+     */
+    public function removeAddress(AddressInterface $address);
+
+    /**
+     * Has address?
+     *
+     * @param AddressInterface $address
+     *
+     * @return Boolean
+     */
+    public function hasAddress(AddressInterface $address);
+}

--- a/src/Sylius/Component/Addressing/Model/BillingAddressAwareInterface.php
+++ b/src/Sylius/Component/Addressing/Model/BillingAddressAwareInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Addressing\Model;
+
+interface BillingAddressAwareInterface
+{
+    /**
+     * @return AddressInterface
+     */
+    public function getBillingAddress();
+
+    /**
+     * @param AddressInterface $address
+     */
+    public function setBillingAddress(AddressInterface $address = null);
+}

--- a/src/Sylius/Component/Addressing/Model/ShippingAddressAwareInterface.php
+++ b/src/Sylius/Component/Addressing/Model/ShippingAddressAwareInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Addressing\Model;
+
+interface ShippingAddressAwareInterface
+{
+    /**
+     * @return AddressInterface
+     */
+    public function getShippingAddress();
+
+    /**
+     * @param AddressInterface $address
+     */
+    public function setShippingAddress(AddressInterface $address = null);
+}

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -63,13 +63,6 @@ class Order extends Cart implements OrderInterface
     protected $payment;
 
     /**
-     * Currency ISO code.
-     *
-     * @var string
-     */
-    protected $currency;
-
-    /**
      * Promotion coupon
      *
      * @var CouponInterface
@@ -412,24 +405,6 @@ class Order extends Cart implements OrderInterface
     public function getPromotionSubjectItemCount()
     {
         return $this->items->count();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getCurrency()
-    {
-        return $this->currency;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setCurrency($currency)
-    {
-        $this->currency = $currency;
-
-        return $this;
     }
 
     /**

--- a/src/Sylius/Component/Core/Model/OrderInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderInterface.php
@@ -12,19 +12,33 @@
 namespace Sylius\Component\Core\Model;
 
 use Doctrine\Common\Collections\Collection;
-use Sylius\Component\Addressing\Model\AddressInterface;
 use Sylius\Component\Cart\Model\CartInterface;
 use Sylius\Component\Order\Model\AdjustmentInterface;
-use Sylius\Component\Payment\Model\PaymentInterface;
 use Sylius\Component\Promotion\Model\CouponInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Component\Addressing\Model\BillingAddressAwareInterface;
+use Sylius\Component\Order\Model\UserAwareInterface;
+use Sylius\Component\Payment\Model\PaymentAwareInterface;
+use Sylius\Component\Addressing\Model\ShippingAddressAwareInterface;
+use Sylius\Component\Promotion\Model\PromotionTotalAwareInterface;
+use Sylius\Component\Shipping\Model\ShippingTotalAwareInterface;
+use Sylius\Component\Taxation\Model\TaxTotalAwareInterface;
 
 /**
  * Sylius core Order model.
  *
  * @author Paweł Jędrzejewski <pjedrzejewski@diweb.pl>
  */
-interface OrderInterface extends CartInterface, PromotionSubjectInterface
+interface OrderInterface extends
+    CartInterface,
+    PromotionSubjectInterface,
+    PaymentAwareInterface,
+    ShippingAddressAwareInterface,
+    BillingAddressAwareInterface,
+    TaxTotalAwareInterface,
+    PromotionTotalAwareInterface,
+    ShippingTotalAwareInterface,
+    UserAwareInterface
 {
     // Labels for tax, shipping and promotion adjustments.
     const TAX_ADJUSTMENT       = 'tax';
@@ -46,41 +60,6 @@ interface OrderInterface extends CartInterface, PromotionSubjectInterface
     public function setUser(UserInterface $user);
 
     /**
-     * Get shipping address.
-     *
-     * @return AddressInterface
-     */
-    public function getShippingAddress();
-
-    /**
-     * Set shipping address.
-     *
-     * @param AddressInterface $address
-     */
-    public function setShippingAddress(AddressInterface $address);
-
-    /**
-     * Get billing address.
-     *
-     * @return AddressInterface
-     */
-    public function getBillingAddress();
-
-    /**
-     * Set billing address.
-     *
-     * @param AddressInterface $address
-     */
-    public function setBillingAddress(AddressInterface $address);
-
-    /**
-     * Get the tax total.
-     *
-     * @return float
-     */
-    public function getTaxTotal();
-
-    /**
      * Get all tax adjustments.
      *
      * @return Collection|AdjustmentInterface[]
@@ -91,13 +70,6 @@ interface OrderInterface extends CartInterface, PromotionSubjectInterface
      * Remove all tax adjustments.
      */
     public function removeTaxAdjustments();
-
-    /**
-     * Get the promotion total.
-     *
-     * @return float
-     */
-    public function getPromotionTotal();
 
     /**
      * Get all promotion adjustments.
@@ -112,13 +84,6 @@ interface OrderInterface extends CartInterface, PromotionSubjectInterface
     public function removePromotionAdjustments();
 
     /**
-     * Get shipping total.
-     *
-     * @return float
-     */
-    public function getShippingTotal();
-
-    /**
      * Get all shipping adjustments.
      *
      * @return Collection|AdjustmentInterface[]
@@ -129,34 +94,6 @@ interface OrderInterface extends CartInterface, PromotionSubjectInterface
      * Remove all shipping adjustments.
      */
     public function removeShippingAdjustments();
-
-    /**
-     * Get the payment associated with the order.
-     *
-     * @return PaymentInterface
-     */
-    public function getPayment();
-
-    /**
-     * Set payment.
-     *
-     * @param PaymentInterface $payment
-     */
-    public function setPayment(PaymentInterface $payment);
-
-    /**
-     * Get the payment state.
-     *
-     * @return string
-     */
-    public function getPaymentState();
-
-    /**
-     * Set the payment state.
-     *
-     * @param string $paymentState
-     */
-    public function setPaymentState($paymentState);
 
     /**
      * Get all inventory units.
@@ -210,22 +147,6 @@ interface OrderInterface extends CartInterface, PromotionSubjectInterface
      * @return Boolean
      */
     public function hasShipment(ShipmentInterface $shipment);
-
-    /**
-     * Get currency.
-     *
-     * @return string
-     */
-    public function getCurrency();
-
-    /**
-     * Set currency.
-     *
-     * @param string
-     *
-     * @return OrderInterface
-     */
-    public function setCurrency($currency);
 
     /**
      * Set promotion coupon.

--- a/src/Sylius/Component/Core/Model/UserInterface.php
+++ b/src/Sylius/Component/Core/Model/UserInterface.php
@@ -15,114 +15,56 @@ use Doctrine\Common\Collections\Collection;
 use FOS\UserBundle\Model\UserInterface as BaseUserInterface;
 use Sylius\Component\Addressing\Model\AddressInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
+use FOS\UserBundle\Model\UserInterface as FosUserInterface;
+use Sylius\Component\Addressing\Model\AddressAwareInterface;
+use Sylius\Component\Addressing\Model\BillingAddressAwareInterface;
+use Sylius\Component\Addressing\Model\ShippingAddressAwareInterface;
+use Sylius\Component\Order\Model\UserInterface as BaseUserInterface;
+use Sylius\Bundle\ResourceBundle\Model\TimestampableInterface;
 
 /**
- * User interface.
- *
  * @author Paweł Jędrzejewski <pjedrzejewski@diweb.pl>
  */
-interface UserInterface extends BaseUserInterface, TimestampableInterface
+interface UserInterface extends
+    FosUserInterface,
+    BaseUserInterface,
+    AddressAwareInterface,
+    BillingAddressAwareInterface,
+    ShippingAddressAwareInterface,
+    TimestampableInterface
 {
     /**
-     * Get first name
+     * @return string
      */
     public function getFirstName();
 
     /**
-     * Set first name
-     *
      * @param string $firstName
      */
     public function setFirstName($firstName);
 
     /**
-     * Get last name
+     * @return string
      */
     public function getLastName();
 
     /**
-     * Set last name
-     *
      * @param string $lastName
      */
     public function setLastName($lastName);
 
     /**
-     * Get currency
-     *
      * @return string
      */
     public function getCurrency();
 
     /**
-     * Set currency
-     *
      * @param string $currency
      */
     public function setCurrency($currency);
 
     /**
-     * Get orders.
-     *
-     * @return Collection|OrderInterface
+     * @return Collection|OrderInterface[]
      */
     public function getOrders();
-
-    /**
-     * Get billing address.
-     *
-     * @return AddressInterface
-     */
-    public function getBillingAddress();
-
-    /**
-     * Set billing address.
-     *
-     * @param AddressInterface $billingAddress
-     */
-    public function setBillingAddress(AddressInterface $billingAddress = null);
-
-    /**
-     * Get shipping address.
-     *
-     * @return AddressInterface
-     */
-    public function getShippingAddress();
-
-    /**
-     * Set shipping address.
-     *
-     * @param AddressInterface $shippingAddress
-     */
-    public function setShippingAddress(AddressInterface $shippingAddress = null);
-
-    /**
-     * Get addresses.
-     *
-     * @return Collection|AddressInterface[]
-     */
-    public function getAddresses();
-
-    /**
-     * Add address.
-     *
-     * @param AddressInterface $address
-     */
-    public function addAddress(AddressInterface $address);
-
-    /**
-     * Remove address.
-     *
-     * @param AddressInterface $address
-     */
-    public function removeAddress(AddressInterface $address);
-
-    /**
-     * Has address?
-     *
-     * @param AddressInterface $address
-     *
-     * @return Boolean
-     */
-    public function hasAddress(AddressInterface $address);
 }

--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -79,6 +79,13 @@ class Order implements OrderInterface
     protected $total = 0;
 
     /**
+     * Currency ISO code.
+     *
+     * @var string
+     */
+    protected $currency;
+
+    /**
      * Whether order was confirmed.
      *
      * @var Boolean
@@ -396,6 +403,24 @@ class Order implements OrderInterface
     public function setTotal($total)
     {
         $this->total = $total;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCurrency()
+    {
+        return $this->currency;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCurrency($currency)
+    {
+        $this->currency = $currency;
 
         return $this;
     }

--- a/src/Sylius/Component/Order/Model/OrderInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderInterface.php
@@ -143,6 +143,22 @@ interface OrderInterface extends AdjustableInterface, TimestampableInterface, So
     public function setTotal($total);
 
     /**
+     * Get currency.
+     *
+     * @return string
+     */
+    public function getCurrency();
+
+    /**
+     * Set currency.
+     *
+     * @param string
+     *
+     * @return OrderInterface
+     */
+    public function setCurrency($currency);
+
+    /**
      * Calculate total.
      * Items total + Adjustments total.
      */

--- a/src/Sylius/Component/Order/Model/UserAwareInterface.php
+++ b/src/Sylius/Component/Order/Model/UserAwareInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Order\Model;
+
+interface UserAwareInterface
+{
+    /**
+     * @return UserInterface
+     */
+    public function getUser();
+}

--- a/src/Sylius/Component/Order/Model/UserInterface.php
+++ b/src/Sylius/Component/Order/Model/UserInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Order\Model;
+
+interface UserInterface
+{
+    /**
+     * @return string
+     */
+    public function getEmail();
+
+    /**
+     * @param string
+     */
+    public function setEmail($email);
+}

--- a/src/Sylius/Component/Payment/Model/PaymentAwareInterface.php
+++ b/src/Sylius/Component/Payment/Model/PaymentAwareInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+* This file is part of the Sylius package.
+*
+* (c) Paweł Jędrzejewski
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Sylius\Component\Payment\Model;
+
+interface PaymentAwareInterface
+{
+    /**
+     * @return PaymentInterface
+     */
+    public function getPayment();
+
+    /**
+     * @param PaymentInterface $payment
+     */
+    public function setPayment(PaymentInterface $payment);
+
+    /**
+     * @return string
+     */
+    public function getPaymentState();
+
+    /**
+     * @param string $paymentState
+     */
+    public function setPaymentState($paymentState);
+}

--- a/src/Sylius/Component/Promotion/Model/PromotionTotalAwareInterface.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionTotalAwareInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Promotion\Model;
+
+interface PromotionTotalAwareInterface
+{
+    /**
+     * Get the promotion total.
+     *
+     * @return float
+     */
+    public function getPromotionTotal();
+}

--- a/src/Sylius/Component/Shipping/Model/ShippingTotalAwareInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingTotalAwareInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Shipping\Model;
+
+interface ShippingTotalAwareInterface
+{
+    /**
+     * @return float
+     */
+    public function getShippingTotal();
+} 

--- a/src/Sylius/Component/Taxation/Model/TaxTotalAwareInterface.php
+++ b/src/Sylius/Component/Taxation/Model/TaxTotalAwareInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Taxation\Model;
+
+interface TaxTotalAwareInterface
+{
+    /**
+     * Get the tax total.
+     *
+     * @return float
+     */
+    public function getTaxTotal();
+}


### PR DESCRIPTION
The interface already quite big. What if we split it a bit:

``` php
<?php

interface OrderInterface extends FooInterface, BarInterface, BazInterface
{
}
```

For example get\set payment method could be moved to separate interface, which could be placed to payments bundle. Shipping method to shipping bundle and so on.

This way for example payum actions could be decoupled from core bundle and require `OrderBundle` and `PaymentsBundle` bundles only. It allows one reuse these actions with orders developed in house without downloading half of the sylius.

Thoughts?

> **Note**:
> Please don't comment that something is not working, it's not production ready, nor finished approach (yet). For now please consider this as idea for extending & possible way of improvements.
