### PR TITLE
[ResourceBundle] Fix conflict of resource names in sylius.config.classes

### DIFF
--- a/src/Sylius/Bundle/InventoryBundle/DependencyInjection/SyliusInventoryExtension.php
+++ b/src/Sylius/Bundle/InventoryBundle/DependencyInjection/SyliusInventoryExtension.php
@@ -68,11 +68,5 @@ class SyliusInventoryExtension extends AbstractResourceExtension
                 );
             }
         }
-
-        if ($container->hasParameter('sylius.config.classes')) {
-            $classes = array_merge($classes, $container->getParameter('sylius.config.classes'));
-        }
-
-        $container->setParameter('sylius.config.classes', $classes);
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/AbstractResourceExtension.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/AbstractResourceExtension.php
@@ -120,11 +120,16 @@ abstract class AbstractResourceExtension extends Extension
             $this->registerFormTypes($config, $container);
         }
 
+        $configClasses = array();
+
         if ($container->hasParameter('sylius.config.classes')) {
-            $classes = array_merge($classes, $container->getParameter('sylius.config.classes'));
+            $configClasses = array_merge_recursive(
+                array($this->applicationName => $classes),
+                $container->getParameter('sylius.config.classes')
+            );
         }
 
-        $container->setParameter('sylius.config.classes', $classes);
+        $container->setParameter('sylius.config.classes', $configClasses);
 
         return array($config, $loader);
     }

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
@@ -47,11 +47,16 @@ class SyliusResourceExtension extends Extension
 
         $this->createResourceServices($classes, $container);
 
+        $configClasses = array();
+
         if ($container->hasParameter('sylius.config.classes')) {
-            $classes = array_merge($classes, $container->getParameter('sylius.config.classes'));
+            $configClasses = array_merge_recursive(
+                array('default' => $classes),
+                $container->getParameter('sylius.config.classes')
+            );
         }
 
-        $container->setParameter('sylius.config.classes', $classes);
+        $container->setParameter('sylius.config.classes', $configClasses);
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/EventListener/LoadODMMetadataSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/LoadODMMetadataSubscriber.php
@@ -67,11 +67,13 @@ class LoadODMMetadataSubscriber implements EventSubscriber
 
     private function setCustomRepositoryClasses(ClassMetadataInfo $metadata)
     {
-        foreach ($this->classes as $class) {
-            if (array_key_exists('model', $class) && $class['model'] === $metadata->getName()) {
-                $metadata->isMappedSuperclass = false;
-                if (array_key_exists('repository', $class)) {
-                    $metadata->setCustomRepositoryClass($class['repository']);
+        foreach ($this->classes as $application => $classes) {
+            foreach ($classes as $class) {
+                if (isset($class['model']) && $class['model'] === $metadata->getName()) {
+                    $metadata->isMappedSuperclass = false;
+                    if (isset($class['repository'])) {
+                        $metadata->setCustomRepositoryClass($class['repository']);
+                    }
                 }
             }
         }

--- a/src/Sylius/Bundle/ResourceBundle/EventListener/LoadORMMetadataSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/LoadORMMetadataSubscriber.php
@@ -67,17 +67,19 @@ class LoadORMMetadataSubscriber implements EventSubscriber
 
     private function process(ClassMetadataInfo $metadata)
     {
-        foreach ($this->classes as $class) {
-            if ((isset($class['model']) &&
-                $class['model'] === $metadata->getName())
-                ||
-                (isset($class['translation']['model']) &&
-                $class['translation']['model'] === $metadata->getName())
-            ) {
-                $metadata->isMappedSuperclass = false;
+        foreach ($this->classes as $application => $classes) {
+            foreach ($classes as $class) {
+                if ((isset($class['model']) &&
+                        $class['model'] === $metadata->getName())
+                    ||
+                    (isset($class['translation']['model']) &&
+                        $class['translation']['model'] === $metadata->getName())
+                ) {
+                    $metadata->isMappedSuperclass = false;
 
-                if (array_key_exists('repository', $class)) {
-                    $metadata->setCustomRepositoryClass($class['repository']);
+                    if (isset($class['repository'])) {
+                        $metadata->setCustomRepositoryClass($class['repository']);
+                    }
                 }
             }
         }

--- a/src/Sylius/Bundle/SettingsBundle/DependencyInjection/SyliusSettingsExtension.php
+++ b/src/Sylius/Bundle/SettingsBundle/DependencyInjection/SyliusSettingsExtension.php
@@ -50,12 +50,6 @@ class SyliusSettingsExtension extends AbstractResourceExtension implements Prepe
         if (isset($parameterClasses['repository'])) {
             $container->setParameter('sylius.repository.parameter.class', $parameterClasses['repository']);
         }
-
-        if ($container->hasParameter('sylius.config.classes')) {
-            $classes = array_merge($classes, $container->getParameter('sylius.config.classes'));
-        }
-
-        $container->setParameter('sylius.config.classes', $classes);
     }
 
     /**


### PR DESCRIPTION
When two applications have the two resources with the same name one on them is going to be overridden in `sylius.config.classes`, so I have stored resources' classes under their application names in `sylius.config.classes`.