### PR TITLE
[ResourceBundle] Api request should not return RedirectResponse

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
         "symfony/symfony":                      "~2.3",
         "twig/extensions":                      "1.0.*",
         "white-october/pagerfanta-bundle":      "1.0.*@dev",
-        "winzou/state-machine-bundle":          "~0.1.2"
+        "winzou/state-machine-bundle":          "~0.1.2",
+        "willdurand/hateoas-bundle":            "@stable"
     },
     "require-dev": {
         "behat/behat":                       "~3.0",

--- a/src/Sylius/Bundle/CoreBundle/Kernel/Kernel.php
+++ b/src/Sylius/Bundle/CoreBundle/Kernel/Kernel.php
@@ -90,6 +90,7 @@ abstract class Kernel extends BaseKernel
             new \HWI\Bundle\OAuthBundle\HWIOAuthBundle(),
             new \Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new \WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
+            new \Bazinga\Bundle\HateoasBundle\BazingaHateoasBundle(),
         );
 
         if (in_array($this->environment, array('dev', 'test'))) {

--- a/src/Sylius/Bundle/ResourceBundle/composer.json
+++ b/src/Sylius/Bundle/ResourceBundle/composer.json
@@ -30,7 +30,8 @@
         "friendsofsymfony/rest-bundle":    "~1.0",
         "jms/serializer-bundle":           "~0.12",
         "white-october/pagerfanta-bundle": "1.0.*",
-        "doctrine/doctrine-bundle":        "~1.3@dev"
+        "doctrine/doctrine-bundle":        "~1.3@dev",
+        "willdurand/hateoas-bundle":       "@stable"
     },
     "require-dev": {
         "phpspec/phpspec":      "~2.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | possible |
| Deprecations? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The delete, create and update actions return a RedirectResponse,  we lost some advantages of the `FosRestBundle`. 
- For a deletion, if you want to send a response with empty body (see empty_content), it is impossible to configure the HTTP code returned.
- For a update, I got a infinite redirection loop when I tried to update a resource using the PUT method. Moreover, if your client is not a browser, it is possible that it does not support redirect response.

I know that some methods has a lot of return has a lot of return, some developer does not like it but I have not problem with it. I need it ASAP for a project so I am here if you want to talk about this !
