### PR TITLE
[BUG FIX] /administration/logout should not be used.

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -21,7 +21,7 @@ security:
                 use_forward:  false
                 use_referer:  true
             logout:
-                path:   /administration/logout
+                path:   /logout
                 target: /administration/login
             anonymous: true
 

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/security.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/security.yml
@@ -12,9 +12,3 @@ sylius_backend_security_login_check:
     methods: [POST]
     defaults:
         _controller: sylius.controller.backend.security:checkAction
-
-sylius_backend_security_logout:
-    path: /logout
-    methods: [GET]
-    defaults:
-        _controller: sylius.controller.backend.security:logoutAction


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | y |
| New Feature? | n |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | n |
| Fixed Tickets |  |
| License | MIT |
| Doc PR |  |

Administration firewall can't invalidate remember me (`APP_REMEMBER_ME`) cookie, we should remove it.
