### PR TITLE
Fix ability to specify form via class name.

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -324,7 +324,9 @@ class ResourceController extends FOSRestController
     {
         $type = $this->config->getFormType();
 
-        if (!$this->get('form.registry')->hasType($type)) {
+        if (strpos($type, '\\') !== false) { // full class name specified
+            $type = new $type();
+        } elseif (!$this->get('form.registry')->hasType($type)) { // form alias is not registered
             $defaultFormFactory = new DefaultFormFactory($this->container->get('form.factory'));
 
             return $defaultFormFactory->create($resource, $this->container->get($this->config->getServiceName('manager')));
@@ -332,10 +334,6 @@ class ResourceController extends FOSRestController
 
         if ($this->config->isApiRequest()) {
             return $this->container->get('form.factory')->createNamed('', $type, $resource, array('csrf_protection' => false));
-        }
-
-        if (strpos($type, '\\') !== false) {
-            $type = new $type;
         }
 
         return $this->createForm($type, $resource);

--- a/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ResourceControllerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Sylius/Bundle/ResourceBundle/Controller/ResourceControllerSpec.php
@@ -2,8 +2,19 @@
 
 namespace spec\Sylius\Bundle\ResourceBundle\Controller;
 
+use Doctrine\Common\Persistence\ObjectManager;
+
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Sylius\Bundle\ResourceBundle\Controller\Configuration;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Resource controller spec.
@@ -12,9 +23,28 @@ use Sylius\Bundle\ResourceBundle\Controller\Configuration;
  */
 class ResourceControllerSpec extends ObjectBehavior
 {
-    function let(Configuration $configuration)
-    {
+    function let(
+        Configuration $configuration,
+        ContainerInterface $container,
+        RouterInterface $router,
+        SessionInterface $session,
+        TranslatorInterface $translator,
+        ObjectManager $objectManager,
+        EventDispatcherInterface $eventDispatcher,
+        FormFactoryInterface $formFactory
+    ) {
         $this->beConstructedWith($configuration);
+        $configuration->isApiRequest()->willReturn(false);
+
+        $configuration->getServiceName('manager')->willReturn('some_manager');
+        $container->get('router')->willReturn($router);
+        $container->get('session')->willReturn($session);
+        $container->get('translator')->willReturn($translator);
+        $container->get('some_manager')->willReturn($objectManager);
+        $container->get('event_dispatcher')->willReturn($eventDispatcher);
+        $container->get('form.factory')->willReturn($formFactory);
+
+        $this->setContainer($container);
     }
 
     function it_is_initializable()
@@ -25,5 +55,28 @@ class ResourceControllerSpec extends ObjectBehavior
     function it_is_a_controller()
     {
         $this->shouldHaveType('Symfony\Bundle\FrameworkBundle\Controller\Controller');
+    }
+
+    function it_gets_form_from_class_name(
+        Configuration $configuration,
+        FormFactoryInterface $formFactory,
+        FormInterface $form
+    ) {
+        $formClass = 'spec\Sylius\Bundle\ResourceBundle\Controller\TestFormType';
+        $configuration->getFormType()->willReturn($formClass);
+        $formFactory->create(Argument::type($formClass), Argument::cetera())->shouldBeCalled()->willReturn($form);
+
+        $this->getForm()->shouldReturn($form);
+    }
+}
+
+class TestFormType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sylius_test_form';
     }
 }


### PR DESCRIPTION
According to documentation we should be able to specify the form class directly, but this is not the case, unless the form is also registered in the form factory. This PR fixes this, but also highlights how much mocking overhead comes with testing the resource controller.
