### PR TITLE
Get children taxons ordered

### DIFF
--- a/src/Sylius/Bundle/TaxonomiesBundle/Resources/config/doctrine/model/Taxon.mongodb.xml
+++ b/src/Sylius/Bundle/TaxonomiesBundle/Resources/config/doctrine/model/Taxon.mongodb.xml
@@ -19,7 +19,7 @@
 
     <mapped-superclass name="Sylius\Bundle\TaxonomiesBundle\Document\Taxon" collection="sylius_taxon">
         <order-by>
-            <order-by-field name="left" direction="DESC" />
+            <order-by-field name="left" direction="ASC" />
         </order-by>
         <field name="name" column="name" type="string" />
         <field name="slug" column="slug" type="string" unique="true">

--- a/src/Sylius/Bundle/TaxonomiesBundle/Resources/config/doctrine/model/Taxon.orm.xml
+++ b/src/Sylius/Bundle/TaxonomiesBundle/Resources/config/doctrine/model/Taxon.orm.xml
@@ -49,10 +49,13 @@
             <cascade>
                 <cascade-all />
             </cascade>
+            <order-by>
+                <order-by-field name="left" direction="ASC" />
+            </order-by>
         </one-to-many>
 
         <order-by>
-            <order-by-field name="left" direction="DESC" />
+            <order-by-field name="left" direction="ASC" />
         </order-by>
 
         <field name="left" column="tree_left" type="integer">


### PR DESCRIPTION
Hi, I like and use this bundle but I've found an couple of problems about the Taxon entity mapping
-If we don`t set order-by attribute in children relation, we get children ordered by id not by left.
-The right order is "left ASC".

According with https://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/tree.md#xml-mapping-example.

Thanks for your time!
