### PR TITLE
Inventory unit's sync shipping callback bug fix.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/state-machine.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/state-machine.yml
@@ -108,7 +108,7 @@ winzou_state_machine:
         callbacks:
             after:
                 sylius_sync_shipping:
-                    to:   '-sold'
+                    excluded_to: [sold]
                     do:   [@sm.callback.cascade_transition, 'apply']
                     args: ['object', 'event', 'null', '"sylius_shipment_item"']
 


### PR DESCRIPTION
Use exclude_to replace minus sign.

According to @winzou minus sign is not supported by the new state machine.

https://github.com/Sylius/Sylius/commit/e1446025c98d5ae562f12effb29f26970462c4aa#commitcomment-6730929
