### PR TITLE
[ResourceBundle][Fix]Missing Method

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Doctrine/ODM/PHPCR/DocumentRepository.php
+++ b/src/Sylius/Bundle/ResourceBundle/Doctrine/ODM/PHPCR/DocumentRepository.php
@@ -83,6 +83,15 @@ class DocumentRepository extends BaseDocumentRepository implements RepositoryInt
         $queryBuilder->end();
     }
 
+    protected function getPropertyName($name)
+    {
+        if (false === strpos($name, '.')) {
+            return $this->getAlias().'.'.$name;
+        }
+
+        return $name;
+    }
+
     protected function getAlias()
     {
         return 'o';


### PR DESCRIPTION
It miss the method `getPropertyName` in `DocumentRepository`, I copy paste it from `EntityRepository`. The better solution is to use a trait but it is not compatible with `5.3.3`
