### PR TITLE
Fix STORAGE_KEY bug when using CookieStorage

### DIFF
--- a/src/Sylius/Component/Cart/Context/CartContextInterface.php
+++ b/src/Sylius/Component/Cart/Context/CartContextInterface.php
@@ -22,7 +22,7 @@ use Sylius\Component\Cart\Model\CartInterface;
 interface CartContextInterface
 {
     // Key used to store the cart in storage.
-    const STORAGE_KEY = '_sylius.cart_id';
+    const STORAGE_KEY = '_sylius_cart_id';
 
     /**
      * Get the currently active cart.

--- a/src/Sylius/Component/Currency/Context/CurrencyContextInterface.php
+++ b/src/Sylius/Component/Currency/Context/CurrencyContextInterface.php
@@ -20,7 +20,7 @@ namespace Sylius\Component\Currency\Context;
 interface CurrencyContextInterface
 {
     // Key used to store the currency in storage.
-    const STORAGE_KEY = '_sylius.currency';
+    const STORAGE_KEY = '_sylius_currency';
 
     /**
      * Get the default currency.

--- a/src/Sylius/Component/Locale/Context/LocaleContextInterface.php
+++ b/src/Sylius/Component/Locale/Context/LocaleContextInterface.php
@@ -20,7 +20,7 @@ namespace Sylius\Component\Locale\Context;
 interface LocaleContextInterface
 {
     // Key used to store the locale in storage.
-    const STORAGE_KEY = '_sylius.locale';
+    const STORAGE_KEY = '_sylius_locale';
 
     /**
      * Get the default locale.


### PR DESCRIPTION
Unfortunately PHP will convert **dot**s into underscore when parsing cookie names! So we have to remove dots in our `STORAKE_KEY`s so that is possible to use a CookieStorage.

[The full list of field-name characters that PHP converts to _ .](http://ca.php.net/manual/en/language.variables.external.php#81080)
[A random blog post .](http://harrybailey.com/2009/04/dots-arent-allowed-in-php-cookie-names/)