### PR TITLE
[WebBundle] Fix error in finalize step

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
@@ -115,7 +115,9 @@
 
 <div class="form-horizontal">
     <div class="form-actions">
+        {% if context.previousStep is not null %}
         <a href="{{ path(context.process.displayRoute, {'stepName': context.previousStep.name}) }}" class="btn btn-lg"><i class="icon-chevron-left"></i> {{ 'sylius.checkout.back'|trans }}</a> &nbsp;
+        {% endif %}
         <a href="{{ path(context.process.forwardRoute, {'stepName': context.currentStep.name}) }}" class="btn btn-lg btn-success"><i class="icon-ok"></i> {{ 'sylius.checkout.finalize.place_order'|trans }}</a> &nbsp;
     </div>
 </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | [yes]
| New feature?  | [no]
| BC breaks?    | [no]
| Deprecations? | no]
| Fixed tickets | None
| License       | MIT

If you have a checkout process consisting of only one step there is no previous step.  Hence the view gives an error.   A simple test is introduced to mitigate this problem