### PR TITLE
A more flexible "sylius.cache" parameter.

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -116,8 +116,7 @@ swiftmailer:
 
 liip_doctrine_cache:
     namespaces:
-        sylius_settings:
-            type: %sylius.cache%
+        sylius_settings: %sylius.cache%
 
 knp_gaufrette:
     adapters:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -16,7 +16,8 @@ parameters:
 
     sylius.currency:                  EUR
 
-    sylius.cache:             file_system
+    sylius.cache:
+        type: file_system
 
     paypal.express_checkout.username: EDITME
     paypal.express_checkout.password: EDITME


### PR DESCRIPTION
This change will allow more "complex" cache driver settings:

``` yml
sylius.cache:
    type: memcache
    host: localhost
    port: 11211
```
