### PR TITLE
Remove hard-coded formatting pattern for currency

### DIFF
--- a/src/Sylius/Bundle/MoneyBundle/Templating/Helper/MoneyHelper.php
+++ b/src/Sylius/Bundle/MoneyBundle/Templating/Helper/MoneyHelper.php
@@ -32,17 +32,11 @@ class MoneyHelper extends Helper
      */
     private $formatter;
 
-    /**
-     * @var string
-     */
-    private $pattern = '¤#,##0.00;-¤#,##0.00';
-
     public function __construct(CurrencyContextInterface $currencyContext, CurrencyConverterInterface $converter, $locale = null)
     {
         $this->currencyContext = $currencyContext;
         $this->converter       = $converter;
         $this->formatter       = new \NumberFormatter($locale ?: \Locale::getDefault(), \NumberFormatter::CURRENCY);
-        $this->formatter->setPattern($this->pattern);
     }
 
     /**


### PR DESCRIPTION
According to this issue : https://github.com/Sylius/Sylius/issues/1448

PHP Intl will do this automatically when changing sylius.locale parameter in parameters.yml
