### PR TITLE
Move UnexpectedTypeException from ResourceBundle into Component

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checker/RestrictedZoneChecker.php
+++ b/src/Sylius/Bundle/CoreBundle/Checker/RestrictedZoneChecker.php
@@ -11,11 +11,11 @@
 
 namespace Sylius\Bundle\CoreBundle\Checker;
 
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Addressing\Checker\RestrictedZoneCheckerInterface;
 use Sylius\Component\Addressing\Matcher\ZoneMatcherInterface;
 use Sylius\Component\Addressing\Model\AddressInterface;
 use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
 class RestrictedZoneChecker implements RestrictedZoneCheckerInterface

--- a/src/Sylius/Bundle/CoreBundle/EventListener/CouponUsageListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/CouponUsageListener.php
@@ -11,8 +11,8 @@
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**

--- a/src/Sylius/Bundle/CoreBundle/EventListener/CustomerWelcomeEmailListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/CustomerWelcomeEmailListener.php
@@ -13,8 +13,8 @@ namespace Sylius\Bundle\CoreBundle\EventListener;
 
 use FOS\UserBundle\Event\FilterUserResponseEvent;
 use Sylius\Bundle\CoreBundle\Mailer\CustomerWelcomeMailerInterface;
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\UserInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 
 /**
  * Sends Customer welcome email when triggered by event
@@ -41,7 +41,7 @@ class CustomerWelcomeEmailListener
     /**
      * @param FilterUserResponseEvent $event
      *
-     * @throws \InvalidArgumentException
+     * @throws UnexpectedTypeException
      */
     public function handleEvent(FilterUserResponseEvent $event)
     {

--- a/src/Sylius/Bundle/CoreBundle/EventListener/ImageUploadListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/ImageUploadListener.php
@@ -11,10 +11,10 @@
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Uploader\ImageUploaderInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Sylius\Component\Taxonomy\Model\TaxonInterface;
 use Sylius\Component\Taxonomy\Model\TaxonomyInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -59,7 +59,6 @@ class ImageUploadListener
         if ($subject->hasFile()) {
             $this->uploader->upload($subject);
         }
-
     }
 
     public function uploadTaxonomyImage(GenericEvent $event)
@@ -76,6 +75,5 @@ class ImageUploadListener
         if ($subject->getRoot()->hasFile()) {
             $this->uploader->upload($subject->getRoot());
         }
-
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/EventListener/InventoryUnitListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/InventoryUnitListener.php
@@ -11,8 +11,8 @@
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\InventoryUnitInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Sylius\Component\Shipping\Model\ShipmentInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 

--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderConfirmationEmailListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderConfirmationEmailListener.php
@@ -12,8 +12,8 @@
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
 use Sylius\Bundle\CoreBundle\Mailer\OrderConfirmationMailerInterface;
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -34,8 +34,9 @@ class OrderConfirmationEmailListener
     }
 
     /**
-     * @param  GenericEvent              $event
-     * @throws \InvalidArgumentException
+     * @param GenericEvent $event
+     *
+     * @throws UnexpectedTypeException
      */
     public function processOrderConfirmation(GenericEvent $event)
     {

--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderCurrencyListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderCurrencyListener.php
@@ -12,9 +12,9 @@
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
 use Sylius\Bundle\CartBundle\Event\CartEvent;
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Money\Context\CurrencyContextInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 
 /**
  * Sets currently selected currency on order object.

--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderInventoryListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderInventoryListener.php
@@ -11,10 +11,10 @@
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\OrderProcessing\InventoryHandlerInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -94,6 +94,10 @@ class OrderInventoryListener
      * Gets order from event.
      *
      * @param GenericEvent $event
+     *
+     * @return OrderInterface
+     *
+     * @throws UnexpectedTypeException
      */
     protected function getOrder(GenericEvent $event)
     {
@@ -113,6 +117,10 @@ class OrderInventoryListener
      * Gets order from event.
      *
      * @param GenericEvent $event
+     *
+     * @return OrderInterface
+     *
+     * @throws UnexpectedTypeException
      */
     protected function getItem(GenericEvent $event)
     {

--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderPaymentListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderPaymentListener.php
@@ -12,11 +12,11 @@
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\OrderProcessing\PaymentProcessorInterface;
 use Sylius\Component\Core\SyliusOrderEvents;
 use Sylius\Component\Payment\Model\PaymentInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -95,7 +95,7 @@ class OrderPaymentListener
      *
      * @param GenericEvent $event
      *
-     * @throws \InvalidArgumentException
+     * @throws UnexpectedTypeException
      */
     public function voidOrderPayment(GenericEvent $event)
     {
@@ -125,7 +125,7 @@ class OrderPaymentListener
         $order = $this->orderRepository->findOneBy(array('payment' => $payment));
 
         if (null === $order) {
-            throw new \Exception(sprintf('Cannot retrieve Order from Payment with id %s', $payment->getId()));
+            throw new \RuntimeException(sprintf('Cannot retrieve Order from Payment with id %s', $payment->getId()));
         }
 
         if (PaymentInterface::STATE_COMPLETED === $payment->getState()) {
@@ -135,9 +135,11 @@ class OrderPaymentListener
     }
 
     /**
-     * @param  GenericEvent              $event
+     * @param GenericEvent $event
+     *
      * @return OrderInterface
-     * @throws \InvalidArgumentException
+     *
+     * @throws UnexpectedTypeException
      */
     protected function getOrder(GenericEvent $event)
     {

--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderPromotionListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderPromotionListener.php
@@ -11,10 +11,10 @@
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Promotion\Processor\PromotionProcessorInterface;
 use Sylius\Component\Promotion\SyliusPromotionEvents;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -62,7 +62,7 @@ class OrderPromotionListener
      *
      * @param GenericEvent $event
      *
-     * @throws \InvalidArgumentException
+     * @throws UnexpectedTypeException
      */
     public function processOrderPromotion(GenericEvent $event)
     {

--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderShippingListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderShippingListener.php
@@ -11,10 +11,10 @@
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\OrderProcessing\ShipmentFactoryInterface;
 use Sylius\Component\Core\OrderProcessing\ShippingChargesProcessorInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Sylius\Component\Shipping\Model\ShipmentInterface;
 use Sylius\Component\Shipping\Processor\ShipmentProcessorInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;

--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderStateListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderStateListener.php
@@ -11,9 +11,9 @@
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\OrderProcessing\StateResolverInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -45,7 +45,7 @@ class OrderStateListener
      *
      * @param GenericEvent $event
      *
-     * @throws \InvalidArgumentException
+     * @throws UnexpectedTypeException
      */
     public function resolveOrderStates(GenericEvent $event)
     {

--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderTaxationListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderTaxationListener.php
@@ -11,9 +11,9 @@
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\OrderProcessing\TaxationProcessorInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -44,6 +44,8 @@ class OrderTaxationListener
      * Get the order from event and run the taxation processor on it.
      *
      * @param GenericEvent $event
+     *
+     * @throws UnexpectedTypeException
      */
     public function applyTaxes(GenericEvent $event)
     {

--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderUserListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderUserListener.php
@@ -12,8 +12,8 @@
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
 use Sylius\Bundle\CartBundle\Event\CartEvent;
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 

--- a/src/Sylius/Bundle/CoreBundle/EventListener/ShipmentListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/ShipmentListener.php
@@ -11,12 +11,12 @@
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderShippingStates;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\OrderProcessing\StateResolverInterface;
 use Sylius\Component\Core\SyliusOrderEvents;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Sylius\Component\Shipping\Processor\ShipmentProcessorInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;

--- a/src/Sylius/Bundle/CoreBundle/EventListener/UserUpdateListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/UserUpdateListener.php
@@ -13,7 +13,7 @@ namespace Sylius\Bundle\CoreBundle\EventListener;
 
 use FOS\UserBundle\Model\UserInterface;
 use FOS\UserBundle\Model\UserManagerInterface;
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**

--- a/src/Sylius/Component/Core/Promotion/Checker/NthOrderRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/NthOrderRuleChecker.php
@@ -11,10 +11,10 @@
 
 namespace Sylius\Component\Core\Promotion\Checker;
 
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Promotion\Checker\RuleCheckerInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 
 /**
  * Checks if users order is the nth one.

--- a/src/Sylius/Component/Core/Promotion/Checker/ShippingCountryRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/ShippingCountryRuleChecker.php
@@ -11,10 +11,10 @@
 
 namespace Sylius\Component\Core\Promotion\Checker;
 
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Promotion\Checker\RuleCheckerInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 
 /**
  * Checks if shipping country match.

--- a/src/Sylius/Component/Core/Promotion/Checker/TaxonomyRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/TaxonomyRuleChecker.php
@@ -11,10 +11,10 @@
 
 namespace Sylius\Component\Core\Promotion\Checker;
 
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Promotion\Checker\RuleCheckerInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 
 /**
  * Checks if order contains products with given taxonomy.

--- a/src/Sylius/Component/Core/Promotion/Checker/UserLoyalityRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/UserLoyalityRuleChecker.php
@@ -11,10 +11,10 @@
 
 namespace Sylius\Component\Core\Promotion\Checker;
 
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Promotion\Checker\RuleCheckerInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 
 /**
  * Checks if user is created before/after configured period of time.

--- a/src/Sylius/Component/Resource/Exception/UnexpectedTypeException.php
+++ b/src/Sylius/Component/Resource/Exception/UnexpectedTypeException.php
@@ -9,10 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\ResourceBundle\Exception;
+namespace Sylius\Component\Resource\Exception;
 
 class UnexpectedTypeException extends \InvalidArgumentException
 {
+    /**
+     * @param mixed $value
+     * @param int   $expectedType
+     */
     public function __construct($value, $expectedType)
     {
         parent::__construct(sprintf(

--- a/src/Sylius/Component/Shipping/Processor/ShipmentProcessor.php
+++ b/src/Sylius/Component/Shipping/Processor/ShipmentProcessor.php
@@ -12,9 +12,9 @@
 namespace Sylius\Component\Shipping\Processor;
 
 use Doctrine\Common\Collections\Collection;
-use Sylius\Bundle\ResourceBundle\Exception\UnexpectedTypeException;
 use Sylius\Component\Shipping\Model\ShipmentInterface;
 use Sylius\Component\Shipping\Model\ShipmentItemInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 
 /**
  * Shipment processor.


### PR DESCRIPTION
Without this, components: Promotions & Shipping have broken dependencies, as they should only depend on Resource Component, but they require ResourceBundle.
