### PR TITLE
fix(LocaleBundle): Changing locale using PUT, PATCH works now.

### DIFF
--- a/src/Sylius/Bundle/LocaleBundle/Controller/LocaleController.php
+++ b/src/Sylius/Bundle/LocaleBundle/Controller/LocaleController.php
@@ -21,9 +21,19 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class LocaleController extends ResourceController
 {
-    public function changeAction(Request $request, $locale)
+    public function changeAction(Request $request)
     {
+        $locale = $request->get('locale');
         $this->getLocaleContext()->setLocale($locale);
+
+        if ($this->config->isApiRequest()) {
+            $view = $this
+                ->view()
+                ->setData(array('locale' => $locale))
+            ;
+
+            return $this->handleView($view);
+        }
 
         return $this->redirect($request->headers->get('referer'));
     }


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | yes
New feature?  | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

I needed to change locale using `PATCH` like below:
```yml
acme_api_locale_current_put:
    path: /current
    methods: [PUT, PATCH]
    defaults:
        _controller: sylius.controller.locale:changeAction
```

But `changeAction` threw an error:

```
Controller "Sylius\Bundle\LocaleBundle\Controller\LocaleController::changeAction()"
requires that you provide a value for the "$locale" argument
(because there is no default value or because there is a non optional argument after this one).
```