### PR TITLE
Create routes with GET parameters.

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -147,7 +147,7 @@ class ResourceController extends FOSRestController
                     $resources,
                     new Route(
                         $request->attributes->get('_route'),
-                        $request->attributes->get('_route_params')
+                        array_merge($request->attributes->get('_route_params'), $request->query->all())
                     )
                 );
             }


### PR DESCRIPTION
Without this change, in API returns, it will generate prev / next page route without get parameter, and it can be a problem sometimes.

#### Before

```
"next": {
  "href": "http://example.com/search?page=2"
}
```

#### After

```
"next": {
  "href": "http://example.com/search?page=2&keyword=foo"
}
```