### PR TITLE
Fix #2055; php error in ShippingCountryRuleChecker if no country selected

### DIFF
--- a/features/frontend/checkout_addressing.feature
+++ b/features/frontend/checkout_addressing.feature
@@ -72,3 +72,12 @@ Feature: Checkout addressing
           And I fill in the billing address to USA
           And I press "Continue"
          Then I should be on the checkout shipping step
+
+    Scenario: Validating shipping country is entered
+        Given I am not logged in
+          And I added product "PHP Top" to cart
+         When I go to the checkout start page
+          And I fill in "sylius_checkout_guest[email]" with "example@example.com"
+          And I press "Proceed with your order"
+          And I press "Continue"
+         Then I should see "Please select country."

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressingStepType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressingStepType.php
@@ -74,7 +74,8 @@ class AddressingStepType extends AbstractResourceType
 
         $resolver
             ->setDefaults(array(
-                'user' => null
+                'user' => null,
+                'cascade_validation' => true
             ))
         ;
     }


### PR DESCRIPTION
Here's my proposed fitch for #2055 
It adds a cascade_validation to the checkout addressing form. Also behat scenario attached to Test. 
Let me know if this could work. 
