### PR TITLE
[Bug Fix] Fix zone can add only `country` member type.

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Form/EventListener/ResizeZoneMemberCollectionListener.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/EventListener/ResizeZoneMemberCollectionListener.php
@@ -100,7 +100,7 @@ class ResizeZoneMemberCollectionListener extends ResizeFormListener
      *
      * @throws UnexpectedTypeException
      */
-    public function preBind(FormEvent $event)
+    public function preSubmit(FormEvent $event)
     {
         $data = $event->getData();
         if (null === $data || '' === $data) {

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Zone/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Zone/_form.html.twig
@@ -20,7 +20,7 @@
                                 {% if member.offsetExists(form.type.vars.value) %}
                                     <div class="sylius-zone-members-{{ form.type.vars.value }} row" style="margin-bottom: 10px;">
                                         <div class="col-md-11">
-                                            {{ form_widget(member[form.type.vars.value], {'attr': {'class': 'select2 float-right input-large'}}) }}
+                                            {{ form_widget(member, {'attr': {'class': 'select2 float-right input-large'}}) }}
                                         </div>
                                         <div class="col-md-1">
                                             <a href="#" class="btn btn-danger float-left" data-collection-button="delete" data-collection="sylius-zone-members" data-collection-item="{{ form.type.vars.value }}"><i class="glyphicon glyphicon-trash icon-white"></i></a>


### PR DESCRIPTION
| Q	                       | A     |
|--------------------------|------ |
| Bug Fix?        	| yes     |
| New Feature?	| n     |
| BC Breaks?	       | n     |
| Deprecations?	| y     |
| Tests Pass?	       | n     |
| Fixed Tickets	       | #652       |
| License	               | MIT |
| Doc PR                  |        |  

  * [AddressingBundle] Remove `preBind` deprecated by Symfony 2.3 and never call by default.
  * [WebBundle] Fix twig form zone members render.

Note:  This can be bug if use AddressingBundle as standalone. https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/AddressingBundle/Form/EventListener/ResizeZoneMemberCollectionListener.php#L132