### PR TITLE
Allow null values in TaxonSelectionToCollectionTransformer

### DIFF
--- a/src/Sylius/Bundle/TaxonomiesBundle/Form/DataTransformer/TaxonSelectionToCollectionTransformer.php
+++ b/src/Sylius/Bundle/TaxonomiesBundle/Form/DataTransformer/TaxonSelectionToCollectionTransformer.php
@@ -80,6 +80,10 @@ class TaxonSelectionToCollectionTransformer implements DataTransformerInterface
         $taxons = new ArrayCollection();
 
         foreach ($value as $taxonomy) {
+            if (null === $taxonomy) {
+                continue;
+            }
+
             foreach ($taxonomy as $taxon) {
                 $taxons->add($taxon);
             }


### PR DESCRIPTION
In our project we have:

``` diff
diff --git a/src/Sylius/Bundle/TaxonomiesBundle/Form/Type/TaxonSelectionType.php b/src/Sylius/Bundle/TaxonomiesBundle/Form/Type/TaxonSelectionType.php
index a9dcb36..9c77828 100644
--- a/src/Sylius/Bundle/TaxonomiesBundle/Form/Type/TaxonSelectionType.php
+++ b/src/Sylius/Bundle/TaxonomiesBundle/Form/Type/TaxonSelectionType.php
@@ -70,6 +70,7 @@ class TaxonSelectionType extends AbstractType
             $builder->add($taxonomy->getId(), 'choice', array(
                 'choice_list' => new ObjectChoiceList($this->taxonRepository->getTaxonsAsList($taxonomy)),
                 'multiple'    => $options['multiple'],
+                'empty_value' => '---',
                 'label'       => /** @Ignore */ $taxonomy->getName()
             ));
         }
```

This causes `ContextErrorException: Warning: Invalid argument supplied for foreach() in src/Sylius/Bundle/TaxonomiesBundle/Form/DataTransformer/TaxonSelectionToCollectionTransformer.php line 83`.
