### PR TITLE
Auto-generating PHPCR proxies in debug mode.

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -68,6 +68,7 @@ doctrine_phpcr:
         password: %phpcr_pass%
     odm:
         auto_mapping: true
+        auto_generate_proxy_classes: %kernel.debug%
 
 swiftmailer:
     transport: %sylius.mailer.transport%


### PR DESCRIPTION
Without this setting fixture loading and the store were not working.

```
PHP Warning:  require(/var/www/sylius/app/cache/dev/doctrine/PHPCRProxies/__CG__DoctrineODMPHPCRDocumentGeneric.php): failed to open stream: No such file or directory in /var/www/sylius/vendor/doctrine/common/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php on line 207
```
