### PR TITLE
sylius_product_variant table data update (FIX)

### DIFF
--- a/app/migrations/Version20140409203042.php
+++ b/app/migrations/Version20140409203042.php
@@ -39,6 +39,7 @@ class Version20140409203042 extends AbstractMigration
         $this->addSql("ALTER TABLE sylius_product_prototype_attribute DROP FOREIGN KEY FK_99041F2A549213EC");
         $this->addSql("ALTER TABLE sylius_product_prototype_attribute CHANGE property_id attribute_id INT NOT NULL");
         $this->addSql("ALTER TABLE sylius_product_prototype_attribute ADD CONSTRAINT FK_E0C47001B6E62EFA FOREIGN KEY (attribute_id) REFERENCES sylius_product_attribute (id)");
+        $this->addSql("ALTER TABLE sylius_product_variant ADD pricing_calculator VARCHAR(255) NOT NULL, ADD pricing_configuration LONGTEXT NOT NULL COMMENT '(DC2Type:array)'");
         $this->addSql("UPDATE sylius_product_variant SET pricing_calculator = 'standard', pricing_configuration = 'a:0:{}'");
     }
 


### PR DESCRIPTION
Adding an alter query to add the 2 missing sylius_product_variant columns before updating datas

Fix for this wrong pull [#1423](https://github.com/Sylius/Sylius/pull/1423)

According to this error

```
Twig_Error_Runtime: "An exception has been thrown during the rendering of a template ("Could not convert database value "" to Doctrine Type array") in "LVPWebBundle:Frontend/Product:_singleBox.html.twig"
```

sylius_product_variant table should be updated to fill the missing pricing_calculator and pricing_configuration datas.

This SQL update solve this migration problem for my project.
