### PR TITLE
[BUG FIX - API] Add missing api province route.

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/serializer/Model.Address.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/serializer/Model.Address.yml
@@ -22,6 +22,8 @@ Sylius\Component\Addressing\Model\Address:
                 parameters:
                     id: expr(object.getCountry().getId())
         - rel: province
+          exclusion:
+                exclude_if: expr(!object.getProvince())
           href:
                 route: sylius_api_province_show
                 parameters:

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/province.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/province.yml
@@ -10,3 +10,13 @@ sylius_api_province_delete:
             criteria:
                 id: $id
                 country: $countryId
+
+sylius_api_province_show:
+    path: /{id}
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.province:showAction
+        _sylius:
+            criteria:
+                id: $id
+                country: $countryId


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | y |
| New Feature? | n |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | n |
| Fixed Tickets |  |
| License | MIT |
| Doc PR |  |
- add `exclusion` condition to `relations` prevent  error "get  method of none object" (Province is nullable).
