### PR TITLE
Don't use deprecated `getRequest()` method in flow

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
@@ -43,7 +43,7 @@ class AddressingStep extends CheckoutStep
      */
     public function forwardAction(ProcessContextInterface $context)
     {
-        $request = $this->getRequest();
+        $request = $context->getRequest();
 
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::ADDRESSING_INITIALIZE, $order);

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
@@ -42,7 +42,7 @@ class PaymentStep extends CheckoutStep
      */
     public function forwardAction(ProcessContextInterface $context)
     {
-        $request = $this->getRequest();
+        $request = $context->getRequest();
 
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::PAYMENT_INITIALIZE, $order);

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/PurchaseStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/PurchaseStep.php
@@ -52,7 +52,7 @@ class PurchaseStep extends CheckoutStep
      */
     public function forwardAction(ProcessContextInterface $context)
     {
-        $token = $this->getHttpRequestVerifier()->verify($this->getRequest());
+        $token = $this->getHttpRequestVerifier()->verify($context->getRequest());
         $this->getHttpRequestVerifier()->invalidate($token);
 
         $status = new GetStatus($token);

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
@@ -58,7 +58,7 @@ class SecurityStep extends CheckoutStep
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::SECURITY_INITIALIZE, $order);
 
-        $request          = $this->getRequest();
+        $request          = $context->getRequest();
         $guestForm        = $this->getGuestForm($order);
         $registrationForm = $this->getRegistrationForm();
 

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
@@ -54,7 +54,7 @@ class ShippingStep extends CheckoutStep
      */
     public function forwardAction(ProcessContextInterface $context)
     {
-        $request = $this->getRequest();
+        $request = $context->getRequest();
 
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::SHIPPING_INITIALIZE, $order);

--- a/src/Sylius/Bundle/CoreBundle/spec/Checkout/Step/PurchaseStepSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Checkout/Step/PurchaseStepSpec.php
@@ -45,7 +45,6 @@ class PurchaseStepSpec extends ObjectBehavior
         HttpRequestVerifierInterface $httpRequestVerifier,
         TokenInterface $token,
         Request $request,
-        RequestStack $requestStack,
         CartProviderInterface $cartProvider,
         RegistryInterface $payum,
         PaymentInterface $payment,
@@ -57,7 +56,6 @@ class PurchaseStepSpec extends ObjectBehavior
         TranslatorInterface $translator,
         FactoryInterface $factory
     ) {
-        $requestStack->getCurrentRequest()->willReturn($request);
         $session->getFlashBag()->willReturn($flashBag);
         $doctrine->getManager()->willReturn($objectManager);
         $token->getPaymentName()->willReturn('aPaymentName');
@@ -66,8 +64,6 @@ class PurchaseStepSpec extends ObjectBehavior
         $httpRequestVerifier->invalidate($token)->willReturn(null);
 
         $container->get('payum.security.http_request_verifier')->willReturn($httpRequestVerifier);
-        $container->get('request')->willReturn($request);
-        $container->get('request_stack')->willReturn($requestStack);
         $container->get('sylius.cart_provider')->willReturn($cartProvider);
         $container->get('payum')->willReturn($payum);
         $container->get('event_dispatcher')->willReturn($eventDispatcher);
@@ -93,12 +89,15 @@ class PurchaseStepSpec extends ObjectBehavior
     }
 
     function it_must_dispatch_pre_and_post_payment_state_changed_if_state_changed(
+        Request $request,
         $factory,
         ProcessContextInterface $context,
         PaymentInterface $payment,
         EventDispatcherInterface $eventDispatcher,
         StateMachineInterface $sm
     ) {
+        $context->getRequest()->willReturn($request);
+
         $order = new Order();
         $paymentModel = new Payment();
         $paymentModel->setState(Payment::STATE_NEW);
@@ -145,12 +144,15 @@ class PurchaseStepSpec extends ObjectBehavior
     }
 
     function it_must_not_dispatch_pre_and_post_payment_state_changed_if_state_not_changed(
+        Request $request,
         $factory,
         ProcessContextInterface $context,
         PaymentInterface $payment,
         EventDispatcherInterface $eventDispatcher,
         StateMachineInterface $sm
     ) {
+        $context->getRequest()->willReturn($request);
+
         $order = new Order();
         $paymentModel = new Payment();
         $paymentModel->setState(Payment::STATE_COMPLETED);

--- a/src/Sylius/Bundle/FlowBundle/Process/Context/ProcessContext.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Context/ProcessContext.php
@@ -280,7 +280,7 @@ class ProcessContext implements ProcessContextInterface
         $history = $this->getStepHistory();
 
         while ($top = end($history)) {
-            if ($top != $this->currentStep->getName()) {
+            if ($top !== $this->currentStep->getName()) {
                 array_pop($history);
             } else {
                 break;
@@ -292,6 +292,14 @@ class ProcessContext implements ProcessContextInterface
         }
 
         $this->setStepHistory($history);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setNextStepByName($stepName)
+    {
+        $this->nextStep = $this->process->getStepByName($stepName);
     }
 
     /**
@@ -309,20 +317,10 @@ class ProcessContext implements ProcessContextInterface
     /**
      * Calculates progress based on current step index.
      *
-     * @param integer $currentStepIndex
+     * @param int $currentStepIndex
      */
     protected function calculateProgress($currentStepIndex)
     {
-        $totalSteps = $this->process->countSteps();
-
-        $this->progress = floor(($currentStepIndex + 1) / $totalSteps * 100);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setNextStepByName($stepName)
-    {
-        $this->nextStep = $this->process->getStepByName($stepName);
+        $this->progress = floor(($currentStepIndex + 1) / $this->process->countSteps() * 100);
     }
 }

--- a/src/Sylius/Bundle/FlowBundle/Process/Coordinator/Coordinator.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Coordinator/Coordinator.php
@@ -104,16 +104,16 @@ class Coordinator implements CoordinatorInterface
         try {
             $this->context->rewindHistory();
         } catch (NotFoundHttpException $e) {
-            //the step we are supposed to display was not found in the history.
+            // The step we are supposed to display was not found in the history.
             if (null === $this->context->getPreviousStep()) {
-                //there is no previous step go to start
+                // There is no previous step go to start
                 return $this->start($scenarioAlias, $queryParameters);
             }
 
-            //we will go back to previous step...
+            // We will go back to previous step...
             $history = $this->context->getStepHistory();
             if (empty($history)) {
-                //there is no history
+                // There is no history
                 return $this->start($scenarioAlias);
             }
             $step = $process->getStepByName(end($history));
@@ -127,9 +127,7 @@ class Coordinator implements CoordinatorInterface
             return $this->context->getProcess()->getValidator()->getResponse($step);
         }
 
-        $result = $step->displayAction($this->context);
-
-        return $this->processStepResult($process, $result);
+        return $this->processStepResult($process, $step->displayAction($this->context));
     }
 
     /**
@@ -147,9 +145,7 @@ class Coordinator implements CoordinatorInterface
             return $this->context->getProcess()->getValidator()->getResponse($step);
         }
 
-        $result = $step->forwardAction($this->context);
-
-        return $this->processStepResult($process, $result);
+        return $this->processStepResult($process, $step->forwardAction($this->context));
     }
 
     public function processStepResult(ProcessInterface $process, $result)
@@ -170,9 +166,7 @@ class Coordinator implements CoordinatorInterface
             if ($this->context->isLastStep()) {
                 $this->context->close();
 
-                $url = $this->router->generate($process->getRedirect(), $process->getRedirectParams());
-
-                return new RedirectResponse($url);
+                return new RedirectResponse($this->router->generate($process->getRedirect(), $process->getRedirectParams()));
             }
 
             // Handle default linear behaviour.
@@ -239,9 +233,7 @@ class Coordinator implements CoordinatorInterface
             $routeParameters = array_merge($queryParameters->all(), $routeParameters);
         }
 
-        $url = $this->router->generate('sylius_flow_display', $routeParameters);
-
-        return new RedirectResponse($url);
+        return new RedirectResponse($this->router->generate('sylius_flow_display', $routeParameters));
     }
 
     /**
@@ -253,9 +245,7 @@ class Coordinator implements CoordinatorInterface
      */
     protected function buildProcess($scenarioAlias)
     {
-        $processScenario = $this->loadScenario($scenarioAlias);
-
-        $process = $this->builder->build($processScenario);
+        $process = $this->builder->build($this->loadScenario($scenarioAlias));
         $process->setScenarioAlias($scenarioAlias);
 
         return $process;

--- a/src/Sylius/Bundle/FlowBundle/Process/Process.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Process.php
@@ -206,8 +206,7 @@ class Process implements ProcessInterface
 
         $index = array_search($this->steps[$name], $this->orderedSteps);
 
-        unset($this->steps[$name]);
-        unset($this->orderedSteps[$index]);
+        unset($this->steps[$name], $this->orderedSteps[$index]);
         $this->orderedSteps = array_values($this->orderedSteps); //keep sequential index intact
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | #2529
| License       | MIT