### PR TITLE
Docblock fixes

### DIFF
--- a/src/Sylius/Bundle/SettingsBundle/Model/Parameter.php
+++ b/src/Sylius/Bundle/SettingsBundle/Model/Parameter.php
@@ -47,7 +47,9 @@ class Parameter implements ParameterInterface
     protected $value;
 
     /**
-     * {@inheritdoc}
+     * Gets Parameter id
+     *
+     * @return int
      */
     public function getId()
     {


### PR DESCRIPTION
The entity `Sylius\Bundle\SettingsBundle\Model\Parameter` implements `Sylius\Bundle\SettingsBundle\Model\ParameterInterface` which does not contain any method like `getId`.
