### PR TITLE
Only create new payment if there is none.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderPaymentListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderPaymentListener.php
@@ -69,7 +69,9 @@ class OrderPaymentListener
      */
     public function createOrderPayment(GenericEvent $event)
     {
-        $this->paymentProcessor->createPayment($this->getOrder($event));
+        if (false === $this->getOrder($event)->getLastPayment(PaymentInterface::STATE_NEW)) {
+            $this->paymentProcessor->createPayment($this->getOrder($event));
+        }
     }
 
     /**


### PR DESCRIPTION
Without this fix, a new payment will be created every time customer visit payment step.
