### PR TITLE
Adjust Cart\ItemResolverInterface to remove dependency on Symfony Request class

### DIFF
--- a/src/Sylius/Bundle/CartBundle/Resolver/ItemResolverInterface.php
+++ b/src/Sylius/Bundle/CartBundle/Resolver/ItemResolverInterface.php
@@ -12,23 +12,23 @@
 namespace Sylius\Bundle\CartBundle\Resolver;
 
 use Sylius\Bundle\CartBundle\Model\CartItemInterface;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Resolver returns cart item that needs to be added based on request.
+ * Resolver returns cart item that needs to be added based on given data.
  *
  * @author Paweł Jędrzejewski <pjedrzejewski@diweb.pl>
  */
 interface ItemResolverInterface
 {
     /**
-     * Returns item to add.
-     * It takes empty and clean item object as first argument.
+     * Returns item that will be added into the cart.
      *
-     * @param CartItemInterface $item
-     * @param Request           $request
+     * @param CartItemInterface $item Empty and clean item object as first argument
+     * @param mixed             $data Mixed data from which item identifier is extracted
      *
      * @return CartItemInterface
+     *
+     * @throws ItemResolvingException
      */
-    public function resolve(CartItemInterface $item, Request $request);
+    public function resolve(CartItemInterface $item, $data);
 }

--- a/src/Sylius/Bundle/CartBundle/Resolver/ItemResolvingException.php
+++ b/src/Sylius/Bundle/CartBundle/Resolver/ItemResolvingException.php
@@ -17,6 +17,6 @@ namespace Sylius\Bundle\CartBundle\Resolver;
  *
  * @author Paweł Jędrzejewski <pjedrzejewski@diweb.pl>
  */
-class ItemResolvingException extends \Exception
+class ItemResolvingException extends \InvalidArgumentException
 {
 }

--- a/src/Sylius/Bundle/CoreBundle/Cart/ItemResolver.php
+++ b/src/Sylius/Bundle/CoreBundle/Cart/ItemResolver.php
@@ -18,7 +18,7 @@ use Sylius\Bundle\CoreBundle\Model\OrderItem;
 use Sylius\Bundle\CoreBundle\Model\Product;
 use Sylius\Bundle\InventoryBundle\Checker\AvailabilityCheckerInterface;
 use Sylius\Bundle\ResourceBundle\Model\RepositoryInterface;
-use Symfony\Component\Form\FormFactory;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Sylius\Bundle\CoreBundle\Checker\RestrictedZoneCheckerInterface;
 use Sylius\Bundle\CartBundle\Provider\CartProviderInterface;
@@ -57,7 +57,7 @@ class ItemResolver implements ItemResolverInterface
     /**
      * Form factory.
      *
-     * @var FormFactory
+     * @var FormFactoryInterface
      */
     protected $formFactory;
 
@@ -79,8 +79,9 @@ class ItemResolver implements ItemResolverInterface
      * Constructor.
      *
      * @param CartProviderInterface          $cartProvider
+     * @param PriceCalculatorInterface       $priceCalculator
      * @param RepositoryInterface            $productRepository
-     * @param FormFactory                    $formFactory
+     * @param FormFactoryInterface           $formFactory
      * @param AvailabilityCheckerInterface   $availabilityChecker
      * @param RestrictedZoneCheckerInterface $restrictedZoneChecker
      */
@@ -88,7 +89,7 @@ class ItemResolver implements ItemResolverInterface
         CartProviderInterface          $cartProvider,
         PriceCalculatorInterface       $priceCalculator,
         RepositoryInterface            $productRepository,
-        FormFactory                    $formFactory,
+        FormFactoryInterface           $formFactory,
         AvailabilityCheckerInterface   $availabilityChecker,
         RestrictedZoneCheckerInterface $restrictedZoneChecker
     )
@@ -103,32 +104,20 @@ class ItemResolver implements ItemResolverInterface
 
     /**
      * {@inheritdoc}
-     *
-     * Here we create the item that is going to be added to cart, basing on the current request.
      */
-    public function resolve(CartItemInterface $item, Request $request)
+    public function resolve(CartItemInterface $item, $data)
     {
-        if (!$request->isMethod('POST')) {
-            throw new ItemResolvingException('Wrong request method');
-        }
-
-        /*
-         * We're getting here product id via query but you can easily override route
-         * pattern and use attributes, which are available through request object.
-         */
-        if (!$id = $request->get('id')) {
-            throw new ItemResolvingException('Error while trying to add item to cart');
-        }
+        $id = $this->resolveItemIdentifier($data);
 
         /* @var $product Product */
         if (!$product = $this->productRepository->find($id)) {
-            throw new ItemResolvingException('Requested product was not found');
+            throw new ItemResolvingException('Requested product was not found.');
         }
 
         // We use forms to easily set the quantity and pick variant but you can do here whatever is required to create the item.
         $form = $this->formFactory->create('sylius_cart_item', null, array('product' => $product));
 
-        $form->submit($request);
+        $form->submit($data);
         /* @var $item OrderItem */
         $item = $form->getData();
 
@@ -165,5 +154,35 @@ class ItemResolver implements ItemResolverInterface
         }
 
         return $item;
+    }
+
+    /**
+     * Here we resolve the item identifier that is going to be added into the cart.
+     *
+     * @param mixed $request
+     *
+     * @return string|integer
+     *
+     * @throws ItemResolvingException
+     */
+    public function resolveItemIdentifier($request)
+    {
+        if (!$request instanceof Request) {
+            throw new ItemResolvingException('Invalid request data.');
+        }
+
+        if (!$request->isMethod('POST') && !$request->isMethod('PUT')) {
+            throw new ItemResolvingException('Invalid request method.');
+        }
+
+        /*
+         * We're getting here product id via query but you can easily override route
+         * pattern and use attributes, which are available through request object.
+         */
+        if (!$id = $request->get('id')) {
+            throw new ItemResolvingException('Error while trying to add item to cart.');
+        }
+
+        return $id;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Cart/ItemResolverSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Cart/ItemResolverSpec.php
@@ -18,7 +18,7 @@ use Sylius\Bundle\InventoryBundle\Checker\AvailabilityCheckerInterface;
 use Sylius\Bundle\ResourceBundle\Model\RepositoryInterface;
 use Sylius\Bundle\CartBundle\Provider\CartProviderInterface;
 use Sylius\Bundle\CoreBundle\Calculator\PriceCalculatorInterface;
-use Symfony\Component\Form\FormFactory;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -30,7 +30,7 @@ class ItemResolverSpec extends ObjectBehavior
         CartProviderInterface $cartProvider,
         PriceCalculatorInterface $priceCalculator,
         RepositoryInterface $productRepository,
-        FormFactory $formFactory,
+        FormFactoryInterface $formFactory,
         AvailabilityCheckerInterface $availabilityChecker,
         RestrictedZoneCheckerInterface $restrictedZoneChecker
     )
@@ -48,9 +48,10 @@ class ItemResolverSpec extends ObjectBehavior
         $this->shouldImplement('Sylius\Bundle\CartBundle\Resolver\ItemResolverInterface');
     }
 
-    function it_throws_exception_unless_request_method_is_POST(CartItemInterface $item, Request $request)
+    function it_throws_exception_unless_request_method_is_POST_or_PUT(CartItemInterface $item, Request $request)
     {
         $request->isMethod('POST')->willReturn(false);
+        $request->isMethod('PUT')->willReturn(false);
 
         $this
             ->shouldThrow('Sylius\Bundle\CartBundle\Resolver\ItemResolvingException')


### PR DESCRIPTION
After little discussion in #1233 I have decided to follow those suggestion and remove dependency on `Request` class in `ItemResolverInterface`.

@pjedrzejewski @patkar What do you think about this change?
