### PR TITLE
Resource bundle depend on symfony form.

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/composer.json
+++ b/src/Sylius/Bundle/ResourceBundle/composer.json
@@ -28,7 +28,8 @@
         "friendsofsymfony/rest-bundle":    "~1.0",
         "jms/serializer-bundle":           "0.12.*",
         "white-october/pagerfanta-bundle": "1.0.*",
-        "doctrine/doctrine-bundle":        "~1.3@dev"
+        "doctrine/doctrine-bundle":        "~1.3@dev",
+        "symfony/form":                    "~2.3"
     },
     "require-dev": {
         "phpspec/phpspec":      "2.0.*@dev",


### PR DESCRIPTION
`EntityToIdentifierType` and `EntityToIdentifierTransformer` use some classes of the form component .
