### PR TITLE
Fix item based promotion issue

### DIFF
--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadUsersData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadUsersData.php
@@ -79,6 +79,7 @@ class LoadUsersData extends DataFixture
         $user = $this->getUserRepository()->createNew();
         $user->setFirstname($this->faker->firstName);
         $user->setLastname($this->faker->lastName);
+        $user->setUsername($email);
         $user->setEmail($email);
         $user->setPlainPassword($password);
         $user->setRoles($roles);


### PR DESCRIPTION
Steps to reproduce:
- Add something to cart, with some "order item adjustment" (promotion) applied.
- Edit the promotion settings, makes it ineligible.
- Update the cart, you will see the "order item adjustment" still attached. Ideally it should have been removed.

Thanks for reporting it @kayue!
