### PR TITLE
[RFC] Bump minimal PHP requirement to 5.3.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php":                                  ">=5.3.3",
+        "php":                                  ">=5.3.9",
         "a2lix/translation-form-bundle":        "~2.0",
         "doctrine/collections":                 "~1.2",
         "doctrine/common":                      "~2.3",

--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "symfony/framework-bundle":        "~2.3",
         "stof/doctrine-extensions-bundle": "~1.1",

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php":                      ">=5.3.3",
+        "php":                      ">=5.3.9",
 
         "sylius/resource-bundle":               "0.13.*@dev",
         "symfony/framework-bundle":             "~2.3",

--- a/src/Sylius/Bundle/ArchetypeBundle/composer.json
+++ b/src/Sylius/Bundle/ArchetypeBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "symfony/framework-bundle":        "~2.3",
         "stof/doctrine-extensions-bundle": "~1.1",

--- a/src/Sylius/Bundle/AttributeBundle/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "symfony/framework-bundle":        "~2.3",
         "stof/doctrine-extensions-bundle": "~1.1",

--- a/src/Sylius/Bundle/CartBundle/composer.json
+++ b/src/Sylius/Bundle/CartBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "symfony/framework-bundle": "~2.3",
         "sylius/order-bundle":      "0.13.*@dev",

--- a/src/Sylius/Bundle/ContactBundle/composer.json
+++ b/src/Sylius/Bundle/ContactBundle/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php":                      ">=5.3.3",
+        "php":                      ">=5.3.9",
 
         "sylius/resource-bundle":   "0.13.*@dev",
         "sylius/contact":           "0.13.*@dev",

--- a/src/Sylius/Bundle/ContentBundle/composer.json
+++ b/src/Sylius/Bundle/ContentBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php":                               ">=5.3.3",
+        "php":                               ">=5.3.9",
 
         "jackalope/jackalope-doctrine-dbal": "1.1.*",
         "sylius/resource-bundle":            "0.13.*@dev",

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php":                            ">=5.3.3",
+        "php":                            ">=5.3.9",
 
         "a2lix/translation-form-bundle":  "2.*@dev",
         "friendsofsymfony/user-bundle":   "2.0.*@dev",

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php":                      ">=5.3.3",
+        "php":                      ">=5.3.9",
 
         "sylius/currency":          "0.13.*@dev",
         "sylius/money-bundle":      "0.13.*@dev",

--- a/src/Sylius/Bundle/FixturesBundle/composer.json
+++ b/src/Sylius/Bundle/FixturesBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/core-bundle": "0.13.*@dev"
     },

--- a/src/Sylius/Bundle/FlowBundle/composer.json
+++ b/src/Sylius/Bundle/FlowBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "symfony/framework-bundle": "~2.1"
     },

--- a/src/Sylius/Bundle/InstallerBundle/Requirement/SettingsRequirements.php
+++ b/src/Sylius/Bundle/InstallerBundle/Requirement/SettingsRequirements.php
@@ -16,7 +16,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 class SettingsRequirements extends RequirementCollection
 {
-    const REQUIRED_PHP_VERSION = '5.3.3';
+    const REQUIRED_PHP_VERSION = '5.3.9';
 
     public function __construct(TranslatorInterface $translator)
     {
@@ -31,13 +31,6 @@ class SettingsRequirements extends RequirementCollection
                 version_compare(phpversion(), self::REQUIRED_PHP_VERSION, '>='),
                 '>='.self::REQUIRED_PHP_VERSION,
                 phpversion()
-            ))
-            ->add(new Requirement(
-                $translator->trans('sylius.settings.version_recommanded', array(), 'requirements'),
-                version_compare(phpversion(), '5.3.8', '>='),
-                '>=5.3.8',
-                phpversion(),
-                false
             ))
             ->add(new Requirement(
                 $translator->trans('sylius.settings.timezone', array(), 'requirements'),

--- a/src/Sylius/Bundle/InstallerBundle/composer.json
+++ b/src/Sylius/Bundle/InstallerBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "symfony/framework-bundle": "~2.3",
         "sylius/resource-bundle":   "0.13.*@dev",

--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "symfony/framework-bundle":        "~2.3",
         "stof/doctrine-extensions-bundle": "~1.1",

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php":                      ">=5.3.3",
+        "php":                      ">=5.3.9",
 
         "sylius/locale":            "0.13.*@dev",
         "sylius/resource-bundle":   "0.13.*@dev",

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php":                      ">=5.3.3",
+        "php":                      ">=5.3.9",
 
         "symfony/framework-bundle": "~2.3",
         "symfony/intl":             "~2.3",

--- a/src/Sylius/Bundle/OrderBundle/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "symfony/framework-bundle":        "~2.3",
         "stof/doctrine-extensions-bundle": "~1.1",

--- a/src/Sylius/Bundle/PaymentBundle/composer.json
+++ b/src/Sylius/Bundle/PaymentBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php":                             ">=5.3.3",
+        "php":                             ">=5.3.9",
 
         "symfony/framework-bundle":        "~2.3",
         "stof/doctrine-extensions-bundle": "~1.1",

--- a/src/Sylius/Bundle/PayumBundle/composer.json
+++ b/src/Sylius/Bundle/PayumBundle/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php":                    ">=5.3.3",
+        "php":                    ">=5.3.9",
 
         "sylius/core":                          "0.13.*@dev",
         "sylius/currency":                      "0.13.*@dev",

--- a/src/Sylius/Bundle/PricingBundle/composer.json
+++ b/src/Sylius/Bundle/PricingBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "stof/doctrine-extensions-bundle": "~1.1",
         "sylius/pricing":                  "0.13.*@dev",

--- a/src/Sylius/Bundle/ProductBundle/composer.json
+++ b/src/Sylius/Bundle/ProductBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "symfony/framework-bundle":        "~2.3",
         "stof/doctrine-extensions-bundle": "~1.1",

--- a/src/Sylius/Bundle/PromotionBundle/composer.json
+++ b/src/Sylius/Bundle/PromotionBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "jms/translation-bundle":          "1.1.*",
         "stof/doctrine-extensions-bundle": "~1.1",

--- a/src/Sylius/Bundle/ResourceBundle/composer.json
+++ b/src/Sylius/Bundle/ResourceBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "symfony/framework-bundle":        "~2.3",
         "symfony/twig-bundle":             "~2.3",

--- a/src/Sylius/Bundle/SearchBundle/composer.json
+++ b/src/Sylius/Bundle/SearchBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/product-bundle":            "0.13.*@dev",
         "sylius/resource-bundle":           "0.13.*@dev",

--- a/src/Sylius/Bundle/SequenceBundle/composer.json
+++ b/src/Sylius/Bundle/SequenceBundle/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "symfony/framework-bundle": "~2.3",
         "sylius/resource-bundle":   "0.13.*@dev",

--- a/src/Sylius/Bundle/SettingsBundle/composer.json
+++ b/src/Sylius/Bundle/SettingsBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "symfony/framework-bundle":        "~2.3",
         "doctrine/doctrine-cache-bundle":  "~1.0",

--- a/src/Sylius/Bundle/ShippingBundle/composer.json
+++ b/src/Sylius/Bundle/ShippingBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php":                             ">=5.3.3",
+        "php":                             ">=5.3.9",
 
         "symfony/framework-bundle":        "~2.3",
         "stof/doctrine-extensions-bundle": "~1.1",

--- a/src/Sylius/Bundle/TaxationBundle/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php":                             ">=5.3.3",
+        "php":                             ">=5.3.9",
 
         "symfony/framework-bundle":        "~2.3",
         "stof/doctrine-extensions-bundle": "~1.1",

--- a/src/Sylius/Bundle/TaxonomyBundle/composer.json
+++ b/src/Sylius/Bundle/TaxonomyBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "jms/translation-bundle":          "1.1.*",
         "symfony/framework-bundle":        "~2.3",

--- a/src/Sylius/Bundle/TranslationBundle/composer.json
+++ b/src/Sylius/Bundle/TranslationBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "symfony/framework-bundle":        "~2.3",
         "stof/doctrine-extensions-bundle": "~1.1",

--- a/src/Sylius/Bundle/VariationBundle/composer.json
+++ b/src/Sylius/Bundle/VariationBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php":                             ">=5.3.3",
+        "php":                             ">=5.3.9",
 
         "symfony/framework-bundle":        "~2.3",
         "stof/doctrine-extensions-bundle": "~1.1",

--- a/src/Sylius/Bundle/WebBundle/composer.json
+++ b/src/Sylius/Bundle/WebBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php":                       ">=5.3.3",
+        "php":                       ">=5.3.9",
 
         "jms/translation-bundle":    "1.1.*",
         "symfony/framework-bundle":  "~2.3",

--- a/src/Sylius/Component/Addressing/Model/AddressInterface.php
+++ b/src/Sylius/Component/Addressing/Model/AddressInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Addressing\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -18,7 +19,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Paweł Jędrzejewski <pjedrzejewski@sylius.pl>
  */
-interface AddressInterface extends TimestampableInterface
+interface AddressInterface extends GetIdInterface, TimestampableInterface
 {
     /**
      * Get first name.

--- a/src/Sylius/Component/Addressing/Model/CountryInterface.php
+++ b/src/Sylius/Component/Addressing/Model/CountryInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Addressing\Model;
 
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Resource\Model\GetIdInterface;
 
 /**
  * Country interface.
@@ -19,10 +20,8 @@ use Doctrine\Common\Collections\Collection;
  * @author Paweł Jędrzejewski <pjedrzejewski@sylius.pl>
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-interface CountryInterface extends CountryTranslationInterface
+interface CountryInterface extends GetIdInterface, CountryTranslationInterface
 {
-    public function getId();
-
     /**
      * Get country ISO name.
      *

--- a/src/Sylius/Component/Addressing/Model/CountryTranslationInterface.php
+++ b/src/Sylius/Component/Addressing/Model/CountryTranslationInterface.php
@@ -11,12 +11,14 @@
 
 namespace Sylius\Component\Addressing\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
+
 /**
  * Country translation interface.
  *
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-interface CountryTranslationInterface
+interface CountryTranslationInterface extends GetIdInterface
 {
     /**
      * Get country name.

--- a/src/Sylius/Component/Addressing/Model/ProvinceInterface.php
+++ b/src/Sylius/Component/Addressing/Model/ProvinceInterface.php
@@ -11,18 +11,15 @@
 
 namespace Sylius\Component\Addressing\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
+
 /**
  * Province interface.
  *
  * @author Paweł Jędrzejewski <pjedrzejewski@sylius.pl>
  */
-interface ProvinceInterface
+interface ProvinceInterface extends GetIdInterface
 {
-    /**
-     * @return mixed
-     */
-    public function getId();
-
     /**
      * @return string
      */

--- a/src/Sylius/Component/Addressing/Model/ZoneInterface.php
+++ b/src/Sylius/Component/Addressing/Model/ZoneInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Addressing\Model;
 
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Resource\Model\GetIdInterface;
 
 /**
  * Zone interface.
@@ -19,16 +20,11 @@ use Doctrine\Common\Collections\Collection;
  * @author Saša Stamenković <umpirsky@gmail.com>
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-interface ZoneInterface
+interface ZoneInterface extends GetIdInterface
 {
     const TYPE_COUNTRY = 'country';
     const TYPE_PROVINCE = 'province';
     const TYPE_ZONE = 'zone';
-
-    /**
-     * @return mixed
-     */
-    public function getId();
 
     /**
      * @return string
@@ -79,7 +75,7 @@ interface ZoneInterface
     public function setMembers(Collection $members);
 
     /**
-     * @return Boolean
+     * @return bool
      */
     public function hasMembers();
 
@@ -100,7 +96,7 @@ interface ZoneInterface
     /**
      * @param ZoneMemberInterface $member
      *
-     * @return Boolean
+     * @return bool
      */
     public function hasMember(ZoneMemberInterface $member);
 }

--- a/src/Sylius/Component/Addressing/Model/ZoneMemberInterface.php
+++ b/src/Sylius/Component/Addressing/Model/ZoneMemberInterface.php
@@ -11,18 +11,15 @@
 
 namespace Sylius\Component\Addressing\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
+
 /**
  * Zone member interface.
  *
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-interface ZoneMemberInterface
+interface ZoneMemberInterface extends GetIdInterface
 {
-    /**
-     * @return mixed
-     */
-    public function getId();
-
     /**
      * @return ZoneInterface
      */

--- a/src/Sylius/Component/Addressing/composer.json
+++ b/src/Sylius/Component/Addressing/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/resource": "0.13.*@dev"
     },

--- a/src/Sylius/Component/Archetype/Model/Archetype.php
+++ b/src/Sylius/Component/Archetype/Model/Archetype.php
@@ -94,7 +94,7 @@ class Archetype extends AbstractTranslatable implements ArchetypeInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getCode()
     {
@@ -102,7 +102,7 @@ class Archetype extends AbstractTranslatable implements ArchetypeInterface
     }
 
     /**
-     * @param string $code
+     * {@inheritdoc}
      */
     public function setCode($code)
     {

--- a/src/Sylius/Component/Archetype/Model/ArchetypeInterface.php
+++ b/src/Sylius/Component/Archetype/Model/ArchetypeInterface.php
@@ -13,6 +13,7 @@ namespace Sylius\Component\Archetype\Model;
 
 use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Attribute\Model\AttributeInterface as BaseAttributeInterface;
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 use Sylius\Component\Variation\Model\OptionInterface as BaseOptionInterface;
 
@@ -24,7 +25,7 @@ use Sylius\Component\Variation\Model\OptionInterface as BaseOptionInterface;
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Adam Elsodaney <adam.elso@gmail.com>
  */
-interface ArchetypeInterface extends TimestampableInterface, ArchetypeTranslationInterface
+interface ArchetypeInterface extends GetIdInterface, TimestampableInterface, ArchetypeTranslationInterface
 {
     /**
      * Returns all prototype attributes.
@@ -96,12 +97,12 @@ interface ArchetypeInterface extends TimestampableInterface, ArchetypeTranslatio
      *
      * @param BaseOptionInterface $option
      *
-     * @return boolean
+     * @return bool
      */
     public function hasOption(BaseOptionInterface $option);
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function hasParent();
 

--- a/src/Sylius/Component/Archetype/Model/ArchetypeTranslationInterface.php
+++ b/src/Sylius/Component/Archetype/Model/ArchetypeTranslationInterface.php
@@ -11,10 +11,12 @@
 
 namespace Sylius\Component\Archetype\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
+
 /**
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-interface ArchetypeTranslationInterface
+interface ArchetypeTranslationInterface extends GetIdInterface
 {
     /**
      * Get name, in most cases it will be displayed by user only in backend.

--- a/src/Sylius/Component/Archetype/composer.json
+++ b/src/Sylius/Component/Archetype/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/resource":  "0.13.*@dev",
         "sylius/attribute": "0.13.*@dev",

--- a/src/Sylius/Component/Attribute/Model/AttributeInterface.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Attribute\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -19,7 +20,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-interface AttributeInterface extends TimestampableInterface, AttributeTranslationInterface
+interface AttributeInterface extends GetIdInterface, TimestampableInterface, AttributeTranslationInterface
 {
     /**
      * Get internal name.

--- a/src/Sylius/Component/Attribute/Model/AttributeTranslationInterface.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeTranslationInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sylius package.
  *
@@ -10,10 +11,12 @@
 
 namespace Sylius\Component\Attribute\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
+
 /**
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-interface AttributeTranslationInterface
+interface AttributeTranslationInterface extends GetIdInterface
 {
     /**
      * The name displayed to user.
@@ -28,5 +31,4 @@ interface AttributeTranslationInterface
      * @param string $presentation
      */
     public function setPresentation($presentation);
-
-} 
+}

--- a/src/Sylius/Component/Attribute/Model/AttributeValueInterface.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeValueInterface.php
@@ -11,6 +11,8 @@
 
 namespace Sylius\Component\Attribute\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
+
 /**
  * Attribute value model.
  *
@@ -18,7 +20,7 @@ namespace Sylius\Component\Attribute\Model;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface AttributeValueInterface
+interface AttributeValueInterface extends GetIdInterface
 {
     /**
      * Get subject.

--- a/src/Sylius/Component/Attribute/composer.json
+++ b/src/Sylius/Component/Attribute/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/resource": "0.13.*@dev"
     },

--- a/src/Sylius/Component/Cart/composer.json
+++ b/src/Sylius/Component/Cart/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/resource": "0.13.*@dev",
         "sylius/order":    "0.13.*@dev"

--- a/src/Sylius/Component/Contact/Model/RequestInterface.php
+++ b/src/Sylius/Component/Contact/Model/RequestInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Contact\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -18,7 +19,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
  */
-interface RequestInterface extends TimestampableInterface
+interface RequestInterface extends GetIdInterface, TimestampableInterface
 {
     /**
      * @return string

--- a/src/Sylius/Component/Contact/Model/TopicInterface.php
+++ b/src/Sylius/Component/Contact/Model/TopicInterface.php
@@ -11,12 +11,14 @@
 
 namespace Sylius\Component\Contact\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
+
 /**
  * Interface for the model representing a contact topic.
  *
  * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
  */
-interface TopicInterface
+interface TopicInterface extends GetIdInterface
 {
     /**
      * @return string

--- a/src/Sylius/Component/Contact/composer.json
+++ b/src/Sylius/Component/Contact/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/resource": "0.13.*@dev"
     },

--- a/src/Sylius/Component/Core/Model/ImageInterface.php
+++ b/src/Sylius/Component/Core/Model/ImageInterface.php
@@ -11,12 +11,13 @@
 
 namespace Sylius\Component\Core\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
-interface ImageInterface extends TimestampableInterface
+interface ImageInterface extends GetIdInterface, TimestampableInterface
 {
     /**
-     * @return Boolean
+     * @return bool
      */
     public function hasFile();
 

--- a/src/Sylius/Component/Core/Model/UserOAuth.php
+++ b/src/Sylius/Component/Core/Model/UserOAuth.php
@@ -30,9 +30,7 @@ class UserOAuth implements UserOAuthInterface
     protected $user;
 
     /**
-     * Get id
-     *
-     * @return integer
+     * {@inheritdoc}
      */
     public function getId()
     {

--- a/src/Sylius/Component/Core/Model/UserOAuthInterface.php
+++ b/src/Sylius/Component/Core/Model/UserOAuthInterface.php
@@ -11,13 +11,15 @@
 
 namespace Sylius\Component\Core\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
+
 /**
  * User OAuth account interface.
  *
  * @author Sergio Marchesini
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
-interface UserOAuthInterface extends UserAwareInterface
+interface UserOAuthInterface extends GetIdInterface, UserAwareInterface
 {
     /**
      * Get OAuth provider name.

--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/product":    "0.13.*@dev",
         "sylius/cart":       "0.13.*@dev",

--- a/src/Sylius/Component/Currency/Model/CurrencyInterface.php
+++ b/src/Sylius/Component/Currency/Model/CurrencyInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Currency\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -18,7 +19,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface CurrencyInterface extends TimestampableInterface
+interface CurrencyInterface extends GetIdInterface, TimestampableInterface
 {
     /**
      * @return string
@@ -48,12 +49,12 @@ interface CurrencyInterface extends TimestampableInterface
     public function setExchangeRate($rate);
 
     /**
-     * @return Boolean
+     * @return bool
      */
     public function isEnabled();
 
     /**
-     * @param Boolean $enabled
+     * @param bool $enabled
      */
     public function setEnabled($enabled);
 }

--- a/src/Sylius/Component/Currency/composer.json
+++ b/src/Sylius/Component/Currency/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/resource": "0.13.*@dev",
         "sylius/storage": "0.13.*@dev"

--- a/src/Sylius/Component/Inventory/Model/InventoryUnitInterface.php
+++ b/src/Sylius/Component/Inventory/Model/InventoryUnitInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Inventory\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -18,7 +19,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface InventoryUnitInterface extends TimestampableInterface
+interface InventoryUnitInterface extends GetIdInterface, TimestampableInterface
 {
     /**
      * Default states.

--- a/src/Sylius/Component/Inventory/composer.json
+++ b/src/Sylius/Component/Inventory/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/resource": "0.13.*@dev"
     },

--- a/src/Sylius/Component/Locale/Model/LocaleInterface.php
+++ b/src/Sylius/Component/Locale/Model/LocaleInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Locale\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -18,7 +19,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface LocaleInterface extends TimestampableInterface
+interface LocaleInterface extends GetIdInterface, TimestampableInterface
 {
     /**
      * Get locale code.
@@ -37,14 +38,14 @@ interface LocaleInterface extends TimestampableInterface
     /**
      * Is activated?
      *
-     * @return Boolean
+     * @return bool
      */
     public function isEnabled();
 
     /**
      * Set activation status.
      *
-     * @param Boolean $enabled
+     * @param bool $enabled
      */
     public function setEnabled($enabled);
 }

--- a/src/Sylius/Component/Locale/composer.json
+++ b/src/Sylius/Component/Locale/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/resource": "0.13.*@dev",
         "sylius/storage": "0.13.*@dev"

--- a/src/Sylius/Component/Order/Model/AdjustmentInterface.php
+++ b/src/Sylius/Component/Order/Model/AdjustmentInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Order\Model;
 
 use Sylius\Component\Originator\Model\OriginAwareInterface;
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -19,7 +20,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface AdjustmentInterface extends TimestampableInterface, OriginAwareInterface
+interface AdjustmentInterface extends GetIdInterface, TimestampableInterface, OriginAwareInterface
 {
     /**
      * Get adjustment subject.

--- a/src/Sylius/Component/Order/Model/CommentInterface.php
+++ b/src/Sylius/Component/Order/Model/CommentInterface.php
@@ -11,24 +11,11 @@
 
 namespace Sylius\Component\Order\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
-interface CommentInterface extends TimestampableInterface
+interface CommentInterface extends GetIdInterface, OrderAwareInterface, TimestampableInterface
 {
-    /**
-     * Return order.
-     *
-     * @return OrderInterface
-     */
-    public function getOrder();
-
-    /**
-     * Set order.
-     *
-     * @param OrderInterface $order
-     */
-    public function setOrder(OrderInterface $order = null);
-
     /**
      * Return state.
      *

--- a/src/Sylius/Component/Order/Model/Identity.php
+++ b/src/Sylius/Component/Order/Model/Identity.php
@@ -35,14 +35,21 @@ class Identity implements IdentityInterface
     /**
      * Identity name, for instance "ebay id"
      *
+     * @var string
      */
     protected $name;
 
     /**
      * Identity value, for instance "2342343242"
      *
+     * @var string
      */
     protected $value;
+
+    public function getId()
+    {
+        return $this->id;
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Order/Model/IdentityInterface.php
+++ b/src/Sylius/Component/Order/Model/IdentityInterface.php
@@ -11,24 +11,26 @@
 
 namespace Sylius\Component\Order\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
+
 /**
  * Sylius order Identity model.
  *
  * @author Daniel Kucharski <daniel@xerias.be>
  */
-interface IdentityInterface
+interface IdentityInterface extends GetIdInterface, OrderAwareInterface
 {
     /**
      * Get identity name
      *
-     * @return string $name
+     * @return string
      */
     public function getName();
 
     /**
      * Get identity value
      *
-     * @param string $value
+     * @return string
      */
     public function getValue();
 
@@ -42,22 +44,7 @@ interface IdentityInterface
     /**
      * Set identity value
      *
-     * @return OrderInterface
+     * @param string $value
      */
     public function setValue($value);
-
-    /**
-     * Return order.
-     *
-     * @return OrderInterface
-     */
-    public function getOrder();
-
-    /**
-     * Set order.
-     *
-     * @param OrderInterface $order
-     */
-    public function setOrder(OrderInterface $order = null);
-
 }

--- a/src/Sylius/Component/Order/Model/OrderInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Order\Model;
 
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\SoftDeletableInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 use Sylius\Component\Sequence\Model\SequenceSubjectInterface;
@@ -21,7 +22,7 @@ use Sylius\Component\Sequence\Model\SequenceSubjectInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface OrderInterface extends AdjustableInterface, CommentAwareInterface, TimestampableInterface, SoftDeletableInterface, SequenceSubjectInterface
+interface OrderInterface extends AdjustableInterface, CommentAwareInterface, GetIdInterface, SoftDeletableInterface, SequenceSubjectInterface, TimestampableInterface
 {
     const STATE_CART        = 'cart';
     const STATE_CART_LOCKED = 'cart_locked';
@@ -49,7 +50,7 @@ interface OrderInterface extends AdjustableInterface, CommentAwareInterface, Tim
     /**
      * Has the order been completed by user and can be handled.
      *
-     * @return Boolean
+     * @return bool
      */
     public function isCompleted();
 
@@ -89,7 +90,7 @@ interface OrderInterface extends AdjustableInterface, CommentAwareInterface, Tim
     /**
      * Returns number of order items.
      *
-     * @return integer
+     * @return int
      */
     public function countItems();
 
@@ -112,14 +113,14 @@ interface OrderInterface extends AdjustableInterface, CommentAwareInterface, Tim
      *
      * @param OrderItemInterface $item
      *
-     * @return Boolean
+     * @return bool
      */
     public function hasItem(OrderItemInterface $item);
 
     /**
      * Get items total.
      *
-     * @return integer
+     * @return int
      */
     public function getItemsTotal();
 
@@ -132,14 +133,14 @@ interface OrderInterface extends AdjustableInterface, CommentAwareInterface, Tim
     /**
      * Get order total.
      *
-     * @return integer
+     * @return int
      */
     public function getTotal();
 
     /**
      * Set total.
      *
-     * @param integer $total
+     * @param int $total
      */
     public function setTotal($total);
 
@@ -159,14 +160,14 @@ interface OrderInterface extends AdjustableInterface, CommentAwareInterface, Tim
     /**
      * Returns total quantity of items in cart.
      *
-     * @return integer
+     * @return int
      */
     public function getTotalQuantity();
 
     /**
      * Checks whether the cart is empty or not.
      *
-     * @return Boolean
+     * @return bool
      */
     public function isEmpty();
 
@@ -193,14 +194,13 @@ interface OrderInterface extends AdjustableInterface, CommentAwareInterface, Tim
      * Add an identity to this order.  Eg. external identity to refer to an ebay order id
      *
      * @param IdentityInterface $identity
-     * @return mixed
      */
     public function addIdentity(IdentityInterface $identity);
 
     /**
      * Remove identity from order.
      *
-     * @param IdentityInterface $item
+     * @param IdentityInterface $identity
      */
     public function removeIdentity(IdentityInterface $identity);
 
@@ -208,6 +208,8 @@ interface OrderInterface extends AdjustableInterface, CommentAwareInterface, Tim
      * Is the identity already contained in this order?
      *
      * @param IdentityInterface $identity
+     *
+     * @return bool
      */
     public function hasIdentity(IdentityInterface $identity);
 

--- a/src/Sylius/Component/Order/Model/OrderItemInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderItemInterface.php
@@ -11,12 +11,14 @@
 
 namespace Sylius\Component\Order\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
+
 /**
  * Interface for order line item model.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface OrderItemInterface extends AdjustableInterface, OrderAwareInterface
+interface OrderItemInterface extends AdjustableInterface, GetIdInterface, OrderAwareInterface
 {
     /**
      * Get item quantity.

--- a/src/Sylius/Component/Order/composer.json
+++ b/src/Sylius/Component/Order/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/originator": "0.13.*@dev",
         "sylius/sequence":   "0.13.*@dev"

--- a/src/Sylius/Component/Originator/composer.json
+++ b/src/Sylius/Component/Originator/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "doctrine/common":         "~2.3",
         "sylius/resource":         "0.13.*@dev",

--- a/src/Sylius/Component/Payment/Model/CreditCardInterface.php
+++ b/src/Sylius/Component/Payment/Model/CreditCardInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Payment\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -18,7 +19,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface CreditCardInterface extends PaymentSourceInterface, TimestampableInterface
+interface CreditCardInterface extends GetIdInterface, PaymentSourceInterface, TimestampableInterface
 {
     /**
      * Supported CC brands.
@@ -117,28 +118,28 @@ interface CreditCardInterface extends PaymentSourceInterface, TimestampableInter
     /**
      * Get expiry month.
      *
-     * @return integer
+     * @return int
      */
     public function getExpiryMonth();
 
     /**
      * Set expiry month.
      *
-     * @param integer
+     * @param int
      */
     public function setExpiryMonth($expiryMonth);
 
     /**
      * Get expiry year.
      *
-     * @return integer
+     * @return int
      */
     public function getExpiryYear();
 
     /**
      * Set expiry year.
      *
-     * @param integer $expiryYear
+     * @param int $expiryYear
      */
     public function setExpiryYear($expiryYear);
 }

--- a/src/Sylius/Component/Payment/Model/PaymentInterface.php
+++ b/src/Sylius/Component/Payment/Model/PaymentInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Payment\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -18,7 +19,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface PaymentInterface extends TimestampableInterface
+interface PaymentInterface extends GetIdInterface, TimestampableInterface
 {
     // Payment states.
     const STATE_NEW        = 'new';
@@ -99,14 +100,14 @@ interface PaymentInterface extends TimestampableInterface
     /**
      * Get amount.
      *
-     * @return integer
+     * @return int
      */
     public function getAmount();
 
     /**
      * Set amount.
      *
-     * @param integer $amount
+     * @param int $amount
      *
      * @return PaymentInterface
      */

--- a/src/Sylius/Component/Payment/Model/PaymentMethodInterface.php
+++ b/src/Sylius/Component/Payment/Model/PaymentMethodInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Payment\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -18,19 +19,19 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface PaymentMethodInterface extends TimestampableInterface
+interface PaymentMethodInterface extends GetIdInterface, TimestampableInterface
 {
     /**
      * Check whether the payments method is currently enabled.
      *
-     * @return Boolean
+     * @return bool
      */
     public function isEnabled();
 
     /**
      * Enable or disable the payments method.
      *
-     * @param Boolean $enabled
+     * @param bool $enabled
      */
     public function setEnabled($enabled);
 

--- a/src/Sylius/Component/Payment/composer.json
+++ b/src/Sylius/Component/Payment/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/resource": "0.13.*@dev"
     },

--- a/src/Sylius/Component/Pricing/composer.json
+++ b/src/Sylius/Component/Pricing/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/resource": "0.13.*@dev",
         "sylius/registry": "0.13.*@dev"

--- a/src/Sylius/Component/Product/Model/AttributeTranslationInterface.php
+++ b/src/Sylius/Component/Product/Model/AttributeTranslationInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sylius package.
  *
@@ -19,4 +20,4 @@ use Sylius\Component\Attribute\Model\AttributeTranslationInterface as BaseAttrib
  */
 interface AttributeTranslationInterface extends BaseAttributeTranslationInterface
 {
-} 
+}

--- a/src/Sylius/Component/Product/Model/ProductInterface.php
+++ b/src/Sylius/Component/Product/Model/ProductInterface.php
@@ -12,7 +12,7 @@
 namespace Sylius\Component\Product\Model;
 
 use Sylius\Component\Archetype\Model\ArchetypeSubjectInterface;
-use Sylius\Component\Resource\Model\SlugAwareInterface;
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\SoftDeletableInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
@@ -24,10 +24,10 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  */
 interface ProductInterface extends
     ArchetypeSubjectInterface,
-    SlugAwareInterface,
+    GetIdInterface,
+    ProductTranslationInterface,
     SoftDeletableInterface,
-    TimestampableInterface,
-    ProductTranslationInterface
+    TimestampableInterface
 {
     /**
      * Check whether the product is available.

--- a/src/Sylius/Component/Product/Model/ProductTranslationInterface.php
+++ b/src/Sylius/Component/Product/Model/ProductTranslationInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Product\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\SlugAwareInterface;
 
 /**
@@ -18,7 +19,7 @@ use Sylius\Component\Resource\Model\SlugAwareInterface;
  *
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-interface ProductTranslationInterface extends SlugAwareInterface
+interface ProductTranslationInterface extends GetIdInterface, SlugAwareInterface
 {
     /**
      * Get product name.

--- a/src/Sylius/Component/Product/composer.json
+++ b/src/Sylius/Component/Product/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
  
         "sylius/resource":  "0.13.*@dev",
         "sylius/archetype": "0.13.*@dev"

--- a/src/Sylius/Component/Promotion/Model/ActionInterface.php
+++ b/src/Sylius/Component/Promotion/Model/ActionInterface.php
@@ -11,12 +11,14 @@
 
 namespace Sylius\Component\Promotion\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
+
 /**
  * Promotion action model interface.
  *
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-interface ActionInterface
+interface ActionInterface extends GetIdInterface
 {
     const TYPE_FIXED_DISCOUNT      = 'fixed_discount';
     const TYPE_PERCENTAGE_DISCOUNT = 'percentage_discount';

--- a/src/Sylius/Component/Promotion/Model/CouponInterface.php
+++ b/src/Sylius/Component/Promotion/Model/CouponInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Promotion\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\SoftDeletableInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
@@ -19,7 +20,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-interface CouponInterface extends SoftDeletableInterface, TimestampableInterface
+interface CouponInterface extends GetIdInterface, SoftDeletableInterface, TimestampableInterface
 {
     /**
      * Get code
@@ -38,28 +39,28 @@ interface CouponInterface extends SoftDeletableInterface, TimestampableInterface
     /**
      * Get usage limit
      *
-     * @return integer
+     * @return int
      */
     public function getUsageLimit();
 
     /**
      * Set usage limit
      *
-     * @param integer $usageLimit
+     * @param int $usageLimit
      */
     public function setUsageLimit($usageLimit);
 
     /**
      * Get number of times this coupon has been used
      *
-     * @return integer
+     * @return int
      */
     public function getUsed();
 
     /**
      * Set number of times this coupon has been used
      *
-     * @param integer $used
+     * @param int $used
      */
     public function setUsed($used);
 
@@ -99,7 +100,7 @@ interface CouponInterface extends SoftDeletableInterface, TimestampableInterface
     /**
      * Is this coupon valid?
      *
-     * @return Boolean
+     * @return bool
      */
     public function isValid();
 }

--- a/src/Sylius/Component/Promotion/Model/PromotionInterface.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Promotion\Model;
 
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -19,7 +20,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-interface PromotionInterface extends TimestampableInterface
+interface PromotionInterface extends GetIdInterface, TimestampableInterface
 {
     /**
      * Get name
@@ -52,14 +53,14 @@ interface PromotionInterface extends TimestampableInterface
     /**
      * Get priority
      *
-     * @return integer
+     * @return int
      */
     public function getPriority();
 
     /**
      * Set priority
      *
-     * @param integer $priority
+     * @param int $priority
      *
      * @return PromotionInterface
      */
@@ -68,14 +69,14 @@ interface PromotionInterface extends TimestampableInterface
     /**
      * Is exclusive
      *
-     * @return boolean
+     * @return bool
      */
     public function isExclusive();
 
     /**
      * Set exclusive
      *
-     * @param boolean $exclusive
+     * @param bool $exclusive
      *
      * @return PromotionInterface
      */
@@ -84,28 +85,28 @@ interface PromotionInterface extends TimestampableInterface
     /**
      * Get usage limit
      *
-     * @return integer
+     * @return int
      */
     public function getUsageLimit();
 
     /**
      * Set usage limit
      *
-     * @param integer $usageLimit
+     * @param int $usageLimit
      */
     public function setUsageLimit($usageLimit);
 
     /**
      * Get usage
      *
-     * @return integer
+     * @return int
      */
     public function getUsed();
 
     /**
      * Set usage
      *
-     * @param integer $used
+     * @param int $used
      */
     public function setUsed($used);
 
@@ -143,12 +144,12 @@ interface PromotionInterface extends TimestampableInterface
     public function setEndsAt(\DateTime $endsAt = null);
 
     /**
-     * @return Boolean
+     * @return bool
      */
     public function isCouponBased();
 
     /**
-     * @param Boolean $couponBased
+     * @param bool $couponBased
      *
      * @return self
      */
@@ -162,12 +163,12 @@ interface PromotionInterface extends TimestampableInterface
     /**
      * @param CouponInterface $coupon
      *
-     * @return Boolean
+     * @return bool
      */
     public function hasCoupon(CouponInterface $coupon);
 
     /**
-     * @return Boolean
+     * @return bool
      */
     public function hasCoupons();
 
@@ -193,12 +194,12 @@ interface PromotionInterface extends TimestampableInterface
     /**
      * @param RuleInterface $rule
      *
-     * @return Boolean
+     * @return bool
      */
     public function hasRule(RuleInterface $rule);
 
     /**
-     * @return Boolean
+     * @return bool
      */
     public function hasRules();
 
@@ -224,12 +225,12 @@ interface PromotionInterface extends TimestampableInterface
     /**
      * @param ActionInterface $action
      *
-     * @return Boolean
+     * @return bool
      */
     public function hasAction(ActionInterface $action);
 
     /**
-     * @return Boolean
+     * @return bool
      */
     public function hasActions();
 

--- a/src/Sylius/Component/Promotion/Model/RuleInterface.php
+++ b/src/Sylius/Component/Promotion/Model/RuleInterface.php
@@ -11,12 +11,14 @@
 
 namespace Sylius\Component\Promotion\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
+
 /**
  * Promotion rule model interface.
  *
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-interface RuleInterface
+interface RuleInterface extends GetIdInterface
 {
     const TYPE_ITEM_TOTAL = 'item_total';
     const TYPE_ITEM_COUNT = 'item_count';

--- a/src/Sylius/Component/Promotion/composer.json
+++ b/src/Sylius/Component/Promotion/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/registry": "0.13.*@dev",
         "sylius/resource": "0.13.*@dev"

--- a/src/Sylius/Component/Registry/composer.json
+++ b/src/Sylius/Component/Registry/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.9"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.1"

--- a/src/Sylius/Component/Resource/Model/GetIdInterface.php
+++ b/src/Sylius/Component/Resource/Model/GetIdInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Resource\Model;
+
+/**
+ * @author Joseph Bielawski <stloyd@gmail.com>
+ */
+interface GetIdInterface
+{
+    /**
+     * Get the identifier.
+     *
+     * @return int
+     */
+    public function getId();
+}

--- a/src/Sylius/Component/Resource/composer.json
+++ b/src/Sylius/Component/Resource/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php":                      ">=5.3.3",
+        "php":                      ">=5.3.9",
 
         "doctrine/collections":     "~1.0",
         "doctrine/common":          "~2.3",

--- a/src/Sylius/Component/Sequence/Model/Sequence.php
+++ b/src/Sylius/Component/Sequence/Model/Sequence.php
@@ -14,19 +14,22 @@ namespace Sylius\Component\Sequence\Model;
 class Sequence implements SequenceInterface
 {
     /**
-     * Identifier
-     * @var integer
+     * Identifier.
+     * 
+     * @var int
      */
     protected $id;
 
     /**
-     * Sequence index
-     * @var integer
+     * Sequence index.
+     * 
+     * @var int
      */
     protected $index = 0;
 
     /**
-     * Sequence type
+     * Sequence type.
+     * 
      * @var string
      */
     protected $type;
@@ -62,7 +65,7 @@ class Sequence implements SequenceInterface
      */
     public function incrementIndex()
     {
-        $this->index++;
+        ++$this->index;
 
         return $this;
     }

--- a/src/Sylius/Component/Sequence/Model/SequenceInterface.php
+++ b/src/Sylius/Component/Sequence/Model/SequenceInterface.php
@@ -11,22 +11,27 @@
 
 namespace Sylius\Component\Sequence\Model;
 
-interface SequenceInterface
+use Sylius\Component\Resource\Model\GetIdInterface;
+
+interface SequenceInterface extends GetIdInterface
 {
     /**
-     * Return sequence type
+     * Return sequence type.
+     *
      * @return string
      */
     public function getType();
 
     /**
-     * Get the sequence index
-     * @return integer
+     * Get the sequence index.
+     *
+     * @return int
      */
     public function getIndex();
 
     /**
-     * Increment sequence type
+     * Increment sequence type.
+     *
      * @return self
      */
     public function incrementIndex();

--- a/src/Sylius/Component/Sequence/composer.json
+++ b/src/Sylius/Component/Sequence/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/resource": "0.13.*@dev",
         "sylius/registry": "0.13.*@dev"

--- a/src/Sylius/Component/Shipping/Model/RuleInterface.php
+++ b/src/Sylius/Component/Shipping/Model/RuleInterface.php
@@ -11,12 +11,14 @@
 
 namespace Sylius\Component\Shipping\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
+
 /**
  * Shipping method rule model interface.
  *
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-interface RuleInterface
+interface RuleInterface extends GetIdInterface
 {
     const TYPE_ITEM_TOTAL = 'item_total';
     const TYPE_ITEM_COUNT = 'item_count';

--- a/src/Sylius/Component/Shipping/Model/ShipmentInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShipmentInterface.php
@@ -12,13 +12,14 @@
 namespace Sylius\Component\Shipping\Model;
 
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Resource\Model\GetIdInterface;
 
 /**
  * Shipment interface.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface ShipmentInterface extends ShippingSubjectInterface
+interface ShipmentInterface extends GetIdInterface, ShippingSubjectInterface
 {
     // Shipment default states.
     const STATE_CHECKOUT    = 'checkout';
@@ -84,7 +85,7 @@ interface ShipmentInterface extends ShippingSubjectInterface
      *
      * @param ShipmentItemInterface $item
      *
-     * @return Boolean
+     * @return bool
      */
     public function hasItem(ShipmentItemInterface $item);
 
@@ -105,7 +106,7 @@ interface ShipmentInterface extends ShippingSubjectInterface
     /**
      * Check if this shipment has any tracking.
      *
-     * @return Boolean
+     * @return bool
      */
     public function isTracked();
 }

--- a/src/Sylius/Component/Shipping/Model/ShipmentItemInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShipmentItemInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Shipping\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -18,7 +19,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface ShipmentItemInterface extends TimestampableInterface
+interface ShipmentItemInterface extends GetIdInterface, TimestampableInterface
 {
     /**
      * Get shipment.

--- a/src/Sylius/Component/Shipping/Model/ShippingCategoryInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingCategoryInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Shipping\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -18,7 +19,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface ShippingCategoryInterface extends TimestampableInterface
+interface ShippingCategoryInterface extends GetIdInterface, TimestampableInterface
 {
     /**
      * Get category name.

--- a/src/Sylius/Component/Shipping/Model/ShippingMethodInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethodInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Shipping\Model;
 
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -20,7 +21,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-interface ShippingMethodInterface extends TimestampableInterface, ShippingMethodTranslationInterface
+interface ShippingMethodInterface extends GetIdInterface, TimestampableInterface, ShippingMethodTranslationInterface
 {
     // Shippables requirement to match given method.
     const CATEGORY_REQUIREMENT_MATCH_NONE = 0;
@@ -49,14 +50,14 @@ interface ShippingMethodInterface extends TimestampableInterface, ShippingMethod
      * 2) At least one of shippables matches the category.
      * 3) All shippables have to match the method category.
      *
-     * @return integer
+     * @return int
      */
     public function getCategoryRequirement();
 
     /**
      * Set the requirement.
      *
-     * @param integer $categoryRequirement
+     * @param int $categoryRequirement
      */
     public function setCategoryRequirement($categoryRequirement);
 
@@ -70,14 +71,14 @@ interface ShippingMethodInterface extends TimestampableInterface, ShippingMethod
     /**
      * Check whether the shipping method is currently enabled.
      *
-     * @return Boolean
+     * @return bool
      */
     public function isEnabled();
 
     /**
      * Enable or disable the shipping method.
      *
-     * @param Boolean $enabled
+     * @param bool $enabled
      */
     public function setEnabled($enabled);
 
@@ -121,7 +122,7 @@ interface ShippingMethodInterface extends TimestampableInterface, ShippingMethod
      *
      * @param RuleInterface $rule
      *
-     * @return Boolean
+     * @return bool
      */
     public function hasRule(RuleInterface $rule);
 

--- a/src/Sylius/Component/Shipping/Model/ShippingMethodTranslationInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethodTranslationInterface.php
@@ -12,14 +12,14 @@
 namespace Sylius\Component\Shipping\Model;
 
 use Doctrine\Common\Collections\Collection;
-use Sylius\Component\Resource\Model\TimestampableInterface;
+use Sylius\Component\Resource\Model\GetIdInterface;
 
 /**
  * Shipping method translation interface.
  *
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-interface ShippingMethodTranslationInterface
+interface ShippingMethodTranslationInterface extends GetIdInterface
 {
     /**
      * Get shipping method name.

--- a/src/Sylius/Component/Shipping/composer.json
+++ b/src/Sylius/Component/Shipping/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php":                      ">=5.3.3",
+        "php":                      ">=5.3.9",
 
         "sylius/resource":          "0.13.*@dev",
         "symfony/options-resolver": "~2.3",

--- a/src/Sylius/Component/Storage/composer.json
+++ b/src/Sylius/Component/Storage/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.9"
     },
     "require-dev": {
         "doctrine/cache": "~1.3",

--- a/src/Sylius/Component/Taxation/Model/TaxCategoryInterface.php
+++ b/src/Sylius/Component/Taxation/Model/TaxCategoryInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Taxation\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -18,7 +19,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface TaxCategoryInterface extends TimestampableInterface
+interface TaxCategoryInterface extends GetIdInterface, TimestampableInterface
 {
     /**
      * Get category name.

--- a/src/Sylius/Component/Taxation/Model/TaxRateInterface.php
+++ b/src/Sylius/Component/Taxation/Model/TaxRateInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Taxation\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -18,7 +19,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface TaxRateInterface extends TimestampableInterface
+interface TaxRateInterface extends GetIdInterface, TimestampableInterface
 {
     /**
      * Get category.
@@ -72,14 +73,14 @@ interface TaxRateInterface extends TimestampableInterface
     /**
      * Is included in price?
      *
-     * @return Boolean
+     * @return bool
      */
     public function isIncludedInPrice();
 
     /**
      * Set as included in price or not.
      *
-     * @param Boolean $includedInPrice
+     * @param bool $includedInPrice
      */
     public function setIncludedInPrice($includedInPrice);
 

--- a/src/Sylius/Component/Taxation/composer.json
+++ b/src/Sylius/Component/Taxation/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/resource": "0.13.*@dev"
     },

--- a/src/Sylius/Component/Taxonomy/Model/TaxonInterface.php
+++ b/src/Sylius/Component/Taxonomy/Model/TaxonInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Taxonomy\Model;
 
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Translation\Model\TranslatableInterface;
 use Sylius\Component\Resource\Model\SoftDeletableInterface;
 
@@ -21,15 +22,8 @@ use Sylius\Component\Resource\Model\SoftDeletableInterface;
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-interface TaxonInterface extends SoftDeletableInterface, TaxonTranslationInterface, TranslatableInterface
+interface TaxonInterface extends GetIdInterface, SoftDeletableInterface, TaxonTranslationInterface, TranslatableInterface
 {
-    /**
-     * Get the id of taxonomy.
-     *
-     * @return int
-     */
-    public function getId();
-
     /**
      * Get the taxonomy.
      *

--- a/src/Sylius/Component/Taxonomy/Model/TaxonTranslationInterface.php
+++ b/src/Sylius/Component/Taxonomy/Model/TaxonTranslationInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Taxonomy\Model;
 
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\SlugAwareInterface;
 
 /**
@@ -19,7 +20,7 @@ use Sylius\Component\Resource\Model\SlugAwareInterface;
  *
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-interface TaxonTranslationInterface extends SlugAwareInterface
+interface TaxonTranslationInterface extends GetIdInterface, SlugAwareInterface
 {
     /**
      * Get taxon name.

--- a/src/Sylius/Component/Taxonomy/Model/TaxonomyInterface.php
+++ b/src/Sylius/Component/Taxonomy/Model/TaxonomyInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Taxonomy\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Translation\Model\TranslatableInterface;
 
 /**
@@ -19,15 +20,8 @@ use Sylius\Component\Translation\Model\TranslatableInterface;
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-interface TaxonomyInterface extends TranslatableInterface, TaxonomyTranslationInterface, TaxonsAwareInterface
+interface TaxonomyInterface extends GetIdInterface, TranslatableInterface, TaxonomyTranslationInterface, TaxonsAwareInterface
 {
-    /**
-     * Get taxonomy id.
-     *
-     * @return mixed
-     */
-    public function getId();
-
     /**
      * Get root taxon.
      *

--- a/src/Sylius/Component/Taxonomy/Model/TaxonomyTranslationInterface.php
+++ b/src/Sylius/Component/Taxonomy/Model/TaxonomyTranslationInterface.php
@@ -11,20 +11,15 @@
 
 namespace Sylius\Component\Taxonomy\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
+
 /**
  * Taxonomy translation model interface.
  *
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-interface TaxonomyTranslationInterface
+interface TaxonomyTranslationInterface extends GetIdInterface
 {
-    /**
-     * Get taxonomy id.
-     *
-     * @return mixed
-     */
-    public function getId();
-
     /**
      * Get name.
      *

--- a/src/Sylius/Component/Taxonomy/composer.json
+++ b/src/Sylius/Component/Taxonomy/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/resource": "0.13.*@dev"
     },

--- a/src/Sylius/Component/Translation/Model/TranslatableInterface.php
+++ b/src/Sylius/Component/Translation/Model/TranslatableInterface.php
@@ -17,24 +17,26 @@ namespace Sylius\Component\Translation\Model;
 interface TranslatableInterface
 {
     /**
-     * Get all translations
+     * Get all translations.
      *
      * @return TranslationInterface[]
      */
     public function getTranslations();
 
     /**
-     * Add a new translation
+     * Add a new translation.
      *
      * @param TranslationInterface $translation
+     *
      * @return self
      */
     public function addTranslation(TranslationInterface $translation);
 
     /**
-     * Remove a translation
+     * Remove a translation.
      *
      * @param TranslationInterface $translation
+     *
      * @return $this
      */
     public function removeTranslation(TranslationInterface $translation);

--- a/src/Sylius/Component/Translation/Model/TranslationInterface.php
+++ b/src/Sylius/Component/Translation/Model/TranslationInterface.php
@@ -17,31 +17,33 @@ namespace Sylius\Component\Translation\Model;
 interface TranslationInterface
 {
     /**
-     * Get the translatable object
+     * Get the translatable object.
      *
      * @return TranslatableInterface
      */
     public function getTranslatable();
 
     /**
-     * Set the translatable object
+     * Set the translatable object.
      *
      * @param TranslatableInterface $translatable
+     *
      * @return self
      */
     public function setTranslatable(TranslatableInterface $translatable = null);
 
     /**
-     * Get the locale
+     * Get the locale.
      *
      * @return string
      */
     public function getLocale();
 
     /**
-     * Set the locale
+     * Set the locale.
      *
      * @param string $locale
+     *
      * @return $this
      */
     public function setLocale($locale);

--- a/src/Sylius/Component/Translation/composer.json
+++ b/src/Sylius/Component/Translation/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "doctrine/collections"          : "~1.2",
         "doctrine/orm"                 : "~2.4"

--- a/src/Sylius/Component/Variation/Model/OptionInterface.php
+++ b/src/Sylius/Component/Variation/Model/OptionInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Variation\Model;
 
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -22,7 +23,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface OptionInterface extends TimestampableInterface, OptionTranslationInterface
+interface OptionInterface extends GetIdInterface, TimestampableInterface, OptionTranslationInterface
 {
     /**
      * Get internal name.

--- a/src/Sylius/Component/Variation/Model/OptionTranslationInterface.php
+++ b/src/Sylius/Component/Variation/Model/OptionTranslationInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Variation\Model;
 
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -19,7 +20,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-interface OptionTranslationInterface
+interface OptionTranslationInterface extends GetIdInterface
 {
     /**
      * The name displayed to user.

--- a/src/Sylius/Component/Variation/Model/OptionValueInterface.php
+++ b/src/Sylius/Component/Variation/Model/OptionValueInterface.php
@@ -11,12 +11,14 @@
 
 namespace Sylius\Component\Variation\Model;
 
+use Sylius\Component\Resource\Model\GetIdInterface;
+
 /**
  * Option value interface.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface OptionValueInterface
+interface OptionValueInterface extends GetIdInterface
 {
     /**
      * Get option.

--- a/src/Sylius/Component/Variation/Model/VariantInterface.php
+++ b/src/Sylius/Component/Variation/Model/VariantInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Variation\Model;
 
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Resource\Model\GetIdInterface;
 use Sylius\Component\Resource\Model\SoftDeletableInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
@@ -20,19 +21,19 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface VariantInterface extends SoftDeletableInterface, TimestampableInterface
+interface VariantInterface extends GetIdInterface, SoftDeletableInterface, TimestampableInterface
 {
     /**
      * Checks whether variant is master.
      *
-     * @return Boolean
+     * @return bool
      */
     public function isMaster();
 
     /**
      * Defines whether variant is master.
      *
-     * @param Boolean $master
+     * @param bool $master
      */
     public function setMaster($master);
 
@@ -100,7 +101,7 @@ interface VariantInterface extends SoftDeletableInterface, TimestampableInterfac
      *
      * @param OptionValueInterface $option
      *
-     * @return Boolean
+     * @return bool
      */
     public function hasOption(OptionValueInterface $option);
 

--- a/src/Sylius/Component/Variation/composer.json
+++ b/src/Sylius/Component/Variation/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.9",
 
         "sylius/resource": "0.13.*@dev"
     },


### PR DESCRIPTION
> Prior to PHP 5.3.9, a class could not implement two interfaces that specified
> a method with the same name, since it would cause ambiguity. More recent versions
> of PHP allow this as long as the duplicate methods have the same signature.