### PR TITLE
Rename liip_imagine size filter

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -132,29 +132,13 @@ knp_gaufrette:
 liip_imagine:
     data_root: %kernel.root_dir%/../web/media/image
     filter_sets:
-        sylius_16x16:
+        sylius_small:
             filters:
-                thumbnail: { size: [16, 16], mode: outbound }
-        sylius_50x40:
+                thumbnail: { size: [120, 90], mode: outbound }
+        sylius_medium:
             filters:
-                thumbnail: { size: [50, 40], mode: outbound }
-        sylius_90x60:
-            filters:
-                thumbnail: { size: [90, 60], mode: outbound }
-        sylius_200x200:
-            filters:
-                thumbnail: { size: [200, 200], mode: outbound }
-
-        sylius_262x255:
-            filters:
-                thumbnail: { size: [265, 255], mode: outbound }
-        sylius_310x300:
-            filters:
-                thumbnail: { size: [310, 300], mode: outbound }
-        sylius_610x600:
-            filters:
-                thumbnail: { size: [610, 600], mode: outbound }
-        sylius_gallery:
+                thumbnail: { size: [240, 180], mode: outbound }
+        sylius_large:
             filters:
                 thumbnail: { size: [640, 480], mode: outbound }
 

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
@@ -98,7 +98,7 @@
             <td class="picture text-center">
                 <a href="{{ path('sylius_backend_product_show', {'id': product.id}) }}"
                    title="View {{ product.name|escape('html_attr') }} details.">
-                    <img src="{{ product.image ? product.image.path|imagine_filter('sylius_90x60') : 'http://placehold.it/90x60' }}" alt="" class="imgmedia-object" />
+                    <img src="{{ product.image ? product.image.path|imagine_filter('sylius_small') : 'http://placehold.it/90x60' }}" alt="" class="imgmedia-object" />
                 </a>
             </td>
             <td class="info">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_images.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_images.html.twig
@@ -21,8 +21,8 @@
         <div class="sylius-assortment-variant-images-image row">
             <div class="col-md-1">
                 {% if image.path|length > 0 %}
-                <a href="{{ image.path|imagine_filter('sylius_gallery') }}" data-gallery="gallery">
-                    <img class="img-rounded" src="{{ image.path|imagine_filter('sylius_90x60') }}" alt="" />
+                <a href="{{ image.path|imagine_filter('sylius_large') }}" data-gallery="gallery">
+                    <img class="img-rounded" src="{{ image.path|imagine_filter('sylius_small') }}" alt="" />
                 </a>
                 {% endif %}
             </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/macros.html.twig
@@ -25,7 +25,7 @@
                 <div class="media">
                     <a href="{{ path('sylius_backend_product_show', {'id': product.id}) }}" class="pull-left"
                        title="{{ 'sylius.product.view_details'|trans({'%product%': product.name})|escape('html_attr') }}">
-                        <img src="{{ product.image ? product.image.path|imagine_filter('sylius_50x40') : 'http://placehold.it/50x40' }}" alt="" class="imgmedia-object" />
+                        <img src="{{ product.image ? product.image.path|imagine_filter('sylius_small') : 'http://placehold.it/50x40' }}" alt="" class="imgmedia-object" />
                     </a>
                     <div class="media-body">
                         <h5 class="media-heading">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
@@ -145,8 +145,8 @@
         {% if product.images|length > 0 %}
             <div id="gallery">
                 {% for image in product.images %}
-                <a href="{{ image.path|imagine_filter('sylius_gallery') }}" title="{{ product.name }}" class="thumbnail">
-                    <img src="{{ image.path|imagine_filter('sylius_90x60') }}" alt="{{ product.name }}" />
+                <a href="{{ image.path|imagine_filter('sylius_large') }}" title="{{ product.name }}" class="thumbnail">
+                    <img src="{{ image.path|imagine_filter('sylius_small') }}" alt="{{ product.name }}" />
                 </a>
                 {% endfor %}
             </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/macros.html.twig
@@ -29,8 +29,8 @@
     <td>
         <span style="border-left: {{ (taxon.level - 1) * 20}}px solid #f1f1f1; padding-left: 10px;">
             {% if taxon.path|length > 0 %}
-                <a href="{{ taxon.path|imagine_filter('sylius_gallery') }}" title="{{ taxon.name }}">
-                    <img src="{{ taxon.path|imagine_filter('sylius_50x40') }}" alt="" class="img-rounded" />
+                <a href="{{ taxon.path|imagine_filter('sylius_large') }}" title="{{ taxon.name }}">
+                    <img src="{{ taxon.path|imagine_filter('sylius_small') }}" alt="" class="img-rounded" />
                 </a>
             {% endif %}
             {{ taxon.name }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxonomy/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxonomy/macros.html.twig
@@ -21,8 +21,8 @@
             <td>
                 {% if taxonomy.root is not null and taxonomy.root.path|length > 0 %}
                     <div data-toggle="modal-gallery" data-target="#modal-gallery">
-                        <a href="{{ taxonomy.root.path|imagine_filter('sylius_gallery') }}"  data-gallery="gallery" title="{{ taxonomy.name }}">
-                            <img src="{{ taxonomy.root.path|imagine_filter('sylius_50x40') }}" alt="" class="img-rounded" />
+                        <a href="{{ taxonomy.root.path|imagine_filter('sylius_large') }}"  data-gallery="gallery" title="{{ taxonomy.name }}">
+                            <img src="{{ taxonomy.root.path|imagine_filter('sylius_small') }}" alt="" class="img-rounded" />
                         </a>
                     </div>
                 {% else %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Variant/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Variant/_form.html.twig
@@ -32,7 +32,7 @@
             <div class="sylius-assortment-variant-images-image">
                 <div class="control-group">
                     <div class="controls">
-                        <a href="{{ imageForm.vars.value.path|imagine_filter('sylius_90x60') }}" target="_blank"><img class="img-polaroid" src="{{ imageForm.vars.value.path|imagine_filter('sylius_90x60') }}" alt="" /></a>
+                        <a href="{{ imageForm.vars.value.path|imagine_filter('sylius_small') }}" target="_blank"><img class="img-polaroid" src="{{ imageForm.vars.value.path|imagine_filter('sylius_90x60') }}" alt="" /></a>
                         &nbsp;
                         {{ form_widget(imageForm.file) }}
                         &nbsp;

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Variant/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Variant/macros.html.twig
@@ -26,7 +26,7 @@
             <td>{{ variant.id }}</td>
             <td>{{ variant.sku ?: '-' }}</td>
             <td>{% if variant.images.count > 0 %}
-                <img class="img-polaroid" src="{{ variant.images.offsetGet(0).path|imagine_filter('sylius_90x60') }}" />
+                <img class="img-polaroid" src="{{ variant.images.offsetGet(0).path|imagine_filter('sylius_small') }}" />
             {% endif %}
             </td>
             <td><span class="label label-{{ variant.available ? 'success' : 'important' }}">{{ variant.availableOn|date }}</span></td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_single.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_single.html.twig
@@ -1,7 +1,7 @@
 <div class="row product">
     <div class="col-md-3">
         <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}" class="thumbnail">
-            <img src="{{ product.image ? product.image.path|imagine_filter('sylius_200x200') : 'http://placehold.it/200x200' }}" alt="{{ product.name }}" />
+            <img src="{{ product.image ? product.image.path|imagine_filter('sylius_medium') : 'http://placehold.it/200x200' }}" alt="{{ product.name }}" />
         </a>
     </div>
     <div class="col-md-9">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_singleBox.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_singleBox.html.twig
@@ -1,7 +1,7 @@
 <div class="product-box">
     <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}"><h4>{{ product.name|truncate(18) }}</h4></a>
     <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}">
-        <img class="img-rounded img-responsive" src="{{ product.image ? product.image.path|imagine_filter('sylius_262x255') : 'http://placehold.it/262x255' }}" alt="{{ product.name }}" />
+        <img class="img-rounded img-responsive" src="{{ product.image ? product.image.path|imagine_filter('sylius_medium') : 'http://placehold.it/262x255' }}" alt="{{ product.name }}" />
         <span class="label label-primary">{{ product.price|sylius_price }}</span>
         <button class="btn btn-success btn-xs pull-right"><i class="icon-shopping-cart icon-white"></i> {{ 'sylius.add_to_cart'|trans }}</button>
     </a>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_variant.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_variant.html.twig
@@ -1,6 +1,6 @@
 {% set product = variant.product %}
 <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}" class="thumbnail pull-left" style="margin-right: 15px;">
-    <img src="{{ product.image ? product.image.path|imagine_filter('sylius_90x60', true) : 'http://placehold.it/90x60' }}" alt="{{ product.name }}" />
+    <img src="{{ product.image ? product.image.path|imagine_filter('sylius_small', true) : 'http://placehold.it/90x60' }}" alt="{{ product.name }}" />
 </a>
 <div>
     <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}"><strong>{{ product.name }}</strong></a>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/latestSidebar.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/latestSidebar.html.twig
@@ -4,7 +4,7 @@
     {% for product in products %}
         <li>
             <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}" class="btn btn-link">
-                <img class="thumbnail" src="{{ product.image ? product.image.path|imagine_filter('sylius_50x40') : 'http://placehold.it/50x40' }}" alt="{{ product.name }}" />
+                <img class="thumbnail" src="{{ product.image ? product.image.path|imagine_filter('sylius_small') : 'http://placehold.it/50x40' }}" alt="{{ product.name }}" />
                 <h4>{{ product.name }}</h4>
             </a>
         </li>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
@@ -6,7 +6,7 @@
 <div class="row">
     <div class="col-md-3">
         <a href="{{ path('sylius_product_show', {'slug': product.slug}) }}" class="thumbnail">
-            <img src="{{ product.image ? product.image.path|imagine_filter('sylius_200x200') : 'http://placehold.it/200x200' }}" alt="{{ product.name }}" />
+            <img src="{{ product.image ? product.image.path|imagine_filter('sylius_medium') : 'http://placehold.it/200x200' }}" alt="{{ product.name }}" />
         </a>
     </div>
     <div class="col-md-9">
@@ -18,8 +18,8 @@
 <hr>
 <div id="gallery">
     {% for image in product.images %}
-        <a href="{{ image.path|imagine_filter('sylius_gallery') }}" title="{{ product.name }}">
-            <img class="img-rounded" src="{{ image.path|imagine_filter('sylius_90x60') }}" alt="{{ product.name }}" />
+        <a href="{{ image.path|imagine_filter('sylius_large') }}" title="{{ product.name }}">
+            <img class="img-rounded" src="{{ image.path|imagine_filter('sylius_small') }}" alt="{{ product.name }}" />
         </a>
     {% endfor %}
 </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/menu.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/menu.html.twig
@@ -5,5 +5,5 @@
     {% if not item.labelAttribute('iconOnly') %}
         {% if options.allow_safe_labels and item.getExtra('safe_label', false) %}{{ item.label|trans|raw }}{% else %}{{ item.label|trans }}{% endif %}
     {% endif %}
-    {% if item.labelAttribute('data-image') %}<img src="{{ item.labelAttribute('data-image')|imagine_filter('sylius_16x16', true) }}" alt="{{ item.name }}" class="menu-thumbnail"/>{% endif %}
+    {% if item.labelAttribute('data-image') %}<img src="{{ item.labelAttribute('data-image')|imagine_filter('sylius_small', true) }}" alt="{{ item.name }}" class="menu-thumbnail"/>{% endif %}
 {% endblock %}


### PR DESCRIPTION
Hi guys, I want to rename our size filter from `sylius_16x16` to `sylius_icon`, `sylius_small`, `sylius_medium`, `sylius_large` etc, so we can change the size without renaming the filter.

This naming really bugging me.

``` yml
liip_imagine:
    data_root: %kernel.root_dir%/../web/media/image
    filter_sets:
        sylius_16x16:
            filters:
                thumbnail: { size: [16, 16], mode: outbound }
        sylius_50x40:
            filters:
                thumbnail: { size: [50, 40], mode: outbound }
        sylius_90x60:
            filters:
                thumbnail: { size: [90, 60], mode: outbound }
        sylius_200x200:
            filters:
                thumbnail: { size: [200, 200], mode: outbound }

        sylius_262x255:
            filters:
                thumbnail: { size: [265, 255], mode: outbound }
        sylius_310x300:
            filters:
                thumbnail: { size: [310, 300], mode: outbound }
        sylius_610x600:
            filters:
                thumbnail: { size: [610, 600], mode: outbound }
        sylius_gallery:
            filters:
                thumbnail: { size: [640, 480], mode: outbound }
```

https://github.com/Sylius/Sylius/blob/master/app/config/config.yml#L135-L159

We do have a lot of sizes, should we remove some of them too? if so how many should we keep?
