### PR TITLE
[Shipping] Removing tracking code requirement

### DIFF
--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShipmentTrackingType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShipmentTrackingType.php
@@ -35,8 +35,7 @@ class ShipmentTrackingType extends AbstractType
                 'label' => 'sylius.form.shipment.tracking_code',
                 'attr' => array(
                     'placeholder' => 'sylius.form.shipment.tracking_code'
-                ),
-                'constraints' => array(new NotBlank())
+                )
             ))
         ;
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #1015 |
| License | MIT |
| Doc PR |  |

Removing NotBlank constraint on shipment tracking code form. This allows shipments to be shipped without giving a tracking code, as some couriers/postal services don't have tracking codes.

As previously mentioned in issue #1015
