### PR TITLE
Payment status "PARTIALLY_REFUNDED"

### DIFF
--- a/src/Sylius/Component/Core/OrderProcessing/StateResolver.php
+++ b/src/Sylius/Component/Core/OrderProcessing/StateResolver.php
@@ -37,12 +37,17 @@ class StateResolver implements StateResolverInterface
             foreach ($payments as $payment) {
                 if (PaymentInterface::STATE_COMPLETED === $payment->getState()) {
                     $completedPaymentTotal += $payment->getAmount();
+                } elseif (PaymentInterface::STATE_REFUNDED == $payment->getState()) {
+                    $completedPaymentTotal -= $payment->getAmount();
+                    $paymentState = PaymentInterface::STATE_PARTIALLY_REFUNDED;
                 }
             }
 
             if ($completedPaymentTotal >= $order->getTotal()) {
                 // Payment is completed if we have received full amount.
                 $paymentState = PaymentInterface::STATE_COMPLETED;
+            } elseif ($completedPaymentTotal <= 0 && $paymentState === PaymentInterface::STATE_PARTIALLY_REFUNDED) {
+                $paymentState = PaymentInterface::STATE_REFUNDED;
             } else {
                 // Payment is processing if one of the payment is.
                 if ($payments->exists(function ($key, $payment) {

--- a/src/Sylius/Component/Core/spec/OrderProcessing/StateResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/StateResolverSpec.php
@@ -157,4 +157,46 @@ class StateResolverSpec extends ObjectBehavior
         $order->setPaymentState(PaymentInterface::STATE_NEW)->shouldBeCalled();
         $this->resolvePaymentState($order);
     }
+
+    function it_marks_order_as_partially_refunded_if_payment_is_partially_refunded(OrderInterface $order)
+    {
+        $payment1 = new Payment();
+        $payment1->setAmount(5000);
+        $payment1->setState(PaymentInterface::STATE_COMPLETED);
+        $payment2 = new Payment();
+        $payment2->setAmount(4000);
+        $payment2->setState(PaymentInterface::STATE_PARTIALLY_REFUNDED);
+        $payments = new ArrayCollection(array($payment1, $payment2));
+
+        $order->hasPayments()->willReturn(true);
+        $order->getPayments()->willReturn($payments);
+        $order->getTotal()->willReturn(5000);
+
+        $order->setPaymentState(PaymentInterface::STATE_REFUNDED)->shouldBeCalled();
+        $this->resolvePaymentState($order);
+
+    }
+
+    function it_marks_order_as_refunded_if_payment_is_fully_refunded(OrderInterface $order)
+    {
+        $payment1 = new Payment();
+        $payment1->setAmount(5000);
+        $payment1->setState(PaymentInterface::STATE_NEW);
+        $payment2 = new Payment();
+        $payment2->setAmount(4000);
+        $payment2->setState(PaymentInterface::STATE_PARTIALLY_REFUNDED);
+        $payment3 = new Payment();
+        $payment3->setAmount(1000);
+        $payment3->setState(PaymentInterface::STATE_PARTIALLY_REFUNDED);
+        $payments = new ArrayCollection(array($payment1, $payment2, $payment3));
+
+        $order->hasPayments()->willReturn(true);
+        $order->getPayments()->willReturn($payments);
+        $order->getTotal()->willReturn(5000);
+
+        $order->setPaymentState(PaymentInterface::STATE_REFUNDED)->shouldBeCalled();
+        $this->resolvePaymentState($order);
+
+    }
+
 }

--- a/src/Sylius/Component/Payment/Model/PaymentInterface.php
+++ b/src/Sylius/Component/Payment/Model/PaymentInterface.php
@@ -21,16 +21,17 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
 interface PaymentInterface extends TimestampableInterface
 {
     // Payment states.
-    const STATE_NEW        = 'new';
-    const STATE_PENDING    = 'pending';
-    const STATE_PROCESSING = 'processing';
-    const STATE_COMPLETED  = 'completed';
-    const STATE_AUTHORIZED = 'authorized';
-    const STATE_FAILED     = 'failed';
-    const STATE_CANCELLED  = 'cancelled';
-    const STATE_VOID       = 'void';
-    const STATE_REFUNDED   = 'refunded';
-    const STATE_UNKNOWN    = 'unknown';
+    const STATE_NEW                = 'new';
+    const STATE_PENDING            = 'pending';
+    const STATE_PROCESSING         = 'processing';
+    const STATE_COMPLETED          = 'completed';
+    const STATE_AUTHORIZED         = 'authorized';
+    const STATE_FAILED             = 'failed';
+    const STATE_CANCELLED          = 'cancelled';
+    const STATE_VOID               = 'void';
+    const STATE_REFUNDED           = 'refunded';
+    const STATE_PARTIALLY_REFUNDED = 'partially_refunded';
+    const STATE_UNKNOWN            = 'unknown';
 
     /**
      * Get payment method associated with this payment.


### PR DESCRIPTION
There is no indication if an order has been refunded partially vs a fully closed order.  

There is also a bug during fixture loading that was causing all order->getPaymentStatus() to be set a "NEW" regardless of the actual payment.status values for that order.
