### PR TITLE
[ResourceBundle] Check for existence of controller class before creating definition

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDatabaseDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDatabaseDriver.php
@@ -52,10 +52,12 @@ abstract class AbstractDatabaseDriver implements DatabaseDriverInterface
 
     public function load(array $classes)
     {
-        $this->container->setDefinition(
-            $this->getContainerKey('controller'),
-            $this->getControllerDefinition($classes['controller'])
-        );
+        if (isset($classes['controller'])) {
+            $this->container->setDefinition(
+                $this->getContainerKey('controller'),
+                $this->getControllerDefinition($classes['controller'])
+            );
+        }
 
         $this->container->setDefinition(
             $this->getContainerKey('repository'),


### PR DESCRIPTION
Not sure if there's a better way to do this or not but I have a couple of entities that don't require controllers and I'm using the Configuration to resolve target entities / change classes etc. 
