### PR TITLE
Fix order item compare

### DIFF
--- a/src/Sylius/Component/Core/Model/OrderItem.php
+++ b/src/Sylius/Component/Core/Model/OrderItem.php
@@ -86,7 +86,6 @@ class OrderItem extends CartItem implements OrderItemInterface
     {
         return parent::equals($item) || ($item instanceof self
             && $item->getVariant() === $this->variant
-            && $item->getUnitPrice() === $this->getUnitPrice()
         );
     }
 


### PR DESCRIPTION
Admin can change price during user checkout, in this case user will end up with duplicated items, and they will be with the same price, because prices are updated in https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/CoreBundle/EventListener/OrderPricingListener.php#L67.
