### PR TITLE
Added dbal.path config parameter for test environment

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -16,6 +16,7 @@ swiftmailer:
 doctrine:
     dbal:
         dbname: %sylius.database.name%_test
+        path:   %sylius.database.path%
 
 sylius_money:
     currency: EUR

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -3,6 +3,7 @@ parameters:
     sylius.database.host:             127.0.0.1
     sylius.database.port:             ~
     sylius.database.name:             sylius
+    sylius.database.path:             ~
     sylius.database.user:             root
     sylius.database.password:         ~
 


### PR DESCRIPTION
Parameter %sylius.database.path% was added to the parameter.yml.dist
file so that at install time it is possible to choose the data file when
using pdo_sqlite as a persistence driver.
This is especially useful in test environment when using sqlite data
file on a fast/memory filesystem (such as tmpfs), to speed up test
execution.

The parameter defaults to null (~) not to interfere with standard
configuration.
