### PR TITLE
Change visibility of getEmailFromConfiguration

### DIFF
--- a/src/Sylius/Component/Mailer/Provider/EmailProvider.php
+++ b/src/Sylius/Component/Mailer/Provider/EmailProvider.php
@@ -71,7 +71,7 @@ class EmailProvider implements EmailProviderInterface
      *
      * @return EmailInterface
      */
-    private function getEmailFromConfiguration($code)
+    protected function getEmailFromConfiguration($code)
     {
         if (!isset($this->configuration[$code])) {
             throw new \InvalidArgumentException(sprintf('Email with code "%s" does not exist!', $code));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | no
| License       | MIT
| Doc PR        | no

Hi,

This PR allow to overwrite the `getEmailFromConfiguration` method of the `EmailProvider`.