### PR TITLE
Use 'user' variable and fix Profile page 'buttons' error

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/AddressController.php
+++ b/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/AddressController.php
@@ -37,6 +37,7 @@ class AddressController extends FOSRestController
             ->view()
             ->setTemplate('SyliusWebBundle:Frontend/Account:Address/index.html.twig')
             ->setData(array(
+                'user' => $this->getUser(),
                 'addresses' => $this->getUser()->getAddresses(),
             ))
         ;

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Address/index.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Address/index.html.twig
@@ -4,12 +4,12 @@
 {% block content %}
     <h4>{{ 'sylius.account.address.list'|trans }}</h4>
 
-    {% if app.user.billingAddress is empty or app.user.shippingAddress is empty %}
+    {% if user.billingAddress is empty or user.shippingAddress is empty %}
         <p>
-        {% if app.user.billingAddress is empty %}
+        {% if user.billingAddress is empty %}
             <span class="label label-success">{{ 'sylius.account.address.default.no_billing'|trans }}</span>
         {% endif %}
-        {% if app.user.shippingAddress is empty %}
+        {% if user.shippingAddress is empty %}
             <span class="label label-primary">{{ 'sylius.account.address.default.no_shipping'|trans }}</span>
         {% endif %}
         </p>
@@ -25,20 +25,20 @@
                             {{ include('SyliusWebBundle:Frontend/Address:_show.html.twig') }}
                         </td>
                         <td>
-                            {% if address == app.user.billingAddress %}
+                            {% if address == user.billingAddress %}
                                 <span id="defaultBillingAddress" class="label label-success">{{ 'sylius.account.address.default.billing'|trans }}</span><br><br>
                             {% endif %}
-                            {% if address == app.user.shippingAddress %}
+                            {% if address == user.shippingAddress %}
                                 <span id="defaultShippingAddress" class="label label-info">{{ 'sylius.account.address.default.shipping'|trans }}</span><br><br>
                             {% endif %}
 
-                            {% if address != app.user.billingAddress %}
+                            {% if address != user.billingAddress %}
                                 {{ buttons.patch(
                                     path('sylius_account_address_set_default_billing', {'id': address.id}),
                                     'sylius.account.address.action.billing', 'star-empty') }}
                                 <br>
                             {% endif %}
-                            {% if address != app.user.shippingAddress %}
+                            {% if address != user.shippingAddress %}
                                 {{ buttons.patch(
                                     path('sylius_account_address_set_default_shipping', {'id': address.id}),
                                     'sylius.account.address.action.shipping', 'star') }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Profile/index.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Profile/index.html.twig
@@ -1,6 +1,6 @@
 {% extends 'SyliusWebBundle:Frontend/Account:layout.html.twig' %}
 
-{% import 'SyliusResourceBundle:Macros:buttons.html.twig' as buttons %}
+{% import 'SyliusWebBundle:Frontend/Macros:buttons.html.twig' as buttons %}
 {% from 'SyliusWebBundle:Backend/Macros:misc.html.twig' import pagination %}
 {% from 'SyliusWebBundle:Backend/Order:macros.html.twig' import simple_list %}
 
@@ -12,10 +12,10 @@
     <div class="row">
         <div class="col-md-7">{{ 'sylius.account.home.outline'|trans }} </div>
         <div class="col-md-5">
-            <strong>{{ app.user.lastName|upper }} {{ app.user.firstName }}</strong><br><br>
-            {{ 'sylius.account.home.id'|trans }} {{ app.user.id }} <br>
-            {{ 'sylius.account.home.email'|trans }} {{ app.user.email }}<br>
-            {{ 'sylius.account.home.since'|trans }} {{ app.user.createdAt|date() }}
+            <strong>{{ user.lastName|upper }} {{ user.firstName }}</strong><br><br>
+            {{ 'sylius.account.home.id'|trans }} {{ user.id }} <br>
+            {{ 'sylius.account.home.email'|trans }} {{ user.email }}<br>
+            {{ 'sylius.account.home.since'|trans }} {{ user.createdAt|date() }}
         </div>
     </div>
 


### PR DESCRIPTION
It's better to use `user` variable (in profile and address pages) just like other controllers and templates.
Also replaces: #2618.

@pjedrzejewski @aRn0D ping ;)