### PR TITLE
[RbacBundle] Do not throw exception when user is anonymous

### DIFF
--- a/src/Sylius/Bundle/RbacBundle/Provider/SecurityIdentityProvider.php
+++ b/src/Sylius/Bundle/RbacBundle/Provider/SecurityIdentityProvider.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\RbacBundle\Provider;
 
 use Sylius\Component\Rbac\Model\IdentityInterface;
 use Sylius\Component\Rbac\Provider\CurrentIdentityProviderInterface;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
@@ -39,6 +40,10 @@ class SecurityIdentityProvider implements CurrentIdentityProviderInterface
     public function getIdentity()
     {
         if (null === $token = $this->securityContext->getToken()) {
+            return null;
+        }
+
+        if ($token instanceof AnonymousToken) {
             return null;
         }
 

--- a/src/Sylius/Bundle/RbacBundle/spec/Provider/SecurityIdentityProviderSpec.php
+++ b/src/Sylius/Bundle/RbacBundle/spec/Provider/SecurityIdentityProviderSpec.php
@@ -13,6 +13,7 @@ namespace spec\Sylius\Bundle\RbacBundle\Provider;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Rbac\Model\IdentityInterface;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -48,6 +49,13 @@ class SecurityIdentityProviderSpec extends ObjectBehavior
     {
         $securityContext->getToken()->shouldBeCalled()->willReturn($token);
         $token->getUser()->shouldBeCalled()->willReturn(null);
+
+        $this->getIdentity()->shouldReturn(null);
+    }
+
+    function it_returns_null_if_token_exists_but_its_an_anonymous_user($securityContext, AnonymousToken $token)
+    {
+        $securityContext->getToken()->shouldBeCalled()->willReturn($token);
 
         $this->getIdentity()->shouldReturn(null);
     }


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | yes
New feature?  | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

Because of this line:
https://github.com/symfony/Security/blob/master/Http/Firewall/AnonymousAuthenticationListener.php#L54