### PR TITLE
Fix PromotionEligibilityChecker, fix specs

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
@@ -95,7 +95,7 @@ class UserProvider extends FOSUBUserProvider
         }
 
         if (!$user->getUsername()) {
-            $user->setUsername($response->getEmail());
+            $user->setUsername($response->getEmail() ?: $response->getNickname());
         }
 
         // set random password to prevent issue with not nullable field & potential security hole

--- a/src/Sylius/Bundle/VariationBundle/spec/Sylius/Bundle/VariationBundle/Validator/VariantUniqueValidatorSpec.php
+++ b/src/Sylius/Bundle/VariationBundle/spec/Sylius/Bundle/VariationBundle/Validator/VariantUniqueValidatorSpec.php
@@ -11,10 +11,10 @@
 
 namespace spec\Sylius\Bundle\VariationBundle\Validator;
 
-use Doctrine\Common\Persistence\ObjectRepository;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\VariationBundle\Validator\Constraint\VariantUnique;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Variation\Model\VariantInterface;
 use Symfony\Component\Validator\ExecutionContextInterface;
 
@@ -24,7 +24,7 @@ use Symfony\Component\Validator\ExecutionContextInterface;
 class VariantUniqueValidatorSpec extends ObjectBehavior
 {
     function let(
-        ObjectRepository $variantRepository,
+        RepositoryInterface $variantRepository,
         ExecutionContextInterface $context
     ) {
         $this->beConstructedWith($variantRepository);
@@ -53,7 +53,7 @@ class VariantUniqueValidatorSpec extends ObjectBehavior
         ));
 
         $variant->getPresentation()->willReturn('IPHONE5WHITE');
-        $variantRepository->findOneBy(array('presentation' => 'IPHONE5WHITE'))->shouldBeCalled()->willReturn($conflictualVariant);
+        $variantRepository->findOneBy(array('presentation' => 'IPHONE5WHITE'))->willReturn($conflictualVariant);
 
         $context->addViolationAt('presentation', 'Variant with given presentation already exists', Argument::any())->shouldBeCalled();
 
@@ -71,7 +71,7 @@ class VariantUniqueValidatorSpec extends ObjectBehavior
         ));
 
         $variant->getPresentation()->willReturn('111AAA');
-        $variantRepository->findOneBy(array('presentation' => '111AAA'))->shouldBeCalled()->willReturn(null);
+        $variantRepository->findOneBy(array('presentation' => '111AAA'))->willReturn(null);
 
         $context->addViolationAt(Argument::any())->shouldNotBeCalled();
 
@@ -89,7 +89,7 @@ class VariantUniqueValidatorSpec extends ObjectBehavior
         ));
 
         $variant->getPresentation()->willReturn('111AAA');
-        $variantRepository->findOneBy(array('presentation' => '111AAA'))->shouldBeCalled()->willReturn($variant);
+        $variantRepository->findOneBy(array('presentation' => '111AAA'))->willReturn($variant);
 
         $context->addViolationAt(Argument::any())->shouldNotBeCalled();
 

--- a/src/Sylius/Component/Promotion/Checker/PromotionEligibilityChecker.php
+++ b/src/Sylius/Component/Promotion/Checker/PromotionEligibilityChecker.php
@@ -87,7 +87,7 @@ class PromotionEligibilityChecker implements PromotionEligibilityCheckerInterfac
             return $eligible;
         }
 
-        return $this->areCouponsEligibleForPromotion($subject, $promotion, $eligible);
+        return $this->areCouponsEligibleForPromotion($subject, $promotion);
     }
 
     /**
@@ -177,12 +177,12 @@ class PromotionEligibilityChecker implements PromotionEligibilityCheckerInterfac
      *
      * @param PromotionSubjectInterface $subject
      * @param PromotionInterface        $promotion
-     * @param bool                      $eligible
      *
      * @return Boolean
      */
-    private function areCouponsEligibleForPromotion(PromotionSubjectInterface $subject, PromotionInterface $promotion, $eligible)
+    private function areCouponsEligibleForPromotion(PromotionSubjectInterface $subject, PromotionInterface $promotion)
     {
+        $eligible = false;
         if ($subject instanceof PromotionCouponAwareSubjectInterface) {
             if (null !== $coupon = $subject->getPromotionCoupon() && $promotion === $coupon->getPromotion()) {
                 $eligible = true;

--- a/src/Sylius/Component/Promotion/spec/Sylius/Component/Promotion/Checker/PromotionEligibilityCheckerSpec.php
+++ b/src/Sylius/Component/Promotion/spec/Sylius/Component/Promotion/Checker/PromotionEligibilityCheckerSpec.php
@@ -147,7 +147,6 @@ class PromotionEligibilityCheckerSpec extends ObjectBehavior
     }
 
     function it_recognizes_subject_as_not_eligible_if_promotion_subject_is_not_coupon_aware(
-        $dispatcher,
         $registry,
         RuleCheckerInterface $checker,
         PromotionSubjectInterface $subject,


### PR DESCRIPTION
This is kinda revert of #1901 which introduced issue that coupon(s) was always marked as eligible when promotion was marked as eligible.
