### PR TITLE
Add knplabs/knp-gaufrette-bundle as a requirement of the Core Component

### DIFF
--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -33,7 +33,9 @@
         "sylius/inventory":  "0.10.*@dev",
         "sylius/taxonomy":   "0.10.*@dev",
         "sylius/payment":    "0.10.*@dev",
-        "sylius/resource":   "0.10.*@dev"
+        "sylius/resource":   "0.10.*@dev",
+
+        "knplabs/knp-gaufrette-bundle": "*@dev"
     },
     "require-dev": {
         "phpspec/phpspec":              "~2.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Hi,

Currently, the `knplabs/knp-gaufrette-bundle` dependency is part of the `required-dev` section of the `Core`'s composer.json, but the class `Sylius\Component\Core\Uploader\ImageUploader` uses  `Gaufrette\Filesystem` as its constructor parameter which makes it a `require`.
