### PR TITLE
form prependClientTransformer fix

### DIFF
--- a/src/Sylius/Bundle/VariableProductBundle/Form/Type/VariantChoiceType.php
+++ b/src/Sylius/Bundle/VariableProductBundle/Form/Type/VariantChoiceType.php
@@ -32,7 +32,7 @@ class VariantChoiceType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if ($options['multiple']) {
-            $builder->prependClientTransformer(new CollectionToArrayTransformer());
+            $builder->addViewTransformer(new CollectionToArrayTransformer());
         }
     }
 


### PR DESCRIPTION
Method 'prependClientTransformer' was removed in symfony2.3 in favor of 'addViewTransformer'
