### PR TITLE
Allow to override label bootstrap col class attribute in templates

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/forms.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/forms.html.twig
@@ -24,7 +24,7 @@
 
 {% block form_label %}
 {% spaceless %}
-    {% set label_attr = label_attr|merge({'class': label_attr.class|default('') ~ ' control-label col-lg-2'}) %}
+    {% set label_attr = label_attr|merge({'class': label_attr.class|default('col-lg-2') ~ ' control-label'}) %}
     {{ parent() }}
 {% endspaceless %}
 {% endblock form_label %}


### PR DESCRIPTION
Now it's not possible to override e.g. in `src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig` 

line with label class attribute

```
{{ form_row(form.promotionCoupon, {'label_attr': {'class': 'col-lg-12'}}) }}
```

is always overriden by default value `col-lg-2`
