### PR TITLE
Order user can be null

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Payum/Be2bill/Action/CapturePaymentUsingBe2billFormAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Payum/Be2bill/Action/CapturePaymentUsingBe2billFormAction.php
@@ -67,11 +67,11 @@ class CapturePaymentUsingBe2billFormAction extends AbstractCapturePaymentAction
 
         $details = array();
         $details['AMOUNT'] = $order->getTotal();
-        $details['CLIENTEMAIL'] = $order->getUser()->getEmail();
+        $details['CLIENTEMAIL'] = $order->getEmail();
         $details['HIDECLIENTEMAIL'] = 'yes';
         $details['CLIENTUSERAGENT'] = $this->httpRequest->headers->get('User-Agent', 'Unknown');
         $details['CLIENTIP'] = $this->httpRequest->getClientIp();
-        $details['CLIENTIDENT'] = $order->getUser()->getId();
+        $details['CLIENTIDENT'] = $order->getUser() ? $order->getUser()->getId() : $order->getEmail();
         $details['DESCRIPTION'] = sprintf('Order containing %d items for a total of %01.2f', $order->getItems()->count(), $order->getTotal() / 100);
         $details['ORDERID'] = $payment->getId();
 

--- a/src/Sylius/Bundle/PayumBundle/Payum/Be2bill/Action/CapturePaymentUsingCreditCardAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Payum/Be2bill/Action/CapturePaymentUsingCreditCardAction.php
@@ -56,10 +56,10 @@ class CapturePaymentUsingCreditCardAction extends AbstractCapturePaymentAction
 
         $details = array();
         $details['AMOUNT'] = $order->getTotal();
-        $details['CLIENTEMAIL'] = $order->getUser()->getEmail();
+        $details['CLIENTEMAIL'] = $order->getEmail();
         $details['CLIENTUSERAGENT'] = $this->httpRequest->headers->get('User-Agent', 'Unknown');
         $details['CLIENTIP'] = $this->httpRequest->getClientIp();
-        $details['CLIENTIDENT'] = $order->getUser()->getId();
+        $details['CLIENTIDENT'] = $order->getUser() ? $order->getUser()->getId() : $order->getEmail();
         $details['DESCRIPTION'] = sprintf('Order containing %d items for a total of %01.2f', $order->getItems()->count(), $order->getTotal() / 100);
         $details['ORDERID'] = $payment->getId();
         $details['CARDCODE'] = new SensitiveValue($obtainCreditCardRequest->getCreditCard()->getNumber());


### PR DESCRIPTION
After https://github.com/Sylius/Sylius/pull/1816 `order.user` can be null.

So, all code like `$order->getUser()->` should be fixed to support this change.

For example https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/PayumBundle/Payum/Be2bill/Action/CapturePaymentUsingBe2billFormAction.php#L70.
