### PR TITLE
Fix release ONHOLD sold units

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OrderProcessing/InventoryHandler.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderProcessing/InventoryHandler.php
@@ -123,16 +123,16 @@ class InventoryHandler implements InventoryHandlerInterface
 
             foreach ($units as $unit) {
                 if (in_array($unit->getInventoryState(), array(InventoryUnitInterface::STATE_ONHOLD, InventoryUnitInterface::STATE_CHECKOUT))) {
-                    $unit->setInventoryState(InventoryUnitInterface::STATE_SOLD);
-
                     if (InventoryUnitInterface::STATE_ONHOLD === $unit->getInventoryState()) {
                         $quantity++;
                     }
+                    
+                    $unit->setInventoryState(InventoryUnitInterface::STATE_SOLD);
                 }
             }
 
-            $this->inventoryOperator->decrease($units);
             $this->inventoryOperator->release($item->getVariant(), $quantity);
+            $this->inventoryOperator->decrease($units);
         }
     }
 


### PR DESCRIPTION
1. Put counting $quantity before change state :) coz we never release ONHOLD.
2. When backorders are off and you try to buy last product-variant (on_hand=1) not available on demand (available_on_demand=0) after payment
   inventoryOperator->decrease($units); throws InsufficientStockException
   isStockSufficient function doesn't know that ONHOLD units waiting for our order.

We can release ONHOLD units before decrease (like in this PR)
or we should send to decrease fucntion $quantity var.
