### PR TITLE
[RbacBundle] Allow deep merging for roles_hierarchy

### DIFF
--- a/src/Sylius/Bundle/RbacBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/RbacBundle/DependencyInjection/Configuration.php
@@ -157,7 +157,6 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('roles_hierarchy')
                     ->useAttributeAsKey('id')
                     ->prototype('array')
-                        ->performNoDeepMerging()
                         ->beforeNormalization()->ifString()->then(function ($v) { return array('value' => $v); })->end()
                         ->beforeNormalization()
                             ->ifTrue(function ($v) { return is_array($v) && isset($v['value']); })


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | no
New feature?  | yes
BC breaks? | yes
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

I needed to append some roles under `administrator` in my project. In fact I have a plugin system so that every bundle has its own `config.yml`, hence they might try to add addtional roles under adminstrator. 

Since currently there is no way to dynamically modify `Rbac` information I thought I can use symfony's config merging as an easy way to extend `rbac` in my plugins, but to be able to do that I need to remove `performNoDeepMerging` from `roles_hierarchy`.

Do you guys think it's safe and right to do this on original `RbacBundle`?

/cc @pjedrzejewski @stloyd 