### PR TITLE
Promotion rule using ExpressionLanguage

### DIFF
--- a/features/promotions/expression_rule.feature
+++ b/features/promotions/expression_rule.feature
@@ -17,8 +17,8 @@ Feature: Promotion rules based on expressions
             | name        | description                                |
             | opensky.com | Discount for users from opensky.com domain |
           And promotion "opensky.com" has following rules defined:
-            | type       | configuration                                         |
-            | Expression | expr: user.email matches ^[A-Z0-9._%+-]+@opensky.com$ |
+            | type       | configuration                                                                 |
+            | Expression | expr: user.getEmail() matches "/[_a-z0-9-]+(\.[_a-z0-9-]+)*@(?i)opensky.com/" |
           And promotion "opensky.com" has following actions defined:
             | type           | configuration |
             | Fixed discount | Amount: 20    |

--- a/features/promotions/expression_rule.feature
+++ b/features/promotions/expression_rule.feature
@@ -1,0 +1,40 @@
+@promotions
+Feature: Promotion rules based on expressions
+    In order to handle product promotions
+    As a store owner
+    I want to apply promotion discounts during checkout
+
+    Background:
+        Given there are following taxonomies defined:
+            | name     |
+            | Category |
+          And taxonomy "Category" has following taxons:
+            | Clothing > Ubuntu T-Shirts |
+          And the following products exist:
+            | name | price | taxons          |
+            | Ubu  | 42    | Ubuntu T-Shirts |
+          And the following promotions exist:
+            | name        | description                                |
+            | opensky.com | Discount for users from opensky.com domain |
+          And promotion "opensky.com" has following rules defined:
+            | type       | configuration                                         |
+            | Expression | expr: user.email matches ^[A-Z0-9._%+-]+@opensky.com$ |
+          And promotion "opensky.com" has following actions defined:
+            | type           | configuration |
+            | Fixed discount | Amount: 20    |
+
+    Scenario: Fixed discount promotion is applied when the order fulfills
+              the requirment stored in expression
+        Given I am logged in as user "john@opensky.com"
+         When I add product "Ubu" to cart, with quantity "2"
+         Then I should be on the cart summary page
+          And "Promotion total: -€20.00" should appear on the page
+          And "Grand total: €64.00" should appear on the page
+
+    Scenario: Fixed discount promotion is not applied when the cart
+              is not accepted by the expression
+        Given I am logged in as user "rick@example.com"
+         When I add product "Ubu" to cart, with quantity "3"
+         Then I should be on the cart summary page
+          And "Promotion total" should not appear on the page
+          And "Grand total: €126.00" should appear on the page

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Rule/ExpressionConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Rule/ExpressionConfigurationType.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Form\Type\Rule;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+/**
+ * Rule checker configuration for type "expression".
+ *
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+class ExpressionConfigurationType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('expr', 'text', array(
+                'label' => 'sylius.form.rule.expression_configuration.expr',
+                'constraints' => array(
+                    new NotBlank(),
+                )
+            ))
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sylius_promotion_rule_expression_configuration';
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -15,6 +15,8 @@
 
         <parameter key="sylius.checker.restricted_zone.class">Sylius\Bundle\CoreBundle\Checker\RestrictedZoneChecker</parameter>
 
+        <parameter key="sylius.expression_language_factory.class">Sylius\Component\Core\ExpressionLanguage\ExpressionLanguageFactory</parameter>
+
         <parameter key="sylius.checkout_scenario.class">Sylius\Bundle\CoreBundle\Checkout\CheckoutProcessScenario</parameter>
 
         <parameter key="sylius.checkout_step.security.class">Sylius\Bundle\CoreBundle\Checkout\Step\SecurityStep</parameter>
@@ -80,6 +82,7 @@
         <parameter key="sylius.promotion_rule_checker.user_loyality.class">Sylius\Component\Core\Promotion\Checker\UserLoyalityRuleChecker</parameter>
         <parameter key="sylius.promotion_rule_checker.shipping_country.class">Sylius\Component\Core\Promotion\Checker\ShippingCountryRuleChecker</parameter>
         <parameter key="sylius.promotion_rule_checker.taxonomy.class">Sylius\Component\Core\Promotion\Checker\TaxonomyRuleChecker</parameter>
+        <parameter key="sylius.promotion_rule_checker.expression.class">Sylius\Component\Core\Promotion\Checker\ExpressionRuleChecker</parameter>
         <parameter key="sylius.promotion_action.fixed_discount.class">Sylius\Component\Core\Promotion\Action\FixedDiscountAction</parameter>
         <parameter key="sylius.promotion_action.percentage_discount.class">Sylius\Component\Core\Promotion\Action\PercentageDiscountAction</parameter>
         <parameter key="sylius.promotion_action.shipping_discount.class">Sylius\Component\Core\Promotion\Action\ShippingDiscountAction</parameter>
@@ -126,6 +129,8 @@
             <argument type="service" id="security.context" />
             <argument type="service" id="sylius.zone_matcher" />
         </service>
+
+        <service id="sylius.expression_language_factory" class="%sylius.expression_language_factory.class%" />
 
         <!-- checkout -->
         <service id="sylius.checkout_scenario" class="%sylius.checkout_scenario.class%">
@@ -451,6 +456,10 @@
         </service>
         <service id="sylius.promotion_rule_checker.taxonomy" class="%sylius.promotion_rule_checker.taxonomy.class%">
             <tag name="sylius.promotion_rule_checker" type="taxonomy" label="Taxonomy" />
+        </service>
+        <service id="sylius.promotion_rule_checker.expression" class="%sylius.promotion_rule_checker.expression.class%">
+            <argument type="service" id="sylius.expression_language_factory" />
+            <tag name="sylius.promotion_rule_checker" type="expression" label="Expression" />
         </service>
         <service id="sylius.promotion_action.fixed_discount" class="%sylius.promotion_action.fixed_discount.class%">
             <argument type="service" id="sylius.repository.adjustment" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -77,6 +77,7 @@
         <parameter key="sylius.form.type.promotion_rule.shipping_country_configuration.class">Sylius\Bundle\CoreBundle\Form\Type\Rule\ShippingCountryConfigurationType</parameter>
         <parameter key="sylius.form.type.promotion_rule.taxonomy_configuration.class">Sylius\Bundle\CoreBundle\Form\Type\Rule\TaxonomyConfigurationType</parameter>
         <parameter key="sylius.form.type.promotion_action.shipping_discount_configuration.class">Sylius\Bundle\CoreBundle\Form\Type\Action\ShippingDiscountConfigurationType</parameter>
+        <parameter key="sylius.form.type.promotion_rule.expression_configuration.class">Sylius\Bundle\CoreBundle\Form\Type\Rule\ExpressionConfigurationType</parameter>
 
         <parameter key="sylius.promotion_rule_checker.nth_order.class">Sylius\Component\Core\Promotion\Checker\NthOrderRuleChecker</parameter>
         <parameter key="sylius.promotion_rule_checker.user_loyality.class">Sylius\Component\Core\Promotion\Checker\UserLoyalityRuleChecker</parameter>
@@ -444,6 +445,9 @@
         <service id="sylius.form.type.promotion_action.shipping_discount_configuration" class="%sylius.form.type.promotion_action.shipping_discount_configuration.class%">
             <argument>%sylius.validation_group.promotion_action_shipping_discount_configuration%</argument>
             <tag name="form.type" alias="sylius_promotion_action_shipping_discount_configuration" />
+        </service>
+        <service id="sylius.form.type.promotion_rule.expression_configuration" class="%sylius.form.type.promotion_rule.expression_configuration.class%">
+            <tag name="form.type" alias="sylius_promotion_rule_expression_configuration" />
         </service>
         <service id="sylius.promotion_rule_checker.nth_order" class="%sylius.promotion_rule_checker.nth_order.class%">
             <tag name="sylius.promotion_rule_checker" type="nth_order" label="Nth order" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
@@ -8,6 +8,9 @@ sylius:
                 price: Unit price
                 quantity: Quantity
                 variant: Variant
+        rule:
+            expression_configuration:
+                expr: Expression
         block:
             body: Body
             id: ID

--- a/src/Sylius/Component/Core/ExpressionLanguage/ExpressionLanguageFactory.php
+++ b/src/Sylius/Component/Core/ExpressionLanguage/ExpressionLanguageFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+* This file is part of the Sylius package.
+*
+* (c) Paweł Jędrzejewski
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Sylius\Component\Core\ExpressionLanguage;
+
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+/**
+ * Expression language factory.
+ *
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+class ExpressionLanguageFactory implements ExpressionLanguageFactoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function create()
+    {
+        return new ExpressionLanguage();
+    }
+}

--- a/src/Sylius/Component/Core/ExpressionLanguage/ExpressionLanguageFactoryInterface.php
+++ b/src/Sylius/Component/Core/ExpressionLanguage/ExpressionLanguageFactoryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+* This file is part of the Sylius package.
+*
+* (c) Paweł Jędrzejewski
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Sylius\Component\Core\ExpressionLanguage;
+
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+/**
+ * Expression language factory.
+ *
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+interface ExpressionLanguageFactoryInterface
+{
+    /**
+     * Return new expression language instance.
+     *
+     * @return ExpressionLanguage
+     */
+    public function create();
+}

--- a/src/Sylius/Component/Core/Promotion/Checker/ExpressionRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/ExpressionRuleChecker.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Promotion\Checker;
+
+use Sylius\Component\Core\ExpressionLanguage\ExpressionLanguageFactoryInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Promotion\Checker\RuleCheckerInterface;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
+
+/**
+ * Evaluates the expression stored in the configuration.
+ *
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+class ExpressionRuleChecker implements RuleCheckerInterface
+{
+    /**
+     * @var ExpressionLanguageFactoryInterface
+     */
+    protected $expressionLanguageFactory;
+
+    /**
+     * @param ExpressionLanguageFactoryInterface $expressionLanguageFactory
+     */
+    public function __construct(ExpressionLanguageFactoryInterface $expressionLanguageFactory)
+    {
+        $this->expressionLanguageFactory = $expressionLanguageFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEligible(PromotionSubjectInterface $subject, array $configuration)
+    {
+        if (!$subject instanceof OrderInterface) {
+            throw new UnexpectedTypeException($subject, 'Sylius\Component\Core\Model\OrderInterface');
+        }
+
+        if (!array_key_exists('expr', $configuration)) {
+            return false;
+        }
+
+        $context = array('order' => $subject, 'cart' => $subject);
+
+        if (null !== $user = $subject->getUser()) {
+            $context['user'] = $user;
+        }
+
+        return $this->expressionLanguageFactory->create()->evaluate($configuration['expr'], $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigurationFormType()
+    {
+        return 'sylius_promotion_rule_expression_configuration';
+    }
+}

--- a/src/Sylius/Component/Core/spec/Sylius/Component/Core/ExpressionLanguage/ExpressionLanguageFactorySpec.php
+++ b/src/Sylius/Component/Core/spec/Sylius/Component/Core/ExpressionLanguage/ExpressionLanguageFactorySpec.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Core\ExpressionLanguage;
+
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+class ExpressionLanguageFactorySpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Core\ExpressionLanguage\ExpressionLanguageFactory');
+    }
+
+    function it_implements_Sylius_expression_language_factory_interface()
+    {
+        $this->shouldImplement('Sylius\Component\Core\ExpressionLanguage\ExpressionLanguageFactoryInterface');
+    }
+
+    function it_creates_new_expression_factory_instance()
+    {
+        $this->create()->shouldHaveType('Symfony\Component\ExpressionLanguage\ExpressionLanguage');
+    }
+}

--- a/src/Sylius/Component/Core/spec/Sylius/Component/Core/Promotion/Checker/ExpressionRuleCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Sylius/Component/Core/Promotion/Checker/ExpressionRuleCheckerSpec.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Core\Promotion\Checker;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\ExpressionLanguage\ExpressionLanguageFactoryInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\UserInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+/**
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+class ExpressionRuleCheckerSpec extends ObjectBehavior
+{
+    function let(ExpressionLanguageFactoryInterface $factory)
+    {
+        $this->beConstructedWith($factory);
+    }
+
+    function it_should_be_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Core\Promotion\Checker\ExpressionRuleChecker');
+    }
+
+    function it_should_be_Sylius_rule_checker()
+    {
+        $this->shouldImplement('Sylius\Component\Promotion\Checker\RuleCheckerInterface');
+    }
+
+    function it_should_evaluate_the_expression_stored_in_configuration(OrderInterface $order, UserInterface $user, ExpressionLanguage $expr, $factory)
+    {
+        $order->getUser()->shouldBeCalled()->willReturn($user);
+        $factory->create()->shouldBeCalled()->willReturn($expr);
+
+        $context = array('order' => $order, 'cart' => $order, 'user' => $user);
+
+        $expr->evaluate('user.id = 5', $context)->shouldBeCalled()->willReturn(false);
+        $this->isEligible($order, array('expr' => 'user.id = 5'))->shouldReturn(false);
+
+        $expr->evaluate('user.id = 2', $context)->shouldBeCalled()->willReturn(true);
+        $this->isEligible($order, array('expr' => 'user.id = 2'))->shouldReturn(true);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This PR adds a new type of promotion rule, which allows user to enter an expression in the configuration. It is evaluated by the ExpressionLanguage component with `cart`, `order` and `user` context values.

I'd love to rewrite the Rules system with Ruler library or ExpressionLanguage, but still this is a good start and adds ton of flexibility for the promotions.

It has the drawbacks of course, someone who does not now EL, probably should not edit these rules... (non technical store managers, without training)

Let me know what do you think.