### PR TITLE
Translation fixes for slideshow filter labels in EN and NO locales

### DIFF
--- a/src/Sylius/Bundle/ContentBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/ContentBundle/Resources/translations/messages.en.yml
@@ -10,9 +10,9 @@ sylius:
         imagine_block:
             parent: Parent
             internal_name: Internal name
-            slideshow_small: 'Slideshow Large (full width)'
+            slideshow_small: 'Slideshow Small (side)'
             slideshow_medium: 'Slideshow Medium (content)'
-            slideshow_large: 'Slideshow Small (side)'
+            slideshow_large: 'Slideshow Large (full width)'
 
         menu:
             childrens: Childrens


### PR DESCRIPTION
The translations for EN and NO labels were switched in places.