### PR TITLE
fix namespace for comment email listener

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderCommentEmailListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderCommentEmailListener.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Sylius\Bundle\CoreBundle\Mailer\OrderUpdateMailerInterface;
+use Sylius\Bundle\CoreBundle\Mailer\OrderCommentMailerInterface;
 use Sylius\Component\Order\Model\CommentInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -24,11 +24,11 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 class OrderCommentEmailListener
 {
     /**
-     * @var OrderUpdateMailerInterface
+     * @var OrderCommentMailerInterface
      */
     protected $mailer;
 
-    public function __construct(OrderUpdateMailerInterface $mailer)
+    public function __construct(OrderCommentMailerInterface $mailer)
     {
         $this->mailer = $mailer;
     }
@@ -51,7 +51,7 @@ class OrderCommentEmailListener
 
         // Trigger notification?
         if ($comment->getNotifyCustomer()) {
-            $this->mailer->sendOrderUpdate($comment->getOrder(), $comment);
+            $this->mailer->sendOrderComment($comment->getOrder(), $comment);
         }
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/mailer/order_comment_listener.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/mailer/order_comment_listener.xml
@@ -17,7 +17,7 @@
                                http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="sylius.listener.order_comment_email.class">Sylius\Bundle\CoreBundle\EventListener\OrderUpdateEmailListener</parameter>
+        <parameter key="sylius.listener.order_comment_email.class">Sylius\Bundle\CoreBundle\EventListener\OrderCommentEmailListener</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
I have an error in my custom sylius setup when enabling email. Tracked it down to the order comment email listener services which reference non-existent class.
