### PR TITLE
Enable payment validation in backend

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/ConfirmOrderListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/ConfirmOrderListener.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\EventListener;
+
+use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
+use Sylius\Component\Order\Model\OrderInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+class ConfirmOrderListener
+{
+    /**
+     * Set an Order as completed
+     *
+     * @param GenericEvent $event
+     * @throws UnexpectedTypeException
+     */
+    public function confirmOrder(GenericEvent $event)
+    {
+        $order = $event->getSubject();
+
+        if (!$order instanceof OrderInterface) {
+            throw new UnexpectedTypeException(
+                $order,
+                'Sylius\Component\Order\Model\OrderInterface'
+            );
+        }
+
+        $order->setState(OrderInterface::STATE_CONFIRMED);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -52,6 +52,7 @@
         <parameter key="sylius.listener.order_user.class">Sylius\Bundle\CoreBundle\EventListener\OrderUserListener</parameter>
         <parameter key="sylius.listener.purchase.class">Sylius\Bundle\CoreBundle\EventListener\PurchaseListener</parameter>
         <parameter key="sylius.listener.insufficient_stock_exception.class">Sylius\Bundle\CoreBundle\EventListener\InsufficientStockExceptionListener</parameter>
+        <parameter key="sylius.listener.confirm_order.class">Sylius\Bundle\CoreBundle\EventListener\ConfirmOrderListener</parameter>
 
         <parameter key="sylius.checkout_form.addressing.class">Sylius\Bundle\CoreBundle\Form\Type\Checkout\AddressingStepType</parameter>
         <parameter key="sylius.checkout_form.shipping.class">Sylius\Bundle\CoreBundle\Form\Type\Checkout\ShippingStepType</parameter>
@@ -274,6 +275,9 @@
         </service>
         <service id="sylius.listener.inventory_unit" class="%sylius.listener.inventory_unit.class%">
             <tag name="kernel.event_listener" event="sylius.inventory_unit.pre_state_change" method="updateState" />
+        </service>
+        <service id="sylius.listener.confirm_order" class="%sylius.listener.confirm_order.class%">
+            <tag name="kernel.event_listener" event="sylius.order.pre_pay" method="confirmOrder" />
         </service>
         <service id="sylius.listener.order_state" class="%sylius.listener.order_state.class%">
             <argument type="service" id="sylius.order_processing.state_resolver" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | na |
| License | MIT |
| Doc PR | na |

This fixes 2 things:
- the order state, which was stuck on `cart` before. Now thanks to the listener it's changed to `confirmed` when Order is fully paid (listening at order.pre_pay event)
- the proper event dispatching when changing manually the state of a payment. Now it dispatches the payment.pre_state_change event, that triggers itself order.pre_pay and so it confirms the Order

You can now use non-instant payment like check and transfer, and confirm the Order manually once the payment is received from the backend.
