### PR TITLE
[ProductBundle] Allow nullable availableOn field for product varaints

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Variant.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Variant.orm.xml
@@ -17,7 +17,7 @@
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <mapped-superclass name="Sylius\Component\Product\Model\Variant" table="sylius_product_variant">
-        <field name="availableOn" column="available_on" type="datetime" />
+        <field name="availableOn" column="available_on" type="datetime" nullable="true" />
     </mapped-superclass>
 
 </doctrine-mapping>


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | no
New feature?  | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

If it's really not a BC I think it should allow null value. 