### PR TITLE
[AttributeBundle] Fix CollectionType and AttributeChoices form type

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/Form/EventListener/BuildAttributeFormChoicesListener.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/EventListener/BuildAttributeFormChoicesListener.php
@@ -67,7 +67,9 @@ class BuildAttributeFormChoicesListener implements EventSubscriberInterface
             $choices = $data['choices'];
         }
 
-        $data['configuration'] = $choices;
+        $data['configuration'] = array(
+            'choices' => $choices
+        );
 
         if (!$event->getForm()->has('configuration')) {
             $event->getForm()->add(

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
@@ -56,12 +56,7 @@ class AttributeValueType extends AbstractResourceType
             ->addEventSubscriber(new BuildAttributeValueFormListener($builder->getFormFactory()))
         ;
 
-        $prototypes = array();
-        foreach ($this->getAttributes($builder) as $attribute) {
-            $prototypes[] = $builder->create('value', $attribute->getType(), $attribute->getConfiguration())->getForm();
-        }
-
-        $builder->setAttribute('prototypes', $prototypes);
+        $this->buildAttributeValuePrototypes($builder);
     }
 
     /**
@@ -85,14 +80,19 @@ class AttributeValueType extends AbstractResourceType
     }
 
     /**
-     * Get attributes
+     * Build attribute values' prototypes
      *
      * @param FormBuilderInterface $builder
-     *
-     * @return AttributeInterface[]
      */
-    private function getAttributes(FormBuilderInterface $builder)
+    protected function buildAttributeValuePrototypes($builder)
     {
-        return $builder->get('attribute')->getOption('choice_list')->getChoices();
+        $attributes = $builder->get('attribute')->getOption('choice_list')->getChoices();
+
+        $prototypes = array();
+        foreach ($attributes as $attribute) {
+            $prototypes[] = $builder->create('value', $attribute->getType(), $attribute->getConfiguration())->getForm();
+        }
+
+        $builder->setAttribute('prototypes', $prototypes);
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/Resources/views/forms.html.twig
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/views/forms.html.twig
@@ -5,7 +5,7 @@
     {% spaceless %}
         <div data-form-type="collection"
              {{ block('widget_container_attributes') }}
-             {% if prototype is defined and allow_add and prototype is not empty %}
+             {% if prototype is defined and allow_add %}
              data-prototype='{{ _self.collectionItem(prototype, allow_delete, button_delete_label, '__name__')|e }}'
              {%- endif -%}>
 
@@ -51,8 +51,11 @@
                         </a>
                     </p>
                 {% endif %}
-
-                {{ form_rest(form) }}
+                {% if not form.children|length %}
+                    {{ form_widget(form) }}
+                {% else %}
+                    {{ form_rest(form) }}
+                {% endif %}
             </div>
         </div>
     {% endspaceless %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_attributes.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_attributes.html.twig
@@ -1,22 +1,5 @@
 {% form_theme form 'SyliusWebBundle:Backend:forms.html.twig' %}
 
 <div class="tab-pane" id="attributes">
-    <div id="sylius-assortment-product-attributes" class="collection-container" data-prototype="{{ ('<div id="sylius_product_attributes___name__">' ~ form_row(form.attributes.vars.prototype.attribute, {'attr': {'class': 'attribute-chooser'}}))|e }}{{ (form_row(form.attributes.vars.prototype.value) ~ '</div>')|e }}">
-        {% for attributeForm in form.attributes %}
-        <div class="sylius-assortment-product-attributes-attribute row">
-            <div class="col-md-10">
-                {{ form_widget(attributeForm) }}
-            </div>
-            <div class="col-md-2">
-                <a href="#" class="btn btn-danger" data-collection-button="delete" data-collection="sylius-assortment-product-attributes" data-collection-item="attribute"><i class="glyphicon glyphicon-trash"></i>&nbsp;{{ 'sylius.product.remove_attribute'|trans }}</a>
-            </div>
-        </div>
-        {% endfor %}
-        {% for key, prototype in form.attributes.vars.prototype.vars.prototypes %}
-            <div id="attribute-prototype_{{ key }}" class="attribute-prototypes" data-prototype="{{ form_widget(prototype)|e }}"></div>
-        {% endfor %}
-    </div>
-    <a href="#" class="btn btn-success btn-block" data-collection-button="add" data-prototype="sylius-assortment-product-attributes" data-collection="sylius-assortment-product-attributes">
-        {{ 'sylius.product.add_attribute'|trans }}
-    </a>
+    {{ form_row(form.attributes, { 'label': false }) }}
 </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductAttribute/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductAttribute/_form.html.twig
@@ -5,29 +5,7 @@
     {{ form_row(form.translations, {'attr': {'class': 'input-lg'}}) }}
     {{ form_row(form.type, {'attr': {'class': 'input-lg'}}) }}
     {% if form.choices is defined %}
-    {% spaceless %}
-        <div class="property-choices-container hidden">
-            <hr />
-            <div id="sylius-assortment-property-choices" class="collection-container" data-prototype="{{ form_row(form.choices.vars.prototype, {'label' : 'Choice __name__'})|e }}">
-                {% for key, choice in form.choices %}
-                    <div class="control-group">
-                        {{ form_label(choice, 'Choice ' ~ key) }}
-                        <div class="controls">
-                            {{ form_widget(choice) }}
-                            <a class="btn btn-danger delete-link sylius_property_choices_{{ key }}_delete" href="#"><i class="glyphicon glyphicon-trash"></i></a>
-                        </div>
-                    </div>
-                {% endfor %}
-            </div>
-            <div class="control-group">
-                <div class="controls">
-                    <a href="#" class="btn btn-success" data-collection-button="add" data-prototype="sylius-assortment-property-choices" data-collection="sylius-assortment-property-choices">
-                        {{ 'sylius.property.add_choice'|trans }}
-                    </a>
-                </div>
-            </div>
-        </div>
-    {% endspaceless %}
+        {{ form_row(form.choices) }}
     {% endif %}
 </fieldset>
 


### PR DESCRIPTION
Hopefully fixes #2575 and also a little bug in `collection_widget` that could not work with collections which have only a single form type such as a collection of `text` types.