### PR TITLE
[ResourceBundle] Set the property path default to the ID of the entity for entity_hidden form type

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Form/Type/EntityHiddenType.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/Type/EntityHiddenType.php
@@ -29,6 +29,9 @@ class EntityHiddenType extends AbstractType
      */
     protected $manager;
 
+    /**
+     * @param ManagerRegistry $manager
+     */
     public function __construct(ManagerRegistry $manager)
     {
         $this->manager = $manager;
@@ -64,6 +67,7 @@ class EntityHiddenType extends AbstractType
     {
         $resolver->setDefaults(array(
             'identifier' => 'id',
+            'property_path' => 'id',
         ));
     }
 

--- a/src/Sylius/Bundle/ResourceBundle/spec/Form/Type/EntityHiddenTypeSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Form/Type/EntityHiddenTypeSpec.php
@@ -53,6 +53,7 @@ class EntityHiddenTypeSpec extends ObjectBehavior
     {
         $resolver->setDefaults(array(
             'identifier' => 'id',
+            'property_path' => 'id',
         ))->shouldBeCalled($resolver);
 
         $this->setDefaultOptions($resolver);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | ?
| Deprecations? | no
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

If the `data_class` option specified for the `entity_hidden` form type implements a `__toString()` method and that method returns something other than the ID of the entity, this will be the value of the hidden input rendered on the form, resulting in a transformation error when submitted (screenshot attached).

This is fixed by explicitly setting the default `property_path` to 'id`. I could have added this option to my own form type, but as the form input is hidden and a magic method is used, this can be difficult to debug, so I thought it would be better to set it as a default.

This may cause BC breaks however, but I'm not certain.

Code that produced the error:

```php
public function buildForm(FormBuilderInterface $builder, array $options)
{
    $builder->add('archetype', 'entity_hidden', [
        'data_class' => AdvertisementArchetype::class,
    ]);
}
```
![screen shot 2015-01-31 at 23 18 54](https://cloud.githubusercontent.com/assets/5972864/5990248/1dabe8e6-a9a0-11e4-9059-8130af9556db.png)
