### PR TITLE
[WIP] BeforeScenario is running multiple times slowing behat tests

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -12,6 +12,7 @@ default:
         account:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\AddressingBundle\Behat\AddressingContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\ProductBundle\Behat\ProductContext
@@ -25,6 +26,7 @@ default:
         addressing:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\AddressingBundle\Behat\AddressingContext
                 - Sylius\Bundle\AddressingBundle\Behat\FormContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
@@ -37,6 +39,7 @@ default:
         cart:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\ProductBundle\Behat\ProductContext
                 - Sylius\Bundle\TaxonomyBundle\Behat\TaxonomyContext
@@ -48,6 +51,7 @@ default:
         checkout:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\AddressingBundle\Behat\AddressingContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\PaymentBundle\Behat\PaymentContext
@@ -62,6 +66,7 @@ default:
         contact:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\MoneyBundle\Behat\MoneyContext
                 - Sylius\Bundle\ResourceBundle\Behat\BaseContext
@@ -73,6 +78,7 @@ default:
         currencies:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\MoneyBundle\Behat\MoneyContext
                 - Sylius\Bundle\ProductBundle\Behat\ProductContext
@@ -85,6 +91,7 @@ default:
         dashboard:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\AddressingBundle\Behat\AddressingContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\ProductBundle\Behat\ProductContext
@@ -96,6 +103,7 @@ default:
         homepage:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\WebBundle\Behat\WebContext
                 - Sylius\Bundle\MoneyBundle\Behat\MoneyContext
@@ -105,6 +113,7 @@ default:
         inventory:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\ProductBundle\Behat\ProductContext
                 - Sylius\Bundle\ResourceBundle\Behat\BaseContext
@@ -116,6 +125,7 @@ default:
         localization:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\ResourceBundle\Behat\BaseContext
                 - Sylius\Bundle\WebBundle\Behat\WebContext
@@ -126,6 +136,7 @@ default:
         oauth:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\CoreBundle\Behat\OAuthContext
                 - Sylius\Bundle\MoneyBundle\Behat\MoneyContext
                 - Sylius\Bundle\WebBundle\Behat\WebContext
@@ -135,6 +146,7 @@ default:
         orders:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\AddressingBundle\Behat\AddressingContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\ProductBundle\Behat\ProductContext
@@ -148,6 +160,7 @@ default:
         payments:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\PaymentBundle\Behat\PaymentContext
                 - Sylius\Bundle\ResourceBundle\Behat\BaseContext
@@ -159,6 +172,7 @@ default:
         pricing:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\AddressingBundle\Behat\AddressingContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\MoneyBundle\Behat\MoneyContext
@@ -172,6 +186,7 @@ default:
         products:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\MoneyBundle\Behat\MoneyContext
                 - Sylius\Bundle\ProductBundle\Behat\ProductContext
@@ -185,6 +200,7 @@ default:
         promotions:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\AddressingBundle\Behat\AddressingContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\ProductBundle\Behat\ProductContext
@@ -200,6 +216,7 @@ default:
         settings:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\WebBundle\Behat\WebContext
                 - Sylius\Bundle\MoneyBundle\Behat\MoneyContext
@@ -209,6 +226,7 @@ default:
         shipping:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\AddressingBundle\Behat\AddressingContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\ProductBundle\Behat\ProductContext
@@ -224,6 +242,7 @@ default:
         taxation:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\AddressingBundle\Behat\AddressingContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\ResourceBundle\Behat\BaseContext
@@ -236,6 +255,7 @@ default:
         taxonomies:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\ResourceBundle\Behat\BaseContext
                 - Sylius\Bundle\TaxonomyBundle\Behat\TaxonomyContext
@@ -247,6 +267,7 @@ default:
         users:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\AddressingBundle\Behat\AddressingContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\ProductBundle\Behat\ProductContext
@@ -258,6 +279,7 @@ default:
         javascript:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\AddressingBundle\Behat\AddressingContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\MoneyBundle\Behat\MoneyContext
@@ -275,6 +297,7 @@ default:
         i18n:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\MoneyBundle\Behat\MoneyContext
                 - Sylius\Bundle\ProductBundle\Behat\ProductContext
@@ -289,6 +312,7 @@ default:
         search:
             contexts:
                 - Sylius\Bundle\SearchBundle\Behat\SearchContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Behat\MinkExtension\Context\MinkContext
                 - Sylius\Bundle\AddressingBundle\Behat\AddressingContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
@@ -304,6 +328,7 @@ default:
         search_orm_only:
             contexts:
                 - Sylius\Bundle\SearchBundle\Behat\SearchContext
+                - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Behat\MinkExtension\Context\MinkContext
                 - Sylius\Bundle\AddressingBundle\Behat\AddressingContext
                 - Sylius\Bundle\TaxonomyBundle\Behat\TaxonomyContext

--- a/src/Sylius/Bundle/CoreBundle/Behat/HookContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Behat/HookContext.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Behat;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Symfony2Extension\Context\KernelAwareContext;
+use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
+ */
+class HookContext implements Context, KernelAwareContext
+{
+    /**
+     * @var KernelInterface
+     */
+    protected $kernel;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setKernel(KernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    /**
+     * @BeforeScenario
+     */
+    public function purgeDatabase(BeforeScenarioScope $scope)
+    {
+        $entityManager = $this->getService('doctrine.orm.entity_manager');
+        $entityManager->getConnection()->getConfiguration()->setSQLLogger(null);
+
+        $entityManager->getConnection()->executeUpdate("SET foreign_key_checks = 0;");
+
+        $purger = new ORMPurger($entityManager);
+        $purger->purge();
+
+        $entityManager->getConnection()->executeUpdate("SET foreign_key_checks = 1;");
+        $entityManager->clear();
+    }
+
+    /**
+     * Get service by id.
+     *
+     * @param string $id
+     *
+     * @return object
+     */
+    protected function getService($id)
+    {
+        return $this->getContainer()->get($id);
+    }
+
+    /**
+     * Returns Container instance.
+     *
+     * @return ContainerInterface
+     */
+    protected function getContainer()
+    {
+        return $this->kernel->getContainer();
+    }
+} 

--- a/src/Sylius/Bundle/ResourceBundle/Behat/DefaultContext.php
+++ b/src/Sylius/Bundle/ResourceBundle/Behat/DefaultContext.php
@@ -66,23 +66,6 @@ abstract class DefaultContext extends RawMinkContext implements Context, KernelA
     }
 
     /**
-     * @BeforeScenario
-     */
-    public function purgeDatabase(BeforeScenarioScope $scope)
-    {
-        $entityManager = $this->getService('doctrine.orm.entity_manager');
-        $entityManager->getConnection()->getConfiguration()->setSQLLogger(null);
-
-        $entityManager->getConnection()->executeUpdate("SET foreign_key_checks = 0;");
-
-        $purger = new ORMPurger($entityManager);
-        $purger->purge();
-
-        $entityManager->getConnection()->executeUpdate("SET foreign_key_checks = 1;");
-        $entityManager->clear();
-    }
-
-    /**
      * Find one resource by name.
      *
      * @param string $type


### PR DESCRIPTION
BeforeScenario is defined in DefaultContext, so for every context that inherits from it, the hook is run once.
In a suite with multiple contexts that extend the DefaultContext the hook is run once for every context.

I've separated the BeforeScenario in a separate context, it's placed in CoreBundle, if you believe Resource bundle is a better place I'll change it.

I've only added the HookContext for the inventory suite for now, if this PR is ok I will add it to the other suites.

In our suites this has reduced behat execution times dramatically. I've run a few sylius tests and there is a reduction in overall times, but nothing drastic.