### PR TITLE
Refactor EntityToIdentifier stuff into ObjectToIdentifier

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Rule/ShippingCountryConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Rule/ShippingCountryConfigurationType.php
@@ -26,8 +26,8 @@ class ShippingCountryConfigurationType extends AbstractType
     protected $dataClass;
 
     /**
-     * @param array $validationGroups Array of validation groups
-     * @param type  $dataClass        Class of Country model
+     * @param array  $validationGroups Array of validation groups
+     * @param string $dataClass        Class of Country model
      */
     public function __construct(array $validationGroups, $dataClass)
     {

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/AbstractResourceExtension.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/AbstractResourceExtension.php
@@ -13,7 +13,6 @@ namespace Sylius\Bundle\ResourceBundle\DependencyInjection;
 
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\DatabaseDriverFactory;
 use Sylius\Bundle\ResourceBundle\Exception\Driver\InvalidDriverException;
-use Sylius\Bundle\ResourceBundle\Exception\Driver\UnknownDriverException;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
@@ -134,7 +133,7 @@ abstract class AbstractResourceExtension extends Extension
      * @param XmlFileLoader         $loader
      * @param null|ContainerBuilder $container
      *
-     * @throws UnknownDriverException
+     * @throws InvalidDriverException
      */
     protected function loadDatabaseDriver(array $config, XmlFileLoader $loader, ContainerBuilder $container)
     {
@@ -179,7 +178,7 @@ abstract class AbstractResourceExtension extends Extension
      * Get the configuration directory
      *
      * @return string
-     * @throws \Exception
+     * @throws \RuntimeException
      */
     protected function getConfigurationDirectory()
     {
@@ -187,7 +186,7 @@ abstract class AbstractResourceExtension extends Extension
         $fileName = $reflector->getFileName();
 
         if (!is_dir($directory = dirname($fileName) . $this->configDirectory)) {
-            throw new \Exception(sprintf('The configuration directory "%s" does not exists.', $directory));
+            throw new \RuntimeException(sprintf('The configuration directory "%s" does not exists.', $directory));
         }
 
         return $directory;

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Compiler/ObjectToIdentifierServicePass.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Compiler/ObjectToIdentifierServicePass.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Joseph Bielawski <stloyd@gmail.com>
+ */
+class ObjectToIdentifierServicePass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasDefinition('doctrine')) {
+            $definition = new DefinitionDecorator('sylius.form.type.object_to_identifier');
+            $definition->addArgument(new Reference('doctrine'));
+            $definition->addArgument('sylius_entity_to_identifier');
+            $definition->addTag('form.type', array('alias' => 'sylius_entity_to_identifier'));
+
+            $container->setDefinition('sylius_entity_to_identifier', $definition);
+        }
+
+        if ($container->hasDefinition('doctrine_mongodb')) {
+            $definition = new DefinitionDecorator('sylius.form.type.object_to_identifier');
+            $definition->addArgument(new Reference('doctrine_mongodb'));
+            $definition->addArgument('sylius_document_to_identifier');
+            $definition->addTag('form.type', array('alias' => 'sylius_document_to_identifier'));
+
+            $container->setDefinition('sylius_document_to_identifier', $definition);
+
+            if (!$container->hasDefinition('sylius_entity_to_identifier')) {
+                $container->setAlias('sylius_entity_to_identifier', 'sylius_document_to_identifier');
+            }
+        }
+
+        if ($container->hasDefinition('doctrine_phpcr')) {
+            $definition = new DefinitionDecorator('sylius.form.type.object_to_identifier');
+            $definition->addArgument(new Reference('doctrine_phpcr'));
+            $definition->addArgument('sylius_phpcr_document_to_identifier');
+            $definition->addTag('form.type', array('alias' => 'sylius_phpcr_document_to_identifier'));
+
+            $container->setDefinition('sylius_phpcr_document_to_identifier', $definition);
+
+            if (!$container->hasDefinition('sylius_entity_to_identifier')) {
+                $container->setAlias('sylius_entity_to_identifier', 'sylius_phpcr_document_to_identifier');
+            }
+        }
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/Form/DataTransformer/ObjectToIdentifierTransformer.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/DataTransformer/ObjectToIdentifierTransformer.php
@@ -18,11 +18,11 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
- * Entity to id transformer.
+ * Object to id transformer.
  *
  * @author Alexandre Bacco <alexandre.bacco@gmail.com>
  */
-class EntityToIdentifierTransformer implements DataTransformerInterface
+class ObjectToIdentifierTransformer implements DataTransformerInterface
 {
     /**
      * Repository.
@@ -61,7 +61,7 @@ class EntityToIdentifierTransformer implements DataTransformerInterface
 
         if (null === $entity = $this->repository->findOneBy(array($this->identifier => $value))) {
             throw new TransformationFailedException(sprintf(
-                'Entity "%s" with identifier "%s"="%s" does not exist.',
+                'Object "%s" with identifier "%s"="%s" does not exist.',
                 $this->repository->getClassName(),
                 $this->identifier,
                 $value
@@ -74,20 +74,20 @@ class EntityToIdentifierTransformer implements DataTransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function reverseTransform($entity)
+    public function reverseTransform($value)
     {
-        if (null === $entity) {
+        if (null === $value) {
             return '';
         }
 
         $class = $this->repository->getClassName();
 
-        if (!$entity instanceof $class) {
-            throw new UnexpectedTypeException($entity, $class);
+        if (!$value instanceof $class) {
+            throw new UnexpectedTypeException($value, $class);
         }
 
         $accessor = PropertyAccess::createPropertyAccessor();
 
-        return $accessor->getValue($entity, $this->identifier);
+        return $accessor->getValue($value, $this->identifier);
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/Form/Type/ObjectToIdentifierType.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/Type/ObjectToIdentifierType.php
@@ -11,29 +11,37 @@
 
 namespace Sylius\Bundle\ResourceBundle\Form\Type;
 
-use Doctrine\Common\Persistence\ObjectManager;
-use Sylius\Bundle\ResourceBundle\Form\DataTransformer\EntityToIdentifierTransformer;
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Sylius\Bundle\ResourceBundle\Form\DataTransformer\ObjectToIdentifierTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
- * Entity to identifier type.
+ * Object to identifier type.
  *
  * @author Alexandre Bacco <alexandre.bacco@gmail.com>
  */
-class EntityToIdentifierType extends AbstractType
+class ObjectToIdentifierType extends AbstractType
 {
     /**
-     * Object Manager.
+     * Manager registry.
      *
-     * @var ObjectManager
+     * @var ManagerRegistry
      */
-    protected $om;
+    protected $manager;
 
-    public function __construct(ObjectManager $om)
+    /**
+     * Form name.
+     *
+     * @var string
+     */
+    protected $name;
+
+    public function __construct(ManagerRegistry $manager, $name)
     {
-        $this->om = $om;
+        $this->manager = $manager;
+        $this->name = $name;
     }
 
     /**
@@ -42,7 +50,7 @@ class EntityToIdentifierType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->addModelTransformer(
-            new EntityToIdentifierTransformer($this->om->getRepository($options['class']), $options['identifier'])
+            new ObjectToIdentifierTransformer($this->manager->getRepository($options['class']), $options['identifier'])
         );
     }
 
@@ -74,6 +82,6 @@ class EntityToIdentifierType extends AbstractType
      */
     public function getName()
     {
-        return 'sylius_entity_to_identifier';
+        return $this->name;
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/container/services.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/container/services.xml
@@ -22,7 +22,7 @@
         <parameter key="sylius.expression_language.class">Sylius\Bundle\ResourceBundle\ExpressionLanguage\ExpressionLanguage</parameter>
 
         <parameter key="sylius.twig.resource.class">Sylius\Bundle\ResourceBundle\Twig\SyliusResourceExtension</parameter>
-        <parameter key="sylius.form.type.entity_to_identifier.class">Sylius\Bundle\ResourceBundle\Form\Type\EntityToIdentifierType</parameter>
+        <parameter key="sylius.form.type.object_to_identifier.class">Sylius\Bundle\ResourceBundle\Form\Type\ObjectToIdentifierType</parameter>
 
         <parameter key="sylius.event_subscriber.load_metadata.class">Sylius\Bundle\ResourceBundle\EventListener\LoadMetadataSubscriber</parameter>
         <parameter key="sylius.event_subscriber.kernel_controller.class">Sylius\Bundle\ResourceBundle\EventListener\KernelControllerSubscriber</parameter>
@@ -57,10 +57,7 @@
             <tag name="kernel.event_subscriber" />
         </service>
 
-        <service id="sylius.form.type.entity_to_identifier" class="%sylius.form.type.entity_to_identifier.class%">
-             <argument type="service" id="doctrine.orm.entity_manager" />
-             <tag name="form.type" alias="sylius_entity_to_identifier" />
-         </service>
+        <service id="sylius.form.type.object_to_identifier" class="%sylius.form.type.object_to_identifier.class%" abstract="true" />
     </services>
 
 </container>

--- a/src/Sylius/Bundle/ResourceBundle/SyliusResourceBundle.php
+++ b/src/Sylius/Bundle/ResourceBundle/SyliusResourceBundle.php
@@ -11,6 +11,8 @@
 
 namespace Sylius\Bundle\ResourceBundle;
 
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\ObjectToIdentifierServicePass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -24,4 +26,12 @@ class SyliusResourceBundle extends Bundle
     const DRIVER_DOCTRINE_ORM         = 'doctrine/orm';
     const DRIVER_DOCTRINE_MONGODB_ODM = 'doctrine/mongodb-odm';
     const DRIVER_DOCTRINE_PHPCR_ODM   = 'doctrine/phpcr-odm';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new ObjectToIdentifierServicePass());
+    }
 }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Form/DataTransformer/ObjectToIdentifierTransformerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Form/DataTransformer/ObjectToIdentifierTransformerSpec.php
@@ -9,7 +9,7 @@ use Prophecy\Argument;
 // Since the root namespace "spec" is not in our autoload
 require_once __DIR__.DIRECTORY_SEPARATOR.'FakeEntity.php';
 
-class EntityToIdentifierTransformerSpec extends ObjectBehavior
+class ObjectToIdentifierTransformerSpec extends ObjectBehavior
 {
     function let(ObjectRepository $repository)
     {
@@ -19,16 +19,14 @@ class EntityToIdentifierTransformerSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\Form\DataTransformer\EntityToIdentifierTransformer');
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\Form\DataTransformer\ObjectToIdentifierTransformer');
     }
 
     function it_does_not_transform_null_value(ObjectRepository $repository)
     {
-        $value = null;
-
         $repository->findOneBy(Argument::any())->shouldNotBeCalled();
 
-        $this->transform($value)->shouldReturn(null);
+        $this->transform(null)->shouldReturn(null);
     }
 
     function it_throws_an_exception_on_non_existing_entity(ObjectRepository $repository)
@@ -51,16 +49,13 @@ class EntityToIdentifierTransformerSpec extends ObjectBehavior
 
     function it_does_not_reverse_null_value()
     {
-        $value = null;
-
-        $this->reverseTransform($value)->shouldReturn('');
+        $this->reverseTransform(null)->shouldReturn('');
     }
 
     function it_reverses_entity_in_identifier(FakeEntity $value)
     {
-        $id = 6;
-        $value->getId()->shouldBeCalled()->willReturn($id);
+        $value->getId()->shouldBeCalled()->willReturn(6);
 
-        $this->reverseTransform($value)->shouldReturn($id);
+        $this->reverseTransform($value)->shouldReturn(6);
     }
 }

--- a/src/Sylius/Bundle/SettingsBundle/Transformer/ObjectToIdentifierTransformer.php
+++ b/src/Sylius/Bundle/SettingsBundle/Transformer/ObjectToIdentifierTransformer.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\SettingsBundle\Transformer;
 
-use Sylius\Bundle\ResourceBundle\Form\DataTransformer\EntityToIdentifierTransformer;
+use Sylius\Bundle\ResourceBundle\Form\DataTransformer\ObjectToIdentifierTransformer as BaseTransformer;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
@@ -19,7 +19,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
  *
  * @author Paweł Jędrzejewski <pjedrzejewski@diweb.pl>
  */
-class ObjectToIdentifierTransformer extends EntityToIdentifierTransformer implements ParameterTransformerInterface
+class ObjectToIdentifierTransformer extends BaseTransformer implements ParameterTransformerInterface
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Remove hardcoded dependency on Doctrine ORM, and allow instead to register transformer for every persistence type (ORM, ODM, PHPCR).

This is alternative approach to the #1244. Fixes #1199.
