### PR TITLE
Fixed multiple sorting in Doctrine ORM EntityRepository

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/EntityRepository.php
+++ b/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/EntityRepository.php
@@ -184,7 +184,7 @@ class EntityRepository extends BaseEntityRepository implements RepositoryInterfa
 
         foreach ($sorting as $property => $order) {
             if (!empty($order)) {
-                $queryBuilder->orderBy($this->getPropertyName($property), $order);
+                $queryBuilder->addOrderBy($this->getPropertyName($property), $order);
             }
         }
     }


### PR DESCRIPTION
QueryBuilder's orderBy method replaces any previously specified orderings, addOrderBy must be used to append more than one.
