### PR TITLE
Make height of backend signin form automatical

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/assets/css/backend.css
+++ b/src/Sylius/Bundle/WebBundle/Resources/assets/css/backend.css
@@ -32,7 +32,6 @@ form.form-signin {
     padding: 40px;
     background-color: #fff;
     width: 400px;
-    height: 300px;
     border-radius: 3px;
 }
 form.form-signin label {


### PR DESCRIPTION
1. Make sure you are not logged in
2. Go to some admin URL, you should get sign-in form `administration/login` (looks all good so far)
3. Type in invalid credentials, hit button
4. Alert pops up and pushes half of button out of the white space.

With that change form in `app_dev.php/administration/login` looks fine both with and without alert.
