### PR TITLE
[OrderBundle] Fixed #1187. Don't generate order number if it exists

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/EventListener/OrderNumberListener.php
+++ b/src/Sylius/Bundle/OrderBundle/EventListener/OrderNumberListener.php
@@ -66,6 +66,10 @@ class OrderNumberListener
     public function generateOrderNumber(GenericEvent $event)
     {
         $order = $event->getSubject();
+        
+        if (null !== $order->getNumber()) {
+            return;
+        }
 
         $number = $this->numberRepository->createNew();
         $number->setOrder($order);


### PR DESCRIPTION
This fixes #1187 - order number should not be re-generated if it's already assigned

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #1187 |
| License | MIT |
| Doc PR | - |
