### PR TITLE
Enhance deploy script

### DIFF
--- a/app/config/deploy.rb.dist
+++ b/app/config/deploy.rb.dist
@@ -23,36 +23,20 @@ set :deploy_via,  :remote_cache
 ssh_options[:forward_agent] = true
 
 set :use_composer,   true
-set :update_vendors, true
+set :update_vendors, false
 
 set :dump_assetic_assets, true
 
-set :writable_dirs,     ["app/cache", "app/logs"]
-set :webserver_user,    "www-data"
+set :writable_dirs,     [cache_path, log_path]
 set :permission_method, :acl
+set :use_set_permissions, true
 
-set :shared_files,    ["app/config/parameters.yml", "web/.htaccess", "web/robots.txt"]
-set :shared_children, ["app/logs"]
-
-set :model_manager, "doctrine"
+set :shared_files,    ["#{app_config_path}/#{app_config_file}", web_path+"/.htaccess", web_path+"/robots.txt"]
+set :shared_children, [log_path]
 
 set :use_sudo,    false
 
 set :keep_releases, 3
 
-before 'symfony:composer:update', 'symfony:copy_vendors'
-
-namespace :symfony do
-  desc "Copy vendors from previous release"
-  task :copy_vendors, :except => { :no_release => true } do
-    if Capistrano::CLI.ui.agree("Do you want to copy last release vendor dir then do composer install ?: (y/N)")
-      capifony_pretty_print "--> Copying vendors from previous release"
-
-      run "cp -a #{previous_release}/vendor #{latest_release}/"
-      capifony_puts_ok
-    end
-  end
-end
-
-after "deploy:update", "deploy:cleanup"
-after "deploy", "deploy:set_permissions"
+after "deploy", "symfony:cache:clear"
+after "deploy", "deploy:cleanup"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | kind of
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | no
| License       | MIT
| Doc PR        | none

Hi there,

Just made a few changes to the `deploy.rb.dist` script : 
- Set update_vendors to true cause it's a potential problem if you deploy in production and one of your lib gets updated. Normally you have to commit your `composer.lock` file so that all your environment vendors are the same.
- Following this update, I decided to remove the copy vendor task which is, IMHO, not needed anymore.
- I also removed a few variables which are set by default by capifony (webserver_user, model_manager)
- The script now relies on capifony variables (log_path, cache_path, web_path) instead of hardcoded strings
- Replaced the `after "deploy", "deploy:set_permissions"` line by `set :use_set_permissions, true`

What do you think?