### PR TITLE
[WebBundle] [WIP] Extendable backend menu

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Event/MenuBuilderEvent.php
+++ b/src/Sylius/Bundle/WebBundle/Event/MenuBuilderEvent.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\WebBundle\Event;
+
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Menu builder event. Used for extending the menus.
+ *
+ * @author Patrik Karisch <patrik.karisch@abimus.com>
+ */
+class MenuBuilderEvent extends Event
+{
+    const BACKEND_MAIN = 'sylius.menu_builder.backend.main';
+    const BACKEND_SIDEBAR = 'sylius.menu_builder.backend.sidebar';
+
+    /**
+     * @var FactoryInterface
+     */
+    private $factory;
+
+    /**
+     * @var ItemInterface
+     */
+    private $menu;
+
+    /**
+     * @param FactoryInterface $factory
+     * @param ItemInterface    $menu
+     */
+    public function __construct(FactoryInterface $factory, ItemInterface $menu)
+    {
+        $this->factory = $factory;
+        $this->menu = $menu;
+    }
+
+    /**
+     * @return FactoryInterface
+     */
+    public function getFactory()
+    {
+        return $this->factory;
+    }
+
+    /**
+     * @return ItemInterface
+     */
+    public function getMenu()
+    {
+        return $this->menu;
+    }
+}

--- a/src/Sylius/Bundle/WebBundle/Menu/BackendMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/BackendMenuBuilder.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\WebBundle\Menu;
 
 use Knp\Menu\ItemInterface;
+use Sylius\Bundle\WebBundle\Event\MenuBuilderEvent;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -60,6 +61,8 @@ class BackendMenuBuilder extends MenuBuilder
             'route' => 'fos_user_security_logout'
         ))->setLabel($this->translate('sylius.backend.logout'));
 
+        $this->eventDispatcher->dispatch(MenuBuilderEvent::BACKEND_MAIN, new MenuBuilderEvent($this->factory, $menu));
+
         return $menu;
     }
 
@@ -88,6 +91,8 @@ class BackendMenuBuilder extends MenuBuilder
         $this->addCustomersMenu($menu, $childOptions, 'sidebar');
         $this->addContentMenu($menu, $childOptions, 'sidebar');
         $this->addConfigurationMenu($menu, $childOptions, 'sidebar');
+
+        $this->eventDispatcher->dispatch(MenuBuilderEvent::BACKEND_SIDEBAR, new MenuBuilderEvent($this->factory, $menu));
 
         return $menu;
     }

--- a/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
@@ -17,6 +17,7 @@ use Sylius\Bundle\CartBundle\Provider\CartProviderInterface;
 use Sylius\Bundle\MoneyBundle\Twig\SyliusMoneyExtension;
 use Sylius\Bundle\ResourceBundle\Model\RepositoryInterface;
 use Sylius\Bundle\TaxonomiesBundle\Model\TaxonInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -63,6 +64,7 @@ class FrontendMenuBuilder extends MenuBuilder
      * @param FactoryInterface         $factory
      * @param SecurityContextInterface $securityContext
      * @param TranslatorInterface      $translator
+     * @param EventDispatcherInterface $eventDispatcher
      * @param RepositoryInterface      $exchangeRateRepository
      * @param RepositoryInterface      $taxonomyRepository
      * @param CartProviderInterface    $cartProvider
@@ -72,13 +74,14 @@ class FrontendMenuBuilder extends MenuBuilder
         FactoryInterface         $factory,
         SecurityContextInterface $securityContext,
         TranslatorInterface      $translator,
+        EventDispatcherInterface $eventDispatcher,
         RepositoryInterface      $exchangeRateRepository,
         RepositoryInterface      $taxonomyRepository,
         CartProviderInterface    $cartProvider,
         SyliusMoneyExtension     $moneyExtension
     )
     {
-        parent::__construct($factory, $securityContext, $translator);
+        parent::__construct($factory, $securityContext, $translator, $eventDispatcher);
 
         $this->exchangeRateRepository = $exchangeRateRepository;
         $this->taxonomyRepository = $taxonomyRepository;

--- a/src/Sylius/Bundle/WebBundle/Menu/MenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/MenuBuilder.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\WebBundle\Menu;
 
 use Knp\Menu\FactoryInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
@@ -53,17 +54,29 @@ abstract class MenuBuilder
     protected $request;
 
     /**
+     * @var EventDispatcherInterface
+     */
+    protected $eventDispatcher;
+
+    /**
      * Constructor.
      *
      * @param FactoryInterface         $factory
      * @param SecurityContextInterface $securityContext
      * @param TranslatorInterface      $translator
+     * @param EventDispatcherInterface $eventDispatcher
      */
-    public function __construct(FactoryInterface $factory, SecurityContextInterface $securityContext, TranslatorInterface $translator)
+    public function __construct(
+        FactoryInterface $factory,
+        SecurityContextInterface $securityContext,
+        TranslatorInterface $translator,
+        EventDispatcherInterface $eventDispatcher
+    )
     {
         $this->factory = $factory;
         $this->securityContext = $securityContext;
         $this->translator = $translator;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**

--- a/src/Sylius/Bundle/WebBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/services.xml
@@ -53,6 +53,7 @@
             <argument type="service" id="knp_menu.factory" />
             <argument type="service" id="security.context" />
             <argument type="service" id="translator" />
+            <argument type="service" id="event_dispatcher" />
             <argument type="service" id="sylius.repository.exchange_rate" />
             <argument type="service" id="sylius.repository.taxonomy" />
             <argument type="service" id="sylius.cart_provider" />
@@ -65,6 +66,7 @@
             <argument type="service" id="knp_menu.factory" />
             <argument type="service" id="security.context" />
             <argument type="service" id="translator" />
+            <argument type="service" id="event_dispatcher" />
         </service>
 
         <service id="sylius.menu.frontend.main" class="Knp\Menu\MenuItem" factory-service="sylius.menu_builder.frontend" factory-method="createMainMenu" scope="request">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | n/a |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | Sylius/Sylius-Docs#135 |

This feature enables to extend the whole backend menu with custom menu entries via [menu builder events](https://github.com/KnpLabs/KnpMenuBundle/blob/master/Resources/doc/events.md).
- [x] Needs review and feedback
- [ ] Add tests for this feature (need help which)
- [x] Submit PR for the documentation

Usage:

``` php
// src/Acme/ReportsBundle/EventListener/MenuBuilderListener.php
<?php

namespace Acme\ReportsBundle\EventListener;

use Sylius\Bundle\WebBundle\Event\MenuBuilderEvent;

class MenuBuilderListener
{
    public function addBackendMenuItems(MenuBuilderEvent $event)
    {
        $menu = $event->getMenu();

        $menu['sales']->addChild('reports', array(
            'route' => 'acme_reports_index',
            'labelAttributes' => array('icon' => 'glyphicon glyphicon-stats'),
        ))->setLabel('Daily and monthly reports');
    }
}
```

``` xml
<!-- src/Acme/ReportsBundle/Resources/config/services.xml -->
<services>
    <service id="acme_reports.menu_builder" class="Acme\ReportsBundle\EventListener\MenuBuilderListener">
        <tag name="kernel.event_listener" event="sylius.menu_builder.backend.main" method="addBackendMenuItems" />
        <tag name="kernel.event_listener" event="sylius.menu_builder.backend.sidebar" method="addBackendMenuItems" />
    </service>
</services>
```
