### PR TITLE
[Installer] Fix missing output when using runCommands

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Command/AbstractInstallCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/AbstractInstallCommand.php
@@ -118,7 +118,7 @@ abstract class AbstractInstallCommand extends ContainerAwareCommand
                 $parameters = array();
             }
 
-            $this->commandExecutor->runCommand($command, $parameters);
+            $this->commandExecutor->runCommand($command, $parameters, $output);
 
             // PDO does not always close the connection after Doctrine commands.
             // See https://github.com/symfony/symfony/issues/11750.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Currently we are not able to see output (therefore errors) of commands run through `Sylius\Bundle\InstallerBundle\Command\AbstractInstallCommand::runCommands`