### PR TITLE
[VariableProductBundle] Only valid variants should be dispatched

### DIFF
--- a/src/Sylius/Bundle/VariableProductBundle/Generator/VariantGenerator.php
+++ b/src/Sylius/Bundle/VariableProductBundle/Generator/VariantGenerator.php
@@ -105,9 +105,9 @@ class VariantGenerator implements VariantGeneratorInterface
 
             if (0 < count($this->validator->validate($variant, array('sylius')))) {
                 $product->removeVariant($variant);
+            } else {
+                $this->eventDispatcher->dispatch('sylius.variant.pre_create', new GenericEvent($variant));
             }
-
-            $this->eventDispatcher->dispatch('sylius.variant.pre_create', new GenericEvent($variant));
         }
     }
 


### PR DESCRIPTION
In previous version the event was dispatched for all the variants which is not totally correct as if variant is not valid - it wouldn't be attached to product and saved, so calling the event dispatcher here is ineffective and can cause unpredictable bugs.
