### PR TITLE
Improve + Handle null option in variant to combination transformer

### DIFF
--- a/src/Sylius/Bundle/VariationBundle/Form/DataTransformer/VariantToCombinationTransformer.php
+++ b/src/Sylius/Bundle/VariationBundle/Form/DataTransformer/VariantToCombinationTransformer.php
@@ -81,17 +81,13 @@ class VariantToCombinationTransformer implements DataTransformerInterface
     private function matches($value)
     {
         foreach ($this->variable->getVariants() as $variant) {
-            $matches = true;
-
             foreach ($value as $option) {
-                if (!$variant->hasOption($option)) {
-                    $matches = false;
+                if (null === $option || !$variant->hasOption($option)) {
+                    continue 2;
                 }
             }
 
-            if ($matches) {
-                return $variant;
-            }
+            return $variant;
         }
 
         return null;

--- a/src/Sylius/Bundle/VariationBundle/spec/Form/DataTransformer/VariantToCombinationTransformerSpec.php
+++ b/src/Sylius/Bundle/VariationBundle/spec/Form/DataTransformer/VariantToCombinationTransformerSpec.php
@@ -98,4 +98,13 @@ class VariantToCombinationTransformerSpec extends ObjectBehavior
 
         $this->reverseTransform(array($optionValue))->shouldReturn(null);
     }
+
+    function it_should_not_reverse_transform_variable_with_variants_if_options_are_missing(
+        VariableInterface $variable,
+        VariantInterface $variant
+    ) {
+        $variable->getVariants()->willReturn(array($variant));
+
+        $this->reverseTransform(array(null))->shouldReturn(null);
+    }
 }


### PR DESCRIPTION
Hey!

This PR fixes an issue I encounter when I extend the cart item form with my own. Basically, my use case allows an empty value for option value choices. Then, the option values in the cart item can be null if the user does not select a value or try to send an unknown/maliscious value in the form. So, in multiple cases, it can result to a fatal error due to the typehint of the `ProductVariant::hasOption` method. 

This PR adds an extra check about the option validity before checking the option availability. Additionally, I have improved the performance by continuing the two loops with a `continue`.