### PR TITLE
[Fixture][ProductVariantImage] Rely on repository createNew instead of constructor

### DIFF
--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadImagesData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadImagesData.php
@@ -35,7 +35,7 @@ class LoadImagesData extends DataFixture
         $uploader = $this->get('sylius.image_uploader');
 
         foreach ($finder->files()->in(__DIR__.$this->path) as $img) {
-            $image = new ProductVariantImage();
+            $image = $this->getProductVariantImageRepository()->createNew();
             $image->setFile(new UploadedFile($img->getRealPath(), $img->getFilename()));
             $uploader->upload($image);
 


### PR DESCRIPTION
Hey!

Instead of instantiating the product variant image manually, the fixture should rely on the repository as it is done elsewhere.