### PR TITLE
[SearchBundle] Allow false value for enabled pre search filter field

### DIFF
--- a/src/Sylius/Bundle/SearchBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/SearchBundle/DependencyInjection/Configuration.php
@@ -76,7 +76,6 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                                 ->booleanNode('enabled')
                                     ->isRequired()
-                                    ->cannotBeEmpty()
                                 ->end()
                             ->end()
                         ->end()


### PR DESCRIPTION
Hey!

This PR fixes an issue introduced in #2418. Using `cannotBeEmpty` on a boolean node seems to not allow us to use false as value.