### PR TITLE
Match all applicable zones in TaxataionProcessor and allow multiple taxes per zone

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OrderProcessing/TaxationProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderProcessing/TaxationProcessor.php
@@ -98,7 +98,7 @@ class TaxationProcessor implements TaxationProcessorInterface
             return;
         }
 
-       $zones = array();
+        $zones = array();
 
         if (null !== $order->getShippingAddress()) {
             // Match the tax zone.

--- a/src/Sylius/Bundle/CoreBundle/OrderProcessing/TaxationProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderProcessing/TaxationProcessor.php
@@ -98,50 +98,56 @@ class TaxationProcessor implements TaxationProcessorInterface
             return;
         }
 
-        $zone = null;
+       $zones = array();
 
         if (null !== $order->getShippingAddress()) {
             // Match the tax zone.
-            $zone = $this->zoneMatcher->match($order->getShippingAddress());
+            $zones = $this->zoneMatcher->matchAll($order->getShippingAddress());
         }
 
-        if ($this->settings->has('default_tax_zone')) {
+        if (empty($zones) && $this->settings->has('default_tax_zone')) {
             // If address does not match any zone, use the default one.
-            $zone = $zone ?: $this->settings->get('default_tax_zone');
+            $zones = array($this->settings->get('default_tax_zone'));
         }
 
-        if (null === $zone) {
+        if (empty($zones)) {
             return;
         }
 
-        $taxes = $this->processTaxes($order, $zone);
+        $taxes = $this->processTaxes($order, $zones);
 
         $this->addAdjustments($taxes, $order);
 
         $order->calculateTotal();
     }
 
-    private function processTaxes(OrderInterface $order, $zone)
+    private function processTaxes(OrderInterface $order, $zones)
     {
         $taxes = array();
+        $zonesById = array_map(function(ZoneInterface $zone) {
+            return $zone->getId();
+        }, $zones);
+
         foreach ($order->getItems() as $item) {
-            $rate = $this->taxRateResolver->resolve($item->getProduct(), array('zone' => $zone));
+            $rates = $this->taxRateResolver->resolve($item->getProduct(), array('zone' => $zonesById));
 
             // Skip this item is there is not matching tax rate.
-            if (null === $rate) {
+            if (empty($rates)) {
                 continue;
             }
 
             $item->calculateTotal();
 
-            $amount = $this->calculator->calculate($item->getTotal(), $rate);
-            $taxAmount = $rate->getAmountAsPercentage();
-            $description = sprintf('%s (%s%%)', $rate->getName(), (float) $taxAmount);
+            foreach($rates as $rate) {
+                $amount = $this->calculator->calculate($item->getTotal(), $rate);
+                $taxAmount = $rate->getAmountAsPercentage();
+                $description = sprintf('%s (%s%%)', $rate->getName(), (float) $taxAmount);
 
-            $taxes[$description] = array(
-                'amount'   => (isset($taxes[$description]['amount']) ? $taxes[$description]['amount'] : 0) + $amount,
-                'included' => $rate->isIncludedInPrice()
-            );
+                $taxes[$description] = array(
+                    'amount'   => (isset($taxes[$description]['amount']) ? $taxes[$description]['amount'] : 0) + $amount,
+                    'included' => $rate->isIncludedInPrice()
+                );
+            }
         }
 
         return $taxes;

--- a/src/Sylius/Component/Taxation/Resolver/TaxRateResolver.php
+++ b/src/Sylius/Component/Taxation/Resolver/TaxRateResolver.php
@@ -49,6 +49,6 @@ class TaxRateResolver implements TaxRateResolverInterface
 
         $criteria = array_merge(array('category' => $category), $criteria);
 
-        return $this->taxRateRepository->findOneBy($criteria);
+        return $this->taxRateRepository->findBy($criteria);
     }
 }

--- a/src/Sylius/Component/Taxation/Resolver/TaxRateResolverInterface.php
+++ b/src/Sylius/Component/Taxation/Resolver/TaxRateResolverInterface.php
@@ -27,7 +27,7 @@ interface TaxRateResolverInterface
      * @param TaxableInterface $taxable
      * @param array            $criteria
      *
-     * @return null|TaxRateInterface[]
+     * @return TaxRateInterface[]
      */
     public function resolve(TaxableInterface $taxable, array $criteria = array());
 }

--- a/src/Sylius/Component/Taxation/Resolver/TaxRateResolverInterface.php
+++ b/src/Sylius/Component/Taxation/Resolver/TaxRateResolverInterface.php
@@ -27,7 +27,7 @@ interface TaxRateResolverInterface
      * @param TaxableInterface $taxable
      * @param array            $criteria
      *
-     * @return null|TaxRateInterface
+     * @return null|TaxRateInterface[]
      */
     public function resolve(TaxableInterface $taxable, array $criteria = array());
 }

--- a/src/Sylius/Component/Taxation/spec/Sylius/Component/Taxation/Resolver/TaxRateResolverSpec.php
+++ b/src/Sylius/Component/Taxation/spec/Sylius/Component/Taxation/Resolver/TaxRateResolverSpec.php
@@ -44,7 +44,7 @@ class TaxRateResolverSpec extends ObjectBehavior
         TaxRateInterface $taxRate
     ) {
         $taxable->getTaxCategory()->willReturn($taxCategory);
-        $taxRateRepository->findOneBy(array('category' => $taxCategory))->shouldBeCalled()->willReturn(array($taxRate));
+        $taxRateRepository->findBy(array('category' => $taxCategory))->shouldBeCalled()->willReturn(array($taxRate));
 
         $this->resolve($taxable)->shouldReturn(array($taxRate));
     }
@@ -55,7 +55,7 @@ class TaxRateResolverSpec extends ObjectBehavior
         TaxCategoryInterface $taxCategory
     ) {
         $taxable->getTaxCategory()->willReturn($taxCategory);
-        $taxRateRepository->findOneBy(array('category' => $taxCategory))->shouldBeCalled()->willReturn(array());
+        $taxRateRepository->findBy(array('category' => $taxCategory))->shouldBeCalled()->willReturn(array());
 
         $this->resolve($taxable)->shouldReturn(array());
     }

--- a/src/Sylius/Component/Taxation/spec/Sylius/Component/Taxation/Resolver/TaxRateResolverSpec.php
+++ b/src/Sylius/Component/Taxation/spec/Sylius/Component/Taxation/Resolver/TaxRateResolverSpec.php
@@ -44,9 +44,9 @@ class TaxRateResolverSpec extends ObjectBehavior
         TaxRateInterface $taxRate
     ) {
         $taxable->getTaxCategory()->willReturn($taxCategory);
-        $taxRateRepository->findOneBy(array('category' => $taxCategory))->shouldBeCalled()->willReturn($taxRate);
+        $taxRateRepository->findOneBy(array('category' => $taxCategory))->shouldBeCalled()->willReturn(array($taxRate));
 
-        $this->resolve($taxable)->shouldReturn($taxRate);
+        $this->resolve($taxable)->shouldReturn(array($taxRate));
     }
 
     function it_returns_null_if_tax_rate_for_given_taxable_category_does_not_exist(
@@ -55,9 +55,9 @@ class TaxRateResolverSpec extends ObjectBehavior
         TaxCategoryInterface $taxCategory
     ) {
         $taxable->getTaxCategory()->willReturn($taxCategory);
-        $taxRateRepository->findOneBy(array('category' => $taxCategory))->shouldBeCalled()->willReturn(null);
+        $taxRateRepository->findOneBy(array('category' => $taxCategory))->shouldBeCalled()->willReturn(array());
 
-        $this->resolve($taxable)->shouldReturn(null);
+        $this->resolve($taxable)->shouldReturn(array());
     }
 
     function it_returns_null_if_taxable_does_not_belong_to_any_category(


### PR DESCRIPTION
Note: I submitted this earlier but I majorly screwed up my git repo with rookie mistakes. Trying this again, hopefully should be good.

I was just looking at the taxation model and realized it may be useful to allow multiple taxes per zone. However, what I really ended up needing is matching all zones instead of finding the best zone. I think the changes still make sylius more flexible.

One thing we have to be careful about is that I could foresee a lot of problems for current projects that have taxes on over-lapping zones as they will all now be applied.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Fixed tickets | #1882 |
| License | MIT |
| Doc PR | -- |
