### PR TITLE
[SettingsBundle] default to file_system cache if %sylius.cache% is not set

### DIFF
--- a/src/Sylius/Bundle/SettingsBundle/DependencyInjection/SyliusSettingsExtension.php
+++ b/src/Sylius/Bundle/SettingsBundle/DependencyInjection/SyliusSettingsExtension.php
@@ -50,6 +50,10 @@ class SyliusSettingsExtension extends AbstractResourceExtension implements Prepe
         if (isset($parameterClasses['repository'])) {
             $container->setParameter('sylius.repository.parameter.class', $parameterClasses['repository']);
         }
+
+        if (!$container->hasParameter('sylius.cache')) {
+            $container->setParameter('sylius.cache', 'file_system');
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2684
| License       | MIT
| Doc PR        |

SyliusSettingsBundle currently requires %sylius_cache% to be set, but
this variable doesn't exist when using it standalone. I am providing
this PR based on @stloyd's comments in #2684