### PR TITLE
#2042 Issue fix - installation on Vagrant

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Requirement/FilesystemRequirements.php
+++ b/src/Sylius/Bundle/InstallerBundle/Requirement/FilesystemRequirements.php
@@ -15,7 +15,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class FilesystemRequirements extends RequirementCollection
 {
-    public function __construct(TranslatorInterface $translator, $root)
+    public function __construct(TranslatorInterface $translator, $root, $cacheDir, $logDir)
     {
         parent::__construct($translator->trans('sylius.filesystem', array(), 'requirements'));
 
@@ -33,19 +33,19 @@ class FilesystemRequirements extends RequirementCollection
             ))
             ->add(new Requirement(
                 $translator->trans('sylius.filesystem.cache', array(), 'requirements'),
-                $status = is_writable($root.'/cache'),
+                $status = is_writable($cacheDir),
                 $translator->trans('sylius.filesystem.writable', array(), 'requirements'),
                 $status ? $translator->trans('sylius.filesystem.writable', array(), 'requirements') : $translator->trans('sylius.filesystem.not_writable', array(), 'requirements'),
                 true,
-                $translator->trans('sylius.filesystem.cache.help', array('%path%' => $root.'/cache'), 'requirements')
+                $translator->trans('sylius.filesystem.cache.help', array('%path%' => $cacheDir), 'requirements')
             ))
             ->add(new Requirement(
                 $translator->trans('sylius.filesystem.logs', array(), 'requirements'),
-                $status = is_writable($root.'/logs'),
+                $status = is_writable($logDir),
                 $writable,
                 $status ? $writable : $notWritable,
                 true,
-                $translator->trans('sylius.filesystem.logs.help', array('%path%' => $root.'/logs'), 'requirements')
+                $translator->trans('sylius.filesystem.logs.help', array('%path%' => $logDir), 'requirements')
             ))
             ->add(new Requirement(
                 $translator->trans('sylius.filesystem.parameters', array(), 'requirements'),

--- a/src/Sylius/Bundle/InstallerBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/InstallerBundle/Resources/config/services.xml
@@ -55,6 +55,8 @@
                     <service class="%sylius.requirements.filesystem.class%">
                         <argument type="service" id="translator" />
                         <argument>%kernel.root_dir%</argument>
+                        <argument>%kernel.cache_dir%</argument>
+                        <argument>%kernel.logs_dir%</argument>
                     </service>
                 </argument>
             </argument>


### PR DESCRIPTION
[InstallerBundle] Fixed cache and logs writable check, it was wrong for Vagrant environment (automatically remapped to /dev/shm in Kernel).

| Q | A |
| --- | --- |
| Fixed tickets | #2042 |
| License | MIT |
