### PR TITLE
Bind action when buttons are dynamically loaded

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/public/js/confirm-modal.js
+++ b/src/Sylius/Bundle/WebBundle/Resources/public/js/confirm-modal.js
@@ -12,7 +12,7 @@
     $(document).ready(function() {
         var deleteButton;
 
-        $('.btn-confirm').click(function(e) {
+        $(document).on('click', '.btn-confirm',function(e) {
             e.preventDefault();
 
             deleteButton = $(this);


### PR DESCRIPTION
If confirmation buttons are loaded in the page via ajax this click event is not binded, with this minor change every time a button with class 'btn-confirm' is loaded into the page the click event will bind to it.
