### PR TITLE
Add a fixed parameter in WeightCalculator

### DIFF
--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/Calculator/WeightRateConfigurationType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/Calculator/WeightRateConfigurationType.php
@@ -47,8 +47,15 @@ class WeightRateConfigurationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('amount', 'sylius_money', array(
-                'label' => 'sylius.form.shipping_calculator.weight_rate_configuration.amount',
+            ->add('fixed', 'sylius_money', array(
+                'label' => 'sylius.form.shipping_calculator.weight_rate_configuration.fixed',
+                'constraints' => array(
+                    new NotBlank(),
+                    new Type(array('type' => 'integer')),
+                )
+            ))
+            ->add('variable', 'sylius_money', array(
+                'label' => 'sylius.form.shipping_calculator.weight_rate_configuration.variable',
                 'constraints' => array(
                     new NotBlank(),
                     new Type(array('type' => 'integer')),

--- a/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
@@ -38,7 +38,8 @@ sylius:
 
             weight_rate_configuration:
                 label: Weight based rate
-                amount: Amount
+                fixed: Fixed amount
+                variable: Variable amount
                 division: Division
 
             volume_rate_configuration:

--- a/src/Sylius/Component/Shipping/Calculator/WeightRateCalculator.php
+++ b/src/Sylius/Component/Shipping/Calculator/WeightRateCalculator.php
@@ -26,7 +26,7 @@ class WeightRateCalculator extends Calculator
      */
     public function calculate(ShippingSubjectInterface $subject, array $configuration)
     {
-        return (int) round($configuration['amount'] * ($subject->getShippingWeight() / $configuration['division']));
+        return (int) ($configuration['fixed'] + round($configuration['variable'] * ($subject->getShippingWeight() / $configuration['division'])));
     }
 
     /**
@@ -52,15 +52,18 @@ class WeightRateCalculator extends Calculator
     {
         $resolver
             ->setDefaults(array(
-                'division' => 1
+                'division' => 1,
+                'fixed'    => 0,
             ))
             ->setRequired(array(
-                'amount',
-                'division'
+                'variable',
+                'division',
+                'fixed',
             ))
             ->setAllowedTypes(array(
-                'amount'   => array('numeric'),
-                'division' => array('numeric')
+                'variable' => array('numeric'),
+                'division' => array('numeric'),
+                'fixed'    => array('numeric'),
             ))
         ;
     }

--- a/src/Sylius/Component/Shipping/spec/Calculator/WeightRateCalculatorSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Calculator/WeightRateCalculatorSpec.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Shipping\Calculator;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+
+/**
+ * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ */
+class WeightRateCalculatorSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Shipping\Calculator\WeightRateCalculator');
+    }
+
+    function it_should_implement_Sylius_shipping_calculator_interface()
+    {
+        $this->shouldImplement('Sylius\Component\Shipping\Calculator\CalculatorInterface');
+    }
+
+    function it_is_configurable()
+    {
+        $this->shouldBeConfigurable();
+    }
+
+    function it_returns_weight_rate_configuration_form_type()
+    {
+        $this->getConfigurationFormType()->shouldReturn('sylius_shipping_calculator_weight_rate_configuration');
+    }
+
+    function it_should_calculate_the_flat_rate_amount_configured_on_the_method(ShippingSubjectInterface $subject)
+    {
+        $subject->getShippingWeight()->willReturn(10);
+
+        $this->calculate($subject, array('fixed' => 200, 'variable' => 500, 'division' => 1))->shouldReturn(200 + 500*10);
+    }
+
+    function its_calculated_value_should_be_an_integer(ShippingSubjectInterface $subject)
+    {
+        $subject->getShippingWeight()->willReturn(10);
+
+        $this->calculate($subject, array('fixed' => 200, 'variable' => 500, 'division' => 1))->shouldBeInteger();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Add the ability to use a linear function for the weight shipping charges (`a + b*x`, here the `a` is added).