### PR TITLE
Reset payment details before forwarding to gateway.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderPaymentListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderPaymentListener.php
@@ -88,6 +88,7 @@ class OrderPaymentListener
 
         $payment->setCurrency($order->getCurrency());
         $payment->setAmount($order->getTotal());
+        $payment->setDetails(array());
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/EventListener/OrderPaymentListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/EventListener/OrderPaymentListenerSpec.php
@@ -81,6 +81,7 @@ class OrderPaymentListenerSpec extends ObjectBehavior
 
         $payment->setAmount(1000)->shouldBeCalled();
         $payment->setCurrency('USD')->shouldBeCalled();
+        $payment->setDetails(array())->shouldBeCalled();
 
         $this->updateOrderPayment($event);
     }


### PR DESCRIPTION
### Problem

I have a payment gateway require me to set a unique "merchant reference number" to each payment, and  this information is set in `CaptureOrderAction` via `$payment->setDetails(['ref' => 'xxx'])`.

However, if the payment's details is already set, `CaptureOrderAction` will [reuse all the existing details](https://github.com/Sylius/Sylius/blob/1f76020d41f7f5dd1e96a59eb88fe6756d58dbd3/src/Sylius/Bundle/PayumBundle/Payum/Be2bill/Action/CaptureOrderUsingBe2billFormAction.php#L61-L72), and it will end up reusing the last "merchant reference number".
### Solution

This PR will reset the payment detail before forwarding the customer to payment gateway, make sure `CaptureOrderAction` will generate a new number for that payment.
