### PR TITLE
Shipment state on hold while payment is processing

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderShippingListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderShippingListener.php
@@ -85,7 +85,7 @@ class OrderShippingListener
     }
 
     /**
-     * Update shipment states when payment is waiting for confirmation
+     * Update shipment states after order is created.
      *
      * @param GenericEvent $event
      */
@@ -99,7 +99,7 @@ class OrderShippingListener
     }
 
     /**
-     * Update shipment states after order is confirmed
+     * Update shipment states after order is confirmed.
      *
      * @param GenericEvent $event
      */
@@ -107,7 +107,8 @@ class OrderShippingListener
     {
         $this->shippingProcessor->updateShipmentStates(
             $this->getOrder($event)->getShipments(),
-            ShipmentInterface::STATE_READY
+            ShipmentInterface::STATE_READY,
+            ShipmentInterface::STATE_ONHOLD
         );
     }
 


### PR DESCRIPTION
Part of https://github.com/Sylius/Sylius/wiki/Status#wiki-successful-order.

BTW @pjedrzejewski @winzou We extended state resolver internally to resolve order state, it looks sth like this https://gist.github.com/umpirsky/2008fc7ca2484631b7f7 What do you think? Can we have something similar in Sylius?
