### PR TITLE
VariantGenerator Spec coverage + Create Cartesian set builder for generating variants

### DIFF
--- a/src/Sylius/Component/Variation/Generator/CartesianSetBuilder.php
+++ b/src/Sylius/Component/Variation/Generator/CartesianSetBuilder.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Sylius\Component\Variation\Generator;
+
+class CartesianSetBuilder implements SetBuilderInterface
+{
+    /**
+     * Get all permutations of option set.
+     * Cartesian product.
+     *
+     * @param array[] $setTuples
+     * @param boolean $isRecursiveStep
+     *
+     * @return array
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function build(array $setTuples, $isRecursiveStep = false)
+    {
+        $countArrays = count($setTuples);
+
+        if (1 === $countArrays) {
+            return reset($setTuples);
+        } elseif (0 === $countArrays) {
+            throw new \InvalidArgumentException('The set builder requires a single array of one or more array sets.');
+        }
+
+        foreach ($setTuples as $tuple) {
+            if (!is_array($tuple)) {
+                throw new \InvalidArgumentException('The set builder requires a single array of one or more array sets.');
+            }
+        }
+
+        $keys = array_keys($setTuples);
+
+        $a = array_shift($setTuples);
+        $k = array_shift($keys);
+
+        $b = $this->build($setTuples, true);
+
+        $result = array();
+
+        foreach ($a as $valueA) {
+            if ($valueA) {
+                foreach ($b as $valueB) {
+                    if ($isRecursiveStep) {
+                        $result[] = array_merge(array($valueA), (array) $valueB);
+                    } else {
+                        $result[] = array($k => $valueA) + array_combine($keys, (array) $valueB);
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Sylius/Component/Variation/Generator/SetBuilderInterface.php
+++ b/src/Sylius/Component/Variation/Generator/SetBuilderInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Sylius\Component\Variation\Generator;
+
+interface SetBuilderInterface
+{
+    /**
+     * @param array   $setTuples
+     * @param boolean $isRecursiveStep
+     *
+     * @return array
+     */
+    public function build(array $setTuples, $isRecursiveStep = false);
+}

--- a/src/Sylius/Component/Variation/Generator/VariantGenerator.php
+++ b/src/Sylius/Component/Variation/Generator/VariantGenerator.php
@@ -111,6 +111,8 @@ class VariantGenerator implements VariantGeneratorInterface
      */
     protected function getPermutations($array, $recursing = false)
     {
+        // $setBuilder = new CartesianSetBuilder(); return $setBuilder->build($array, $recursing);
+
         $countArrays = count($array);
 
         if (1 === $countArrays) {

--- a/src/Sylius/Component/Variation/spec/Sylius/Component/Variation/Generator/CartesianSetBuilderSpec.php
+++ b/src/Sylius/Component/Variation/spec/Sylius/Component/Variation/Generator/CartesianSetBuilderSpec.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace spec\Sylius\Component\Variation\Generator;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class CartesianSetBuilderSpec extends ObjectBehavior
+{
+    function it_is_a_set_builder()
+    {
+        $this->shouldImplement('Sylius\Component\Variation\Generator\SetBuilderInterface');
+    }
+
+    function it_returns_the_same_set_as_the_Cartesian_product_when_only_one_was_given()
+    {
+        $set = array('a', 'b', 'c');
+
+        $this->build(array($set), false)->shouldReturn($set);
+    }
+
+    function it_requires_an_array_of_tuple_sets_to_build_from()
+    {
+        $tupleSetNotInArray = array('a', 'b', 'c');
+
+        $this->shouldThrow('InvalidArgumentException')->duringBuild($tupleSetNotInArray, Argument::any());
+    }
+
+    function it_builds_the_Cartesian_product_set_from_two_sets()
+    {
+        $setA = array('a', 'b', 'c');
+        $setB = array('1', '2', '3');
+
+        $this->build(array($setA, $setB), false)->shouldReturn(array(
+            array('a', '1'),
+            array('a', '2'),
+            array('a', '3'),
+
+            array('b', '1'),
+            array('b', '2'),
+            array('b', '3'),
+
+            array('c', '1'),
+            array('c', '2'),
+            array('c', '3'),
+        ));
+    }
+}

--- a/src/Sylius/Component/Variation/spec/Sylius/Component/Variation/Generator/VariantGeneratorSpec.php
+++ b/src/Sylius/Component/Variation/spec/Sylius/Component/Variation/Generator/VariantGeneratorSpec.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace spec\Sylius\Component\Variation\Generator;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\Component\Variation\Model\OptionInterface;
+use Sylius\Component\Variation\Model\OptionValueInterface;
+use Sylius\Component\Variation\Model\VariableInterface;
+
+class VariantGeneratorSpec extends ObjectBehavior
+{
+    function let(RepositoryInterface $variantRepository)
+    {
+        $this->beConstructedWith($variantRepository);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Variation\Generator\VariantGenerator');
+    }
+
+    function it_is_a_Sylius_variant_generator()
+    {
+        $this->shouldImplement('Sylius\Component\Variation\Generator\VariantGenerator');
+    }
+
+    function it_cannot_generate_variants_for_an_object_without_options(VariableInterface $variable)
+    {
+        $variable->hasOptions()->willReturn(false);
+
+        $this->shouldThrow('InvalidArgumentException')->duringGenerate($variable);
+    }
+}


### PR DESCRIPTION
- [x] Extract `VariantGenerator::getPermutations` as `CartesianSetBuilder`.
- [ ] Cover `VariantGenerator` with specs.
