### PR TITLE
[PromotionBundle] Force 'classes' configuration

### DIFF
--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Configuration.php
@@ -129,6 +129,7 @@ class Configuration implements ConfigurationInterface
         $node
             ->children()
                 ->arrayNode('classes')
+                    ->isRequired()
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->arrayNode('promotion')


### PR DESCRIPTION
If ``sylius.classes.promotion_subject`` is not set, ``DoctrineTargetEntitiesResolver`` will throw an exception:

    The class sylius.model.promotion_subject.class does not exist.