### PR TITLE
Change billing address mapping to cascade-persist

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Order.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Order.orm.xml
@@ -15,7 +15,7 @@
 
         <many-to-one field="billingAddress" target-entity="Sylius\Component\Addressing\Model\AddressInterface">
             <cascade>
-                <cascade-all/>
+                <cascade-persist/>
             </cascade>
             <join-column name="billing_address_id" referenced-column-name="id" nullable="true" />
         </many-to-one>


### PR DESCRIPTION
Refer to #2161 . It seems that the cascade-all mapping at billingAddress preventing the deletion of orders/cart unlike shippingAddress which uses cascade-persist only. I guess when we softdelete an order, the billing address must stay too, right?
