### PR TITLE
Hide the "Links" sidebar widget when there are no links.

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/translations/menu.en.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/menu.en.yml
@@ -92,6 +92,8 @@ sylius:
                 login: Login
                 logout: Logout
                 register: Register
+            sidebar:
+                links: Links
             social:
                 facebook: Facebook
                 github: GitHub

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/menu.fr.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/menu.fr.yml
@@ -87,6 +87,8 @@ sylius:
         login: Connexion
         logout: Déconnexion
         register: Créer un compte
+      sidebar:
+        links: Liens
       social:
         facebook: Facebook
         github: GitHub

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/menu.fr.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/menu.fr.yml
@@ -87,8 +87,6 @@ sylius:
         login: Connexion
         logout: Déconnexion
         register: Créer un compte
-      sidebar:
-        links: Liens
       social:
         facebook: Facebook
         github: GitHub

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/layout.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/layout.html.twig
@@ -89,14 +89,17 @@
                 {{ sonata_block_render({'name': '/cms/blocks/banner'}) }}
                 {% block slideshow_sidebar %}{% endblock %}
 
-                    <h2>Links</h2>
-                    <ul>
-                    {% for child in cmf_children(cmf_find('/cms/pages')) %}
-                        <li>
-                            <a href="{{ path(child) }}">{{ child.title|striptags }}</a>
-                        </li>
-                    {% endfor %}
-                    </ul>
+                {% set links = cmf_children(cmf_find('/cms/pages')) %}
+                {% if links is not empty %}
+                <h2>{{ 'sylius.frontend.menu.sidebar.links'|trans }}</h2>
+                <ul>
+                  {% for link in links %}
+                    <li>
+                      <a href="{{ path(link) }}">{{ link.title|striptags }}</a>
+                    </li>
+                  {% endfor %}
+                </ul>
+                {% endif %}
                 {% endblock %}
             </div>
             <div class="col-md-9">


### PR DESCRIPTION
Also, add the "Links" header to the translation mapping (en and fr).

I'm not sure how to add the `'sylius.frontend.menu.sidebar.links'` translation to other languages, especially given that their mappings' indentations are inconsistent (sometimes 2 spaces, sometimes 4).

This PR is mostly a paper-cut fix, but I'm new to Sylius so... low hanging fruit and such...

Also, maybe the Links widget should be in his own block, to ease overriding ? I'm not sure how you envision this ; I'm new ! :)

Do tell me if you think this needs more work, I plan to spend some time on Sylius in the next couple of months.