### PR TITLE
[MoneyBundle] Add option to return formatted price without currency sign

### DIFF
--- a/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/CurrencyHelper.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/CurrencyHelper.php
@@ -45,7 +45,7 @@ class CurrencyHelper extends Helper
     /**
      * Convert amount to target or currently used currency.
      *
-     * @param integer     $amount
+     * @param int         $amount
      * @param string|null $currency
      *
      * @return string
@@ -60,17 +60,18 @@ class CurrencyHelper extends Helper
     /**
      * Convert amount and format it!
      *
-     * @param integer     $amount
+     * @param int         $amount
      * @param string|null $currency
+     * @param bool        $decimal
      *
      * @return string
      */
-    public function convertAndFormatAmount($amount, $currency = null)
+    public function convertAndFormatAmount($amount, $currency = null, $decimal = false)
     {
         $currency = $currency ?: $this->currencyContext->getCurrency();
         $amount = $this->converter->convert($amount, $currency);
 
-        return $this->moneyHelper->formatAmount($amount, $currency);
+        return $this->moneyHelper->formatAmount($amount, $currency, $decimal);
     }
 
     /**

--- a/src/Sylius/Bundle/MoneyBundle/Templating/Helper/MoneyHelper.php
+++ b/src/Sylius/Bundle/MoneyBundle/Templating/Helper/MoneyHelper.php
@@ -25,7 +25,12 @@ class MoneyHelper extends Helper
     /**
      * @var \NumberFormatter
      */
-    private $formatter;
+    private $formatterCurrency;
+
+    /**
+     * @var \NumberFormatter
+     */
+    private $formatterDecimal;
 
     /**
      * @param string $locale   The locale used to format money.
@@ -33,25 +38,32 @@ class MoneyHelper extends Helper
      */
     public function __construct($locale, $currency)
     {
-        $this->currency = $currency;
-        $this->formatter = new \NumberFormatter($locale ?: \Locale::getDefault(), \NumberFormatter::CURRENCY);
+        $this->currency          = $currency;
+        $this->formatterCurrency = new \NumberFormatter($locale ?: \Locale::getDefault(), \NumberFormatter::CURRENCY);
+        $this->formatterDecimal  = new \NumberFormatter($locale ?: \Locale::getDefault(), \NumberFormatter::DECIMAL);
     }
 
     /**
      * Format the money amount to nice display form.
      *
-     * @param integer     $amount
+     * @param int         $amount
      * @param string|null $currency
+     * @param bool        $decimal
      *
      * @return string
      *
      * @throws \InvalidArgumentException
      */
-    public function formatAmount($amount, $currency = null)
+    public function formatAmount($amount, $currency = null, $decimal = false)
     {
-        $currency = $currency ?: $this->getDefaultCurrency();
-        $result = $this->formatter->formatCurrency($amount / 100, $currency);
+        if ($decimal) {
+            $formatter = $this->formatterDecimal;
+        } else {
+            $formatter = $this->formatterCurrency;
+        }
 
+        $currency = $currency ?: $this->getDefaultCurrency();
+        $result   = $formatter->formatCurrency($amount / 100, $currency);
         if (false === $result) {
             throw new \InvalidArgumentException(sprintf('The amount "%s" of type %s cannot be formatted to currency "%s".', $amount, gettype($amount), $currency));
         }


### PR DESCRIPTION
With this change you can get formatted price: `3050` => `30.50`, not `3050` => `30.50 $`.
