### PR TITLE
PayPal's L_PAYMENTREQUEST_0_AMT bug fix.

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Payum/Paypal/Action/CaptureOrderUsingExpressCheckoutAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Payum/Paypal/Action/CaptureOrderUsingExpressCheckoutAction.php
@@ -64,7 +64,7 @@ class CaptureOrderUsingExpressCheckoutAction extends PaymentAwareAction
 
             $m = 0;
             foreach ($order->getItems() as $item) {
-                $details['L_PAYMENTREQUEST_0_AMT'.$m] = number_format($item->getTotal() / 100, 2);
+                $details['L_PAYMENTREQUEST_0_AMT'.$m] = number_format($item->getUnitPrice() / 100, 2);
                 $details['L_PAYMENTREQUEST_0_QTY'.$m] = $item->getQuantity();
 
                 $m++;


### PR DESCRIPTION
PayPal's `L_PAYMENTREQUEST_0_AMT` should take unit price, not subtotal.
