### PR TITLE
Use SyliusWebBundle buttons instead of SyliusResourceBundle buttons

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Profile/index.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Profile/index.html.twig
@@ -1,6 +1,6 @@
 {% extends 'SyliusWebBundle:Frontend/Account:layout.html.twig' %}
 
-{% import 'SyliusResourceBundle:Macros:buttons.html.twig' as buttons %}
+{% import 'SyliusWebBundle:Frontend/Macros:buttons.html.twig' as buttons %}
 {% from 'SyliusWebBundle:Backend/Macros:misc.html.twig' import pagination %}
 {% from 'SyliusWebBundle:Backend/Order:macros.html.twig' import simple_list %}
 


### PR DESCRIPTION
**btn()** macro, needed by `SyliusWebBundle:Frontend/Account:Order/_list.html.twig` does not exists in `SyliusResourceBundle:Macros:buttons`.

This hopefully fixes the error [mentioned here](https://github.com/Sylius/Sylius/pull/2494#issuecomment-85500591).