### PR TITLE
[OrderBundle] Skip adjustments on empty carts

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Model/Order.php
+++ b/src/Sylius/Bundle/OrderBundle/Model/Order.php
@@ -397,8 +397,11 @@ class Order implements OrderInterface
     {
         $this->calculateItemsTotal();
         $this->calculateAdjustmentsTotal();
+        $this->total = $this->itemsTotal;
 
-        $this->total = $this->itemsTotal + $this->adjustmentsTotal;
+        if (!$this->isEmpty()) {
+            $this->total += $this->adjustmentsTotal;
+        }
 
         if ($this->total < 0) {
             $this->total = 0;


### PR DESCRIPTION
Fixed #1310. Skips adjustments when calculating total price on empty carts.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #1310 |
| License | MIT |
| Doc PR | - |
