### PR TITLE
rename output for css assets

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Security/login.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Security/login.html.twig
@@ -15,7 +15,7 @@
         <![endif]-->
 
         {% block stylesheets %}
-            {% stylesheets output='assets/compiled/backend.css' filter='cssrewrite'
+            {% stylesheets output='assets/compiled/backend_login.css' filter='cssrewrite'
                 '//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css'
                 '//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css'
                 '@SyliusWebBundle/Resources/assets/css/backend.css'


### PR DESCRIPTION
In a production environment, when trying to dump the assets, for some reason if the name of the output is backend.css (same of the layout.html.twig), it is overwritten by this and the blueimp gallery is lost.
In the dev environment that doesn't happen.
Renaming the output to something else fixed it for me.
