### PR TITLE
Throw event before and after sending email

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
@@ -61,7 +61,8 @@ class SyliusCoreExtension extends AbstractResourceExtension implements PrependEx
         'api_form',
         'templating',
         'twig',
-        'reports'
+        'reports',
+        'mailer'
     );
 
     /**

--- a/src/Sylius/Bundle/MailerBundle/Renderer/Adapter/TwigAdapter.php
+++ b/src/Sylius/Bundle/MailerBundle/Renderer/Adapter/TwigAdapter.php
@@ -12,12 +12,14 @@
 namespace Sylius\Bundle\MailerBundle\Renderer\Adapter;
 
 use Sylius\Component\Mailer\Event\EmailEvent;
+use Sylius\Component\Mailer\Event\EmailRenderEvent;
 use Sylius\Component\Mailer\Model\EmailInterface;
 use Sylius\Component\Mailer\Renderer\Adapter\AbstractAdapter;
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
+use Sylius\Component\Mailer\SyliusMailerEvents;
 
 /**
- * Default Sylius mailer using Twig and SwiftMailer.
+ * Default Sylius Twig renderer.
  *
  * @author Daniel Richter <nexyz9@gmail.com>
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -62,7 +64,7 @@ class TwigAdapter extends AbstractAdapter
         }
 
         /** @var EmailEvent $event */
-        $event = $this->dispatcher->dispatch(self::EVENT_EMAIL_RENDERED, new EmailEvent(new RenderedEmail($subject, $body)));
+        $event = $this->dispatcher->dispatch(SyliusMailerEvents::EMAIL_PRE_RENDER, new EmailRenderEvent(new RenderedEmail($subject, $body)));
 
         return $event->getRenderedEmail();
     }

--- a/src/Sylius/Component/Mailer/Event/EmailRenderEvent.php
+++ b/src/Sylius/Component/Mailer/Event/EmailRenderEvent.php
@@ -17,7 +17,7 @@ use Symfony\Component\EventDispatcher\Event;
 /**
  * @author Jérémy Leherpeur <jeremy@leherpeur.net>
  */
-class EmailEvent extends Event
+class EmailRenderEvent extends Event
 {
     /**
      * @var RenderedEmail

--- a/src/Sylius/Component/Mailer/Event/EmailSendEvent.php
+++ b/src/Sylius/Component/Mailer/Event/EmailSendEvent.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Mailer\Event;
+
+use Sylius\Component\Mailer\Model\EmailInterface;
+use Sylius\Component\Mailer\Renderer\RenderedEmail;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
+ */
+class EmailSendEvent extends Event
+{
+    /**
+     * @var mixed
+     */
+    protected $message;
+
+    /**
+     * @var string[]
+     */
+    protected $recipients;
+
+    /**
+     * @var EmailInterface
+     */
+    protected $email;
+
+    /**
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * @param mixed $message
+     * @param array $recipients
+     * @param EmailInterface $email
+     * @param array $data
+     */
+    public function __construct(
+        $message,
+        EmailInterface $email,
+        array $data,
+        array $recipients = array()
+    )
+    {
+        $this->message = $message;
+        $this->email = $email;
+        $this->data = $data;
+        $this->recipients = $recipients;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRecipients()
+    {
+        return $this->recipients;
+    }
+
+    /**
+     * @return EmailInterface
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    /**
+     * @return array
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+}

--- a/src/Sylius/Component/Mailer/Renderer/Adapter/AdapterInterface.php
+++ b/src/Sylius/Component/Mailer/Renderer/Adapter/AdapterInterface.php
@@ -19,8 +19,6 @@ use Sylius\Component\Mailer\Renderer\RenderedEmail;
  */
 interface AdapterInterface
 {
-    const EVENT_EMAIL_RENDERED = 'sylius.email_rendered';
-
     /**
      * Render an e-mail.
      *

--- a/src/Sylius/Component/Mailer/Sender/Adapter/AdapterInterface.php
+++ b/src/Sylius/Component/Mailer/Sender/Adapter/AdapterInterface.php
@@ -11,23 +11,24 @@
 
 namespace Sylius\Component\Mailer\Sender\Adapter;
 
+use Sylius\Component\Mailer\Model\EmailInterface;
 use Sylius\Component\Mailer\Renderer\RenderedEmail;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Jérémy Leherpeur <jeremy@leherpeur.net>
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 interface AdapterInterface
 {
-    const EVENT_EMAIL_SENT = 'sylius.email_sent';
-
     /**
      * Send an e-mail.
      *
      * @param array  $recipients
      * @param string $senderAddress
      * @param string $senderName
-     * @param RenderedEmail $email
+     * @param RenderedEmail $renderedEmail
+     * @param EmailInterface $email
      */
-    public function send(array $recipients, $senderAddress, $senderName, RenderedEmail $email);
+    public function send(array $recipients, $senderAddress, $senderName, RenderedEmail $renderedEmail, EmailInterface $email, array $data);
 }

--- a/src/Sylius/Component/Mailer/Sender/Sender.php
+++ b/src/Sylius/Component/Mailer/Sender/Sender.php
@@ -21,6 +21,7 @@ use Sylius\Component\Mailer\Provider\EmailProviderInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Jérémy Leherpeur <jeremy@leherpeur.net>
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
 class Sender implements SenderInterface
 {
@@ -78,6 +79,6 @@ class Sender implements SenderInterface
 
         $renderedEmail = $this->rendererAdapter->render($email, $data);
 
-        $this->senderAdapter->send($recipients, $senderAddress, $senderName, $renderedEmail);
+        $this->senderAdapter->send($recipients, $senderAddress, $senderName, $renderedEmail, $email, $data);
     }
 }

--- a/src/Sylius/Component/Mailer/SyliusMailerEvents.php
+++ b/src/Sylius/Component/Mailer/SyliusMailerEvents.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Mailer;
+
+/**
+ * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
+ */
+class SyliusMailerEvents
+{
+    const EMAIL_PRE_RENDER = 'sylius.email_rendered';
+    const EMAIL_PRE_SEND = 'sylius.email_send.pre_send';
+    const EMAIL_POST_SEND = 'sylius.email_send.post_send';
+}

--- a/src/Sylius/Component/Mailer/spec/Sender/SenderSpec.php
+++ b/src/Sylius/Component/Mailer/spec/Sender/SenderSpec.php
@@ -53,10 +53,12 @@ class SenderSpec extends ObjectBehavior
         $email->getSenderAddress()->shouldBeCalled();
         $email->getSenderName()->shouldBeCalled();
 
-        $rendererAdapter->render($email, array('foo' => 2))->willReturn($renderedEmail);
-        $senderAdapter->send(array('jonh@example.com'), null, null, $renderedEmail)->shouldBeCalled();
+        $data = array('foo' => 2);
 
-        $this->send('bar', array('jonh@example.com'), array('foo' => 2));
+        $rendererAdapter->render($email, array('foo' => 2))->willReturn($renderedEmail);
+        $senderAdapter->send(array('jonh@example.com'), null, null, $renderedEmail, $email, $data)->shouldBeCalled();
+
+        $this->send('bar', array('jonh@example.com'), $data);
     }
 
     function it_does_not_send_disabled_emails(
@@ -69,7 +71,7 @@ class SenderSpec extends ObjectBehavior
         $email->isEnabled()->shouldBeCalled()->willReturn(false);
 
         $rendererAdapter->render($email, array('foo' => 2))->shouldNotBeCalled();
-        $senderAdapter->send(array('jonh@example.com'), "mail@sylius.org", "Sylius Mailer", null)->shouldNotBeCalled();
+        $senderAdapter->send(array('jonh@example.com'), "mail@sylius.org", "Sylius Mailer", null, $email, array())->shouldNotBeCalled();
 
         $this->send('bar', array('jonh@example.com'), array('foo' => 2));
     }


### PR DESCRIPTION
```
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT
```
In our app we need to add custom headers before sending emails, and thought this might be something other people could need.

Also in `` src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php`` the mailer services where not being loaded (don't know if this is on purpose or not).