### PR TITLE
Removed useless route.

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/payment.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/payment.yml
@@ -39,14 +39,6 @@ sylius_backend_payment_delete:
             template: SyliusWebBundle:Backend/Misc:delete.html.twig
             redirect: sylius_backend_payment_index
 
-sylius_backend_payment_show:
-    pattern: /{id}
-    methods: [GET]
-    defaults:
-        _controller: sylius.controller.payment:show
-        _sylius:
-            template: SyliusWebBundle:Backend/Payment:show.html.twig
-
 sylius_backend_payment_history:
     pattern: /{id}/history
     methods: [GET]


### PR DESCRIPTION
The action show in Sylius\Bundle\CoreBundle\Controller\PaymentController and the template associated do not exist in the project.
