### PR TITLE
[ResourceBundle][Proposal] Target entity resolver

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration.php
@@ -58,6 +58,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('model')->isRequired()->cannotBeEmpty()->end()
                                     ->scalarNode('controller')->defaultValue('Sylius\Bundle\ResourceBundle\Controller\ResourceController')->end()
                                     ->scalarNode('repository')->end()
+                                    ->scalarNode('interface')->end()
                                 ->end()
                             ->end()
                         ->end()

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/DoctrineTargetEntitiesResolver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/DoctrineTargetEntitiesResolver.php
@@ -32,14 +32,12 @@ class DoctrineTargetEntitiesResolver
 
         $resolveTargetEntityListener = $container->findDefinition('doctrine.orm.listeners.resolve_target_entity');
 
-        foreach ($interfaces as $interface => $parameter) {
-            if (!$container->hasParameter($parameter)) {
-                continue;
-            }
-
+        foreach ($interfaces as $interface => $model) {
             $resolveTargetEntityListener
                 ->addMethodCall('addResolveTargetEntity', array(
-                    $interface, $container->getParameter($parameter), array()
+                    $this->getInterface($container, $interface),
+                    $this->getClass($container, $model),
+                    array()
                 ))
             ;
         }
@@ -47,5 +45,49 @@ class DoctrineTargetEntitiesResolver
         if (!$resolveTargetEntityListener->hasTag('doctrine.event_listener')) {
             $resolveTargetEntityListener->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'));
         }
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param string           $key
+     *
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    private function getInterface(ContainerBuilder $container, $key)
+    {
+        if ($container->hasParameter($key)) {
+            return $container->getParameter($key);
+        }
+
+        if (interface_exists($key)) {
+            return $key;
+        }
+
+        throw new \InvalidArgumentException(
+            sprintf('The interface %s does not exists.', $key)
+        );
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param string           $key
+     *
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    private function getClass(ContainerBuilder $container, $key)
+    {
+        if ($container->hasParameter($key)) {
+            return $container->getParameter($key);
+        }
+
+        if (class_exists($key)) {
+            return $key;
+        }
+
+        throw new \InvalidArgumentException(
+            sprintf('The class %s does not exists.', $key)
+        );
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/DependencyInjection/Compiler/ResolveDoctrineTargetEntitiesPassSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/DependencyInjection/Compiler/ResolveDoctrineTargetEntitiesPassSpec.php
@@ -12,6 +12,8 @@
 namespace spec\Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler;
 
 use PhpSpec\ObjectBehavior;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * Compiler pass which resolves interfaces into target entity names during
@@ -36,5 +38,22 @@ class ResolveDoctrineTargetEntitiesPassSpec extends ObjectBehavior
     function it_is_a_compiler_pass()
     {
         $this->shouldImplement('Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface');
+    }
+
+    function it_should_resolve_entities(ContainerBuilder $container, Definition $resolverDefinition)
+    {
+        $container->getParameter('sylius_resource.driver')
+            ->shouldBeCalled()
+            ->willReturn('doctrine/orm');
+
+        $container->hasDefinition('doctrine.orm.listeners.resolve_target_entity')
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $container->findDefinition('doctrine.orm.listeners.resolve_target_entity')
+            ->shouldBeCalled()
+            ->willReturn($resolverDefinition);
+
+        $this->process($container);
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/DependencyInjection/DoctrineTargetEntitiesResolverSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/DependencyInjection/DoctrineTargetEntitiesResolverSpec.php
@@ -11,7 +11,10 @@
 
 namespace spec\Sylius\Bundle\ResourceBundle\DependencyInjection;
 
+use Doctrine\ORM\Tools\ResolveTargetEntityListener;
 use PhpSpec\ObjectBehavior;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 
 /**
  * Doctrine target entities resolver spec.
@@ -24,5 +27,85 @@ class DoctrineTargetEntitiesResolverSpec extends ObjectBehavior
     function it_is_initializable()
     {
         $this->shouldHaveType('Sylius\Bundle\ResourceBundle\DependencyInjection\DoctrineTargetEntitiesResolver');
+    }
+
+    function it_should_get_interfaces_from_the_container(ContainerBuilder $container, Definition $resolverDefinition)
+    {
+        $resolverDefinition->hasTag('doctrine.event_listener')
+            ->shouldBeCalled()
+            ->willReturn(false);
+
+        $resolverDefinition->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'))
+            ->shouldBeCalled();
+
+        $container->hasDefinition('doctrine.orm.listeners.resolve_target_entity')
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $container->findDefinition('doctrine.orm.listeners.resolve_target_entity')
+            ->shouldBeCalled()
+            ->willReturn($resolverDefinition);
+
+        $container->hasParameter('sylius.resource.interface')
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $container->getParameter('sylius.resource.interface')
+            ->shouldBeCalled()
+            ->willReturn('spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\FooInterface');
+
+        $container->hasParameter('sylius.resource.model')
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $container->getParameter('sylius.resource.model')
+            ->shouldBeCalled()
+            ->willReturn('spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\Foo');
+
+        $resolverDefinition->addMethodCall(
+            'addResolveTargetEntity',
+            array(
+                'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\FooInterface', 'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\Foo', array()
+            ))->shouldBeCalled();
+
+        $this->resolve($container, array(
+            'sylius.resource.interface' => 'sylius.resource.model'
+        ));
+    }
+
+    function it_should_get_interfaces(ContainerBuilder $container, Definition $resolverDefinition)
+    {
+        $resolverDefinition->hasTag('doctrine.event_listener')
+            ->shouldBeCalled()
+            ->willReturn(false);
+
+        $resolverDefinition->addTag('doctrine.event_listener', array('event' => 'loadClassMetadata'))
+            ->shouldBeCalled();
+
+        $container->hasDefinition('doctrine.orm.listeners.resolve_target_entity')
+            ->shouldBeCalled()
+            ->willReturn(true);
+
+        $container->findDefinition('doctrine.orm.listeners.resolve_target_entity')
+            ->shouldBeCalled()
+            ->willReturn($resolverDefinition);
+
+        $container->hasParameter('Sylius\Bundle\ResourceBundle\Model\RepositoryInterface')
+            ->shouldBeCalled()
+            ->willReturn(false);
+
+        $container->hasParameter('spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\Foo')
+            ->shouldBeCalled()
+            ->willReturn(false);
+
+        $resolverDefinition->addMethodCall(
+            'addResolveTargetEntity',
+            array(
+                'Sylius\Bundle\ResourceBundle\Model\RepositoryInterface', 'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\Foo', array()
+            ))->shouldBeCalled();
+
+        $this->resolve($container, array(
+            'Sylius\Bundle\ResourceBundle\Model\RepositoryInterface' => 'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\Foo'
+        ));
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Fixture/Entity/FooInterface.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Fixture/Entity/FooInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\Fixture\Entity;
+
+/**
+ * Foo Interface.
+ *
+ * @author Arnaud Langlade <arn0d.dev@gmail.com>
+ */
+interface FooInterface
+{
+}


### PR DESCRIPTION
Now, The target entity resolver can find the interfaces in the container like model. It checks if the configured classes or interfaces exist (it prevent error like #1113). The specs have been improved too.

I have a problem with the spec `it_should_get_interfaces`  I can not use the `spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\FooInterface` because `interface_exists()` does not consider that is a valid interface.

Useful when you use the resource bundle standalone.
