### PR TITLE
Fix AddressController methods visibility

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/AddressController.php
+++ b/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/AddressController.php
@@ -175,7 +175,7 @@ class AddressController extends FOSRestController
      *
      * @return FormInterface
      */
-    private function getAddressForm(AddressInterface $address)
+    protected function getAddressForm(AddressInterface $address)
     {
         return $this->get('form.factory')->create('sylius_address', $address);
     }
@@ -183,7 +183,7 @@ class AddressController extends FOSRestController
     /**
      * @return ObjectManager
      */
-    private function getUserManager()
+    protected function getUserManager()
     {
         return $this->get('sylius.manager.user');
     }
@@ -191,12 +191,12 @@ class AddressController extends FOSRestController
     /**
      * @return RepositoryInterface
      */
-    private function getAddressRepository()
+    protected function getAddressRepository()
     {
         return $this->get('sylius.repository.address');
     }
 
-    private function redirectToIndex()
+    protected function redirectToIndex()
     {
         return $this->redirect($this->generateUrl('sylius_account_address_index'));
     }
@@ -211,7 +211,7 @@ class AddressController extends FOSRestController
      * @throws NotFoundHttpException
      * @throws AccessDeniedException
      */
-    private function findUserAddressOr404($id)
+    protected function findUserAddressOr404($id)
     {
         if (!$address = $this->getAddressRepository()->find($id)) {
             throw new NotFoundHttpException('Requested address does not exist.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | kind of
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

If you want to override the AddressController, you can't reuse some of its methods because they are private so I switched their visibility to protected.

Are you all right with that @pjedrzejewski ?