### PR TITLE
Use "limit" instead of "paginate" for limit parameter.

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -404,7 +404,7 @@ class ResourceController extends FOSRestController
      */
     protected function getPagerfantaFactory()
     {
-        return new PagerfantaFactory('page', 'limit');
+        return new PagerfantaFactory();
     }
 
     protected function handleView(View $view)


### PR DESCRIPTION
Right now in API, if developer want to change the number of result per page, they have to use "paginate":

```
http://example.com/products?paginate=10
```

This PR will change it to default, which is "limit", a more common term for such parameter:

```
http://example.com/products?limit=10
```

Reference:

- http://docs.sylius.org/en/latest/api/products.html