### PR TITLE
Leftjoin because order.user can be null

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -122,7 +122,8 @@ class OrderRepository extends CartRepository implements OrderRepositoryInterface
         $queryBuilder = parent::getCollectionQueryBuilder();
         $queryBuilder
             ->andWhere($queryBuilder->expr()->isNotNull('o.completedAt'))
-            ->innerJoin('o.user', 'user')
+            ->leftJoin('o.user', 'user')
+            ->addSelect('user')
         ;
 
         if ($deleted) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | -
| License       | MIT

Guest orders were not displayed on /admin/orders