### PR TITLE
Change visibility of createTaxonomiesMenuNode

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
@@ -330,7 +330,7 @@ class FrontendMenuBuilder extends MenuBuilder
         return $menu;
     }
 
-    private function createTaxonomiesMenuNode(ItemInterface $menu, TaxonInterface $taxon)
+    protected function createTaxonomiesMenuNode(ItemInterface $menu, TaxonInterface $taxon)
     {
         foreach ($taxon->getChildren() as $child) {
             $childMenu = $menu->addChild($child->getName(), array(


### PR DESCRIPTION
Change visibility of createTaxonomiesMenuNode because if you override method createTaxonomiesMenu, then can't call method createTaxonomiesMenuNode