### PR TITLE
[Attribute] Rename `SubjectInterface` into `AttributeSubjectInterface`

### DIFF
--- a/src/Sylius/Component/Attribute/Model/AttributeSubjectInterface.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeSubjectInterface.php
@@ -19,7 +19,7 @@ use Doctrine\Common\Collections\Collection;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface SubjectInterface
+interface AttributeSubjectInterface
 {
     /**
      * Returns all product product properties.

--- a/src/Sylius/Component/Attribute/Model/AttributeValue.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeValue.php
@@ -28,7 +28,7 @@ class AttributeValue implements AttributeValueInterface
     /**
      * Subject.
      *
-     * @var SubjectInterface
+     * @var AttributeSubjectInterface
      */
     protected $subject;
 
@@ -73,7 +73,7 @@ class AttributeValue implements AttributeValueInterface
     /**
      * {@inheritdoc}
      */
-    public function setSubject(SubjectInterface $subject = null)
+    public function setSubject(AttributeSubjectInterface $subject = null)
     {
         $this->subject = $subject;
 

--- a/src/Sylius/Component/Attribute/Model/AttributeValueInterface.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeValueInterface.php
@@ -23,16 +23,16 @@ interface AttributeValueInterface
     /**
      * Get subject.
      *
-     * @return SubjectInterface
+     * @return AttributeSubjectInterface
      */
     public function getSubject();
 
     /**
      * Set subject.
      *
-     * @param SubjectInterface|null $subject
+     * @param AttributeSubjectInterface|null $subject
      */
-    public function setSubject(SubjectInterface $subject = null);
+    public function setSubject(AttributeSubjectInterface $subject = null);
 
     /**
      * Get attribute.

--- a/src/Sylius/Component/Attribute/spec/Sylius/Component/Attribute/Model/AttributeValueSpec.php
+++ b/src/Sylius/Component/Attribute/spec/Sylius/Component/Attribute/Model/AttributeValueSpec.php
@@ -14,7 +14,7 @@ namespace spec\Sylius\Component\Attribute\Model;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Attribute\Model\AttributeInterface;
 use Sylius\Component\Attribute\Model\AttributeTypes;
-use Sylius\Component\Attribute\Model\SubjectInterface;
+use Sylius\Component\Attribute\Model\AttributeSubjectInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -41,13 +41,13 @@ class AttributeValueSpec extends ObjectBehavior
         $this->getSubject()->shouldReturn(null);
     }
 
-    function it_allows_assigning_itself_to_a_subject(SubjectInterface $subject)
+    function it_allows_assigning_itself_to_a_subject(AttributeSubjectInterface $subject)
     {
         $this->setSubject($subject);
         $this->getSubject()->shouldReturn($subject);
     }
 
-    function it_allows_detaching_itself_from_a_subject(SubjectInterface $subject)
+    function it_allows_detaching_itself_from_a_subject(AttributeSubjectInterface $subject)
     {
         $this->setSubject($subject);
         $this->getSubject()->shouldReturn($subject);

--- a/src/Sylius/Component/Product/Model/ProductInterface.php
+++ b/src/Sylius/Component/Product/Model/ProductInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Component\Product\Model;
 
-use Sylius\Component\Attribute\Model\SubjectInterface;
+use Sylius\Component\Attribute\Model\AttributeSubjectInterface;
 use Sylius\Component\Resource\Model\SoftDeletableInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 use Sylius\Component\Variation\Model\VariableInterface;
@@ -22,7 +22,7 @@ use Sylius\Component\Variation\Model\VariableInterface;
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
 interface ProductInterface extends
-    SubjectInterface,
+    AttributeSubjectInterface,
     VariableInterface,
     SoftDeletableInterface,
     TimestampableInterface


### PR DESCRIPTION
This change is done to be consistent with other subject like model interfaces.
