### PR TITLE
[Core] added correct form type for product translations to config

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
@@ -79,6 +79,8 @@ sylius_product:
                 targetEntity: Sylius\Component\Core\Model\ProductTranslation
         product_translation:
             model: Sylius\Component\Core\Model\ProductTranslation
+            form:
+                default: Sylius\Bundle\CoreBundle\Form\Type\ProductTranslationType
 
 
 sylius_archetype:


### PR DESCRIPTION
Product translations form in backend lacked shortDescription added in corebundle.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -