### PR TITLE
[CoreBundle] Remove dead code in RestrictedZoneListener

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/RestrictedZoneListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/RestrictedZoneListener.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\CoreBundle\EventListener;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Component\Addressing\Checker\RestrictedZoneCheckerInterface;
+use Sylius\Component\Cart\Model\CartInterface;
 use Sylius\Component\Cart\Provider\CartProviderInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -37,9 +38,12 @@ class RestrictedZoneListener
 
     public function handleRestrictedZone(GenericEvent $event)
     {
-        $removed = false;
-        $cart = $this->cartProvider->getCart();
+        $cart = $event->getSubject();
+        if (!$cart instanceof CartInterface) {
+            $cart = $this->cartProvider->getCart();
+        }
 
+        $removed = false;
         foreach ($cart->getItems() as $item) {
             if ($this->restrictedZoneChecker->isRestricted($product = $item->getProduct(), $cart->getShippingAddress())) {
                 $cart->removeItem($item);

--- a/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/EventListener/RestrictedZoneListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Sylius/Bundle/CoreBundle/EventListener/RestrictedZoneListenerSpec.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\CoreBundle\EventListener;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Addressing\Checker\RestrictedZoneCheckerInterface;
+use Sylius\Component\Addressing\Model\AddressInterface;
+use Sylius\Component\Cart\Provider\CartProviderInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class RestrictedZoneListenerSpec extends ObjectBehavior
+{
+    function let(RestrictedZoneCheckerInterface $restrictedZoneChecker, CartProviderInterface $cartProvider, ObjectManager $cartManager, SessionInterface $session, TranslatorInterface $translator)
+    {
+        $this->beConstructedWith($restrictedZoneChecker, $cartProvider, $cartManager, $session, $translator);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\CoreBundle\EventListener\RestrictedZoneListener');
+    }
+
+    function it_sets_cart_if_event_contains_invalid_data(
+        $cartProvider,
+        GenericEvent $event,
+        OrderInterface $cart
+    )
+    {
+        $event->getSubject()->willReturn(null);
+
+        $cartProvider->getCart()->willReturn($cart);
+
+        $cart->getItems()->willReturn(array());
+        $cart->calculateTotal()->shouldNotBeCalled();
+
+        $this->handleRestrictedZone($event);
+    }
+
+    function it_uses_cart_from_event(
+        $cartProvider,
+        GenericEvent $event,
+        OrderInterface $cart
+    )
+    {
+        $event->getSubject()->willReturn($cart);
+
+        $cartProvider->getCart()->shouldNotBeCalled();
+
+        $cart->getItems()->willReturn(array());
+        $cart->calculateTotal()->shouldNotBeCalled();
+
+        $this->handleRestrictedZone($event);
+    }
+
+    function it_validates_every_cart_item(
+        $cartProvider,
+        $restrictedZoneChecker,
+        OrderItemInterface $item,
+        GenericEvent $event,
+        OrderInterface $cart,
+        ProductInterface $product,
+        AddressInterface $address
+    )
+    {
+        $event->getSubject()->willReturn($cart);
+
+        $cartProvider->getCart()->shouldNotBeCalled();
+
+        $item->getProduct()->willReturn($product);
+
+        $cart->getItems()->willReturn(array($item));
+        $cart->getShippingAddress()->willReturn($address);
+
+        $restrictedZoneChecker->isRestricted($product, $address)->willReturn(false);
+
+        $cart->calculateTotal()->shouldNotBeCalled();
+
+        $this->handleRestrictedZone($event);
+    }
+
+    function it_removes_invalid_cart_items(
+        $cartProvider,
+        $restrictedZoneChecker,
+        $session,
+        $translator,
+        $cartManager,
+        OrderItemInterface $item,
+        GenericEvent $event,
+        OrderInterface $cart,
+        ProductInterface $product,
+        AddressInterface $address,
+        FlashBag $flashBag
+    )
+    {
+        $event->getSubject()->willReturn($cart);
+
+        $cartProvider->getCart()->shouldNotBeCalled();
+
+        $item->getProduct()->willReturn($product);
+
+        $product->getName()->willReturn('invalid');
+
+        $cart->getItems()->willReturn(array($item));
+        $cart->getShippingAddress()->willReturn($address);
+        $cart->removeItem($item)->shouldBeCalled();
+
+        $restrictedZoneChecker->isRestricted($product, $address)->willReturn(true);
+
+        $session->getBag('flashes')->willReturn($flashBag);
+        $flashBag->add('error', Argument::any())->shouldBeCalled();
+
+        $translator->trans('sylius.cart.restricted_zone_removal', array('%product%' => 'invalid'), 'flashes')->shouldBeCalled();
+
+        $cart->calculateTotal()->shouldBeCalled();
+
+        $cartManager->persist($cart)->shouldBeCalled();
+        $cartManager->flush()->shouldBeCalled();
+
+        $this->handleRestrictedZone($event);
+    }
+}


### PR DESCRIPTION
First it should try to use data sent in event, and if it's not expected one, ask provider for correct data.
