### PR TITLE
Fix CartRepository->findExpiredCarts()

### DIFF
--- a/src/Sylius/Bundle/CartBundle/Doctrine/ORM/CartRepository.php
+++ b/src/Sylius/Bundle/CartBundle/Doctrine/ORM/CartRepository.php
@@ -32,8 +32,9 @@ class CartRepository extends OrderRepository implements CartRepositoryInterface
 
         $queryBuilder
             ->andWhere($queryBuilder->expr()->lt($this->getAlias().'.expiresAt', ':now'))
-            ->andWhere($queryBuilder->expr()->eq($this->getAlias().'.state', OrderInterface::STATE_CART))
+            ->andWhere($queryBuilder->expr()->eq($this->getAlias().'.state', ':state'))
             ->setParameter('now', new \DateTime())
+            ->setParameter('state', OrderInterface::STATE_CART)
         ;
 
         return $queryBuilder->getQuery()->getResult();


### PR DESCRIPTION
Fix exception due to varchar field without quotes
[Doctrine\ORM\Query\QueryException]  
[Semantical Error] line 0, col 124 near 'cart': Error: 'cart' is not defined.
