### PR TITLE
getLastShipment returns false, not null. fixed in isInvoiceAvailable

### DIFF
--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -479,7 +479,7 @@ class Order extends Cart implements OrderInterface
      */
     public function isInvoiceAvailable()
     {
-        if (null !== $lastShipment = $this->getLastShipment()) {
+        if (false !== $lastShipment = $this->getLastShipment()) {
             return in_array($lastShipment->getState(), array(ShipmentInterface::STATE_RETURNED, ShipmentInterface::STATE_SHIPPED));
         }
 


### PR DESCRIPTION
While working with Sylius I ran into an error on the order page. It turns out that because getLastShipment returns false when there are no shipments but isInvoiceAvailable tests for null, the if is entered and getState is executed on a non-object.

In an earlier version the docblock actually said getLastShipment would return null (but it did return false). I've updated isInvoiceAvailable to reflect the docblock and behaviour.