### PR TITLE
[BugFix] Doctrine mapping for removing variants from product model

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Product.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Product.orm.xml
@@ -45,7 +45,7 @@
             <gedmo:versioned />
         </one-to-many>
 
-        <one-to-many field="variants" target-entity="Sylius\Component\Product\Model\VariantInterface" mapped-by="object">
+        <one-to-many field="variants" target-entity="Sylius\Component\Product\Model\VariantInterface" mapped-by="object" orphan-removal="true">
             <cascade>
                 <cascade-all />
             </cascade>


### PR DESCRIPTION
Fixes issue #2162

This is needed for when you remove a variant with `Product::removeVariant` and then flush the changes.
