### PR TITLE
[ResourceBundle][Proposal/idea]The configuration directory can be overwrote easily.

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/DependencyInjection/SyliusAddressingExtension.php
+++ b/src/Sylius/Bundle/AddressingBundle/DependencyInjection/SyliusAddressingExtension.php
@@ -26,8 +26,6 @@ class SyliusAddressingExtension extends BaseExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config';
-
         $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE | self::CONFIGURE_PARAMETERS | self::CONFIGURE_VALIDATORS);
     }
 }

--- a/src/Sylius/Bundle/CartBundle/DependencyInjection/SyliusCartExtension.php
+++ b/src/Sylius/Bundle/CartBundle/DependencyInjection/SyliusCartExtension.php
@@ -34,8 +34,6 @@ class SyliusCartExtension extends BaseExtension implements PrependExtensionInter
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config';
-
         list($config) = $this->configure($config, new Configuration(), $container);
 
         $container->setAlias('sylius.cart_provider', $config['provider']);

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
@@ -51,8 +51,6 @@ class SyliusCoreExtension extends BaseExtension implements PrependExtensionInter
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config';
-
         list($config, $loader) = $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE | self::CONFIGURE_PARAMETERS);
 
         $loader->load('mailer/mailer.xml');

--- a/src/Sylius/Bundle/InstallerBundle/DependencyInjection/SyliusInstallerExtension.php
+++ b/src/Sylius/Bundle/InstallerBundle/DependencyInjection/SyliusInstallerExtension.php
@@ -21,8 +21,6 @@ class SyliusInstallerExtension extends BaseExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config';
-
         list($config) = $this->configure($config, new Configuration(), $container);
 
         foreach ($config['classes'] as $model => $classes) {

--- a/src/Sylius/Bundle/InventoryBundle/DependencyInjection/SyliusInventoryExtension.php
+++ b/src/Sylius/Bundle/InventoryBundle/DependencyInjection/SyliusInventoryExtension.php
@@ -32,8 +32,6 @@ class SyliusInventoryExtension extends BaseExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config';
-
         list($config) = $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE);
 
         $container->setParameter('sylius.backorders', $config['backorders']);

--- a/src/Sylius/Bundle/MoneyBundle/DependencyInjection/SyliusMoneyExtension.php
+++ b/src/Sylius/Bundle/MoneyBundle/DependencyInjection/SyliusMoneyExtension.php
@@ -26,8 +26,6 @@ class SyliusMoneyExtension extends BaseExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config';
-
         list($config) = $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE | self::CONFIGURE_PARAMETERS);
 
         $container->setParameter('sylius.money.locale', $config['locale']);

--- a/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
+++ b/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
@@ -26,8 +26,6 @@ class SyliusOrderExtension extends BaseExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config';
-
         $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE | self::CONFIGURE_PARAMETERS | self::CONFIGURE_VALIDATORS);
     }
 }

--- a/src/Sylius/Bundle/PaymentsBundle/DependencyInjection/SyliusPaymentsExtension.php
+++ b/src/Sylius/Bundle/PaymentsBundle/DependencyInjection/SyliusPaymentsExtension.php
@@ -26,8 +26,6 @@ class SyliusPaymentsExtension extends BaseExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config';
-
         list($config) = $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE | self::CONFIGURE_PARAMETERS | self::CONFIGURE_VALIDATORS);
 
         $container->setParameter('sylius.payment_gateways', $config['gateways']);

--- a/src/Sylius/Bundle/PayumBundle/DependencyInjection/SyliusPayumExtension.php
+++ b/src/Sylius/Bundle/PayumBundle/DependencyInjection/SyliusPayumExtension.php
@@ -21,8 +21,6 @@ class SyliusPayumExtension extends BaseExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config';
-
         $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE | self::CONFIGURE_PARAMETERS);
     }
 }

--- a/src/Sylius/Bundle/ProductBundle/DependencyInjection/SyliusProductExtension.php
+++ b/src/Sylius/Bundle/ProductBundle/DependencyInjection/SyliusProductExtension.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class SyliusProductExtension extends BaseExtension
 {
+    protected $configDirectory = '/../Resources/config/container';
     protected $configFiles = array(
         'products',
         'properties',
@@ -32,8 +33,6 @@ class SyliusProductExtension extends BaseExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config/container';
-
         $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE | self::CONFIGURE_PARAMETERS | self::CONFIGURE_VALIDATORS);
     }
 }

--- a/src/Sylius/Bundle/PromotionsBundle/DependencyInjection/SyliusPromotionsExtension.php
+++ b/src/Sylius/Bundle/PromotionsBundle/DependencyInjection/SyliusPromotionsExtension.php
@@ -26,8 +26,6 @@ class SyliusPromotionsExtension extends BaseExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config';
-
         $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE | self::CONFIGURE_PARAMETERS | self::CONFIGURE_VALIDATORS);
     }
 }

--- a/src/Sylius/Bundle/SettingsBundle/DependencyInjection/SyliusSettingsExtension.php
+++ b/src/Sylius/Bundle/SettingsBundle/DependencyInjection/SyliusSettingsExtension.php
@@ -26,8 +26,6 @@ class SyliusSettingsExtension extends BaseExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config';
-
         list($config) = $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE);
 
         $classes = $config['classes'];

--- a/src/Sylius/Bundle/ShippingBundle/DependencyInjection/SyliusShippingExtension.php
+++ b/src/Sylius/Bundle/ShippingBundle/DependencyInjection/SyliusShippingExtension.php
@@ -26,7 +26,6 @@ class SyliusShippingExtension extends BaseExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config';
         $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE | self::CONFIGURE_PARAMETERS | self::CONFIGURE_VALIDATORS);
     }
 }

--- a/src/Sylius/Bundle/TaxationBundle/DependencyInjection/SyliusTaxationExtension.php
+++ b/src/Sylius/Bundle/TaxationBundle/DependencyInjection/SyliusTaxationExtension.php
@@ -26,8 +26,6 @@ class SyliusTaxationExtension extends BaseExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config';
-
         $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE | self::CONFIGURE_PARAMETERS | self::CONFIGURE_VALIDATORS);
     }
 }

--- a/src/Sylius/Bundle/TaxonomiesBundle/DependencyInjection/SyliusTaxonomiesExtension.php
+++ b/src/Sylius/Bundle/TaxonomiesBundle/DependencyInjection/SyliusTaxonomiesExtension.php
@@ -26,8 +26,6 @@ class SyliusTaxonomiesExtension extends BaseExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config';
-
         $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE | self::CONFIGURE_PARAMETERS | self::CONFIGURE_VALIDATORS);
     }
 }

--- a/src/Sylius/Bundle/VariableProductBundle/DependencyInjection/SyliusVariableProductExtension.php
+++ b/src/Sylius/Bundle/VariableProductBundle/DependencyInjection/SyliusVariableProductExtension.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
  */
 class SyliusVariableProductExtension extends BaseExtension implements PrependExtensionInterface
 {
+    protected $configDirectory = '/../Resources/config/container';
     protected $configFiles = array(
         'options',
         'variants',
@@ -33,8 +34,6 @@ class SyliusVariableProductExtension extends BaseExtension implements PrependExt
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configDir = __DIR__.'/../Resources/config/container';
-
         $config[0]['driver'] = $container->getParameter('sylius_product.driver');
         $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE | self::CONFIGURE_PARAMETERS | self::CONFIGURE_VALIDATORS);
     }


### PR DESCRIPTION
Before this PR, you have to define the configuration directory in `BaseExtension::load` all the time. Now, the default value is `/../Resources/config`and you just need to override this attribute if you want to change it (the path to the root of the bundle is calculated too). It is useful if your bundles embed their own configuration (like Sylius) when use this bundle standalone.
