### PR TITLE
Add class used in service sylius.route_provider to parameters

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -80,6 +80,7 @@
         <parameter key="sylius.data_collector.class">Sylius\Bundle\CoreBundle\DataCollector\SyliusDataCollector</parameter>
         <parameter key="sylius.dynamic_router.class">Symfony\Cmf\Component\Routing\DynamicRouter</parameter>
         <parameter key="sylius.generator.class">Sylius\Bundle\CoreBundle\Routing\SyliusAwareGenerator</parameter>
+        <parameter key="sylius.route_provider.class">Sylius\Bundle\CoreBundle\Routing\RouteProvider</parameter>
     </parameters>
 
     <services>
@@ -490,7 +491,7 @@
                 <argument>%sylius.route_classes%</argument>
             </call>
         </service>
-        <service id="sylius.route_provider" class="Sylius\Bundle\CoreBundle\Routing\RouteProvider">
+        <service id="sylius.route_provider" class="%sylius.route_provider.class%">
             <argument type="service" id="doctrine"/>
             <argument>%sylius.route_classes%</argument>
             <call method="setRouteCollectionLimit"><argument>%sylius.route_collection_limit%</argument></call>


### PR DESCRIPTION
[Core] Move class name from "sylius.route_provider" service declaration to parameters

| Q | A |
| --- | --- |
| Fixed tickets | no |
| License | MIT |
