### PR TITLE
Set shipment state to onhold before process payment.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderShippingListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderShippingListener.php
@@ -85,6 +85,20 @@ class OrderShippingListener
     }
 
     /**
+     * Update shipment states when payment is waiting for confirmation
+     *
+     * @param GenericEvent $event
+     */
+    public function updateShipmentStatesOnhold(GenericEvent $event)
+    {
+        $this->shippingProcessor->updateShipmentStates(
+            $this->getOrder($event)->getShipments(),
+            ShipmentInterface::STATE_ONHOLD,
+            ShipmentInterface::STATE_CHECKOUT
+        );
+    }
+
+    /**
      * Update shipment states after order is confirmed
      *
      * @param GenericEvent $event
@@ -93,8 +107,7 @@ class OrderShippingListener
     {
         $this->shippingProcessor->updateShipmentStates(
             $this->getOrder($event)->getShipments(),
-            ShipmentInterface::STATE_READY,
-            ShipmentInterface::STATE_CHECKOUT
+            ShipmentInterface::STATE_READY
         );
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -265,6 +265,7 @@
             <argument type="service" id="sylius.order_processing.shipping_processor" />
             <tag name="kernel.event_listener" event="sylius.checkout.shipping.initialize" method="processOrderShipments" />
             <tag name="kernel.event_listener" event="sylius.checkout.shipping.pre_complete" method="processOrderShippingCharges" />
+            <tag name="kernel.event_listener" event="sylius.checkout.finalize.pre_complete" method="updateShipmentStatesOnhold" />
             <tag name="kernel.event_listener" event="sylius.order.pre_pay" method="updateShipmentStatesReady" />
         </service>
         <service id="sylius.listener.shipment" class="%sylius.listener.shipment.class%">


### PR DESCRIPTION
See: https://github.com/Sylius/Sylius/wiki/Status

In the "Checkout finished (not paid)" step, shipment state should be changed to "onhold".
