### PR TITLE
PayPal order item amount bug fixed.

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Payum/Paypal/Action/CaptureOrderUsingExpressCheckoutAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Payum/Paypal/Action/CaptureOrderUsingExpressCheckoutAction.php
@@ -54,18 +54,23 @@ class CaptureOrderUsingExpressCheckoutAction extends PaymentAwareAction
                 $request->getToken()->getPaymentName(),
                 $order
             )->getTargetUrl();
-            $details['INVNUM'] = $order->getNumber();
-
+            $details['PAYMENTREQUEST_0_INVNUM'] = $order->getNumber();
             $details['PAYMENTREQUEST_0_CURRENCYCODE'] = $order->getCurrency();
             $details['PAYMENTREQUEST_0_AMT'] = number_format($order->getTotal() / 100, 2);
-            $details['PAYMENTREQUEST_0_ITEMAMT'] = number_format(($order->getItemsTotal() + $order->getPromotionTotal())/ 100, 2);
-            $details['PAYMENTREQUEST_0_TAXAMT'] = number_format($order->getTaxTotal() / 100, 2);
-            $details['PAYMENTREQUEST_0_SHIPPINGAMT'] = number_format($order->getShippingTotal() / 100, 2);
+            $details['PAYMENTREQUEST_0_ITEMAMT'] = number_format($order->getTotal() / 100, 2);
 
             $m = 0;
             foreach ($order->getItems() as $item) {
-                $details['L_PAYMENTREQUEST_0_AMT'.$m] = number_format($item->getUnitPrice() / 100, 2);
+                $details['L_PAYMENTREQUEST_0_AMT'.$m] = number_format($item->getTotal()/$item->getQuantity()/100, 2);
                 $details['L_PAYMENTREQUEST_0_QTY'.$m] = $item->getQuantity();
+
+                $m++;
+            }
+
+            if ($order->getTaxTotal() !== 0) {
+                $details['L_PAYMENTREQUEST_0_NAME'.$m] = 'Tax Total';
+                $details['L_PAYMENTREQUEST_0_AMT'.$m]  = number_format($order->getTaxTotal() / 100, 2);
+                $details['L_PAYMENTREQUEST_0_QTY'.$m]  = 1;
 
                 $m++;
             }
@@ -73,6 +78,14 @@ class CaptureOrderUsingExpressCheckoutAction extends PaymentAwareAction
             if ($order->getPromotionTotal() !== 0) {
                 $details['L_PAYMENTREQUEST_0_NAME'.$m] = 'Discount';
                 $details['L_PAYMENTREQUEST_0_AMT'.$m]  = number_format($order->getPromotionTotal() / 100, 2);
+                $details['L_PAYMENTREQUEST_0_QTY'.$m]  = 1;
+
+                $m++;
+            }
+
+            if ($order->getShippingTotal() !== 0) {
+                $details['L_PAYMENTREQUEST_0_NAME'.$m] = 'Shipping Total';
+                $details['L_PAYMENTREQUEST_0_AMT'.$m]  = number_format($order->getShippingTotal() / 100, 2);
                 $details['L_PAYMENTREQUEST_0_QTY'.$m]  = 1;
             }
 


### PR DESCRIPTION
As title.

`$item->getUnitPrice()` didn't include order item adjustment.
