### PR TITLE
[ResourceController] Use Symfony security first, than fallback to Sylius one

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -451,14 +451,22 @@ class ResourceController extends FOSRestController
 
     protected function isGrantedOr403($permission)
     {
-        if (!$this->container->has('sylius.authorization_checker')) {
-            return true;
-        }
-
         $permission = $this->config->getPermission($permission);
-
-        if ($permission && !$this->get('sylius.authorization_checker')->isGranted(sprintf('%s.%s.%s', $this->config->getBundlePrefix(), $this->config->getResourceName(), $permission))) {
-            throw new AccessDeniedHttpException();
+        if ($permission) {
+            // Check access in Symfony security, if fail use Sylius one
+            if (!$this->get('security.context')->isGranted($permission)) {
+                if ($this->container->has('sylius.authorization_checker')) {
+                    if (!$this->get('sylius.authorization_checker')->isGranted(sprintf('%s.%s.%s', $this->config->getBundlePrefix(), $this->config->getResourceName(), $permission))) {
+                        throw new AccessDeniedHttpException();
+                    }
+                    
+                    return true;
+                }
+                
+                throw new AccessDeniedHttpException();
+            }
         }
+
+        return true;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | #2538
| License       | MIT