### PR TITLE
[BugFix] [Feature] Fixes issue #1682

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
@@ -65,7 +65,7 @@ class AddressingStep extends CheckoutStep
 
     protected function renderStep(ProcessContextInterface $context, OrderInterface $order, FormInterface $form)
     {
-        return $this->render('SyliusWebBundle:Frontend/Checkout/Step:addressing.html.twig', array(
+        return $this->render($this->container->getParameter(sprintf('sylius.checkout.step.%s.template', $this->getName())), array(
             'order'   => $order,
             'form'    => $form->createView(),
             'context' => $context

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/FinalizeStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/FinalizeStep.php
@@ -52,7 +52,7 @@ class FinalizeStep extends CheckoutStep
 
     protected function renderStep(ProcessContextInterface $context, OrderInterface $order)
     {
-        return $this->render('SyliusWebBundle:Frontend/Checkout/Step:finalize.html.twig', array(
+        return $this->render($this->container->getParameter(sprintf('sylius.checkout.step.%s.template', $this->getName())), array(
             'context' => $context,
             'order'   => $order
         ));

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
@@ -65,7 +65,7 @@ class PaymentStep extends CheckoutStep
 
     protected function renderStep(ProcessContextInterface $context, OrderInterface $order, FormInterface $form)
     {
-        return $this->render('SyliusWebBundle:Frontend/Checkout/Step:payment.html.twig', array(
+        return $this->render($this->container->getParameter(sprintf('sylius.checkout.step.%s.template', $this->getName())), array(
             'order'   => $order,
             'form'    => $form->createView(),
             'context' => $context

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
@@ -90,7 +90,7 @@ class SecurityStep extends CheckoutStep
      */
     protected function renderStep(ProcessContextInterface $context, FormInterface $registrationForm)
     {
-        return $this->render('SyliusWebBundle:Frontend/Checkout/Step:security.html.twig', array(
+        return $this->render($this->container->getParameter(sprintf('sylius.checkout.step.%s.template', $this->getName())), array(
             'context'           => $context,
             'registration_form' => $registrationForm->createView(),
         ));

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
@@ -77,7 +77,7 @@ class ShippingStep extends CheckoutStep
 
     protected function renderStep(ProcessContextInterface $context, OrderInterface $order, FormInterface $form)
     {
-        return $this->render('SyliusWebBundle:Frontend/Checkout/Step:shipping.html.twig', array(
+        return $this->render($this->container->getParameter(sprintf('sylius.checkout.step.%s.template', $this->getName())), array(
             'order'   => $order,
             'form'    => $form->createView(),
             'context' => $context,

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\CoreBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -32,6 +33,7 @@ class Configuration implements ConfigurationInterface
         $this->addClassesSection($rootNode);
         $this->addEmailsSection($rootNode);
         $this->addRoutingSection($rootNode);
+        $this->addCheckoutSection($rootNode);
 
         return $treeBuilder;
     }
@@ -177,5 +179,56 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
+    }
+
+    /**
+     * Adds `checkout` section.
+     *
+     * @param ArrayNodeDefinition $node
+     */
+    private function addCheckoutSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('checkout')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('steps')
+                            ->addDefaultsIfNotSet()
+                            ->info('Templates used for steps in the checkout flow process')
+                            ->children()
+                                ->append($this->addCheckoutStepNode('security', 'SyliusWebBundle:Frontend/Checkout/Step:security.html.twig'))
+                                ->append($this->addCheckoutStepNode('addressing', 'SyliusWebBundle:Frontend/Checkout/Step:addressing.html.twig'))
+                                ->append($this->addCheckoutStepNode('shipping', 'SyliusWebBundle:Frontend/Checkout/Step:shipping.html.twig'))
+                                ->append($this->addCheckoutStepNode('payment', 'SyliusWebBundle:Frontend/Checkout/Step:payment.html.twig'))
+                                ->append($this->addCheckoutStepNode('finalize', 'SyliusWebBundle:Frontend/Checkout/Step:finalize.html.twig'))
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * Helper method to append checkout step nodes.
+     *
+     * @param $name
+     * @param $defaultTemplate
+     * @return NodeDefinition
+     */
+    private function addCheckoutStepNode($name, $defaultTemplate)
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root($name);
+
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->scalarNode('template')->defaultValue($defaultTemplate)->end()
+            ->end()
+        ;
+
+        return $node;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
@@ -67,6 +67,7 @@ class SyliusCoreExtension extends AbstractResourceExtension implements PrependEx
         $loader->load('state_machine.xml');
 
         $this->loadEmailsConfiguration($config['emails'], $container, $loader);
+        $this->loadCheckoutConfiguration($config['checkout'], $container);
     }
 
     /**
@@ -116,6 +117,13 @@ class SyliusCoreExtension extends AbstractResourceExtension implements PrependEx
             if ($config['enabled'] && $config[$emailType]['enabled']) {
                 $loader->load('mailer/'.$emailType.'_listener.xml');
             }
+        }
+    }
+
+    protected function loadCheckoutConfiguration(array $config, ContainerBuilder $container)
+    {
+        foreach ($config['steps'] as $name => $step) {
+            $container->setParameter(sprintf('sylius.checkout.step.%s.template', $name), $step['template']);
         }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | #1682 |
| License | MIT |

Makes the checkout steps configurable, for now only the templates can be configured. Of course, you could also override the default templates by doing so in `app/Resources` or overriding the bundle. But since you are tight to the path `Frontend/Checkout/Step:[name].html.twig` it is not very flexible. So with this PR you could define your own way to where you want your templates to be stored. This is similair to the routing part, where you can also configure your product and taxon templates.

Usage:

```
sylius_core:
    checkout:
        steps:
            security:
                template: CheckoutBundle:Step/security.html.twig
            finalize:
                template: AnotherBundle:Step/finalize.html.twig
```
