### PR TITLE
[ProductBundle] Fix missing parent call in bundle that broke mappings

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/SyliusProductBundle.php
+++ b/src/Sylius/Bundle/ProductBundle/SyliusProductBundle.php
@@ -42,6 +42,8 @@ class SyliusProductBundle extends AbstractResourceBundle
      */
     public function build(ContainerBuilder $container)
     {
+        parent::build($container);
+
         $container->addCompilerPass(new ValidatorPass());
     }
 


### PR DESCRIPTION
Fix #1898.
