### PR TITLE
Don't make ajax request for provinces if contry value is empty

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/public/js/province-choices.js
+++ b/src/Sylius/Bundle/WebBundle/Resources/public/js/province-choices.js
@@ -16,7 +16,10 @@
             var $provinceContainer = $select.closest('div.form-group').next('div.province-container');
             var provinceName = $select.attr('name').replace('country', 'province');
 
-            if (null === $select.val()) {
+            if ('' === $select.val()) {
+                $provinceContainer.fadeOut('slow', function () {
+                    $provinceContainer.html('');
+                });
                 return;
             }
 


### PR DESCRIPTION
When entering in a page whit address involved like checkout addressing step or create new address, you get 404 error in chrome dev when province-choice.js does the ajax request to get the provinces of the selected country.

This patch changes the null comparation to `''` and also fades out the provinceContainer in case user selects first option of the combo countries again. 
