### PR TITLE
Leveraging sylius_money instead of money type.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Filter/OrderFilterType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Filter/OrderFilterType.php
@@ -27,14 +27,14 @@ class OrderFilterType extends AbstractType
                     'placeholder' => 'sylius.form.order_filter.number'
                 )
             ))
-            ->add('totalFrom', 'money', array(
+            ->add('totalFrom', 'sylius_money', array(
                 'required' => false,
                 'label'    => 'sylius.form.order_filter.total_from',
                 'attr'     => array(
                     'placeholder' => 'sylius.form.order_filter.total_from'
                 )
             ))
-            ->add('totalTo', 'money', array(
+            ->add('totalTo', 'sylius_money', array(
                 'required' => false,
                 'label'    => 'sylius.form.order_filter.total_to',
                 'attr'     => array(

--- a/src/Sylius/Bundle/OrderBundle/Form/Type/AdjustmentType.php
+++ b/src/Sylius/Bundle/OrderBundle/Form/Type/AdjustmentType.php
@@ -34,8 +34,7 @@ class AdjustmentType extends AbstractResourceType
                 'label'    => 'sylius.form.adjustment.description',
                 'required' => false,
             ))
-            ->add('amount', 'money', array(
-                'divisor' => 100,
+            ->add('amount', 'sylius_money', array(
                 'label'   => 'sylius.form.adjustment.amount'
             ))
         ;

--- a/src/Sylius/Bundle/OrderBundle/Form/Type/OrderItemType.php
+++ b/src/Sylius/Bundle/OrderBundle/Form/Type/OrderItemType.php
@@ -30,8 +30,7 @@ class OrderItemType extends AbstractResourceType
             ->add('quantity', 'integer', array(
                 'label' => 'sylius.form.order_item.quantity'
             ))
-            ->add('unitPrice', 'money', array(
-                'divisor' => 100,
+            ->add('unitPrice', 'sylius_money', array(
                 'label'   => 'sylius.form.order_item.unit_price'
             ))
         ;

--- a/src/Sylius/Bundle/OrderBundle/spec/Sylius/Bundle/OrderBundle/Form/Type/AdjustmentTypeSpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Sylius/Bundle/OrderBundle/Form/Type/AdjustmentTypeSpec.php
@@ -49,7 +49,7 @@ class AdjustmentTypeSpec extends ObjectBehavior
         ;
 
         $builder
-            ->add('amount', 'money', Argument::any())
+            ->add('amount', 'sylius_money', Argument::any())
             ->willReturn($builder)
         ;
 

--- a/src/Sylius/Bundle/OrderBundle/spec/Sylius/Bundle/OrderBundle/Form/Type/OrderItemTypeSpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Sylius/Bundle/OrderBundle/Form/Type/OrderItemTypeSpec.php
@@ -44,7 +44,7 @@ class OrderItemTypeSpec extends ObjectBehavior
         ;
 
         $builder
-            ->add('unitPrice', 'money', Argument::any())
+            ->add('unitPrice', 'sylius_money', Argument::any())
             ->willReturn($builder)
         ;
 


### PR DESCRIPTION
There are a few areas where we're using 'money' type instead of 'sylius_money', so the currency defaults to EUR instead of the default set.
