### PR TITLE
Use FOS UserInterface for easier extending

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
@@ -16,7 +16,7 @@ use FOS\UserBundle\Event\FormEvent;
 use FOS\UserBundle\FOSUserEvents;
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\Model\UserInterface;
+use FOS\UserBundle\Model\UserInterface;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Response;


### PR DESCRIPTION
I'm using SyliusCoreBundle inside my application (for handling only commerce parts of my site) and I have my own user bundle, so I just wanted to override `saveUser` to make it compatible with my own logic.

P.S
I have a `ProfileBundle` to decouple commerce-related user fields to a dedicated `CommerceProfile` and have my own `UserBundle` which has a simple clean `User` model - each User can have many `Profile`s.