### PR TITLE
Fix a fatal error in some PHP versions.

### DIFF
--- a/src/Sylius/Bundle/SearchBundle/Indexer/OrmIndexer.php
+++ b/src/Sylius/Bundle/SearchBundle/Indexer/OrmIndexer.php
@@ -120,7 +120,8 @@ class OrmIndexer implements IndexerInterface
      */
     private function createIndex($entity, array $fields)
     {
-        foreach (array_keys($fields) as &$value) {
+        $fieldNames = array_keys($fields);
+        foreach ($fieldNames as &$value) {
             $value = 'u.'.$value;
         }
 


### PR DESCRIPTION
Takes care of:

```
PHP Fatal error:  Cannot create references to elements of a temporary array expression in /var/www/sylius/src/Sylius/Bundle/SearchBundle/Indexer/OrmIndexer.php on line 123

Fatal error: Cannot create references to elements of a temporary array expression in /var/www/sylius/src/Sylius/Bundle/SearchBundle/Indexer/OrmIndexer.php on line 123
```

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
