### PR TITLE
[ResourceBundle] Improve redirection.

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
@@ -180,10 +180,52 @@ class Configuration
         }
 
         if (is_array($redirect)) {
+            if (!empty($redirect['referer'])) {
+                return 'referer';
+            }
+
             return $redirect['route'];
         }
 
         return $redirect;
+    }
+
+    /**
+     * Get url hash fragment (#text) which is you configured.
+     *
+     * @return null|string
+     */
+    public function getRedirectHash()
+    {
+        $redirect = $this->parameters->get('redirect');
+
+        if (!is_array($redirect) || empty($redirect['hash'])) {
+            return null;
+        }
+
+        return '#' . $redirect['hash'];
+    }
+
+    /**
+     * Get redirect referer, This will detected by configuration
+     * If not exists, The `referrer` from headers will be used.
+     *
+     * @return null|string
+     */
+    public function getRedirectReferer()
+    {
+        $redirect = $this->parameters->get('redirect');
+        $referer = $this->request->headers->get('referer');
+
+        if (!is_array($redirect) || empty($redirect['referer'])) {
+            return $referer;
+        }
+
+        if ($redirect['referer'] === true) {
+            return $referer;
+        }
+
+        return $redirect['referer'];
     }
 
     /**
@@ -195,7 +237,7 @@ class Configuration
     {
         $redirect = $this->parameters->get('redirect');
 
-        if (null === $redirect || !is_array($redirect)) {
+        if (!is_array($redirect) || empty($redirect['parameters'])) {
             $redirect = array('parameters' => array());
         }
 

--- a/src/Sylius/Bundle/ResourceBundle/Controller/RedirectHandler.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/RedirectHandler.php
@@ -83,7 +83,7 @@ class RedirectHandler
      */
     public function redirect($url, $status = 302)
     {
-        return new RedirectResponse($url, $status);
+        return new RedirectResponse($url . $this->config->getRedirectHash(), $status);
     }
 
     /**
@@ -91,6 +91,6 @@ class RedirectHandler
      */
     public function redirectToReferer()
     {
-        return $this->redirect($this->config->getRequest()->headers->get('referer'));
+        return $this->redirect($this->config->getRedirectReferer());
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ConfigurationSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ConfigurationSpec.php
@@ -154,6 +154,14 @@ class ConfigurationSpec extends ObjectBehavior
         $this->getRouteName('custom')->shouldReturn('sylius_product_custom');
     }
 
+    function it_generates_redirect_referer(Parameters $parameters, Request $request, ParameterBag $bag)
+    {
+        $request->headers = $bag;
+        $bag->get('referer')->willReturn('http://myurl.com');
+        $parameters->get('redirect')->willReturn(array('referer' => 'http://myurl.com'));
+        $this->getRedirectReferer()->shouldReturn('http://myurl.com');
+    }
+
     function it_generates_redirect_route(Parameters $parameters)
     {
         $parameters->get('redirect')->willReturn(null);

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/RedirectHandlerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/RedirectHandlerSpec.php
@@ -5,6 +5,7 @@ namespace spec\Sylius\Bundle\ResourceBundle\Controller;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\ResourceBundle\Controller\Configuration;
+use Sylius\Bundle\ResourceBundle\Controller\Parameters;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
@@ -26,6 +27,7 @@ class RedirectHandlerSpec extends ObjectBehavior
         $config->getRedirectParameters('resource')->willReturn(array());
         $config->getRedirectRoute('show')->willReturn('my_route');
         $router->generate('my_route', array())->willReturn('http://myurl.com');
+        $config->getRedirectHash()->willReturn(null);
 
         $this->redirectTo('resource')->shouldHaveType('Symfony\Component\HttpFoundation\RedirectResponse');
     }
@@ -35,6 +37,7 @@ class RedirectHandlerSpec extends ObjectBehavior
         $config->getRedirectRoute('index')->willReturn('my_route');
         $config->getRedirectParameters()->willReturn(array());
         $router->generate('my_route', array())->willReturn('http://myurl.com');
+        $config->getRedirectHash()->willReturn(null);
 
         $this->redirectToIndex()->shouldHaveType('Symfony\Component\HttpFoundation\RedirectResponse');
     }
@@ -47,8 +50,9 @@ class RedirectHandlerSpec extends ObjectBehavior
             ->shouldHaveType('Symfony\Component\HttpFoundation\RedirectResponse');
     }
 
-    function it_redirects()
+    function it_redirects($config)
     {
+        $config->getRedirectHash()->willReturn(null);
         $this->redirect('http://myurl.com')->shouldHaveType('Symfony\Component\HttpFoundation\RedirectResponse');
     }
 
@@ -58,6 +62,8 @@ class RedirectHandlerSpec extends ObjectBehavior
 
         $bag->get('referer')->willReturn('http://myurl.com');
         $config->getRequest()->willreturn($request);
+        $config->getRedirectHash()->willReturn(null);
+        $config->getRedirectReferer()->willreturn('http://myurl.com');
 
         $this->redirectToReferer()->shouldHaveType('Symfony\Component\HttpFoundation\RedirectResponse');
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | n |
| New Feature? | y |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | y |
| Fixed Tickets |  |
| License | MIT |
| Doc PR |  |

New PR for #1971

This PR contains two features

**Improve referer redirect with added `referer` as key of redirect config**

``` yaml
_sylius:
    redirect:
        # To set referer redirect by using query parameter e.g. ?_referer=url_path
        referer: $_referer
        # or specify with static
        referer: http://someurl
        # or use default header referer
        referer: true

# or using older style
_sylius:
    redirect: referer
```

**Add `hash` key for redirect with hash**

``` yaml
_sylius:
    redirect:
        route: ...
        parameters: ...
        hash: some_hash # This will redirect with url_path#some_hash
# or
_sylius:
    redirect:
        referer: ...
        hash: some_hash # This will redirect with referer_url#some_hash
```
