### PR TITLE
[AttributeBundle] Do not save unnecessary 'choices' in attribute configuration

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/Form/EventListener/BuildAttributeFormChoicesListener.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/EventListener/BuildAttributeFormChoicesListener.php
@@ -61,15 +61,13 @@ class BuildAttributeFormChoicesListener implements EventSubscriberInterface
     public function buildConfiguration(FormEvent $event)
     {
         $data = $event->getData();
-        $choices = array();
+        $data['configuration'] = array();
 
         if (array_key_exists('type', $data) && AttributeTypes::CHOICE === $data['type'] && !empty($data['choices'])) {
-            $choices = $data['choices'];
+            $data['configuration'] = array(
+                'choices' => $data['choices']
+            );
         }
-
-        $data['configuration'] = array(
-            'choices' => $choices
-        );
 
         if (!$event->getForm()->has('configuration')) {
             $event->getForm()->add(


### PR DESCRIPTION
Should not save 'choices' in attribute configuration when type is not choice, otherwise when user selects `choice` as attribute type then he changes back to `text` we're going to have `Unknown option [choices]` when rendering the form.