### PR TITLE
Stable version of DoctrineCacheBundle

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -66,7 +66,7 @@ class AppKernel extends Kernel
             new Symfony\Bundle\TwigBundle\TwigBundle(),
 
             // Third party bundles.
-            new Liip\DoctrineCacheBundle\LiipDoctrineCacheBundle(),
+            new Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle(),
             new Liip\ImagineBundle\LiipImagineBundle(),
             new Knp\Bundle\MenuBundle\KnpMenuBundle(),
             new Knp\Bundle\GaufretteBundle\KnpGaufretteBundle(),

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -115,8 +115,8 @@ swiftmailer:
     password:  %sylius.mailer.password%
     spool:     { type: memory }
 
-liip_doctrine_cache:
-    namespaces:
+doctrine_cache:
+    providers:
         sylius_settings: %sylius.cache%
 
 knp_gaufrette:

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -25,8 +25,8 @@ sylius_payments:
         test:   Test
         stripe: Stripe
 
-liip_doctrine_cache:
-    namespaces:
+doctrine_cache:
+    providers:
         sylius_settings:
             type: array
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php":                                  ">=5.3.3",
 
         "doctrine/doctrine-bundle":             "~1.3@dev",
-        "doctrine/doctrine-cache-bundle":       "@dev",
+        "doctrine/doctrine-cache-bundle":       "~1.0",
         "doctrine/orm":                         "~2.3",
         "friendsofsymfony/rest-bundle":         "~1.0",
         "friendsofsymfony/user-bundle":         "2.0.*@dev",
@@ -32,7 +32,6 @@
         "jms/translation-bundle":               "1.1.*",
         "knplabs/knp-gaufrette-bundle":         "*@dev",
         "knplabs/knp-snappy-bundle":            "*@dev",
-        "liip/doctrine-cache-bundle":           "*",
         "liip/imagine-bundle":                  "~0.9",
         "mathiasverraes/money":                 "*@dev",
         "sensio/distribution-bundle":           "2.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "fd737e09c6f54d8986cb20e5763f46ea",
+    "hash": "7f102e8dd116c2536edb45d56b5a19ed",
     "packages": [
         {
             "name": "ajbdev/authorizenet-php-api",
@@ -44,12 +44,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "40db0c96985aab2822edbc4848b3bd2429e02670"
+                "reference": "v1.1.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/40db0c96985aab2822edbc4848b3bd2429e02670",
-                "reference": "40db0c96985aab2822edbc4848b3bd2429e02670",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/v1.1.2",
+                "reference": "v1.1.2",
                 "shasum": ""
             },
             "require": {
@@ -474,7 +474,7 @@
         },
         {
             "name": "doctrine/doctrine-cache-bundle",
-            "version": "dev-master",
+            "version": "1.0.0",
             "target-dir": "Doctrine/Bundle/DoctrineCacheBundle",
             "source": {
                 "type": "git",
@@ -1905,7 +1905,7 @@
             ],
             "authors": [
                 {
-                    "name": "Johannes M. Schmitt",
+                    "name": "Johannes Schmitt",
                     "email": "schmittjoh@gmail.com",
                     "homepage": "http://jmsyst.com",
                     "role": "Developer of wrapped JMSSerializerBundle"
@@ -2464,54 +2464,6 @@
             "time": "2013-05-19 03:41:15"
         },
         {
-            "name": "liip/doctrine-cache-bundle",
-            "version": "1.0.4",
-            "target-dir": "Liip/DoctrineCacheBundle",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/liip/LiipDoctrineCacheBundle.git",
-                "reference": "fd154ded8a51a60219d1fa864eb668e4cc70ec21"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/liip/LiipDoctrineCacheBundle/zipball/fd154ded8a51a60219d1fa864eb668e4cc70ec21",
-                "reference": "fd154ded8a51a60219d1fa864eb668e4cc70ec21",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/common": ">=2.2",
-                "php": ">=5.3.0",
-                "symfony/symfony": ">=2.0"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Liip\\DoctrineCacheBundle\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Liip AG",
-                    "homepage": "http://www.liip.ch/"
-                }
-            ],
-            "description": "This Bundle provides integration into Symfony2 with the Doctrine Common Cache layer.",
-            "keywords": [
-                "Symfony2",
-                "cache"
-            ],
-            "time": "2014-02-17 02:17:48"
-        },
-        {
             "name": "liip/imagine-bundle",
             "version": "v0.21.1",
             "target-dir": "Liip/ImagineBundle",
@@ -2695,13 +2647,13 @@
             "version": "v0.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "b1cc9ce676b4350b23d0fafc8244d08eee2fe287"
+                "url": "https://github.com/nikic/PHP-Parser",
+                "reference": "v0.9.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/b1cc9ce676b4350b23d0fafc8244d08eee2fe287",
-                "reference": "b1cc9ce676b4350b23d0fafc8244d08eee2fe287",
+                "url": "https://github.com/nikic/PHP-Parser/archive/v0.9.1.zip",
+                "reference": "v0.9.1",
                 "shasum": ""
             },
             "require": {
@@ -2727,7 +2679,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2012-04-23 22:52:11"
+            "time": "2012-04-23 15:52:11"
         },
         {
             "name": "omnipay/omnipay",
@@ -3385,13 +3337,13 @@
             "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+                "url": "https://github.com/php-fig/log",
+                "reference": "1.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "url": "https://github.com/php-fig/log/archive/1.0.0.zip",
+                "reference": "1.0.0",
                 "shasum": ""
             },
             "type": "library",
@@ -4347,7 +4299,9 @@
             "authors": [
                 {
                     "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
                 },
                 {
                     "name": "Symfony Community",
@@ -4663,7 +4617,7 @@
             ],
             "authors": [
                 {
-                    "name": "William Durand",
+                    "name": "William DURAND",
                     "email": "william.durand1@gmail.com",
                     "homepage": "http://www.willdurand.fr"
                 }
@@ -5220,8 +5174,7 @@
                 {
                     "name": "Jonathan Wage",
                     "email": "jonwage@gmail.com",
-                    "homepage": "http://www.jwage.com/",
-                    "role": "Creator"
+                    "homepage": "http://www.jwage.com/"
                 }
             ],
             "description": "Data Fixtures for all Doctrine Object Managers",
@@ -5986,7 +5939,6 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "doctrine/doctrine-bundle": 20,
-        "doctrine/doctrine-cache-bundle": 20,
         "friendsofsymfony/user-bundle": 20,
         "knplabs/knp-gaufrette-bundle": 20,
         "knplabs/knp-snappy-bundle": 20,

--- a/src/Sylius/Bundle/SettingsBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/SettingsBundle/Resources/config/services.xml
@@ -36,7 +36,7 @@
             <argument type="service" id="form.factory" />
         </service>
 
-        <service id="sylius.settings.cache" alias="liip_doctrine_cache.ns.sylius_settings" />
+        <service id="sylius.settings.cache" alias="doctrine_cache.providers.sylius_settings" />
 
         <service id="sylius.settings.manager" class="%sylius.settings.manager.class%">
             <argument type="service" id="sylius.settings.schema_registry" />

--- a/src/Sylius/Bundle/SettingsBundle/composer.json
+++ b/src/Sylius/Bundle/SettingsBundle/composer.json
@@ -25,7 +25,7 @@
         "symfony/framework-bundle":        "~2.3",
         "sylius/resource-bundle":          "0.9.*@dev",
         "stof/doctrine-extensions-bundle": "1.1.*",
-        "liip/doctrine-cache-bundle":      "*"
+        "doctrine/doctrine-cache-bundle":  "~1.0"
     },
     "require-dev": {
         "phpspec/phpspec":          "~2.0",


### PR DESCRIPTION
DoctrineCacheBundle has a stable version now. 
LiipCacheBundle is deprecated.
