### PR TITLE
[FixturesBundles] Rationalizes product references

### DIFF
--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadProductsData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadProductsData.php
@@ -118,7 +118,7 @@ class LoadProductsData extends DataFixture
 
         $this->generateVariants($product);
 
-        $this->setReference('Sylius.Product-'.$i, $product);
+        $this->setReference('Sylius.Product.'.$i, $product);
 
         return $product;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

Not really a bugfix nor a feature but had this problem when trying to create my own fixtures : sometimes it's a dot, others a hyphen.
I have rationalized the behavior to use dots everywhere and it breaks the BC for those using the hyphen.
What I can do is add another `setReference` call so that there are 2 references pointing to the same object.
What do you guys prefer ?
