### PR TITLE
Allow to use Doctrine MongoDB registry if default Doctrine is not available

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Compiler/ObjectToIdentifierServicePass.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Compiler/ObjectToIdentifierServicePass.php
@@ -33,6 +33,9 @@ class ObjectToIdentifierServicePass implements CompilerPassInterface
             $definition->addTag('form.type', array('alias' => 'sylius_entity_to_identifier'));
 
             $container->setDefinition('sylius_entity_to_identifier', $definition);
+
+            $definition = $container->findDefinition('sylius.form.type.entity_hidden');
+            $definition->replaceArgument(0, new Reference('doctrine'));
         }
 
         if ($container->hasDefinition('doctrine_mongodb')) {
@@ -45,6 +48,11 @@ class ObjectToIdentifierServicePass implements CompilerPassInterface
 
             if (!$container->hasDefinition('sylius_entity_to_identifier')) {
                 $container->setAlias('sylius_entity_to_identifier', 'sylius_document_to_identifier');
+            }
+
+            if (!$container->hasDefinition('doctrine')) {
+                $definition = $container->findDefinition('sylius.form.type.entity_hidden');
+                $definition->replaceArgument(0, new Reference('doctrine_mongodb'));
             }
         }
 

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
@@ -22,9 +22,9 @@
         <parameter key="sylius.controller.parameters.class">Sylius\Bundle\ResourceBundle\Controller\Parameters</parameter>
         <parameter key="sylius.expression_language.class">Sylius\Bundle\ResourceBundle\ExpressionLanguage\ExpressionLanguage</parameter>
 
+        <parameter key="sylius.form.extension.collection.class">Sylius\Bundle\ResourceBundle\Form\Extension\CollectionExtension</parameter>
         <parameter key="sylius.form.type.entity_hidden.class">Sylius\Bundle\ResourceBundle\Form\Type\EntityHiddenType</parameter>
         <parameter key="sylius.form.type.object_to_identifier.class">Sylius\Bundle\ResourceBundle\Form\Type\ObjectToIdentifierType</parameter>
-        <parameter key="sylius.form.extension.collection.class">Sylius\Bundle\ResourceBundle\Form\Extension\CollectionExtension</parameter>
         <parameter key="sylius.form.type.resource_choice.class">Sylius\Bundle\ResourceBundle\Form\Type\ResourceChoiceType</parameter>
 
         <parameter key="sylius.event_subscriber.load_orm_metadata.class">Sylius\Bundle\ResourceBundle\EventListener\LoadORMMetadataSubscriber</parameter>
@@ -34,6 +34,7 @@
 
         <!-- Sylius State Machine -->
         <parameter key="sylius.state_machine.class">Sylius\Component\Resource\StateMachine\StateMachine</parameter>
+
         <parameter key="symfony.expression.language.class">Sylius\Bundle\ResourceBundle\ExpressionLanguage\ExpressionLanguage</parameter>
     </parameters>
 
@@ -69,12 +70,11 @@
         </service>
 
         <service id="sylius.form.type.entity_hidden" class="%sylius.form.type.entity_hidden.class%">
-            <argument type="service" id="doctrine" />
+            <argument /> <!-- Argument set by compiler pass -->
             <tag name="form.type" alias="entity_hidden" />
         </service>
         <service id="sylius.form.type.object_to_identifier" class="%sylius.form.type.object_to_identifier.class%" abstract="true" />
-        <service id="sylius.form.extension.collection"
-                 class="%sylius.form.extension.collection.class%">
+        <service id="sylius.form.extension.collection" class="%sylius.form.extension.collection.class%">
             <tag name="form.type_extension" alias="collection" />
         </service>
     </services>


### PR DESCRIPTION
Should fix #2201.