### PR TITLE
Fix Promotion Coupon condition

### DIFF
--- a/src/Sylius/Component/Promotion/Checker/PromotionEligibilityChecker.php
+++ b/src/Sylius/Component/Promotion/Checker/PromotionEligibilityChecker.php
@@ -156,7 +156,7 @@ class PromotionEligibilityChecker implements PromotionEligibilityCheckerInterfac
     private function isCouponEligibleToPromotion(PromotionInterface $promotion, CouponInterface $coupon = null)
     {
         if ($promotion->isCouponBased()) {
-            if (null !== $coupon && $promotion !== $coupon->getPromotion()) {
+            if (null === $coupon || $promotion !== $coupon->getPromotion()) {
                 return false;
             }
 


### PR DESCRIPTION
If I'm not wrong: $coupon === null => not eligible.
It was applying all coupon-based promotion here, whereas no coupon has been defined on the order.
