### PR TITLE
[CoreBundle] Fix version constraint on jms/serializer-bundle

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -24,7 +24,7 @@
 
         "friendsofsymfony/user-bundle":   "2.0.*@dev",
         "hwi/oauth-bundle":               "~0.3",
-        "jms/serializer-bundle":          "0.12.*",
+        "jms/serializer-bundle":          "~0.13",
         "knplabs/gaufrette":              "0.2.*@dev",
         "knplabs/knp-gaufrette-bundle":   "0.2.*@dev",
         "mathiasverraes/money":           "*@dev",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Related to #2172, makes version requirements for `jms/serializer-bundle` consistent with Sylius/composer.json and ResourceBundle/composer.json files.
