### PR TITLE
Make Core bundle's Taxon model extendtable

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
@@ -17,7 +17,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Sylius\Bundle\CoreBundle\Model\Taxon" table="sylius_taxon">
+    <entity name="Sylius\Bundle\CoreBundle\Model\Taxon" table="sylius_taxon" inheritance-type="SINGLE_TABLE">
         <field name="path" nullable="true" />
 
        <many-to-many field="products" mapped-by="taxons" target-entity="Sylius\Bundle\ProductBundle\Model\ProductInterface"/>


### PR DESCRIPTION
fixing "It is illegal to put an inverse side one-to-many or many-to-many association on mapped superclass 'Sylius\Bundle\CoreBundle\Model\Taxon#products'." error.

issue #985
