### PR TITLE
Fixed ShippingMethod validation

### DIFF
--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/validation.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/validation.xml
@@ -33,19 +33,6 @@
     </class>
 
     <class name="Sylius\Component\Shipping\Model\ShippingMethod">
-        <property name="name">
-            <constraint name="NotBlank">
-                <option name="message">sylius.shipping_method.name.not_blank</option>
-                <option name="groups">sylius</option>
-            </constraint>
-            <constraint name="Length">
-                <option name="min">2</option>
-                <option name="max">255</option>
-                <option name="minMessage">sylius.shipping_method.name.min_length</option>
-                <option name="maxMessage">sylius.shipping_method.name.max_length</option>
-                <option name="groups">sylius</option>
-            </constraint>
-        </property>
         <property name="translations">
             <constraint name="Valid" />
         </property>


### PR DESCRIPTION
Removed constraints for ``name`` property from ``ShippingMethod`` since it is moved to ``ShippingMethodTranslation``.
This was preventing creation of new ShippingMethod from backend.