### PR TITLE
[ResourceBundle] Classes of first extension may get lost

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/AbstractResourceExtension.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/AbstractResourceExtension.php
@@ -120,11 +120,11 @@ abstract class AbstractResourceExtension extends Extension
             $this->registerFormTypes($config, $container);
         }
 
-        $configClasses = array();
+        $configClasses = array($this->applicationName => $classes);
 
         if ($container->hasParameter('sylius.config.classes')) {
             $configClasses = array_merge_recursive(
-                array($this->applicationName => $classes),
+                $configClasses,
                 $container->getParameter('sylius.config.classes')
             );
         }


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | yes
New feature?  | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

If `sylius.config.classes` is not defined before first loaded bundle, its config classes will not be added in `sylius.config.classes`.