### PR TITLE
[PricingBundle] Remove unnecessary complexity

### DIFF
--- a/src/Sylius/Bundle/PricingBundle/Form/Extension/PriceableTypeExtension.php
+++ b/src/Sylius/Bundle/PricingBundle/Form/Extension/PriceableTypeExtension.php
@@ -64,7 +64,6 @@ class PriceableTypeExtension extends AbstractTypeExtension
         ;
 
         $prototypes = array();
-        $prototypes['calculators'] = array();
 
         foreach ($this->calculatorRegistry->all() as $type => $calculator) {
             $formType = sprintf('sylius_price_calculator_%s', $calculator->getType());
@@ -74,7 +73,7 @@ class PriceableTypeExtension extends AbstractTypeExtension
             }
 
             try {
-                $prototypes['calculators'][$type] = $builder->create('pricingConfiguration', $formType)->getForm();
+                $prototypes[$type] = $builder->create('pricingConfiguration', $formType)->getForm();
             } catch (\InvalidArgumentException $e) {
                 continue;
             }
@@ -90,10 +89,8 @@ class PriceableTypeExtension extends AbstractTypeExtension
     {
         $view->vars['prototypes'] = array();
 
-        foreach ($form->getConfig()->getAttribute('prototypes') as $group => $prototypes) {
-            foreach ($prototypes as $type => $prototype) {
-                $view->vars['prototypes'][$group.'_'.$type] = $prototype->createView($view);
-            }
+        foreach ($form->getConfig()->getAttribute('prototypes') as $type => $prototype) {
+            $view->vars['prototypes'][$type] = $prototype->createView($view);
         }
     }
 


### PR DESCRIPTION
@pjedrzejewski @stloyd I'm working on a AngularJS admin and now that I'm working on field prototypes this portion of code is breaking my code.

I expect `prototypes` var to contain an associative array in which the keys are **exactly** equal to the values that the "value provider" field generates (in this `PricingBundle` case, the `pricingCalculator` is the "value provider").

So that I can find appropriate calculator `prototype` based on current `pricingCalculator` value on my forms.

I took a quick look around the whole source code and couldn't find any use of `$group` prefix for `prototypes` array.
