### PR TITLE
fix query select for order number

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
@@ -45,11 +45,11 @@ class OrderRepository extends EntityRepository implements OrderRepositoryInterfa
     public function isNumberUsed($number)
     {
         return (bool) $this->createQueryBuilder('o')
-            ->select('COUNT(*) > 0')
+            ->select('COUNT(o.id)')
             ->where('o.number = :number')
             ->setParameter('number', $number)
             ->getQuery()
-            ->getSingleScalarResult()
+            ->getSingleScalarResult() > 0
         ;
     }
 


### PR DESCRIPTION
I tried to override the order number generator. But, I got an exception saying something like Parse error, unexpected * etc. I changed it to this and it worked.