### PR TITLE
Make translatable translation class retrieval static

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/spec/Fixture/Document/TranslatableFoo.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Fixture/Document/TranslatableFoo.php
@@ -20,7 +20,7 @@ use Sylius\Component\Translation\Model\AbstractTranslatable;
  */
 class TranslatableFoo extends AbstractTranslatable
 {
-    protected function getTranslationClass()
+    public static function getTranslationClass()
     {
         return 'spec\Sylius\Bundle\ResourceBundle\Fixture\Document\Foo';
     }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Fixture/Entity/TranslatableFoo.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Fixture/Entity/TranslatableFoo.php
@@ -20,7 +20,8 @@ use Sylius\Component\Translation\Model\AbstractTranslatable;
  */
 class TranslatableFoo extends AbstractTranslatable
 {
-    protected function getTranslationClass(){
+    public static function getTranslationClass()
+    {
         return  'spec\Sylius\Bundle\ResourceBundle\Fixture\Entity\Foo';
     }
 }

--- a/src/Sylius/Component/Addressing/Model/Country.php
+++ b/src/Sylius/Component/Addressing/Model/Country.php
@@ -157,12 +157,4 @@ class Country extends AbstractTranslatable implements CountryInterface
     {
         return $this->provinces->contains($province);
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTranslationClass()
-    {
-        return get_class().'Translation';
-    }
 }

--- a/src/Sylius/Component/Archetype/Model/Archetype.php
+++ b/src/Sylius/Component/Archetype/Model/Archetype.php
@@ -290,12 +290,4 @@ class Archetype extends AbstractTranslatable implements ArchetypeInterface
 
         return $this;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTranslationClass()
-    {
-        return get_class().'Translation';
-    }
 }

--- a/src/Sylius/Component/Attribute/Model/Attribute.php
+++ b/src/Sylius/Component/Attribute/Model/Attribute.php
@@ -192,12 +192,4 @@ class Attribute extends AbstractTranslatable implements AttributeInterface
 
         return $this;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTranslationClass()
-    {
-        return get_class().'Translation';
-    }
 }

--- a/src/Sylius/Component/Core/Model/Product.php
+++ b/src/Sylius/Component/Core/Model/Product.php
@@ -304,12 +304,4 @@ class Product extends BaseProduct implements ProductInterface
         $this->translate()->setShortDescription($shortDescription);
         return $this;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTranslationClass()
-    {
-        return get_class().'Translation';
-    }
 }

--- a/src/Sylius/Component/Core/Model/ShippingMethod.php
+++ b/src/Sylius/Component/Core/Model/ShippingMethod.php
@@ -52,6 +52,6 @@ class ShippingMethod extends BaseShippingMethod implements ShippingMethodInterfa
      */
     public static function getTranslationClass()
     {
-        return get_parent_class().'Translation';
+        return 'Sylius\Component\Shipping\Model\ShippingMethodTranslation';
     }
 }

--- a/src/Sylius/Component/Core/Model/ShippingMethod.php
+++ b/src/Sylius/Component/Core/Model/ShippingMethod.php
@@ -52,6 +52,6 @@ class ShippingMethod extends BaseShippingMethod implements ShippingMethodInterfa
      */
     public static function getTranslationClass()
     {
-        return parent::getTranslationClass();
+        return get_parent_class().'Translation';
     }
 }

--- a/src/Sylius/Component/Core/Model/ShippingMethod.php
+++ b/src/Sylius/Component/Core/Model/ShippingMethod.php
@@ -50,7 +50,7 @@ class ShippingMethod extends BaseShippingMethod implements ShippingMethodInterfa
     /**
      * {@inheritdoc}
      */
-    protected function getTranslationClass()
+    public static function getTranslationClass()
     {
         return parent::getTranslationClass();
     }

--- a/src/Sylius/Component/Core/Model/Taxon.php
+++ b/src/Sylius/Component/Core/Model/Taxon.php
@@ -152,4 +152,12 @@ class Taxon extends BaseTaxon implements ImageInterface, TaxonInterface
     {
         $this->products = $products;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getTranslationClass()
+    {
+        return 'Sylius\Component\Taxonomy\Model\TaxonTranslation';
+    }
 }

--- a/src/Sylius/Component/Core/Model/Taxonomy.php
+++ b/src/Sylius/Component/Core/Model/Taxonomy.php
@@ -30,6 +30,6 @@ class Taxonomy extends BaseTaxonomy
      */
     public static function getTranslationClass()
     {
-        return get_parent_class().'Translation';
+        return 'Sylius\Component\Taxonomy\Model\TaxonomyTranslation';
     }
 }

--- a/src/Sylius/Component/Core/Model/Taxonomy.php
+++ b/src/Sylius/Component/Core/Model/Taxonomy.php
@@ -24,4 +24,12 @@ class Taxonomy extends BaseTaxonomy
 
         $this->setRoot(new Taxon());
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getTranslationClass()
+    {
+        return get_parent_class().'Translation';
+    }
 }

--- a/src/Sylius/Component/Product/Model/Archetype.php
+++ b/src/Sylius/Component/Product/Model/Archetype.php
@@ -21,11 +21,4 @@ use Sylius\Component\Archetype\Model\Archetype as BaseArchetype;
  */
 class Archetype extends BaseArchetype implements ArchetypeInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTranslationClass()
-    {
-        return get_class().'Translation';
-    }
 }

--- a/src/Sylius/Component/Product/Model/Attribute.php
+++ b/src/Sylius/Component/Product/Model/Attribute.php
@@ -21,11 +21,4 @@ use Sylius\Component\Attribute\Model\Attribute as BaseAttribute;
  */
 class Attribute extends BaseAttribute implements AttributeInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTranslationClass()
-    {
-        return get_class().'Translation';
-    }
 }

--- a/src/Sylius/Component/Product/Model/Option.php
+++ b/src/Sylius/Component/Product/Model/Option.php
@@ -21,11 +21,4 @@ use Sylius\Component\Variation\Model\Option as BaseOption;
  */
 class Option extends BaseOption implements OptionInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTranslationClass()
-    {
-        return get_class().'Translation';
-    }
 }

--- a/src/Sylius/Component/Product/Model/Product.php
+++ b/src/Sylius/Component/Product/Model/Product.php
@@ -549,12 +549,4 @@ class Product extends AbstractTranslatable implements ProductInterface
 
         return $this;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTranslationClass()
-    {
-        return get_class().'Translation';
-    }
 }

--- a/src/Sylius/Component/Shipping/Model/ShippingMethod.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethod.php
@@ -327,12 +327,4 @@ class ShippingMethod extends AbstractTranslatable implements ShippingMethodInter
             ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_ALL  => 'All items have to match method category',
         );
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTranslationClass()
-    {
-        return get_class().'Translation';
-    }
 }

--- a/src/Sylius/Component/Taxonomy/Model/Taxon.php
+++ b/src/Sylius/Component/Taxonomy/Model/Taxon.php
@@ -358,12 +358,4 @@ class Taxon extends AbstractTranslatable implements TaxonInterface
 
         return $this;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTranslationClass()
-    {
-        return get_class().'Translation';
-    }
 }

--- a/src/Sylius/Component/Taxonomy/Model/Taxonomy.php
+++ b/src/Sylius/Component/Taxonomy/Model/Taxonomy.php
@@ -140,12 +140,4 @@ class Taxonomy extends AbstractTranslatable implements TaxonomyInterface
 
         return $this;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTranslationClass()
-    {
-        return get_class().'Translation';
-    }
 }

--- a/src/Sylius/Component/Translation/Model/AbstractTranslatable.php
+++ b/src/Sylius/Component/Translation/Model/AbstractTranslatable.php
@@ -174,5 +174,8 @@ abstract class AbstractTranslatable implements TranslatableInterface
      *
      * @return string
      */
-    abstract protected function getTranslationClass();
+    public static function getTranslationClass()
+    {
+        return get_called_class().'Translation';
+    }
 }

--- a/src/Sylius/Component/Translation/spec/Model/AbstractTranslatableSpec.php
+++ b/src/Sylius/Component/Translation/spec/Model/AbstractTranslatableSpec.php
@@ -94,7 +94,8 @@ class AbstractTranslatableSpec extends ObjectBehavior
 
 class ConcreteTranslatable extends AbstractTranslatable
 {
-    protected function getTranslationClass(){
+    public static function getTranslationClass()
+    {
         return  'spec\Sylius\Component\Translation\Model\ConcreteTranslatableTranslation';
     }
 }

--- a/src/Sylius/Component/Variation/Model/Option.php
+++ b/src/Sylius/Component/Variation/Model/Option.php
@@ -216,12 +216,4 @@ class Option extends AbstractTranslatable implements OptionInterface
 
         return $this;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getTranslationClass()
-    {
-        return get_class().'Translation';
-    }
 }


### PR DESCRIPTION
The method to retrieve a `Translatable`'s `Translation` class should be public and static.