### PR TITLE
[Core] Fix removing taxon from product

### DIFF
--- a/src/Sylius/Component/Core/Model/Product.php
+++ b/src/Sylius/Component/Core/Model/Product.php
@@ -182,7 +182,7 @@ class Product extends BaseProduct implements ProductInterface
     public function removeTaxon(BaseTaxonInterface $taxon)
     {
         if ($this->hasTaxon($taxon)) {
-            $this->taxons->remove($taxon);
+            $this->taxons->removeElement($taxon);
         }
 
         return $this;


### PR DESCRIPTION
`Collection::remove()` expects to get key, not object.
