### PR TITLE
Update order user on cart update.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -232,7 +232,7 @@
         <service id="sylius.listener.user_aware" class="%sylius.listener.user_aware.class%">
             <argument type="service" id="security.context" />
             <tag name="kernel.event_listener" event="sylius.checkout.security.pre_complete" method="setUser" priority="100" />
-            <tag name="kernel.event_listener" event="sylius.cart.initialize" method="setUser" />
+            <tag name="kernel.event_listener" event="sylius.cart.cart_change" method="setUser" />
         </service>
         <service id="sylius.listener.order_inventory" class="%sylius.listener.order_inventory.class%">
             <argument type="service" id="sylius.order_processing.inventory_handler" />


### PR DESCRIPTION
On cart init is not enough. A customer might init create cart as a guest, and then he log-in.