### PR TITLE
[ResourceBundle] Add symfony/expression-language as dependency

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/composer.json
+++ b/src/Sylius/Bundle/ResourceBundle/composer.json
@@ -24,6 +24,7 @@
 
         "symfony/framework-bundle":        "~2.3",
         "symfony/twig-bundle":             "~2.3",
+        "symfony/expression-language":     "~2.4",
         "friendsofsymfony/rest-bundle":    "~1.0",
         "jms/serializer-bundle":           "0.12.*",
         "white-october/pagerfanta-bundle": "1.0.*",


### PR DESCRIPTION
Add `symfony/expression-language` as dependency, because the `ExpressionLanguage` gets injected into the `ParametersParser`. It's not used at the moment, but I think @pjedrzejewski has his reasons to include it.
