### PR TITLE
[VariationBundle] [ProductBundle] move 'sylius.validator.variant.unique' service definition

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/services.xml
@@ -23,6 +23,7 @@
         <parameter key="sylius.generator.product_variant.class">Sylius\Bundle\ProductBundle\Generator\VariantGenerator</parameter>
 
         <parameter key="sylius.validator.product.unique.class">Sylius\Bundle\ProductBundle\Validator\ProductUniqueValidator</parameter>
+        <parameter key="sylius.validator.variant.unique.class">Sylius\Bundle\VariationBundle\Validator\VariantUniqueValidator</parameter>
     </parameters>
 
     <services>
@@ -56,6 +57,10 @@
         <service id="sylius.validator.product.unique" class="%sylius.validator.product.unique.class%">
             <argument type="service" id="sylius.repository.product" />
             <tag name="validator.constraint_validator" alias="sylius.validator.product.unique" />
+        </service>
+        <service id="sylius.validator.variant.unique" class="%sylius.validator.variant.unique.class%">
+            <argument type="service" id="sylius.repository.product_variant" />
+            <tag name="validator.constraint_validator" alias="sylius.validator.variant.unique" />
         </service>
     </services>
 

--- a/src/Sylius/Bundle/VariationBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/VariationBundle/Resources/config/services.xml
@@ -19,7 +19,6 @@
     <parameters>
         <parameter key="sylius.event_subscriber.variation.load_metadata.class">Sylius\Bundle\VariationBundle\EventListener\LoadMetadataSubscriber</parameter>
 
-        <parameter key="sylius.validator.variant.unique.class">Sylius\Bundle\VariationBundle\Validator\VariantUniqueValidator</parameter>
         <parameter key="sylius.validator.variant.combination.class">Sylius\Bundle\VariationBundle\Validator\VariantCombinationValidator</parameter>
     </parameters>
 
@@ -29,10 +28,6 @@
             <argument>%sylius.variation.variables%</argument>
         </service>
 
-        <service id="sylius.validator.variant.unique" class="%sylius.validator.variant.unique.class%">
-            <argument type="service" id="sylius.repository.product_variant" />
-            <tag name="validator.constraint_validator" alias="sylius.validator.variant.unique" />
-        </service>
         <service id="sylius.validator.variant.combination" class="%sylius.validator.variant.combination.class%">
             <tag name="validator.constraint_validator" alias="sylius.validator.variant.combination" />
         </service>


### PR DESCRIPTION
From VariationBundle to ProductBundle, to allow standalone usage of VariationBundle.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #1449 |
| License | MIT |
| Doc PR | -- |
