### PR TITLE
[LocaleBundle] Add traditional calendar systems support and related twig functions

### DIFF
--- a/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/ArrayGregorianToCalendarSystemTransformer.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/ArrayGregorianToCalendarSystemTransformer.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\LocaleBundle\Form\DataTransformer;
+
+use Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelper;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+/**
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
+ */
+class ArrayGregorianToCalendarSystemTransformer implements DataTransformerInterface {
+
+    /**
+     * @var LocaleHelper
+     */
+    private $localeHelper;
+
+    /**
+     * Constructor.
+     *
+     * @param $localeHelper
+     */
+    public function __construct(LocaleHelper $localeHelper)
+    {
+        $this->localeHelper = $localeHelper;
+    }
+
+    /**
+     * Transforms a date array into a calendar-aware localized date array.
+     *
+     * @param array $date Normalized date array.
+     *
+     * @return array Translated localized date array.
+     */
+    public function transform($date)
+    {
+        if (!is_array($date)) {
+            throw new TransformationFailedException('Expected an array.');
+        }
+
+        if ($this->localeHelper->getCalendar() !== 'gregorian') {
+
+            $dateTime = \DateTime::createFromFormat('Y-m-d', $date['year'] . '-' . $date['month'] . '-' . $date['day']);
+            $translatedDate = $this->localeHelper->formatDate($dateTime, 'Y-m-d');
+
+            list($year, $month, $day) = explode('-', $translatedDate);
+
+            return array(
+                'year' => $year,
+                'month' => $month,
+                'day' => $day
+            );
+        } else {
+            return $date;
+        }
+    }
+
+    /**
+     * Transforms a calendar-aware localized date into a normalized date.
+     *
+     * @param array $value Normalized date array
+     *
+     * @return array Normalized date
+     *
+     * @throws TransformationFailedException If the given value is not an array.
+     */
+    public function reverseTransform($value)
+    {
+        if (!is_array($value)) {
+            throw new TransformationFailedException('Expected an array.');
+        }
+
+        if ($this->localeHelper->getCalendar() !== 'gregorian') {
+
+            // Use helper method `parseDate()` to translate the whole date
+            // stored inside the array to its corresponding localized version.
+            $dateTime = $this->localeHelper->parseDate($value['year'] . '-' . $value['month'] . '-' . $value['day'], 'Y-m-d');
+            list($year, $month, $day) = explode('-', $dateTime->format('Y-m-d'));
+
+            return array(
+                'year' => $year,
+                'month' => $month,
+                'day' => $day
+            );
+        } else {
+            return $value;
+        }
+    }
+} 

--- a/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/StringGregorianToCalendarSystemTransformer.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/StringGregorianToCalendarSystemTransformer.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\LocaleBundle\Form\DataTransformer;
+
+use Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelper;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
+ */
+class StringGregorianToCalendarSystemTransformer implements DataTransformerInterface {
+
+    /**
+     * @var string PHP-compatible date format
+     */
+    private $format;
+
+    /**
+     * @var LocaleHelper
+     */
+    private $localeHelper;
+
+    /**
+     * Constructor.
+     *
+     * @param string $format PHP-compatible date format
+     * @param LocaleHelper $localeHelper
+     *
+     */
+    public function __construct($format, LocaleHelper $localeHelper)
+    {
+        $this->format = $format;
+        $this->localeHelper = $localeHelper;
+    }
+
+    /**
+     * Transforms a date string into a calendar-aware localized date string.
+     *
+     * @param string $date Normalized date.
+     * @return string Translated localized date.
+     */
+    public function transform($date)
+    {
+        if ($this->localeHelper->getCalendar() !== 'gregorian') {
+
+            // Since symfony's default DateType is using \IntlDateFormatter
+            // but not correctly (Only sets locale and not calendar system)
+            // we need to use a IntlDateFormatter similar to one DateType used
+            // to change back everything to the original \DateTime that was used.
+            //
+            // For example when you set locale to `persian` it converts 2014
+            // to it's persian character (۲۰۱۴) representation.
+            // So we need to change it back to latin characters.
+            $originalFormatter = new \IntlDateFormatter(
+                \Locale::getDefault(),
+                null,
+                null,
+                'UTC',
+                \IntlDateFormatter::GREGORIAN,
+                LocaleHelper::convertDatePhpToIcu($this->format)
+            );
+
+            $dateTime = new \DateTime();
+            $dateTime->setTimestamp($originalFormatter->parse($date));
+
+            // Now we can easily translate teh date using helper method.
+            $translatedDate = $this->localeHelper->formatDate($dateTime, $this->format);
+
+            return $translatedDate;
+        } else {
+            return $date;
+        }
+    }
+
+    /**
+     * Transforms a calendar-aware localized date string into a normalized date string.
+     *
+     * @param string $value Translated localized date.
+     * @return string Normalized date.
+     */
+    public function reverseTransform($value)
+    {
+        if ($this->localeHelper->getCalendar() !== 'gregorian') {
+            $dateTime = $this->localeHelper->parseDate($value, $this->format);
+            return $dateTime->format($this->format);
+        } else {
+            return $value;
+        }
+    }
+}

--- a/src/Sylius/Bundle/LocaleBundle/Form/Extension/DateExtension.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/Extension/DateExtension.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\LocaleBundle\Form\Extension;
+
+use Sylius\Bundle\LocaleBundle\Form\DataTransformer\ArrayGregorianToCalendarSystemTransformer;
+use Sylius\Bundle\LocaleBundle\Form\DataTransformer\StringGregorianToCalendarSystemTransformer;
+use Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelper;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\AbstractTypeExtension;
+
+/**
+ * Class DateExtension
+ *
+ * Extension for DateType to add calendar-aware date capabilities
+ */
+class DateExtension extends AbstractTypeExtension {
+
+    /**
+     * @var LocaleHelper
+     */
+    protected $localeHelper;
+
+    /**
+     * @param LocaleHelper $helper
+     */
+    public function __construct(LocaleHelper $helper)
+    {
+        $this->localeHelper = $helper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        if ($this->localeHelper->getCalendar() === 'gregorian') {
+            // We only need to alter default behaviour when
+            // we're having a traditional calendar system.
+            return;
+        }
+
+        if ('single_text' === $options['widget']) {
+            // When date is in string format
+            $builder->addViewTransformer(new StringGregorianToCalendarSystemTransformer(
+                'Y-m-d',
+                $this->localeHelper
+            ));
+
+        } elseif ('array' === $options['input']) {
+            // When date is in array (of `year`, `month`, `day`) format
+            $builder->addViewTransformer(new ArrayGregorianToCalendarSystemTransformer(
+                $this->localeHelper
+            ));
+        }
+
+        switch ($options['widget']) {
+
+            // If widget is type of `choice` so we need to translate choice items
+            // stored in `choices` option of the field to their localized version.
+            case 'choice':
+
+                $this->translateChoices($builder, 'year', 'Y');
+                $this->translateChoices($builder, 'month', 'm');
+                $this->translateChoices($builder, 'day', 'd');
+
+                break;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function finishView(FormView $view, FormInterface $form, array $options)
+    {
+        if ('single_text' === $options['widget']) {
+            // Native browsers do not support different calendar systems
+            // so we have to use "text" type instead of "date" for the input.
+            if ($this->localeHelper->getCalendar() !== 'gregorian') {
+                // We only need to alter default behaviour when
+                // we're having a traditional calendar system.
+                $view->vars['type'] = 'text';
+            }
+        }
+    }
+
+    /**
+     * A helper method to translate choices of a date-related field
+     * to their localized version.
+     *
+     * e.g. For a year field it should
+     *      translate 2014 (gregorian) choice to to 1393 (persian)
+     *
+     * @param FormBuilderInterface $builder Form builder instance
+     * @param string $fieldName Field to translate its choices
+     * @param string $format PHP-compatible date format to read choices as!
+     */
+    private function translateChoices(FormBuilderInterface $builder, $fieldName, $format)
+    {
+        $field   = $builder->get($fieldName);
+
+        $options = $field->getOptions();
+        $type    = $field->getType()->getName();
+
+        if (isset($options['choices'])) {
+            $newValues = array();
+            $values = $options['choices'];
+
+            // Translate values
+            foreach ($values as $value => $presentation) {
+                $newVal = $this->localeHelper->formatDate(\DateTime::createFromFormat($format, $value), $format);
+                $newValues[$newVal] = $newVal;
+            }
+
+            $options['choices'] = $newValues;
+        }
+
+        unset($options['choice_list']);
+
+        // Replace the field
+        $builder->add($fieldName, $type, $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedType()
+    {
+        return 'date';
+    }
+} 

--- a/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
@@ -20,6 +20,7 @@
         <parameter key="sylius.locale_provider.class">Sylius\Bundle\LocaleBundle\Provider\LocaleProvider</parameter>
         <parameter key="sylius.event_listener.locale.class">Sylius\Bundle\LocaleBundle\EventListener\LocaleListener</parameter>
         <parameter key="sylius.context.locale.class">Sylius\Component\Locale\Context\LocaleContext</parameter>
+        <parameter key="sylius.locale.form.date_extension.class">Sylius\Bundle\LocaleBundle\Form\Extension\DateExtension</parameter>
     </parameters>
 
     <services>
@@ -39,9 +40,13 @@
             <argument>%sylius.locale%</argument>
         </service>
 
+        <service id="sylius.locale.form.date_extension" class="%sylius.locale.form.date_extension.class%">
+            <argument type="service" id="sylius.templating.helper.locale" />
+            <tag name="form.type_extension" alias="date" />
+        </service>
+
         <service id="sylius.event_listener.locale" class="%sylius.event_listener.locale.class%">
             <argument type="service" id="sylius.context.locale" />
-
             <tag name="kernel.event_subscriber" />
         </service>
     </services>

--- a/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
+++ b/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
@@ -16,6 +16,7 @@ use Symfony\Component\Templating\Helper\Helper;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
  */
 class LocaleHelper extends Helper
 {
@@ -24,6 +25,11 @@ class LocaleHelper extends Helper
      */
     private $localeContext;
 
+    /**
+     * Constructor.
+     *
+     * @param LocaleContextInterface $localeContext
+     */
     public function __construct(LocaleContextInterface $localeContext)
     {
         $this->localeContext = $localeContext;
@@ -37,6 +43,192 @@ class LocaleHelper extends Helper
     public function getLocale()
     {
         return $this->localeContext->getLocale();
+    }
+
+    /**
+     * Get currently active calendar system.
+     *
+     * @return string
+     */
+    public function getCalendar()
+    {
+        return $this->localeContext->getCalendar();
+    }
+
+    /**
+     * Get currently active language direction.
+     *
+     * @return string
+     */
+    public function getDirection()
+    {
+        return $this->localeContext->getDirection();
+    }
+
+    /**
+     * Format date in a calendar-aware fashion
+     *
+     * @param string|\DateTime     $date     Date to format
+     * @param string               $format   PHP-compatible date format
+     * @param string|\DateTimeZone $timezone Timezone
+     * @param string               $calendar Calendar name
+     *
+     * @return bool|string Calendar-aware localized formatted date
+     */
+    public function formatDate($date, $format = null, $timezone = null, $locale = null, $calendar = null)
+    {
+        // Determine the timezone
+        if (!$timezone) {
+            $timezone = date_default_timezone_get();
+        }
+
+        if (!$timezone instanceof \DateTimeZone) {
+            $timezone = new \DateTimeZone($timezone);
+        }
+
+        if ($locale === null) {
+            $locale = $this->localeContext->getLocale();
+        }
+
+        if ($calendar === null) {
+            $calendar = $this->localeContext->getCalendar();
+        }
+
+        if ($date instanceof \DateTime || $date instanceof \DateTimeInterface) {
+            $date = clone $date;
+
+            if (false !== $timezone) {
+                $date->setTimezone($timezone);
+            }
+        } else {
+            // If $date's string representation is somehow numeric,
+            // we'll assume it's a timestamp then prepend an @ and pass it to \DateTime.
+            $asString = (string) $date;
+            if (ctype_digit($asString) || (!empty($asString) && '-' === $asString[0] && ctype_digit(substr($asString, 1)))) {
+                $date = '@' . $date;
+            }
+
+            $date = new \DateTime($date, $timezone);
+        }
+
+        if ('gregorian' === $calendar || null === $calendar) {
+            return $date->format($format);
+        } else {
+            $dateFormatter = new \IntlDateFormatter("$locale@calendar=$calendar", null, null, $timezone, \IntlDateFormatter::TRADITIONAL, self::convertDatePhpToIcu($format));
+            return $dateFormatter->format($date);
+        }
+    }
+
+    /**
+     * Parses a calendar-aware localized date string to \DateTime
+     *
+     * @param string               $date     Date to parse
+     * @param string               $format   PHP-compatible date format
+     * @param string|\DateTimeZone $timezone Timezone
+     * @param string               $calendar Calendar name
+     *
+     * @return \DateTime
+     */
+    public function parseDate($date, $format, $timezone = null, $locale = null, $calendar = null)
+    {
+        // Determine the timezone
+        if (!$timezone) {
+            $timezone = date_default_timezone_get();
+        }
+
+        if (!$timezone instanceof \DateTimeZone) {
+            $timezone = new \DateTimeZone($timezone);
+        }
+
+        if ($locale === null) {
+            $locale = $this->localeContext->getLocale();
+        }
+
+        if ($calendar === null) {
+            $calendar = $this->localeContext->getCalendar();
+        }
+
+        $dateTime = new \DateTime(null, $timezone);
+
+        if ('gregorian' === $calendar || null === $calendar) {
+            $dateTime->setTimestamp(strtotime($date));
+        } else {
+            $dateFormatter = new \IntlDateFormatter("$locale@calendar=$calendar", null, null, $timezone, \IntlDateFormatter::TRADITIONAL, self::convertDatePhpToIcu($format));
+            $dateTime->setTimestamp($dateFormatter->parse($date));
+        }
+
+        return $dateTime;
+    }
+
+    /**
+     * The method below is borrowed from Yii Project
+     * (https://github.com/yiisoft/yii2/blob/master/framework/helpers/BaseFormatConverter.php#L241)
+     *
+     * Converts a date format pattern from [php date() function format][] to [ICU format][].
+     *
+     * The conversion is limited to date patterns that do not use escaped characters.
+     * Patterns like `jS \o\f F Y` which will result in a date like `1st of December 2014` may not be converted correctly
+     * because of the use of escaped characters.
+     *
+     * Pattern constructs that are not supported by the ICU format will be removed.
+     *
+     * [php date() function format]: http://php.net/manual/en/function.date.php
+     * [ICU format]: http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax
+     *
+     * @param string $pattern date format pattern in php date()-function format.
+     *
+     * @return string The converted date format pattern.
+     */
+    public static function convertDatePhpToIcu($pattern)
+    {
+        // Translation from PHP DateTime to UCI pattern
+        // http://php.net/manual/en/function.date.php
+        return strtr($pattern, array(
+            // Day
+            'd' => 'dd',    // Day of the month, 2 digits with leading zeros 	01 to 31
+            'D' => 'eee',   // A textual representation of a day, three letters 	Mon through Sun
+            'j' => 'd',     // Day of the month without leading zeros 	1 to 31
+            'l' => 'eeee',  // A full textual representation of the day of the week 	Sunday through Saturday
+            'N' => 'e',     // ISO-8601 numeric representation of the day of the week, 1 (for Monday) through 7 (for Sunday)
+            'S' => '',      // English ordinal suffix for the day of the month, 2 characters 	st, nd, rd or th. Works well with j
+            'w' => '',      // Numeric representation of the day of the week 	0 (for Sunday) through 6 (for Saturday)
+            'z' => 'D',     // The day of the year (starting from 0) 	0 through 365
+            // Week
+            'W' => 'w',     // ISO-8601 week number of year, weeks starting on Monday (added in PHP 4.1.0) 	Example: 42 (the 42nd week in the year)
+            // Month
+            'F' => 'MMMM',  // A full textual representation of a month, January through December
+            'm' => 'MM',    // Numeric representation of a month, with leading zeros 	01 through 12
+            'M' => 'MMM',   // A short textual representation of a month, three letters 	Jan through Dec
+            'n' => 'M',     // Numeric representation of a month, without leading zeros 	1 through 12, not supported by ICU but we fallback to "with leading zero"
+            't' => '',      // Number of days in the given month 	28 through 31
+            // Year
+            'L' => '',      // Whether it's a leap year, 1 if it is a leap year, 0 otherwise.
+            'o' => 'Y',     // ISO-8601 year number. This has the same value as Y, except that if the ISO week number (W) belongs to the previous or next year, that year is used instead.
+            'Y' => 'yyyy',  // A full numeric representation of a year, 4 digits 	Examples: 1999 or 2003
+            'y' => 'yy',    // A two digit representation of a year 	Examples: 99 or 03
+            // Time
+            'a' => 'a',     // Lowercase Ante meridiem and Post meridiem, am or pm
+            'A' => 'a',     // Uppercase Ante meridiem and Post meridiem, AM or PM, not supported by ICU but we fallback to lowercase
+            'B' => '',      // Swatch Internet time 	000 through 999
+            'g' => 'h',     // 12-hour format of an hour without leading zeros 	1 through 12
+            'G' => 'H',     // 24-hour format of an hour without leading zeros 0 to 23h
+            'h' => 'hh',    // 12-hour format of an hour with leading zeros, 01 to 12 h
+            'H' => 'HH',    // 24-hour format of an hour with leading zeros, 00 to 23 h
+            'i' => 'mm',    // Minutes with leading zeros 	00 to 59
+            's' => 'ss',    // Seconds, with leading zeros 	00 through 59
+            'u' => '',      // Microseconds. Example: 654321
+            // Timezone
+            'e' => 'VV',    // Timezone identifier. Examples: UTC, GMT, Atlantic/Azores
+            'I' => '',      // Whether or not the date is in daylight saving time, 1 if Daylight Saving Time, 0 otherwise.
+            'O' => 'xx',    // Difference to Greenwich time (GMT) in hours, Example: +0200
+            'P' => 'xxx',   // Difference to Greenwich time (GMT) with colon between hours and minutes, Example: +02:00
+            'T' => 'zzz',   // Timezone abbreviation, Examples: EST, MDT ...
+            'Z' => '',    // Timezone offset in seconds. The offset for timezones west of UTC is always negative, and for those east of UTC is always positive. -43200 through 50400
+            // Full Date/Time
+            'c' => 'yyyy-MM-dd\'T\'HH:mm:ssxxx', // ISO 8601 date, e.g. 2004-02-12T15:19:21+00:00
+            'r' => 'eee, dd MMM yyyy HH:mm:ss xx', // RFC 2822 formatted date, Example: Thu, 21 Dec 2000 16:01:07 +0200
+            'U' => '',      // Seconds since the Unix Epoch (January 1 1970 00:00:00 GMT)
+        ));
     }
 
     /**

--- a/src/Sylius/Bundle/LocaleBundle/Twig/LocaleExtension.php
+++ b/src/Sylius/Bundle/LocaleBundle/Twig/LocaleExtension.php
@@ -12,11 +12,13 @@
 namespace Sylius\Bundle\LocaleBundle\Twig;
 
 use Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelper;
+use Symfony\Component\Intl\Intl;
 
 /**
  * Sylius locale Twig helper.
  *
  * @author Paweł Jędrzejewski <pjedrzejewski@diweb.pl>
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
  */
 class LocaleExtension extends \Twig_Extension
 {
@@ -39,18 +41,105 @@ class LocaleExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            new \Twig_SimpleFunction('sylius_locale', array($this, 'getLocale')),
+            new \Twig_SimpleFilter('sylius_localized_date', array($this, 'dateFilter'),
+                array('needs_environment' => true)),
         );
     }
 
     /**
-     * Get currently selected locale code.
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction('sylius_locale', array($this, 'getLocale')),
+            new \Twig_SimpleFunction('sylius_language', array($this, 'getLanguage')),
+            new \Twig_SimpleFunction('sylius_direction', array($this, 'getDirection')),
+            new \Twig_SimpleFunction('sylius_calendar', array($this, 'getCalendar')),
+            new \Twig_SimpleFunction('sylius_rtl', array($this, 'isRtl')),
+        );
+    }
+
+    /**
+     * Returns localized language name from context or passed locale code
+     *
+     * @param string|null $code
      *
      * @return string
+     */
+    public function getLanguage($code = null)
+    {
+        if ($code === null) {
+            $code = $this->helper->getLocale();
+        }
+
+        return Intl::getLocaleBundle()->getLocaleName($code);
+    }
+
+    /**
+     * Returns currently active calendar system
+     *
+     * @return string Possible values are `gregorian`, `persian`, `islamic`, `hebrew`, etc.
+     */
+    public function getCalendar()
+    {
+        return $this->helper->getCalendar();
+    }
+
+    /**
+     * Returns currectly active locale
+     *
+     * @return string Locale code
      */
     public function getLocale()
     {
         return $this->helper->getLocale();
+    }
+
+    /**
+     * Returns current language direction
+     *
+     * @return string Possible values are `rtl` and `ltr`
+     */
+    public function getDirection()
+    {
+        return $this->helper->getDirection();
+    }
+
+    /**
+     * Checks whether if current language direction is RTL or not.
+     *
+     * @return bool True if language direction is RTL
+     */
+    public function isRtl()
+    {
+        return $this->helper->getDirection() === 'rtl';
+    }
+
+    /**
+     * Twig filter to format date in a calendar-aware fashion
+     *
+     * @param \Twig_Environment $env
+     * @param $date
+     * @param $timezone
+     * @param $format
+     *
+     * @return bool|string
+     * @throws \Twig_Error_Runtime
+     */
+    public function dateFilter(\Twig_Environment $env, $date, $format = null, $timezone = null)
+    {
+        if (null === $format) {
+            $formats = $env->getExtension('core')->getDateFormat();
+            $format = $date instanceof \DateInterval ? $formats[1] : $formats[0];
+        }
+
+        // Determine the timezone
+        if (!$timezone) {
+            $timezone = $env->getExtension('core')->getTimezone();
+        }
+
+        return $this->helper->formatDate($date, $format, $timezone);
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/views/layout.html.twig
@@ -47,7 +47,7 @@
             {% endblock %}
             <hr>
             <footer>
-                <p>&copy; <a href="http://Sylius.org">Sylius.org</a>, 2011 - {{ 'now'|date('Y') }}.</p>
+                <p>&copy; <a href="http://Sylius.org">Sylius.org</a>, 2011 - {{ 'now'|sylius_localized_date('Y') }}.</p>
             </footer>
         </div>
         {% block sylius_javascripts %}

--- a/src/Sylius/Bundle/TaxationBundle/Resources/views/TaxCategory/macros.html.twig
+++ b/src/Sylius/Bundle/TaxationBundle/Resources/views/TaxCategory/macros.html.twig
@@ -17,7 +17,7 @@
         <tr>
             <td>{{ tax_category.id }}</td>
             <td>{{ tax_category.name }}</td>
-            <td>{{ tax_category.updatedAt|date }}</td>
+            <td>{{ tax_category.updatedAt|sylius_localized_date }}</td>
             <td>
                 <div class="btn-group pull-right">
                     {{ buttons.show(path('sylius_tax_category_show', {'id': tax_category.id})) }}

--- a/src/Sylius/Bundle/TaxationBundle/Resources/views/TaxRate/macros.html.twig
+++ b/src/Sylius/Bundle/TaxationBundle/Resources/views/TaxRate/macros.html.twig
@@ -29,7 +29,7 @@
                 </span>
             </td>
             <td><span class="label label info">{{ tax_rate.calculator }}</span></td>
-            <td>{{ tax_rate.updatedAt|date }}</td>
+            <td>{{ tax_rate.updatedAt|sylius_localized_date }}</td>
             <td>
                 <div class="btn-group pull-right">
                     {{ buttons.show(path('sylius_tax_rate_show', {'id': tax_rate.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/Imagine/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/Imagine/macros.html.twig
@@ -27,9 +27,9 @@
                         {{ block.publishable ? 'sylius.yes'|trans : 'sylius.no'|trans }}
                     </span>
                 </td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.updatedAt|date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_imagine_block_update', {'id': block.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/Simple/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/Simple/macros.html.twig
@@ -27,9 +27,9 @@
                         {{ block.publishable ? 'sylius.yes'|trans : 'sylius.no'|trans }}
                     </span>
                 </td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.updatedAt|date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_simple_block_update', {'id': block.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/Slideshow/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/Slideshow/macros.html.twig
@@ -27,9 +27,9 @@
                         {{ block.publishable ? 'sylius.yes'|trans : 'sylius.no'|trans }}
                     </span>
                 </td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.updatedAt|date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_slideshow_block_update', {'id': block.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/String/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/String/macros.html.twig
@@ -27,9 +27,9 @@
                         {{ block.publishable ? 'sylius.yes'|trans : 'sylius.no'|trans }}
                     </span>
                 </td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.updatedAt|date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_string_block_update', {'id': block.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Menu/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Menu/macros.html.twig
@@ -26,8 +26,8 @@
                         {{ menu.publishable ? 'sylius.yes'|trans : 'sylius.no'|trans }}
                     </span>
                 </td>
-                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|date }}</td>
-                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|date }}</td>
+                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_menu_update', {'id': menu.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/MenuNode/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/MenuNode/macros.html.twig
@@ -27,8 +27,8 @@
                         {{ menu.publishable ? 'sylius.yes'|trans : 'sylius.no'|trans }}
                     </span>
                 </td>
-                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|date }}</td>
-                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|date }}</td>
+                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_menu_node_update', {'id': menu.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/StaticContent/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/StaticContent/macros.html.twig
@@ -26,8 +26,8 @@
                         {{ page.publishable ? 'sylius.yes'|trans : 'sylius.no'|trans }}
                     </span>
                 </td>
-                <td>{{ page.publishStartDate is empty ? '-' : page.publishStartDate|date }}</td>
-                <td>{{ page.publishStartDate is empty ? '-' : page.publishStartDate|date }}</td>
+                <td>{{ page.publishStartDate is empty ? '-' : page.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ page.publishStartDate is empty ? '-' : page.publishStartDate|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_static_content_update', {'id': page.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Coupon/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Coupon/macros.html.twig
@@ -41,7 +41,7 @@
                     {{ promotion_coupon.used }}
                 </span>
             </td>
-            <td>{{ promotion_coupon.expiresAt|date }}</td>
+            <td>{{ promotion_coupon.expiresAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_promotion_coupon_update', {'promotionId': promotion.id, 'id': promotion_coupon.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Currency/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Currency/macros.html.twig
@@ -26,7 +26,7 @@
                     {{ currency.enabled ? 'sylius.yes'|trans : 'sylius.no'|trans }}
                 </span>
             </td>
-            <td>{{ currency.updatedAt|date }}</td>
+            <td>{{ currency.updatedAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                 {{ buttons.edit(path('sylius_backend_currency_update', {'id': currency.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Email/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Email/macros.html.twig
@@ -23,7 +23,7 @@
                 <td>
                     {{ misc.state_label(email.enabled) }}
                 </td>
-                <td>{{ email.updatedAt|date }}</td>
+                <td>{{ email.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_email_update', {'id': email.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Inventory/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Inventory/macros.html.twig
@@ -68,7 +68,7 @@
                             {% for variant in product.variants %}
                                 <tr>
                                     <td>{{ variant.id }}</td>
-                                    <td><span class="label label-{{ variant.available ? 'success' : 'danger' }}">{{ variant.availableOn|date }}</span></td>
+                                    <td><span class="label label-{{ variant.available ? 'success' : 'danger' }}">{{ variant.availableOn|sylius_localized_date }}</span></td>
                                     <td>
                                         <ul>
                                         {% for option in variant.options %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Locale/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Locale/macros.html.twig
@@ -21,7 +21,7 @@
                 <td>
                     {{ misc.state_label(locale.enabled) }}
                 </td>
-                <td>{{ locale.updatedAt|date }}</td>
+                <td>{{ locale.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_locale_update', {'id': locale.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
@@ -30,7 +30,7 @@
         <div class="list-group">
             <div class="list-group-item">
                 <h4 class="list-group-item-heading">{{ 'sylius.order.created_at'|trans }}</h4>
-                <div class="list-group-item-text">{{ order.createdAt|date }}</div>
+                <div class="list-group-item-text">{{ order.createdAt|sylius_localized_date }}</div>
             </div>
             <div class="list-group-item">
                 <h4 class="list-group-item-heading">{{ 'sylius.order.order_state'|trans }}</h4>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/macros.html.twig
@@ -24,7 +24,7 @@
         {% for order in orders %}
         <tr id="{{ order.id }}" {% if order.deleted %} class="danger"{% endif %}>
             <td class="center-text"><input type="checkbox" value="{{ order.id }}" /></td>
-            <td>{{ order.createdAt|date }}</td>
+            <td>{{ order.createdAt|sylius_localized_date }}</td>
             <td>
                 <a href="{{ path('sylius_backend_order_show', {'id': order.id}) }}">
                     <strong>#{{ order.number }}</strong>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
@@ -49,7 +49,7 @@
         <h4>Order Details</h4>
         <dl>
             <dt>{{ 'sylius.order.created_at'|trans }}</dt>
-            <dd>{{ order.createdAt|date }}</dd>
+            <dd>{{ order.createdAt|sylius_localized_date }}</dd>
             <dt>Email</dt>
             <dd>
                 {% if order.user %}
@@ -232,7 +232,7 @@
                             {{ (comment.notifyCustomer ? 'sylius.order.comment.customer.notified' : 'sylius.order.comment.customer.not_notified')|trans }}
                         </span>
                     </td>
-                    <td>{{ comment.createdAt|date }}</td>
+                    <td>{{ comment.createdAt|sylius_localized_date }}</td>
                 </tr>
             {% endfor %}
                 <tr>
@@ -266,8 +266,8 @@
                     <td>{{ unit.inventoryName }}</td>
                     <td>{{ unit.inventoryState|humanize }}</td>
                     <td>{{ unit.shippingState|humanize }}</td>
-                    <td>{{ unit.createdAt|date }}</td>
-                    <td>{{ unit.updatedAt|date }}</td>
+                    <td>{{ unit.createdAt|sylius_localized_date }}</td>
+                    <td>{{ unit.updatedAt|sylius_localized_date }}</td>
                     <td>
                         {% for transition in ['backorder', 'sell', 'return'] if sm_can(unit, transition, 'sylius_inventory_unit') %}
                             <form action="{{ path('sylius_backend_inventory_unit_update_state', {'id': unit.id, 'transition': transition}) }}" method="post">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Payment/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Payment/macros.html.twig
@@ -26,8 +26,8 @@
                 {{ payment.amount|sylius_price(payment.currency) }}
             </td>
             <td>{{ misc.state_label(payment.state, 'payment') }}</td>
-            <td>{{ payment.createdAt|date }}</td>
-            <td>{{ payment.updatedAt|date }}</td>
+            <td>{{ payment.createdAt|sylius_localized_date }}</td>
+            <td>{{ payment.updatedAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_payment_update', {'id': payment.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/PaymentMethod/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/PaymentMethod/macros.html.twig
@@ -29,7 +29,7 @@
                     {{ payment_method.enabled ? 'sylius.yes'|trans : 'sylius.no'|trans }}
                 </span>
             </td>
-            <td>{{ payment_method.updatedAt|date }}</td>
+            <td>{{ payment_method.updatedAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                 {{ buttons.edit(path('sylius_backend_payment_method_update', {'id': payment_method.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Permission/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Permission/macros.html.twig
@@ -21,7 +21,7 @@
                     <strong>{{ permission.description }}</strong> <i>({{ permission.code }})</i>
                     </span>
                 </td>
-                <td>{{ permission.updatedAt|date }}</td>
+                <td>{{ permission.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_permission_update', {'id': permission.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/macros.html.twig
@@ -83,7 +83,7 @@
             {% endif %}
 
             <td class="updated-at">
-                {{ product.updatedAt|date('Y/m/d') }}
+                {{ product.updatedAt|sylius_localized_date('Y/m/d') }}
             </td>
             <td class="center-text">
                 {% if product.deleted %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
@@ -73,7 +73,7 @@
                 </tr>
                 <tr>
                     <td>{{ 'sylius.product.available_on'|trans }}</td>
-                    <td><span class="label label-{{ product.available ? 'success' : 'danger' }}">{{ product.availableOn|date }}</span></td>
+                    <td><span class="label label-{{ product.available ? 'success' : 'danger' }}">{{ product.availableOn|sylius_localized_date }}</span></td>
                 </tr>
                 <tr>
                     <td>{{ 'sylius.product.options'|trans }}</td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductArchetype/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductArchetype/macros.html.twig
@@ -37,7 +37,7 @@
                     {% endfor %}
                 </ul>
             </td>
-            <td>{{ archetype.updatedAt|date }}</td>
+            <td>{{ archetype.updatedAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                 {{ buttons.create(path('sylius_backend_product_create', {'archetype': archetype.code}), 'sylius.product.create'|trans) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductAttribute/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductAttribute/macros.html.twig
@@ -22,7 +22,7 @@
                 <td>{{ attribute.name }}</td>
                 <td>{{ attribute.presentation }}</td>
                 <td><span class="label label-primary">{{ attribute.type|upper }}</span></td>
-                <td>{{ attribute.updatedAt|date }}</td>
+                <td>{{ attribute.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_product_attribute_update', {'id': attribute.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductOption/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductOption/macros.html.twig
@@ -30,7 +30,7 @@
                         {% endfor %}
                     </ul>
                 </td>
-                <td>{{ option.updatedAt|date }}</td>
+                <td>{{ option.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_product_option_update', {'id': option.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/macros.html.twig
@@ -29,8 +29,8 @@
                 <img class="img-polaroid" src="{{ variant.images.offsetGet(0).path|imagine_filter('sylius_small') }}" />
             {% endif %}
             </td>
-            <td><span class="label label-{{ variant.available ? 'success' : 'important' }}">{{ variant.availableOn|date }}</span></td>
-            <td>{{ product.updatedAt|date }}</td>
+            <td><span class="label label-{{ variant.available ? 'success' : 'important' }}">{{ variant.availableOn|sylius_localized_date }}</span></td>
+            <td>{{ product.updatedAt|sylius_localized_date }}</td>
             <td>
                 <ul>
                 {% for option in variant.options %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Promotion/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Promotion/macros.html.twig
@@ -50,8 +50,8 @@
                     </span>
                 </td>
                 <td>{{ promotion.priority }}</td>
-                <td>{{ promotion.startsAt is empty ? '-' : promotion.startsAt|date }}</td>
-                <td>{{ promotion.endsAt is empty ? '-' : promotion.endsAt|date }}</td>
+                <td>{{ promotion.startsAt is empty ? '-' : promotion.startsAt|sylius_localized_date }}</td>
+                <td>{{ promotion.endsAt is empty ? '-' : promotion.endsAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                         {{ buttons.move(path('sylius_backend_promotion_move_up', {'id': promotion.id}), 'up', loop.first and not promotions.hasPreviousPage, loop.last and not promotions.hasNextPage) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Promotion/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Promotion/show.html.twig
@@ -53,11 +53,11 @@
                 </tr>
                 <tr>
                     <td><strong>{{ 'sylius.promotion.starts_at'|trans }}</strong></td>
-                    <td>{{ promotion.startsAt is empty ? '-' : promotion.startsAt|date }}</td>
+                    <td>{{ promotion.startsAt is empty ? '-' : promotion.startsAt|sylius_localized_date }}</td>
                 </tr>
                 <tr>
                     <td><strong>{{ 'sylius.promotion.ends_at'|trans }}</strong></td>
-                    <td>{{ promotion.endsAt is empty ? '-' : promotion.endsAt|date }}</td>
+                    <td>{{ promotion.endsAt is empty ? '-' : promotion.endsAt|sylius_localized_date }}</td>
                 </tr>
                 <tr>
                     <td><strong>{{ 'sylius.promotion.usage_limit'|trans }}</strong></td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Role/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Role/macros.html.twig
@@ -25,7 +25,7 @@
                 <td>
                     {{ role.description }}
                 </td>
-                <td>{{ role.updatedAt|date }}</td>
+                <td>{{ role.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_role_update', {'id': role.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/macros.html.twig
@@ -32,7 +32,7 @@
             <td>{{ misc.shipment_state(shipment.state) }}</td>
             <td>{{ address.firstname }} {{ address.lastname }} ({{ address.city }}, {{ address.country }})</td>
             <td class="text-center">{{ shipment.items|length }}</td>
-            <td>{{ shipment.createdAt|date }}</td>
+            <td>{{ shipment.createdAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                     {{ buttons.show(path('sylius_backend_shipment_show', {'id': shipment.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/show.html.twig
@@ -85,7 +85,7 @@
                 </tr>
                 <tr>
                     <td><strong>{{ 'sylius.order.created_at'|trans }}</strong></td>
-                    <td>{{ order.createdAt|date }}</td>
+                    <td>{{ order.createdAt|sylius_localized_date }}</td>
                 </tr>
             </tbody>
         </table>
@@ -128,8 +128,8 @@
                 <td>{{ item.inventoryName }}</td>
                 <td><span class="label label-success">{{ item.shippingState }}</span></td>
                 <td><span class="label label-{{ item.sold ? 'success' : 'important' }}">{{ item.inventoryState }}</span></td>
-                <td>{{ item.createdAt|date }}</td>
-                <td>{{ item.updatedAt|date }}</td>
+                <td>{{ item.createdAt|sylius_localized_date }}</td>
+                <td>{{ item.updatedAt|sylius_localized_date }}</td>
             </tr>
         {% endfor %}
         </tbody>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ShippingCategory/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ShippingCategory/macros.html.twig
@@ -18,7 +18,7 @@
             <tr id="{{ shipping_category.id }}">
                 <td>{{ shipping_category.id }}</td>
                 <td>{{ shipping_category.name }}</td>
-                <td>{{ shipping_category.updatedAt|date }}</td>
+                <td>{{ shipping_category.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_shipping_category_update', {'id': shipping_category.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ShippingMethod/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ShippingMethod/show.html.twig
@@ -43,7 +43,7 @@
                 </span>
             </td>
             <td><span class="label label-info">{{ shipping_method.calculator|humanize }}</span></td>
-            <td>{{ shipping_method.updatedAt|date }}</td>
+            <td>{{ shipping_method.updatedAt|sylius_localized_date }}</td>
         </tr>
     </tbody>
 </table>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/TaxCategory/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/TaxCategory/macros.html.twig
@@ -20,7 +20,7 @@
             <td>{{ tax_category.id }}</td>
             <td>{{ tax_category.name }}</td>
             <td>{{ tax_category.description|default('sylius.tax_category.no_description'|trans) }}</td>
-            <td>{{ tax_category.updatedAt|date }}</td>
+            <td>{{ tax_category.updatedAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_tax_category_update', {'id': tax_category.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/TaxRate/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/TaxRate/macros.html.twig
@@ -31,7 +31,7 @@
                 {{ misc.state_label(tax_rate.includedInPrice) }}
             </td>
             <td><span class="label label-primary">{{ tax_rate.calculator|humanize|upper }}</span></td>
-            <td>{{ tax_rate.updatedAt|date }}</td>
+            <td>{{ tax_rate.updatedAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                 {{ buttons.show(path('sylius_backend_tax_rate_show', {'id': tax_rate.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/User/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/User/macros.html.twig
@@ -24,7 +24,7 @@
             <td>{{ user.firstName }}</td>
             <td>{{ user.lastName }}</td>
             <td><a href="{{ path('sylius_backend_user_show', {'id': user.id}) }}">{{ user.email }}</a></td>
-            <td>{{ user.createdAt|date('d-m-Y H:i') }}</td>
+            <td>{{ user.createdAt|sylius_localized_date('d-m-Y H:i') }}</td>
             <td>
                 {{ misc.state_label(user.enabled) }}
             </td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/User/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/User/show.html.twig
@@ -71,7 +71,7 @@
             {% if user.lastLogin %}
                 <tr>
                     <td><strong>{{ 'sylius.user.last_login'|trans }}</strong></td>
-                    <td>{{ user.lastLogin|date }}</td>
+                    <td>{{ user.lastLogin|sylius_localized_date }}</td>
                 </tr>
             {% endif %}
             <tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/_history_table.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/_history_table.html.twig
@@ -1,6 +1,6 @@
 {% macro formatValue(key, value) %}
 {% if value.timestamp is defined %}
-    {{ value|date() }}
+    {{ value|sylius_localized_date() }}
 {% elseif key == 'price' or key == 'unitPrice' %}
     {{ value|sylius_price() }}
 {% elseif value is empty %}
@@ -28,7 +28,7 @@
     {% for log in logs %}
         <tr>
             <td><span class="label label-{{ log.action == 'danger' ? 'warning' : (log.action == 'update' ? 'success' : 'primary') }}">{{ log.action|upper }}</span></td>
-            <td>{{ log.loggedAt|date }} (#{{ log.version }})</td>
+            <td>{{ log.loggedAt|sylius_localized_date }} (#{{ log.version }})</td>
             <td>
                 {% if log.data is not empty %}
                 <ul>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/layout.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/layout.html.twig
@@ -63,7 +63,7 @@
                     {% include 'SyliusWebBundle::confirm-modal.html.twig' %}
 
                     <footer>
-                        <p>&copy; <a href="http://Sylius.org">Sylius</a>, 2011 - {{ 'now'|date('Y') }}.</p>
+                        <p>&copy; <a href="http://Sylius.org">Sylius</a>, 2011 - {{ 'now'|sylius_localized_date('Y') }}.</p>
                     </footer>
                 </div>
             </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Common/forms.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Common/forms.html.twig
@@ -18,6 +18,11 @@
     {% if 'file' == type %}
         <span class="btn-primary btn-lg file-overlay"><i class="icon-folder-open"></i> {{ 'sylius.form.choose_file'|trans }}</span>
     {% endif %}
+
+    {% if 'datepicker' in attr.class %}
+        {% set attr = attr|merge({'data-locale': sylius_locale(), 'data-direction': sylius_direction()}) %}
+    {% endif %}
+
     {{ parent() }}
 {% endspaceless %}
 {% endblock form_widget_simple %}
@@ -61,6 +66,7 @@
 {% block date_widget %}
 {% spaceless %}
     {% if widget == 'single_text' %}
+        {% set attr = attr|merge({'data-calendar': sylius_calendar()}) %}
         {{ block('form_widget_simple') }}
     {% else %}
             {{ '{{ year }} / {{ month }} / {{ day }}'|replace({

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
@@ -4,7 +4,7 @@
 
 <div class="row well well-sm" id="information">
     <div class="col-md-6">
-        <strong>{{ 'sylius.account.order.created_at'|trans }} {{ order.createdAt|date() }}</strong><br><br>
+        <strong>{{ 'sylius.account.order.created_at'|trans }} {{ order.createdAt|sylius_localized_date() }}</strong><br><br>
         {#{{ 'sylius.account.order.shipment_mode'|trans }} <strong>TODO</strong><br>#}
         {#{{ 'sylius.account.order.payment_mode'|trans }} <strong>TODO</strong><br>#}
     </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_list.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_list.html.twig
@@ -14,7 +14,7 @@
             <tbody>
             {% for order in orders %}
                 <tr class="order" id="order-{{ order.number }}">
-                    <td>{{ order.createdAt|date }}</td>
+                    <td>{{ order.createdAt|sylius_localized_date }}</td>
                     <td>{{ order.number }}</td>
                     <td>{{ order.total|sylius_money }}</td>
                     <td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_state.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_state.html.twig
@@ -1,11 +1,11 @@
 {% set shipment = order.lastShipment %}
 {% if shipment %}
-    {{ ('sylius.account.order.shipment.' ~ shipment.state) |trans({'%at%': shipment.updatedAt|date}) }}
+    {{ ('sylius.account.order.shipment.' ~ shipment.state) |trans({'%at%': shipment.updatedAt|sylius_localized_date}) }}
     {% if shipment.tracking %}
         <br>
         {{ 'sylius.account.order.tracking_number'|trans}}
         {{ shipment.tracking }}
     {% endif %}
 {% else %}
-    {{ 'sylius.account.order.placed_at'|trans({'%at%': order.createdAt|date}) }}
+    {{ 'sylius.account.order.placed_at'|trans({'%at%': order.createdAt|sylius_localized_date}) }}
 {% endif %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Profile/index.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Profile/index.html.twig
@@ -15,7 +15,7 @@
             <strong>{{ user.lastName|upper }} {{ user.firstName }}</strong><br><br>
             {{ 'sylius.account.home.id'|trans }} {{ user.id }} <br>
             {{ 'sylius.account.home.email'|trans }} {{ user.email }}<br>
-            {{ 'sylius.account.home.since'|trans }} {{ user.createdAt|date() }}
+            {{ 'sylius.account.home.since'|trans }} {{ user.createdAt|sylius_localized_date() }}
         </div>
     </div>
 

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/layout.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/layout.html.twig
@@ -129,7 +129,7 @@
         {% block footer %}
             <div class="footer">
                 <p class="text-muted">
-                    &copy; Sylius, 2011 - {{ 'now'|date('Y') }}.
+                    &copy; Sylius, 2011 - {{ 'now'|sylius_localized_date('Y') }}.
                 </p>
                 {{ knp_menu_render('sylius.frontend.social', {'template': 'SyliusWebBundle:Frontend:menu.html.twig'}) }}
             </div>

--- a/src/Sylius/Component/Locale/Context/LocaleContext.php
+++ b/src/Sylius/Component/Locale/Context/LocaleContext.php
@@ -18,6 +18,7 @@ use Sylius\Component\Storage\StorageInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Joseph Bielawski <stloyd@gmail.com>
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
  */
 class LocaleContext implements LocaleContextInterface
 {
@@ -34,6 +35,59 @@ class LocaleContext implements LocaleContextInterface
      * @var StorageInterface
      */
     protected $storage;
+
+    /**
+     * Meta data for special languages,
+     * by default we assume that all languages are LTR except mentioned otherwise.
+     *
+     * TODO This list should be completed
+     *
+     * @var array
+     */
+    protected static $localeMetaData = array(
+        'fa' => array(
+            'direction' => 'rtl',
+            'calendar' => 'persian'
+        ),
+        'fa_IR' => array(
+            'direction' => 'rtl',
+            'calendar' => 'persian'
+        ),
+        'fa_AF' => array(
+            'direction' => 'rtl',
+            'calendar' => 'persian'
+        ),
+        'ar' => array(
+            'direction' => 'rtl',
+            'calendar' => 'islamic'
+        ),
+        'ckb' => array(
+            'direction' => 'rtl',
+            'calendar' => 'persian'
+        ),
+        'he_IL' => array(
+            'direction' => 'rtl',
+            'calendar' => 'hebrew'
+        ),
+        'ug_CN' => array(
+            'direction' => 'rtl',
+        ),
+        'dv' => array(
+            'direction' => 'rtl',
+        ),
+        'ha' => array(
+            'direction' => 'rtl',
+        ),
+        'ps' => array(
+            'direction' => 'rtl',
+        ),
+        'uz_UZ' => array(
+            'direction' => 'rtl',
+        ),
+        'yi' => array(
+            'direction' => 'rtl',
+        )
+    );
 
     public function __construct(StorageInterface $storage, $defaultLocale)
     {
@@ -63,5 +117,25 @@ class LocaleContext implements LocaleContextInterface
     public function setLocale($locale)
     {
         return $this->storage->setData(self::STORAGE_KEY, $locale);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getCalendar()
+    {
+        $code = $this->getLocale();
+        return @self::$localeMetaData[$code]['calendar'] ?: 'gregorian';
+    }
+
+    /**
+     * Get the currently active language direction.
+     *
+     * @return string
+     */
+    public function getDirection()
+    {
+        $code = $this->getLocale();
+        return @self::$localeMetaData[$code]['direction'] ?: 'ltr';
     }
 }

--- a/src/Sylius/Component/Locale/Context/LocaleContextInterface.php
+++ b/src/Sylius/Component/Locale/Context/LocaleContextInterface.php
@@ -16,6 +16,7 @@ namespace Sylius\Component\Locale\Context;
  * locale.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
  */
 interface LocaleContextInterface
 {
@@ -42,4 +43,21 @@ interface LocaleContextInterface
      * @param string $locale
      */
     public function setLocale($locale);
+
+    /**
+     * Get the currently active language direction.
+     *
+     * @return string Possible values are `rtl` and `ltr`
+     */
+    public function getDirection();
+
+    /**
+     * Get the currently active calendar system.
+     *
+     * @return string Possible values are:
+     *              gregorian, japanese, buddhist,
+     *              chinese, persian, indian, islamic,
+     *              hebrew, coptic, ethiopic
+     */
+    public function getCalendar();
 }


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | no
New feature?  | yes
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

This is a proposal to add support for traditional calendar systems into Sylius. I'm so new to Symfony2 so please forgive me if you see some bad practices ;)

Your comments are really appreciated ;)

Here is a list of twig filters/functions I've added:
* `sylius_localized_date([date], [format], [timezone])` Twig date filter with calendar-aware conversion, based on current locale.
* `sylius_language([code])` Returns localized language name of current (or provided) locale code.
* `sylius_rtl()` Returns true if current locale code is of an RTL-type language. e.g  If current locale is RTL so that we can load RTL stylesheets and whatnot.
* `sylius_direction()` Returns current locale language direction. (`rtl`, `ltr`)
* `sylius_calendar()` Returns current locale calendar system. (`gregorian`, `persian`, `hebrew`, `islamic`, etc)

* I've created a TypeExtension for Symfony's `date` FormType to support calendar-aware dates.