### PR TITLE
Volume-based setPricingConfiguration parameter is counterintuitive

### DIFF
--- a/features/pricing/volume_based_pricing.feature
+++ b/features/pricing/volume_based_pricing.feature
@@ -23,13 +23,20 @@ Feature: Volume based pricing
           And the default tax zone is "UK"
           And the following products exist:
             | name        | price | taxons       | tax category  |
-            | Symfony Tee | 69.00 | PHP T-Shirts | Taxable Goods |
+            | Symfony Tee | 70.00 | PHP T-Shirts | Taxable Goods |
           And product "Symfony Tee" has the following volume based pricing:
             | range | price |
-            | 0-9   | 69.00 |
+            | 1-9   | 69.00 |
             | 10-19 | 65.00 |
             | 20-29 | 60.00 |
             | 30+   | 55.99 |
+
+    Scenario: Volume-based pricing has priority over price attribute
+        Given I am on the store homepage
+         When I add product "Symfony Tee" to cart, with quantity "1"
+         Then I should be on the cart summary page
+          And "Tax total: €10.35" should appear on the page
+          And "Grand total: €79.35" should appear on the page
 
     Scenario: Price is calculated based on the quantity
         Given I am on the store homepage
@@ -44,3 +51,10 @@ Feature: Volume based pricing
          Then I should be on the cart summary page
           And "Tax total: €225.00" should appear on the page
           And "Grand total: €1,725.00" should appear on the page
+
+    Scenario: Lowest price is given for highest quantity and above
+        Given I am on the store homepage
+         When I add product "Symfony Tee" to cart, with quantity "100"
+         Then I should be on the cart summary page
+          And "Tax total: €839.85" should appear on the page
+          And "Grand total: €6,438.85" should appear on the page

--- a/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
@@ -292,8 +292,8 @@ class CoreContext extends DefaultContext
 
         foreach ($table->getHash() as $data) {
             if (false !== strpos($data['range'], '+')) {
-                $min = null;
-                $max = (int) trim(str_replace('+', '', $data['range']));
+                $min = (int) trim(str_replace('+', '', $data['range']));
+                $max = null;
             } else {
                 list($min, $max) = array_map(function ($value) { return (int) trim($value); }, explode('-', $data['range']));
             }
@@ -301,7 +301,7 @@ class CoreContext extends DefaultContext
             $configuration[] = array(
                 'min'   => $min,
                 'max'   => $max,
-                'price' => (int) $data['price'] * 100
+                'price' => (int) ($data['price'] * 100)
             );
         }
 

--- a/src/Sylius/Component/Pricing/Calculator/VolumeBasedCalculator.php
+++ b/src/Sylius/Component/Pricing/Calculator/VolumeBasedCalculator.php
@@ -52,15 +52,18 @@ class VolumeBasedCalculator implements CalculatorInterface
         $quantity = array_key_exists('quantity', $context) ? $context['quantity'] : 1;
 
         foreach ($configuration as $range) {
-            if (null === $range['min'] || null === $range['price']) {
-                continue; // silently ignore absurd ranges -- why not throw ?
+            if (null === $range['price']) {
+                throw new \Exception('Volume-based price ranges require a `price`.');
             }
 
-            if ($range['min'] <= $quantity && empty($range['max'])) {
-                return $range['price'];
-            }
-
-            if ($range['min'] <= $quantity && $quantity <= $range['max']) {
+            if (
+                // Given that undefined minimum is assumed to be 1,
+                (empty($range['min']) && $range['max'] <= $quantity) ||
+                // and that undefined maximum is assumed to be infinite,
+                ($range['min'] <= $quantity && empty($range['max'])) ||
+                // are we in this price range ?
+                ($range['min'] <= $quantity && $quantity <= $range['max'])
+            ) {
                 return $range['price'];
             }
         }

--- a/src/Sylius/Component/Pricing/Calculator/VolumeBasedCalculator.php
+++ b/src/Sylius/Component/Pricing/Calculator/VolumeBasedCalculator.php
@@ -58,7 +58,7 @@ class VolumeBasedCalculator implements CalculatorInterface
 
             if (
                 // Given that undefined minimum is assumed to be 1,
-                (empty($range['min']) && $range['max'] <= $quantity) ||
+                (empty($range['min']) && $quantity <= $range['max']) ||
                 // and that undefined maximum is assumed to be infinite,
                 ($range['min'] <= $quantity && empty($range['max'])) ||
                 // are we in this price range ?

--- a/src/Sylius/Component/Pricing/Calculator/VolumeBasedCalculator.php
+++ b/src/Sylius/Component/Pricing/Calculator/VolumeBasedCalculator.php
@@ -16,7 +16,31 @@ use Sylius\Component\Pricing\Model\PriceableInterface;
 /**
  * Volume based pricing calculator.
  *
+ * It accepts a configuration array containing quantity ranges of the form :
+ *
+ * ``` php
+ * $configuration = array(
+ *     // Between 1 and 9 items, the price for each is 2.00
+ *     array(
+ *         'min' => 1,
+ *         'max' => 9,
+ *         'price' => 200,
+ *     ),
+ *     // For 10 items and more, the price lowers to 1.50
+ *     array(
+ *         'min' => 10,
+ *         'max' => null,
+ *         'price' => 150,
+ *     )
+ * )
+ * ```
+ *
+ * You can provide as many ranges as you want, and if they overlap the first
+ * range found will be picked. Ranges do not have to be provided in sequential
+ * order, and their boundaries are inclusive. The price must be given in cents.
+ *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Antoine Goutenoir <antoine@goutenoir.com>
  */
 class VolumeBasedCalculator implements CalculatorInterface
 {
@@ -29,10 +53,10 @@ class VolumeBasedCalculator implements CalculatorInterface
 
         foreach ($configuration as $range) {
             if (null === $range['min'] || null === $range['price']) {
-                continue;
+                continue; // silently ignore absurd ranges -- why not throw ?
             }
 
-            if (empty($range['max']) && $quantity > $range['min']) {
+            if ($range['min'] <= $quantity && empty($range['max'])) {
                 return $range['price'];
             }
 


### PR DESCRIPTION
Look at https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php#L295

If the range is `30+` then the generated pricing configuration for `setPricingConfiguration()` is

``` php
array(
  'min' => null,
  'max' => 30,
  // ...
)
```

whereas it should be :

``` php
array(
  'min' => 30,
  'max' => null,
  // ...
)
```

What am I missing ?
