### PR TITLE
[VariationBundle] Require driver node definition

### DIFF
--- a/src/Sylius/Bundle/VariationBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/VariationBundle/DependencyInjection/Configuration.php
@@ -36,7 +36,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->addDefaultsIfNotSet()
             ->children()
-                ->scalarNode('driver')->defaultNull()->end()
+                ->scalarNode('driver')->isRequired()->cannotBeEmpty()->end()
             ->end()
         ;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2348
| License       | MIT
| Doc PR        | n/a

As reported in the Fix Ticket, the following code in `SyliusVariationExtension` would error when `$driver` is set to null by default. This PR requires `driver` to be configured (though, only one value is supported at present).

```php
$choiceTypeClasses = array(
    SyliusResourceBundle::DRIVER_DOCTRINE_ORM => 'Sylius\Bundle\VariationBundle\Form\Type\OptionEntityChoiceType'
);

$optionChoiceFormType = new Definition($choiceTypeClasses[$driver]);
```