### PR TITLE
Fix confirmation modal tests

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Behat/WebUser.php
+++ b/src/Sylius/Bundle/WebBundle/Behat/WebUser.php
@@ -823,9 +823,9 @@ class WebUser extends MinkContext implements KernelAwareInterface
      */
     public function iClickOnConfirmationModal($button)
     {
-        $this->assertSession()->elementExists('css', '#confirmationModalContainer');
+        $this->assertSession()->elementExists('css', '#confirmation-modal');
 
-        $modalContainer = $this->getSession()->getPage()->find('css', '#confirmationModalContainer');
+        $modalContainer = $this->getSession()->getPage()->find('css', '#confirmation-modal');
         $primaryButton = $modalContainer->find('css', sprintf('a:contains("%s")' ,$button));
 
         $this->getSession()->wait(100);


### PR DESCRIPTION
This is the proof that nobody is running `@javascript` scenarios. :smile: 

BTW, why are they not executed on Travis? Why do we have:

```
    - wget http://selenium-release.storage.googleapis.com/2.41/selenium-server-standalone-2.41.0.jar
    - java -jar selenium-server-standalone-2.41.0.jar > /dev/null &
```

in travis.yml then?
