### PR TITLE
[CartBundle] Fixed event used in CartListener and added specs

### DIFF
--- a/src/Sylius/Bundle/CartBundle/EventListener/CartListener.php
+++ b/src/Sylius/Bundle/CartBundle/EventListener/CartListener.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\CartBundle\EventListener;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Bundle\CartBundle\Event\CartEvent;
+use Sylius\Bundle\CartBundle\Event\CartItemEvent;
 use Sylius\Component\Cart\Provider\CartProviderInterface;
 use Sylius\Component\Cart\SyliusCartEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -70,13 +71,13 @@ class CartListener implements EventSubscriberInterface
         );
     }
 
-    public function addItem(CartEvent $event)
+    public function addItem(CartItemEvent $event)
     {
         $cart = $event->getCart();
         $cart->addItem($event->getItem());
     }
 
-    public function removeItem(CartEvent $event)
+    public function removeItem(CartItemEvent $event)
     {
         $cart = $event->getCart();
         $cart->removeItem($event->getItem());

--- a/src/Sylius/Bundle/CartBundle/spec/Sylius/Bundle/CartBundle/EventListener/CartListenerSpec.php
+++ b/src/Sylius/Bundle/CartBundle/spec/Sylius/Bundle/CartBundle/EventListener/CartListenerSpec.php
@@ -13,11 +13,17 @@ namespace spec\Sylius\Bundle\CartBundle\EventListener;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Cart\Model\CartInterface;
+use Sylius\Component\Cart\Model\CartItemInterface;
+use Sylius\Bundle\CartBundle\Event\CartEvent;
+use Sylius\Bundle\CartBundle\Event\CartItemEvent;
 use Sylius\Component\Cart\Provider\CartProviderInterface;
 use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
  * @author Joseph Bielawski <stloyd@gmail.com>
+ * @author Fran Moreno <franmomu@gmail.com>
  */
 class CartListenerSpec extends ObjectBehavior
 {
@@ -29,5 +35,63 @@ class CartListenerSpec extends ObjectBehavior
     function it_is_initializable()
     {
         $this->shouldHaveType('Sylius\Bundle\CartBundle\EventListener\CartListener');
+    }
+
+    function it_should_add_a_item_to_a_cart_from_event(CartItemEvent $event, CartInterface $cart, CartItemInterface $cartItem)
+    {
+        $event->getCart()->willReturn($cart);
+        $event->getItem()->willReturn($cartItem);
+        $cart->addItem($cartItem)->shouldBeCalled();
+
+        $this->addItem($event);
+    }
+
+    function it_should_remove_a_item_to_a_cart_from_event(CartItemEvent $event, CartInterface $cart, CartItemInterface $cartItem)
+    {
+        $event->getCart()->willReturn($cart);
+        $event->getItem()->willReturn($cartItem);
+        $cart->removeItem($cartItem)->shouldBeCalled();
+
+        $this->removeItem($event);
+    }
+
+    function it_should_clear_a_cart_from_event(CartEvent $event, CartInterface $cart, $manager, $provider)
+    {
+        $event->getCart()->willReturn($cart);
+        $manager->remove($cart)->shouldBeCalled();
+        $manager->flush()->shouldBeCalled();
+        $provider->abandonCart()->shouldBeCalled();
+
+        $this->clearCart($event);
+    }
+
+    function it_should_save_a_valid_cart($manager, $provider, CartEvent $event, CartInterface $cart)
+    {
+        $event->getCart()->willReturn($cart);
+        $manager->persist($cart)->shouldBeCalled();
+        $manager->flush()->shouldBeCalled();
+        $provider->setCart($cart)->shouldBeCalled();
+
+        $this->saveCart($event);
+    }
+
+    function it_should_not_save_an_invalid_cart(
+        $manager,
+        $provider,
+        $validator,
+        CartEvent $event,
+        CartInterface $cart,
+        ConstraintViolationListInterface $constraintList
+    )
+    {
+        $constraintList->count()->willReturn(1);
+        $event->getCart()->willReturn($cart);
+        $validator->validate($cart)->shouldBeCalled()->willReturn($constraintList);
+
+        $manager->persist($cart)->shouldNotBeCalled();
+        $manager->flush()->shouldNotBeCalled();
+        $provider->setCart($cart)->shouldNotBeCalled();
+
+        $this->saveCart($event);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

The dispatched event in `addItem` and `removeItem` is CartItemEvent instead of CartEvent, it uses the getItem method only available in CartItemEvent
