### PR TITLE
[OrderBundle] Add helpers to clear adjustments

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Model/AdjustableInterface.php
+++ b/src/Sylius/Bundle/OrderBundle/Model/AdjustableInterface.php
@@ -49,6 +49,11 @@ interface AdjustableInterface
     public function getAdjustmentsTotal();
 
     /**
+     * Clears all adjustments.
+     */
+    public function clearAdjustments();
+
+    /**
      * Calculate adjustments total.
      */
     public function calculateAdjustmentsTotal();

--- a/src/Sylius/Bundle/OrderBundle/Model/Order.php
+++ b/src/Sylius/Bundle/OrderBundle/Model/Order.php
@@ -361,6 +361,16 @@ class Order implements OrderInterface
     /**
      * {@inheritdoc}
      */
+    public function clearAdjustments()
+    {
+        $this->adjustments->clear();
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function calculateAdjustmentsTotal()
     {
         $this->adjustmentsTotal = 0;

--- a/src/Sylius/Bundle/OrderBundle/Model/OrderItem.php
+++ b/src/Sylius/Bundle/OrderBundle/Model/OrderItem.php
@@ -197,6 +197,14 @@ class OrderItem implements OrderItemInterface
     /**
      * {@inheritdoc}
      */
+    public function clearAdjustments()
+    {
+        return $this->adjustments->clear();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function calculateAdjustmentsTotal()
     {
         $this->adjustmentsTotal = 0;

--- a/src/Sylius/Bundle/OrderBundle/spec/Sylius/Bundle/OrderBundle/Model/OrderSpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Sylius/Bundle/OrderBundle/Model/OrderSpec.php
@@ -348,4 +348,24 @@ class OrderSpec extends ObjectBehavior
 
         $this->countItems()->shouldReturn(1);
     }
+
+    function it_should_be_able_to_clear_items(OrderItemInterface $item)
+    {
+        $this->shouldBeEmpty();
+        $this->addItem($item);
+        $this->countItems()->shouldReturn(1);
+        $this->clearItems();
+        $this->shouldBeEmpty();
+    }
+
+    function it_should_be_able_to_clear_adjustments(AdjustmentInterface $adjustment)
+    {
+        $this->hasAdjustment($adjustment)->shouldReturn(false);
+        $this->addAdjustment($adjustment);
+        $this->hasAdjustment($adjustment)->shouldReturn(true);
+
+        $this->clearAdjustments();
+
+        $this->hasAdjustment($adjustment)->shouldReturn(false);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Partially related to Sylius/Sylius#1321 - adds extra helpers to clear adjustments, just as items can be cleared.
