### PR TITLE
Disable GC in PHP on Travis-CI for performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
 before_script:
     - echo '' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
     - echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+    - echo "zend.enable_gc = 0" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
     - echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
     - export MINK_EXTENSION_PARAMS='base_url=http://localhost:8000/app_test.php'


### PR DESCRIPTION
This change gives quite a lot of performance (for big suites it works 2-2,5x faster!), while unfortunately wasting a bit more memory (~5-10%).
