### PR TITLE
Not able to select a shipping method where there are both shipping zone and product restricted zone that match user's shipping address

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
@@ -30,7 +30,7 @@ class ShippingStep extends CheckoutStep
     /**
      * @var null|ZoneInterface
      */
-    private $zone;
+    private $zones;
 
     /**
      * {@inheritdoc}
@@ -42,7 +42,7 @@ class ShippingStep extends CheckoutStep
 
         $form = $this->createCheckoutShippingForm($order);
 
-        if (null === $this->zone) {
+        if (empty($this->zones)) {
             return $this->proceed($context->getPreviousStep()->getName());
         }
 
@@ -86,14 +86,16 @@ class ShippingStep extends CheckoutStep
 
     protected function createCheckoutShippingForm(OrderInterface $order)
     {
-        $this->zone = $this->getZoneMatcher()->match($order->getShippingAddress());
+        $this->zones = $this->getZoneMatcher()->matchAll($order->getShippingAddress());
 
-        if (null === $this->zone) {
+        if (empty($this->zones)) {
             $this->get('session')->getFlashBag()->add('error', 'sylius.checkout.shipping.error');
         }
 
         return $this->createForm('sylius_checkout_shipping', $order, array(
-            'criteria' => array('zone' => $this->zone)
+            'criteria' => array('zone' => !empty($this->zones) ? array_map(function($zone) {
+                return $zone->getId();
+            }, $this->zones) : null)
         ));
     }
 }


### PR DESCRIPTION
Currently there is no way we can differentiate between shipping zones and product restricted zones in the `sylius_zone` table. So when users go to checkout Delivery And Payment step, they may not be able to select a shipping method because the zone matcher does not always return a shipping zone with shipping methods in it. Instead, a product restricted zone is returned. How can we prevent a product restricted zone from being used in this case?

/cc @kayue
