### PR TITLE
[FOSUserBundle] Add user reset password functionality to login page

### DIFF
--- a/app/Resources/FOSUserBundle/translations/FOSUserBundle.en.yml
+++ b/app/Resources/FOSUserBundle/translations/FOSUserBundle.en.yml
@@ -4,8 +4,17 @@ security:
         email: "Email:"
         header: <h1>Login <small>Sylius store</small></h1>
         info: Please login using "<strong>sylius@example.com</strong>" email and "<strong>sylius</strong>" as password.
+        forgot_password: Forgot password?
+        no_account: No account yet?
 
 # Registration
 registration:
     register_header: <h1>Registration <small>Create an account in store</small></h1>
     confirmed_header: <h1>Welcome <small>Your registration was successful</small></h1>
+
+# Password resetting
+resetting:
+    request:
+        header: <h1>Password reset request</h1>
+    reset:
+        header: <h1>Reset password</h1>

--- a/app/Resources/FOSUserBundle/translations/FOSUserBundle.fr.yml
+++ b/app/Resources/FOSUserBundle/translations/FOSUserBundle.fr.yml
@@ -1,0 +1,33 @@
+# Security
+security:
+    login:
+        email: "Email"
+        header: <h1>Connexion <small>Boutique LVP</small></h1>
+        info: Connectez vous en utilisant l'email "<strong>sylius@example.com</strong>" et "<strong>sylius</strong>" comme mot de passe.
+        forgot_password: Mot de passe oublié ?
+        no_account: Pas encore de compte ?
+        username: "Nom d'utilisateur"
+        password: "Mot de passe"
+
+# Registration
+registration:
+    register_header: <h1>Enregistrement <small>Créer votre compte</small></h1>
+    confirmed_header: <h1>Bienvenue <small>Votre compte a été créé avec succès</small></h1>
+
+# Form field labels
+form:
+    group_name: "Nom du groupe"
+    username: "Nom d'utilisateur"
+    email: "Adresse e-mail"
+    current_password: "Mot de passe actuel"
+    password: "Mot de passe"
+    password_confirmation: "Vérification"
+    new_password: "Nouveau mot de passe"
+    new_password_confirmation: "Vérification"
+
+# Password resetting
+resetting:
+    request:
+        header: <h1>Demande de réinitialisation de mot de passe</h1>
+    reset:
+        header: <h1>Réinitialiser votre mot de passe</h1>

--- a/app/Resources/FOSUserBundle/views/Resetting/checkEmail.html.twig
+++ b/app/Resources/FOSUserBundle/views/Resetting/checkEmail.html.twig
@@ -1,0 +1,9 @@
+{% extends 'SyliusWebBundle:Frontend:layout.html.twig' %}
+
+{% trans_default_domain 'FOSUserBundle' %}
+
+{% block content %}
+    <div class="alert alert-success">
+        {{ 'resetting.check_email'|trans({'%email%': email}) }}
+    </div>
+{% endblock %}

--- a/app/Resources/FOSUserBundle/views/Resetting/email.txt.twig
+++ b/app/Resources/FOSUserBundle/views/Resetting/email.txt.twig
@@ -1,0 +1,12 @@
+{% trans_default_domain 'FOSUserBundle' %}
+{% block subject %}
+{% autoescape false %}
+{{ 'resetting.email.subject'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}) }}
+{% endautoescape %}
+{% endblock %}
+{% block body_text %}
+{% autoescape false %}
+{{ 'resetting.email.message'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}) }}
+{% endautoescape %}
+{% endblock %}
+{% block body_html %}{% endblock %}

--- a/app/Resources/FOSUserBundle/views/Resetting/passwordAlreadyRequested.html.twig
+++ b/app/Resources/FOSUserBundle/views/Resetting/passwordAlreadyRequested.html.twig
@@ -1,0 +1,9 @@
+{% extends 'SyliusWebBundle:Frontend:layout.html.twig' %}
+
+{% trans_default_domain 'FOSUserBundle' %}
+
+{% block content %}
+    <div class="alert alert-info">
+        {{ 'resetting.password_already_requested'|trans }}
+    </div>
+{% endblock %}

--- a/app/Resources/FOSUserBundle/views/Resetting/request.html.twig
+++ b/app/Resources/FOSUserBundle/views/Resetting/request.html.twig
@@ -1,0 +1,10 @@
+{% extends 'SyliusWebBundle:Frontend:layout.html.twig' %}
+
+{% trans_default_domain 'FOSUserBundle' %}
+
+{% block content %}
+    <div class="page-header">
+        {{ 'resetting.request.header'|trans|raw }}
+    </div>
+    {% include "FOSUserBundle:Resetting:request_content.html.twig" %}
+{% endblock content %}

--- a/app/Resources/FOSUserBundle/views/Resetting/request_content.html.twig
+++ b/app/Resources/FOSUserBundle/views/Resetting/request_content.html.twig
@@ -1,0 +1,22 @@
+{% trans_default_domain 'FOSUserBundle' %}
+
+{% if invalid_username is defined %}
+    <div class="alert alert-danger">
+        {{ 'resetting.request.invalid_username'|trans({'%username%': invalid_username}) }}
+    </div>
+{% endif %}
+
+<form action="{{ path('fos_user_resetting_send_email') }}" method="POST" class="fos_user_resetting_request form-horizontal">
+<fieldset>
+    <div class="form-group">
+        <label for="username" class="col-sm-3 control-label">{{ 'security.login.email'|trans }}</label>
+    	<div class="col-sm-9">
+            <input type="text" id="username" name="username" required="required" class="form-control" />
+        </div>
+    </div>
+</fieldset>
+<div class="form-actions clearfix">
+    <button type="submit" class="btn btn-primary btn-lg" name="login"><i class="icon-lock"></i> {{ 'resetting.request.submit'|trans }}</button>
+</div>
+
+</form>

--- a/app/Resources/FOSUserBundle/views/Resetting/reset.html.twig
+++ b/app/Resources/FOSUserBundle/views/Resetting/reset.html.twig
@@ -1,0 +1,10 @@
+{% extends 'SyliusWebBundle:Frontend:layout.html.twig' %}
+
+{% trans_default_domain 'FOSUserBundle' %}
+
+{% block content %}
+    <div class="page-header">
+        {{ 'resetting.reset.header'|trans|raw }}
+    </div>
+    {% include "FOSUserBundle:Resetting:reset_content.html.twig" %}
+{% endblock content %}

--- a/app/Resources/FOSUserBundle/views/Resetting/reset_content.html.twig
+++ b/app/Resources/FOSUserBundle/views/Resetting/reset_content.html.twig
@@ -1,0 +1,14 @@
+{% trans_default_domain 'FOSUserBundle' %}
+
+<form action="{{ path('fos_user_resetting_reset', {'token': token}) }}" {{ form_enctype(form) }} method="POST" class="fos_user_resetting_reset form-horizontal">
+<fieldset>
+    <div class="form-group">
+    	<div class="col-sm-9">
+            {{ form_widget(form) }}
+    	</div>
+    </div>
+</fieldset>
+<div class="form-actions clearfix">
+    <button type="submit" class="btn btn-primary btn-lg" name="login"><i class="icon-lock"></i> {{ 'resetting.reset.submit'|trans }}</button>
+</div>
+</form>

--- a/app/Resources/FOSUserBundle/views/Security/login.html.twig
+++ b/app/Resources/FOSUserBundle/views/Security/login.html.twig
@@ -36,10 +36,16 @@
         <div class="col-sm-offset-3 col-sm-9">
             <div class="checkbox">
                 <label for="remember_me">
-                    {{ 'security.login.remember_me'|trans }}? &nbsp; <input type="checkbox" id="remember_me" name="_remember_me" value="on" />
+                    {{ 'security.login.remember_me'|trans }} &nbsp; <input type="checkbox" id="remember_me" name="_remember_me" value="on" />
                 </label>
             </div>
         </div>
+    </div>
+    <div class="pull-right">
+    	<p>
+    		<a href="{{ path('fos_user_resetting_request') }}" class="btn btn-info btn-sm">{{ 'security.login.forgot_password'|trans }}</a>
+    		<a href="{{ path('fos_user_registration_register') }}" class="btn btn-primary btn-sm">{{ 'security.login.no_account'|trans }}</a>
+    	</p>
     </div>
 </fieldset>
 <div class="form-actions clearfix">


### PR DESCRIPTION
Hi all,

A little PR for adding the possibility for a customer to reset his password.
I add some FOSUserBundle template override to match sylius ones.
Needed for my own project, maybe this could interest you ?

Waiting comments ;)

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

![login](https://cloud.githubusercontent.com/assets/1230954/3352022/09a2fd5c-fa2e-11e3-8600-59fb7d72c023.jpg)
![request](https://cloud.githubusercontent.com/assets/1230954/3352025/09aa8aea-fa2e-11e3-86d6-1f2d03d6eb5c.jpg)
![request-confirmation](https://cloud.githubusercontent.com/assets/1230954/3352023/09a5305e-fa2e-11e3-9cb3-bf9b3f82cb1c.jpg)
![reset](https://cloud.githubusercontent.com/assets/1230954/3352024/09a72b20-fa2e-11e3-98ae-d9739f00ce20.jpg)
![reset-confirmation](https://cloud.githubusercontent.com/assets/1230954/3352026/09ac515e-fa2e-11e3-9b8a-0f25906cd13b.jpg)
