### PR TITLE
The default value of the required form option has been changed to false

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Form/Extension/FormExtension.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/Extension/FormExtension.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class FormExtension extends AbstractTypeExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'required' => false,
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedType()
+    {
+        return 'form';
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
@@ -24,6 +24,7 @@
 
         <parameter key="sylius.form.type.entity_hidden.class">Sylius\Bundle\ResourceBundle\Form\Type\EntityHiddenType</parameter>
         <parameter key="sylius.form.type.object_to_identifier.class">Sylius\Bundle\ResourceBundle\Form\Type\ObjectToIdentifierType</parameter>
+        <parameter key="sylius.form.type.form_extension.class">Sylius\Bundle\ResourceBundle\Form\Extension\FormExtension</parameter>
 
         <parameter key="sylius.event_subscriber.load_orm_metadata.class">Sylius\Bundle\ResourceBundle\EventListener\LoadORMMetadataSubscriber</parameter>
         <parameter key="sylius.event_subscriber.load_odm_metadata.class">Sylius\Bundle\ResourceBundle\EventListener\LoadODMMetadataSubscriber</parameter>
@@ -70,6 +71,9 @@
             <tag name="form.type" alias="entity_hidden" />
         </service>
         <service id="sylius.form.type.object_to_identifier" class="%sylius.form.type.object_to_identifier.class%" abstract="true" />
+        <service id="sylius.form.type.form_extension" class="%sylius.form.type.form_extension.class%">
+            <tag name="form.type_extension" alias="form" />
+        </service>
     </services>
 
 </container>

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Form/Extension/FormExtensionSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Form/Extension/FormExtensionSpec.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\Form\Extension;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class FormExtensionSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\Form\Extension\FormExtension');
+    }
+
+    public function it_is_a_type_extension()
+    {
+        $this->shouldHaveType('Symfony\Component\Form\AbstractTypeExtension');
+    }
+
+    public function it_configures_the_resolver(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'required' => false,
+        ))->shouldBeCalled();
+
+        $this->setDefaultOptions($resolver);
+    }
+
+    public function it_extends_form_type()
+    {
+        $this->getExtendedType()->shouldReturn('form');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | a bit :)
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This feature will be introduce into SF 2.6. With this PR we could clean all the form and remove this option because we don't use html5 validation.