### PR TITLE
Make shipping method "enabled" parameter optional in behat tests.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
@@ -362,6 +362,10 @@ class CoreContext extends DefaultContext
             $calculator = array_key_exists('calculator', $data) ? str_replace(' ', '_', strtolower($data['calculator'])) : DefaultCalculators::PER_ITEM_RATE;
             $configuration = array_key_exists('configuration', $data) ? $this->getConfiguration($data['configuration']) : null;
 
+            if (!isset($data['enabled'])) {
+                $data['enabled'] = 'yes';
+            }
+
             $this->thereIsShippingMethod($data['name'], $data['zone'], $calculator, $configuration, 'yes' === $data['enabled'], false);
         }
 


### PR DESCRIPTION
My earlier PR https://github.com/Sylius/Sylius/pull/2110 introduced a warning for existing behat tests which don't contain the "enabled" parameter.
