### PR TITLE
Enable back softdeleteable filter in OrderRepository

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -193,10 +193,14 @@ class OrderRepository extends CartRepository implements OrderRepositoryInterface
             ->setParameter('coupons', (array) $coupon)
         ;
 
-        return (int) $queryBuilder
+        $count = (int) $queryBuilder
             ->getQuery()
             ->getSingleScalarResult()
         ;
+
+        $this->_em->getFilters()->enable('softdeleteable');
+
+        return $count;
     }
 
     /**


### PR DESCRIPTION
Filters are globals, we need to enable them back after we disable them for a single query.
