### PR TITLE
Fix promotion coupons not properly filtering based on promotion ID

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/promotion_coupon.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/promotion_coupon.yml
@@ -9,6 +9,7 @@ sylius_backend_promotion_coupon_index:
         _sylius:
             template: SyliusWebBundle:Backend/Coupon:index.html.twig
             criteria: { promotion: $promotionId }
+            filterable: true
 
 sylius_backend_promotion_coupon_create:
     path: /new


### PR DESCRIPTION
Needs filterable = true in order to filter based on promotion ID criteria.

Fixes issue #2046 
