### PR TITLE
[Installer] Fix isDatabasePresent

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Command/InstallDatabaseCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/InstallDatabaseCommand.php
@@ -94,7 +94,7 @@ EOT
         try {
             $schemaManager = $this->getSchemaManager();
         } catch (\Exception $exception) {
-            if (false !== strpos($exception->getMessage(), sprintf("SQLSTATE[HY000] [1049] Unknown database '%s'", $databaseName))) {
+            if (false !== strpos($exception->getMessage(), sprintf("Unknown database '%s'", $databaseName))) {
                 return false;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2454
| License       | MIT
| Doc PR        |

The check done on PDOException message when dealing with an unknown database is too strict.
For example, it won't match `SQLSTATE[42000] [1049] Unknown database 'xxxx'` given on certain installation