### PR TITLE
[Taxonomy] [Web] Sortable integration for taxons

### DIFF
--- a/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonType.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonType.php
@@ -33,6 +33,9 @@ class TaxonType extends AbstractResourceType
                 'form_type' => new TaxonTranslationType($this->dataClass.'Translation', $this->validationGroups),
                 'label'    => 'sylius.form.taxon.name'
             ))
+            ->add('position', 'integer', array(
+                'label'    => 'sylius.form.taxon.position'
+            ))
             ->addEventSubscriber(new BuildTaxonFormListener($builder->getFormFactory()))
         ;
     }

--- a/src/Sylius/Bundle/TaxonomyBundle/Resources/config/doctrine/model/Taxon.orm.xml
+++ b/src/Sylius/Bundle/TaxonomyBundle/Resources/config/doctrine/model/Taxon.orm.xml
@@ -30,6 +30,7 @@
         <many-to-one field="parent" target-entity="Sylius\Component\Taxonomy\Model\TaxonInterface" inversed-by="children">
             <join-column name="parent_id" referenced-column-name="id" nullable="true" on-delete="CASCADE" />
             <gedmo:tree-parent />
+			<gedmo:sortable-group />
         </many-to-one>
 
         <one-to-many field="children" target-entity="Sylius\Component\Taxonomy\Model\TaxonInterface" mapped-by="parent">
@@ -37,7 +38,7 @@
                 <cascade-all />
             </cascade>
             <order-by>
-                <order-by-field name="left" direction="ASC" />
+                <order-by-field name="position" direction="ASC" />
             </order-by>
         </one-to-many>
 
@@ -53,6 +54,10 @@
         </field>
         <field name="level" column="tree_level" type="integer">
             <gedmo:tree-level />
+        </field>
+		
+        <field name="position" column="position" type="integer">
+            <gedmo:sortable-position />
         </field>
 
         <field name="deletedAt" column="deleted_at" type="datetime" nullable="true" />

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/_form.html.twig
@@ -3,6 +3,7 @@
 <fieldset>
     {{ form_row(form.translations, {'attr': {'class': 'input-lg'}}) }}
     {{ form_row(form.parent, {'attr': {'class': 'input-lg'} }) }}
+    {{ form_row(form.position) }}
     {{ form_row(form.file) }}
 </fieldset>
 

--- a/src/Sylius/Component/Resource/Model/SortableInterface.php
+++ b/src/Sylius/Component/Resource/Model/SortableInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Resource\Model;
+
+/**
+ * @author Matthias Esterl <inventor@madcity.at>
+ */
+interface SortableInterface
+{
+    /**
+     * Get position of the item.
+     *
+     * @return integer
+     */
+    public function getPosition();
+}

--- a/src/Sylius/Component/Resource/Model/SortableInterface.php
+++ b/src/Sylius/Component/Resource/Model/SortableInterface.php
@@ -22,4 +22,11 @@ interface SortableInterface
      * @return integer
      */
     public function getPosition();
+
+    /**
+     * Set position of the item.
+     *
+     * @param integer $position
+     */
+    public function setPosition($position);
 }

--- a/src/Sylius/Component/Taxonomy/Model/Taxon.php
+++ b/src/Sylius/Component/Taxonomy/Model/Taxon.php
@@ -71,6 +71,13 @@ class Taxon extends AbstractTranslatable implements TaxonInterface
      * @var mixed
      */
     protected $level;
+	
+    /**
+     * Required by DoctrineExtensions.
+     *
+     * @var mixed
+     */
+    protected $position;
 
     /**
      * Deletion time.
@@ -329,6 +336,24 @@ class Taxon extends AbstractTranslatable implements TaxonInterface
     public function setLevel($level)
     {
         $this->level = $level;
+
+        return $this;
+    }
+	
+    /**
+     * {@inheritdoc}
+     */
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPosition($position)
+    {
+        $this->position = $position;
 
         return $this;
     }

--- a/src/Sylius/Component/Taxonomy/Model/Taxon.php
+++ b/src/Sylius/Component/Taxonomy/Model/Taxon.php
@@ -75,7 +75,7 @@ class Taxon extends AbstractTranslatable implements TaxonInterface
     /**
      * Required by DoctrineExtensions.
      *
-     * @var mixed
+     * @var integer
      */
     protected $position;
 

--- a/src/Sylius/Component/Taxonomy/Model/TaxonInterface.php
+++ b/src/Sylius/Component/Taxonomy/Model/TaxonInterface.php
@@ -14,6 +14,7 @@ namespace Sylius\Component\Taxonomy\Model;
 use Doctrine\Common\Collections\Collection;
 use Prezent\Doctrine\Translatable\TranslatableInterface;
 use Sylius\Component\Resource\Model\SoftDeletableInterface;
+use Sylius\Component\Resource\Model\SortableInterface;
 
 /**
  * Interface for taxons.
@@ -21,7 +22,7 @@ use Sylius\Component\Resource\Model\SoftDeletableInterface;
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-interface TaxonInterface extends SoftDeletableInterface, TaxonTranslationInterface, TranslatableInterface
+interface TaxonInterface extends SortableInterface, SoftDeletableInterface, TaxonTranslationInterface, TranslatableInterface
 {
     /**
      * Get the id of taxonomy.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This is a first pull request regarding #2312, that introduces the possibility to sort taxons via the backend. At the moment, taxons can be sorted via an input field while editing. It breaks BC (i think) as it adds a position field to the taxon table.

As a future improvement, i'd like to add support for sorting them in list view like this:
![Sortable arrows](https://cloud.githubusercontent.com/assets/343392/5719021/2d781a14-9b14-11e4-8ba9-33266173e9fe.png)
To do so, i could need some input on whats the best way to update the database from a link in backend.

This is my first PR to this project. I'd like to start working on a similar feature for products this week, so it would be great, if we could finish this PR in the next couple of days.