### PR TITLE
use correct namespace in one doctrine migration

### DIFF
--- a/app/migrations/Version20140620085516.php
+++ b/app/migrations/Version20140620085516.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Application\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;


### PR DESCRIPTION
app/console do:mi:mi doesn't work without this correct namespace :)
