### PR TITLE
[Core] Attach InventoryUnit to OrderItem instead of Order

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderInventoryListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderInventoryListener.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
 use Sylius\Bundle\CoreBundle\Model\OrderInterface;
+use Sylius\Bundle\CoreBundle\Model\OrderItemInterface;
 use Sylius\Bundle\CoreBundle\OrderProcessing\InventoryHandlerInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -81,10 +82,10 @@ class OrderInventoryListener
      *
      * @param GenericEvent $event
      */
-    public function createInventoryUnits(GenericEvent $event)
+    public function processInventoryUnits(GenericEvent $event)
     {
         $this->inventoryHandler->processInventoryUnits(
-            $this->getOrder($event)
+            $this->getItem($event)
         );
     }
 
@@ -104,5 +105,23 @@ class OrderInventoryListener
         }
 
         return $order;
+    }
+
+    /**
+     * Gets order from event.
+     *
+     * @param GenericEvent $event
+     */
+    protected function getItem(GenericEvent $event)
+    {
+        $item = $event->getSubject();
+
+        if (!$item instanceof OrderItemInterface) {
+            throw new \InvalidArgumentException(
+                'Order inventory listener requires event subject to be instance of "Sylius\Bundle\CoreBundle\Model\OrderItemInterface"'
+            );
+        }
+
+        return $item;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderItemInventoryListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderItemInventoryListener.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\EventListener;
+
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Sylius\Bundle\CoreBundle\Model\OrderItemInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * Order item inventory processing listener.
+ *
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+class OrderItemInventoryListener
+{
+    /**
+     * Event Dispatcher
+     *
+     * @var EventDispatcherInterface
+     */
+    protected $eventDispatcher;
+
+    /**
+     * Constructor.
+     *
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function prePersist(LifecycleEventArgs $args)
+    {
+        $item = $args->getEntity();
+
+        if (!$this->supports($item)) {
+            return;
+        }
+
+        $this->eventDispatcher->dispatch('sylius.order_item.pre_create', new GenericEvent($item));
+    }
+
+    public function preUpdate(LifecycleEventArgs $args)
+    {
+        $item = $args->getEntity();
+
+        if (!$this->supports($item)) {
+            return;
+        }
+
+        $this->eventDispatcher->dispatch('sylius.order_item.pre_update', new GenericEvent($item));
+    }
+
+    protected function supports($entity)
+    {
+        return $entity instanceof OrderItemInterface;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Model/InventoryUnit.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/InventoryUnit.php
@@ -33,9 +33,9 @@ class InventoryUnit extends BaseInventoryUnit implements InventoryUnitInterface
     /**
      * Order.
      *
-     * @var OrderInterface
+     * @var OrderItemInterface
      */
-    protected $order;
+    protected $orderItem;
 
     /**
      * Shipment
@@ -76,17 +76,17 @@ class InventoryUnit extends BaseInventoryUnit implements InventoryUnitInterface
     /**
      * {@inheritdoc}
      */
-    public function getOrder()
+    public function getOrderItem()
     {
-        return $this->order;
+        return $this->orderItem;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function setOrder(OrderInterface $order = null)
+    public function setOrderItem(OrderItemInterface $orderItem = null)
     {
-        $this->order = $order;
+        $this->orderItem = $orderItem;
 
         return $this;
     }

--- a/src/Sylius/Bundle/CoreBundle/Model/InventoryUnitInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/InventoryUnitInterface.php
@@ -24,10 +24,10 @@ interface InventoryUnitInterface extends BaseInventoryUnitInterface, ShipmentIte
     /**
      * @return null|OrderInterface
      */
-    public function getOrder();
+    public function getOrderItem();
 
     /**
      * @param null|OrderInterface $order
      */
-    public function setOrder(OrderInterface $order = null);
+    public function setOrderItem(OrderItemInterface $orderItem = null);
 }

--- a/src/Sylius/Bundle/CoreBundle/Model/Order.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/Order.php
@@ -63,13 +63,6 @@ class Order extends Cart implements OrderInterface
     protected $payment;
 
     /**
-     * Inventory units.
-     *
-     * @var Collection|InventoryUnitInterface[]
-     */
-    protected $inventoryUnits;
-
-    /**
      * Currency ISO code.
      *
      * @var string
@@ -112,7 +105,6 @@ class Order extends Cart implements OrderInterface
     {
         parent::__construct();
 
-        $this->inventoryUnits = new ArrayCollection();
         $this->shipments = new ArrayCollection();
         $this->promotions = new ArrayCollection();
     }
@@ -321,7 +313,15 @@ class Order extends Cart implements OrderInterface
      */
     public function getInventoryUnits()
     {
-        return $this->inventoryUnits;
+        $units = new ArrayCollection;
+
+        foreach ($this->getItems() as $item) {
+            foreach ($item->getInventoryUnits() as $unit) {
+                $units->add($unit);
+            }
+        }
+
+        return $units;
     }
 
     /**
@@ -329,43 +329,9 @@ class Order extends Cart implements OrderInterface
      */
     public function getInventoryUnitsByVariant(VariantInterface $variant)
     {
-        return $this->inventoryUnits->filter(function (InventoryUnitInterface $unit) use ($variant) {
+        return $this->getInventoryUnits()->filter(function (InventoryUnitInterface $unit) use ($variant) {
             return $variant === $unit->getStockable();
         });
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function addInventoryUnit(InventoryUnitInterface $unit)
-    {
-        if (!$this->inventoryUnits->contains($unit)) {
-            $unit->setOrder($this);
-            $this->inventoryUnits->add($unit);
-        }
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function removeInventoryUnit(InventoryUnitInterface $unit)
-    {
-        if ($this->inventoryUnits->contains($unit)) {
-            $unit->setOrder(null);
-            $this->inventoryUnits->removeElement($unit);
-        }
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasInventoryUnit(InventoryUnitInterface $unit)
-    {
-        return $this->inventoryUnits->contains($unit);
     }
 
     /**
@@ -489,7 +455,7 @@ class Order extends Cart implements OrderInterface
      */
     public function isBackorder()
     {
-        foreach ($this->inventoryUnits as $unit) {
+        foreach ($this->getInventoryUnits() as $unit) {
             if (InventoryUnitInterface::STATE_BACKORDERED === $unit->getInventoryState()) {
                 return true;
             }

--- a/src/Sylius/Bundle/CoreBundle/Model/OrderInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/OrderInterface.php
@@ -175,29 +175,6 @@ interface OrderInterface extends CartInterface, PromotionSubjectInterface
     public function getInventoryUnitsByVariant(VariantInterface $variant);
 
     /**
-     * Add inventory unit.
-     *
-     * @param InventoryUnitInterface $unit
-     */
-    public function addInventoryUnit(InventoryUnitInterface $unit);
-
-    /**
-     * Remove inventory unit.
-     *
-     * @param InventoryUnitInterface $unit
-     */
-    public function removeInventoryUnit(InventoryUnitInterface $unit);
-
-    /**
-     * Has inventory unit?
-     *
-     * @param InventoryUnitInterface $unit
-     *
-     * @return Boolean
-     */
-    public function hasInventoryUnit(InventoryUnitInterface $unit);
-
-    /**
      * Get all shipments associated with this order.
      *
      * @return Collection|ShipmentInterface[]

--- a/src/Sylius/Bundle/CoreBundle/Model/OrderItem.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/OrderItem.php
@@ -11,7 +11,12 @@
 
 namespace Sylius\Bundle\CoreBundle\Model;
 
+use Doctrine\Common\Collections\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
 use Sylius\Bundle\CartBundle\Model\CartItem;
+use Sylius\Bundle\CoreBundle\Model\InventoryUnit;
+use Sylius\Bundle\CoreBundle\Model\InventoryUnitInterface;
 use Sylius\Bundle\OrderBundle\Model\OrderItemInterface as BaseOrderItemInterface;
 
 /**
@@ -27,6 +32,20 @@ class OrderItem extends CartItem implements OrderItemInterface
      * @var VariantInterface
      */
     protected $variant;
+
+    /**
+     * Inventory units.
+     *
+     * @var Collection|InventoryUnitInterface[]
+     */
+    protected $inventoryUnits;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->inventoryUnits = new ArrayCollection;
+    }
 
     /**
      * {@inheritdoc}
@@ -63,5 +82,45 @@ class OrderItem extends CartItem implements OrderItemInterface
             && $item->getVariant() === $this->variant
             && $item->getUnitPrice() === $this->getUnitPrice()
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInventoryUnits()
+    {
+        return $this->inventoryUnits;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addInventoryUnit(InventoryUnitInterface $unit)
+    {
+        if (!$this->hasInventoryUnit($unit)) {
+            $unit->setOrderItem($this);
+            $this->inventoryUnits->add($unit);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeInventoryUnit(InventoryUnitInterface $unit)
+    {
+        $unit->setOrderItem(null);
+        $this->inventoryUnits->removeElement($unit);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasInventoryUnit(InventoryUnitInterface $unit)
+    {
+        return $this->inventoryUnits->contains($unit);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Model/OrderItemInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/OrderItemInterface.php
@@ -40,4 +40,34 @@ interface OrderItemInterface extends CartItemInterface
      * @param VariantInterface $variant
      */
     public function setVariant(VariantInterface $variant);
+
+    /**
+     * Get all inventory units.
+     *
+     * @return Collection|InventoryUnitInterface[]
+     */
+    public function getInventoryUnits();
+
+    /**
+     * Add inventory unit.
+     *
+     * @param InventoryUnitInterface $unit
+     */
+    public function addInventoryUnit(InventoryUnitInterface $unit);
+
+    /**
+     * Remove inventory unit.
+     *
+     * @param InventoryUnitInterface $unit
+     */
+    public function removeInventoryUnit(InventoryUnitInterface $unit);
+
+    /**
+     * Has inventory unit?
+     *
+     * @param InventoryUnitInterface $unit
+     *
+     * @return Boolean
+     */
+    public function hasInventoryUnit(InventoryUnitInterface $unit);
 }

--- a/src/Sylius/Bundle/CoreBundle/OrderProcessing/InventoryHandlerInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderProcessing/InventoryHandlerInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\CoreBundle\OrderProcessing;
 
 use Sylius\Bundle\CoreBundle\Model\OrderInterface;
+use Sylius\Bundle\CoreBundle\Model\OrderItemInterface;
 
 /**
  * Order inventory handler service interface.
@@ -31,7 +32,7 @@ interface InventoryHandlerInterface
      *
      * @param OrderInterface $order
      */
-    public function processInventoryUnits(OrderInterface $order);
+    public function processInventoryUnits(OrderItemInterface $order);
 
     /**
      * Put inventory on hold.

--- a/src/Sylius/Bundle/CoreBundle/Repository/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Repository/OrderRepository.php
@@ -61,7 +61,7 @@ class OrderRepository extends CartRepository
         $queryBuilder
             ->leftJoin('o.adjustments', 'adjustment')
             ->leftJoin('o.user', 'user')
-            ->leftJoin('o.inventoryUnits', 'inventoryUnit')
+            ->leftJoin('item.inventoryUnits', 'inventoryUnit')
             ->leftJoin('o.shipments', 'shipment')
             ->leftJoin('shipment.method', 'shippingMethod')
             ->leftJoin('o.payment', 'payment')

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/InventoryUnit.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/InventoryUnit.orm.xml
@@ -6,8 +6,8 @@
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <mapped-superclass name="Sylius\Bundle\CoreBundle\Model\InventoryUnit" table="sylius_inventory_unit">
-        <many-to-one field="order" target-entity="Sylius\Bundle\OrderBundle\Model\OrderInterface" inversed-by="inventoryUnits">
-            <join-column name="order_id" referenced-column-name="id" nullable="false" />
+        <many-to-one field="orderItem" target-entity="Sylius\Bundle\OrderBundle\Model\OrderItemInterface" inversed-by="inventoryUnits">
+            <join-column name="order_item_id" referenced-column-name="id" nullable="false" />
         </many-to-one>
 
         <field name="shippingState" column="shipping_state" type="string" nullable="false" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Order.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Order.orm.xml
@@ -31,12 +31,6 @@
             <join-column name="coupon_id" on-delete="SET NULL" />
         </many-to-one>
 
-        <one-to-many field="inventoryUnits" target-entity="Sylius\Bundle\InventoryBundle\Model\InventoryUnitInterface" mapped-by="order" orphan-removal="true">
-            <cascade>
-                <cascade-all/>
-            </cascade>
-        </one-to-many>
-
         <one-to-many field="shipments" target-entity="Sylius\Bundle\ShippingBundle\Model\ShipmentInterface" mapped-by="order" orphan-removal="true">
             <cascade>
                 <cascade-all/>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/OrderItem.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/OrderItem.orm.xml
@@ -20,6 +20,12 @@
         <many-to-one field="variant" target-entity="Sylius\Bundle\VariableProductBundle\Model\VariantInterface">
             <join-column name="variant_id" referenced-column-name="id" nullable="false" />
         </many-to-one>
+        
+        <one-to-many field="inventoryUnits" target-entity="Sylius\Bundle\InventoryBundle\Model\InventoryUnitInterface" mapped-by="orderItem" orphan-removal="true">
+            <cascade>
+                <cascade-all/>
+            </cascade>
+        </one-to-many>
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -33,6 +33,7 @@
 
         <parameter key="sylius.listener.order_currency.class">Sylius\Bundle\CoreBundle\EventListener\OrderCurrencyListener</parameter>
         <parameter key="sylius.listener.order_inventory.class">Sylius\Bundle\CoreBundle\EventListener\OrderInventoryListener</parameter>
+        <parameter key="sylius.listener.order_item_inventory.class">Sylius\Bundle\CoreBundle\EventListener\OrderItemInventoryListener</parameter>
         <parameter key="sylius.listener.inventory_unit.class">Sylius\Bundle\CoreBundle\EventListener\InventoryUnitListener</parameter>
         <parameter key="sylius.listener.order_state.class">Sylius\Bundle\CoreBundle\EventListener\OrderStateListener</parameter>
         <parameter key="sylius.listener.order_payment.class">Sylius\Bundle\CoreBundle\EventListener\OrderPaymentListener</parameter>
@@ -241,7 +242,13 @@
             <tag name="kernel.event_listener" event="sylius.checkout.finalize.pre_complete" method="holdInventoryUnits" />
             <tag name="kernel.event_listener" event="sylius.order.pre_release" method="releaseInventoryUnits" />
             <tag name="kernel.event_listener" event="sylius.order.pre_pay" method="updateInventoryUnits" />
-            <tag name="kernel.event_listener" event="sylius.cart_change" method="createInventoryUnits" priority="-100" />
+            <tag name="kernel.event_listener" event="sylius.order_item.pre_create" method="processInventoryUnits" />
+            <tag name="kernel.event_listener" event="sylius.order_item.pre_update" method="processInventoryUnits" />
+        </service>
+        <service id="sylius.listener.order_item_inventory" class="%sylius.listener.order_item_inventory.class%">
+            <argument type="service" id="event_dispatcher" />
+            <tag name="doctrine.event_listener" event="prePersist" />
+            <tag name="doctrine.event_listener" event="preUpdate" />
         </service>
         <service id="sylius.listener.inventory_unit" class="%sylius.listener.inventory_unit.class%">
             <tag name="kernel.event_listener" event="sylius.inventory_unit.pre_state_change" method="updateState" />

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/EventListener/OrderInventoryListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/EventListener/OrderInventoryListenerSpec.php
@@ -13,6 +13,7 @@ namespace spec\Sylius\Bundle\CoreBundle\EventListener;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\CoreBundle\Model\OrderInterface;
+use Sylius\Bundle\CoreBundle\Model\OrderItemInterface;
 use Sylius\Bundle\CoreBundle\OrderProcessing\InventoryHandlerInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -56,12 +57,13 @@ class OrderInventoryListenerSpec extends ObjectBehavior
     function it_creates_inventory_units(
             InventoryHandlerInterface $inventoryHandler,
             GenericEvent $event,
-            OrderInterface $order
+            OrderItemInterface $item
     )
     {
-        $event->getSubject()->willReturn($order);
-        $inventoryHandler->processInventoryUnits($order)->shouldBeCalled();
+        $event->getSubject()->willReturn($item);
 
-        $this->createInventoryUnits($event);
+        $inventoryHandler->processInventoryUnits($item)->shouldBeCalled();
+
+        $this->processInventoryUnits($event);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Model/InventoryUnitSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Model/InventoryUnitSpec.php
@@ -13,6 +13,7 @@ namespace spec\Sylius\Bundle\CoreBundle\Model;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\CoreBundle\Model\OrderInterface;
+use Sylius\Bundle\CoreBundle\Model\OrderItemInterface;
 use Sylius\Bundle\ShippingBundle\Model\ShipmentItemInterface;
 use Sylius\Bundle\ShippingBundle\Model\ShipmentInterface;
 
@@ -69,23 +70,23 @@ class InventoryUnitSpec extends ObjectBehavior
         $this->getShippingState()->shouldReturn(ShipmentInterface::STATE_SHIPPED);
     }
 
-    function it_does_not_belong_to_an_order_by_default()
+    function it_does_not_belong_to_an_order_item_by_default()
     {
-        $this->getOrder()->shouldReturn(null);
+        $this->getOrderItem()->shouldReturn(null);
     }
 
-    function it_allows_attaching_itself_to_an_order(OrderInterface $order)
+    function it_allows_attaching_itself_to_an_order_item(OrderItemInterface $order_item)
     {
-        $this->setOrder($order);
-        $this->getOrder()->shouldReturn($order);
+        $this->setOrderItem($order_item);
+        $this->getOrderItem()->shouldReturn($order_item);
     }
 
-    function it_allows_detaching_itself_from_an_order(OrderInterface $order)
+    function it_allows_detaching_itself_from_an_order_item(OrderItemInterface $order_item)
     {
-        $this->setOrder($order);
-        $this->getOrder()->shouldReturn($order);
+        $this->setOrderItem($order_item);
+        $this->getOrderItem()->shouldReturn($order_item);
 
-        $this->setOrder(null);
-        $this->getOrder()->shouldReturn(null);
+        $this->setOrderItem(null);
+        $this->getOrderItem()->shouldReturn(null);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Model/OrderSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Model/OrderSpec.php
@@ -19,6 +19,7 @@ use Sylius\Bundle\CoreBundle\Model\ShipmentInterface;
 use Sylius\Bundle\CoreBundle\Model\UserInterface;
 use Sylius\Bundle\CoreBundle\Model\InventoryUnitInterface;
 use Sylius\Bundle\OrderBundle\Model\AdjustmentInterface;
+use Sylius\Bundle\CoreBundle\Model\OrderItemInterface;
 
 /**
  * @author Paweł Jędrzejewski <pjedrzejewski@diweb.pl>
@@ -76,25 +77,6 @@ class OrderSpec extends ObjectBehavior
     function it_should_initialize_inventory_units_collection_by_default()
     {
         $this->getInventoryUnits()->shouldHaveType('Doctrine\Common\Collections\Collection');
-    }
-
-    function it_should_add_inventory_units_properly(InventoryUnitInterface $unit)
-    {
-        $unit->setOrder($this)->shouldBeCalled();
-        $this->addInventoryUnit($unit);
-    }
-
-    function it_should_remove_inventory_units_properly(InventoryUnitInterface $unit)
-    {
-        $unit->setOrder($this)->shouldBeCalled();
-        $this->addInventoryUnit($unit);
-
-        $this->hasInventoryUnit($unit)->shouldReturn(true);
-
-        $unit->setOrder(null)->shouldBeCalled();
-        $this->removeInventoryUnit($unit);
-
-        $this->hasInventoryUnit($unit)->shouldReturn(false);
     }
 
     function it_should_initialize_shipments_collection_by_default()
@@ -227,34 +209,34 @@ class OrderSpec extends ObjectBehavior
 
     function it_is_a_backorder_if_contains_at_least_one_backordered_unit(
         InventoryUnitInterface $unit1,
-        InventoryUnitInterface $unit2
+        InventoryUnitInterface $unit2,
+        OrderItemInterface $item
     )
     {
-        $unit1->setOrder($this)->shouldBeCalled();
-        $unit2->setOrder($this)->shouldBeCalled();
-
-        $this->addInventoryUnit($unit1);
-        $this->addInventoryUnit($unit2);
-
         $unit1->getInventoryState()->willReturn(InventoryUnitInterface::STATE_BACKORDERED);
         $unit2->getInventoryState()->willReturn(InventoryUnitInterface::STATE_SOLD);
+
+        $item->getInventoryUnits()->willReturn(array($unit1, $unit2));
+
+        $item->setOrder($this)->shouldBeCalled();
+        $this->addItem($item);
 
         $this->shouldBeBackorder();
     }
 
     function it_not_a_backorder_if_contains_no_backordered_units(
         InventoryUnitInterface $unit1,
-        InventoryUnitInterface $unit2
+        InventoryUnitInterface $unit2,
+         OrderItemInterface $item
     )
     {
-        $unit1->setOrder($this)->shouldBeCalled();
-        $unit2->setOrder($this)->shouldBeCalled();
-
-        $this->addInventoryUnit($unit1);
-        $this->addInventoryUnit($unit2);
-
         $unit1->getInventoryState()->willReturn(InventoryUnitInterface::STATE_SOLD);
         $unit2->getInventoryState()->willReturn(InventoryUnitInterface::STATE_SOLD);
+
+        $item->getInventoryUnits()->willReturn(array($unit1, $unit2));
+
+        $item->setOrder($this)->shouldBeCalled();
+        $this->addItem($item);
 
         $this->shouldNotBeBackorder();
     }

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/OrderProcessing/InventoryHandlerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/OrderProcessing/InventoryHandlerSpec.php
@@ -15,11 +15,11 @@ use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\CoreBundle\Model\OrderInterface;
-use Sylius\Bundle\CoreBundle\Model\OrderItem;
 use Sylius\Bundle\CoreBundle\Model\VariantInterface;
 use Sylius\Bundle\CoreBundle\Model\InventoryUnitInterface;
 use Sylius\Bundle\InventoryBundle\Factory\InventoryUnitFactory;
 use Sylius\Bundle\InventoryBundle\Operator\InventoryOperatorInterface;
+use Sylius\Bundle\CoreBundle\Model\OrderItemInterface;
 
 /**
  * @author Paweł Jędrzejewski <pjedrzejewski@diweb.pl>
@@ -44,100 +44,55 @@ class InventoryHandlerSpec extends ObjectBehavior
         $this->shouldImplement('Sylius\Bundle\CoreBundle\OrderProcessing\InventoryHandlerInterface');
     }
 
-    function it_does_not_create_any_inventory_units_if_order_has_no_items(OrderInterface $order)
-    {
-        $order->getItems()->willReturn(array());
-        $order->getInventoryUnits()->willReturn(array());
-        $order->addInventoryUnit(Argument::any())->shouldNotBeCalled();
-
-        $this->processInventoryUnits($order);
-    }
-
     function it_creates_inventory_units_via_the_factory(
         $inventoryUnitFactory,
-        OrderInterface $order,
-        OrderItem $item,
+        OrderItemInterface $item,
         VariantInterface $variant,
         InventoryUnitInterface $unit1,
         InventoryUnitInterface $unit2
     )
     {
-        $order->getItems()->willReturn(array($item));
-        $order->getInventoryUnits()->shouldBeCalled()->willReturn(array());
-
         $item->getVariant()->willReturn($variant);
         $item->getQuantity()->willReturn(2);
 
-        $order->getInventoryUnitsByVariant($variant)->shouldBeCalled()->willReturn(array());
+        $item->getInventoryUnits()->shouldBeCalled()->willReturn(new ArrayCollection());
 
         $inventoryUnitFactory->create($variant, 2, InventoryUnitInterface::STATE_CHECKOUT)->shouldBeCalled()->willReturn(array($unit1, $unit2));
 
-        $order->addInventoryUnit($unit1)->shouldBeCalled();
-        $order->addInventoryUnit($unit2)->shouldBeCalled();
+        $item->addInventoryUnit($unit1)->shouldBeCalled();
+        $item->addInventoryUnit($unit2)->shouldBeCalled();
 
-        $this->processInventoryUnits($order);
+        $this->processInventoryUnits($item);
     }
 
     function it_creates_only_missing_inventory_units_via_the_factory(
         $inventoryUnitFactory,
-        OrderInterface $order,
-        OrderItem $item,
+        OrderItemInterface $item,
         VariantInterface $variant,
         InventoryUnitInterface $unit1,
-        InventoryUnitInterface $unit2
+        InventoryUnitInterface $unit2,
+        ArrayCollection $units
     )
     {
-        $order->getItems()->willReturn(array($item));
-        $order->getInventoryUnits()->shouldBeCalled()->willReturn(array($unit1, $unit2));
-        $unit1->getStockable()->shouldBeCalled()->willReturn($variant);
-        $unit2->getStockable()->shouldBeCalled()->willReturn($variant);
+        $item->getInventoryUnits()->shouldBeCalled()->willReturn(new ArrayCollection(array($unit1)));
+        $unit1->getStockable()->willReturn($variant);
+        $unit2->getStockable()->willReturn($variant);
 
         $item->getVariant()->willReturn($variant);
         $item->getQuantity()->willReturn(2);
 
-        $order->getInventoryUnitsByVariant($variant)->shouldBeCalled()->willReturn(array($unit1));
-
         $inventoryUnitFactory->create($variant, 1, InventoryUnitInterface::STATE_CHECKOUT)->shouldBeCalled()->willReturn(array($unit2));
 
-        $order->addInventoryUnit($unit1)->shouldNotBeCalled();
-        $order->addInventoryUnit($unit2)->shouldBeCalled();
+        $item->addInventoryUnit($unit1)->shouldNotBeCalled();
+        $item->addInventoryUnit($unit2)->shouldBeCalled();
 
-        $this->processInventoryUnits($order);
-    }
-
-    function it_removes_extra_inventory_units(
-        $inventoryUnitFactory,
-        OrderInterface $order,
-        OrderItem $item,
-        VariantInterface $variant,
-        ArrayCollection $units,
-        InventoryUnitInterface $unit1,
-        InventoryUnitInterface $unit2,
-        InventoryUnitInterface $unit3
-    )
-    {
-        $order->getItems()->willReturn(array($item));
-
-        $item->getVariant()->willReturn($variant);
-        $item->getQuantity()->willReturn(1);
-        $units->count()->willReturn(2);
-
-        $order->getInventoryUnitsByVariant($variant)->shouldBeCalled()->willReturn($units);
-        $order->getInventoryUnits()->shouldBeCalled()->willReturn(array($unit3));
-        $units->slice(0, 1)->shouldBeCalled()->willReturn(array($unit2));
-
-        $inventoryUnitFactory->create(Argument::any())->shouldNotBeCalled();
-
-        $order->removeInventoryUnit($unit2)->shouldBeCalled();
-        $order->removeInventoryUnit($unit3)->shouldBeCalled();
-
-        $this->processInventoryUnits($order);
+        $this->processInventoryUnits($item);
     }
 
     function it_holds_the_variant_stock_via_inventory_operator(
         $inventoryOperator,
         OrderInterface $order,
-        OrderItem $item,
+        OrderItemInterface $item,
         VariantInterface $variant,
         InventoryUnitInterface $unit1,
         InventoryUnitInterface $unit2
@@ -146,14 +101,14 @@ class InventoryHandlerSpec extends ObjectBehavior
         $order->getItems()->willReturn(array($item));
 
         $item->getVariant()->willReturn($variant);
-        $item->getQuantity()->willReturn(1);
-
-        $order->getInventoryUnitsByVariant($variant)->shouldBeCalled()->willReturn(array($unit1, $unit2));
+        $item->getQuantity()->willReturn(2);
+        $item->getInventoryUnits()->shouldBeCalled()->willReturn(array($unit1, $unit2));
 
         $unit1->getInventoryState()->shouldBeCalled()->willReturn(InventoryUnitInterface::STATE_CHECKOUT);
-        $unit2->getInventoryState()->shouldBeCalled()->willReturn(InventoryUnitInterface::STATE_CHECKOUT);
         $unit1->setInventoryState(InventoryUnitInterface::STATE_ONHOLD)->shouldBeCalled();
-        $unit2->setInventoryState(InventoryUnitInterface::STATE_ONHOLD)->shouldBeCalled();
+
+        $unit2->getInventoryState()->shouldBeCalled()->willReturn(InventoryUnitInterface::STATE_ONHOLD);
+        $unit2->setInventoryState(InventoryUnitInterface::STATE_ONHOLD)->shouldNotBeCalled();
 
         $inventoryOperator->hold($variant, 1)->shouldBeCalled();
 
@@ -163,7 +118,7 @@ class InventoryHandlerSpec extends ObjectBehavior
     function it_releases_the_variant_stock_via_inventory_operator(
         $inventoryOperator,
         OrderInterface $order,
-        OrderItem $item,
+        OrderItemInterface $item,
         VariantInterface $variant,
         InventoryUnitInterface $unit1,
         InventoryUnitInterface $unit2
@@ -172,14 +127,14 @@ class InventoryHandlerSpec extends ObjectBehavior
         $order->getItems()->willReturn(array($item));
 
         $item->getVariant()->willReturn($variant);
-        $item->getQuantity()->willReturn(1);
-
-        $order->getInventoryUnitsByVariant($variant)->shouldBeCalled()->willReturn(array($unit1, $unit2));
+        $item->getQuantity()->willReturn(2);
+        $item->getInventoryUnits()->shouldBeCalled()->willReturn(array($unit1, $unit2));
 
         $unit1->getInventoryState()->shouldBeCalled()->willReturn(InventoryUnitInterface::STATE_ONHOLD);
-        $unit2->getInventoryState()->shouldBeCalled()->willReturn(InventoryUnitInterface::STATE_ONHOLD);
         $unit1->setInventoryState(InventoryUnitInterface::STATE_CHECKOUT)->shouldBeCalled();
-        $unit2->setInventoryState(InventoryUnitInterface::STATE_CHECKOUT)->shouldBeCalled();
+
+        $unit2->getInventoryState()->shouldBeCalled()->willReturn(InventoryUnitInterface::STATE_CHECKOUT);
+        $unit2->setInventoryState(InventoryUnitInterface::STATE_CHECKOUT)->shouldNotBeCalled();
 
         $inventoryOperator->release($variant, 1)->shouldBeCalled();
 
@@ -189,7 +144,7 @@ class InventoryHandlerSpec extends ObjectBehavior
     function it_decreases_the_variant_stock_via_inventory_operator(
         $inventoryOperator,
         OrderInterface $order,
-        OrderItem $item,
+        OrderItemInterface $item,
         VariantInterface $variant,
         InventoryUnitInterface $unit1,
         InventoryUnitInterface $unit2
@@ -198,13 +153,13 @@ class InventoryHandlerSpec extends ObjectBehavior
         $order->getItems()->willReturn(array($item));
 
         $item->getVariant()->willReturn($variant);
-        $item->getQuantity()->willReturn(1);
-
-        $order->getInventoryUnitsByVariant($variant)->shouldBeCalled()->willReturn(array($unit1, $unit2));
+        $item->getQuantity()->willReturn(2);
+        $item->getInventoryUnits()->shouldBeCalled()->willReturn(array($unit1, $unit2));
 
         $unit1->getInventoryState()->shouldBeCalled()->willReturn(InventoryUnitInterface::STATE_ONHOLD);
-        $unit2->getInventoryState()->shouldBeCalled()->willReturn(InventoryUnitInterface::STATE_ONHOLD);
         $unit1->setInventoryState(InventoryUnitInterface::STATE_SOLD)->shouldBeCalled();
+
+        $unit2->getInventoryState()->shouldBeCalled()->willReturn(InventoryUnitInterface::STATE_CHECKOUT);
         $unit2->setInventoryState(InventoryUnitInterface::STATE_SOLD)->shouldBeCalled();
 
         $inventoryOperator->decrease(array($unit1, $unit2))->shouldBeCalled();


### PR DESCRIPTION
We still have a synchronization issue between order items and inventory units. Promotion with free product breaks it, because it's attached to an event that `InventoryHandler` doesn't listen.

I suggest we attach inventory units to order item instead of the order itself. We will then be able to create inventory units at the moment we attach items to order (not implemented yet). With this solution, we ensure inventory units are perfectly synchronized with items: created when we attach item to order, and deleted when we delete item (there is an orphanRemoval true on the relation).

In this way, we do not need the `InventoryHandler::processInventoryUnits` method anymore. The handler service will only take care of states & cie.

What do you think?

The only drawback is that we kind of hardcode the link, by creating via `new InventoryUnit` inside Order or OrderItem. But this is something anyone can override and get back to the old and buggy behavior.
