### PR TITLE
[WIP] Add CurrencyBasedCalculator

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Pricing/CurrencyBasedConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Pricing/CurrencyBasedConfigurationType.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Form\Type\Pricing;
+
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+class CurrencyBasedConfigurationType extends AbstractType
+{
+    protected $currencyRepository;
+
+    /**
+     * @param RepositoryInterface $groupRepository
+     */
+    public function __construct(RepositoryInterface $currencyRepository)
+    {
+        $this->currencyRepository = $currencyRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        foreach ($this->currencyRepository->findAll() as $currency) {
+            $builder
+                ->add($currency->getCode(), 'text', array(
+                    'label'    => $currency->getCode(),
+                    'required' => false,
+                ))
+            ;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver
+            ->setDefaults(array(
+                'data_class' => null
+            ))
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sylius_price_calculator_currency_based';
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Pricing/CurrencyBasedConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Pricing/CurrencyBasedConfigurationType.php
@@ -38,9 +38,10 @@ class CurrencyBasedConfigurationType extends AbstractType
     {
         foreach ($this->currencyRepository->findAll() as $currency) {
             $builder
-                ->add($currency->getCode(), 'text', array(
+                ->add($currency->getCode(), 'sylius_money', array(
                     'label'    => $currency->getCode(),
                     'required' => false,
+                    'currency' => $currency->getCode()
                 ))
             ;
         }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/form.xml
@@ -34,6 +34,7 @@
 
         <parameter key="sylius.form.type.price_calculator.group_based.class">Sylius\Bundle\CoreBundle\Form\Type\Pricing\GroupBasedConfigurationType</parameter>
         <parameter key="sylius.form.type.price_calculator.zone_based.class">Sylius\Bundle\CoreBundle\Form\Type\Pricing\ZoneBasedConfigurationType</parameter>
+        <parameter key="sylius.form.type.price_calculator.currency_based.class">Sylius\Bundle\CoreBundle\Form\Type\Pricing\CurrencyBasedConfigurationType</parameter>
 
         <parameter key="sylius.form.type.promotion_rule.nth_order_configuration.class">Sylius\Bundle\CoreBundle\Form\Type\Rule\NthOrderConfigurationType</parameter>
         <parameter key="sylius.form.type.promotion_rule.user_loyalty_configuration.class">Sylius\Bundle\CoreBundle\Form\Type\Rule\UserLoyaltyConfigurationType</parameter>
@@ -164,6 +165,10 @@
         <service id="sylius.form.type.price_calculator.zone_based" class="%sylius.form.type.price_calculator.zone_based.class%">
             <argument type="service" id="sylius.repository.zone" />
             <tag name="form.type" alias="sylius_price_calculator_zone_based" />
+        </service>
+        <service id="sylius.form.type.price_calculator.currency_based" class="%sylius.form.type.price_calculator.currency_based.class%">
+            <argument type="service" id="sylius.repository.currency" />
+            <tag name="form.type" alias="sylius_price_calculator_currency_based" />
         </service>
     </services>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -76,6 +76,7 @@
         <parameter key="sylius.price_calculator.group_based.class">Sylius\Component\Core\Pricing\GroupBasedCalculator</parameter>
         <parameter key="sylius.price_calculator.zone_based.class">Sylius\Component\Core\Pricing\ZoneBasedCalculator</parameter>
         <parameter key="sylius.price_calculator.currency_based.class">Sylius\Component\Core\Pricing\CurrencyBasedCalculator</parameter>
+        <parameter key="sylius.price_calculator.class">Sylius\Component\Core\Pricing\DelegatingCalculator</parameter>
         <parameter key="sylius.oauth.user_provider.class">Sylius\Bundle\CoreBundle\OAuth\UserProvider</parameter>
         <parameter key="sylius.data_collector.class">Sylius\Bundle\CoreBundle\DataCollector\SyliusDataCollector</parameter>
         <parameter key="sylius.dynamic_router.class">Symfony\Cmf\Component\Routing\DynamicRouter</parameter>
@@ -388,6 +389,12 @@
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="sylius.registry.promotion_rule_checker" />
             <argument type="service" id="event_dispatcher" />
+        </service>
+
+        <service id="sylius.price_calculator" class="%sylius.price_calculator.class%">
+            <argument type="service" id="sylius.registry.price_calculator" />
+            <argument type="service" id="sylius.context.currency" />
+            <argument type="service" id="sylius.currency_converter" />
         </service>
 
         <service id="sylius.price_calculator.group_based" class="%sylius.price_calculator.group_based.class%">

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -75,6 +75,7 @@
         <parameter key="sylius.checker.restricted_zone.class">Sylius\Bundle\CoreBundle\Checker\RestrictedZoneChecker</parameter>
         <parameter key="sylius.price_calculator.group_based.class">Sylius\Component\Core\Pricing\GroupBasedCalculator</parameter>
         <parameter key="sylius.price_calculator.zone_based.class">Sylius\Component\Core\Pricing\ZoneBasedCalculator</parameter>
+        <parameter key="sylius.price_calculator.currency_based.class">Sylius\Component\Core\Pricing\CurrencyBasedCalculator</parameter>
         <parameter key="sylius.oauth.user_provider.class">Sylius\Bundle\CoreBundle\OAuth\UserProvider</parameter>
         <parameter key="sylius.data_collector.class">Sylius\Bundle\CoreBundle\DataCollector\SyliusDataCollector</parameter>
         <parameter key="sylius.dynamic_router.class">Symfony\Cmf\Component\Routing\DynamicRouter</parameter>
@@ -395,6 +396,11 @@
 
         <service id="sylius.price_calculator.zone_based" class="%sylius.price_calculator.zone_based.class%">
             <tag name="sylius.price_calculator" type="zone_based" label="Customer zone based" />
+        </service>
+
+        <service id="sylius.price_calculator.currency_based" class="%sylius.price_calculator.currency_based.class%">
+            <argument type="service" id="sylius.context.currency" />
+            <tag name="sylius.price_calculator" type="currency_based" label="Currency based" />
         </service>
 
         <!-- money -->

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/twig.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/twig.xml
@@ -18,6 +18,7 @@
 
     <parameters>
         <parameter key="sylius.twig.extension.restricted_zone.class">Sylius\Bundle\CoreBundle\Twig\RestrictedZoneExtension</parameter>
+        <parameter key="sylius.twig.extension.pricing.class">Sylius\Bundle\CoreBundle\Twig\PricingExtension</parameter>
     </parameters>
 
     <services>

--- a/src/Sylius/Bundle/CoreBundle/Twig/PricingExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/PricingExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Twig;
+
+use Sylius\Bundle\PricingBundle\Twig\PricingExtension as BasePricingExtension;
+use Sylius\Component\Pricing\Model\PriceableInterface;
+
+class PricingExtension extends BasePricingExtension
+{
+    /**
+     * Returns calculated price for given priceable and currency.
+     *
+     * @param PriceableInterface $priceable
+     * @param array              $context
+     * @param string|null        $currency
+     *
+     * @return integer
+     */
+    public function calculatePrice(PriceableInterface $priceable, array $context = array(), $currency = null)
+    {
+        return $this->helper->calculatePrice($priceable, $context, $currency);
+    }
+}

--- a/src/Sylius/Bundle/SearchBundle/Resources/views/SearchResultSnippets/product.html.twig
+++ b/src/Sylius/Bundle/SearchBundle/Resources/views/SearchResultSnippets/product.html.twig
@@ -4,7 +4,7 @@
         <img class="img-rounded img-responsive"
              src="{{ result.image ? result.image.path|imagine_filter('sylius_medium') : 'http://placehold.it/262x255' }}"
              alt="{{ result.name }}"/>
-        <span class="label label-primary">{{ sylius_calculate_price(result.masterVariant)|sylius_price }}</span>
+        <span class="label label-primary">{{ sylius_calculate_price(result.masterVariant)|sylius_money }}</span>
         <button class="btn btn-success btn-xs pull-right"><i
                     class="icon-shopping-cart icon-white"></i> {{ 'sylius.add_to_cart'|trans }}</button>
     </a>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_singleBox.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_singleBox.html.twig
@@ -2,7 +2,7 @@
     <a href="{{ path(product) }}"><h4>{{ product.name|truncate(18) }}</h4></a>
     <a href="{{ path(product) }}">
         <img class="img-rounded img-responsive" src="{{ product.image ? product.image.path|imagine_filter('sylius_medium') : 'http://placehold.it/262x255' }}" alt="{{ product.name }}" />
-        <span class="label label-primary">{{ sylius_calculate_price(product.masterVariant)|sylius_price }}</span>
+        <span class="label label-primary">{{ sylius_calculate_price(product.masterVariant)|sylius_money }}</span>
         <button class="btn btn-success btn-xs pull-right"><i class="icon-shopping-cart icon-white"></i> {{ 'sylius.add_to_cart'|trans }}</button>
     </a>
 </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
@@ -79,7 +79,7 @@
                             {% endif %}
                         </td>
                         <td>
-                            <span class="label label-success">{{ sylius_calculate_price(variant)|sylius_price }}</span>
+                            <span class="label label-success">{{ sylius_calculate_price(variant)|sylius_money }}</span>
                         </td>
                         <td>
                         {% if sylius_inventory_is_available(variant) %}
@@ -99,7 +99,7 @@
             {% endif %}
         {% else %}
             <h4>
-                <span class="label label-success pull-right">{{ sylius_calculate_price(product.masterVariant)|sylius_price }}</span>
+                <span class="label label-success pull-right">{{ sylius_calculate_price(product.masterVariant)|sylius_money }}</span>
                 {{ 'sylius.variant.price'|trans }}
             </h4>
         {% endif %}

--- a/src/Sylius/Component/Core/Pricing/Calculators.php
+++ b/src/Sylius/Component/Core/Pricing/Calculators.php
@@ -25,4 +25,7 @@ class Calculators extends BaseCalculators
 
     // Address zone based pricing.
     const ZONE_BASED = 'zone_based';
+
+    // Currency based pricing.
+    const CURRENCY_BASED = 'currency_based';
 }

--- a/src/Sylius/Component/Core/Pricing/CurrencyAwareCalculatorInterface.php
+++ b/src/Sylius/Component/Core/Pricing/CurrencyAwareCalculatorInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Pricing;
+
+use Sylius\Component\Pricing\Calculator\CalculatorInterface;
+use Sylius\Component\Pricing\Model\PriceableInterface;
+
+/**
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+interface CurrencyAwareCalculatorInterface extends CalculatorInterface
+{
+    /**
+     * Determine if calculator output must skip currency conversion or not
+     *
+     * @return boolean
+     */
+    public function isCurrencySpecific();
+}

--- a/src/Sylius/Component/Core/Pricing/CurrencyBasedCalculator.php
+++ b/src/Sylius/Component/Core/Pricing/CurrencyBasedCalculator.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Pricing;
+
+use Sylius\Component\Currency\Context\CurrencyContextInterface;
+use Sylius\Component\Pricing\Calculator\CalculatorInterface;
+use Sylius\Component\Pricing\Model\PriceableInterface;
+
+/**
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+class CurrencyBasedCalculator implements CalculatorInterface
+{
+    /**
+     * @var CurrencyContextInterface
+     */
+    protected $currencyContext;
+
+    public function __construct(CurrencyContextInterface $currencyContext)
+    {
+        $this->currencyContext = $currencyContext;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function calculate(PriceableInterface $subject, array $configuration, array $context = array())
+    {
+        $currency = $this->currencyContext->getCurrency();
+
+        if (!isset($configuration[$currency])) {
+            return $subject->getPrice();
+        }
+
+        return (int) ($configuration[$currency] * 100); // *100 because we don't use a money form type
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return Calculators::CURRENCY_BASED;
+    }
+}

--- a/src/Sylius/Component/Core/Pricing/CurrencyBasedCalculator.php
+++ b/src/Sylius/Component/Core/Pricing/CurrencyBasedCalculator.php
@@ -41,7 +41,7 @@ class CurrencyBasedCalculator implements CalculatorInterface
             return $subject->getPrice();
         }
 
-        return (int) ($configuration[$currency] * 100); // *100 because we don't use a money form type
+        return (int) $configuration[$currency];
     }
 
     /**

--- a/src/Sylius/Component/Core/Pricing/CurrencyBasedCalculator.php
+++ b/src/Sylius/Component/Core/Pricing/CurrencyBasedCalculator.php
@@ -18,7 +18,7 @@ use Sylius\Component\Pricing\Model\PriceableInterface;
 /**
  * @author Alexandre Bacco <alexandre.bacco@gmail.com>
  */
-class CurrencyBasedCalculator implements CalculatorInterface
+class CurrencyBasedCalculator implements CurrencyAwareCalculatorInterface
 {
     /**
      * @var CurrencyContextInterface
@@ -50,5 +50,13 @@ class CurrencyBasedCalculator implements CalculatorInterface
     public function getType()
     {
         return Calculators::CURRENCY_BASED;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCurrencySpecific()
+    {
+        return true;
     }
 }

--- a/src/Sylius/Component/Core/Pricing/DelegatingCalculator.php
+++ b/src/Sylius/Component/Core/Pricing/DelegatingCalculator.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Pricing;
+
+use Sylius\Component\Currency\Context\CurrencyContextInterface;
+use Sylius\Component\Currency\Converter\CurrencyConverterInterface;
+use Sylius\Component\Pricing\Calculator\DelegatingCalculator as BaseDelegatingCalculator;
+use Sylius\Component\Pricing\Model\PriceableInterface;
+use Sylius\Component\Registry\ServiceRegistryInterface;
+
+class DelegatingCalculator extends BaseDelegatingCalculator
+{
+    /**
+     * @var CurrencyContextInterface
+     */
+    protected $currencyContext;
+
+    /**
+     * @var CurrencyConverterInterface
+     */
+    protected $currencyConverter;
+
+    /**
+     * @param ServiceRegistryInterface   $registry
+     * @param CurrencyContextInterface   $currencyContext
+     * @param CurrencyConverterInterface $currencyConverter
+     */
+    public function __construct(ServiceRegistryInterface $registry, CurrencyContextInterface $currencyContext, CurrencyConverterInterface $currencyConverter)
+    {
+        parent::__construct($registry);
+
+        $this->currencyContext   = $currencyContext;
+        $this->currencyConverter = $currencyConverter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function calculate(PriceableInterface $subject, array $context = array(), $currency = null)
+    {
+        $price = parent::calculate($subject, $context);
+
+        if (!$this->isConversionNeeded($subject)) {
+            return $price;
+        }
+
+        return $this->currencyConverter->convert($price, $currency ?: $this->currencyContext->getCurrency());
+    }
+
+    /**
+     * Returns true if calculator's output needs currency conversion
+     *
+     * @param PriceableInterface $subject
+     *
+     * @return bool
+     */
+    protected function isConversionNeeded(PriceableInterface $subject)
+    {
+        $calculator = $this->registry->get($subject->getPricingCalculator());
+
+        return ! (in_array('Sylius\Component\Core\Pricing\CurrencyAwareCalculatorInterface', class_implements($calculator)) && $calculator->isCurrencySpecific());
+    }
+}

--- a/src/Sylius/Component/Core/spec/Pricing/CurrencyBasedCalculatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Pricing/CurrencyBasedCalculatorSpec.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Core\Pricing;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Currency\Context\CurrencyContextInterface;
+use Sylius\Component\Pricing\Model\PriceableInterface;
+
+/**
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+class CurrencyBasedCalculatorSpec extends ObjectBehavior
+{
+    function let(CurrencyContextInterface $currencyContext)
+    {
+        $this->beConstructedWith($currencyContext);
+    }
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Core\Pricing\CurrencyBasedCalculator');
+    }
+
+    function it_implements_sylius_pricing_calculator_interface()
+    {
+        $this->shouldImplement('Sylius\Component\Pricing\Calculator\CalculatorInterface');
+    }
+
+    function it_returns_default_price_if_currency_is_not_in_configuration(PriceableInterface $priceable, $currencyContext)
+    {
+        $configuration = array(
+            'SGD' => 49.99,
+            'USD' => 45.99
+        );
+
+        $currencyContext->getCurrency()->willReturn('EUR');
+
+        $priceable->getPrice()->shouldBeCalled()->willReturn(5500);
+
+        $this->calculate($priceable, $configuration)->shouldReturn(5500);
+    }
+
+    function it_returns_the_price_for_currency_if_configuration_exists(PriceableInterface $priceable, $currencyContext)
+    {
+        $configuration = array(
+            'EUR' => 55.99,
+            'SGD' => 49.99,
+            'USD' => 45.99
+        );
+
+        $currencyContext->getCurrency()->willReturn('SGD');
+
+        $this->calculate($priceable, $configuration)->shouldReturn(4999);
+    }
+}

--- a/src/Sylius/Component/Core/spec/Pricing/CurrencyBasedCalculatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Pricing/CurrencyBasedCalculatorSpec.php
@@ -37,8 +37,8 @@ class CurrencyBasedCalculatorSpec extends ObjectBehavior
     function it_returns_default_price_if_currency_is_not_in_configuration(PriceableInterface $priceable, $currencyContext)
     {
         $configuration = array(
-            'SGD' => 49.99,
-            'USD' => 45.99
+            'SGD' => 4999,
+            'USD' => 4599
         );
 
         $currencyContext->getCurrency()->willReturn('EUR');
@@ -51,9 +51,9 @@ class CurrencyBasedCalculatorSpec extends ObjectBehavior
     function it_returns_the_price_for_currency_if_configuration_exists(PriceableInterface $priceable, $currencyContext)
     {
         $configuration = array(
-            'EUR' => 55.99,
-            'SGD' => 49.99,
-            'USD' => 45.99
+            'EUR' => 5599,
+            'SGD' => 4999,
+            'USD' => 4599
         );
 
         $currencyContext->getCurrency()->willReturn('SGD');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | #2353 |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| License | MIT |

The calculator itself is working well.

But as it returns the price directly in the right currency, I need a way not to trigger the currency conversion. This is how it's done in the view: 

```
sylius_calculate_price(variant)|sylius_price
```

What would be the best way to avoid this conversion just for this calculator?
Should we use only `sylius_money` when using `sylius_calculate_price` and thus make the latter currency aware? So that it's the DelegatingCalculator that does the conversion if needed?
What do you think?
