### PR TITLE
[ResourceBundle] added the ability to secure resources routes/actions based on users roles

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Paweł Jędrzejewski <pjedrzejewski@sylius.pl>
  * @author Saša Stamenković <umpirsky@gmail.com>
+ * @author Gustavo Perdomo <gperdomor@gmail.com>
  */
 class Configuration
 {
@@ -347,5 +348,10 @@ class Configuration
     public function getSerializationVersion()
     {
         return $this->parameters->get('serialization_version');
+    }
+
+    public function getRoles()
+    {
+        return $this->parameters->get('roles');
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/translations/messages.en.yml
@@ -1,0 +1,3 @@
+sylius:
+    route_access:
+        forbidden: Unable to access this page!

--- a/src/Sylius/Bundle/ResourceBundle/Resources/translations/messages.es.yml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/translations/messages.es.yml
@@ -1,0 +1,3 @@
+sylius:
+    route_access:
+        forbidden: No es posible acceder a esta página!


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

In large projects, many users can access to the same backend, but depending on your needs, maybe not all of them should have access to all available actions, for example:
    - User A only have permissions to view details products.
    - User B have permissions for all products actions, except for the delete action.
    - User C have permissions for all products actions (including for the delete action).

You can configure this with some validations:
    - Hiding menues and buttons action based on user's roles. (Bad idea, the user can type the url in the browser to execute the action).
    - In security.yml file using access_control rules, this works but depending on the amount of resources and actions available, this file could grow a lot and is more prone to errors because you can add a new action and forget to update security.yml file, causing a potential security issue.

This PR enables simple and practical way, set these permissions directly on the resource's routing, adding the 'roles' parameter, as shown in the attached image.

According to the configuration shown in the image, a user can delete a user resource, only if have the role "ROLE_USER_DELETE", while could see the user details if have the roles "ROLE_USER_ADMIN" or "ROLE_USER_SHOW".

If the user not have the required roles, an 403 error is displayed.

If the "roles" parameter is not configured, the action is executed as usual.

![screen shot 2014-11-08 at 11 05 41 pm](https://cloud.githubusercontent.com/assets/371939/4966378/8f042c0e-67c1-11e4-8477-9e902abba5fa.png)
