### PR TITLE
Remove hardcoded environment names where isDebug switch is good enough

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -27,6 +27,10 @@ class AppKernel extends Kernel
             // Put here your own bundles!
         );
 
+        if (in_array($this->environment, array('dev', 'test'))) {
+            $bundles[] = new \Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
+        }
+
         return array_merge(parent::registerBundles(), $bundles);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Kernel/Kernel.php
+++ b/src/Sylius/Bundle/CoreBundle/Kernel/Kernel.php
@@ -102,10 +102,6 @@ abstract class Kernel extends BaseKernel
             new \WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
         );
 
-        if ($this->isDebug()) {
-            $bundles[] = new \Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
-        }
-
         return $bundles;
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Kernel/Kernel.php
+++ b/src/Sylius/Bundle/CoreBundle/Kernel/Kernel.php
@@ -102,7 +102,7 @@ abstract class Kernel extends BaseKernel
             new \WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
         );
 
-        if (in_array($this->environment, array('dev', 'test'))) {
+        if ($this->isDebug()) {
             $bundles[] = new \Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
         }
 


### PR DESCRIPTION
Ran into this being a problem since for local development I use the environment 'local'.
What do you think?

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Improvement | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT