### PR TITLE
[POC] Add initial CustomizationBundle

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
@@ -53,6 +53,7 @@ class SyliusCoreExtension extends AbstractResourceExtension implements PrependEx
         'sylius_variation',
         'sylius_translation',
         'sylius_rbac',
+        'sylius_customization',
     );
 
     protected $configFiles = array(

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/CartItemType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/CartItemType.php
@@ -14,6 +14,8 @@ namespace Sylius\Bundle\CoreBundle\Form\Type;
 use Sylius\Bundle\CartBundle\Form\Type\CartItemType as BaseCartItemType;
 use Sylius\Component\Core\Model\Product;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -40,6 +42,21 @@ class CartItemType extends BaseCartItemType
                 'variable'  => $options['product']
             ));
         }
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function(FormEvent $event) use($options) {
+            $item = $event->getData();
+
+            if (null === $item) {
+                return;
+            }
+
+            $product = isset($options['product']) ? $options['product'] : $item->getProduct();
+
+            $event->getForm()->add('customizationValues', 'sylius_customization_values', array(
+                'subjectInstance' => $item,
+                'customizations'  => $product->getCustomizations()
+            ));
+        });
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/ProductType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/ProductType.php
@@ -59,6 +59,10 @@ class ProductType extends BaseProductType
                 'empty_value' => '---',
                 'label'       => 'sylius.form.product.restricted_zone',
             ))
+            ->add('customizations', 'sylius_customization_choice', array(
+                'required'     => false,
+                'multiple'     => true
+            ))
         ;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Kernel/Kernel.php
+++ b/src/Sylius/Bundle/CoreBundle/Kernel/Kernel.php
@@ -70,6 +70,7 @@ abstract class Kernel extends BaseKernel
             new \Sylius\Bundle\SearchBundle\SyliusSearchBundle(),
             new \Sylius\Bundle\RbacBundle\SyliusRbacBundle(),
             new \Sylius\Bundle\UserBundle\SyliusUserBundle(),
+            new \Sylius\Bundle\CustomizationBundle\SyliusCustomizationBundle(),
 
             new \Sylius\Bundle\CoreBundle\SyliusCoreBundle(),
             new \Sylius\Bundle\WebBundle\SyliusWebBundle(),

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
@@ -283,6 +283,13 @@ sylius_mailer:
             subject: sylius.emails.user.password_reset.subject
             template: SyliusWebBundle:Email:passwordReset.html.twig
 
+sylius_customization:
+    classes:
+        customization_subject:
+            model: %sylius.model.product.class%
+        customization_subject_instance:
+            model: %sylius.model.order_item.class%
+
 sylius_rbac:
     classes:
         role:
@@ -600,6 +607,13 @@ sylius_rbac:
         sylius.accounts: Manage user accounts
         sylius.taxes: Manage taxes
         sylius.support: Manage customer support
+
+        sylius.manage.customization: Manage customizations
+        sylius.customization.show: Show customization
+        sylius.customization.index: List customizations
+        sylius.customization.create: Create customization
+        sylius.customization.update: Edit customization
+        sylius.customization.delete: Delete customization
     permissions_hierarchy:
         sylius.manage.channel: [sylius.channel.show, sylius.channel.index, sylius.channel.create, sylius.channel.update, sylius.channel.delete]
         sylius.manage.customer: [sylius.customer.show, sylius.customer.index, sylius.customer.create, sylius.customer.update, sylius.customer.delete]
@@ -642,8 +656,9 @@ sylius_rbac:
         sylius.manage.contact_request: [sylius.contact_request.show, sylius.contact_request.index, sylius.contact_request.create, sylius.contact_request.update, sylius.contact_request.delete]
         sylius.manage.contact_topic: [sylius.contact_topic.show, sylius.contact_topic.index, sylius.contact_topic.create, sylius.contact_topic.update, sylius.contact_topic.delete]
         sylius.manage.settings: [sylius.settings.general, sylius.settings.security, sylius.settings.taxation]
+        sylius.manage.customization: [sylius.customization.show, sylius.customization.index, sylius.customization.create, sylius.customization.update, sylius.customization.delete]
 
-        sylius.catalog: [sylius.manage.product, sylius.manage.product_attribute, sylius.manage.product_option, sylius.manage.product_archetype, sylius.manage.product_variant, sylius.manage.taxonomy, sylius.manage.taxon]
+        sylius.catalog: [sylius.manage.product, sylius.manage.product_attribute, sylius.manage.product_option, sylius.manage.product_archetype, sylius.manage.product_variant, sylius.manage.taxonomy, sylius.manage.taxon, sylius.manage.customization]
         sylius.sales: [sylius.manage.order, sylius.manage.payment, sylius.manage.report]
         sylius.marketing: [sylius.manage.promotion, sylius.manage.promotion_coupon, sylius.manage.email]
         sylius.shipping: [sylius.manage.shipment, sylius.manage.shipping_method, sylius.manage.shipping_category]

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/OrderItem.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/OrderItem.orm.xml
@@ -43,6 +43,12 @@
             <gedmo:versioned />
         </many-to-many>
 
+        <one-to-many field="customizationValues" mapped-by="subjectInstance" target-entity="Sylius\Component\Customization\Model\CustomizationValueInterface">
+            <cascade>
+                <cascade-all />
+            </cascade>
+        </one-to-many>
+
         <gedmo:loggable />
     </mapped-superclass>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Product.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Product.orm.xml
@@ -57,6 +57,20 @@
             </join-table>
         </many-to-many>
 
+        <many-to-many field="customizations" target-entity="Sylius\Component\Customization\Model\CustomizationInterface">
+            <join-table name="sylius_product_customization">
+                <join-columns>
+                    <join-column name="product_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="customization_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
+                </inverse-join-columns>
+            </join-table>
+            <cascade>
+                <cascade-persist/>
+            </cascade>
+        </many-to-many>
+
         <gedmo:loggable />
     </mapped-superclass>
 

--- a/src/Sylius/Bundle/CustomizationBundle/.gitignore
+++ b/src/Sylius/Bundle/CustomizationBundle/.gitignore
@@ -1,0 +1,5 @@
+vendor/
+bin/
+
+composer.phar
+composer.lock

--- a/src/Sylius/Bundle/CustomizationBundle/.travis.yml
+++ b/src/Sylius/Bundle/CustomizationBundle/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+
+before_script: composer install --prefer-source --no-interaction
+
+script: bin/phpspec run -fpretty --verbose
+
+notifications:
+    email: "travis-ci@sylius.org"
+    irc:   "irc.freenode.org#sylius-dev"

--- a/src/Sylius/Bundle/CustomizationBundle/CHANGELOG.md
+++ b/src/Sylius/Bundle/CustomizationBundle/CHANGELOG.md
@@ -1,0 +1,6 @@
+CHANGELOG
+=========
+
+### v0.14
+
+* Initial dev release.

--- a/src/Sylius/Bundle/CustomizationBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/CustomizationBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CustomizationBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This class contains the configuration information for the bundle.
+ *
+ * This information is solely responsible for how the different configuration
+ * sections are normalized, and merged.
+ *
+ * @author Paweł Jędrzejewski <pjedrzejewski@diweb.pl>
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('sylius_customization');
+
+        $rootNode
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->scalarNode('driver')->defaultNull()->end()
+            ->end()
+        ;
+
+        $this->addClassesSection($rootNode);
+        $this->addValidationGroupsSection($rootNode);
+
+        return $treeBuilder;
+    }
+
+    /**
+     * Adds `validation_groups` section.
+     *
+     * @param ArrayNodeDefinition $node
+     */
+    private function addValidationGroupsSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('validation_groups')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('customization')
+                            ->prototype('scalar')->end()
+                            ->defaultValue(array('sylius'))
+                        ->end()
+                        ->arrayNode('customization_value')
+                            ->prototype('scalar')->end()
+                            ->defaultValue(array('sylius'))
+                        ->end()
+                        ->arrayNode('customization_subject')
+                            ->prototype('scalar')->end()
+                            ->defaultValue(array('sylius'))
+                        ->end()
+                        ->arrayNode('customization_subject_instance')
+                            ->prototype('scalar')->end()
+                            ->defaultValue(array('sylius'))
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * Adds `classes` section.
+     *
+     * @param ArrayNodeDefinition $node
+     */
+    private function addClassesSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('classes')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('customization')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('model')->defaultValue('Sylius\\Component\\Customization\\Model\\Customization')->end()
+                                ->scalarNode('controller')->defaultValue('Sylius\\Bundle\\ResourceBundle\\Controller\\ResourceController')->end()
+                                ->scalarNode('repository')->defaultValue('Sylius\\Bundle\\ResourceBundle\\Doctrine\\ORM\\EntityRepository')->end()
+                                ->scalarNode('form')->defaultValue('Sylius\\Bundle\\CustomizationBundle\\Form\\Type\\CustomizationType')->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('customization_value')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('model')->defaultValue('Sylius\\Component\\Customization\\Model\\CustomizationValue')->end()
+                                ->scalarNode('controller')->defaultValue('Sylius\\Bundle\\ResourceBundle\\Controller\\ResourceController')->end()
+                                ->scalarNode('repository')->defaultValue('Sylius\\Bundle\\ResourceBundle\\Doctrine\\ORM\\EntityRepository')->end()
+                                ->scalarNode('form')->defaultValue('Sylius\\Bundle\\CustomizationBundle\\Form\\Type\\CustomizationValueType')->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('customization_subject')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('model')->defaultValue('Sylius\\Component\\Customization\\Model\\CustomizationSubject')->end()
+                                ->scalarNode('controller')->defaultValue('Sylius\\Bundle\\ResourceBundle\\Controller\\ResourceController')->end()
+                                ->scalarNode('repository')->defaultValue('Sylius\\Bundle\\ResourceBundle\\Doctrine\\ORM\\EntityRepository')->end()
+                                ->scalarNode('form')->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('customization_subject_instance')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('model')->defaultValue('Sylius\\Component\\Customization\\Model\\CustomizationSubjectInstance')->end()
+                                ->scalarNode('controller')->defaultValue('Sylius\\Bundle\\ResourceBundle\\Controller\\ResourceController')->end()
+                                ->scalarNode('repository')->defaultValue('Sylius\\Bundle\\ResourceBundle\\Doctrine\\ORM\\EntityRepository')->end()
+                                ->scalarNode('form')->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+}

--- a/src/Sylius/Bundle/CustomizationBundle/DependencyInjection/SyliusCustomizationExtension.php
+++ b/src/Sylius/Bundle/CustomizationBundle/DependencyInjection/SyliusCustomizationExtension.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CustomizationBundle\DependencyInjection;
+
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractResourceExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+
+/**
+ * Sylius customization system container extension.
+ *
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+class SyliusCustomizationExtension extends AbstractResourceExtension implements PrependExtensionInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $config, ContainerBuilder $container)
+    {
+        $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE | self::CONFIGURE_PARAMETERS | self::CONFIGURE_VALIDATORS);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        if (!$container->hasExtension('sylius_customization')) {
+            return;
+        }
+
+        $container->prependExtensionConfig('sylius_customization', array(
+            'classes' => array(
+                'customization' => array(
+                    'model' => 'Sylius\Component\Customization\Model\Customization',
+                    'form'  => 'Sylius\Bundle\CustomizationBundle\Form\Type\CustomizationType'
+                ),
+                'customization_value' => array(
+                    'model' => 'Sylius\Component\Customization\Model\CustomizationValue',
+                    'form'  => 'Sylius\Bundle\CustomizationBundle\Form\Type\CustomizationValueType'
+                ),
+                'customization_subject' => array(
+                    'model' => 'Sylius\Component\Customization\Model\CustomizationSubject',
+                    'form'  => 'Sylius\Bundle\CustomizationBundle\Form\Type\CustomizationSubjectType'
+                )
+            ))
+        );
+    }
+}

--- a/src/Sylius/Bundle/CustomizationBundle/Form/Type/CustomizationType.php
+++ b/src/Sylius/Bundle/CustomizationBundle/Form/Type/CustomizationType.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CustomizationBundle\Form\Type;
+
+use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Customization form.
+ *
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+class CustomizationType extends AbstractResourceType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('name', 'text')
+            ->add('type', 'choice', array(
+                'choices' => array('text')
+            ))
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sylius_customization';
+    }
+}

--- a/src/Sylius/Bundle/CustomizationBundle/Form/Type/CustomizationValueType.php
+++ b/src/Sylius/Bundle/CustomizationBundle/Form/Type/CustomizationValueType.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CustomizationBundle\Form\Type;
+
+use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * Customization form.
+ *
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+class CustomizationValueType extends AbstractResourceType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $customization = $options['customization'];
+
+        $builder
+            ->add('value', $customization->getType(), array(
+                'label' => $customization->getName()
+            ))
+        ;
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        parent::setDefaultOptions($resolver);
+
+        $resolver
+            ->setRequired(array(
+                'customization',
+            ))
+            ->setAllowedTypes(array(
+                'customization' => 'Sylius\Component\Customization\Model\CustomizationInterface'
+            ))
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sylius_customization_value';
+    }
+}

--- a/src/Sylius/Bundle/CustomizationBundle/Form/Type/CustomizationValuesType.php
+++ b/src/Sylius/Bundle/CustomizationBundle/Form/Type/CustomizationValuesType.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CustomizationBundle\Form\Type;
+
+use Gedmo\Sluggable\Util\Urlizer;
+use Sylius\Component\Customization\Model\CustomizationInterface;
+use Sylius\Component\Customization\Model\CustomizationSubjectInstanceInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class CustomizationValuesType extends AbstractType
+{
+    /**
+     * @var RepositoryInterface
+     */
+    protected $customizationValueRepository;
+
+    public function __construct(RepositoryInterface $repository)
+    {
+        $this->customizationValueRepository = $repository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $repository = $this->customizationValueRepository;
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function(FormEvent $event) use($options, $repository) {
+            /** @var CustomizationSubjectInstanceInterface $subjectInstance */
+            $subjectInstance = $options['subjectInstance'];
+
+            foreach ($options['customizations'] as $i => $customization) {
+                if (!$customization instanceof CustomizationInterface) {
+                    throw new UnexpectedTypeException($customization, 'Sylius\Component\Customization\Model\CustomizationInterface');
+                }
+
+                $customizationValue = $subjectInstance->getCustomizationValueByName($customization->getName());
+
+                if (null === $customizationValue) {
+                    $customizationValue = $repository->createNew();
+                    $customizationValue->setCustomization($customization);
+                    $subjectInstance->addCustomizationValue($customizationValue);
+                }
+
+                $event->getForm()->add(Urlizer::urlize($customization->getName()), 'sylius_customization_value', array(
+                    'customization' => $customization,
+                    'label'         => false,
+                    'data'          => $customizationValue,
+                    'property_path' => '['.$i.']'
+                ));
+            }
+        });
+
+    }
+
+    /**
+     * (@inheritdoc)
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        parent::setDefaultOptions($resolver);
+
+        $resolver
+            ->setRequired(array(
+                'subjectInstance',
+                'customizations'
+            ))
+            ->setAllowedTypes(array(
+                'subjectInstance' => array('Sylius\Component\Customization\Model\CustomizationSubjectInstanceInterface'),
+                'customizations'  => array('array', 'Doctrine\Common\Collections\Collection')
+            ))
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sylius_customization_values';
+    }
+}

--- a/src/Sylius/Bundle/CustomizationBundle/README.md
+++ b/src/Sylius/Bundle/CustomizationBundle/README.md
@@ -1,0 +1,74 @@
+SyliusCustomizationBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusCustomizationBundle.png?branch=master)](http://travis-ci.org/Sylius/SyliusCustomizationBundle)
+===========================
+
+...
+
+Sylius
+------
+
+**Sylius** - Modern ecommerce for Symfony2. Visit [Sylius.org](http://sylius.org).
+
+[phpspec](http://phpspec.net) examples
+--------------------------------------
+
+```bash
+$ composer install
+$ bin/phpspec run -fpretty
+```
+
+Documentation
+-------------
+
+Documentation is available on [**docs.sylius.org**](http://docs.sylius.org/en/latest/bundles/SyliusCustomizationBundle/index.html).
+
+Contributing
+------------
+
+All informations about contributing to Sylius can be found on [this page](http://docs.sylius.org/en/latest/contributing/index.html).
+
+Mailing lists
+-------------
+
+### Users
+
+Questions? Feel free to ask on [users mailing list](http://groups.google.com/group/sylius).
+
+### Developers
+
+To contribute and develop this bundle, use the [developers mailing list](http://groups.google.com/group/sylius-dev).
+
+Sylius twitter account
+----------------------
+
+If you want to keep up with updates, [follow the official Sylius account on twitter](http://twitter.com/Sylius).
+
+Bug tracking
+------------
+
+This bundle uses [GitHub issues](https://github.com/Sylius/SyliusCustomizationBundle/issues).
+If you have found bug, please create an issue.
+
+Versioning
+----------
+
+Releases will be numbered with the format `major.minor.patch`.
+
+And constructed with the following guidelines.
+
+* Breaking backwards compatibility bumps the major.
+* New additions without breaking backwards compatibility bumps the minor.
+* Bug fixes and misc changes bump the patch.
+
+For more information on SemVer, please visit [semver.org website](http://semver.org/).  
+This versioning method is same for all **Sylius** bundles and applications.
+
+MIT License
+-----------
+
+License can be found [here](https://github.com/Sylius/SyliusCustomizationBundle/blob/master/Resources/meta/LICENSE).
+
+Authors
+-------
+
+The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+See the list of [contributors](https://github.com/Sylius/SyliusCustomizationBundle/contributors).

--- a/src/Sylius/Bundle/CustomizationBundle/Resources/config/doctrine/model/Customization.orm.xml
+++ b/src/Sylius/Bundle/CustomizationBundle/Resources/config/doctrine/model/Customization.orm.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                  http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
+                  xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping"
+>
+
+    <mapped-superclass name="Sylius\Component\Customization\Model\Customization" table="sylius_customization">
+        <id name="id" column="id" type="integer">
+            <generator strategy="AUTO" />
+        </id>
+
+        <field name="name" column="name" type="string" />
+
+        <field name="type" column="type" type="string" />
+
+        <field name="createdAt" column="created_at" type="datetime">
+            <gedmo:timestampable on="create"/>
+        </field>
+        <field name="updatedAt" column="updated_at" type="datetime" nullable="true">
+            <gedmo:timestampable on="update"/>
+        </field>
+        <field name="deletedAt" column="deleted_at" type="datetime" nullable="true" />
+
+        <gedmo:soft-deleteable field-name="deletedAt" />
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/src/Sylius/Bundle/CustomizationBundle/Resources/config/doctrine/model/CustomizationSubject.orm.xml
+++ b/src/Sylius/Bundle/CustomizationBundle/Resources/config/doctrine/model/CustomizationSubject.orm.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                  http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
+>
+
+    <mapped-superclass name="Sylius\Component\Customization\Model\CustomizationSubject" table="sylius_customization_subject">
+        <id name="id" column="id" type="integer">
+            <generator strategy="AUTO" />
+        </id>
+
+        <many-to-many field="customizations" target-entity="Sylius\Component\Customization\Model\CustomizationInterface">
+            <join-table name="sylius_customization_subjects">
+                <join-columns>
+                    <join-column name="customization_subject_id" referenced-column-name="id" nullable="false" unique="false" on-delete="CASCADE" />
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="customization_id" referenced-column-name="id" nullable="false" unique="false" on-delete="CASCADE" />
+                </inverse-join-columns>
+            </join-table>
+            <cascade>
+                <cascade-persist />
+            </cascade>
+        </many-to-many>
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/src/Sylius/Bundle/CustomizationBundle/Resources/config/doctrine/model/CustomizationSubjectInstance.orm.xml
+++ b/src/Sylius/Bundle/CustomizationBundle/Resources/config/doctrine/model/CustomizationSubjectInstance.orm.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping">
+
+    <mapped-superclass name="Sylius\Component\Customization\Model\CustomizationSubjectInstance" table="sylius_customization_subject_instance">
+        
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/src/Sylius/Bundle/CustomizationBundle/Resources/config/doctrine/model/CustomizationValue.orm.xml
+++ b/src/Sylius/Bundle/CustomizationBundle/Resources/config/doctrine/model/CustomizationValue.orm.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                  http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
+>
+
+    <mapped-superclass name="Sylius\Component\Customization\Model\CustomizationValue" table="sylius_customization_value">
+        <id name="id" column="id" type="integer">
+            <generator strategy="AUTO" />
+        </id>
+        <field name="value" column="value" type="string" />
+        
+        <many-to-one field="customization" target-entity="Sylius\Component\Customization\Model\CustomizationInterface">
+            <cascade>
+                <cascade-persist />
+            </cascade>
+        </many-to-one>
+        
+        <many-to-one field="subjectInstance" inversed-by="customizationValues" target-entity="Sylius\Component\Customization\Model\CustomizationSubjectInstanceInterface">
+            <join-column name="subject_instance_id" referenced-column-name="id" nullable="false" unique="false" />
+        </many-to-one>
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/src/Sylius/Bundle/CustomizationBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CustomizationBundle/Resources/config/services.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+                               http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sylius.form.type.customization.class">Sylius\Bundle\CustomizationBundle\Form\Type\CustomizationType</parameter>
+        <parameter key="sylius.form.type.customization_value.class">Sylius\Bundle\CustomizationBundle\Form\Type\CustomizationValueType</parameter>
+        <parameter key="sylius.form.type.customization_values.class">Sylius\Bundle\CustomizationBundle\Form\Type\CustomizationValuesType</parameter>
+    </parameters>
+    
+    <services>
+        <service id="sylius.form.type.customization" class="%sylius.form.type.customization.class%">
+            <argument>%sylius.model.customization.class%</argument>
+            <argument>%sylius.validation_group.customization%</argument>
+            <tag name="form.type" alias="sylius_customization" />
+        </service>
+        <service id="sylius.form.type.customization_value" class="%sylius.form.type.customization_value.class%">
+            <argument>%sylius.model.customization_value.class%</argument>
+            <argument>%sylius.validation_group.customization_value%</argument>
+            <tag name="form.type" alias="sylius_customization_value" />
+        </service>
+        <service id="sylius.form.type.customization_values" class="%sylius.form.type.customization_values.class%">
+            <argument type="service" id="sylius.repository.customization_value" />
+            <tag name="form.type" alias="sylius_customization_values" />
+        </service>
+    </services>
+
+</container>

--- a/src/Sylius/Bundle/CustomizationBundle/Resources/meta/LICENSE
+++ b/src/Sylius/Bundle/CustomizationBundle/Resources/meta/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2011-2014 Paweł Jędrzejewski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Sylius/Bundle/CustomizationBundle/SyliusCustomizationBundle.php
+++ b/src/Sylius/Bundle/CustomizationBundle/SyliusCustomizationBundle.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CustomizationBundle;
+
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\ResolveDoctrineTargetEntitiesPass;
+use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * Customization Bundle
+ *
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+class SyliusCustomizationBundle extends Bundle
+{
+    /**
+     * Return array with currently supported drivers.
+     *
+     * @return array
+     */
+    public static function getSupportedDrivers()
+    {
+        return array(
+            SyliusResourceBundle::DRIVER_DOCTRINE_ORM
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $interfaces = array(
+            'Sylius\Component\Customization\Model\CustomizationInterface'                => 'sylius.model.customization.class',
+            'Sylius\Component\Customization\Model\CustomizationValueInterface'           => 'sylius.model.customization_value.class',
+            'Sylius\Component\Customization\Model\CustomizationSubjectInterface'         => 'sylius.model.customization_subject.class',
+            'Sylius\Component\Customization\Model\CustomizationSubjectInstanceInterface' => 'sylius.model.customization_subject_instance.class',
+        );
+
+        $container->addCompilerPass(new ResolveDoctrineTargetEntitiesPass('sylius_customization', $interfaces));
+
+        $mappings = array(
+            realpath(__DIR__ . '/Resources/config/doctrine/model') => 'Sylius\Component\Customization\Model',
+        );
+
+        $container->addCompilerPass(DoctrineOrmMappingsPass::createXmlMappingDriver($mappings, array('doctrine.orm.entity_manager'), 'sylius_customization.driver.doctrine/orm'));
+    }
+}

--- a/src/Sylius/Bundle/CustomizationBundle/composer.json
+++ b/src/Sylius/Bundle/CustomizationBundle/composer.json
@@ -1,0 +1,50 @@
+{
+    "name": "sylius/customization-bundle",
+    "type": "symfony-bundle",
+    "description": "Product catalog system with support for product options and variants.",
+    "keywords": ["shop", "ecommerce", "products", "product", "assortment", "options", "variants"],
+    "homepage": "http://sylius.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name":     "Paweł Jędrzejewski",
+            "homepage": "http://pjedrzejewski.com"
+        },
+        {
+            "name":     "Alexandre Bacco",
+            "homepage": "http://alex.bacco.fr"
+        },
+        {
+            "name":     "Sylius project",
+            "homepage": "http://sylius.org"
+        },
+        {
+            "name":     "Community contributions",
+            "homepage": "http://github.com/Sylius/Sylius/contributors"
+        }
+    ],
+    "require": {
+        "php":                      ">=5.3.3",
+
+        "symfony/framework-bundle": "~2.3",
+        "sylius/resource-bundle":   "1.0.*@dev",
+        "sylius/customization":     "1.0.*@dev"
+    },
+    "require-dev": {
+        "phpspec/phpspec":   "~2.0",
+        "doctrine/orm":      "~2.2",
+        "symfony/form":      "~2.3",
+        "symfony/validator": "~2.3"
+    },
+    "config": {
+        "bin-dir": "bin"
+    },
+    "autoload": {
+        "psr-4": { "Sylius\\Bundle\\CustomizationBundle\\": "" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    }
+}

--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadCustomizationsData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadCustomizationsData.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\FixturesBundle\DataFixtures\ORM;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Sylius\Bundle\FixturesBundle\DataFixtures\DataFixture;
+
+/**
+ * Default assortment product properties to play with Sylius sandbox.
+ *
+ * @author Paweł Jędrzejewski <pjedrzejewski@diweb.pl>
+ */
+class LoadCustomizationsData extends DataFixture
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(ObjectManager $manager)
+    {
+        $customization = $this->createCustomization('Engraving');
+        $customization->setType('text');
+        $manager->persist($customization);
+
+        $customization = $this->createCustomization('Message');
+        $customization->setType('text');
+        $manager->persist($customization);
+
+        $customization = $this->createCustomization('Firstname');
+        $customization->setType('text');
+        $manager->persist($customization);
+
+        $manager->flush();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOrder()
+    {
+        return 2;
+    }
+
+    /**
+     * Create customization.
+     *
+     * @param string $name
+     * @param string $presentation
+     */
+    private function createCustomization($name)
+    {
+        $repository = $this->getCustomizationRepository();
+
+        $customization = $repository->createNew();
+        $customization->setName($name);
+
+        $this->setReference('Sylius.Customization.'.$name, $customization);
+
+        return $customization;
+    }
+}

--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadProductsData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadProductsData.php
@@ -124,6 +124,8 @@ class LoadProductsData extends DataFixture
         $product->addOption($this->getReference('Sylius.Option.T-Shirt size'));
         $product->addOption($this->getReference('Sylius.Option.T-Shirt color'));
 
+        $product->addCustomization($this->getReference('Sylius.Customization.Firstname'));
+
         $this->generateVariants($product);
 
         $this->setReference('Sylius.Product.'.$i, $product);
@@ -168,6 +170,8 @@ class LoadProductsData extends DataFixture
 
         $product->addOption($this->getReference('Sylius.Option.Sticker size'));
 
+        $product->addCustomization($this->getReference('Sylius.Customization.Message'));
+
         $this->generateVariants($product);
 
         $this->setReference('Sylius.Product.'.$i, $product);
@@ -204,6 +208,8 @@ class LoadProductsData extends DataFixture
         $this->addAttribute($product, 'Mug material', $randomMugMaterial);
 
         $product->addOption($this->getReference('Sylius.Option.Mug type'));
+
+        $product->addCustomization($this->getReference('Sylius.Customization.Engraving'));
 
         $this->generateVariants($product);
 

--- a/src/Sylius/Bundle/WebBundle/Menu/BackendMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/BackendMenuBuilder.php
@@ -151,6 +151,13 @@ class BackendMenuBuilder extends MenuBuilder
             ))->setLabel($this->translate(sprintf('sylius.backend.menu.%s.archetypes', $section)));
         }
 
+        if ($this->authorizationChecker->isGranted('sylius.customization.index')) {
+            $child->addChild('customization', array(
+                'route' => 'sylius_backend_customization_index',
+                'labelAttributes' => array('icon' => 'glyphicon glyphicon-list-alt'),
+            ))->setLabel($this->translate(sprintf('sylius.backend.menu.%s.customizations', $section)));
+        }
+
         if (!$child->hasChildren()) {
             $menu->removeChild('assortment');
         }

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/customization.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/customization.yml
@@ -1,0 +1,40 @@
+# This file is part of the Sylius package.
+# (c) Paweł Jędrzejewski
+
+sylius_backend_customization_index:
+    pattern: /
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.customization:indexAction
+        _sylius:
+            template: SyliusWebBundle:Backend/Customization:index.html.twig
+            sortable: true
+            sorting:
+                name: desc
+
+sylius_backend_customization_create:
+    pattern: /new
+    methods: [GET, POST]
+    defaults:
+        _controller: sylius.controller.customization:createAction
+        _sylius:
+            template: SyliusWebBundle:Backend/Customization:create.html.twig
+            redirect: sylius_backend_customization_index
+
+sylius_backend_customization_update:
+    pattern: /{id}/edit
+    methods: [GET, PUT]
+    defaults:
+        _controller: sylius.controller.customization:updateAction
+        _sylius:
+            template: SyliusWebBundle:Backend/Customization:update.html.twig
+            redirect: sylius_backend_customization_index
+
+sylius_backend_customization_delete:
+    pattern: /{id}
+    methods: [DELETE]
+    defaults:
+        _controller: sylius.controller.customization:deleteAction
+        _sylius:
+            template: SyliusWebBundle:Backend/Misc:delete.html.twig
+            redirect: sylius_backend_customization_index

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/main.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/main.yml
@@ -44,6 +44,10 @@ sylius_backend_product_archetype:
     resource: @SyliusWebBundle/Resources/config/routing/backend/product_archetype.yml
     prefix: /product-archetypes
 
+sylius_backend_customization:
+    resource: @SyliusWebBundle/Resources/config/routing/backend/customization.yml
+    prefix: /customizations
+
 sylius_backend_taxonomy:
     resource: @SyliusWebBundle/Resources/config/routing/backend/taxonomy.yml
     prefix: /taxonomies

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/menu.en.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/menu.en.yml
@@ -74,6 +74,7 @@ sylius:
                 report: Reports
                 attributes: Configure attributes
                 archetypes: Product archetypes
+                customizations: Configure customizations
                 sales: Orders
                 security_settings: Security settings
                 shipments: Shipments

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
@@ -747,6 +747,7 @@ sylius:
             attributes: Attributes
             channels: Channels
             pricing: Pricing
+            customizations: Customizations
         tax_category: Tax category
         unavailable: Unavailable
         update_header: Editing product
@@ -803,6 +804,15 @@ sylius:
     promotion_rule:
         configuration: Configuration
         type: Type
+    customization:
+        create: Create customization
+        create_header: New product customization
+        index_header: Product customizations
+        manage: Manage customizations
+        name: name
+        no_results: There are no customization configured.
+        update_header: Editing customization
+        updated_at: last update
     product_attribute:
         add_choice: Add choice
         create: Create product attribute

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customization/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customization/_form.html.twig
@@ -1,0 +1,5 @@
+<fieldset>
+    {{ form_row(form.name, {'attr': {'class': 'input-lg'}}) }}
+</fieldset>
+
+{{ form_widget(form._token) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customization/create.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customization/create.html.twig
@@ -1,0 +1,24 @@
+{% extends 'SyliusWebBundle:Backend:layout.html.twig' %}
+
+{% from 'SyliusResourceBundle:Macros:actions.html.twig' import create %}
+
+{% block topbar %}
+<ol class="breadcrumb">
+    <li>{{ 'sylius.breadcrumb.assortment'|trans }}</li>
+    <li><a href="{{ path('sylius_backend_customization_index') }}">{{ 'sylius.breadcrumb.customization.index'|trans }}</a></li>
+    <li>{{ 'sylius.breadcrumb.new'|trans }}</li>
+</ol>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <h1><i class="glyphicon glyphicon-plus-sign"></i> {{ 'sylius.customization.create_header'|trans|raw }}</h1>
+</div>
+
+{{ form_errors(form) }}
+
+<form action="{{ path('sylius_backend_customization_create') }}" method="post" class="form-horizontal" novalidate>
+    {% include 'SyliusWebBundle:Backend/Customization:_form.html.twig' %}
+    {{ create() }}
+</form>
+{% endblock %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customization/index.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customization/index.html.twig
@@ -1,0 +1,27 @@
+{% extends 'SyliusWebBundle:Backend:layout.html.twig' %}
+
+{% import 'SyliusResourceBundle:Macros:buttons.html.twig' as buttons %}
+{% from 'SyliusWebBundle:Backend/Macros:misc.html.twig' import pagination %}
+{% from 'SyliusWebBundle:Backend/Customization:macros.html.twig' import list %}
+
+{% block topbar %}
+<ol class="breadcrumb">
+    <li>{{ 'sylius.breadcrumb.assortment'|trans }}</li>
+    <li>{{ 'sylius.breadcrumb.customization.index'|trans }}</li>
+</ol>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <div class="actions-menu">
+        {{ buttons.create(path('sylius_backend_customization_create'), 'sylius.customization.create'|trans) }}
+        {{ buttons.manage(path('sylius_backend_customization_index'), 'sylius.customization.manage'|trans) }}
+    </div>
+    <h1><i class="glyphicon glyphicon-list-alt"></i> {{ 'sylius.customization.index_header'|trans|raw }}</h1>
+</div>
+
+{{ pagination(customizations) }}
+{{ list(customizations) }}
+{{ pagination(customizations) }}
+
+{% endblock %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customization/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customization/macros.html.twig
@@ -1,0 +1,38 @@
+{% macro list(customizations) %}
+
+{% import 'SyliusResourceBundle:Macros:buttons.html.twig' as buttons %}
+{% import 'SyliusWebBundle:Backend/Macros:alerts.html.twig' as alerts %}
+
+{% if customizations|length > 0 %}
+    <table class="table">
+        <thead>
+            <tr>
+                <th>{{ sylius_resource_sort('id', '#id') }}</th>
+                <th>{{ sylius_resource_sort('name', 'sylius.customization.name'|trans) }}</th>
+                <th>{{ sylius_resource_sort('name', 'sylius.customization.type'|trans) }}</th>
+                <th>{{ sylius_resource_sort('updatedAt', 'sylius.customization.updated_at'|trans) }}</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for customization in customizations %}
+            <tr id="{{ customization.id }}">
+                <td>{{ customization.id }}</td>
+                <td>{{ customization.name }}</td>
+                <td>{{ customization.type }}</td>
+                <td>{{ customization.updatedAt|date }}</td>
+                <td>
+                    <div class="pull-right">
+                    {{ buttons.edit(path('sylius_backend_customization_update', {'id': customization.id})) }}
+                    {{ buttons.delete(path('sylius_backend_customization_delete', {'id': customization.id})) }}
+                   </div>
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% else %}
+{{ alerts.info('sylius.customization.no_results'|trans) }}
+{% endif %}
+
+{% endmacro %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customization/update.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customization/update.html.twig
@@ -1,0 +1,26 @@
+{% extends 'SyliusWebBundle:Backend:layout.html.twig' %}
+
+{% from 'SyliusResourceBundle:Macros:actions.html.twig' import update %}
+
+{% block topbar %}
+<ol class="breadcrumb">
+    <li>{{ 'sylius.breadcrumb.assortment'|trans }}</li>
+    <li><a href="{{ path('sylius_backend_customization_index') }}">{{ 'sylius.breadcrumb.customization.index'|trans }}</a></li>
+    <li>{{ customization.name }}</li>
+    <li>{{ 'sylius.breadcrumb.edit'|trans }}</li>
+</ol>
+{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <h1><i class="glyphicon glyphicon-pencil"></i> {{ 'sylius.customization.update_header'|trans|raw }}</h1>
+</div>
+
+{{ form_errors(form) }}
+
+<form action="{{ path('sylius_backend_customization_update', {'id': customization.id}) }}" method="post" class="form-horizontal" novalidate>
+    <input type="hidden" name="_method" value="PUT">
+    {% include 'SyliusWebBundle:Backend/Customization:_form.html.twig' %}
+    {{ update() }}
+</form>
+{% endblock %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_customizations.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_customizations.html.twig
@@ -1,0 +1,3 @@
+<div class="tab-pane" id="customizations">
+    {{ form_widget(form.customizations) }}
+</div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_tabs.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_tabs.html.twig
@@ -4,6 +4,7 @@
     <li><a href="#options" data-toggle="tab">{{ 'sylius.product.tabs.options'|trans }}</a></li>
     {% endif %}
     <li><a href="#attributes" data-toggle="tab">{{ 'sylius.product.tabs.attributes'|trans }}</a></li>
+    <li><a href="#customizations" data-toggle="tab">{{ 'sylius.product.tabs.customizations'|trans }}</a></li>
     <li><a href="#categorization" data-toggle="tab">{{ 'sylius.product.tabs.categorization'|trans }}</a></li>
     <li><a href="#images" data-toggle="tab">{{ 'sylius.product.tabs.images'|trans }}</a></li>
     {% if form.channels|length > 0 %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/_form.html.twig
@@ -7,6 +7,7 @@
     {% include 'SyliusWebBundle:Backend/Product/Form:_main.html.twig' %}
     {% include 'SyliusWebBundle:Backend/Product/Form:_options.html.twig' %}
     {% include 'SyliusWebBundle:Backend/Product/Form:_attributes.html.twig' %}
+    {% include 'SyliusWebBundle:Backend/Product/Form:_customizations.html.twig' %}
     {% include 'SyliusWebBundle:Backend/Product/Form:_categorization.html.twig' %}
     {% include 'SyliusWebBundle:Backend/Product/Form:_images.html.twig' %}
     {% if form.channels|length > 0 %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/_item.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/_item.html.twig
@@ -2,7 +2,7 @@
 <tr>
     <td class="col-md-1">{{ loop.index }}</td>
     <td>
-        {{ include('SyliusWebBundle:Frontend/Product:_variant.html.twig', {'variant': item.variant}) }}
+        {{ include('SyliusWebBundle:Frontend/Product:_variant.html.twig', {'variant': item.variant, 'item': item}) }}
     </td>
     <td class="col-md-2">
         {{ form_row(form.items[loop.index0].quantity, {'label': false}) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_variant.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_variant.html.twig
@@ -13,4 +13,11 @@
             {% endfor %}
         </ul>
     {% endif %}
+    {% if not product.customizations.empty and item is defined %}
+        <ul class="list-unstyled">
+            {% for customizationValue in item.customizationValues %}
+                <li><strong>{{ customizationValue.customization.name }}</strong>: {{ customizationValue.value }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
 </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
@@ -110,6 +110,9 @@
         {% else %}
             {{ form_row(form.quantity, {'attr': {'class': 'center-text'}, 'empty_value': '1'}) }}
             {{ form_widget(form._token) }}
+            {% if product.customizations|length > 0 %}
+                {{ form_widget(form.customizationValues) }}
+            {% endif %}
             <br>
             <br>
             {% if sylius_is_restricted(product) %}

--- a/src/Sylius/Component/Core/Model/OrderItemInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderItemInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Core\Model;
 
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Customization\Model\CustomizationSubjectInstanceInterface;
 use Sylius\Component\Cart\Model\CartItemInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
 
@@ -20,7 +21,7 @@ use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface OrderItemInterface extends CartItemInterface, PromotionSubjectInterface
+interface OrderItemInterface extends CartItemInterface, PromotionSubjectInterface, CustomizationSubjectInstanceInterface
 {
     /**
      * Get the product.

--- a/src/Sylius/Component/Core/Model/Product.php
+++ b/src/Sylius/Component/Core/Model/Product.php
@@ -13,6 +13,7 @@ namespace Sylius\Component\Core\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Customization\Model\CustomizationInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Channel\Model\ChannelInterface as BaseChannelInterface;
 use Sylius\Component\Product\Model\Product as BaseProduct;
@@ -71,6 +72,13 @@ class Product extends BaseProduct implements ProductInterface
     protected $channels;
 
     /**
+     * Customizations
+     *
+     * @var Collection|CustomizationInterface[]
+     */
+    protected $customizations;
+
+    /**
      * Constructor.
      */
     public function __construct()
@@ -80,6 +88,7 @@ class Product extends BaseProduct implements ProductInterface
         $this->setMasterVariant(new ProductVariant());
         $this->taxons = new ArrayCollection();
         $this->channels = new ArrayCollection();
+        $this->customizations = new ArrayCollection();
 
         $this->variantSelectionMethod = self::VARIANT_SELECTION_CHOICE;
     }
@@ -300,8 +309,6 @@ class Product extends BaseProduct implements ProductInterface
     public function setChannels(Collection $channels)
     {
         $this->channels = $channels;
-
-        return $this;
     }
 
     /**
@@ -322,6 +329,8 @@ class Product extends BaseProduct implements ProductInterface
         if ($this->hasChannel($channel)) {
             $this->channels->removeElement($channel);
         }
+
+        return $this;
     }
 
     /**
@@ -330,6 +339,46 @@ class Product extends BaseProduct implements ProductInterface
     public function hasChannel(BaseChannelInterface $channel)
     {
         return $this->channels->contains($channel);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomizations()
+    {
+        return $this->customizations;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addCustomization(CustomizationInterface $customization)
+    {
+        if (!$this->hasCustomization($customization)) {
+            $this->customizations->add($customization);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCustomization(CustomizationInterface $customization)
+    {
+        return $this->customizations->contains($customization);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeCustomization(CustomizationInterface $customization)
+    {
+        if ($this->hasCustomization($customization)) {
+            $this->customizations->removeElement($customization);
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Sylius/Component/Core/Model/ProductInterface.php
+++ b/src/Sylius/Component/Core/Model/ProductInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Core\Model;
 
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Customization\Model\CustomizationSubjectInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Channel\Model\ChannelsAwareInterface;
 use Sylius\Component\Product\Model\ProductInterface as BaseProductInterface;
@@ -29,7 +30,8 @@ interface ProductInterface extends
     BaseProductInterface,
     TaxableInterface,
     TaxonsAwareInterface,
-    ChannelsAwareInterface
+    ChannelsAwareInterface,
+    CustomizationSubjectInterface
 {
     /*
      * Variant selection methods.

--- a/src/Sylius/Component/Customization/.gitignore
+++ b/src/Sylius/Component/Customization/.gitignore
@@ -1,0 +1,5 @@
+vendor/
+bin/
+
+composer.phar
+composer.lock

--- a/src/Sylius/Component/Customization/.travis.yml
+++ b/src/Sylius/Component/Customization/.travis.yml
@@ -1,0 +1,15 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+
+before_script: composer install --dev --prefer-source
+
+script: bin/phpspec run -fpretty --verbose
+
+notifications:
+  email: "travis-ci@sylius.org"
+  irc:   "irc.freenode.org#sylius-dev"
+ 

--- a/src/Sylius/Component/Customization/CHANGELOG.md
+++ b/src/Sylius/Component/Customization/CHANGELOG.md
@@ -1,0 +1,6 @@
+CHANGELOG
+=========
+
+### v0.14
+
+* Initial dev release.

--- a/src/Sylius/Component/Customization/LICENCE
+++ b/src/Sylius/Component/Customization/LICENCE
@@ -1,0 +1,19 @@
+Copyright (c) 2011-2014 Paweł Jędrzejewski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE. 

--- a/src/Sylius/Component/Customization/Model/Customization.php
+++ b/src/Sylius/Component/Customization/Model/Customization.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Customization\Model;
+
+/**
+ * Model for customization.
+ *
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+class Customization implements CustomizationInterface
+{
+    /**
+     * id.
+     *
+     * @var mixed
+     */
+    protected $id;
+
+    /**
+     * Name.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * Type.
+     *
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * Creation time.
+     *
+     * @var \DateTime
+     */
+    protected $createdAt;
+
+    /**
+     * Last update time.
+     *
+     * @var \DateTime
+     */
+    protected $updatedAt;
+
+    /**
+     * Deletion time.
+     *
+     * @var \DateTime
+     */
+    protected $deletedAt;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->createdAt = new \DateTime();
+    }
+
+    public function __toString()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get id
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+
+        return $type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCreatedAt(\DateTime $createdAt)
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUpdatedAt()
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUpdatedAt(\DateTime $updatedAt)
+    {
+        $this->updatedAt = $updatedAt;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isDeleted()
+    {
+        return null !== $this->deletedAt && new \DateTime() >= $this->deletedAt;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDeletedAt()
+    {
+        return $this->deletedAt;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDeletedAt(\DateTime $deletedAt = null)
+    {
+        $this->deletedAt = $deletedAt;
+
+        return $this;
+    }
+}

--- a/src/Sylius/Component/Customization/Model/CustomizationInterface.php
+++ b/src/Sylius/Component/Customization/Model/CustomizationInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c); Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Customization\Model;
+
+use Sylius\Component\Resource\Model\SoftDeletableInterface;
+use Sylius\Component\Resource\Model\TimestampableInterface;
+
+/**
+ * Customization Interface
+ *
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+interface CustomizationInterface extends SoftDeletableInterface, TimestampableInterface
+{
+    /**
+     * Get name
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Set name.
+     *
+     * @param string $name
+     */
+    public function setName($name);
+
+    /**
+     * Get type
+     *
+     * @return string
+     */
+    public function getType();
+
+    /**
+     * Set type.
+     *
+     * @param string $type
+     */
+    public function setType($type);
+}

--- a/src/Sylius/Component/Customization/Model/CustomizationSubject.php
+++ b/src/Sylius/Component/Customization/Model/CustomizationSubject.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Customization\Model;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * Default model implementation of CustomizationSubjectInterface.
+ *
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+class CustomizationSubject implements CustomizationSubjectInterface
+{
+    /**
+     * Identifier
+     *
+     * @var integer
+     */
+    protected $id;
+
+    /**
+     * Product customizations.
+     *
+     * @var ArrayCollection|CustomizationInterface[]
+     */
+    protected $customizations;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->customizations = new ArrayCollection();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomizations()
+    {
+        return $this->customizations;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addCustomization(CustomizationInterface $customization)
+    {
+        if (!$this->hasCustomization($customization)) {
+            $this->customizations->add($customization);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeCustomization(CustomizationInterface $customization)
+    {
+        if ($this->hasCustomization($customization)) {
+            $this->customizations->removeElement($customization);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCustomization(CustomizationInterface $customization)
+    {
+        return $this->customizations->contains($customization);
+    }
+}

--- a/src/Sylius/Component/Customization/Model/CustomizationSubjectInstance.php
+++ b/src/Sylius/Component/Customization/Model/CustomizationSubjectInstance.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Customization\Model;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * Customization Subject Instance.
+ *
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+class CustomizationSubjectInstance implements CustomizationSubjectInstanceInterface
+{
+    /**
+     * Identifier
+     *
+     * @var integer
+     */
+    protected $id;
+
+    /**
+     * Customization values.
+     *
+     * @var ArrayCollection|CustomizationValueInterface[]
+     */
+    protected $customizationValues;
+
+    /**
+     * Customization subject
+     *
+     * @var CustomizationSubjectInterface
+     */
+    protected $customizationSubject;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->customizationValues = new ArrayCollection();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomizationValues()
+    {
+        return $this->customizationValues;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomizationSubject()
+    {
+        return $this->customizationSubject;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCustomizationValues(ArrayCollection $customizationValues)
+    {
+        foreach ($customizationValues as $customizationValue) {
+            $customizationValue->setSubjectInstance($this);
+        }
+
+        $this->customizationValues = $customizationValues;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addCustomizationValue(CustomizationValueInterface $customizationValue)
+    {
+        if (!$this->hasCustomizationValue($customizationValue)) {
+            $this->customizationValues->add($customizationValue);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeCustomizationValue(CustomizationValueInterface $customizationValue)
+    {
+        if ($this->hasCustomizationValue($customizationValue)) {
+            $this->customizationValues->removeElement($customizationValue);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCustomizationValue(CustomizationValueInterface $customizationValue)
+    {
+        return $this->customizationValues->contains($customizationValue);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomizationValueByName($name)
+    {
+        foreach ($this->customizationValues as $cv) {
+            if ($name === $cv->getCustomization()->getName()) {
+                return $cv;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Sylius/Component/Customization/Model/CustomizationSubjectInstanceInterface.php
+++ b/src/Sylius/Component/Customization/Model/CustomizationSubjectInstanceInterface.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c); Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Customization\Model;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * Customization subject instance interface
+ *
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+interface CustomizationSubjectInstanceInterface
+{
+    /**
+     * Returns all customization values.
+     *
+     * @return Collection|CustomizationValueInterface[]
+     */
+    public function getCustomizationValues();
+
+    /**
+     * Set all customization values
+     */
+    public function setCustomizationValues(ArrayCollection $customizationValues);
+
+    /**
+     * Adds customization value.
+     *
+     * @param CustomizationValueInterface $customizationValue
+     */
+    public function addCustomizationValue(CustomizationValueInterface $customizationValue);
+
+    /**
+     * Removes customization value from subject instance.
+     *
+     * @param CustomizationValueInterface $customizationValue
+     */
+    public function removeCustomizationValue(CustomizationValueInterface $customizationValue);
+
+    /**
+     * Checks whether subject instance has given customization value.
+     *
+     * @param CustomizationValueInterface $customizationValue
+     *
+     * @return Boolean
+     */
+    public function hasCustomizationValue(CustomizationValueInterface $customizationValue);
+
+    /**
+     * Get the customization subject attached to the current subject instance
+     */
+    public function getCustomizationSubject();
+
+    /**
+     * Get a customizationValue by the name of its customization.
+     *
+     * @param $name
+     *
+     * @return CustomizationValue|null
+     */
+    public function getCustomizationValueByName($name);
+}

--- a/src/Sylius/Component/Customization/Model/CustomizationSubjectInterface.php
+++ b/src/Sylius/Component/Customization/Model/CustomizationSubjectInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Customization\Model;
+
+use Doctrine\Common\Collections\Collection;
+
+/**
+ * Customization subject interface.
+ *
+ * Should be implemented by models that support customizations.
+ *
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+interface CustomizationSubjectInterface
+{
+    /**
+     * Get available customizations.
+     *
+     * @return Collection|CustomizationInterface[]
+     */
+    public function getCustomizations();
+
+    /**
+     * Add a customization.
+     *
+     * @param CustomizationInterface $customization
+     */
+    public function addCustomization(CustomizationInterface $customization);
+
+    /**
+     * Remove customization from subject.
+     *
+     * @param CustomizationInterface $customization
+     */
+    public function removeCustomization(CustomizationInterface $customization);
+
+    /**
+     * Checks whether subject has given customization.
+     *
+     * @param CustomizationInterface $customization
+     *
+     * @return Boolean
+     */
+    public function hasCustomization(CustomizationInterface $customization);
+}

--- a/src/Sylius/Component/Customization/Model/CustomizationValue.php
+++ b/src/Sylius/Component/Customization/Model/CustomizationValue.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Customization\Model;
+
+/**
+ * Customization value.
+ *
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+class CustomizationValue implements CustomizationValueInterface
+{
+    /**
+     * Customization value id.
+     *
+     * @var mixed
+     */
+    protected $id;
+
+    /**
+     * Value.
+     *
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * Customization.
+     *
+     * @var CustomizationInterface
+     */
+    protected $customization;
+
+    /**
+     * Customization subject instance
+     *
+     * @var CustomizationSubjectInstanceInterface
+     */
+    protected $subjectInstance;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomization()
+    {
+        return $this->customization;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCustomization(CustomizationInterface $customization = null)
+    {
+        $this->customization = $customization;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubjectInstance()
+    {
+        return $this->subjectInstance;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSubjectInstance(CustomizationSubjectInstanceInterface $subjectInstance = null)
+    {
+        $this->subjectInstance = $subjectInstance;
+    }
+}

--- a/src/Sylius/Component/Customization/Model/CustomizationValueInterface.php
+++ b/src/Sylius/Component/Customization/Model/CustomizationValueInterface.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c); Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Customization\Model;
+
+/**
+ * Customization value interface.
+ *
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+interface CustomizationValueInterface
+{
+    /**
+     * Get customization.
+     *
+     * @return CustomizationInterface
+     */
+    public function getCustomization();
+
+    /**
+     * Set customization.
+     *
+     * @param CustomizationInterface $customization
+     */
+    public function setCustomization(CustomizationInterface $customization);
+
+    /**
+     * Get internal value.
+     *
+     * @return string
+     */
+    public function getValue();
+
+    /**
+     * Set internal value.
+     *
+     * @param string $value
+     */
+    public function setValue($value);
+
+    /**
+     * Get subject instance
+     *
+     * @return CustomizationSubjectInstanceInterface
+     */
+    public function getSubjectInstance();
+
+    /**
+     * Set subject instance
+     *
+     * @param CustomizationSubjectInstanceInterface $subjectInstance
+     */
+    public function setSubjectInstance(CustomizationSubjectInstanceInterface $subjectInstance = null);
+}

--- a/src/Sylius/Component/Customization/README.md
+++ b/src/Sylius/Component/Customization/README.md
@@ -1,0 +1,47 @@
+Customization Component [![Build status...](https://secure.travis-ci.org/Sylius/Customization.png?branch=master)](http://travis-ci.org/Sylius/Customization)
+===================
+
+Customizations engine for PHP objects.
+
+Sylius
+------
+
+Modern ecommerce for PHP and Symfony2. Visit [Sylius.org](http://sylius.org).
+
+Documentation
+-------------
+
+Documentation is available on [**docs.sylius.org**](http://docs.sylius.org/en/latest/components/Customization/index.html).
+
+Contributing
+------------
+
+All instructions for contributing to Sylius can be found in the [Contributing Guide](http://docs.sylius.org/en/latest/contributing/index.html).
+
+Support
+-------
+
+If you have a question regarding the usage of this library, please ask on
+[Stackoverflow](http://stackoverflow.com). You should use "sylius"
+tag when posting and make sure to [browse existing questions](http://http://stackoverflow.com/questions/tagged/sylius).
+
+Sylius on Twitter
+-----------------
+
+[Follow the official Sylius account on Twitter!](http://twitter.com/Sylius).
+
+Bug Tracking
+------------
+
+If you find a bug, please refer to the [Reporting a Bug](http://docs.sylius.org/en/latest/contributing/code/bugs.html) guide.
+
+MIT License
+-----------
+
+License can be found [here](https://github.com/Sylius/Customization/blob/master/LICENSE).
+
+Authors
+-------
+
+The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+See the list of [contributors](https://github.com/Sylius/Customization/contributors).

--- a/src/Sylius/Component/Customization/composer.json
+++ b/src/Sylius/Component/Customization/composer.json
@@ -1,0 +1,43 @@
+{
+    "name": "sylius/customization",
+    "type": "library",
+    "description": "Component for handling object customizations in PHP projects.",
+    "keywords": ["shop", "ecommerce", "customization", "feature"],
+    "homepage": "http://sylius.org",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Paweł Jędrzejewski",
+            "homepage": "http://pjedrzejewski.com"
+        },
+        {
+            "name": "Alexandre Bacco",
+            "homepage": "http://alex.bacco.fr"
+        },
+        {
+            "name": "Sylius project",
+            "homepage": "http://sylius.org"
+        },
+        {
+            "name": "Community contributions",
+            "homepage": "http://github.com/Sylius/Sylius/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.3"
+    },
+    "require-dev": {
+        "phpspec/phpspec": "2.0.*"
+    },
+    "config": {
+        "bin-dir": "bin"
+    },
+    "autoload": {
+        "psr-4": { "Sylius\\Component\\Customization\\": "" }
+    }
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.10-dev"
+        }
+    }
+}


### PR DESCRIPTION
Hi all,

This is a first implementation of #363.

The new bundle offers customization: it means you have several attributes (let's say tee-shirt printing) that you can attach to Subject (in our case, the tee-shirt product). When attached, you then register a value (the printed text on your tee-shirt) on a SubjectInstance (in our case, the OrderItem of that tee-shirt in the cart).

For now it's all it does. Of course, we miss:
- Allow all type of values (text, date, file, etc.). This first step only provide text values.
- Calculator to handle the price of those customizations. It could be a per character price, etc.
- Your ideas.

I'm still struggling with the CartItem form of the product page: need to add CustomizationValues fields regarding the available Customizations of the product and the values that can already exist... a bit tricky, forms are not my preferred  part.

In the meanwhile, I'd like to have feedbacks on what is already done =)

Thanks
