### PR TITLE
Add back missing cart_locked state.

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Resources/config/state-machine.yml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/state-machine.yml
@@ -5,15 +5,22 @@ winzou_state_machine:
         graph:         sylius_order
         state_machine_class: Sylius\Component\Resource\StateMachine\StateMachine
         states:
-            cart:      ~
-            pending:   ~
-            released:  ~
-            confirmed: ~
-            shipped:   ~
-            abandoned: ~
-            cancelled: ~
-            returned:  ~
+            cart:        ~
+            cart_locked: ~
+            pending:     ~
+            released:    ~
+            confirmed:   ~
+            shipped:     ~
+            abandoned:   ~
+            cancelled:   ~
+            returned:    ~
         transitions:
+            lock_cart:
+                from: [cart]
+                to:   cart_locked
+            unlock_cart:
+                from: [cart_locked]
+                to:   cart
             create:
                 from: [cart]
                 to:   pending


### PR DESCRIPTION
It was missing from the `state-machine.yml`

See https://github.com/Sylius/Sylius/blob/256f1bb868656f4c7d3557765ec3b28aa68757f8/src/Sylius/Component/Order/Model/OrderInterface.php
/cc @winzou 
