### PR TITLE
Correct api fixtures

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/main.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/main.yml
@@ -81,7 +81,6 @@ fos_user:
             type: sylius_user_registration
 
 fos_rest:
-    disable_csrf_role: ROLE_API
     view:
         formats:
             json: true

--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadApiData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadApiData.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\FixturesBundle\DataFixtures\ORM;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use FOS\OAuthServerBundle\Model\ClientManagerInterface;
+use Sylius\Component\Core\Model\UserInterface;
 use OAuth2\OAuth2;
 use Sylius\Bundle\ApiBundle\Model\Client;
 use Sylius\Bundle\FixturesBundle\DataFixtures\DataFixture;
@@ -29,6 +30,17 @@ class LoadApiData extends DataFixture
      */
     public function load(ObjectManager $manager)
     {
+        // create user with API role
+        $user = $this->createUser(
+            'api@example.com',
+            'api',
+            true,
+            array('ROLE_API')
+        );
+
+        $manager->persist($user);
+        $manager->flush();
+
         $clientManager = $this->getClientManager();
 
         /** @var Client $client */
@@ -45,6 +57,31 @@ class LoadApiData extends DataFixture
             )
         );
         $clientManager->updateClient($client);
+    }
+
+    /**
+     * @param string $email
+     * @param string $password
+     * @param bool   $enabled
+     * @param array  $roles
+     * @param string $currency
+     *
+     * @return UserInterface
+     */
+    protected function createUser($email, $password, $enabled = true, array $roles = array('ROLE_USER'), $currency = 'EUR')
+    {
+        /* @var $user UserInterface */
+        $user = $this->getUserRepository()->createNew();
+        $user->setFirstname($this->faker->firstName);
+        $user->setLastname($this->faker->lastName);
+        $user->setUsername($email);
+        $user->setEmail($email);
+        $user->setPlainPassword($password);
+        $user->setRoles($roles);
+        $user->setCurrency($currency);
+        $user->setEnabled($enabled);
+
+        return $user;
     }
 
     /**

--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadUsersData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadUsersData.php
@@ -31,7 +31,7 @@ class LoadUsersData extends DataFixture
             'sylius@example.com',
             'sylius',
             true,
-            array('ROLE_SYLIUS_ADMIN', 'ROLE_API')
+            array('ROLE_SYLIUS_ADMIN')
         );
 
         $manager->persist($user);

--- a/src/Sylius/Bundle/InstallerBundle/Command/SetupCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/SetupCommand.php
@@ -72,7 +72,7 @@ EOT
         $user->setEmail($email);
         $user->setPlainPassword($this->ask($output, 'Choose password:', array(new NotBlank())));
         $user->setEnabled(true);
-        $user->setRoles(array('ROLE_SYLIUS_ADMIN', 'ROLE_API'));
+        $user->setRoles(array('ROLE_SYLIUS_ADMIN'));
 
         $userManager->persist($user);
         $userManager->flush();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

When ROLE_API is assigned the csrf token is disabled and it causes exception in the backend.

```
Method "_token" for object "Symfony\Component\Form\FormView" does not exist
```

Removed csrf token disable from config, it is handled by ResourceController.

Added fixtures to create new user with ROLE_API for api tests.