### PR TITLE
Avoid break of Metadata loading process.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,7 @@
         "behat/mink-browserkit-driver":         "~1.2",
         "behat/mink-selenium2-driver":          "~1.2",
         "behat/mink":                           "~1.6",
+        "bossa/phpspec2-expect":                "*",
         "coduo/php-matcher":                    "~1.0",
         "phpspec/phpspec":                      "~2.1",
         "phpunit/phpunit":                      "~4.1"

--- a/src/Sylius/Bundle/ResourceBundle/EventListener/LoadODMMetadataSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/LoadODMMetadataSubscriber.php
@@ -85,7 +85,7 @@ class LoadODMMetadataSubscriber implements EventSubscriber
     private function setAssociationMappings(ClassMetadataInfo $metadata)
     {
         foreach (class_parents($metadata->getName()) as $parent) {
-            if (isset($this->savedAssociations[$metadata->name])) {
+            if (isset($this->savedAssociations[$parent])) {
                 foreach ($this->savedAssociations[$parent] as $key => $mapping) {
                     $metadata->associationMappings[$key] = $mapping;
                 }

--- a/src/Sylius/Bundle/ResourceBundle/EventListener/LoadODMMetadataSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/LoadODMMetadataSubscriber.php
@@ -85,7 +85,7 @@ class LoadODMMetadataSubscriber implements EventSubscriber
     private function setAssociationMappings(ClassMetadataInfo $metadata)
     {
         foreach (class_parents($metadata->getName()) as $parent) {
-            if (in_array($parent, array_keys($this->savedAssociations))) {
+            if (isset($this->savedAssociations[$metadata->name])) {
                 foreach ($this->savedAssociations[$parent] as $key => $mapping) {
                     $metadata->associationMappings[$key] = $mapping;
                 }

--- a/src/Sylius/Bundle/ResourceBundle/EventListener/LoadORMMetadataSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/LoadORMMetadataSubscriber.php
@@ -85,7 +85,7 @@ class LoadORMMetadataSubscriber implements EventSubscriber
     private function setAssociationMappings(ClassMetadataInfo $metadata)
     {
         foreach (class_parents($metadata->getName()) as $parent) {
-            if (isset($this->savedAssociations[$metadata->name])) {
+            if (isset($this->savedAssociations[$parent])) {
                 foreach ($this->savedAssociations[$parent] as $key => $mapping) {
                     $metadata->associationMappings[$key] = $mapping;
                 }

--- a/src/Sylius/Bundle/ResourceBundle/EventListener/LoadORMMetadataSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/LoadORMMetadataSubscriber.php
@@ -29,6 +29,11 @@ class LoadORMMetadataSubscriber implements EventSubscriber
     protected $classes;
 
     /**
+     * @var array
+     */
+    private $savedAssociations = array();
+
+    /**
      * Constructor
      *
      * @param array $classes
@@ -59,7 +64,7 @@ class LoadORMMetadataSubscriber implements EventSubscriber
         $this->setCustomRepositoryClasses($metadata);
 
         if (!$metadata->isMappedSuperclass) {
-            $this->setAssociationMappings($metadata, $eventArgs->getEntityManager()->getConfiguration());
+            $this->setAssociationMappings($metadata);
         } else {
             $this->unsetAssociationMappings($metadata);
         }
@@ -77,21 +82,12 @@ class LoadORMMetadataSubscriber implements EventSubscriber
         }
     }
 
-    private function setAssociationMappings(ClassMetadataInfo $metadata, $configuration)
+    private function setAssociationMappings(ClassMetadataInfo $metadata)
     {
         foreach (class_parents($metadata->getName()) as $parent) {
-            $parentMetadata = new ClassMetadata(
-                $parent,
-                $configuration->getNamingStrategy()
-            );
-            if (in_array($parent, $configuration->getMetadataDriverImpl()->getAllClassNames())) {
-                $configuration->getMetadataDriverImpl()->loadMetadataForClass($parent, $parentMetadata);
-                if ($parentMetadata->isMappedSuperclass) {
-                    foreach ($parentMetadata->getAssociationMappings() as $key => $value) {
-                        if ($this->hasRelation($value['type'])) {
-                            $metadata->associationMappings[$key] = $value;
-                        }
-                    }
+            if (in_array($parent, array_keys($this->savedAssociations))) {
+                foreach ($this->savedAssociations[$parent] as $key => $mapping) {
+                    $metadata->associationMappings[$key] = $mapping;
                 }
             }
         }
@@ -101,6 +97,10 @@ class LoadORMMetadataSubscriber implements EventSubscriber
     {
         foreach ($metadata->getAssociationMappings() as $key => $value) {
             if ($this->hasRelation($value['type'])) {
+                if (!isset($this->savedAssociations[$metadata->name])) {
+                    $this->savedAssociations[$metadata->name] = array();
+                }
+                $this->savedAssociations[$metadata->name][$key] = $metadata->associationMappings[$key];
                 unset($metadata->associationMappings[$key]);
             }
         }

--- a/src/Sylius/Bundle/ResourceBundle/EventListener/LoadORMMetadataSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/LoadORMMetadataSubscriber.php
@@ -85,7 +85,7 @@ class LoadORMMetadataSubscriber implements EventSubscriber
     private function setAssociationMappings(ClassMetadataInfo $metadata)
     {
         foreach (class_parents($metadata->getName()) as $parent) {
-            if (in_array($parent, array_keys($this->savedAssociations))) {
+            if (isset($this->savedAssociations[$metadata->name])) {
                 foreach ($this->savedAssociations[$parent] as $key => $mapping) {
                     $metadata->associationMappings[$key] = $mapping;
                 }

--- a/src/Sylius/Bundle/ResourceBundle/spec/EventListener/LoadODMMetadataSubscriberSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/EventListener/LoadODMMetadataSubscriberSpec.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\EventListener;
+
+use Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+require_once __DIR__.'/../Fixture/Entity/Foo.php';
+require_once __DIR__ . '/../Fixture/Entity/MappedSuperclass.php';
+require_once __DIR__ . '/../Fixture/Entity/Bar.php';
+
+/**
+ * @author Benoît Burnichon <bburnichon@gmail.com>
+ */
+class LoadODMMetadataSubscriberSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $classes = array(
+            'foo' => array(
+                'model' => 'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\Foo',
+                'repository' => 'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\FooRepository',
+            ),
+        );
+
+        $this->beConstructedWith(
+            $classes
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\EventListener\LoadODMMetadataSubscriber');
+    }
+
+    function it_is_doctrine_event_subscriber()
+    {
+        $this->shouldImplement('Doctrine\Common\EventSubscriber');
+    }
+
+    function it_subscribes_events()
+    {
+        $this::getSubscribedEvents()->shouldReturn(array(
+            'loadClassMetadata',
+        ));
+    }
+
+    function it_should_set_custom_repository_class_and_force_model_to_entity(
+        LoadClassMetadataEventArgs $eventArgs,
+        ClassMetadata $metadata
+    ) {
+        $metadata->isMappedSuperclass = true;
+        $metadata->getName()
+            ->willReturn('spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\Foo');
+        $metadata->setCustomRepositoryClass('spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\FooRepository')
+            ->shouldBeCalled();
+        $eventArgs->getClassMetadata()->willReturn($metadata);
+
+        $this->loadClassMetadata($eventArgs);
+
+        expect($metadata->isMappedSuperclass)->toBe(false);
+    }
+
+    function it_should_unset_association_mappings_of_mapped_superclasses(
+        LoadClassMetadataEventArgs $eventArgs,
+        ClassMetadata $metadata
+    ) {
+        $metadata->isMappedSuperclass = true;
+        $metadata->name = 'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\MappedSuperclass';
+        $metadata->associationMappings = array(
+            'refOne' => array('association' => ClassMetadata::REFERENCE_ONE),
+            'refMany' => array('association' => ClassMetadata::REFERENCE_MANY),
+            'embedOne' => array('association' => ClassMetadata::EMBED_ONE),
+            'embedMany' => array('association' => ClassMetadata::EMBED_MANY),
+        );
+        $metadata->getName()
+            ->willReturn($metadata->name);
+        $eventArgs->getClassMetadata()->willReturn($metadata);
+
+        $this->loadClassMetadata($eventArgs);
+
+        expect($metadata->associationMappings)->toBe(array(
+        ));
+    }
+
+    function it_should_set_association_mappings_of_mapped_superclasses(
+        LoadClassMetadataEventArgs $superClassEventArgs,
+        ClassMetadata $superClassMetadata,
+        LoadClassMetadataEventArgs $eventArgs,
+        ClassMetadata $metadata
+    ) {
+        $superClassMetadata->isMappedSuperclass = true;
+        $superClassMetadata->name = 'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\MappedSuperclass';
+        $superClassMetadata->associationMappings = array(
+            'refOne' => array('association' => ClassMetadata::REFERENCE_ONE),
+            'refMany' => array('association' => ClassMetadata::REFERENCE_MANY),
+            'embedOne' => array('association' => ClassMetadata::EMBED_ONE),
+            'embedMany' => array('association' => ClassMetadata::EMBED_MANY),
+        );
+        $superClassMetadata->getName()
+            ->willReturn($superClassMetadata->name);
+        $superClassEventArgs->getClassMetadata()->willReturn($superClassMetadata);
+
+        $metadata->isMappedSuperclass = false;
+        $metadata->name = 'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\Bar';
+        $metadata->associationMappings = array(
+            'BarRefOne' => array('association' => ClassMetadata::REFERENCE_ONE),
+            'BarRefMany' => array('association' => ClassMetadata::REFERENCE_MANY),
+            'BarEmbedOne' => array('association' => ClassMetadata::EMBED_ONE),
+            'BarEmbedMany' => array('association' => ClassMetadata::EMBED_MANY),
+        );
+        $metadata->getName()
+            ->willReturn($metadata->name);
+        $eventArgs->getClassMetadata()->willReturn($metadata);
+
+        $this->loadClassMetadata($superClassEventArgs);
+        $this->loadClassMetadata($eventArgs);
+
+        expect($metadata->associationMappings)->toBe(array(
+            'BarRefOne' => array('association' => ClassMetadata::REFERENCE_ONE),
+            'BarRefMany' => array('association' => ClassMetadata::REFERENCE_MANY),
+            'BarEmbedOne' => array('association' => ClassMetadata::EMBED_ONE),
+            'BarEmbedMany' => array('association' => ClassMetadata::EMBED_MANY),
+            'refOne' => array('association' => ClassMetadata::REFERENCE_ONE),
+            'refMany' => array('association' => ClassMetadata::REFERENCE_MANY),
+            'embedOne' => array('association' => ClassMetadata::EMBED_ONE),
+            'embedMany' => array('association' => ClassMetadata::EMBED_MANY),
+        ));
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/spec/EventListener/LoadORMMetadataSubscriberSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/EventListener/LoadORMMetadataSubscriberSpec.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\EventListener;
+
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+require_once __DIR__.'/../Fixture/Entity/Foo.php';
+require_once __DIR__ . '/../Fixture/Entity/MappedSuperclass.php';
+require_once __DIR__ . '/../Fixture/Entity/Bar.php';
+
+/**
+ * @author Benoît Burnichon <bburnichon@gmail.com>
+ */
+class LoadORMMetadataSubscriberSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $classes = array(
+            'foo' => array(
+                'model' => 'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\Foo',
+                'repository' => 'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\FooRepository',
+            ),
+        );
+
+        $this->beConstructedWith(
+            $classes
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\EventListener\LoadORMMetadataSubscriber');
+    }
+
+    function it_is_doctrine_event_subscriber()
+    {
+        $this->shouldImplement('Doctrine\Common\EventSubscriber');
+    }
+
+    function it_subscribes_events()
+    {
+        $this::getSubscribedEvents()->shouldReturn(array(
+            'loadClassMetadata',
+        ));
+    }
+
+    function it_should_set_custom_repository_class_and_force_model_to_entity(
+        LoadClassMetadataEventArgs $eventArgs,
+        ClassMetadata $metadata
+    ) {
+        $metadata->isMappedSuperclass = true;
+        $metadata->getName()
+            ->willReturn('spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\Foo');
+        $metadata->setCustomRepositoryClass('spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\FooRepository')
+            ->shouldBeCalled();
+        $eventArgs->getClassMetadata()->willReturn($metadata);
+
+        $this->loadClassMetadata($eventArgs);
+
+        expect($metadata->isMappedSuperclass)->toBe(false);
+    }
+
+    function it_should_unset_association_mappings_of_mapped_superclasses(
+        LoadClassMetadataEventArgs $eventArgs,
+        ClassMetadata $metadata
+    ) {
+        $metadata->isMappedSuperclass = true;
+        $metadata->name = 'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\MappedSuperclass';
+        $metadata->associationMappings = array(
+            'oneToOne' => array('type' => ClassMetadata::ONE_TO_ONE),
+            'oneToMany' => array('type' => ClassMetadata::ONE_TO_MANY),
+            'manyToOne' => array('type' => ClassMetadata::MANY_TO_ONE),
+            'manyToMany' => array('type' => ClassMetadata::MANY_TO_MANY),
+        );
+        $metadata->getName()
+            ->willReturn($metadata->name);
+        $metadata->getAssociationMappings()
+            ->willReturn($metadata->associationMappings);
+        $eventArgs->getClassMetadata()->willReturn($metadata);
+
+        $this->loadClassMetadata($eventArgs);
+
+        expect($metadata->associationMappings)->toBe(array(
+            'manyToOne' => array('type' => ClassMetadata::MANY_TO_ONE),
+        ));
+    }
+
+    function it_should_set_association_mappings_of_mapped_superclasses(
+        LoadClassMetadataEventArgs $superClassEventArgs,
+        ClassMetadata $superClassMetadata,
+        LoadClassMetadataEventArgs $eventArgs,
+        ClassMetadata $metadata
+    ) {
+        $superClassMetadata->isMappedSuperclass = true;
+        $superClassMetadata->name = 'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\MappedSuperclass';
+        $superClassMetadata->associationMappings = array(
+            'oneToOne' => array('type' => ClassMetadata::ONE_TO_ONE),
+            'oneToMany' => array('type' => ClassMetadata::ONE_TO_MANY),
+            'manyToOne' => array('type' => ClassMetadata::MANY_TO_ONE),
+            'manyToMany' => array('type' => ClassMetadata::MANY_TO_MANY),
+        );
+        $superClassMetadata->getName()
+            ->willReturn($superClassMetadata->name);
+        $superClassMetadata->getAssociationMappings()
+            ->willReturn($superClassMetadata->associationMappings);
+        $superClassEventArgs->getClassMetadata()->willReturn($superClassMetadata);
+
+        $metadata->isMappedSuperclass = false;
+        $metadata->name = 'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\Bar';
+        $metadata->associationMappings = array(
+            'BarOneToOne' => array('type' => ClassMetadata::ONE_TO_ONE),
+            'BarOneToMany' => array('type' => ClassMetadata::ONE_TO_MANY),
+            'BarManyToOne' => array('type' => ClassMetadata::MANY_TO_ONE),
+            'BarManyToMany' => array('type' => ClassMetadata::MANY_TO_MANY),
+        );
+        $metadata->getName()
+            ->willReturn($metadata->name);
+        $metadata->getAssociationMappings()
+            ->willReturn($metadata->associationMappings);
+        $eventArgs->getClassMetadata()->willReturn($metadata);
+
+        $this->loadClassMetadata($superClassEventArgs);
+        $this->loadClassMetadata($eventArgs);
+
+        expect($metadata->associationMappings)->toBe(array(
+            'BarOneToOne' => array('type' => ClassMetadata::ONE_TO_ONE),
+            'BarOneToMany' => array('type' => ClassMetadata::ONE_TO_MANY),
+            'BarManyToOne' => array('type' => ClassMetadata::MANY_TO_ONE),
+            'BarManyToMany' => array('type' => ClassMetadata::MANY_TO_MANY),
+            'oneToOne' => array('type' => ClassMetadata::ONE_TO_ONE),
+            'oneToMany' => array('type' => ClassMetadata::ONE_TO_MANY),
+            'manyToMany' => array('type' => ClassMetadata::MANY_TO_MANY),
+        ));
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/spec/Fixture/Entity/Bar.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Fixture/Entity/Bar.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\Fixture\Entity;
+
+/**
+ * Mapped Superclass entity.
+ *
+ * @author Benoît Burnichon <bburnichon@gmail.com>
+ */
+class Bar extends MappedSuperclass
+{
+}

--- a/src/Sylius/Bundle/ResourceBundle/spec/Fixture/Entity/MappedSuperclass.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Fixture/Entity/MappedSuperclass.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\Fixture\Entity;
+
+/**
+ * Mapped Superclass entity.
+ *
+ * @author Benoît Burnichon <bburnichon@gmail.com>
+ */
+class MappedSuperclass
+{
+}


### PR DESCRIPTION
refs #1630 

In my case, I want to be able to override attribute of numbered entity for example.

Not sure all cases are handled this way but seems to be working on my local tests. (ODM part not tested as I currently don't have this requirement)
