### PR TITLE
Use Sylius repositories instead of Doctrine in RouteProvider

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/RoutingRepositoryPass.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/RoutingRepositoryPass.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
+ */
+class RoutingRepositoryPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->hasParameter('sylius.repository_by_classes') &&
+            $container->hasDefinition('sylius.route_provider')) {
+
+            $repositoryByClasses = $container->getParameter('sylius.repository_by_classes');
+            $routeProvider = $container->getDefinition('sylius.route_provider');
+
+            foreach ($repositoryByClasses as $class => $repository) {
+                $routeProvider->addMethodCall('addRepository', array($class, new Reference($repository)));
+            }
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -161,6 +161,7 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('defaults')->isRequired()->cannotBeEmpty()->info('Defaults to add to the generated route.')
                             ->children()
                                 ->scalarNode('controller')->isRequired()->cannotBeEmpty()->info('Controller where the request should be routed.')->end()
+                                ->scalarNode('repository')->isRequired()->cannotBeEmpty()->info('Repository where the router will find the class.')->end()
                                 ->arrayNode('sylius')->isRequired()->cannotBeEmpty()->info('Sylius defaults to add to generated route.')
                                     ->useAttributeAsKey('sylius')
                                     ->prototype('variable')

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\Reference;
  * Core extension.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class SyliusCoreExtension extends AbstractResourceExtension implements PrependExtensionInterface
 {
@@ -96,18 +97,20 @@ class SyliusCoreExtension extends AbstractResourceExtension implements PrependEx
             }
         }
 
-        $routeClasses = $controllerByClasses = $syliusByClasses = array();
+        $routeClasses = $controllerByClasses = $repositoryByClasses = $syliusByClasses = array();
         foreach ($config['routing'] as $className => $routeConfig) {
             $routeClasses[$className] = array(
                 'field'  => $routeConfig['field'],
                 'prefix' => $routeConfig['prefix'],
             );
             $controllerByClasses[$className] = $routeConfig['defaults']['controller'];
+            $repositoryByClasses[$className] = $routeConfig['defaults']['repository'];
             $syliusByClasses[$className] = $routeConfig['defaults']['sylius'];
         }
 
         $container->setParameter('sylius.route_classes', $routeClasses);
         $container->setParameter('sylius.controller_by_classes', $controllerByClasses);
+        $container->setParameter('sylius.repository_by_classes', $repositoryByClasses);
         $container->setParameter('sylius.sylius_by_classes', $syliusByClasses);
         $container->setParameter('sylius.route_collection_limit', $config['route_collection_limit']);
         $container->setParameter('sylius.route_uri_filter_regexp', $config['route_uri_filter_regexp']);

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
@@ -8,6 +8,7 @@ sylius_core:
             prefix: /p
             defaults:
                 controller: sylius.controller.product:showAction
+                repository: sylius.repository.product
                 sylius:
                     template: SyliusWebBundle:Frontend/Product:show.html.twig
                     criteria: {slug: $slug}
@@ -16,6 +17,7 @@ sylius_core:
             prefix: /t
             defaults:
                 controller: sylius.controller.product:indexByTaxonAction
+                repository: sylius.repository.taxon
                 sylius:
                     template: SyliusWebBundle:Frontend/Product:indexByTaxon.html.twig
 

--- a/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
+++ b/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\CoreBundle;
 
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\DoctrineSluggablePass;
+use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\RoutingRepositoryPass;
 use Sylius\Bundle\ResourceBundle\AbstractResourceBundle;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -20,6 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * Sylius core bundle.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class SyliusCoreBundle extends AbstractResourceBundle
 {
@@ -41,6 +43,7 @@ class SyliusCoreBundle extends AbstractResourceBundle
         parent::build($container);
 
         $container->addCompilerPass(new DoctrineSluggablePass());
+        $container->addCompilerPass(new RoutingRepositoryPass());
     }
 
     /**


### PR DESCRIPTION
This PR refers to this RFC: #2147

Basically the RouteProvider looks for entities in repository classes instantiated by doctrine, this PR injects the Sylius repositories.
