### PR TITLE
Update composer.json problem with CMF

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,9 @@
         "phpspec/phpspec":                   "2.0.*@dev",
         "phpunit/phpunit":                   "~3.7"
     },
+    "provide": {
+        "phpcr/phpcr-implementation": "2.1.0"
+    },
     "scripts": {
         "post-install-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",


### PR DESCRIPTION
Resloving this error
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - doctrine/phpcr-bundle 1.0.0 requires phpcr/phpcr-implementation 2.1.\* -> no matching package found.
    - symfony-cmf/menu-bundle 1.0.0 requires doctrine/phpcr-bundle 1.0.\* -> satisfiable by doctrine/phpcr-bundle[1.0.0].
    - Installation request for symfony-cmf/menu-bundle 1.0.\* -> satisfiable by symfony-cmf/menu-bundle[1.0.0].

Potential causes:
- A typo in the package name
- The package is not available in a stable-enough version according to your minimum-stability setting
  see https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion for more details.

Read http://getcomposer.org/doc/articles/troubleshooting.md for further common problems.
vagrant@precise64:/vagrant$ php composer.phar update
