### PR TITLE
Fix start number in generator

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/NumberRepository.php
+++ b/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/NumberRepository.php
@@ -20,7 +20,7 @@ class NumberRepository extends EntityRepository implements NumberRepositoryInter
     public function getLastNumber()
     {
         try {
-            return $this->getQueryBuilder()
+            return (int) $this->getQueryBuilder()
                 ->select($this->getAlias().'.id')
                 ->orderBy($this->getAlias().'.id', 'desc')
                 ->setMaxResults(1)

--- a/src/Sylius/Bundle/OrderBundle/Generator/OrderNumberGenerator.php
+++ b/src/Sylius/Bundle/OrderBundle/Generator/OrderNumberGenerator.php
@@ -53,8 +53,8 @@ class OrderNumberGenerator implements OrderNumberGeneratorInterface
     public function __construct(NumberRepositoryInterface $numberRepository, $numberLength = 9, $startNumber = 1)
     {
         $this->numberRepository = $numberRepository;
-        $this->numberLength = $numberLength;
-        $this->startNumber = $startNumber;
+        $this->numberLength = (int) $numberLength;
+        $this->startNumber = (int) $startNumber;
     }
 
     /**
@@ -80,6 +80,6 @@ class OrderNumberGenerator implements OrderNumberGeneratorInterface
             return $this->startNumber;
         }
 
-        return (int) $number + 1;
+        return $this->startNumber + $number;
     }
 }


### PR DESCRIPTION
Start number was used only for the very first number generated.
