### PR TITLE
Added scope to zone

### DIFF
--- a/features/backend/zones.feature
+++ b/features/backend/zones.feature
@@ -8,11 +8,11 @@ Feature: Zones
         Given I am logged in as administrator
           And there is default currency configured
           And there are following zones:
-            | name                      | type     | members                                       |
-            | Baltic states             | country  | Lithuania, Latvia, Estonia                    |
-            | USA GMT-8                 | province | Washington, Oregon, Nevada, Idaho, California |
-            | Baltic states + USA GMT-8 | zone     | Baltic states, USA GMT-8                      |
-            | Germany                   | country  | Germany                                       |
+            | name                      | type     | members                                       | scope      |
+            | Baltic states             | country  | Lithuania, Latvia, Estonia                    | content    |
+            | USA GMT-8                 | province | Washington, Oregon, Nevada, Idaho, California | shipping   |
+            | Baltic states + USA GMT-8 | zone     | Baltic states, USA GMT-8                      |            |
+            | Germany                   | country  | Germany                                       | price      |
 
     Scenario: Seeing index of all zones
         Given I am on the dashboard page
@@ -51,10 +51,12 @@ Feature: Zones
           And I select "Country" from "Type"
           And I click "Add member"
           And I select "Estonia" from "Country"
+          And I select "shipping" from "Scope"
          When I press "Create"
          Then I should be on the page of zone "EU"
           And I should see "Zone has been successfully created."
           And "Estonia" should appear on the page
+          And "shipping" should appear on the page
 
     Scenario: Created zones appear in the list
         Given I created zone "EU"

--- a/src/Sylius/Bundle/AddressingBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/AddressingBundle/DependencyInjection/Configuration.php
@@ -22,6 +22,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  * sections are normalized, and merged.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class Configuration implements ConfigurationInterface
 {
@@ -42,6 +43,7 @@ class Configuration implements ConfigurationInterface
 
         $this->addClassesSection($rootNode);
         $this->addValidationGroupsSection($rootNode);
+        $this->addScopesSection($rootNode);
 
         return $treeBuilder;
     }
@@ -171,6 +173,18 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end()
+        ;
+    }
+
+    private function addScopesSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('scopes')
+                    ->prototype('scalar')->end()
+                ->end()
+            ->end()
+
         ;
     }
 }

--- a/src/Sylius/Bundle/AddressingBundle/DependencyInjection/SyliusAddressingExtension.php
+++ b/src/Sylius/Bundle/AddressingBundle/DependencyInjection/SyliusAddressingExtension.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * Addressing system extension.
  *
  * @author Paweł Jędrzejewski <pjedrzejewski@sylius.pl>
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class SyliusAddressingExtension extends AbstractResourceExtension
 {
@@ -26,6 +27,8 @@ class SyliusAddressingExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE | self::CONFIGURE_PARAMETERS | self::CONFIGURE_VALIDATORS);
+        list($config, $loader) = $this->configure($config, new Configuration(), $container, self::CONFIGURE_LOADER | self::CONFIGURE_DATABASE | self::CONFIGURE_PARAMETERS | self::CONFIGURE_VALIDATORS);
+
+        $container->setParameter('sylius.scope.zone', $config['scopes']);
     }
 }

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
@@ -15,11 +15,13 @@ use Sylius\Component\Addressing\Model\ZoneInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface;
 
 /**
  * Zone form type.
  *
  * @author Saša Stamenković <umpirsky@gmail.com>
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class ZoneType extends AbstractType
 {
@@ -38,15 +40,24 @@ class ZoneType extends AbstractType
     protected $validationGroups;
 
     /**
+     * Scopes.
+     *
+     * @var array
+     */
+    protected $scopeChoices;
+
+    /**
      * Constructor.
      *
-     * @param string   $dataClass
-     * @param string[] $validationGroups
+     * @param string $dataClass
+     * @param array  $validationGroups
+     * @param array  $scopeChoices
      */
-    public function __construct($dataClass, array $validationGroups)
+    public function __construct($dataClass, array $validationGroups, array $scopeChoices = array())
     {
         $this->dataClass = $dataClass;
         $this->validationGroups = $validationGroups;
+        $this->scopeChoices = $scopeChoices;
     }
 
     /**
@@ -65,6 +76,10 @@ class ZoneType extends AbstractType
                     ZoneInterface::TYPE_PROVINCE => 'sylius.form.zone.types.province',
                     ZoneInterface::TYPE_ZONE     => 'sylius.form.zone.types.zone',
                 ),
+            ))
+            ->add('scope', 'choice', array(
+                'label'   => 'sylius.form.zone.scope',
+                'choices' => $this->scopeChoices,
             ))
             ->add('members', 'sylius_zone_member_collection', array(
                 'label' => 'sylius.form.zone.members'

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Zone.orm.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Zone.orm.xml
@@ -20,6 +20,7 @@
 
         <field name="name" column="name" type="string" />
         <field name="type" column="type" type="string" length="8" />
+        <field name="scope" column="scope" type="string" nullable="true"/>
 
         <one-to-many field="members" target-entity="Sylius\Component\Addressing\Model\ZoneMemberInterface" mapped-by="belongsTo">
             <cascade>

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/services.xml
@@ -51,6 +51,7 @@
         <service id="sylius.form.type.zone" class="%sylius.form.type.zone.class%">
             <argument>%sylius.model.zone.class%</argument>
             <argument>%sylius.validation_group.zone%</argument>
+            <argument>%sylius.scope.zone%</argument>
             <tag name="form.type" alias="sylius_zone" />
         </service>
         <service id="sylius.form.type.zone_member_country" class="%sylius.form.type.zone_member_country.class%">

--- a/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.en.yml
@@ -25,6 +25,7 @@ sylius:
                 country: Country
                 province: Province
                 zone: Zone
+            scope: Scope
         zone_member_country:
             country: Country
         zone_member_province:

--- a/src/Sylius/Bundle/AddressingBundle/Resources/views/Zone/_form.html.twig
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/views/Zone/_form.html.twig
@@ -2,6 +2,7 @@
 <fieldset>
     {{ form_row(form.name, {'attr': {'class': 'input-lg'}}) }}
     {{ form_row(form.type) }}
+    {{ form_row(form.scope) }}
     <div class="control-group">
         {% for type in ['country', 'province', 'zone'] %}
             <div id="sylius-addressing-zone-members-{{ type }}" data-prototype="{{ form_widget(form.members.vars.prototypes['sylius_zone_member_' ~ type], {'attr': {'class': 'select2 input-lg'}})|e }}">

--- a/src/Sylius/Bundle/AddressingBundle/Resources/views/Zone/macros.html.twig
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/views/Zone/macros.html.twig
@@ -9,6 +9,7 @@
                 <th>{{ sylius_resource_sort('id', '#id') }}</th>
                 <th>{{ sylius_resource_sort('name') }}</th>
                 <th>{{ sylius_resource_sort('type') }}</th>
+                <th>{{ sylius_resource_sort('scope') }}</th>
                 <th></th>
             </tr>
         </thead>
@@ -18,6 +19,7 @@
                 <td>{{ zone.id }}</td>
                 <td>{{ zone.name }}</td>
                 <td>{{ zone.type }}</td>
+                <td>{{ zone.scope }}</td>
                 <td>
                     <div class="btn-group pull-right">
                         {{ buttons.edit(path('sylius_zone_update', {'id': zone.id})) }}

--- a/src/Sylius/Bundle/AddressingBundle/spec/Sylius/Bundle/AddressingBundle/Form/Type/ZoneTypeSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/Sylius/Bundle/AddressingBundle/Form/Type/ZoneTypeSpec.php
@@ -18,12 +18,13 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * @author Julien Janvier <j.janvier@gmail.com>
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class ZoneTypeSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith('Zone', array('sylius'));
+        $this->beConstructedWith('Zone', array('sylius'), array('shipping', 'pricing'));
     }
 
     function it_is_initializable()
@@ -50,6 +51,11 @@ class ZoneTypeSpec extends ObjectBehavior
 
         $builder
             ->add('type', 'choice', Argument::any())
+            ->shouldBeCalled()
+            ->willReturn($builder);
+
+        $builder
+            ->add('scope', 'choice', Argument::any())
             ->shouldBeCalled()
             ->willReturn($builder);
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
@@ -118,7 +118,11 @@ sylius_payment:
 
 sylius_payum: ~
 
-sylius_addressing: ~
+sylius_addressing:
+    scopes:
+        shipping: shipping
+        content: content
+        price: price
 
 sylius_order:
     classes:

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
@@ -730,5 +730,6 @@ sylius:
         show_header: Zone details
         type: Type
         update_header: Editing zone
+        scope: Scope
     zone_member:
         members: Members

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Zone/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Zone/_form.html.twig
@@ -6,6 +6,7 @@
         <div class="col-md-6">
             {{ form_row(form.name, {'attr': {'class': 'input-lg'}}) }}
             {{ form_row(form.type) }}
+            {{ form_row(form.scope) }}
         </div>
         <div class="col-md-6">
             <div class="control-group">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Zone/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Zone/macros.html.twig
@@ -10,6 +10,7 @@
             <th>{{ sylius_resource_sort('id', '#id') }}</th>
             <th>{{ sylius_resource_sort('name', 'sylius.zone.name'|trans) }}</th>
             <th>{{ sylius_resource_sort('type', 'sylius.zone.type'|trans) }}</th>
+            <th>{{ sylius_resource_sort('type', 'sylius.zone.scope'|trans) }}</th>
             <th></th>
         </tr>
     </thead>
@@ -19,6 +20,7 @@
             <td>{{ zone.id }}</td>
             <td><a href="{{ path('sylius_backend_zone_show', {'id': zone.id}) }}"><strong>{{ zone.name }}</strong></a></td>
             <td><span class="label label-primary">{{ zone.type }}</span></td>
+            <td>{{ zone.scope }}</td>
             <td>
                 <div class="pull-right">
                 {{ buttons.edit(path('sylius_backend_zone_update', {'id': zone.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Zone/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Zone/show.html.twig
@@ -26,12 +26,14 @@
         <tr>
             <th>{{ 'sylius.zone.name'|trans }}</th>
             <th>{{ 'sylius.zone.type'|trans }}</th>
+            <th>{{ 'sylius.zone.scope'|trans }}</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td>{{ zone.name }}</td>
             <td>{{ zone.type }}</td>
+            <td>{{ zone.scope }}</td>
         </tr>
     </tbody>
 </table>

--- a/src/Sylius/Component/Addressing/Matcher/ZoneMatcher.php
+++ b/src/Sylius/Component/Addressing/Matcher/ZoneMatcher.php
@@ -23,6 +23,7 @@ use Sylius\Component\Addressing\Model\ZoneMemberInterface;
  * It also handles sub-zones.
  *
  * @author Saša Stamenković <umpirsky@gmail.com>
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class ZoneMatcher implements ZoneMatcherInterface
 {
@@ -46,11 +47,11 @@ class ZoneMatcher implements ZoneMatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function match(AddressInterface $address)
+    public function match(AddressInterface $address, $scope = null)
     {
         $zones = array();
 
-        foreach ($this->getZones() as $zone) {
+        foreach ($this->getZones($scope) as $zone) {
             if ($this->addressBelongsToZone($address, $zone)) {
                 $zones[$zone->getType()] = $zone;
             }
@@ -74,11 +75,11 @@ class ZoneMatcher implements ZoneMatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function matchAll(AddressInterface $address)
+    public function matchAll(AddressInterface $address, $scope = null)
     {
         $zones = array();
 
-        foreach ($this->getZones() as $zone) {
+        foreach ($this->getZones($scope) as $zone) {
             if ($this->addressBelongsToZone($address, $zone)) {
                 $zones[] = $zone;
             }
@@ -138,10 +139,16 @@ class ZoneMatcher implements ZoneMatcherInterface
     /**
      * Gets all zones
      *
+     * @param string|null $scope
+     *
      * @return array $zones
      */
-    protected function getZones()
+    protected function getZones($scope = null)
     {
-        return $this->repository->findAll();
+        if (null === $scope) {
+            return $this->repository->findAll();
+        }
+
+        return $this->repository->findBy(array('scope' => $scope));
     }
 }

--- a/src/Sylius/Component/Addressing/Matcher/ZoneMatcherInterface.php
+++ b/src/Sylius/Component/Addressing/Matcher/ZoneMatcherInterface.php
@@ -20,6 +20,7 @@ use Sylius\Component\Addressing\Model\ZoneInterface;
  * best matching zones for provided address model.
  *
  * @author Saša Stamenković <umpirsky@gmail.com>
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 interface ZoneMatcherInterface
 {
@@ -27,17 +28,19 @@ interface ZoneMatcherInterface
      * Returns the best matching zone for given address.
      *
      * @param AddressInterface $address
+     * @param string|null      $scope
      *
      * @return ZoneInterface|null
      */
-    public function match(AddressInterface $address);
+    public function match(AddressInterface $address, $scope = null);
 
     /**
      * Returns all matching zones for given address.
      *
      * @param AddressInterface $address
+     * @param string|null      $scope
      *
      * @return Collection|ZoneInterface[]
      */
-    public function matchAll(AddressInterface $address);
+    public function matchAll(AddressInterface $address, $scope = null);
 }

--- a/src/Sylius/Component/Addressing/Model/Zone.php
+++ b/src/Sylius/Component/Addressing/Model/Zone.php
@@ -18,6 +18,7 @@ use Doctrine\Common\Collections\Collection;
  * Default zone model.
  *
  * @author Saša Stamenković <umpirsky@gmail.com>
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class Zone implements ZoneInterface
 {
@@ -41,6 +42,13 @@ class Zone implements ZoneInterface
      * @var string
      */
     protected $type;
+
+    /**
+     * Zone scope.
+     *
+     * @var string
+     */
+    protected $scope;
 
     /**
      * Zone members.
@@ -115,6 +123,24 @@ class Zone implements ZoneInterface
     public static function getTypes()
     {
         return array(self::TYPE_COUNTRY, self::TYPE_PROVINCE, self::TYPE_ZONE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getScope()
+    {
+        return $this->scope;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setScope($scope)
+    {
+        $this->scope = $scope;
+
+        return $this;
     }
 
     /**

--- a/src/Sylius/Component/Addressing/Model/ZoneInterface.php
+++ b/src/Sylius/Component/Addressing/Model/ZoneInterface.php
@@ -17,6 +17,7 @@ use Doctrine\Common\Collections\Collection;
  * Zone interface.
  *
  * @author Saša Stamenković <umpirsky@gmail.com>
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 interface ZoneInterface
 {
@@ -52,6 +53,18 @@ interface ZoneInterface
      * @return ZoneInterface
      */
     public function setType($type);
+
+    /**
+     * @return string
+     */
+    public function getScope();
+
+    /**
+     * @param string $scope
+     *
+     * @return ZoneInterface
+     */
+    public function setScope($scope);
 
     /**
      * @return Collection|ZoneMemberInterface[]

--- a/src/Sylius/Component/Addressing/spec/Sylius/Component/Addressing/Matcher/ZoneMatcherSpec.php
+++ b/src/Sylius/Component/Addressing/spec/Sylius/Component/Addressing/Matcher/ZoneMatcherSpec.php
@@ -23,6 +23,7 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class ZoneMatcherSpec extends ObjectBehavior
 {
@@ -65,6 +66,24 @@ class ZoneMatcherSpec extends ObjectBehavior
         $this->match($address)->shouldReturn($zone);
     }
 
+    function it_should_match_address_by_province_and_scope(
+        $repository,
+        ProvinceInterface $province,
+        AddressInterface $address,
+        ZoneMemberProvince $memberProvince,
+        ZoneInterface $zone
+    )
+    {
+        $repository->findBy(array('scope' => 'shipping'))->shouldBeCalled()->willReturn(array($zone));
+        $address->getProvince()->shouldBeCalled()->willReturn($province);
+        $memberProvince->getProvince()->shouldBeCalled()->willReturn($province);
+        $zone->getType()->shouldBeCalled()->willReturn(ZoneInterface::TYPE_PROVINCE);
+        $zone->getMembers()->shouldBeCalled()->willReturn(array($memberProvince));
+        $memberProvince->getBelongsTo()->willReturn($zone);
+
+        $this->match($address, 'shipping')->shouldReturn($zone);
+    }
+
     function it_should_match_address_by_country(
         $repository,
         CountryInterface $country,
@@ -80,6 +99,23 @@ class ZoneMatcherSpec extends ObjectBehavior
         $memberCountry->getBelongsTo()->willReturn($zone);
 
         $this->match($address)->shouldReturn($zone);
+    }
+
+    function it_should_match_address_by_country_and_scope(
+        $repository,
+        CountryInterface $country,
+        AddressInterface $address,
+        ZoneMemberCountry $memberCountry,
+        ZoneInterface $zone)
+    {
+        $repository->findBy(array('scope' => 'shipping'))->shouldBeCalled()->willReturn(array($zone));
+        $address->getCountry()->shouldBeCalled()->willReturn($country);
+        $memberCountry->getCountry()->shouldBeCalled()->willReturn($country);
+        $zone->getType()->shouldBeCalled()->willReturn(ZoneInterface::TYPE_COUNTRY);
+        $zone->getMembers()->shouldBeCalled()->willReturn(array($memberCountry));
+        $memberCountry->getBelongsTo()->willReturn($zone);
+
+        $this->match($address, 'shipping')->shouldReturn($zone);
     }
 
     function it_should_match_address_for_nested_zones(
@@ -105,6 +141,31 @@ class ZoneMatcherSpec extends ObjectBehavior
         $repository->findAll()->shouldBeCalled()->willReturn(array($rootZone));
 
         $this->match($address)->shouldReturn($rootZone);
+    }
+
+    function it_should_match_address_for_nested_zones_and_scope(
+        $repository,
+        CountryInterface $country,
+        AddressInterface $address,
+        ZoneMemberCountry $memberCountry,
+        ZoneInterface $subZone,
+        ZoneMemberZone $memberZone,
+        ZoneInterface $rootZone
+    )
+    {
+        $address->getCountry()->shouldBeCalled()->willReturn($country);
+        $memberCountry->getCountry()->shouldBeCalled()->willReturn($country);
+        $subZone->getMembers()->shouldBeCalled()->willReturn(array($memberCountry));
+        $subZone->getType()->shouldBeCalled()->willReturn(ZoneInterface::TYPE_COUNTRY);
+        $memberZone->getZone()->shouldBeCalled()->willReturn($subZone);
+        $rootZone->getMembers()->shouldBeCalled()->willReturn(array($memberZone));
+        $rootZone->getType()->shouldBeCalled()->willReturn(ZoneInterface::TYPE_ZONE);
+
+        $memberCountry->getBelongsTo()->willReturn($subZone);
+        $memberZone->getBelongsTo()->willReturn($rootZone);
+        $repository->findBy(array('scope' => 'shipping'))->shouldBeCalled()->willReturn(array($rootZone));
+
+        $this->match($address, 'shipping')->shouldReturn($rootZone);
     }
 
     function it_should_match_address_from_province_when_many_are_found(
@@ -135,6 +196,34 @@ class ZoneMatcherSpec extends ObjectBehavior
         $this->match($address)->shouldReturn($zoneProvince);
     }
 
+    function it_should_match_address_from_province_when_many_are_found_by_scope(
+        $repository,
+        CountryInterface $country,
+        ProvinceInterface $province,
+        AddressInterface $address,
+        ZoneMemberCountry $memberCountry,
+        ZoneMemberProvince $memberProvince,
+        ZoneInterface $zoneCountry,
+        ZoneInterface $zoneProvince
+    )
+    {
+        $address->getProvince()->willReturn($province);
+        $address->getCountry()->willReturn($country);
+        $memberProvince->getProvince()->willReturn($province);
+        $memberCountry->getCountry()->willReturn($country);
+
+        $zoneProvince->getMembers()->willReturn(array($memberProvince));
+        $zoneProvince->getType()->willReturn(ZoneInterface::TYPE_PROVINCE);
+        $zoneCountry->getMembers()->willReturn(array($memberCountry));
+        $zoneCountry->getType()->willReturn(ZoneInterface::TYPE_COUNTRY);
+
+        $repository->findBy(array('scope' => 'shipping'))->shouldBeCalled()->willReturn(array($zoneCountry, $zoneProvince));
+        $memberProvince->getBelongsTo()->willReturn($zoneProvince);
+        $memberCountry->getBelongsTo()->willReturn($zoneCountry);
+
+        $this->match($address, 'shipping')->shouldReturn($zoneProvince);
+    }
+
     function it_should_match_all_zones_when_one_zone_for_address_is_defined(
         $repository,
         CountryInterface $country,
@@ -151,5 +240,23 @@ class ZoneMatcherSpec extends ObjectBehavior
         $memberCountry->getBelongsTo()->willReturn($zoneCountry);
 
         $this->matchAll($address)->shouldReturn(array($zoneCountry));
+    }
+
+    function it_should_match_all_zones_by_scope_when_one_zone_for_address_is_defined(
+        $repository,
+        CountryInterface $country,
+        AddressInterface $address,
+        ZoneMemberCountry $memberCountry,
+        ZoneInterface $zoneCountry
+    )
+    {
+        $repository->findBy(array('scope' => 'shipping'))->shouldBeCalled()->willReturn(array($zoneCountry));
+        $address->getCountry()->shouldBeCalled()->willReturn($country);
+        $memberCountry->getCountry()->shouldBeCalled()->willReturn($country);
+        $zoneCountry->getType()->shouldBeCalled()->willReturn(ZoneInterface::TYPE_COUNTRY);
+        $zoneCountry->getMembers()->shouldBeCalled()->willReturn(array($memberCountry));
+        $memberCountry->getBelongsTo()->willReturn($zoneCountry);
+
+        $this->matchAll($address, 'shipping')->shouldReturn(array($zoneCountry));
     }
 }

--- a/src/Sylius/Component/Addressing/spec/Sylius/Component/Addressing/Model/ZoneSpec.php
+++ b/src/Sylius/Component/Addressing/spec/Sylius/Component/Addressing/Model/ZoneSpec.php
@@ -17,6 +17,7 @@ use Sylius\Component\Addressing\Model\ZoneMemberInterface;
 
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class ZoneSpec extends ObjectBehavior
 {
@@ -89,11 +90,23 @@ class ZoneSpec extends ObjectBehavior
         $this->hasMember($member)->shouldReturn(false);
     }
 
+    function it_has_no_scope_by_default()
+    {
+        $this->getScope()->shouldReturn(null);
+    }
+
+    function its_scope_is_mutable()
+    {
+        $this->setScope('shipping');
+        $this->getScope()->shouldReturn('shipping');
+    }
+
     function it_has_fluent_interface(ZoneMemberInterface $member, Collection $members)
     {
         $this->setName('Yugoslavia')->shouldReturn($this);
         $this->setMembers($members)->shouldReturn($this);
         $this->addMember($member)->shouldReturn($this);
         $this->removeMember($member)->shouldReturn($this);
+        $this->setScope('shipping')->shouldReturn($this);
     }
 }


### PR DESCRIPTION
This PR refers to this RFC: https://github.com/Sylius/Sylius/issues/1582
Scope has been added to zones, a service is used to retrieve the scope choices, if no service is defined, a default one is created and gets the choices from configuration:

```
sylius_addressing:
    scopes:
       shipping: Shipping
        content: Content
        price: Price
```

or

```
sylius_addressing:
    scopes:
        - shipping
        - content
        - price
```

I've created a twig extension so that the choice value is displayed nicely in the list view, but I'm not sure if this is the correct way to do it.

Also if no scope is defined in configuration, a select with a blank choice is displayed, should we display a 'Default' scope instead?

Behat tests and validation are still missing, but I'd like to confirm that what I've done is correct before moving on.

![screen shot 2014-06-09 at 16 05 37](https://cloud.githubusercontent.com/assets/4030438/3218203/f1f3bd72-efe7-11e3-9a8d-478b3d4c1fba.jpg)
