### PR TITLE
[CartBundle] Clear cart if user tries to remove last item

### DIFF
--- a/src/Sylius/Bundle/CartBundle/Controller/CartItemController.php
+++ b/src/Sylius/Bundle/CartBundle/Controller/CartItemController.php
@@ -119,6 +119,8 @@ class CartItemController extends Controller
             $eventDispatcher->dispatch(SyliusCartEvents::ITEM_REMOVE_ERROR, new FlashEvent());
 
             return $this->redirectToCartSummary();
+        } elseif ($item->getQuantity() === $cart->getTotalQuantity()) {
+            return $this->redirect($this->generateUrl('sylius_cart_clear'));
         }
 
         $event = new CartItemEvent($cart, $item);


### PR DESCRIPTION
Fixed #1310. Redirect request to clearAction if the quantity of the item about to be removed equals total quantity in cart.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #1310 |
| License | MIT |
| Doc PR | - |
