### PR TITLE
Retrieve forward/display route from Process object.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/PurchaseStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/PurchaseStep.php
@@ -40,7 +40,7 @@ class PurchaseStep extends CheckoutStep
         $captureToken = $this->getTokenFactory()->createCaptureToken(
             $payment->getMethod()->getGateway(),
             $payment,
-            'sylius_checkout_forward',
+            $context->getProcess()->getForwardRoute(),
             array('stepName' => $this->getName())
         );
 

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/addressing.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/addressing.html.twig
@@ -16,7 +16,7 @@
 
 {% include 'SyliusWebBundle:Frontend/Checkout:_progressBar.html.twig' %}
 
-<form method="post" action="{{ path('sylius_checkout_forward', {'stepName': context.currentStep.name}) }}" class="form-horizontal" novalidate>
+<form method="post" action="{{ path(context.process.forwardRoute, {'stepName': context.currentStep.name}) }}" class="form-horizontal" novalidate>
 
 {{ form_errors(form) }}
 

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
@@ -111,8 +111,8 @@
 
 <div class="form-horizontal">
     <div class="form-actions">
-        <a href="{{ path('sylius_checkout_display', {'stepName': context.previousStep.name}) }}" class="btn btn-lg"><i class="icon-chevron-left"></i> {{ 'sylius.checkout.back'|trans }}</a> &nbsp;
-        <a href="{{ path('sylius_checkout_forward', {'stepName': context.currentStep.name}) }}" class="btn btn-lg btn-success"><i class="icon-ok"></i> {{ 'sylius.checkout.finalize.place_order'|trans }}</a> &nbsp;
+        <a href="{{ path(context.process.displayRoute, {'stepName': context.previousStep.name}) }}" class="btn btn-lg"><i class="icon-chevron-left"></i> {{ 'sylius.checkout.back'|trans }}</a> &nbsp;
+        <a href="{{ path(context.process.forwardRoute, {'stepName': context.currentStep.name}) }}" class="btn btn-lg btn-success"><i class="icon-ok"></i> {{ 'sylius.checkout.finalize.place_order'|trans }}</a> &nbsp;
     </div>
 </div>
 {% endblock %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/payment.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/payment.html.twig
@@ -7,7 +7,7 @@
 
 {% include 'SyliusWebBundle:Frontend/Checkout:_progressBar.html.twig' %}
 
-<form method="post" action="{{ path('sylius_checkout_forward', {'stepName': context.currentStep.name}) }}" class="form-horizontal" novalidate>
+<form method="post" action="{{ path(context.process.forwardRoute, {'stepName': context.currentStep.name}) }}" class="form-horizontal" novalidate>
 
 {{ form_errors(form) }}
 
@@ -21,7 +21,7 @@
 {{ form_widget(form._token) }}
 
 <div class="form-actions">
-    <a href="{{ path('sylius_checkout_display', {'stepName': context.previousStep.name}) }}" class="btn btn-lg"><i class="icon-chevron-left"></i> {{ 'sylius.checkout.back'|trans }}</a> &nbsp;
+    <a href="{{ path(context.process.displayRoute, {'stepName': context.previousStep.name}) }}" class="btn btn-lg"><i class="icon-chevron-left"></i> {{ 'sylius.checkout.back'|trans }}</a> &nbsp;
     <button type="submit" class="btn btn-primary btn-lg">{{ 'sylius.checkout.forward'|trans }} <i class="icon-chevron-right"></i></button>
 </div>
 

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/security.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/security.html.twig
@@ -34,7 +34,7 @@
     </div>
     <div class="col-md-6 checkout-new-customer">
         <div class="well">
-            <form action="{{ path('sylius_checkout_forward', {'stepName': context.currentStep.name}) }}" method="post" novalidate class="form-horizontal">
+            <form action="{{ path(context.process.forwardRoute, {'stepName': context.currentStep.name}) }}" method="post" novalidate class="form-horizontal">
                 <fieldset>
                     <legend>{{ 'sylius.checkout.security.new_customer'|trans }}</legend>
                     {{ form_widget(registration_form) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/shipping.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/shipping.html.twig
@@ -9,7 +9,7 @@
 
 {{ form_errors(form) }}
 
-<form method="post" action="{{ path('sylius_checkout_forward', {'stepName': context.currentStep.name}) }}" class="form-horizontal" novalidate>
+<form method="post" action="{{ path(context.process.forwardRoute, {'stepName': context.currentStep.name}) }}" class="form-horizontal" novalidate>
 
 <fieldset>
 {% for shipment in order.shipments %}
@@ -24,7 +24,7 @@
 {{ form_widget(form._token) }}
 
 <div class="form-actions">
-    <a href="{{ path('sylius_checkout_display', {'stepName': context.previousStep.name}) }}" class="btn btn-lg"><i class="icon-chevron-left"></i> {{ 'sylius.checkout.back'|trans }}</a> &nbsp;
+    <a href="{{ path(context.process.displayRoute, {'stepName': context.previousStep.name}) }}" class="btn btn-lg"><i class="icon-chevron-left"></i> {{ 'sylius.checkout.back'|trans }}</a> &nbsp;
     <button type="submit" class="btn btn-primary btn-lg">{{ 'sylius.checkout.forward'|trans }} <i class="icon-chevron-right"></i></button>
 </div>
 


### PR DESCRIPTION
We should prevent hardcoding the route in template and purchase step, so the step / template can be reuse in different process.
