### PR TITLE
Update SyliusKernel.php

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Kernel/SyliusKernel.php
+++ b/src/Sylius/Bundle/CoreBundle/Kernel/SyliusKernel.php
@@ -139,7 +139,7 @@ abstract class SyliusKernel extends Kernel
      */
     protected function isVagrantEnvironment()
     {
-        return (getenv('HOME') === '/home/vagrant' || getenv('VAGRANT') === 'VAGRANT') && is_dir('/dev/shm');
+        return (getenv('HOME') === '/home/vagrant' || getenv('VAGRANT') === 'VAGRANT' || is_dir('/home/vagrant')) && is_dir('/dev/shm');
     }
 
     /**


### PR DESCRIPTION
While running Sylius via web browser/command line in Vagrant, cache and log folders are under /dev/shm/sylius/.
But if we run any Symfony Command programatically in our app in Vagrant, neither VAGRANT nor HOME environment variables are defined in the command environment, so it looks for both folders under app/cache instead.
