### PR TITLE
[Promotion] Fix $eligible being ignored when checking coupons

### DIFF
--- a/src/Sylius/Component/Promotion/Checker/PromotionEligibilityChecker.php
+++ b/src/Sylius/Component/Promotion/Checker/PromotionEligibilityChecker.php
@@ -177,13 +177,12 @@ class PromotionEligibilityChecker implements PromotionEligibilityCheckerInterfac
      *
      * @param PromotionSubjectInterface $subject
      * @param PromotionInterface        $promotion
+     * @param bool                      $eligible
      *
      * @return Boolean
      */
-    private function areCouponsEligibleForPromotion(PromotionSubjectInterface $subject, PromotionInterface $promotion)
+    private function areCouponsEligibleForPromotion(PromotionSubjectInterface $subject, PromotionInterface $promotion, $eligible)
     {
-        $eligible = false;
-
         if ($subject instanceof PromotionCouponAwareSubjectInterface) {
             if (null !== $coupon = $subject->getPromotionCoupon() && $promotion === $coupon->getPromotion()) {
                 $eligible = true;


### PR DESCRIPTION
Missing change from #1811.
