### PR TITLE
Fix for shipping calculators to return integers

### DIFF
--- a/src/Sylius/Component/Shipping/Calculator/FlatRateCalculator.php
+++ b/src/Sylius/Component/Shipping/Calculator/FlatRateCalculator.php
@@ -28,7 +28,7 @@ class FlatRateCalculator extends Calculator
      */
     public function calculate(ShippingSubjectInterface $subject, array $configuration)
     {
-        return $configuration['amount'];
+        return (int)$configuration['amount'];
     }
 
     /**

--- a/src/Sylius/Component/Shipping/Calculator/FlexibleRateCalculator.php
+++ b/src/Sylius/Component/Shipping/Calculator/FlexibleRateCalculator.php
@@ -41,7 +41,7 @@ class FlexibleRateCalculator extends Calculator
             $additionalItems = $additionalItemLimit >= $additionalItems ? $additionalItems : $additionalItemLimit;
         }
 
-        return $firstItemCost + ($additionalItems * $additionalItemCost);
+        return (int)($firstItemCost + ($additionalItems * $additionalItemCost));
     }
 
     /**

--- a/src/Sylius/Component/Shipping/Calculator/PerItemRateCalculator.php
+++ b/src/Sylius/Component/Shipping/Calculator/PerItemRateCalculator.php
@@ -26,7 +26,7 @@ class PerItemRateCalculator extends Calculator
      */
     public function calculate(ShippingSubjectInterface $subject, array $configuration)
     {
-        return $configuration['amount'] * $subject->getShippingItemCount();
+        return (int)($configuration['amount'] * $subject->getShippingItemCount());
     }
 
     /**


### PR DESCRIPTION
Fix for shipping calculators to return integers because of error thrown during checkout caused by #2427 