### PR TITLE
Optimizing loading fixtures

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Command/InstallCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/InstallCommand.php
@@ -96,14 +96,14 @@ class InstallCommand extends ContainerAwareCommand
 
     protected function setupFixtures(InputInterface $input, OutputInterface $output)
     {
-        $doctrine_config = $this->getContainer()->get('doctrine.orm.entity_manager')->getConnection()->getConfiguration();
-        $logger = $doctrine_config->getSQLLogger();
-        $doctrine_config->setSQLLogger(null);
+        $doctrineConfig = $this->getContainer()->get('doctrine.orm.entity_manager')->getConnection()->getConfiguration();
+        $logger = $doctrineConfig->getSQLLogger();
+        $doctrineConfig->setSQLLogger(null);
         $this
             ->runCommand('doctrine:fixtures:load', $input, $output)
             ->runCommand('doctrine:phpcr:fixtures:load', $input, $output)
         ;
-        $doctrine_config->setSQLLogger($logger);
+        $doctrineConfig->setSQLLogger($logger);
     }
 
     protected function setupAdmin(OutputInterface $output)


### PR DESCRIPTION
While running `sylius:install` in dev environment Doctrine by default is set up to log every SQL query. Most of the time all the queries are located in the memory. It leads to exceeding the memory limit.

If you will need to test fixtures you can just run `doctrine:fixtures:load` only and test it with all debug information (including whole queries). But for `sylius:install` it is not necessary.
