### PR TITLE
[ProductBundle] Add missing locale-bundle dependency

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/composer.json
+++ b/src/Sylius/Bundle/ProductBundle/composer.json
@@ -27,6 +27,7 @@
         "sylius/resource-bundle":          "0.14.*@dev",
         "sylius/product":                  "0.14.*@dev",
         "sylius/archetype-bundle":         "0.14.*@dev",
+        "sylius/locale-bundle":            "0.14.*@dev",
         "sylius/translation-bundle":       "0.14.*@dev"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2480
| License       | MIT
| Doc PR        | n/a

I'm in the process of updating the docs for the ProductBundle.

One of the issues, which has been raised already is a missing dependency.

> ServiceNotFoundException in vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php line 58:
> The service "sylius.repository.product" has a dependency on a non-existent service "sylius.context.locale".

So `product-bundle` now requires `locale-bundle`. As far as I can tell, `product` does not need any classes from `locale` in order to be used, so this is not added.