### PR TITLE
Avoid starting session whenever possible

### DIFF
--- a/src/Sylius/Bundle/CartBundle/Storage/SessionCartStorage.php
+++ b/src/Sylius/Bundle/CartBundle/Storage/SessionCartStorage.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  */
 class SessionCartStorage implements CartStorageInterface
 {
-    const KEY = '_sylius.cart-id';
+    const KEY = '_sylius.cart_id';
 
     /**
      * Session.
@@ -55,7 +55,9 @@ class SessionCartStorage implements CartStorageInterface
      */
     public function getCurrentCartIdentifier()
     {
-        return $this->session->get($this->key);
+        if ($this->session->isStarted()) {
+            return $this->session->get($this->key);
+        }
     }
 
     /**

--- a/src/Sylius/Bundle/CurrencyBundle/Context/CurrencyContext.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Context/CurrencyContext.php
@@ -16,6 +16,8 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class CurrencyContext implements CurrencyContextInterface
 {
+    const SESSION_KEY = '_sylius.currency';
+
     protected $session;
     protected $defaultCurrency;
 
@@ -38,7 +40,11 @@ class CurrencyContext implements CurrencyContextInterface
      */
     public function getCurrency()
     {
-        return $this->session->get('currency', $this->defaultCurrency);
+        if (!$this->session->isStarted()) {
+            return $this->defaultCurrency;
+        }
+
+        return $this->session->get(self::SESSION_KEY, $this->defaultCurrency);
     }
 
     /**
@@ -46,6 +52,6 @@ class CurrencyContext implements CurrencyContextInterface
      */
     public function setCurrency($currency)
     {
-        return $this->session->set('currency', $currency);
+        return $this->session->set(self::SESSION_KEY, $currency);
     }
 }

--- a/src/Sylius/Bundle/LocaleBundle/Context/LocaleContext.php
+++ b/src/Sylius/Bundle/LocaleBundle/Context/LocaleContext.php
@@ -53,6 +53,10 @@ class LocaleContext implements LocaleContextInterface
      */
     public function getLocale()
     {
+        if (!$this->session->isStarted()) {
+            return $this->defaultLocale;
+        }
+
         return $this->session->get(self::SESSION_KEY, $this->defaultLocale);
     }
 


### PR DESCRIPTION
We are looking to improve performances of our store by using HTTP cache.
Moreover, we would like to avoid starting session for non authenticated users.

We need your feedback and ideas on how to make Sylius performance friendly regarding session usage.

Let's start by listing places where session is used:

`_sylius.locale`

```
#0  Symfony\Component\HttpFoundation\Session\Session->get() called at [src/Sylius/Bundle/LocaleBundle/Context/LocaleContext.php:56]
#1  Sylius\Bundle\LocaleBundle\Context\LocaleContext->getLocale() called at [src/Sylius/Bundle/LocaleBundle/EventListener/LocaleListener.php:52]
#2  Sylius\Bundle\LocaleBundle\EventListener\LocaleListener->onKernelRequest()
#3  call_user_func() called at [vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php:458]
#4  Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher->Symfony\Component\HttpKernel\Debug\{closure}()
#5  call_user_func() called at [vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php:164]
#6  Symfony\Component\EventDispatcher\EventDispatcher->doDispatch() called at [vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php:53]
#7  Symfony\Component\EventDispatcher\EventDispatcher->dispatch() called at [vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php:167]
#8  Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher->dispatch() called at [vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php:139]
#9  Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher->dispatch() called at [app/bootstrap.php.cache:2878]
#10 Symfony\Component\HttpKernel\HttpKernel->handleRaw() called at [app/bootstrap.php.cache:2863]
#11 Symfony\Component\HttpKernel\HttpKernel->handle() called at [app/bootstrap.php.cache:2992]
#12 Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel->handle() called at [app/bootstrap.php.cache:2272]
#13 Symfony\Component\HttpKernel\Kernel->handle() called at [web/app_dev.php:42]
```

`_security_user`

```
#0  Symfony\Component\HttpFoundation\Session\Session->get() called at [vendor/symfony/symfony/src/Symfony/Component/Security/Http/Firewall/ContextListener.php:77]
#1  Symfony\Component\Security\Http\Firewall\ContextListener->handle() called at [vendor/symfony/symfony/src/Symfony/Component/Security/Http/Firewall.php:66]
#2  Symfony\Component\Security\Http\Firewall->onKernelRequest()
#3  call_user_func() called at [vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php:458]
#4  Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher->Symfony\Component\HttpKernel\Debug\{closure}()
#5  call_user_func() called at [vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php:164]
#6  Symfony\Component\EventDispatcher\EventDispatcher->doDispatch() called at [vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/EventDispatcher.php:53]
#7  Symfony\Component\EventDispatcher\EventDispatcher->dispatch() called at [vendor/symfony/symfony/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php:167]
#8  Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher->dispatch() called at [vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php:139]
#9  Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher->dispatch() called at [app/bootstrap.php.cache:2878]
#10 Symfony\Component\HttpKernel\HttpKernel->handleRaw() called at [app/bootstrap.php.cache:2863]
#11 Symfony\Component\HttpKernel\HttpKernel->handle() called at [app/bootstrap.php.cache:2992]
#12 Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel->handle() called at [app/bootstrap.php.cache:2272]
#13 Symfony\Component\HttpKernel\Kernel->handle() called at [web/app_dev.php:42]
```

`_sylius.cart-id`

```
#0  Symfony\Component\HttpFoundation\Session\Session->get() called at [src/Sylius/Bundle/CartBundle/Storage/SessionCartStorage.php:58]
#1  Sylius\Bundle\CartBundle\Storage\SessionCartStorage->getCurrentCartIdentifier() called at [src/Sylius/Bundle/CartBundle/Provider/CartProvider.php:148]
#2  Sylius\Bundle\CartBundle\Provider\CartProvider->initializeCart() called at [src/Sylius/Bundle/CartBundle/Provider/CartProvider.php:86]
#3  Sylius\Bundle\CartBundle\Provider\CartProvider->hasCart() called at [src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php:108]
#4  Sylius\Bundle\WebBundle\Menu\FrontendMenuBuilder->createMainMenu() called at [app/cache/dev/appDevDebugProjectContainer.php:10428]
#5  appDevDebugProjectContainer->getSylius_Menu_Frontend_MainService() called at [app/bootstrap.php.cache:1996]
#6  Symfony\Component\DependencyInjection\Container->get() called at [vendor/knplabs/knp-menu-bundle/Knp/Bundle/MenuBundle/Provider/ContainerAwareProvider.php:25]
#7  Knp\Bundle\MenuBundle\Provider\ContainerAwareProvider->get() called at [vendor/knplabs/knp-menu/src/Knp/Menu/Provider/ChainProvider.php:21]
#8  Knp\Menu\Provider\ChainProvider->get() called at [vendor/knplabs/knp-menu/src/Knp/Menu/Twig/Helper.php:46]
#9  Knp\Menu\Twig\Helper->get() called at [vendor/knplabs/knp-menu/src/Knp/Menu/Twig/Helper.php:89]
#10 Knp\Menu\Twig\Helper->render() called at [vendor/knplabs/knp-menu/src/Knp/Menu/Twig/MenuExtension.php:52]
#11 Knp\Menu\Twig\MenuExtension->render() called at [app/cache/dev/twig/60/bc/0a4a9c1a51f5b7e120dbf8b59ccf505ea6ed536c1cc7df02cb99dbf79fc5.php:166]
#12 __TwigTemplate_60bc0a4a9c1a51f5b7e120dbf8b59ccf505ea6ed536c1cc7df02cb99dbf79fc5->block_header() called at [vendor/twig/twig/lib/Twig/Template.php:144]
#13 Twig_Template->displayBlock() called at [app/cache/dev/twig/60/bc/0a4a9c1a51f5b7e120dbf8b59ccf505ea6ed536c1cc7df02cb99dbf79fc5.php:69]
#14 __TwigTemplate_60bc0a4a9c1a51f5b7e120dbf8b59ccf505ea6ed536c1cc7df02cb99dbf79fc5->doDisplay() called at [vendor/twig/twig/lib/Twig/Template.php:279]
#15 Twig_Template->displayWithErrorHandling() called at [vendor/twig/twig/lib/Twig/Template.php:253]
#16 Twig_Template->display() called at [app/cache/dev/twig/9b/25/1a0a57a9f76a786b709f1eeec9aa451b26e2e249f1663393bcda8d50996a.php:24]
#17 __TwigTemplate_9b251a0a57a9f76a786b709f1eeec9aa451b26e2e249f1663393bcda8d50996a->doDisplay() called at [vendor/twig/twig/lib/Twig/Template.php:279]
#18 Twig_Template->displayWithErrorHandling() called at [vendor/twig/twig/lib/Twig/Template.php:253]
#19 Twig_Template->display() called at [vendor/twig/twig/lib/Twig/Template.php:264]
#20 Twig_Template->render() called at [vendor/symfony/symfony/src/Symfony/Bridge/Twig/TwigEngine.php:53]
#21 Symfony\Bridge\Twig\TwigEngine->render() called at [vendor/symfony/symfony/src/Symfony/Bundle/TwigBundle/TwigEngine.php:83]
#22 Symfony\Bundle\TwigBundle\TwigEngine->render() called at [vendor/symfony/symfony/src/Symfony/Bundle/TwigBundle/Debug/TimedTwigEngine.php:50]
#23 Symfony\Bundle\TwigBundle\Debug\TimedTwigEngine->render() called at [vendor/symfony/symfony/src/Symfony/Bundle/TwigBundle/TwigEngine.php:112]
#24 Symfony\Bundle\TwigBundle\TwigEngine->renderResponse() called at [vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php:106]
#25 Symfony\Bundle\FrameworkBundle\Controller\Controller->render() called at [src/Sylius/Bundle/WebBundle/Controller/Frontend/HomepageController.php:31]
#26 Sylius\Bundle\WebBundle\Controller\Frontend\HomepageController->mainAction()
#27 call_user_func_array() called at [app/bootstrap.php.cache:2889]
#28 Symfony\Component\HttpKernel\HttpKernel->handleRaw() called at [app/bootstrap.php.cache:2863]
#29 Symfony\Component\HttpKernel\HttpKernel->handle() called at [app/bootstrap.php.cache:2992]
#30 Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel->handle() called at [app/bootstrap.php.cache:2272]
#31 Symfony\Component\HttpKernel\Kernel->handle() called at [web/app_dev.php:42]
```

`currency`

```
#0  Symfony\Component\HttpFoundation\Session\Session->get() called at [src/Sylius/Bundle/CurrencyBundle/Context/CurrencyContext.php:41]
#1  Sylius\Bundle\CurrencyBundle\Context\CurrencyContext->getCurrency() called at [src/Sylius/Bundle/CoreBundle/Context/CurrencyContext.php:50]
#2  Sylius\Bundle\CoreBundle\Context\CurrencyContext->getCurrency() called at [src/Sylius/Bundle/CurrencyBundle/Templating/Helper/CurrencyHelper.php:71]
#3  Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelper->convertAndFormatAmount() called at [src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php:119]
#4  Sylius\Bundle\WebBundle\Menu\FrontendMenuBuilder->createMainMenu() called at [app/cache/dev/appDevDebugProjectContainer.php:10428]
#5  appDevDebugProjectContainer->getSylius_Menu_Frontend_MainService() called at [app/bootstrap.php.cache:1996]
#6  Symfony\Component\DependencyInjection\Container->get() called at [vendor/knplabs/knp-menu-bundle/Knp/Bundle/MenuBundle/Provider/ContainerAwareProvider.php:25]
#7  Knp\Bundle\MenuBundle\Provider\ContainerAwareProvider->get() called at [vendor/knplabs/knp-menu/src/Knp/Menu/Provider/ChainProvider.php:21]
#8  Knp\Menu\Provider\ChainProvider->get() called at [vendor/knplabs/knp-menu/src/Knp/Menu/Twig/Helper.php:46]
#9  Knp\Menu\Twig\Helper->get() called at [vendor/knplabs/knp-menu/src/Knp/Menu/Twig/Helper.php:89]
#10 Knp\Menu\Twig\Helper->render() called at [vendor/knplabs/knp-menu/src/Knp/Menu/Twig/MenuExtension.php:52]
#11 Knp\Menu\Twig\MenuExtension->render() called at [app/cache/dev/twig/60/bc/0a4a9c1a51f5b7e120dbf8b59ccf505ea6ed536c1cc7df02cb99dbf79fc5.php:166]
#12 __TwigTemplate_60bc0a4a9c1a51f5b7e120dbf8b59ccf505ea6ed536c1cc7df02cb99dbf79fc5->block_header() called at [vendor/twig/twig/lib/Twig/Template.php:144]
#13 Twig_Template->displayBlock() called at [app/cache/dev/twig/60/bc/0a4a9c1a51f5b7e120dbf8b59ccf505ea6ed536c1cc7df02cb99dbf79fc5.php:69]
#14 __TwigTemplate_60bc0a4a9c1a51f5b7e120dbf8b59ccf505ea6ed536c1cc7df02cb99dbf79fc5->doDisplay() called at [vendor/twig/twig/lib/Twig/Template.php:279]
#15 Twig_Template->displayWithErrorHandling() called at [vendor/twig/twig/lib/Twig/Template.php:253]
#16 Twig_Template->display() called at [app/cache/dev/twig/9b/25/1a0a57a9f76a786b709f1eeec9aa451b26e2e249f1663393bcda8d50996a.php:24]
#17 __TwigTemplate_9b251a0a57a9f76a786b709f1eeec9aa451b26e2e249f1663393bcda8d50996a->doDisplay() called at [vendor/twig/twig/lib/Twig/Template.php:279]
#18 Twig_Template->displayWithErrorHandling() called at [vendor/twig/twig/lib/Twig/Template.php:253]
#19 Twig_Template->display() called at [vendor/twig/twig/lib/Twig/Template.php:264]
#20 Twig_Template->render() called at [vendor/symfony/symfony/src/Symfony/Bridge/Twig/TwigEngine.php:53]
#21 Symfony\Bridge\Twig\TwigEngine->render() called at [vendor/symfony/symfony/src/Symfony/Bundle/TwigBundle/TwigEngine.php:83]
#22 Symfony\Bundle\TwigBundle\TwigEngine->render() called at [vendor/symfony/symfony/src/Symfony/Bundle/TwigBundle/Debug/TimedTwigEngine.php:50]
#23 Symfony\Bundle\TwigBundle\Debug\TimedTwigEngine->render() called at [vendor/symfony/symfony/src/Symfony/Bundle/TwigBundle/TwigEngine.php:112]
#24 Symfony\Bundle\TwigBundle\TwigEngine->renderResponse() called at [vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php:106]
#25 Symfony\Bundle\FrameworkBundle\Controller\Controller->render() called at [src/Sylius/Bundle/WebBundle/Controller/Frontend/HomepageController.php:31]
#26 Sylius\Bundle\WebBundle\Controller\Frontend\HomepageController->mainAction()
#27 call_user_func_array() called at [app/bootstrap.php.cache:2889]
#28 Symfony\Component\HttpKernel\HttpKernel->handleRaw() called at [app/bootstrap.php.cache:2863]
#29 Symfony\Component\HttpKernel\HttpKernel->handle() called at [app/bootstrap.php.cache:2992]
#30 Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel->handle() called at [app/bootstrap.php.cache:2272]
#31 Symfony\Component\HttpKernel\Kernel->handle() called at [web/app_dev.php:42]
```

Our guess is that we can start by checking if session is started in `LocaleContext` and return defalt locale if it is not. I guess similar strategy can be applied for currency and cart, and only start it when locale or currency is changed, or new product is added to cart.

What do you think?
