### PR TITLE
[BugFix] Little bug fix inside product model

### DIFF
--- a/src/Sylius/Component/Product/Model/Product.php
+++ b/src/Sylius/Component/Product/Model/Product.php
@@ -353,14 +353,12 @@ class Product implements ProductInterface
      */
     public function setMasterVariant(BaseVariantInterface $masterVariant)
     {
-        if ($this->variants->contains($masterVariant)) {
-            return $this;
-        }
-
-        $masterVariant->setProduct($this);
         $masterVariant->setMaster(true);
 
-        $this->variants->add($masterVariant);
+        if (!$this->variants->contains($masterVariant)) {
+            $masterVariant->setProduct($this);
+            $this->variants->add($masterVariant);
+        }
 
         return $this;
     }


### PR DESCRIPTION
You could not set a master variant if the non-master variant was already added to the product. This patch fixed it.
