### PR TITLE
Guest checkout is missing email validation

### DIFF
--- a/features/frontend/checkout_finalize.feature
+++ b/features/frontend/checkout_finalize.feature
@@ -42,6 +42,21 @@ Feature: Checkout finalization
           And I should see 1 orders in the list
           And I should see "000000001"
 
+    Scenario: Placing the order as Guest without email address
+        Given I am not logged in
+          And I added product "PHP Top" to cart
+          And I go to the checkout start page
+         When I press "Proceed with your order"
+         Then I should see "This value should not be blank."
+
+    Scenario: Placing the order as Guest with invalid email address
+        Given I am not logged in
+          And I added product "PHP Top" to cart
+          And I go to the checkout start page
+         And I fill in "sylius_checkout_guest[email]" with "example"
+          And I press "Proceed with your order"
+         Then I should see "This value is not a valid email address."
+
     Scenario: Placing the order as Guest
         Given I am not logged in
           And I added product "PHP Top" to cart

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/form.xml
@@ -65,6 +65,9 @@
         </service>
         <service id="sylius.checkout_form.guest" class="%sylius.checkout_form.guest.class%">
             <argument>%sylius.model.cart.class%</argument>
+            <argument type="collection">
+                <argument>Guest</argument>
+            </argument>
             <tag name="form.type" alias="sylius_checkout_guest" />
         </service>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation.xml
@@ -23,6 +23,25 @@
         <property name="billingAddress">
             <constraint name="Valid" />
         </property>
+        <property name="email">
+            <constraint name="NotBlank">
+                <option name="groups">
+                    <value>Guest</value>
+                </option>
+            </constraint>
+            <constraint name="Length">
+                <option name="min">2</option>
+                <option name="max">254</option>
+                <option name="groups">
+                    <value>Guest</value>
+                </option>
+            </constraint>
+            <constraint name="Email">
+                <option name="groups">
+                    <value>Guest</value>
+                </option>
+            </constraint>
+        </property>
     </class>
 
     <class name="Sylius\Component\Core\Model\ProductVariant">


### PR DESCRIPTION
With current implementation it is possible to checkout with empty or invalid email address as guest.

We need scenarios for missing or invalid email address too in https://github.com/Sylius/Sylius/pull/1816.
