### PR TITLE
[AddressingBundle] Rework ZoneType form to not depend on Model

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceChoiceType.php
@@ -60,7 +60,7 @@ class ProvinceChoiceType extends AbstractType
             ->setDefaults(array(
                 'choice_list' => $choiceList,
                 'country'     => null,
-                'label'   => 'sylius.form.address.province',
+                'label'       => 'sylius.form.address.province',
                 'empty_value' => 'sylius.form.province.select'
             ))
         ;

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneMemberCollectionType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneMemberCollectionType.php
@@ -52,8 +52,8 @@ class ZoneMemberCollectionType extends AbstractType
     /**
      * Builds prototypes for each of the form types used for the collection.
      *
-     * @param FormBuilderInterface  $builder
-     * @param array                 $options
+     * @param FormBuilderInterface $builder
+     * @param array                $options
      *
      * @return array
      */
@@ -76,10 +76,10 @@ class ZoneMemberCollectionType extends AbstractType
     /**
      * Builds an individual prototype.
      *
-     * @param FormBuilderInterface      $builder
-     * @param string                    $name
-     * @param string|FormTypeInterface  $type
-     * @param array                     $options
+     * @param FormBuilderInterface     $builder
+     * @param string                   $name
+     * @param string|FormTypeInterface $type
+     * @param array                    $options
      *
      * @return FormBuilderInterface
      */

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\AddressingBundle\Form\Type;
 
-use Sylius\Component\Addressing\Model\Zone;
+use Sylius\Component\Addressing\Model\ZoneInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -60,7 +60,11 @@ class ZoneType extends AbstractType
             ))
             ->add('type', 'choice', array(
                 'label'   => 'sylius.form.zone.type',
-                'choices' => Zone::getTypeChoices(),
+                'choices' => array(
+                    ZoneInterface::TYPE_COUNTRY  => 'sylius.form.zone.types.country',
+                    ZoneInterface::TYPE_PROVINCE => 'sylius.form.zone.types.province',
+                    ZoneInterface::TYPE_ZONE     => 'sylius.form.zone.types.zone',
+                ),
             ))
             ->add('members', 'sylius_zone_member_collection', array(
                 'label' => 'sylius.form.zone.members'

--- a/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.en.yml
@@ -21,6 +21,10 @@ sylius:
             members: Members
             name: Name
             type: Type
+            types:
+                country: Country
+                province: Province
+                zone: Zone
         zone_member_country:
             country: Country
         zone_member_province:

--- a/src/Sylius/Component/Addressing/Model/Zone.php
+++ b/src/Sylius/Component/Addressing/Model/Zone.php
@@ -99,7 +99,7 @@ class Zone implements ZoneInterface
     public function setType($type)
     {
         if (!in_array($type, self::getTypes())) {
-            throw new \InvalidArgumentException('Wrong zone type supplied');
+            throw new \InvalidArgumentException('Wrong zone type supplied.');
         }
 
         $this->type = $type;
@@ -114,21 +114,7 @@ class Zone implements ZoneInterface
      */
     public static function getTypes()
     {
-        return array_keys(self::getTypeChoices());
-    }
-
-    /**
-     * Used in form choice field.
-     *
-     * @return array
-     */
-    public static function getTypeChoices()
-    {
-        return array(
-            self::TYPE_COUNTRY   => 'Country',
-            self::TYPE_PROVINCE  => 'Province',
-            self::TYPE_ZONE      => 'Zone',
-        );
+        return array(self::TYPE_COUNTRY, self::TYPE_PROVINCE, self::TYPE_ZONE);
     }
 
     /**


### PR DESCRIPTION
This PR removes one public method: `Model\Zone::getTypeChoices()` but it was not IMO usable at all, yet was adding some polution into code.

> **Note**: This is replacement for #1317 against proper branch.
