### PR TITLE
[WebBundle] Added missing translation

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
@@ -173,6 +173,8 @@ sylius:
         addressing:
             header: Addressing step
         back: Back
+        credit_card:
+            header: Payment details
         finalize:
             address:
                 city: City


### PR DESCRIPTION
Added missing credit card header translation (for PayumBundle > Resources > views > Payum > Action > obtainCreditCard.html.twig)
