### PR TITLE
[Bug] Failed payment shouldn't be counted when confirming an order.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/StateMachineCallback/OrderPaymentCallback.php
+++ b/src/Sylius/Bundle/CoreBundle/StateMachineCallback/OrderPaymentCallback.php
@@ -45,7 +45,9 @@ class OrderPaymentCallback
 
         $total = 0;
         foreach ($order->getPayments() as $payment) {
-            $total += $payment->getAmount();
+            if ($payment->getState() === PaymentInterface::STATE_COMPLETED) {
+                $total += $payment->getAmount();
+            }
         }
 
         if ($total === $order->getTotal()) {


### PR DESCRIPTION
Failed payment shouldn't be counted when confirming an order.
