### PR TITLE
[Variation] Reusable Set Builders for generating variants + VariantGenerator spec coverage

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Generator/VariantGenerator.php
+++ b/src/Sylius/Bundle/ProductBundle/Generator/VariantGenerator.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\ProductBundle\Generator;
 
 use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\Component\Variation\SetBuilder\SetBuilderInterface;
 use Sylius\Component\Variation\Generator\VariantGenerator as BaseVariantGenerator;
 use Sylius\Component\Variation\Model\VariableInterface;
 use Sylius\Component\Variation\Model\VariantInterface;
@@ -44,12 +45,13 @@ class VariantGenerator extends BaseVariantGenerator
      * Constructor.
      *
      * @param RepositoryInterface      $variantRepository
+     * @param SetBuilderInterface      $setBuilder
      * @param ValidatorInterface       $validator
      * @param EventDispatcherInterface $eventDispatcher
      */
-    public function __construct(RepositoryInterface $variantRepository, ValidatorInterface $validator, EventDispatcherInterface $eventDispatcher)
+    public function __construct(RepositoryInterface $variantRepository, SetBuilderInterface $setBuilder, ValidatorInterface $validator, EventDispatcherInterface $eventDispatcher)
     {
-        parent::__construct($variantRepository);
+        parent::__construct($variantRepository, $setBuilder);
 
         $this->validator = $validator;
         $this->eventDispatcher = $eventDispatcher;

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/services.xml
@@ -20,6 +20,7 @@
         <parameter key="sylius.builder.product.class">Sylius\Component\Product\Builder\ProductBuilder</parameter>
         <parameter key="sylius.builder.product_prototype.class">Sylius\Component\Product\Builder\PrototypeBuilder</parameter>
 
+        <parameter key="sylius.set_builder.cartesian.class">Sylius\Component\Variation\SetBuilder\CartesianSetBuilder</parameter>
         <parameter key="sylius.generator.product_variant.class">Sylius\Bundle\ProductBundle\Generator\VariantGenerator</parameter>
 
         <parameter key="sylius.validator.product.unique.class">Sylius\Bundle\ProductBundle\Validator\ProductUniqueValidator</parameter>
@@ -45,10 +46,12 @@
         </service>
         <service id="sylius.builder.product_prototype" class="%sylius.builder.product_prototype.class%">
             <argument type="service" id="sylius.repository.product_attribute_value" />
-          </service>
+        </service>
 
+        <service id="sylius.set_builder.cartesian" class="%sylius.set_builder.cartesian.class%" />
         <service id="sylius.generator.product_variant" class="%sylius.generator.product_variant.class%">
             <argument type="service" id="sylius.repository.product_variant" />
+            <argument type="service" id="sylius.set_builder.cartesian" />
             <argument type="service" id="validator" />
             <argument type="service" id="event_dispatcher"/>
         </service>

--- a/src/Sylius/Component/Variation/Generator/VariantGenerator.php
+++ b/src/Sylius/Component/Variation/Generator/VariantGenerator.php
@@ -14,6 +14,7 @@ namespace Sylius\Component\Variation\Generator;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Variation\Model\VariableInterface;
 use Sylius\Component\Variation\Model\VariantInterface;
+use Sylius\Component\Variation\SetBuilder\SetBuilderInterface;
 
 /**
  * Abstract variant generator service implementation.
@@ -39,13 +40,20 @@ class VariantGenerator implements VariantGeneratorInterface
     protected $variantRepository;
 
     /**
+     * @var SetBuilderInterface
+     */
+    private $setBuilder;
+
+    /**
      * Constructor.
      *
      * @param RepositoryInterface $variantRepository
+     * @param SetBuilderInterface $setBuilder
      */
-    public function __construct(RepositoryInterface $variantRepository)
+    public function __construct(RepositoryInterface $variantRepository, SetBuilderInterface $setBuilder)
     {
         $this->variantRepository = $variantRepository;
+        $this->setBuilder = $setBuilder;
     }
 
     /**
@@ -67,7 +75,7 @@ class VariantGenerator implements VariantGeneratorInterface
             }
         }
 
-        $permutations = $this->getPermutations($optionSet);
+        $permutations = $this->setBuilder->build($optionSet);
 
         foreach ($permutations as $permutation) {
             $variant = $this->variantRepository->createNew();
@@ -96,50 +104,5 @@ class VariantGenerator implements VariantGeneratorInterface
      */
     protected function process(VariableInterface $variable, VariantInterface $variant)
     {
-    }
-
-    /**
-     * Get all permutations of option set.
-     * Cartesian product.
-     *
-     * @param array   $array
-     * @param Boolean $recursing
-     *
-     * @return array
-     *
-     * @throws \InvalidArgumentException
-     */
-    protected function getPermutations($array, $recursing = false)
-    {
-        $countArrays = count($array);
-
-        if (1 === $countArrays) {
-            return reset($array);
-        } elseif (0 === $countArrays) {
-            throw new \InvalidArgumentException('At least one array is required.');
-        }
-
-        $keys = array_keys($array);
-
-        $a = array_shift($array);
-        $k = array_shift($keys);
-
-        $b = $this->getPermutations($array, true);
-
-        $result = array();
-
-        foreach ($a as $valueA) {
-            if ($valueA) {
-                foreach ($b as $valueB) {
-                    if ($recursing) {
-                        $result[] = array_merge(array($valueA), (array) $valueB);
-                    } else {
-                        $result[] = array($k => $valueA) + array_combine($keys, (array) $valueB);
-                    }
-                }
-            }
-        }
-
-        return $result;
     }
 }

--- a/src/Sylius/Component/Variation/SetBuilder/CartesianSetBuilder.php
+++ b/src/Sylius/Component/Variation/SetBuilder/CartesianSetBuilder.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Variation\SetBuilder;
+
+/**
+ * Builds the Cartesian product set from one or more given sets.
+ *
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+class CartesianSetBuilder implements SetBuilderInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \InvalidArgumentException If the array is empty.
+     * @throws \InvalidArgumentException If the array does not contain arrays of set tuples.
+     */
+    public function build(array $setTuples, $isRecursiveStep = false)
+    {
+        $countTuples = count($setTuples);
+
+        if (1 === $countTuples) {
+            return reset($setTuples);
+        }
+
+        if (0 === $countTuples) {
+            throw new \InvalidArgumentException('The set builder requires a single array of one or more array sets.');
+        }
+
+        foreach ($setTuples as $tuple) {
+            if (!is_array($tuple)) {
+                throw new \InvalidArgumentException('The set builder requires a single array of one or more array sets.');
+            }
+        }
+
+        $keys = array_keys($setTuples);
+
+        $a = array_shift($setTuples);
+        $k = array_shift($keys);
+
+        $b = $this->build($setTuples, true);
+
+        $result = array();
+
+        foreach ($a as $valueA) {
+            if ($valueA) {
+                foreach ($b as $valueB) {
+                    if ($isRecursiveStep) {
+                        $result[] = array_merge(array($valueA), (array) $valueB);
+                    } else {
+                        $result[] = array($k => $valueA) + array_combine($keys, (array) $valueB);
+                    }
+                }
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Sylius/Component/Variation/SetBuilder/SetBuilderInterface.php
+++ b/src/Sylius/Component/Variation/SetBuilder/SetBuilderInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Variation\SetBuilder;
+
+/**
+ * Build a product set from one or more given sets.
+ *
+ * @author Adam Elsodaney <adam.elso@gmail.com>
+ */
+interface SetBuilderInterface
+{
+    /**
+     * Get all permutations of option set.
+     *
+     * @param array   $setTuples
+     * @param boolean $isRecursiveStep
+     *
+     * @return array The product set of tuples.
+     */
+    public function build(array $setTuples, $isRecursiveStep = false);
+}

--- a/src/Sylius/Component/Variation/spec/Sylius/Component/Variation/Generator/VariantGeneratorSpec.php
+++ b/src/Sylius/Component/Variation/spec/Sylius/Component/Variation/Generator/VariantGeneratorSpec.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Variation\Generator;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\Component\Variation\SetBuilder\SetBuilderInterface;
+use Sylius\Component\Variation\Model\OptionInterface;
+use Sylius\Component\Variation\Model\OptionValue;
+use Sylius\Component\Variation\Model\VariableInterface;
+use Sylius\Component\Variation\Model\VariantInterface;
+
+/**
+ * @author Adam Elsodaney <adam.elso@gmail.com>
+ */
+class VariantGeneratorSpec extends ObjectBehavior
+{
+    function let(RepositoryInterface $variantRepository, SetBuilderInterface $setBuilder)
+    {
+        $this->beConstructedWith($variantRepository, $setBuilder);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Variation\Generator\VariantGenerator');
+    }
+
+    function it_is_a_Sylius_variant_generator()
+    {
+        $this->shouldImplement('Sylius\Component\Variation\Generator\VariantGeneratorInterface');
+    }
+
+    function it_cannot_generate_variants_for_an_object_without_options(VariableInterface $variable)
+    {
+        $variable->hasOptions()->willReturn(false);
+
+        $this->shouldThrow('InvalidArgumentException')->duringGenerate($variable);
+    }
+
+    function it_generates_variants_for_every_value_of_an_objects_single_option(
+        VariableInterface $productVariable,
+        RepositoryInterface $variantRepository,
+        SetBuilderInterface $setBuilder,
+        OptionInterface $colorOption,
+        OptionValue $blackColor, OptionValue $whiteColor, OptionValue $redColor,
+        VariantInterface $masterVariant, VariantInterface $permutationVariant
+    ) {
+        $productVariable->hasOptions()->willReturn(true);
+
+        $productVariable->getOptions()->willReturn(array($colorOption));
+
+        $colorOption->getValues()->willReturn(array($blackColor, $whiteColor, $redColor));
+
+        // Stubbing `OptionValue` instead of `OptionValueInterface` in order to stub `getId` method.
+        $blackColor->getId()->willReturn('black1');
+        $whiteColor->getId()->willReturn('white2');
+        $redColor->getId()->willReturn('red3');
+
+        $setBuilder->build(array(
+            array('black1', 'white2', 'red3'),
+        ))->willReturn(array(
+            array('black1', 'white2', 'red3'),
+        ));
+
+        $productVariable->getMasterVariant()->willReturn($masterVariant);
+
+        $variantRepository->createNew()->willReturn($permutationVariant);
+        $permutationVariant->setObject($productVariable)->shouldBeCalled();
+        $permutationVariant->setDefaults($masterVariant)->shouldBeCalled();
+        $permutationVariant->addOption(Argument::type('Sylius\Component\Variation\Model\OptionValue'))->shouldBeCalled();
+        $productVariable->addVariant($permutationVariant)->shouldBeCalled();
+
+        $this->generate($productVariable);
+    }
+
+    function it_generates_variants_for_every_possible_permutation_of_an_objects_options_and_option_values(
+        VariableInterface $productVariable,
+        RepositoryInterface $variantRepository,
+        SetBuilderInterface $setBuilder,
+        OptionInterface $colorOption, OptionInterface $sizeOption,
+        OptionValue $blackColor, OptionValue $whiteColor, OptionValue $redColor,
+        OptionValue $smallSize, OptionValue $mediumSize, OptionValue $largeSize,
+        VariantInterface $masterVariant, VariantInterface $permutationVariant
+    ) {
+        $productVariable->hasOptions()->willReturn(true);
+
+        $productVariable->getOptions()->willReturn(array($colorOption, $sizeOption));
+
+        $colorOption->getValues()->willReturn(array($blackColor, $whiteColor, $redColor));
+        $sizeOption->getValues()->willReturn(array($smallSize, $mediumSize, $largeSize));
+
+        $blackColor->getId()->willReturn('black1');
+        $whiteColor->getId()->willReturn('white2');
+        $redColor->getId()->willReturn('red3');
+        $smallSize->getId()->willReturn('small4');
+        $mediumSize->getId()->willReturn('medium5');
+        $largeSize->getId()->willReturn('large6');
+
+        $setBuilder->build(array(
+            array('black1', 'white2', 'red3'),
+            array('small4', 'medium5', 'large6')
+        ))->willReturn(array(
+            array('black1', 'small4'),
+            array('black1', 'medium5'),
+            array('black1', 'large6'),
+            array('white2', 'small4'),
+            array('white2', 'medium5'),
+            array('white2', 'large6'),
+            array('red3', 'small4'),
+            array('red3', 'medium5'),
+            array('red3', 'large6'),
+        ));
+
+        $productVariable->getMasterVariant()->willReturn($masterVariant);
+
+        $variantRepository->createNew()->willReturn($permutationVariant);
+        $permutationVariant->setObject($productVariable)->shouldBeCalled();
+        $permutationVariant->setDefaults($masterVariant)->shouldBeCalled();
+        $permutationVariant->addOption(Argument::type('Sylius\Component\Variation\Model\OptionValue'))->shouldBeCalled();
+        $productVariable->addVariant($permutationVariant)->shouldBeCalled();
+
+        $this->generate($productVariable);
+    }
+}

--- a/src/Sylius/Component/Variation/spec/Sylius/Component/Variation/SetBuilder/CartesianSetBuilderSpec.php
+++ b/src/Sylius/Component/Variation/spec/Sylius/Component/Variation/SetBuilder/CartesianSetBuilderSpec.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Variation\SetBuilder;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+/**
+ * @author Adam Elsodaney <adam.elso@gmail.com>
+ */
+class CartesianSetBuilderSpec extends ObjectBehavior
+{
+    function it_is_a_set_builder()
+    {
+        $this->shouldImplement('Sylius\Component\Variation\SetBuilder\SetBuilderInterface');
+    }
+
+    function it_requires_an_array_of_set_tuples_to_build_from()
+    {
+        $tupleSetNotInArray = array('a', 'b', 'c');
+
+        $this->shouldThrow('InvalidArgumentException')->duringBuild($tupleSetNotInArray, Argument::any());
+    }
+
+    function it_requires_at_least_one_set_tuple()
+    {
+        $this->shouldThrow('InvalidArgumentException')->duringBuild(array(), Argument::any());
+    }
+
+    function it_returns_the_same_set_as_the_Cartesian_product_when_only_one_was_given()
+    {
+        $set = array('a', 'b', 'c');
+
+        $this->build(array($set), false)->shouldReturn($set);
+    }
+
+    function it_builds_the_Cartesian_product_set_from_two_sets()
+    {
+        $setA = array('a', 'b', 'c');
+        $setB = array('1', '2', '3');
+
+        $this->build(array($setA, $setB), false)->shouldReturn(array(
+            array('a', '1'),
+            array('a', '2'),
+            array('a', '3'),
+
+            array('b', '1'),
+            array('b', '2'),
+            array('b', '3'),
+
+            array('c', '1'),
+            array('c', '2'),
+            array('c', '3'),
+        ));
+    }
+
+    function it_builds_the_Cartesian_product_set_from_more_than_two_sets()
+    {
+        $setA = array('a', 'b', 'c');
+        $setB = array('1', '2', '3');
+        $setC = array('!', '@', '$');
+
+        $this->build(array($setA, $setB, $setC), false)->shouldReturn(array(
+            array('a', '1', '!'), array('a', '1', '@'), array('a', '1', '$'),
+            array('a', '2', '!'), array('a', '2', '@'), array('a', '2', '$'),
+            array('a', '3', '!'), array('a', '3', '@'), array('a', '3', '$'),
+
+            array('b', '1', '!'), array('b', '1', '@'), array('b', '1', '$'),
+            array('b', '2', '!'), array('b', '2', '@'), array('b', '2', '$'),
+            array('b', '3', '!'), array('b', '3', '@'), array('b', '3', '$'),
+
+            array('c', '1', '!'), array('c', '1', '@'), array('c', '1', '$'),
+            array('c', '2', '!'), array('c', '2', '@'), array('c', '2', '$'),
+            array('c', '3', '!'), array('c', '3', '@'), array('c', '3', '$'),
+        ));
+    }
+}


### PR DESCRIPTION
Q | A
---|---
Bug fix? | no
New feature? | yes
BC breaks? | yes
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR |  https://github.com/Sylius/Sylius-Docs/pull/232

Whilst working on writing specs for the `VariantGenerator`, I could see why there weren't any to begin with.
Now the most complicated logic has been extracted out to a new class `CartesianSetBuilder`, which implements `SetBuilderInterface`, so this has the added benefit of allowing developers to define their own strategies for generating variants.

Unfortunately, the disadvantage of this being that the set builder has to be explicitly passed to the constructor of `VariantGenerator`, and only math boffins would be aware of what a _set builder_ and the _Cartesian product_ are.