### PR TITLE
[WebBundle] Adjust sidebar menu to better look at smaller screens

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/public/css/backend.css
+++ b/src/Sylius/Bundle/WebBundle/Resources/public/css/backend.css
@@ -251,8 +251,6 @@ form.form-signin .form-control:focus {
     color: #999;
     font-size: 1em;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 #sidebar li a:visited {
     color: #999;
@@ -425,6 +423,15 @@ input[type="file"] {
 
 /* Hide button text on small devices, as well remove some other margin/padding */
 @media (max-width: 992px) {
+    .row {
+        margin-left: 0;
+        margin-right: 0;
+    }
+    .main-container .col-md-10 {
+        padding-left: 15px;
+    }
+}
+@media (max-width: 1350px) {
     .btn i {
         margin-right: 0;
     }
@@ -434,12 +441,34 @@ input[type="file"] {
     .table .btn {
         margin-bottom: 3px;
     }
-    .row {
-        margin-left: 0;
+
+    #sidebar span.nav-header span {
+        display: none;
+    }
+    #sidebar span.nav-header {
+        padding: 0;
+    }
+    #sidebar li a {
+        position: relative;
+        text-align: center;
+        font-size: 1.75em;
+    }
+    #sidebar li a i {
         margin-right: 0;
     }
-    .main-container .col-md-10 {
-        padding-left: 15px;
+    #sidebar li a span {
+        display: none;
+    }
+    #sidebar li a:hover span {
+        background: inherit;
+        border-radius: 0 3px 3px 0;
+        display: block;
+        font-size: 0.75em;
+        left: 68px;
+        padding: 15px;
+        position: absolute;
+        top: 0;
+        z-index: 1000;
     }
 }
 

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/menu.en.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/menu.en.yml
@@ -3,18 +3,22 @@ sylius:
         menu:
             main:
                 assortment: Assortment
+                blocks: Blocks
                 configuration: Configuration
                 countries: Countries
                 customer: Customers
+                content: Content
                 dashboard: Dashboard
                 exchange_rates: Exchange rates
                 general_settings: General settings
+                groups: Groups
                 homepage: Your store
                 locales: Locales
                 new_order: Add new order
                 new_promotion: Add new promotion
                 options: Manage product options
                 orders: Current orders
+                pages: Pages
                 payment_methods: Payment methods
                 payments: Payments
                 products: Products

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
@@ -77,7 +77,7 @@ sylius:
             products: Your products
             users: Users
         statistics:
-            0: This month's statistics
+            header: This month's statistics
             orders_this_month: Total orders
             registrations_this_month: Total registrations
             sales_this_month: Sales

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Dashboard/main.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Dashboard/main.html.twig
@@ -25,7 +25,7 @@
         <table class="table table-condensed">
             <thead>
                 <tr>
-                    <th colspan="2">{{ 'sylius.backend.statistics'|trans }}</th>
+                    <th colspan="2">{{ 'sylius.backend.statistics.header'|trans }}</th>
                 </tr>
             </thead>
             <tbody>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/_breadcrumb.html.twig
@@ -1,3 +1,3 @@
 <ol class="breadcrumb">
-    <li>>{{ 'sylius.breadcrumb.dashboard' | trans }}</li>
+    <li>{{ 'sylius.breadcrumb.dashboard' | trans }}</li>
 </ol>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/layout.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/layout.html.twig
@@ -29,7 +29,7 @@
     <body>
         {% include 'SyliusWebBundle:Backend:_navbar.html.twig' %}
         <div class="row main-container">
-            <div class="col-md-2 hidden-sm hidden-xs">
+            <div class="col-md-1 col-lg-2 hidden-sm hidden-xs">
                 {% block sidebar %}
                 <div id="sidebar">
                     <div class="sidebar-nav">
@@ -38,29 +38,31 @@
                 </div>
                 {% endblock %}
             </div>
-            <div class="col-md-10">
+
+            <div class="col-md-11 col-lg-10">
                 <div id="topbar">
                     {% block topbar %}
                     {% include 'SyliusWebBundle:Backend:_breadcrumb.html.twig' %}
                     {% endblock %}
                 </div>
+
                 <div id="content">
-                {% include 'SyliusWebBundle:Backend:_flashes.html.twig' %}
+                    {% include 'SyliusWebBundle:Backend:_flashes.html.twig' %}
 
-                {% block content %}
-                {% endblock %}
+                    {% block content %}
+                    {% endblock %}
 
-                <hr>
+                    <hr>
 
-                {# Gallery modal #}
-                {% include 'SyliusWebBundle::gallery.html.twig' %}
+                    {# Gallery modal #}
+                    {% include 'SyliusWebBundle::gallery.html.twig' %}
 
-                {# Confirmation modal #}
-                {% include 'SyliusWebBundle::confirm-modal.html.twig' %}
+                    {# Confirmation modal #}
+                    {% include 'SyliusWebBundle::confirm-modal.html.twig' %}
 
-                <footer>
-                    <p>&copy; <a href="http://Sylius.org">Sylius</a>, 2011 - {{ 'now'|date('Y') }}.</p>
-                </footer>
+                    <footer>
+                        <p>&copy; <a href="http://Sylius.org">Sylius</a>, 2011 - {{ 'now'|date('Y') }}.</p>
+                    </footer>
                 </div>
             </div>
         </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/menu.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/menu.html.twig
@@ -3,7 +3,7 @@
 {% block label %}
     {% if item.labelAttribute('icon') %}<i class="{{ item.labelAttribute('icon') }}"></i>{% endif %}
     {% if not item.labelAttribute('iconOnly') %}
-        {% if options.allow_safe_labels and item.getExtra('safe_label', false) %}{{ item.label|trans|raw }}{% else %}{{ item.label|trans }}{% endif %}
+        <span>{% if options.allow_safe_labels and item.getExtra('safe_label', false) %}{{ item.label|trans|raw }}{% else %}{{ item.label|trans }}{% endif %}</span>
     {% endif %}
     {% if item.labelAttribute('data-image') %}<img src="{{ item.labelAttribute('data-image')|imagine_filter('sylius_small', true) }}" alt="{{ item.name }}" class="menu-thumbnail"/>{% endif %}
 {% endblock %}


### PR DESCRIPTION
Add missing translations.

New look:
![small_menu](https://cloud.githubusercontent.com/assets/67402/2741529/96dc01fc-c6ec-11e3-86fc-05fe51702976.png)
