### PR TITLE
Display variant image in cart

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_variant.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_variant.html.twig
@@ -1,6 +1,6 @@
 {% set product = variant.product %}
 <a href="{{ path(product) }}" class="thumbnail pull-left" style="margin-right: 15px;">
-    <img src="{{ product.image ? product.image.path|imagine_filter('sylius_small') : 'http://placehold.it/90x60' }}" alt="{{ product.name }}" />
+    <img src="{{ variant.image ? variant.image.path|imagine_filter('sylius_small') : 'http://placehold.it/90x60' }}" alt="{{ product.name }}" />
 </a>
 <div>
     <a href="{{ path(product) }}"><strong>{{ product.name }}</strong></a>

--- a/src/Sylius/Component/Core/Model/ProductVariant.php
+++ b/src/Sylius/Component/Core/Model/ProductVariant.php
@@ -345,6 +345,18 @@ class ProductVariant extends BaseVariant implements ProductVariantInterface
     /**
      * {@inheritdoc}
      */
+    public function getImage()
+    {
+        if ($this->images->isEmpty()) {
+            return $this->getProduct()->getImage();
+        }
+
+        return $this->images->first();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function addImage(ProductVariantImageInterface $image)
     {
         if (!$this->hasImage($image)) {

--- a/src/Sylius/Component/Core/Model/ProductVariantInterface.php
+++ b/src/Sylius/Component/Core/Model/ProductVariantInterface.php
@@ -36,6 +36,14 @@ interface ProductVariantInterface extends
     public function getImages();
 
     /**
+     * Get variant main image if any.
+     * Fall-back on product master variant
+     *
+     * @return ImageInterface
+     */
+    public function getImage();
+
+    /**
      * Checks if product has image.
      *
      * @param ProductVariantImageInterface $image


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2332
| License       | MIT
| Doc PR        | -

This PR aims to display variant image instead of product master variant image in cart. In case no variant image is available, it displays product master variant image.