### PR TITLE
Add "Canceled" shipment state.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Model/OrderShippingStates.php
+++ b/src/Sylius/Bundle/CoreBundle/Model/OrderShippingStates.php
@@ -22,8 +22,8 @@ class OrderShippingStates
     const ONHOLD            = 'onhold';
     const READY             = 'ready';
     const BACKORDER         = 'backorder';
-    const DISPATCHED        = 'dispatched';
     const PARTIALLY_SHIPPED = 'partially_shipped';
     const SHIPPED           = 'shipped';
     const RETURNED          = 'returned';
+    const CANCELLED         = 'cancelled';
 }

--- a/src/Sylius/Bundle/CoreBundle/OrderProcessing/StateResolver.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderProcessing/StateResolver.php
@@ -59,8 +59,8 @@ class StateResolver implements StateResolverInterface
             ShipmentInterface::STATE_ONHOLD     => OrderShippingStates::ONHOLD,
             ShipmentInterface::STATE_READY      => OrderShippingStates::READY,
             ShipmentInterface::STATE_SHIPPED    => OrderShippingStates::SHIPPED,
-            ShipmentInterface::STATE_DISPATCHED => OrderShippingStates::DISPATCHED,
-            ShipmentInterface::STATE_RETURNED   => OrderShippingStates::RETURNED
+            ShipmentInterface::STATE_RETURNED   => OrderShippingStates::RETURNED,
+            ShipmentInterface::STATE_CANCELLED  => OrderShippingStates::CANCELLED,
         );
 
         foreach ($acceptableStates as $shipmentState => $orderState) {

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/OrderProcessing/StateResolverSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/OrderProcessing/StateResolverSpec.php
@@ -67,25 +67,9 @@ class StateResolverSpec extends ObjectBehavior
         $order->getShipments()->willReturn(array($shipment1, $shipment2));
 
         $shipment1->getState()->willReturn(ShipmentInterface::STATE_SHIPPED);
-        $shipment2->getState()->willReturn(ShipmentInterface::STATE_DISPATCHED);
+        $shipment2->getState()->willReturn(ShipmentInterface::STATE_READY);
 
         $order->setShippingState(OrderShippingStates::PARTIALLY_SHIPPED)->shouldBeCalled();
-        $this->resolveShippingState($order);
-    }
-
-    function it_marks_order_as_dispatched_if_all_shipments_are_dispatched(
-        OrderInterface $order,
-        ShipmentInterface $shipment1,
-        ShipmentInterface $shipment2
-    )
-    {
-        $order->isBackorder()->shouldBeCalled()->willReturn(false);
-        $order->getShipments()->willReturn(array($shipment1, $shipment2));
-
-        $shipment1->getState()->willReturn(ShipmentInterface::STATE_DISPATCHED);
-        $shipment2->getState()->willReturn(ShipmentInterface::STATE_DISPATCHED);
-
-        $order->setShippingState(OrderShippingStates::DISPATCHED)->shouldBeCalled();
         $this->resolveShippingState($order);
     }
 

--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadOrdersData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadOrdersData.php
@@ -146,11 +146,11 @@ class LoadOrdersData extends DataFixture
     {
         return array_rand(array_flip(array(
             ShipmentInterface::STATE_CHECKOUT,
-            ShipmentInterface::STATE_DISPATCHED,
             ShipmentInterface::STATE_SHIPPED,
-            ShipmentInterface::STATE_READY,
             ShipmentInterface::STATE_PENDING,
+            ShipmentInterface::STATE_READY,
             ShipmentInterface::STATE_RETURNED,
+            ShipmentInterface::STATE_CANCELLED,
         )));
     }
 

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShipmentType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShipmentType.php
@@ -55,11 +55,11 @@ class ShipmentType extends AbstractType
                 'label'   => 'sylius.form.shipment.state',
                 'choices' => array(
                     ShipmentInterface::STATE_CHECKOUT   => 'sylius.form.shipment.states.checkout',
-                    ShipmentInterface::STATE_DISPATCHED => 'sylius.form.shipment.states.dispatched',
                     ShipmentInterface::STATE_PENDING    => 'sylius.form.shipment.states.pending',
                     ShipmentInterface::STATE_READY      => 'sylius.form.shipment.states.ready',
                     ShipmentInterface::STATE_SHIPPED    => 'sylius.form.shipment.states.shipped',
                     ShipmentInterface::STATE_RETURNED   => 'sylius.form.shipment.states.returned',
+                    ShipmentInterface::STATE_CANCELLED  => 'sylius.form.shipment.states.cancelled',
                 ),
             ))
             ->add('tracking', 'text', array(

--- a/src/Sylius/Bundle/ShippingBundle/Model/ShipmentInterface.php
+++ b/src/Sylius/Bundle/ShippingBundle/Model/ShipmentInterface.php
@@ -23,11 +23,11 @@ interface ShipmentInterface extends ShippingSubjectInterface
     // Shipment default states.
     const STATE_CHECKOUT   = 'checkout';
     const STATE_ONHOLD     = 'onhold';
-    const STATE_READY      = 'ready';
     const STATE_PENDING    = 'pending';
-    const STATE_DISPATCHED = 'dispatched';
+    const STATE_READY      = 'ready';
     const STATE_SHIPPED    = 'shipped';
     const STATE_RETURNED   = 'returned';
+    const STATE_CANCELLED  = 'cancelled';
 
     /**
      * Get shipment state.

--- a/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
@@ -11,11 +11,11 @@ sylius:
             state: State
             states:
                 checkout:   Checkout
-                dispatched: Dispatched
                 pending:    Pending
                 ready:      Ready
                 shipped:    Shipped
                 returned:   Returned
+                cancelled:  Cancelled
             tracking_code: Tracking Code
 
         shipping_calculator:

--- a/src/Sylius/Bundle/ShippingBundle/spec/Sylius/Bundle/ShippingBundle/Model/ShipmentItemSpec.php
+++ b/src/Sylius/Bundle/ShippingBundle/spec/Sylius/Bundle/ShippingBundle/Model/ShipmentItemSpec.php
@@ -74,8 +74,8 @@ class ShipmentItemSpec extends ObjectBehavior
 
     function its_state_is_mutable()
     {
-        $this->setShippingState(ShipmentInterface::STATE_PENDING);
-        $this->getShippingState()->shouldReturn(ShipmentInterface::STATE_PENDING);
+        $this->setShippingState(ShipmentInterface::STATE_SHIPPED);
+        $this->getShippingState()->shouldReturn(ShipmentInterface::STATE_SHIPPED);
     }
 
     function it_initializes_creation_date_by_default()

--- a/src/Sylius/Bundle/ShippingBundle/spec/Sylius/Bundle/ShippingBundle/Model/ShipmentSpec.php
+++ b/src/Sylius/Bundle/ShippingBundle/spec/Sylius/Bundle/ShippingBundle/Model/ShipmentSpec.php
@@ -43,8 +43,8 @@ class ShipmentSpec extends ObjectBehavior
 
     function its_state_is_mutable()
     {
-        $this->setState(ShipmentInterface::STATE_PENDING);
-        $this->getState()->shouldReturn(ShipmentInterface::STATE_PENDING);
+        $this->setState(ShipmentInterface::STATE_SHIPPED);
+        $this->getState()->shouldReturn(ShipmentInterface::STATE_SHIPPED);
     }
 
     function it_has_no_shipping_method_by_default()


### PR DESCRIPTION
![screen shot 2014-03-14 at 9 49 35 pm](https://f.cloud.github.com/assets/193112/2421253/93a4420c-ab7f-11e3-8ea0-c35ef53a97ff.png)

Should we...
- Add a new "Canceled" shipment state.
- Remove the old "Dispatched" state, it is not being use in anywhere.

Reference: http://guides.spreecommerce.com/developer/shipments.html
