### PR TITLE
Allow logging by username or email

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -4,7 +4,7 @@
 security:
     providers:
         fos_userbundle:
-            id: fos_user.user_provider.username
+            id: fos_user.user_provider.username_email
     encoders:
         FOS\UserBundle\Model\UserInterface: sha512
     firewalls:

--- a/src/Sylius/Component/Core/Model/User.php
+++ b/src/Sylius/Component/Core/Model/User.php
@@ -258,28 +258,6 @@ class User extends BaseUser implements UserInterface
     /**
      * {@inheritdoc}
      */
-    public function setEmail($email)
-    {
-        parent::setEmail($email);
-        $this->setUsername($email);
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setEmailCanonical($emailCanonical)
-    {
-        parent::setEmailCanonical($emailCanonical);
-        $this->setUsernameCanonical($emailCanonical);
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getOAuthAccounts()
     {
         return $this->oauthAccounts;


### PR DESCRIPTION
This is the proper way to allow logging by username and email.

See: https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Resources/doc/logging_by_username_or_email.md
