### PR TITLE
Add friendsofsymfony/user-bundle as a requirement of the Core Component

### DIFF
--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -33,11 +33,12 @@
         "sylius/inventory":  "0.10.*@dev",
         "sylius/taxonomy":   "0.10.*@dev",
         "sylius/payment":    "0.10.*@dev",
-        "sylius/resource":   "0.10.*@dev"
+        "sylius/resource":   "0.10.*@dev",
+
+        "friendsofsymfony/user-bundle": "2.0.*@dev"
     },
     "require-dev": {
-        "phpspec/phpspec":              "~2.0",
-        "friendsofsymfony/user-bundle": "2.0.*@dev"
+        "phpspec/phpspec":              "~2.0"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Hi,

Currently, the `friendsofsymfony/user-bundle` dependency is part of the `required-dev` section of the `Core`'s composer.json, but the class `Sylius\Component\Core\Model\Group` extends `FOS\UserBundle\Model\Group` which makes it a `require`.