### PR TITLE
[WebBundle] Backend side menu not highlighted fix #2387

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Menu/BackendMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/BackendMenuBuilder.php
@@ -77,6 +77,8 @@ class BackendMenuBuilder extends MenuBuilder
             )
         ));
 
+        $menu->setCurrentUri($this->request->getRequestUri());
+
         $childOptions = array(
             'childrenAttributes' => array('class' => 'nav'),
             'labelAttributes'    => array('class' => 'nav-header')

--- a/src/Sylius/Bundle/WebBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/services.xml
@@ -83,6 +83,9 @@
             <argument type="service" id="security.context" />
             <argument type="service" id="translator" />
             <argument type="service" id="event_dispatcher" />
+            <call method="setRequest">
+                <argument type="service" id="request" on-invalid="null" strict="false" />
+            </call>
         </service>
         <service id="sylius.menu_builder.locale" class="%sylius.menu_builder.locale.class%">
             <argument type="service" id="knp_menu.factory" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2387 
| License       | MIT
| Doc PR        | 

Fixes minor issue in backend sidebar menu - the active item wasn't highlighted so it was hard to see where you now.