### PR TITLE
Fix inventory states consistency

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Model/InventoryUnit.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/InventoryUnit.php
@@ -49,7 +49,7 @@ class InventoryUnit extends BaseInventoryUnit implements InventoryUnitInterface
      *
      * @var string ShipmentInterface::STATE_*
      */
-    protected $shippingState = ShipmentInterface::STATE_READY;
+    protected $shippingState = ShipmentInterface::STATE_CHECKOUT;
 
     /**
      * Creation time.

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Model/InventoryUnitSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Model/InventoryUnitSpec.php
@@ -59,9 +59,9 @@ class InventoryUnitSpec extends ObjectBehavior
         $this->getShipment()->shouldReturn(null);
     }
 
-    function it_has_ready_shipping_state_by_default()
+    function it_has_checkout_shipping_state_by_default()
     {
-        $this->getShippingState()->shouldReturn(ShipmentInterface::STATE_READY);
+        $this->getShippingState()->shouldReturn(ShipmentInterface::STATE_CHECKOUT);
     }
 
     function its_shipping_state_is_mutable()

--- a/src/Sylius/Bundle/InventoryBundle/Model/InventoryUnit.php
+++ b/src/Sylius/Bundle/InventoryBundle/Model/InventoryUnit.php
@@ -37,7 +37,7 @@ class InventoryUnit implements InventoryUnitInterface
      *
      * @var string
      */
-    protected $inventoryState = InventoryUnitInterface::STATE_SOLD;
+    protected $inventoryState = InventoryUnitInterface::STATE_CHECKOUT;
 
     /**
      * Creation time.

--- a/src/Sylius/Bundle/InventoryBundle/spec/Sylius/Bundle/InventoryBundle/Model/InventoryUnitSpec.php
+++ b/src/Sylius/Bundle/InventoryBundle/spec/Sylius/Bundle/InventoryBundle/Model/InventoryUnitSpec.php
@@ -46,9 +46,9 @@ class InventoryUnitSpec extends ObjectBehavior
         $this->getStockable()->shouldReturn($stockable);
     }
 
-    function it_has_sold_state_by_default()
+    function it_has_checkout_state_by_default()
     {
-        $this->getInventoryState()->shouldReturn(InventoryUnitInterface::STATE_SOLD);
+        $this->getInventoryState()->shouldReturn(InventoryUnitInterface::STATE_CHECKOUT);
     }
 
     function its_state_is_mutable()
@@ -59,6 +59,8 @@ class InventoryUnitSpec extends ObjectBehavior
 
     function it_is_sold_if_its_state_says_so()
     {
+        $this->setInventoryState(InventoryUnitInterface::STATE_SOLD);
+
         $this->shouldBeSold();
     }
 


### PR DESCRIPTION
Default shipping and inventory states are now checkout by default.

If you want a particular state (ready => to be send, sold => onHand to be decreased, etc.) you need to explicitly change the state.

(this fixes shipping states of the current workflow, which was stuck at ready whereas we have a full checkout > onhold > ready process).
