### PR TITLE
Handle null value

### DIFF
--- a/src/Sylius/Component/Core/Promotion/Checker/PromotionEligibilityChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/PromotionEligibilityChecker.php
@@ -86,7 +86,7 @@ class PromotionEligibilityChecker extends BasePromotionEligibilityChecker
             return true;
         }
 
-        if (0 === $coupon->getPerUserUsageLimit()) {
+        if (!$coupon->getPerUserUsageLimit()) {
             return true;
         }
 


### PR DESCRIPTION
Should handle null value here, or promotions usage limit should not be nullable.

Fixes #2077
