### PR TITLE
Require dev doctrine/mongodb-odm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
         "behat/mink-selenium2-driver":       "*",
         "behat/symfony2-extension":          "*",
         "doctrine/doctrine-fixtures-bundle": "2.2.*",
+        "doctrine/mongodb-odm":              "1.0.*@dev",
         "fzaninotto/faker":                  "1.2.*",
         "phpspec/phpspec":                   "~2.0",
         "phpunit/phpunit":                   "~3.7"

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "8cc0f82d66bf1261aa1f1db8e72a180d",
+    "hash": "9a400e037dcd78d5354b3573bad59149",
     "packages": [
         {
             "name": "ajbdev/authorizenet-php-api",
@@ -5435,6 +5435,156 @@
             "time": "2013-09-05 11:23:37"
         },
         {
+            "name": "doctrine/mongodb",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/mongodb.git",
+                "reference": "1a9b001a97256208e0fc4970305cd48208d5b78c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/mongodb/zipball/1a9b001a97256208e0fc4970305cd48208d5b78c",
+                "reference": "1a9b001a97256208e0fc4970305cd48208d5b78c",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": ">=2.1.0,<2.5-dev",
+                "ext-mongo": ">=1.2.12,<1.6-dev",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "jmikola/geojson": "~1.0"
+            },
+            "suggest": {
+                "jmikola/geojson": "Support GeoJSON geometry objects in 2dsphere queries"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\MongoDB": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bulat Shakirzyanov",
+                    "email": "mallluhuct@gmail.com",
+                    "homepage": "http://avalanche123.com"
+                },
+                {
+                    "name": "Jonathan H. Wage",
+                    "email": "jonwage@gmail.com",
+                    "homepage": "http://www.jwage.com/",
+                    "role": "Creator"
+                },
+                {
+                    "name": "Kris Wallsmith",
+                    "email": "kris.wallsmith@gmail.com",
+                    "homepage": "http://kriswallsmith.net/"
+                },
+                {
+                    "name": "Jeremy Mikola",
+                    "email": "jmikola@gmail.com",
+                    "homepage": "http://jmikola.net"
+                }
+            ],
+            "description": "Doctrine MongoDB Abstraction Layer",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "mongodb",
+                "persistence"
+            ],
+            "time": "2014-03-28 19:22:22"
+        },
+        {
+            "name": "doctrine/mongodb-odm",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/mongodb-odm.git",
+                "reference": "ba003dbee2e715fac5269a1bf356a73374e763d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/mongodb-odm/zipball/ba003dbee2e715fac5269a1bf356a73374e763d5",
+                "reference": "ba003dbee2e715fac5269a1bf356a73374e763d5",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "~1.0",
+                "doctrine/cache": "~1.0",
+                "doctrine/collections": "~1.1",
+                "doctrine/common": "2.4.*",
+                "doctrine/inflector": "~1.0",
+                "doctrine/mongodb": ">=1.1.5,<2.0",
+                "php": ">=5.3.2",
+                "symfony/console": "~2.0"
+            },
+            "require-dev": {
+                "symfony/yaml": "~2.0"
+            },
+            "suggest": {
+                "symfony/yaml": "Enables the YAML metadata mapping driver"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\ODM\\MongoDB": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bulat Shakirzyanov",
+                    "email": "mallluhuct@gmail.com",
+                    "homepage": "http://avalanche123.com"
+                },
+                {
+                    "name": "Jonathan H. Wage",
+                    "email": "jonwage@gmail.com",
+                    "homepage": "http://www.jwage.com/",
+                    "role": "Creator"
+                },
+                {
+                    "name": "Kris Wallsmith",
+                    "email": "kris.wallsmith@gmail.com",
+                    "homepage": "http://kriswallsmith.net/"
+                },
+                {
+                    "name": "Jeremy Mikola",
+                    "email": "jmikola@gmail.com",
+                    "homepage": "http://jmikola.net"
+                }
+            ],
+            "description": "Doctrine MongoDB Object Document Mapper",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "mongodb",
+                "odm",
+                "persistence"
+            ],
+            "time": "2014-04-20 16:45:34"
+        },
+        {
             "name": "fabpot/goutte",
             "version": "v1.0.5",
             "source": {
@@ -6138,7 +6288,8 @@
         "knplabs/knp-snappy-bundle": 20,
         "mathiasverraes/money": 20,
         "pagerfanta/pagerfanta": 20,
-        "white-october/pagerfanta-bundle": 20
+        "white-october/pagerfanta-bundle": 20,
+        "doctrine/mongodb-odm": 20
     },
     "platform": {
         "php": ">=5.3.3"


### PR DESCRIPTION
Sometimes it is useful to run all specs with a simple command.

Running specs before:

```
$ ./bin/phpspec run
Sylius/Bundle/ResourceBundle/Doctrine/ODM/MongoDB/DocumentRepository
  43  ! it is initializable
      exception [exc:ReflectionException("Class Doctrine\ODM\MongoDB\DocumentManager does not exist")] has been thrown.

Sylius/Bundle/ResourceBundle/Doctrine/ODM/MongoDB/DocumentRepository
  48  ! it implements Sylius repository interface
      exception [exc:ReflectionException("Class Doctrine\ODM\MongoDB\DocumentManager does not exist")] has been thrown.

Sylius/Bundle/ResourceBundle/Doctrine/ODM/MongoDB/DocumentRepository
  53  ! it creates Pagerfanta paginator
      exception [exc:ReflectionException("Class Doctrine\ODM\MongoDB\DocumentManager does not exist")] has been thrown.

                       100%                        1700
264 specs
1700 examples (1697 passed, 3 broken)
12487ms
```

And after my changes:

```
$ ./bin/phpspec run
                       100%                        1700
264 specs
1700 examples (1700 passed)
12911ms
```
