### PR TITLE
Fix Elastica deprecated call to setFilter

### DIFF
--- a/src/Sylius/Bundle/SearchBundle/Finder/ElasticsearchFinder.php
+++ b/src/Sylius/Bundle/SearchBundle/Finder/ElasticsearchFinder.php
@@ -184,7 +184,7 @@ class ElasticsearchFinder extends AbstractFinder
                 $typeFilter = new \Elastica\Filter\Type($type);
                 $boolFilter->addMust($typeFilter);
             }
-            $elasticaQuery->setFilter($boolFilter);
+            $elasticaQuery->setPostFilter($boolFilter);
         }
 
         $query = new \Elastica\Query\Filtered();
@@ -220,7 +220,7 @@ class ElasticsearchFinder extends AbstractFinder
                 $typeFilter = new \Elastica\Filter\Type($type);
                 $boolFilter->addMust($typeFilter);
             }
-            $elasticaQuery->setFilter($boolFilter);
+            $elasticaQuery->setPostFilter($boolFilter);
         }
 
         // this is currently the only pre search filter and it's a taxon


### PR DESCRIPTION
This is a minor correction that fixes the use of deprecated "setFilter" method in Elastica query.