### PR TITLE
Enforce the size limitation of the short_description field

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation.xml
@@ -44,6 +44,16 @@
         </property>
     </class>
 
+    <class name="Sylius\Component\Core\Model\ProductTranslation">
+        <property name="shortDescription">
+            <constraint name="Length">
+                <option name="max">255</option>
+                <option name="maxMessage">sylius.product_translation.short_description.max</option>
+                <option name="groups">sylius</option>                
+            </constraint>
+        </property>
+    </class>
+
     <class name="Sylius\Component\Core\Model\ProductVariant">
         <constraint name="Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity">
             <option name="fields">sku</option>

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.en.yml
@@ -24,6 +24,10 @@ sylius:
         price:
             min: Price must not be negative.
             not_blank: Please enter the price.
+    product_translation:
+        short_description:
+            max: Short description must not be longer then {{ limit }} characters.
+
 sylius_shipping:
     method:
         zone:


### PR DESCRIPTION
When creating a translatable product in the administration a
SQL error is generated if this field is too long.
