### PR TITLE
[Shipping] Add missing dependency to `composer.json`

### DIFF
--- a/src/Sylius/Component/Shipping/composer.json
+++ b/src/Sylius/Component/Shipping/composer.json
@@ -23,7 +23,8 @@
         "php":                      ">=5.3.3",
 
         "sylius/resource":          "0.10.*@dev",
-        "symfony/options-resolver": "~2.3"
+        "symfony/options-resolver": "~2.3",
+        "yohang/finite":            "~1.1@dev"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.0"


### PR DESCRIPTION
That dependency is used by: `Processor\ShipmentProcessor`
