### PR TITLE
Sylius install build search index and cache clear

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Command/InstallCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/InstallCommand.php
@@ -88,7 +88,9 @@ class InstallCommand extends ContainerAwareCommand
         $this
             ->runCommand('doctrine:database:create', $input, $output)
             ->runCommand('doctrine:schema:create', $input, $output)
+            ->runCommand('cache:clear', $input, $output)
             ->runCommand('doctrine:phpcr:repository:init', $input, $output)
+            ->runCommand('sylius:search:index', $input, $output)
             ->runCommand('assets:install', $input, $output)
             ->runCommand('assetic:dump', $input, $output)
         ;


### PR DESCRIPTION
-On initial run of sylius:install #2276 search is broken because the indexes are not built
-During re-runs of sylius:install the cache needs to be cleared before running phpcr's init to remove old workspace
