### PR TITLE
[WebBundle] Locale and Currency menu shouldn't be renderd when only 1 exists

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
@@ -187,13 +187,20 @@ class FrontendMenuBuilder extends MenuBuilder
      */
     public function createCurrencyMenu()
     {
+        $currencies = $this->currencyProvider->getAvailableCurrencies();
         $menu = $this->factory->createItem('root', array(
             'childrenAttributes' => array(
                 'class' => 'nav nav-pills'
             )
         ));
 
-        foreach ($this->currencyProvider->getAvailableCurrencies() as $currency) {
+        if (1 === count($currencies)) {
+            $menu->setDisplay(false);
+
+            return $menu;
+        }
+
+        foreach ($currencies as $currency) {
             $code = $currency->getCode();
 
             $menu->addChild($code, array(

--- a/src/Sylius/Bundle/WebBundle/Menu/LocaleMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/LocaleMenuBuilder.php
@@ -61,13 +61,20 @@ class LocaleMenuBuilder extends MenuBuilder
      */
     public function createMenu()
     {
+        $locales = $this->localeProvider->getAvailableLocales();
         $menu = $this->factory->createItem('root', array(
             'childrenAttributes' => array(
                 'class' => 'nav nav-pills'
             )
         ));
 
-        foreach ($this->localeProvider->getAvailableLocales() as $locale) {
+        if (1 === count($locales)) {
+            $menu->setDisplay(false);
+
+            return $menu;
+        }
+
+        foreach ($locales as $locale) {
             $code = $locale->getCode();
 
             $menu->addChild($code, array(


### PR DESCRIPTION
It's weird the menu's are shown when there is no option to cycle through. Currency is shown in many places so you don't need a weird sign on the top to tell you the current currency. Same goes with the language.

This is a clean pr from my last pr: https://github.com/Sylius/Sylius/pull/2485