### PR TITLE
Quantity of units must be greater than 0.

### DIFF
--- a/src/Sylius/Bundle/InventoryBundle/Operator/InventoryOperator.php
+++ b/src/Sylius/Bundle/InventoryBundle/Operator/InventoryOperator.php
@@ -121,7 +121,7 @@ class InventoryOperator implements InventoryOperatorInterface
 
         $quantity = count($inventoryUnits);
 
-        if ($quantity < 0) {
+        if ($quantity < 1) {
             throw new \InvalidArgumentException('Quantity of units must be greater than 0.');
         }
 


### PR DESCRIPTION
In the next few lines it calls `$inventoryUnits->first()` so this array cannot be empty.
