### PR TITLE
Fix Mongo and PHPCR document managers service names

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/DoctrineODMDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/DoctrineODMDriver.php
@@ -65,7 +65,7 @@ class DoctrineODMDriver extends AbstractDatabaseDriver
      */
     protected function getManagerServiceKey()
     {
-        return sprintf('doctrine.odm.mongodb.%_document_manager', $this->managerName);
+        return sprintf('doctrine_mongodb.odm.%s_document_manager', $this->managerName);
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/DoctrinePHPCRDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/DoctrinePHPCRDriver.php
@@ -54,7 +54,7 @@ class DoctrinePHPCRDriver extends AbstractDatabaseDriver
      */
     protected function getManagerServiceKey()
     {
-        return sprintf('doctrine_phpcr.odm.%_document_manager', $this->managerName);
+        return sprintf('doctrine_phpcr.odm.%s_document_manager', $this->managerName);
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/spec/DependencyInjection/Driver/DoctrineODMDriverSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/DependencyInjection/Driver/DoctrineODMDriverSpec.php
@@ -13,6 +13,7 @@ namespace spec\Sylius\Bundle\ResourceBundle\DependencyInjection\Driver;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -47,9 +48,10 @@ class DoctrineODMDriverSpec extends ObjectBehavior
             Argument::type('Symfony\Component\DependencyInjection\Definition')
         )->shouldBeCalled();
 
+        $alias = new Alias('doctrine_mongodb.odm.default_document_manager');
         $container->setAlias(
             'prefix.manager.resource',
-            Argument::type('Symfony\Component\DependencyInjection\Alias')
+            $alias
         )->shouldBeCalled();
 
         $this->beConstructedWith($container, 'prefix', 'resource', 'default');

--- a/src/Sylius/Bundle/ResourceBundle/spec/DependencyInjection/Driver/DoctrinePHPCRDriverSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/DependencyInjection/Driver/DoctrinePHPCRDriverSpec.php
@@ -13,6 +13,7 @@ namespace spec\Sylius\Bundle\ResourceBundle\DependencyInjection\Driver;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -47,9 +48,10 @@ class DoctrinePHPCRDriverSpec extends ObjectBehavior
             Argument::type('Symfony\Component\DependencyInjection\Definition')
         )->shouldBeCalled();
 
+        $alias = new Alias('doctrine_phpcr.odm.default_document_manager');
         $container->setAlias(
             'prefix.manager.resource',
-            Argument::type('Symfony\Component\DependencyInjection\Alias')
+            $alias
         )->shouldBeCalled();
 
         $this->beConstructedWith($container, 'prefix', 'resource', 'default');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |  -
| License       | MIT
| Doc PR        | -

Its my mistake. MongoODM document managers called like `doctrine_mongodb.odm.%s_document_manager` but now its `doctrine.odm.mongodb.%_document_manager`. And `%s` missed.