### PR TITLE
Fixed typo in class and related names of loyalty rule checker

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Rule/UserLoyaltyConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Rule/UserLoyaltyConfigurationType.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints\Type;
  *
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class UserLoyalityConfigurationType extends AbstractType
+class UserLoyaltyConfigurationType extends AbstractType
 {
     protected $validationGroups;
 
@@ -38,26 +38,26 @@ class UserLoyalityConfigurationType extends AbstractType
     {
         $builder
             ->add('time', 'integer', array(
-                'label'       => 'sylius.form.rule.user_loyality_configuration.time',
+                'label'       => 'sylius.form.rule.user_loyalty_configuration.time',
                 'constraints' => array(
                     new NotBlank(),
                     new Type(array('type' => 'numeric')),
                 )
             ))
             ->add('unit', 'choice', array(
-                'label'       => 'sylius.form.rule.user_loyality_configuration.unit',
+                'label'       => 'sylius.form.rule.user_loyalty_configuration.unit',
                 'choices'     => array(
-                    'days'   => 'sylius.form.rule.user_loyality_configuration.unit.days',
-                    'weeks'  => 'sylius.form.rule.user_loyality_configuration.unit.weeks',
-                    'months' => 'sylius.form.rule.user_loyality_configuration.unit.months',
-                    'years'  => 'sylius.form.rule.user_loyality_configuration.unit.years',
+                    'days'   => 'sylius.form.rule.user_loyalty_configuration.unit.days',
+                    'weeks'  => 'sylius.form.rule.user_loyalty_configuration.unit.weeks',
+                    'months' => 'sylius.form.rule.user_loyalty_configuration.unit.months',
+                    'years'  => 'sylius.form.rule.user_loyalty_configuration.unit.years',
                 ),
                 'constraints' => array(
                     new NotBlank(),
                 )
             ))
             ->add('after', 'checkbox', array(
-                'label' => 'sylius.form.rule.user_loyality_configuration.after',
+                'label' => 'sylius.form.rule.user_loyalty_configuration.after',
             ))
         ;
     }
@@ -79,6 +79,6 @@ class UserLoyalityConfigurationType extends AbstractType
      */
     public function getName()
     {
-        return 'sylius_promotion_rule_user_loyality_configuration';
+        return 'sylius_promotion_rule_user_loyalty_configuration';
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -71,13 +71,13 @@
 
         <!-- Promotion Form, Action & Checker -->
         <parameter key="sylius.form.type.promotion_rule.nth_order_configuration.class">Sylius\Bundle\CoreBundle\Form\Type\Rule\NthOrderConfigurationType</parameter>
-        <parameter key="sylius.form.type.promotion_rule.user_loyality_configuration.class">Sylius\Bundle\CoreBundle\Form\Type\Rule\UserLoyalityConfigurationType</parameter>
+        <parameter key="sylius.form.type.promotion_rule.user_loyalty_configuration.class">Sylius\Bundle\CoreBundle\Form\Type\Rule\UserLoyaltyConfigurationType</parameter>
         <parameter key="sylius.form.type.promotion_rule.shipping_country_configuration.class">Sylius\Bundle\CoreBundle\Form\Type\Rule\ShippingCountryConfigurationType</parameter>
         <parameter key="sylius.form.type.promotion_rule.taxonomy_configuration.class">Sylius\Bundle\CoreBundle\Form\Type\Rule\TaxonomyConfigurationType</parameter>
         <parameter key="sylius.form.type.promotion_action.shipping_discount_configuration.class">Sylius\Bundle\CoreBundle\Form\Type\Action\ShippingDiscountConfigurationType</parameter>
 
         <parameter key="sylius.promotion_rule_checker.nth_order.class">Sylius\Component\Core\Promotion\Checker\NthOrderRuleChecker</parameter>
-        <parameter key="sylius.promotion_rule_checker.user_loyality.class">Sylius\Component\Core\Promotion\Checker\UserLoyalityRuleChecker</parameter>
+        <parameter key="sylius.promotion_rule_checker.user_loyalty.class">Sylius\Component\Core\Promotion\Checker\UserLoyaltyRuleChecker</parameter>
         <parameter key="sylius.promotion_rule_checker.shipping_country.class">Sylius\Component\Core\Promotion\Checker\ShippingCountryRuleChecker</parameter>
         <parameter key="sylius.promotion_rule_checker.taxonomy.class">Sylius\Component\Core\Promotion\Checker\TaxonomyRuleChecker</parameter>
         <parameter key="sylius.promotion_action.fixed_discount.class">Sylius\Component\Core\Promotion\Action\FixedDiscountAction</parameter>
@@ -423,9 +423,9 @@
             <argument>%sylius.validation_group.promotion_rule_nth_order_configuration%</argument>
             <tag name="form.type" alias="sylius_promotion_rule_nth_order_configuration" />
         </service>
-        <service id="sylius.form.type.promotion_rule.user_loyality_configuration" class="%sylius.form.type.promotion_rule.user_loyality_configuration.class%">
-            <argument>%sylius.validation_group.promotion_rule_user_loyality_configuration%</argument>
-            <tag name="form.type" alias="sylius_promotion_rule_user_loyality_configuration" />
+        <service id="sylius.form.type.promotion_rule.user_loyalty_configuration" class="%sylius.form.type.promotion_rule.user_loyalty_configuration.class%">
+            <argument>%sylius.validation_group.promotion_rule_user_loyalty_configuration%</argument>
+            <tag name="form.type" alias="sylius_promotion_rule_user_loyalty_configuration" />
         </service>
         <service id="sylius.form.type.promotion_rule.shipping_country_configuration" class="%sylius.form.type.promotion_rule.shipping_country_configuration.class%">
             <argument>%sylius.validation_group.promotion_rule_shipping_country_configuration%</argument>
@@ -443,8 +443,8 @@
         <service id="sylius.promotion_rule_checker.nth_order" class="%sylius.promotion_rule_checker.nth_order.class%">
             <tag name="sylius.promotion_rule_checker" type="nth_order" label="Nth order" />
         </service>
-        <service id="sylius.promotion_rule_checker.user_loyality" class="%sylius.promotion_rule_checker.user_loyality.class%">
-            <tag name="sylius.promotion_rule_checker" type="user_loyality" label="User loyality" />
+        <service id="sylius.promotion_rule_checker.user_loyalty" class="%sylius.promotion_rule_checker.user_loyalty.class%">
+            <tag name="sylius.promotion_rule_checker" type="user_loyalty" label="User loyalty" />
         </service>
         <service id="sylius.promotion_rule_checker.shipping_country" class="%sylius.promotion_rule_checker.shipping_country.class%">
             <tag name="sylius.promotion_rule_checker" type="shipping_country" label="Shipping country" />

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Configuration.php
@@ -74,7 +74,7 @@ class Configuration implements ConfigurationInterface
                             ->prototype('scalar')->end()
                             ->defaultValue(array('sylius'))
                         ->end()
-                        ->arrayNode('promotion_rule_user_loyality_configuration')
+                        ->arrayNode('promotion_rule_user_loyalty_configuration')
                             ->prototype('scalar')->end()
                             ->defaultValue(array('sylius'))
                         ->end()

--- a/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.en.yml
@@ -20,7 +20,7 @@ sylius:
                 equal: Equal
             nth_order_configuration:
                 nth: Nth
-            user_loyality_configuration:
+            user_loyalty_configuration:
                 time: Time
                 unit:
                     days: Days

--- a/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.es.yml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.es.yml
@@ -23,7 +23,7 @@ sylius:
         equal: Igual
       nth_order_configuration:
         nth: Enésimo
-      user_loyality_configuration:
+      user_loyalty_configuration:
         time: Hora
         unit:
           days: Días

--- a/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.fr.yml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.fr.yml
@@ -23,7 +23,7 @@ sylius:
         equal: Égale à
       nth_order_configuration:
         nth: Nième
-      user_loyality_configuration:
+      user_loyalty_configuration:
         time: Temps
         unit:
           days: Jours

--- a/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.nl.yml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.nl.yml
@@ -23,7 +23,7 @@ sylius:
         equal: Gelijk
       nth_order_configuration:
         nth: Nde
-      user_loyality_configuration:
+      user_loyalty_configuration:
         time: Tijd
         unit:
           days: Dagen

--- a/src/Sylius/Component/Core/Promotion/Checker/UserLoyaltyRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/UserLoyaltyRuleChecker.php
@@ -21,7 +21,7 @@ use Sylius\Component\Resource\Exception\UnexpectedTypeException;
  *
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class UserLoyalityRuleChecker implements RuleCheckerInterface
+class UserLoyaltyRuleChecker implements RuleCheckerInterface
 {
     /**
      * {@inheritdoc}
@@ -50,6 +50,6 @@ class UserLoyalityRuleChecker implements RuleCheckerInterface
      */
     public function getConfigurationFormType()
     {
-        return 'sylius_promotion_rule_user_loyality_configuration';
+        return 'sylius_promotion_rule_user_loyalty_configuration';
     }
 }

--- a/src/Sylius/Component/Core/spec/Sylius/Component/Core/Promotion/Checker/UserLoyaltyRuleCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Sylius/Component/Core/Promotion/Checker/UserLoyaltyRuleCheckerSpec.php
@@ -18,11 +18,11 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class UserLoyalityRuleCheckerSpec extends ObjectBehavior
+class UserLoyaltyRuleCheckerSpec extends ObjectBehavior
 {
     function it_should_be_initializable()
     {
-        $this->shouldHaveType('Sylius\Component\Core\Promotion\Checker\UserLoyalityRuleChecker');
+        $this->shouldHaveType('Sylius\Component\Core\Promotion\Checker\UserLoyaltyRuleChecker');
     }
 
     function it_should_be_Sylius_rule_checker()
@@ -32,7 +32,7 @@ class UserLoyalityRuleCheckerSpec extends ObjectBehavior
 
     function it_should_recognize_no_user_as_not_eligible(OrderInterface $subject)
     {
-        $subject->getUser()->shouldBeCalled()->willReturn(null);
+        $subject->getUser()->willReturn(null);
 
         $this->isEligible($subject, array('time' => 30, 'unit' => 'days'))->shouldReturn(false);
     }
@@ -42,8 +42,8 @@ class UserLoyalityRuleCheckerSpec extends ObjectBehavior
         TimestampableInterface $user
     )
     {
-        $subject->getUser()->shouldBeCalled()->willReturn($user);
-        $user->getCreatedAt()->shouldBeCalled()->willReturn(new \DateTime());
+        $subject->getUser()->willReturn($user);
+        $user->getCreatedAt()->willReturn(new \DateTime());
 
         $this->isEligible($subject, array('time' => 30, 'unit' => 'days'))->shouldReturn(false);
     }
@@ -53,8 +53,8 @@ class UserLoyalityRuleCheckerSpec extends ObjectBehavior
         TimestampableInterface $user
     )
     {
-        $subject->getUser()->shouldBeCalled()->willReturn($user);
-        $user->getCreatedAt()->shouldBeCalled()->willReturn(new \DateTime('40 days ago'));
+        $subject->getUser()->willReturn($user);
+        $user->getCreatedAt()->willReturn(new \DateTime('40 days ago'));
 
         $this->isEligible($subject, array('time' => 30, 'unit' => 'days'))->shouldReturn(true);
     }
@@ -75,8 +75,8 @@ class UserLoyalityRuleCheckerSpec extends ObjectBehavior
         TimestampableInterface $user
     )
     {
-        $subject->getUser()->shouldBeCalled()->willReturn($user);
-        $user->getCreatedAt()->shouldBeCalled()->willReturn(new \DateTime());
+        $subject->getUser()->willReturn($user);
+        $user->getCreatedAt()->willReturn(new \DateTime());
 
         $this->isEligible($subject, array('time' => 30, 'unit' => 'days', 'after' => true))->shouldReturn(true);
     }


### PR DESCRIPTION
There is not such word as "loyality".
