### PR TITLE
Numberformatter intl bugs with negative numbers

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -17,7 +17,7 @@ doctrine:
 
 sylius_money:
     currency: EUR
-    locale: en
+    locale: en_US
 
 sylius_payments:
     gateways:

--- a/features/frontend/cart_promotions_complex.feature
+++ b/features/frontend/cart_promotions_complex.feature
@@ -36,7 +36,7 @@ Feature: Checkout promotions with multiple rules and actions
           And I added product "Sarge" to cart, with quantity "5"
          When I add product "Lenny" to cart, with quantity "2"
          Then I should be on the cart summary page
-          And "Promotion total: (€27.75)" should appear on the page
+          And "Promotion total: -€27.75" should appear on the page
           And "Grand total: €127.25" should appear on the page
 
     Scenario: Promotion is not applied when one of the cart does not

--- a/features/frontend/cart_promotions_coupons.feature
+++ b/features/frontend/cart_promotions_coupons.feature
@@ -40,7 +40,7 @@ Feature: Checkout coupon promotions
           And I press "OK"
          Then I should be on the cart summary page
           And I should see "Your promotion coupon has been added to the cart"
-          And "Promotion total: (€5.00)" should appear on the page
+          And "Promotion total: -€5.00" should appear on the page
           And "Grand total: €115.00" should appear on the page
 
     Scenario: An invalid coupon can not be added to the cart

--- a/features/frontend/cart_promotions_dates.feature
+++ b/features/frontend/cart_promotions_dates.feature
@@ -38,5 +38,5 @@ Feature: Checkout limited time promotions
         Given I am on the store homepage
          When I added product "Sarge" to cart, with quantity "8"
          Then I should be on the cart summary page
-          And "Promotion total: (€20.00)" should appear on the page
+          And "Promotion total: -€20.00" should appear on the page
           And "Grand total: €180.00" should appear on the page

--- a/features/frontend/cart_promotions_fixed.feature
+++ b/features/frontend/cart_promotions_fixed.feature
@@ -68,7 +68,7 @@ Feature: Checkout fixed discount promotions
         Given I am on the store homepage
          When I add product "Woody" to cart, with quantity "3"
          Then I should be on the cart summary page
-          And "Promotion total: (€40.00)" should appear on the page
+          And "Promotion total: -€40.00" should appear on the page
           And "Grand total: €335.00" should appear on the page
 
     Scenario: Fixed discount promotion is not applied when the cart
@@ -86,7 +86,7 @@ Feature: Checkout fixed discount promotions
           And I added product "Etch" to cart, with quantity "1"
          When I add product "Lenny" to cart, with quantity "2"
          Then I should be on the cart summary page
-          And "Promotion total: (€15.00)" should appear on the page
+          And "Promotion total: -€15.00" should appear on the page
           And "Grand total: €110.00" should appear on the page
 
     Scenario: Item count promotion is not applied when the cart has
@@ -104,7 +104,7 @@ Feature: Checkout fixed discount promotions
           And I fill in the shipping address to Germany
           And I press "Continue"
           And I go to the cart summary page
-         Then "Promotion total: (€40.00)" should appear on the page
+         Then "Promotion total: -€40.00" should appear on the page
           And "Grand total: €35.00" should appear on the page
 
     Scenario: Shipping country promotion is not applied when shipping country does not match
@@ -121,7 +121,7 @@ Feature: Checkout fixed discount promotions
         Given I am on the store homepage
          When I add product "Ubu" to cart, with quantity "1"
          Then I should be on the cart summary page
-          And "Promotion total: (€40.00)" should appear on the page
+          And "Promotion total: -€40.00" should appear on the page
           And "Grand total: €160.00" should appear on the page
 
     Scenario: Ubuntu T-Shirts promotion is not applied when the cart does not contain Ubuntu T-Shirts
@@ -162,7 +162,7 @@ Feature: Checkout fixed discount promotions
           And I fill in the shipping address to Poland
           And I press "Continue"
           And I go to the cart summary page
-          And "Promotion total: (€10.00)" should appear on the page
+          And "Promotion total: -€10.00" should appear on the page
           And "Grand total: €5.00" should appear on the page
 
     Scenario: Nth order promotion is not applied when user have no orders before
@@ -179,5 +179,5 @@ Feature: Checkout fixed discount promotions
           And I added product "Buzz" to cart, with quantity "1"
          When I add product "Woody" to cart, with quantity "3"
          Then I should still be on the cart summary page
-          And "Promotion total: (€55.00)" should appear on the page
+          And "Promotion total: -€55.00" should appear on the page
           And "Grand total: €1,620.00" should appear on the page

--- a/features/frontend/cart_promotions_percentage.feature
+++ b/features/frontend/cart_promotions_percentage.feature
@@ -40,7 +40,7 @@ Feature: Checkout percentage discount promotions
         Given I am on the store homepage
          When I add product "Woody" to cart, with quantity "3"
          Then I should be on the cart summary page
-          And "Promotion total: (€30.00)" should appear on the page
+          And "Promotion total: -€30.00" should appear on the page
           And "Grand total: €345.00" should appear on the page
 
     Scenario: Fixed discount promotion is not applied when the cart
@@ -58,7 +58,7 @@ Feature: Checkout percentage discount promotions
           And I added product "Etch" to cart, with quantity "1"
          When I add product "Lenny" to cart, with quantity "2"
          Then I should be on the cart summary page
-          And "Promotion total: (€18.75)" should appear on the page
+          And "Promotion total: -€18.75" should appear on the page
           And "Grand total: €106.25" should appear on the page
 
     Scenario: Item count promotion is not applied when the cart has
@@ -76,5 +76,5 @@ Feature: Checkout percentage discount promotions
           And I added product "Buzz" to cart, with quantity "1"
          When I add product "Woody" to cart, with quantity "3"
          Then I should still be on the cart summary page
-          And "Promotion total: (€385.25)" should appear on the page
+          And "Promotion total: -€385.25" should appear on the page
           And "Grand total: €1,289.75" should appear on the page

--- a/features/frontend/cart_promotions_usage_limit.feature
+++ b/features/frontend/cart_promotions_usage_limit.feature
@@ -40,7 +40,7 @@ Feature: Checkout usage limited promotions
         Given I am on the store homepage
          When I add product "Buzz" to cart, with quantity "2"
          Then I should be on the cart summary page
-          And "Promotion total: (€500.00)" should appear on the page
+          And "Promotion total: -€500.00" should appear on the page
           And "Grand total: €500.00" should appear on the page
 
     Scenario: Promotion with usage limit is not applied when the

--- a/src/Sylius/Bundle/MoneyBundle/Twig/SyliusMoneyExtension.php
+++ b/src/Sylius/Bundle/MoneyBundle/Twig/SyliusMoneyExtension.php
@@ -30,6 +30,9 @@ class SyliusMoneyExtension extends \Twig_Extension
         $this->currencyContext = $currencyContext;
         $this->converter       = $converter;
         $this->formatter       = new \NumberFormatter($locale ?: \Locale::getDefault(), \NumberFormatter::CURRENCY);
+        
+        $pattern = "¤#,##0.00;-¤#,##0.00";
+        $this->formatter->setPattern($pattern);
     }
 
     /**


### PR DESCRIPTION
Testing must take place in the en_US locale AND our number formatter must change the pattern 

This solve the behat failures for checking promotional discounts (most locales
show negative number as: -$100.00.  There is no dependable locale across different versions of pecl-intl that display negative currencies the same.

Fixes #853 along with other issues.
