### PR TITLE
Make applyCriteria() more flexible

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/EntityRepository.php
+++ b/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/EntityRepository.php
@@ -176,8 +176,12 @@ class EntityRepository extends BaseEntityRepository implements RepositoryInterfa
                 $queryBuilder->andWhere($queryBuilder->expr()->in($this->getPropertyName($property), $value));
             } elseif ('' !== $value) {
                 $queryBuilder
-                    ->andWhere($queryBuilder->expr()->eq($this->getPropertyName($property), ':' . $property))
-                    ->setParameter($property, $value);
+                    ->andWhere($queryBuilder->expr()->eq(
+                        $this->getPropertyName($property),
+                        ':' . $key = str_replace('.', '_', $property))
+                    )
+                    ->setParameter($key, $value)
+                ;
             }
         }
     }


### PR DESCRIPTION
Here is the use case. I am creating custom repository and function to join and apply some criteria, like this:

```php
<?php

namespace Umpirsky\Bundle\TildaBundle\Repository;

use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
use Sylius\Component\Core\Model\UserInterface;

class FooRepository extends EntityRepository
{
    public function getUsersFoos(UserInterface $user)
    {
        $queryBuilder = $this->getCollectionQueryBuilder()
            ->select($this->getAlias().', foo')
            ->join($this->getAlias().'.foo', 'foo')
        ;

        $this->applyCriteria($queryBuilder, ['foo.deleted' => false]);
        $this->applySorting($queryBuilder, ['foo.updatedAt' => 'DESC', 'foo.startTime' => 'DESC']);

        return $this->getPaginator($queryBuilder);
    }
}
```

I get error:

```
QueryException: [Syntax Error] line 0, col 130: Error: Expected end of string, got '.'  
```

It should be possible to do this after my fix.