### PR TITLE
Change StateResolver method visibility to protected.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OrderProcessing/StateResolver.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderProcessing/StateResolver.php
@@ -44,7 +44,7 @@ class StateResolver implements StateResolverInterface
         $order->setShippingState($this->getShippingState($order));
     }
 
-    private function getShippingState(OrderInterface $order)
+    protected function getShippingState(OrderInterface $order)
     {
         $states = array();
 


### PR DESCRIPTION
I want to extend `StateResolver::resolveShippingState()` and I want to reuse the `getShippingState()` method.
