### PR TITLE
Fix broken product variants feature

### DIFF
--- a/features/backend/product_variants.feature
+++ b/features/backend/product_variants.feature
@@ -56,7 +56,7 @@ Feature: Product variants
 
     Scenario: Generating all possible variants of product
         Given I am viewing product "Black T-Shirt"
-         When I follow "Generate variants"
+         When I press "Generate variants"
          Then I should still be on the page of product with name "Black T-Shirt"
           And I should see "Variants have been successfully generated."
           And I should see 3 variants in the list
@@ -66,14 +66,14 @@ Feature: Product variants
          When I fill in "Price" with "19.99"
           And I select "L" from "T-Shirt size"
           And I press "Create"
-          And I follow "Generate variants"
+          And I press "Generate variants"
          Then I should still be on the page of product with name "Black T-Shirt"
           And I should see "Variants have been successfully generated."
           And I should see 3 variants in the list
 
     Scenario: Generating all possible variants of product with multiple options
         Given I am viewing product "Sylius T-Shirt"
-         When I follow "Generate variants"
+         When I press "Generate variants"
          Then I should still be on the page of product with name "Sylius T-Shirt"
           And I should see "Variants have been successfully generated."
           And I should see 9 variants in the list
@@ -84,7 +84,7 @@ Feature: Product variants
           And I select "L" from "T-Shirt size"
           And I select "Red" from "T-Shirt color"
           And I press "Create"
-          And I follow "Generate variants"
+          And I press "Generate variants"
          Then I should still be on the page of product with name "Sylius T-Shirt"
           And I should see "Variants have been successfully generated."
           And I should see 9 variants in the list


### PR DESCRIPTION
This was broken by my last change, dunno why but locally it worked well when I called "follow" on button, but Travis-CI is failing, so let's replace "follow" with "press" as there is now button not a link to generate variants.
