### PR TITLE
[ResourceBundle][WIP] Global settings

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ConfigurationFactory.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ConfigurationFactory.php
@@ -19,19 +19,26 @@ namespace Sylius\Bundle\ResourceBundle\Controller;
 class ConfigurationFactory
 {
     /**
-     * Current request.
-     *
      * @var ParametersParser
      */
     protected $parametersParser;
 
     /**
+     * Default Settings
+     *
+     * @var array
+     */
+    protected $settings;
+
+    /**
      * Constructor.
      *
      * @param ParametersParser $parametersParser
+     * @param array $settings
      */
-    public function __construct(ParametersParser $parametersParser)
+    public function __construct(ParametersParser $parametersParser, array $settings)
     {
+        $this->settings = $settings;
         $this->parametersParser = $parametersParser;
     }
 
@@ -52,7 +59,8 @@ class ConfigurationFactory
             $bundlePrefix,
             $resourceName,
             $templateNamespace,
-            $templatingEngine
+            $templatingEngine,
+            $this->settings
         );
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/Controller/Parameters.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/Parameters.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\Controller;
+
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+/**
+ * @author Arnaud Langade <arn0d.dev@gmail.com>
+ */
+class Parameters extends ParameterBag
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function get($path, $default = null, $deep = false)
+    {
+        $result = parent::get($path, $default, $deep);
+
+        if ($this->has($path) && null === $result && $default !== null) {
+            $result = $default;
+        }
+
+        return $result;
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/Controller/ParametersParser.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ParametersParser.php
@@ -35,18 +35,21 @@ class ParametersParser
     /**
      * @param array   $parameters
      * @param Request $request
+     * @param array   $settings
      *
      * @return array
      */
-    public function parse(array &$parameters, Request $request)
+    public function parse(array $parameters, Request $request, array $settings = array())
     {
         foreach ($parameters as $key => $value) {
             if (is_array($value)) {
-                $parameters[$key] = $this->parse($value, $request);
+                $parameters[$key] = $this->parse($value, $request, $settings);
             }
 
             if (is_string($value) && 0 === strpos($value, '$')) {
-                $parameters[$key] = $request->get(substr($value, 1));
+                $parameterName = substr($value, 1);
+                $parameters[$key] = $request->get($parameterName);
+                $parameters['parameter_name'][$key] = $parameterName;
             }
 
             if (is_string($value) && 0 === strpos($value, 'expr:')) {

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration.php
@@ -34,6 +34,7 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('sylius_resource');
 
         $this->addResourcesSection($rootNode);
+        $this->addSettingsSection($rootNode);
 
         return $treeBuilder;
     }
@@ -62,6 +63,35 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * Adds `settings` section.
+     *
+     * @param $node
+     */
+    private function addSettingsSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('settings')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->variableNode('paginate')->defaultNull()->end()
+                        ->variableNode('limit')->defaultNull()->end()
+                        ->arrayNode('allowed_paginate')
+                            ->prototype('integer')->end()
+                            ->defaultValue(array(10, 20, 30))
+                        ->end()
+                        ->integerNode('default_page_size')->defaultValue(10)->end()
+                        ->booleanNode('sortable')->defaultFalse()->end()
+                        ->variableNode('sorting')->defaultNull()->end()
+                        ->booleanNode('filterable')->defaultFalse()->end()
+                        ->variableNode('criteria')->defaultNull()->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
@@ -39,6 +39,8 @@ class SyliusResourceExtension extends Extension
 
         $classes = isset($config['resources']) ? $config['resources'] : array();
 
+        $container->setParameter('sylius.resource.settings', $config['settings']);
+
         $this->createResourceServices($classes, $container);
 
         if ($container->hasParameter('sylius.config.classes')) {

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
@@ -19,6 +19,7 @@
     <parameters>
         <parameter key="sylius.controller.configuration_factory.class">Sylius\Bundle\ResourceBundle\Controller\ConfigurationFactory</parameter>
         <parameter key="sylius.controller.parameters_parser.class">Sylius\Bundle\ResourceBundle\Controller\ParametersParser</parameter>
+        <parameter key="sylius.controller.parameters.class">Sylius\Bundle\ResourceBundle\Controller\Parameters</parameter>
         <parameter key="sylius.expression_language.class">Sylius\Bundle\ResourceBundle\ExpressionLanguage\ExpressionLanguage</parameter>
 
         <parameter key="sylius.form.type.object_to_identifier.class">Sylius\Bundle\ResourceBundle\Form\Type\ObjectToIdentifierType</parameter>
@@ -26,6 +27,7 @@
         <parameter key="sylius.event_subscriber.load_orm_metadata.class">Sylius\Bundle\ResourceBundle\EventListener\LoadORMMetadataSubscriber</parameter>
         <parameter key="sylius.event_subscriber.load_odm_metadata.class">Sylius\Bundle\ResourceBundle\EventListener\LoadODMMetadataSubscriber</parameter>
         <parameter key="sylius.event_subscriber.kernel_controller.class">Sylius\Bundle\ResourceBundle\EventListener\KernelControllerSubscriber</parameter>
+        <parameter key="sylius.event_subscriber.kernel_request.class">Sylius\Bundle\ResourceBundle\EventListener\KernelRequestSubscriber</parameter>
 
         <!-- Sylius State Machine -->
         <parameter key="sylius.state_machine.class">Sylius\Component\Resource\StateMachine\StateMachine</parameter>
@@ -34,10 +36,12 @@
     <services>
         <service id="sylius.controller.configuration_factory" class="%sylius.controller.configuration_factory.class%">
             <argument type="service" id="sylius.controller.parameters_parser" />
+            <argument>%sylius.resource.settings%</argument>
         </service>
         <service id="sylius.controller.parameters_parser" class="%sylius.controller.parameters_parser.class%">
             <argument type="service" id="sylius.expresssion_language" />
         </service>
+        <service id="sylius.controller.parameters" class="%sylius.controller.parameters.class%" />
 
         <service id="sylius.expresssion_language" class="%sylius.expression_language.class%">
             <call method="setContainer">
@@ -54,6 +58,9 @@
             <tag name="doctrine_mongodb.odm.event_subscriber" />
         </service>
         <service id="sylius.event_subscriber.kernel_controller" class="%sylius.event_subscriber.kernel_controller.class%">
+            <argument type="service" id="sylius.controller.parameters_parser" />
+            <argument type="service" id="sylius.controller.parameters" />
+            <argument>%sylius.resource.settings%</argument>
             <tag name="kernel.event_subscriber" />
         </service>
 

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/twig.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/twig.xml
@@ -26,6 +26,7 @@
     <services>
         <service id="sylius.twig.extension.resource" class="%sylius.twig.extension.resource.class%">
             <argument type="service" id="router" />
+            <argument type="service" id="sylius.controller.parameters" />
             <argument>%sylius.twig.extension.resource.pagination_template%</argument>
             <argument>%sylius.twig.extension.resource.sorting_template%</argument>
             <tag name="twig.extension" />

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ConfigurationFactorySpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ConfigurationFactorySpec.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\Controller;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\ResourceBundle\Controller\Parameters;
+use Sylius\Bundle\ResourceBundle\Controller\ParametersParser;
+
+/**
+ * @author Arnaud Langade <arn0d.dev@gmail.com>
+ */
+class ConfigurationFactorySpec extends ObjectBehavior
+{
+    function let(ParametersParser $parametersParser)
+    {
+        $this->beConstructedWith($parametersParser, array('paginate' => 10));
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\Controller\ConfigurationFactory');
+    }
+
+    function it_should_create_configuration(ParametersParser $parametersParser)
+    {
+        $this->createConfiguration(
+            $parametersParser,
+            'sylius',
+            'product',
+            'SyliusWebBundle:Product',
+            'twig',
+            array('paginate' => 10)
+        )->shouldHaveType('Sylius\Bundle\ResourceBundle\Controller\Configuration');
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ParametersParserSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ParametersParserSpec.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace spec\Sylius\Bundle\ResourceBundle\Controller;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ResourceBundle\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Arnaud Langade <arn0d.dev@gmail.com>
+ */
+class ParametersParserSpec extends ObjectBehavior
+{
+    function let(ExpressionLanguage $expression)
+    {
+        $this->beConstructedWith($expression);
+    }
+
+    function it_should_parse_parameters(Request $request)
+    {
+        $request->get('criteria')->willReturn('New criteria');
+        $request->get('sorting')->willReturn('New sorting');
+
+        $this->parse(
+            array(
+                'criteria' => '$criteria',
+                'sortable' => '$sorting'
+            ),
+            $request
+        )->shouldReturn(array(
+            'criteria' => 'New criteria',
+            'sortable' => 'New sorting',
+            'parameter_name' => array(
+                'criteria' => 'criteria',
+                'sortable' => 'sorting',
+            ),
+        ));
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ParametersSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ParametersSpec.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\Controller;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+/**
+ * @author Arnaud Langade <arn0d.dev@gmail.com>
+ */
+class ParametersSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\Controller\Parameters');
+    }
+
+    function its_parameters_is_mutable()
+    {
+        $this->replace(array());
+    }
+
+    function it_has_parameters()
+    {
+        $this->replace(array(
+            'criteria' => 'criteria',
+            'paginate' => 'paginate'
+        ));
+
+        $this->all()->shouldReturn(array(
+            'criteria' => 'criteria',
+            'paginate' => 'paginate'
+        ));
+    }
+
+    function it_get_parameter()
+    {
+        $this->replace(array(
+            'criteria' => 'criteria',
+            'paginate' => 'paginate'
+        ));
+
+        $this->get('criteria')->shouldReturn('criteria');
+        $this->get('sorting')->shouldReturn(null);
+        $this->get('sorting', 'default')->shouldReturn('default');
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/EventListener/KernelControllerSubscriberSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/EventListener/KernelControllerSubscriberSpec.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\ResourceBundle\Controller\Configuration;
+use Sylius\Bundle\ResourceBundle\Controller\Parameters;
+use Sylius\Bundle\ResourceBundle\Controller\ParametersParser;
+use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+/**
+ * @author Arnaud Langade <arn0d.dev@gmail.com>
+ */
+class KernelControllerSubscriberSpec extends ObjectBehavior
+{
+    function let(
+        ParametersParser $parametersParser,
+        Parameters $parameters,
+        Request $request,
+        ParameterBag $parameterBag,
+        FilterControllerEvent $event,
+        ResourceController $resourceController,
+        Configuration $configuration
+    )
+    {
+        $resourceController->getConfiguration()->willReturn($configuration);
+
+        $event->getController()->willreturn(array($resourceController));
+        $event->getRequest()->willReturn($request);
+
+        $request->attributes = $parameterBag;
+        $this->beConstructedWith(
+            $parametersParser,
+            $parameters,
+            array(
+                'paginate' => false,
+                'limit' => false,
+                'sortable' => false,
+                'sorting' => null,
+                'filterable' => false,
+                'criteria' => null,
+            )
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\EventListener\KernelControllerSubscriber');
+    }
+
+    function it_is_event_suvscriver()
+    {
+        $this->shouldImplement('Symfony\Component\EventDispatcher\EventSubscriberInterface');
+    }
+
+    function it_subscribes_events()
+    {
+        $this::getSubscribedEvents(array(
+            'kernel.controller' => array('onKernelController', 0)
+        ));
+    }
+
+    function it_should_parse_empty_request(
+        FilterControllerEvent $event,
+        ParametersParser $parametersParser,
+        Parameters $parameters,
+        Request $request,
+        ParameterBag $parameterBag,
+        ResourceController $resourceController
+    ) {
+        $parameterBag->get('_sylius', array())->willReturn(array());
+
+        $request->get('criteria')->willReturn(array('product' => 10));
+        $request->get('paginate')->willReturn(10);
+
+        $parametersParser->parse(
+            array(
+                'paginate' => false,
+                'limit' => false,
+                'sortable' => false,
+                'filterable' => false,
+                'sorting' => null,
+                'criteria' => null,
+            ),
+            $request
+        )->shouldBeCalled()->willReturn(array());
+
+        $parameters->replace(Argument::type('array'))->shouldBeCalled();
+
+        $this->onKernelController($event);
+    }
+
+    function it_should_parse_request(
+        FilterControllerEvent $event,
+        ParametersParser $parametersParser,
+        Parameters $parameters,
+        Request $request,
+        ParameterBag $parameterBag
+    ) {
+        $parameterBag->get('_sylius', array())->willReturn(array(
+            'paginate' => 20,
+            'filterable' => true,
+            'sorting' => '$sorting',
+            'sortable' => true,
+            'criteria' => '$c'
+        ));
+
+        $request->get('criteria')->willReturn(array('product' => 10));
+        $request->get('paginate')->willReturn(10);
+
+        $parametersParser->parse(
+            array(
+                'paginate' => 20,
+                'limit' => false,
+                'sortable' => true,
+                'sorting' => '$sorting',
+                'filterable' => true,
+                'criteria' => '$c',
+            ),
+            $request
+        )->shouldBeCalled()->willReturn(array());
+
+        $parameters->replace(Argument::type('array'))->shouldBeCalled();
+
+        $this->onKernelController($event);
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Twig/ResourceExtensionSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Twig/ResourceExtensionSpec.php
@@ -13,6 +13,9 @@ namespace spec\Sylius\Bundle\ResourceBundle\Twig;
 
 use Pagerfanta\Pagerfanta;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\ResourceBundle\Controller\Parameters;
+use Sylius\Bundle\ResourceBundle\Controller\ParametersParser;
 use Symfony\Bundle\TwigBundle\TwigEngine;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
@@ -28,10 +31,11 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class ResourceExtensionSpec extends ObjectBehavior
 {
-    function let(RouterInterface $router)
+    function let(RouterInterface $router, Parameters $parameters)
     {
         $this->beConstructedWith(
             $router,
+            $parameters,
             'SyliusResourceBundle:Twig:paginate.html.twig',
             'SyliusResourceBundle:Twig:sorting.html.twig'
         );
@@ -62,9 +66,12 @@ class ResourceExtensionSpec extends ObjectBehavior
         Request $request,
         GetResponseEvent $event,
         RouterInterface $router,
-        \Twig_Environment $twig
+        \Twig_Environment $twig,
+        Parameters $parameters
     ) {
-        $request->get('sorting')->willReturn(array());
+        $parameters->get('parameter_name')->willReturn(array());
+        $parameters->get('sortable')->willReturn(true);
+        $parameters->get('sorting', array('id' => 'asc'))->willReturn(array());
 
         $event = $this->getGetResponseEvent($request, $event);
 
@@ -88,9 +95,13 @@ class ResourceExtensionSpec extends ObjectBehavior
         Request $request,
         GetResponseEvent $event,
         RouterInterface $router,
-        \Twig_Environment $twig
+        \Twig_Environment $twig,
+        Parameters $parameters,
+        Request $request
     ) {
-        $request->get('sorting')->willReturn(array('propertyName' => 'asc'));
+        $parameters->get('parameter_name')->willReturn(array());
+        $parameters->get('sortable')->willReturn(true);
+        $parameters->get('sorting', array('id' => 'asc'))->willReturn(array('propertyName' => 'asc'));
 
         $event = $this->getGetResponseEvent($request, $event);
 
@@ -114,9 +125,12 @@ class ResourceExtensionSpec extends ObjectBehavior
         Request $request,
         GetResponseEvent $event,
         RouterInterface $router,
-        \Twig_Environment $twig
+        \Twig_Environment $twig,
+        Parameters $parameters
     ) {
-        $request->get('sorting')->willReturn(array());
+        $parameters->get('sortable')->willReturn(true);
+        $parameters->get('parameter_name')->willReturn(array());
+        $parameters->get('sorting', array('id' => 'asc'))->willReturn(array());
 
         $event = $this->getGetResponseEvent($request, $event);
 
@@ -140,10 +154,12 @@ class ResourceExtensionSpec extends ObjectBehavior
         Request $request,
         GetResponseEvent $event,
         RouterInterface $router,
-        \Twig_Environment $twig
+        \Twig_Environment $twig,
+        Parameters $parameters
     ) {
-        $request->get('sorting')->willReturn(array('propertyName' => 'asc'));
-
+        $parameters->get('sortable')->willReturn(true);
+        $parameters->get('parameter_name')->willReturn(array());
+        $parameters->get('sorting', array('id' => 'asc'))->willReturn(array('propertyName' => 'asc'));
         $event = $this->getGetResponseEvent($request, $event);
 
         $router->generate(
@@ -169,9 +185,13 @@ class ResourceExtensionSpec extends ObjectBehavior
         ));
     }
 
-    function it_should_not_render_sorting_link(Request $request, GetResponseEvent $event, \Twig_Environment $twig)
-    {
-        $request->get('sorting')->willReturn(array());
+    function it_should_not_render_sorting_link(
+        Request $request, 
+        GetResponseEvent $event, 
+        \Twig_Environment $twig,
+        Parameters $parameters
+    ) {
+        $parameters->get('sortable')->willReturn(false);
 
         $event = $this->getGetResponseEvent(
             $request,
@@ -189,10 +209,13 @@ class ResourceExtensionSpec extends ObjectBehavior
         GetResponseEvent $event,
         Pagerfanta $paginator,
         RouterInterface $router,
-        \Twig_Environment $twig
+        \Twig_Environment $twig,
+        Parameters $parameters
     ) {
         $limits = array(10, 20);
 
+        $parameters->get('paginate')->willReturn(10);
+        $parameters->get('parameter_name')->willReturn(array('paginate' => 'paginate'));
         $event = $this->getGetResponseEvent(
             $request,
             $event,
@@ -231,9 +254,12 @@ class ResourceExtensionSpec extends ObjectBehavior
         GetResponseEvent $event,
         Pagerfanta $paginator,
         RouterInterface $router,
-        \Twig_Environment $twig
+        \Twig_Environment $twig,
+        Parameters $parameters
     ) {
         $limits = array(10, 20);
+        $parameters->get('paginate')->willReturn(10);
+        $parameters->get('parameter_name')->willReturn(array('paginate' => 'paginate'));
 
         $event = $this->getGetResponseEvent(
             $request,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | No yet |

Related RFC #1126

The configuration of each route is used in several places (controller and twig extension for example), so we needed to parse it and merge the default settings several time. But I wanted to it only one time and inject it in the container. It is done in the `KernelControllerSubscriber`. I created a new class named `Parameter` which extends `ParameterBag`. This class is declared as a service and use by `ResourceExtension` and `Configuration`.
