### PR TITLE
[ResourceBundle][Proposal] Resource Classes.

### DIFF
--- a/src/Sylius/Bundle/InventoryBundle/DependencyInjection/SyliusInventoryExtension.php
+++ b/src/Sylius/Bundle/InventoryBundle/DependencyInjection/SyliusInventoryExtension.php
@@ -57,10 +57,10 @@ class SyliusInventoryExtension extends AbstractResourceExtension
             }
         }
 
-        if ($container->hasParameter('sylius.config.classes')) {
-            $classes = array_merge($classes, $container->getParameter('sylius.config.classes'));
+        if ($container->hasParameter('sylius_resource.config.classes')) {
+            $classes = array_merge($classes, $container->getParameter('sylius_resource.config.classes'));
         }
 
-        $container->setParameter('sylius.config.classes', $classes);
+        $container->setParameter('sylius_resource.config.classes', $classes);
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/AbstractResourceExtension.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/AbstractResourceExtension.php
@@ -78,11 +78,11 @@ abstract class AbstractResourceExtension extends Extension
             $this->mapValidationGroupParameters($config['validation_groups'], $container);
         }
 
-        if ($container->hasParameter('sylius.config.classes')) {
-            $classes = array_merge($classes, $container->getParameter('sylius.config.classes'));
+        if ($container->hasParameter('sylius_resource.config.classes')) {
+            $classes = array_merge($classes, $container->getParameter('sylius_resource.config.classes'));
         }
 
-        $container->setParameter('sylius.config.classes', $classes);
+        $container->setParameter('sylius_resource.config.classes', $classes);
 
         return array($config, $loader);
     }

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
@@ -41,11 +41,11 @@ class SyliusResourceExtension extends Extension
 
         $this->createResourceServices($classes, $container);
 
-        if ($container->hasParameter('sylius.config.classes')) {
-            $classes = array_merge($classes, $container->getParameter('sylius.config.classes'));
+        if ($container->hasParameter('sylius_resource.config.classes')) {
+            $classes = array_merge($classes, $container->getParameter('sylius_resource.config.classes'));
         }
 
-        $container->setParameter('sylius.config.classes', $classes);
+        $container->setParameter('sylius_resource.config.classes', $classes);
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/container/services.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/container/services.xml
@@ -47,7 +47,7 @@
 
         <service id="sylius.event_subscriber.load_metadata" class="%sylius.event_subscriber.load_metadata.class%">
             <tag name="doctrine.event_subscriber" />
-            <argument>%sylius.config.classes%</argument>
+            <argument>%sylius_resource.config.classes%</argument>
         </service>
         <service id="sylius.event_subscriber.kernel_controller" class="%sylius.event_subscriber.kernel_controller.class%">
             <tag name="kernel.event_subscriber" />

--- a/src/Sylius/Bundle/SettingsBundle/DependencyInjection/SyliusSettingsExtension.php
+++ b/src/Sylius/Bundle/SettingsBundle/DependencyInjection/SyliusSettingsExtension.php
@@ -39,10 +39,10 @@ class SyliusSettingsExtension extends AbstractResourceExtension
             $container->setParameter('sylius.repository.parameter.class', $parameterClasses['repository']);
         }
 
-        if ($container->hasParameter('sylius.config.classes')) {
-            $classes = array_merge($classes, $container->getParameter('sylius.config.classes'));
+        if ($container->hasParameter('sylius_resource.config.classes')) {
+            $classes = array_merge($classes, $container->getParameter('sylius_resource.config.classes'));
         }
 
-        $container->setParameter('sylius.config.classes', $classes);
+        $container->setParameter('sylius_resource.config.classes', $classes);
     }
 }


### PR DESCRIPTION
When you use the resource bundle standalone, you want to configure your resource classes not Sylius ones. I think that `resource` is more generic than `sylius`. I added a new method to the `AbstractResourceExtension` called `setClassesToContainer`.
