### PR TITLE
Add PurchaseStep events

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/PurchaseStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/PurchaseStep.php
@@ -32,6 +32,8 @@ class PurchaseStep extends CheckoutStep
     {
         $order = $this->getCurrentCart();
 
+        $this->dispatchCheckoutEvent(SyliusCheckoutEvents::PURCHASE_INITIALIZE, $order);
+
         $captureToken = $this->getTokenFactory()->createCaptureToken(
             $order->getPayment()->getMethod()->getGateway(),
             $order,
@@ -56,6 +58,8 @@ class PurchaseStep extends CheckoutStep
         /** @var OrderInterface $order */
         $order = $status->getModel();
 
+        $this->dispatchCheckoutEvent(SyliusCheckoutEvents::PURCHASE_INITIALIZE, $order);
+
         if (!$order instanceof OrderInterface) {
             throw new \RuntimeException(sprintf('Expected order to be set as model but it is %s', get_class($order)));
         }
@@ -63,6 +67,8 @@ class PurchaseStep extends CheckoutStep
         $payment = $order->getPayment();
         $previousState = $order->getPayment()->getState();
         $payment->setState($status->getStatus());
+
+        $this->dispatchCheckoutEvent(SyliusCheckoutEvents::PURCHASE_PRE_COMPLETE, $order);
 
         if ($previousState !== $payment->getState()) {
             $this->dispatchEvent(

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -277,7 +277,8 @@
         </service>
         <service id="sylius.listener.order_state" class="%sylius.listener.order_state.class%">
             <argument type="service" id="sylius.order_processing.state_resolver" />
-            <tag name="kernel.event_listener" event="sylius.checkout.finalize.pre_complete" method="resolveOrderStates" />
+            <tag name="kernel.event_listener" event="sylius.checkout.finalize.pre_complete" method="resolveOrderStates" priority="-100" />
+            <tag name="kernel.event_listener" event="sylius.checkout.purchase.pre_complete" method="resolveOrderStates" priority="-100" />
             <tag name="kernel.event_listener" event="sylius.order.pre_pay" method="resolveOrderStates" priority="-100" />
             <tag name="kernel.event_listener" event="sylius.order.pre_ship" method="resolveOrderStates" priority="-100" />
             <tag name="kernel.event_listener" event="sylius.order.pre_cancel" method="resolveOrderStates" priority="-100" />

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Checkout/Step/PurchaseStepSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/Checkout/Step/PurchaseStepSpec.php
@@ -107,6 +107,22 @@ class PurchaseStepSpec extends ObjectBehavior
 
         $eventDispatcher
             ->dispatch(
+                SyliusCheckoutEvents::PURCHASE_INITIALIZE,
+                Argument::type('Symfony\Component\EventDispatcher\GenericEvent')
+            )
+            ->shouldBeCalled()
+        ;
+
+        $eventDispatcher
+            ->dispatch(
+                SyliusCheckoutEvents::PURCHASE_PRE_COMPLETE,
+                Argument::type('Symfony\Component\EventDispatcher\GenericEvent')
+            )
+            ->shouldBeCalled()
+        ;
+
+        $eventDispatcher
+            ->dispatch(
                 SyliusPaymentEvents::PRE_STATE_CHANGE,
                 Argument::type('Symfony\Component\EventDispatcher\GenericEvent')
             )
@@ -148,6 +164,22 @@ class PurchaseStepSpec extends ObjectBehavior
                 $args[0]->setModel($order);
             }
         );
+
+        $eventDispatcher
+            ->dispatch(
+                SyliusCheckoutEvents::PURCHASE_INITIALIZE,
+                Argument::type('Symfony\Component\EventDispatcher\GenericEvent')
+            )
+            ->shouldBeCalled()
+        ;
+
+        $eventDispatcher
+            ->dispatch(
+                SyliusCheckoutEvents::PURCHASE_PRE_COMPLETE,
+                Argument::type('Symfony\Component\EventDispatcher\GenericEvent')
+            )
+            ->shouldBeCalled()
+        ;
 
         $eventDispatcher
             ->dispatch(

--- a/src/Sylius/Component/Core/SyliusCheckoutEvents.php
+++ b/src/Sylius/Component/Core/SyliusCheckoutEvents.php
@@ -34,7 +34,9 @@ class SyliusCheckoutEvents
     const PAYMENT_PRE_COMPLETE = 'sylius.checkout.payment.pre_complete';
     const PAYMENT_COMPLETE     = 'sylius.checkout.payment.complete';
 
-    const PURCHASE_COMPLETE = 'sylius.checkout.purchase.complete';
+    const PURCHASE_INITIALIZE   = 'sylius.checkout.purchase.initialize';
+    const PURCHASE_PRE_COMPLETE = 'sylius.checkout.purchase.pre_complete';
+    const PURCHASE_COMPLETE     = 'sylius.checkout.purchase.complete';
 
     const FINALIZE_INITIALIZE   = 'sylius.checkout.finalize.initialize';
     const FINALIZE_PRE_COMPLETE = 'sylius.checkout.finalize.pre_complete';


### PR DESCRIPTION
And make OrderStateResolver listen to it.

@makasim this is what was missing in #1374. Payment.state was not forwarded to Order.paymentState.
