### PR TITLE
Fix typo in example in docblock

### DIFF
--- a/src/Sylius/Component/Product/Builder/ProductBuilder.php
+++ b/src/Sylius/Component/Product/Builder/ProductBuilder.php
@@ -22,7 +22,7 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
  *
  * <code>
  * <?php
- * $this->get('sylius.product_builder')
+ * $this->get('sylius.builder.product')
  *     ->create('Github mug')
  *     ->setDescription("Coffee. Tea. Coke. Water. Let's face it — humans need to drink liquids")
  *     ->setPrice(1200)


### PR DESCRIPTION
I came across some documentation in the ProductBuilder class on how to use the service. Found out that the servicename used in the example differs from the actual service name. So I made this minor typo fix. 