### PR TITLE
[CartBundle] Removed redundant cart refresh

### DIFF
--- a/src/Sylius/Bundle/CartBundle/EventListener/CartListener.php
+++ b/src/Sylius/Bundle/CartBundle/EventListener/CartListener.php
@@ -75,20 +75,12 @@ class CartListener implements EventSubscriberInterface
     {
         $cart = $event->getCart();
         $cart->addItem($event->getItem());
-
-        if ($event->isFresh()) {
-            $this->refreshCart($cart);
-        }
     }
 
     public function removeItem(CartEvent $event)
     {
         $cart = $event->getCart();
         $cart->removeItem($event->getItem());
-
-        if ($event->isFresh()) {
-            $this->refreshCart($cart);
-        }
     }
 
     public function clearCart(CartEvent $event)
@@ -108,23 +100,11 @@ class CartListener implements EventSubscriberInterface
             $valid  = 0 === count($errors);
         }
 
-        if ($event->isFresh()) {
-            $this->refreshCart($cart);
-        }
-
         if ($valid) {
             $this->cartManager->persist($cart);
             $this->cartManager->flush();
 
             $this->cartProvider->setCart($cart);
         }
-    }
-
-    /**
-     * @param CartInterface $cart
-     */
-    protected function refreshCart(CartInterface $cart)
-    {
-        $cart->calculateTotal();
     }
 }


### PR DESCRIPTION
Cart refresh is handled by RefreshCartListener which subscribes to `SyliusCartEvents::CART_CHANGE`. That event is already dispatched along other cart-changing events such as `SyliusCartEvents::ITEM_REMOVE_INITIALIZE` and therefore `refreshCart()` is redundant and should be removed from CartListener

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Also, you're welcome Pawel ;-)
