### PR TITLE
[ResourceBundle] Simple modification to change the events fired by the domain manager.

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
@@ -350,8 +350,8 @@ class Configuration
         return $this->parameters->get('serialization_version');
     }
 
-    public function getEvent()
+    public function getEvent($default = null)
     {
-        return $this->parameters->get('event');
+        return $this->parameters->get('event', $default);
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Paweł Jędrzejewski <pjedrzejewski@sylius.pl>
  * @author Saša Stamenković <umpirsky@gmail.com>
+ * @author Gustavo Perdomo <gperdomor@gmail.com>
  */
 class Configuration
 {
@@ -347,5 +348,10 @@ class Configuration
     public function getSerializationVersion()
     {
         return $this->parameters->get('serialization_version');
+    }
+
+    public function getEvent()
+    {
+        return $this->parameters->get('event');
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/Controller/DomainManager.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/DomainManager.php
@@ -63,7 +63,8 @@ class DomainManager
      */
     public function create($resource)
     {
-        $event = $this->dispatchEvent('pre_create', new ResourceEvent($resource));
+        $_event = $this->config->getEvent();
+        $event = $this->dispatchEvent(sprintf('pre_%s', $_event ?: 'create'), new ResourceEvent($resource));
 
         if ($event->isStopped()) {
             if (null !== $this->flashHelper) {
@@ -84,7 +85,7 @@ class DomainManager
             $this->flashHelper->setFlash('success', 'create');
         }
 
-        $this->dispatchEvent('post_create', new ResourceEvent($resource));
+        $this->dispatchEvent(sprintf('post_%s', $_event ?: 'create'), new ResourceEvent($resource));
 
         return $resource;
     }
@@ -97,7 +98,8 @@ class DomainManager
      */
     public function update($resource, $flash = 'update')
     {
-        $event = $this->dispatchEvent('pre_update', new ResourceEvent($resource));
+        $_event = $this->config->getEvent();
+        $event = $this->dispatchEvent(sprintf('pre_%s', $_event ?: 'update'), new ResourceEvent($resource));
 
         if ($event->isStopped()) {
             if (null !== $this->flashHelper) {
@@ -118,7 +120,7 @@ class DomainManager
             $this->flashHelper->setFlash('success', $flash);
         }
 
-        $this->dispatchEvent('post_update', new ResourceEvent($resource));
+        $this->dispatchEvent(sprintf('post_%s', $_event ?: 'update'), new ResourceEvent($resource));
 
         return $resource;
     }
@@ -151,7 +153,8 @@ class DomainManager
      */
     public function delete($resource)
     {
-        $event = $this->dispatchEvent('pre_delete', new ResourceEvent($resource));
+        $_event = $this->config->getEvent();
+        $event = $this->dispatchEvent(sprintf('pre_%s', $_event ?: 'delete'), new ResourceEvent($resource));
 
         if ($event->isStopped()) {
             if (null !== $this->flashHelper) {
@@ -172,7 +175,7 @@ class DomainManager
             $this->flashHelper->setFlash('success', 'delete');
         }
 
-        $this->dispatchEvent('post_delete', new ResourceEvent($resource));
+        $this->dispatchEvent(sprintf('post_%s', $_event ?: 'delete'), new ResourceEvent($resource));
 
         return $resource;
     }

--- a/src/Sylius/Bundle/ResourceBundle/Controller/DomainManager.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/DomainManager.php
@@ -21,6 +21,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
  * Domain manager.
  *
  * @author Paweł Jędrzejewski <pjedrzejewski@sylius.pl>
+ * @author Gustavo Perdomo <gperdomor@gmail.com>
  */
 class DomainManager
 {
@@ -63,8 +64,8 @@ class DomainManager
      */
     public function create($resource)
     {
-        $_event = $this->config->getEvent();
-        $event = $this->dispatchEvent(sprintf('pre_%s', $_event ?: 'create'), new ResourceEvent($resource));
+        $eventName = $this->config->getEvent();
+        $event = $this->dispatchEvent(sprintf('pre_%s', $eventName ?: 'create'), new ResourceEvent($resource));
 
         if ($event->isStopped()) {
             if (null !== $this->flashHelper) {
@@ -85,7 +86,7 @@ class DomainManager
             $this->flashHelper->setFlash('success', 'create');
         }
 
-        $this->dispatchEvent(sprintf('post_%s', $_event ?: 'create'), new ResourceEvent($resource));
+        $this->dispatchEvent(sprintf('post_%s', $eventName ?: 'create'), new ResourceEvent($resource));
 
         return $resource;
     }
@@ -98,8 +99,8 @@ class DomainManager
      */
     public function update($resource, $flash = 'update')
     {
-        $_event = $this->config->getEvent();
-        $event = $this->dispatchEvent(sprintf('pre_%s', $_event ?: 'update'), new ResourceEvent($resource));
+        $eventName = $this->config->getEvent();
+        $event = $this->dispatchEvent(sprintf('pre_%s', $eventName ?: 'update'), new ResourceEvent($resource));
 
         if ($event->isStopped()) {
             if (null !== $this->flashHelper) {
@@ -120,7 +121,7 @@ class DomainManager
             $this->flashHelper->setFlash('success', $flash);
         }
 
-        $this->dispatchEvent(sprintf('post_%s', $_event ?: 'update'), new ResourceEvent($resource));
+        $this->dispatchEvent(sprintf('post_%s', $eventName ?: 'update'), new ResourceEvent($resource));
 
         return $resource;
     }
@@ -153,8 +154,8 @@ class DomainManager
      */
     public function delete($resource)
     {
-        $_event = $this->config->getEvent();
-        $event = $this->dispatchEvent(sprintf('pre_%s', $_event ?: 'delete'), new ResourceEvent($resource));
+        $eventName = $this->config->getEvent();
+        $event = $this->dispatchEvent(sprintf('pre_%s', $eventName ?: 'delete'), new ResourceEvent($resource));
 
         if ($event->isStopped()) {
             if (null !== $this->flashHelper) {
@@ -175,7 +176,7 @@ class DomainManager
             $this->flashHelper->setFlash('success', 'delete');
         }
 
-        $this->dispatchEvent(sprintf('post_%s', $_event ?: 'delete'), new ResourceEvent($resource));
+        $this->dispatchEvent(sprintf('post_%s', $eventName ?: 'delete'), new ResourceEvent($resource));
 
         return $resource;
     }

--- a/src/Sylius/Bundle/ResourceBundle/Controller/DomainManager.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/DomainManager.php
@@ -64,8 +64,8 @@ class DomainManager
      */
     public function create($resource)
     {
-        $eventName = $this->config->getEvent();
-        $event = $this->dispatchEvent(sprintf('pre_%s', $eventName ?: 'create'), new ResourceEvent($resource));
+        $eventName = $this->config->getEvent('create');
+        $event = $this->dispatchEvent(sprintf('pre_%s', $eventName), new ResourceEvent($resource));
 
         if ($event->isStopped()) {
             if (null !== $this->flashHelper) {
@@ -86,7 +86,7 @@ class DomainManager
             $this->flashHelper->setFlash('success', 'create');
         }
 
-        $this->dispatchEvent(sprintf('post_%s', $eventName ?: 'create'), new ResourceEvent($resource));
+        $this->dispatchEvent(sprintf('post_%s', $eventName), new ResourceEvent($resource));
 
         return $resource;
     }
@@ -99,8 +99,8 @@ class DomainManager
      */
     public function update($resource, $flash = 'update')
     {
-        $eventName = $this->config->getEvent();
-        $event = $this->dispatchEvent(sprintf('pre_%s', $eventName ?: 'update'), new ResourceEvent($resource));
+        $eventName = $this->config->getEvent('update');
+        $event = $this->dispatchEvent(sprintf('pre_%s', $eventName), new ResourceEvent($resource));
 
         if ($event->isStopped()) {
             if (null !== $this->flashHelper) {
@@ -121,7 +121,7 @@ class DomainManager
             $this->flashHelper->setFlash('success', $flash);
         }
 
-        $this->dispatchEvent(sprintf('post_%s', $eventName ?: 'update'), new ResourceEvent($resource));
+        $this->dispatchEvent(sprintf('post_%s', $eventName), new ResourceEvent($resource));
 
         return $resource;
     }
@@ -154,8 +154,8 @@ class DomainManager
      */
     public function delete($resource)
     {
-        $eventName = $this->config->getEvent();
-        $event = $this->dispatchEvent(sprintf('pre_%s', $eventName ?: 'delete'), new ResourceEvent($resource));
+        $eventName = $this->config->getEvent('delete');
+        $event = $this->dispatchEvent(sprintf('pre_%s', $eventName), new ResourceEvent($resource));
 
         if ($event->isStopped()) {
             if (null !== $this->flashHelper) {
@@ -176,7 +176,7 @@ class DomainManager
             $this->flashHelper->setFlash('success', 'delete');
         }
 
-        $this->dispatchEvent(sprintf('post_%s', $eventName ?: 'delete'), new ResourceEvent($resource));
+        $this->dispatchEvent(sprintf('post_%s', $eventName), new ResourceEvent($resource));
 
         return $resource;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | [no]
| New feature?  | [yes]
| BC breaks?    | [no]
| Deprecations? | [no]
| Fixed tickets | [#2378]
| License       | MIT
| Doc PR        | [#2378]

Hi, this PR adds the ability to use new pre and post events, not only the pre and post create, update and delete.

To configure a custom event, only need add a event parameter on the route configuration like show below

<pre>
route:
    path: /{id}
    methods: [GET]
    defaults:
        _controller: controller:action
        _sylius:
            template: template.html.twig
            method: method
            arguments: [$id]
            event: eventName
</pre>

Until now, the updateAction and UpdateStateAction actions, calls the update method from DomainManager, so in both action the pre and post update event are fired (yes, same events, different actions), and in my case i don't need fire the update event when i change the state of my entity, i need a custom event like pre_state_change or something like that, so i made this PR to solve the problem and i'm sure could be usefull in the future.