### PR TITLE
[FlowBundle][Bug] Query parameters removed at first step

### DIFF
--- a/src/Sylius/Bundle/FlowBundle/Process/Coordinator/Coordinator.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Coordinator/Coordinator.php
@@ -220,9 +220,11 @@ class Coordinator implements CoordinatorInterface
         $this->context->addStepToHistory($step->getName());
 
         if (null !== $route = $process->getDisplayRoute()) {
-            $url = $this->router->generate($route, array_merge($process->getDisplayRouteParams(), array(
-                'stepName' => $step->getName(),
-            )));
+            $url = $this->router->generate($route, array_merge(
+                $process->getDisplayRouteParams(), 
+                array('stepName' => $step->getName()),
+                $queryParameters ? $queryParameters->all() : array()
+            ));
 
             return new RedirectResponse($url);
         }


### PR DESCRIPTION
Due the the way FlowBundle works, it always perform a redirection before the first step.

I have a use case where my first step require some GET parameters (`/step?status=success`), but it is being removed during the redirection. This PR fix that.