### PR TITLE
[ResourceBundle] Check if collection form prototype is defined

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Resources/views/forms.html.twig
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/views/forms.html.twig
@@ -5,9 +5,9 @@
     {% spaceless %}
         <div data-form-type="collection"
              {{ block('widget_container_attributes') }}
-             {% if prototype is not empty %}
+             {% if prototype is defined and allow_add and prototype is not empty %}
              data-prototype='{{ _self.collectionItem(prototype, allow_delete, button_delete_label, '__name__')|e }}'
-             {% endif %}>
+             {%- endif -%}>
 
             {{ error(form.vars.errors) }}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a


If you specify `allow_add` to false when building a form collection property, this will result in a Twig error:

> Variable "prototype" does not exist

In the same form theme template, a check is done to see `prototype` is defined and `allow_add` is true on part of the template, so this same has been done here to fix this issue.

```php
public function buildForm(FormBuilderInterface $builder, array $options)
{
        $builder ->add('attributes', 'collection', [
                'required'     => false,
                'type'         => 'sylius_advertisement_attribute_value',
                'allow_add'    => false,
                'allow_delete' => false,
                'by_reference' => false
        ]);
```