### PR TITLE
Use LocaleContext in MoneyHelper fix #2352

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/templating.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/templating.xml
@@ -18,12 +18,19 @@
 
     <parameters>
         <parameter key="sylius.templating.helper.restricted_zone.class">Sylius\Bundle\CoreBundle\Templating\Helper\RestrictedZoneHelper</parameter>
+        <parameter key="sylius.templating.helper.money.class">Sylius\Bundle\CoreBundle\Templating\Helper\MoneyHelper</parameter>
     </parameters>
 
     <services>
         <service id="sylius.templating.helper.restricted_zone" class="%sylius.templating.helper.restricted_zone.class%">
             <argument type="service" id="sylius.checker.restricted_zone" />
             <tag name="templating.helper" alias="sylius_restricted_zone" />
+        </service>
+
+        <service id="sylius.templating.helper.money" class="%sylius.templating.helper.money.class%">
+            <argument type="service" id="sylius.context.locale" />
+            <argument type="service" id="sylius.context.currency" />
+            <tag name="templating.helper" alias="sylius_money" />
         </service>
     </services>
 

--- a/src/Sylius/Bundle/CoreBundle/Templating/Helper/MoneyHelper.php
+++ b/src/Sylius/Bundle/CoreBundle/Templating/Helper/MoneyHelper.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Templating\Helper;
+
+use Sylius\Bundle\CurrencyBundle\Templating\Helper\MoneyHelper as BaseMoneyHelper;
+use Sylius\Component\Currency\Context\CurrencyContextInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+
+class MoneyHelper extends BaseMoneyHelper
+{
+    /**
+     * @var LocaleContextInterface
+     */
+    protected $localeContext;
+
+    /**
+     * @param LocaleContextInterface   $localeContext   The locale context
+     * @param CurrencyContextInterface $currencyContext The currency context
+     */
+    public function __construct(LocaleContextInterface $localeContext, CurrencyContextInterface $currencyContext)
+    {
+        $this->localeContext = $localeContext;
+
+        parent::__construct($this->getDefaultLocale(), $currencyContext);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDefaultLocale()
+    {
+        return $this->localeContext->getLocale();
+    }
+}

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/templating.xml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/templating.xml
@@ -30,7 +30,6 @@
         </service>
         <service id="sylius.templating.helper.money" class="%sylius.templating.helper.money.class%">
             <argument>%sylius.money.locale%</argument>
-            <argument>%sylius.money.currency%</argument>
             <argument type="service" id="sylius.context.currency" />
             <tag name="templating.helper" alias="sylius_money" />
         </service>

--- a/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/MoneyHelper.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/MoneyHelper.php
@@ -27,13 +27,13 @@ class MoneyHelper extends BaseMoneyHelper
      *
      * @var CurrencyContextInterface
      */
-    private $currencyContext;
+    protected $currencyContext;
 
-    public function __construct($locale, $defaultCurrency, CurrencyContextInterface $currencyContext)
+    public function __construct($locale, CurrencyContextInterface $currencyContext)
     {
-        parent::__construct($locale, $defaultCurrency);
-
         $this->currencyContext = $currencyContext;
+
+        parent::__construct($locale, $this->getDefaultCurrency());
     }
 
     /**

--- a/src/Sylius/Bundle/MoneyBundle/Templating/Helper/MoneyHelper.php
+++ b/src/Sylius/Bundle/MoneyBundle/Templating/Helper/MoneyHelper.php
@@ -23,14 +23,9 @@ class MoneyHelper extends Helper
     private $currency;
 
     /**
-     * @var \NumberFormatter
+     * @var string
      */
-    private $formatterCurrency;
-
-    /**
-     * @var \NumberFormatter
-     */
-    private $formatterDecimal;
+    private $locale;
 
     /**
      * @param string $locale   The locale used to format money.
@@ -38,9 +33,8 @@ class MoneyHelper extends Helper
      */
     public function __construct($locale, $currency)
     {
-        $this->currency          = $currency;
-        $this->formatterCurrency = new \NumberFormatter($locale ?: \Locale::getDefault(), \NumberFormatter::CURRENCY);
-        $this->formatterDecimal  = new \NumberFormatter($locale ?: \Locale::getDefault(), \NumberFormatter::DECIMAL);
+        $this->locale   = $locale ?: \Locale::getDefault();
+        $this->currency = $currency;
     }
 
     /**
@@ -49,6 +43,7 @@ class MoneyHelper extends Helper
      * @param int         $amount
      * @param string|null $currency
      * @param bool        $decimal
+     * @param string|null $locale
      *
      * @return string
      *
@@ -56,13 +51,15 @@ class MoneyHelper extends Helper
      */
     public function formatAmount($amount, $currency = null, $decimal = false)
     {
+        $locale   = $this->getDefaultLocale();
+        $currency = $currency ?: $this->getDefaultCurrency();
+
         if ($decimal) {
-            $formatter = $this->formatterDecimal;
+            $formatter = new \NumberFormatter($locale, \NumberFormatter::DECIMAL);
         } else {
-            $formatter = $this->formatterCurrency;
+            $formatter = new \NumberFormatter($locale, \NumberFormatter::CURRENCY);
         }
 
-        $currency = $currency ?: $this->getDefaultCurrency();
         $result   = $formatter->formatCurrency($amount / 100, $currency);
         if (false === $result) {
             throw new \InvalidArgumentException(sprintf('The amount "%s" of type %s cannot be formatted to currency "%s".', $amount, gettype($amount), $currency));
@@ -87,5 +84,15 @@ class MoneyHelper extends Helper
     protected function getDefaultCurrency()
     {
         return $this->currency;
+    }
+
+    /**
+     * Get the default locale if none is provided as argument.
+     *
+     * @return string The locale code
+     */
+    protected function getDefaultLocale()
+    {
+        return $this->locale;
     }
 }

--- a/src/Sylius/Bundle/MoneyBundle/Templating/Helper/MoneyHelper.php
+++ b/src/Sylius/Bundle/MoneyBundle/Templating/Helper/MoneyHelper.php
@@ -49,9 +49,9 @@ class MoneyHelper extends Helper
      *
      * @throws \InvalidArgumentException
      */
-    public function formatAmount($amount, $currency = null, $decimal = false)
+    public function formatAmount($amount, $currency = null, $decimal = false, $locale = null)
     {
-        $locale   = $this->getDefaultLocale();
+        $locale   = $locale   ?: $this->getDefaultLocale();
         $currency = $currency ?: $this->getDefaultCurrency();
 
         if ($decimal) {

--- a/src/Sylius/Bundle/MoneyBundle/Twig/MoneyExtension.php
+++ b/src/Sylius/Bundle/MoneyBundle/Twig/MoneyExtension.php
@@ -51,9 +51,9 @@ class MoneyExtension extends \Twig_Extension
      *
      * @return string
      */
-    public function formatAmount($amount, $currency = null)
+    public function formatAmount($amount, $currency = null, $locale = null)
     {
-        return $this->helper->formatAmount($amount, $currency);
+        return $this->helper->formatAmount($amount, $currency, false, $locale);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | #2352
| License       | MIT

For the MoneyHelper:
* MoneyBundle is standalone and uses fixed locale and currency
* CurrencyBundle extends the one from MoneyBundle and adds currencyContext
* CoreBundle extends the one from CurrencyBundle and adds localeContext