### PR TITLE
[WIP] Replace Gaufrette with Symfony Filesystem component

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -119,18 +119,8 @@ liip_doctrine_cache:
     namespaces:
         sylius_settings: %sylius.cache%
 
-knp_gaufrette:
-    adapters:
-        sylius_image:
-            local:
-                directory:  %kernel.root_dir%/../web/media/image
-                create:     true
-    filesystems:
-        sylius_image:
-            adapter: sylius_image
-
 liip_imagine:
-    data_root: %kernel.root_dir%/../web/media/image
+    data_root: %sylius.upload_dir%
     filter_sets:
         sylius_small:
             filters:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -19,6 +19,8 @@ parameters:
     sylius.cache:
         type: file_system
 
+    sylius.upload_dir:                %kernel.root_dir%/../web/media/image
+
     paypal.express_checkout.username: EDITME
     paypal.express_checkout.password: EDITME
     paypal.express_checkout.signature: EDITME

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "incenteev/composer-parameter-handler": "~2.0",
         "jms/serializer-bundle":                "0.12.*",
         "jms/translation-bundle":               "1.1.*",
-        "knplabs/knp-gaufrette-bundle":         "*@dev",
         "knplabs/knp-snappy-bundle":            "*@dev",
         "liip/doctrine-cache-bundle":           "*",
         "liip/imagine-bundle":                  "~0.9",

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -385,11 +385,8 @@
         </service>
 
         <service id="sylius.image_uploader" class="%sylius.image_uploader.class%">
-            <argument type="service">
-                <service class="Gaufrette\Filesystem" factory-service="knp_gaufrette.filesystem_map" factory-method="get">
-                    <argument>sylius_image</argument>
-                </service>
-            </argument>
+            <argument type="service" id="filesystem" />
+            <argument>%sylius.upload_dir%</argument>
         </service>
 
         <service id="sylius.form.type.user_filter" class="%sylius.form.type.user_filter.class%">

--- a/src/Sylius/Bundle/CoreBundle/Uploader/ImageUploaderInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Uploader/ImageUploaderInterface.php
@@ -15,6 +15,19 @@ use Sylius\Bundle\CoreBundle\Model\ImageInterface;
 
 interface ImageUploaderInterface
 {
+    /**
+     * Uploads file for given model with new, unique filename & path.
+     *
+     * @param ImageInterface $image
+     */
     public function upload(ImageInterface $image);
+
+    /**
+     * Removes file or directory.
+     *
+     * @param string $path
+     *
+     * @return boolean
+     */
     public function remove($path);
 }

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -41,8 +41,6 @@
         "sylius/resource-bundle":         "0.9.*@dev",
         "friendsofsymfony/user-bundle":   "2.0.*@dev",
         "jms/serializer-bundle":          "0.12.*",
-        "knplabs/gaufrette":              "0.2.*@dev",
-        "knplabs/knp-gaufrette-bundle":   "0.2.*@dev",
         "mathiasverraes/money":           "*@dev",
         "swiftmailer/swiftmailer":        "~5.0",
         "hwi/oauth-bundle":               "0.3.*"

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Uploader/ImageUploaderSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Uploader/ImageUploaderSpec.php
@@ -11,22 +11,22 @@
 
 namespace spec\Sylius\Bundle\CoreBundle\Uploader;
 
-use Gaufrette\Filesystem;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\CoreBundle\Model\ImageInterface;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\File;
 
 class ImageUploaderSpec extends ObjectBehavior
 {
     function let(Filesystem $filesystem, ImageInterface $image)
     {
-        $filesystem->has(Argument::any())->willReturn(false);
+        $filesystem->exists(Argument::any())->willReturn(false);
 
         $file = new File(__FILE__, 'img.jpg');
         $image->getFile()->willReturn($file);
 
-        $this->beConstructedWith($filesystem);
+        $this->beConstructedWith($filesystem, 'fake_dir');
     }
 
     function it_is_initializable()
@@ -44,8 +44,8 @@ class ImageUploaderSpec extends ObjectBehavior
         $image->hasFile()->willReturn(true);
         $image->getPath()->willReturn('foo.jpg');
 
-        $filesystem->delete(Argument::any())->shouldBeCalled();
-        $filesystem->write(Argument::any(), Argument::any())->shouldBeCalled();
+        $filesystem->remove(Argument::any())->shouldBeCalled();
+        $filesystem->dumpFile(Argument::any(), Argument::any())->shouldBeCalled();
 
         $image->setPath(Argument::any())->shouldBeCalled();
 


### PR DESCRIPTION
I know this removes advantages of saving in S3 or something but do we need it? =) Just kidding =) This is first step of the removal, next will be adding kind of adapters that will allow to use plain Symfony component, Gaufrette or i.e. Flysystem.

@Sylius what do you think about such change?
