### PR TITLE
Fixing the parameter parser (see #1168)

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ParametersParser.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ParametersParser.php
@@ -35,29 +35,32 @@ class ParametersParser
     /**
      * @param array   $parameters
      * @param Request $request
-     * @param array   $settings
      *
      * @return array
      */
-    public function parse(array $parameters, Request $request, array $settings = array())
+    public function parse(array $parameters, Request $request)
     {
+        if (!isset($parameterNames)) {
+            $parameterNames = array();
+        }
+
         foreach ($parameters as $key => $value) {
             if (is_array($value)) {
-                $parameters[$key] = $this->parse($value, $request, $settings);
+                list($parameters[$key] , $parameterNames[$key]) = $this->parse($value, $request);
             }
 
             if (is_string($value) && 0 === strpos($value, '$')) {
                 $parameterName = substr($value, 1);
                 $parameters[$key] = $request->get($parameterName);
-                $parameters['parameter_name'][$key] = $parameterName;
+                $parameterNames[$key] = $parameterName;
             }
 
             if (is_string($value) && 0 === strpos($value, 'expr:')) {
-                $parameters[$key] = $this->expression->evaluate(substr($value, 5));
+                $parameters = $this->expression->evaluate(substr($value, 5));
             }
         }
 
-        return $parameters;
+        return array($parameters, $parameterNames);
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/EventListener/KernelControllerSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/KernelControllerSubscriber.php
@@ -73,9 +73,10 @@ class KernelControllerSubscriber implements EventSubscriberInterface
 
             $parameters = $request->attributes->get('_sylius', array());
             $parameters = array_merge($this->settings, $parameters);
-            $parameters = $this->parametersParser->parse($parameters, $request);
+            list($parameters , $parameterNames) = $this->parametersParser->parse($parameters, $request);
 
             $this->parameters->replace($parameters);
+            $this->parameters->set('paramater_name', $parameterNames);
 
             $controller[0]->getConfiguration()->setRequest($request);
             $controller[0]->getConfiguration()->setParameters($this->parameters);

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ParametersParserSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ParametersParserSpec.php
@@ -36,12 +36,43 @@ class ParametersParserSpec extends ObjectBehavior
             ),
             $request
         )->shouldReturn(array(
-            'criteria' => 'New criteria',
-            'sortable' => 'New sorting',
-            'parameter_name' => array(
+            array(
+                'criteria' => 'New criteria',
+                'sortable' => 'New sorting',
+            ),
+            array(
                 'criteria' => 'criteria',
                 'sortable' => 'sorting',
-            ),
+            )
         ));
+    }
+
+    function it_should_parse_complex_parameters(Request $request)
+    {
+        $request->get('enable')->willReturn(true);
+        $request->get('sorting')->willReturn('New sorting');
+
+        $this->parse(
+            array(
+                'criteria' => array(
+                    'enable' => '$enable'
+                ),
+                'sortable' => '$sorting'
+            ),
+            $request
+        )->shouldReturn(array(
+                array(
+                    'criteria' => array(
+                        'enable' => true,
+                    ),
+                    'sortable' => 'New sorting',
+                ),
+                array(
+                    'criteria' => array(
+                        'enable' => 'enable',
+                    ),
+                    'sortable' => 'sorting',
+                )
+            ));
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/EventListener/KernelControllerSubscriberSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/EventListener/KernelControllerSubscriberSpec.php
@@ -97,9 +97,10 @@ class KernelControllerSubscriberSpec extends ObjectBehavior
                 'criteria' => null,
             ),
             $request
-        )->shouldBeCalled()->willReturn(array());
+        )->shouldBeCalled()->willReturn(array(array(), array()));
 
         $parameters->replace(Argument::type('array'))->shouldBeCalled();
+        $parameters->set('paramater_name', Argument::type('array'))->shouldBeCalled();
 
         $this->onKernelController($event);
     }
@@ -132,9 +133,10 @@ class KernelControllerSubscriberSpec extends ObjectBehavior
                 'criteria' => '$c',
             ),
             $request
-        )->shouldBeCalled()->willReturn(array());
+        )->shouldBeCalled()->willReturn(array(array(), array()));
 
         $parameters->replace(Argument::type('array'))->shouldBeCalled();
+        $parameters->set('paramater_name', Argument::type('array'))->shouldBeCalled();
 
         $this->onKernelController($event);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | No yet |

Before : 

``` yaml
# routing.yml
my_route:
    _sylius:
        criteria:
            enable: $enable
```

The parameter parser returned something like:

``` php
array(
    criteria => array(
        'enable' => 'myvalue'
        'parameter_name' => array(
              'enable'
        )
);
```

Now it return two arrays, the names of parameters  are isolated in the second one. 
