### PR TITLE
Fix zone matcher to match by id

### DIFF
--- a/src/Sylius/Component/Addressing/Matcher/ZoneMatcher.php
+++ b/src/Sylius/Component/Addressing/Matcher/ZoneMatcher.php
@@ -128,10 +128,10 @@ class ZoneMatcher implements ZoneMatcherInterface
 
         switch ($type) {
             case ZoneInterface::TYPE_PROVINCE:
-                return null !== $address->getProvince() && $address->getProvince() === $member->getProvince();
+                return null !== $address->getProvince() && $address->getProvince()->getId() === $member->getProvince()->getId();
 
             case ZoneInterface::TYPE_COUNTRY:
-                return null !== $address->getCountry() && $address->getCountry() === $member->getCountry();
+                return null !== $address->getCountry() && $address->getCountry()->getId() === $member->getCountry()->getId();
 
             case ZoneInterface::TYPE_ZONE:
                 return $this->addressBelongsToZone($address, $member->getZone());

--- a/src/Sylius/Component/Addressing/Matcher/ZoneMatcher.php
+++ b/src/Sylius/Component/Addressing/Matcher/ZoneMatcher.php
@@ -128,10 +128,10 @@ class ZoneMatcher implements ZoneMatcherInterface
 
         switch ($type) {
             case ZoneInterface::TYPE_PROVINCE:
-                return null !== $address->getProvince() && $address->getProvince()->getId() === $member->getProvince()->getId();
+                return (null !== $address->getProvince()) && ($address->getProvince()->getId() === $member->getProvince()->getId());
 
             case ZoneInterface::TYPE_COUNTRY:
-                return null !== $address->getCountry() && $address->getCountry()->getId() === $member->getCountry()->getId();
+                return (null !== $address->getCountry()) && ($address->getCountry()->getId() === $member->getCountry()->getId());
 
             case ZoneInterface::TYPE_ZONE:
                 return $this->addressBelongsToZone($address, $member->getZone());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| License | MIT |

I had use case where I wanted to cache zones, because loading all of them from database each time was not optimal. And guess wath, suddenly `ZoneMatcher` started to work incorrectly. It took me quite some time to understand what happens. It's zone member comparison returning false for same objects when comparing objects from database and objects from cache.
It worked after this fix.
