### PR TITLE
Fixed bug that caused an error: "array_merge(): Argument #2 is not an ar...

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
@@ -243,7 +243,7 @@ class Configuration
         if ($this->isFilterable()) {
             $criteria = array_merge(
                 $criteria,
-                $this->parameters->get('criteria'),
+                $this->parameters->get('criteria', array()),
                 $this->request->get('criteria', array())
             );
         }
@@ -261,7 +261,7 @@ class Configuration
         if ($this->isSortable()) {
             $sorting = array_merge(
                 $sorting,
-                $this->parameters->get('sorting'),
+                $this->parameters->get('sorting', array()),
                 $this->request->get('sorting', array())
             );
         }


### PR DESCRIPTION
Fixed bug that caused an error: "array_merge(): Argument #2 is not an array" when there is no parameter with keys "criteria" and "sorting".
