### PR TITLE
Injecting the Request object

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
@@ -16,6 +16,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\UserInterface;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * The addressing step of checkout.
@@ -28,7 +29,7 @@ class AddressingStep extends CheckoutStep
     /**
      * {@inheritdoc}
      */
-    public function displayAction(ProcessContextInterface $context)
+    public function displayAction(ProcessContextInterface $context, Request $request)
     {
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::ADDRESSING_INITIALIZE, $order);
@@ -41,10 +42,8 @@ class AddressingStep extends CheckoutStep
     /**
      * {@inheritdoc}
      */
-    public function forwardAction(ProcessContextInterface $context)
+    public function forwardAction(ProcessContextInterface $context, Request $request)
     {
-        $request = $this->getRequest();
-
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::ADDRESSING_INITIALIZE, $order);
 

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/FinalizeStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/FinalizeStep.php
@@ -16,6 +16,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Sylius\Component\Core\SyliusOrderEvents;
 use Sylius\Component\Order\OrderTransitions;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Final checkout step.
@@ -27,7 +28,7 @@ class FinalizeStep extends CheckoutStep
     /**
      * {@inheritdoc}
      */
-    public function displayAction(ProcessContextInterface $context)
+    public function displayAction(ProcessContextInterface $context, Request $request)
     {
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::FINALIZE_INITIALIZE, $order);
@@ -38,7 +39,7 @@ class FinalizeStep extends CheckoutStep
     /**
      * {@inheritdoc}
      */
-    public function forwardAction(ProcessContextInterface $context)
+    public function forwardAction(ProcessContextInterface $context, Request $request)
     {
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::FINALIZE_INITIALIZE, $order);

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
@@ -15,6 +15,7 @@ use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * The payment step of checkout.
@@ -27,7 +28,7 @@ class PaymentStep extends CheckoutStep
     /**
      * {@inheritdoc}
      */
-    public function displayAction(ProcessContextInterface $context)
+    public function displayAction(ProcessContextInterface $context, Request $request)
     {
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::PAYMENT_INITIALIZE, $order);
@@ -40,10 +41,8 @@ class PaymentStep extends CheckoutStep
     /**
      * {@inheritdoc}
      */
-    public function forwardAction(ProcessContextInterface $context)
+    public function forwardAction(ProcessContextInterface $context, Request $request)
     {
-        $request = $this->getRequest();
-
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::PAYMENT_INITIALIZE, $order);
 

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/PurchaseStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/PurchaseStep.php
@@ -22,13 +22,14 @@ use Sylius\Component\Core\SyliusCheckoutEvents;
 use Sylius\Component\Payment\PaymentTransitions;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 class PurchaseStep extends CheckoutStep
 {
     /**
      * {@inheritdoc}
      */
-    public function displayAction(ProcessContextInterface $context)
+    public function displayAction(ProcessContextInterface $context, Request $request)
     {
         $order = $this->getCurrentCart();
 
@@ -50,9 +51,9 @@ class PurchaseStep extends CheckoutStep
     /**
      * {@inheritdoc}
      */
-    public function forwardAction(ProcessContextInterface $context)
+    public function forwardAction(ProcessContextInterface $context, Request $request)
     {
-        $token = $this->getHttpRequestVerifier()->verify($this->getRequest());
+        $token = $this->getHttpRequestVerifier()->verify($request);
         $this->getHttpRequestVerifier()->invalidate($token);
 
         $status = new GetStatus($token);

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
@@ -20,6 +20,7 @@ use Sylius\Component\Core\Model\UserInterface;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Security step.
@@ -33,7 +34,7 @@ class SecurityStep extends CheckoutStep
     /**
      * {@inheritdoc}
      */
-    public function displayAction(ProcessContextInterface $context)
+    public function displayAction(ProcessContextInterface $context, Request $request)
     {
         // If user is already logged in, transparently jump to next step.
         if ($this->isUserLoggedIn()) {
@@ -53,12 +54,11 @@ class SecurityStep extends CheckoutStep
     /**
      * {@inheritdoc}
      */
-    public function forwardAction(ProcessContextInterface $context)
+    public function forwardAction(ProcessContextInterface $context, Request $request)
     {
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::SECURITY_INITIALIZE, $order);
 
-        $request          = $this->getRequest();
         $guestForm        = $this->getGuestForm($order);
         $registrationForm = $this->getRegistrationForm();
 

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
@@ -16,6 +16,7 @@ use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * The shipping step of checkout.
@@ -35,7 +36,7 @@ class ShippingStep extends CheckoutStep
     /**
      * {@inheritdoc}
      */
-    public function displayAction(ProcessContextInterface $context)
+    public function displayAction(ProcessContextInterface $context, Request $request)
     {
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::SHIPPING_INITIALIZE, $order);
@@ -52,10 +53,8 @@ class ShippingStep extends CheckoutStep
     /**
      * {@inheritdoc}
      */
-    public function forwardAction(ProcessContextInterface $context)
+    public function forwardAction(ProcessContextInterface $context, Request $request)
     {
-        $request = $this->getRequest();
-
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::SHIPPING_INITIALIZE, $order);
 

--- a/src/Sylius/Bundle/FlowBundle/Process/Step/ControllerStep.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Step/ControllerStep.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\FlowBundle\Process\Step;
 
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Step class which extends the base Symfony2 controller.
@@ -47,7 +48,7 @@ abstract class ControllerStep extends Controller implements StepInterface
     /**
      * {@inheritdoc}
      */
-    public function forwardAction(ProcessContextInterface $context)
+    public function forwardAction(ProcessContextInterface $context, Request $request)
     {
         return $this->complete();
     }

--- a/src/Sylius/Bundle/FlowBundle/Process/Step/Step.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Step/Step.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\FlowBundle\Process\Step;
 
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Base step class.
@@ -46,7 +47,7 @@ abstract class Step implements StepInterface
     /**
      * {@inheritdoc}
      */
-    public function forwardAction(ProcessContextInterface $context)
+    public function forwardAction(ProcessContextInterface $context, Request $request)
     {
         return $this->complete();
     }

--- a/src/Sylius/Bundle/FlowBundle/Process/Step/StepInterface.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Step/StepInterface.php
@@ -14,6 +14,7 @@ namespace Sylius\Bundle\FlowBundle\Process\Step;
 use FOS\RestBundle\View\View;
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
 
 interface StepInterface
 {
@@ -35,19 +36,21 @@ interface StepInterface
      * Display action.
      *
      * @param ProcessContextInterface $context
+     * @param Request $request
      *
      * @return ActionResult|Response|View
      */
-    public function displayAction(ProcessContextInterface $context);
+    public function displayAction(ProcessContextInterface $context, Request $request);
 
     /**
      * Forward action.
      *
      * @param ProcessContextInterface $context
+     * @param Request $request
      *
      * @return null|ActionResult|Response|View
      */
-    public function forwardAction(ProcessContextInterface $context);
+    public function forwardAction(ProcessContextInterface $context, Request $request);
 
     /**
      * Is step active in process?

--- a/src/Sylius/Bundle/FlowBundle/Tests/Process/ProcessTest.php
+++ b/src/Sylius/Bundle/FlowBundle/Tests/Process/ProcessTest.php
@@ -15,6 +15,7 @@ use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Bundle\FlowBundle\Process\Process;
 use Sylius\Bundle\FlowBundle\Process\Step\Step;
 use Sylius\Bundle\FlowBundle\Validator\ProcessValidator;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Process test.
@@ -352,7 +353,7 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
 
 class TestStep extends Step
 {
-    public function displayAction(ProcessContextInterface $context)
+    public function displayAction(ProcessContextInterface $context, Request $request)
     {
         // pufff.
     }

--- a/src/Sylius/Bundle/FlowBundle/Tests/Process/Step/ContainerAwareStepTest.php
+++ b/src/Sylius/Bundle/FlowBundle/Tests/Process/Step/ContainerAwareStepTest.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\FlowBundle\Tests\Process\Step;
 
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Bundle\FlowBundle\Process\Step\ContainerAwareStep;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * ContainerAwareStepTest test.
@@ -45,7 +46,7 @@ class TestContainerAwareStep extends ContainerAwareStep
         return $this->container;
     }
 
-    public function displayAction(ProcessContextInterface $context)
+    public function displayAction(ProcessContextInterface $context, Request $request)
     {
         // pufff.
     }

--- a/src/Sylius/Bundle/FlowBundle/Tests/Validator/ProcessValidatorTest.php
+++ b/src/Sylius/Bundle/FlowBundle/Tests/Validator/ProcessValidatorTest.php
@@ -8,6 +8,7 @@ use Sylius\Bundle\FlowBundle\Process\Step\ControllerStep;
 use Sylius\Bundle\FlowBundle\Validator\ProcessValidator;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Templating\PhpEngine;
+use Symfony\Component\HttpFoundation\Request;
 
 class ProcessValidatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -57,7 +58,7 @@ class ProcessValidatorTest extends \PHPUnit_Framework_TestCase
 
 class TestStep extends ControllerStep
 {
-    public function displayAction(ProcessContextInterface $context)
+    public function displayAction(ProcessContextInterface $context, Request $request)
     {
         // pufff.
     }

--- a/src/Sylius/Bundle/InstallerBundle/Process/Step/CheckStep.php
+++ b/src/Sylius/Bundle/InstallerBundle/Process/Step/CheckStep.php
@@ -13,13 +13,14 @@ namespace Sylius\Bundle\InstallerBundle\Process\Step;
 
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Bundle\FlowBundle\Process\Step\ControllerStep;
+use Symfony\Component\HttpFoundation\Request;
 
 class CheckStep extends ControllerStep
 {
     /**
      * {@inheritdoc}
      */
-    public function displayAction(ProcessContextInterface $context)
+    public function displayAction(ProcessContextInterface $context, Request $request)
     {
         return $this->render(
             'SyliusInstallerBundle:Process/Step:check.html.twig',
@@ -30,7 +31,7 @@ class CheckStep extends ControllerStep
     /**
      * {@inheritdoc}
      */
-    public function forwardAction(ProcessContextInterface $context)
+    public function forwardAction(ProcessContextInterface $context, Request $request)
     {
         return $this->complete();
     }

--- a/src/Sylius/Bundle/InstallerBundle/Process/Step/ConfigureStep.php
+++ b/src/Sylius/Bundle/InstallerBundle/Process/Step/ConfigureStep.php
@@ -13,13 +13,14 @@ namespace Sylius\Bundle\InstallerBundle\Process\Step;
 
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Bundle\FlowBundle\Process\Step\ControllerStep;
+use Symfony\Component\HttpFoundation\Request;
 
 class ConfigureStep extends ControllerStep
 {
     /**
      * {@inheritdoc}
      */
-    public function displayAction(ProcessContextInterface $context)
+    public function displayAction(ProcessContextInterface $context, Request $request)
     {
         return $this->render(
             'SyliusInstallerBundle:Process/Step:configure.html.twig',
@@ -30,9 +31,8 @@ class ConfigureStep extends ControllerStep
     /**
      * {@inheritdoc}
      */
-    public function forwardAction(ProcessContextInterface $context)
+    public function forwardAction(ProcessContextInterface $context, Request $request)
     {
-        $request = $this->getRequest();
         $form = $this->createConfigurationForm();
 
         if ($form->handleRequest($request)->isValid()) {

--- a/src/Sylius/Bundle/InstallerBundle/Process/Step/SetupStep.php
+++ b/src/Sylius/Bundle/InstallerBundle/Process/Step/SetupStep.php
@@ -18,13 +18,14 @@ use Doctrine\ORM\Tools\SchemaTool;
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Bundle\FlowBundle\Process\Step\ControllerStep;
 use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
+use Symfony\Component\HttpFoundation\Request;
 
 class SetupStep extends ControllerStep
 {
     /**
      * {@inheritdoc}
      */
-    public function displayAction(ProcessContextInterface $context)
+    public function displayAction(ProcessContextInterface $context, Request $request)
     {
         return $this->render(
             'SyliusInstallerBundle:Process/Step:setup.html.twig',
@@ -35,9 +36,8 @@ class SetupStep extends ControllerStep
     /**
      * {@inheritdoc}
      */
-    public function forwardAction(ProcessContextInterface $context)
+    public function forwardAction(ProcessContextInterface $context, Request $request)
     {
-        $request = $this->getRequest();
         $form = $this->createForm('sylius_setup');
         $em = $this->getDoctrine()->getManager();
 

--- a/src/Sylius/Bundle/InstallerBundle/Process/Step/WelcomeStep.php
+++ b/src/Sylius/Bundle/InstallerBundle/Process/Step/WelcomeStep.php
@@ -13,13 +13,14 @@ namespace Sylius\Bundle\InstallerBundle\Process\Step;
 
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Bundle\FlowBundle\Process\Step\ControllerStep;
+use Symfony\Component\HttpFoundation\Request;
 
 class WelcomeStep extends ControllerStep
 {
     /**
      * {@inheritdoc}
      */
-    public function displayAction(ProcessContextInterface $context)
+    public function displayAction(ProcessContextInterface $context, Request $request)
     {
         return $this->render('SyliusInstallerBundle:Process/Step:welcome.html.twig');
     }
@@ -27,7 +28,7 @@ class WelcomeStep extends ControllerStep
     /**
      * {@inheritdoc}
      */
-    public function forwardAction(ProcessContextInterface $context)
+    public function forwardAction(ProcessContextInterface $context, Request $request)
     {
         return $this->complete();
     }


### PR DESCRIPTION
Calling `getRequest()` is deprecated since Symfony 2.4 and will be removed in 3.0.