### PR TITLE
fix(InstallerBundle): Allow --no-interaction with some fixtures and database improvements

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Command/AbstractInstallCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/AbstractInstallCommand.php
@@ -12,9 +12,8 @@
 namespace Sylius\Bundle\InstallerBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
-use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Helper\ProgressHelper;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
 
@@ -84,6 +83,8 @@ abstract class AbstractInstallCommand extends ContainerAwareCommand
     /**
      * @param OutputInterface $output
      * @param int $length
+     *
+     * @return ProgressHelper
      */
     protected function createProgressBar(OutputInterface $output, $length = 10)
     {
@@ -135,7 +136,12 @@ abstract class AbstractInstallCommand extends ContainerAwareCommand
     }
 
     /**
+     * @param OutputInterface $output
      * @param string $question
+     * @param array $constraints
+     * @param mixed $default
+     *
+     * @return mixed
      */
     protected function ask(OutputInterface $output, $question, array $constraints = array(), $default = null)
     {
@@ -167,6 +173,7 @@ abstract class AbstractInstallCommand extends ContainerAwareCommand
     }
 
     /**
+     * @param OutputInterface $output
      * @param ConstraintViolationList $errors
      */
     protected function writeErrors(OutputInterface $output, ConstraintViolationList $errors)

--- a/src/Sylius/Bundle/InstallerBundle/Command/CommandExecutor.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/CommandExecutor.php
@@ -56,6 +56,9 @@ class CommandExecutor
     /**
      * @param $command
      * @param array $parameters
+     * @param OutputInterface $output
+     *
+     * @return $this
      *
      * @throws \Exception
      */
@@ -94,6 +97,10 @@ class CommandExecutor
 
         if ($this->input->hasOption('env')) {
             $defaultParameters['--env'] = $this->input->hasOption('env') ? $this->input->getOption('env') : Kernel::ENV_DEV;
+        }
+        
+        if ($this->input->hasOption('no-interaction')) {
+            $defaultParameters['--no-interaction'] = true;
         }
 
         if ($this->input->hasOption('verbose') && true === $this->input->getOption('verbose')) {

--- a/src/Sylius/Bundle/InstallerBundle/Command/InstallSampleDataCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/InstallSampleDataCommand.php
@@ -41,8 +41,12 @@ EOT
     {
         $output->writeln(sprintf('<error>Warning! This will erase your database.</error> Your current environment is <info>%s</info>.', $this->getEnvironment()));
 
+        if ($input->getOption('no-interaction')) {
+            return 0;
+        }
+
         if (!$this->getHelperSet()->get('dialog')->askConfirmation($output, '<question>Load sample data? (y/N)</question> ', false)) {
-            return;
+            return 0;
         }
 
         $output->writeln('Loading sample data...');

--- a/src/Sylius/Bundle/RbacBundle/Command/InitializeCommand.php
+++ b/src/Sylius/Bundle/RbacBundle/Command/InitializeCommand.php
@@ -14,12 +14,6 @@ namespace Sylius\Bundle\RbacBundle\Command;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Intl\Intl;
-use Symfony\Component\Validator\Constraints\Country;
-use Symfony\Component\Validator\Constraints\Currency;
-use Symfony\Component\Validator\Constraints\Email;
-use Symfony\Component\Validator\Constraints\Locale;
-use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>

--- a/src/Sylius/Bundle/RbacBundle/Doctrine/RbacInitializer.php
+++ b/src/Sylius/Bundle/RbacBundle/Doctrine/RbacInitializer.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\RbacBundle\Doctrine;
 
+use Doctrine\ORM\NonUniqueResultException;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -57,8 +58,14 @@ class RbacInitializer
 
     public function initialize(OutputInterface $output = null)
     {
-        $this->initializePermissions($output);
-        $this->initializeRoles($output);
+        try {
+            $this->initializePermissions($output);
+            $this->initializeRoles($output);
+        } catch (NonUniqueResultException $exception) {
+            if ($output) {
+                $output->writeln('RBAC already initialized');
+            }
+        }
     }
 
     protected function initializePermissions(OutputInterface $output = null)


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | yes
New feature?  | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

Here is a list of improvements, let's discuss if they're good or not.

1. [Allow `--no-interaction`](https://github.com/Sylius/Sylius/pull/2599/files#diff-b337bb2bae6f6c79cdda641893ca9abbR101) option on sylius:install commands.
2. When using `sylius:install` commands and/or fixtures, if you've already initialized RBAC data it will throw a `Doctrine\ORM\NonUniqueResultException` exception. [Line 64](https://github.com/Sylius/Sylius/pull/2599/files#diff-f8ad521889bf078a95f5ae0043792a6aR64) Is it safe if we just ignore this exception? 