### PR TITLE
[ResourceBundle] Don't use query walkers when pagination is called

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/EntityRepository.php
+++ b/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/EntityRepository.php
@@ -127,7 +127,7 @@ class EntityRepository extends BaseEntityRepository implements RepositoryInterfa
      */
     public function getPaginator(QueryBuilder $queryBuilder)
     {
-        return new Pagerfanta(new DoctrineORMAdapter($queryBuilder));
+        return new Pagerfanta(new DoctrineORMAdapter($queryBuilder, true, false));
     }
 
     /**


### PR DESCRIPTION
This i.e. for product pagination removes one query run on whole table without index usage (you can guess how terrible it is when database have 90k products/variants).

![before](https://cloud.githubusercontent.com/assets/67402/4505922/862ee1d2-4afc-11e4-8cd7-3717bf877aa5.png)
![after](https://cloud.githubusercontent.com/assets/67402/4505923/884a58c0-4afc-11e4-8fb5-4dfad39fb2f1.png)

> note: please ignore time in that queries, both where cached by MySQL...
