### PR TITLE
Added Shipping confirmation E-Mail

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/MailerListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/MailerListener.php
@@ -15,6 +15,7 @@ use FOS\UserBundle\Event\FilterUserResponseEvent;
 use FOS\UserBundle\Model\UserInterface;
 use Sylius\Bundle\CoreBundle\Mailer\Emails;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Sylius\Component\Order\Model\CommentInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
@@ -54,6 +55,28 @@ class MailerListener
         }
 
         $this->emailSender->send(Emails::ORDER_CONFIRMATION, array($order->getEmail()), array('order' => $order));
+    }
+
+    /**
+     * @param GenericEvent $event
+     *
+     * @throws UnexpectedTypeException
+     */
+    public function sendShipmentConfirmationEmail(GenericEvent $event)
+    {
+        $shipment = $event->getSubject();
+
+        if (!$shipment instanceof ShipmentInterface) {
+            throw new UnexpectedTypeException(
+                $shipment,
+                'Sylius\Component\Shipping\Model\ShipmentInterface'
+            );
+        }
+        $order = $shipment->getOrder();
+        $this->emailSender->send(Emails::SHIPMENT_CONFIRMATION, array($order->getEmail()), array(
+            'shipment' => $shipment,
+            'order' => $order
+        ));
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Mailer/Emails.php
+++ b/src/Sylius/Bundle/CoreBundle/Mailer/Emails.php
@@ -16,8 +16,10 @@ namespace Sylius\Bundle\CoreBundle\Mailer;
  */
 class Emails 
 {
-    const ORDER_CONFIRMATION = 'order_confirmation';
-    const ORDER_COMMENT      = 'order_comment';
+    const ORDER_CONFIRMATION    = 'order_confirmation';
+    const ORDER_COMMENT         = 'order_comment';
 
-    const USER_CONFIRMATION  = 'user_confirmation';
+    const SHIPMENT_CONFIRMATION = 'shipment_confirmation';
+
+    const USER_CONFIRMATION     = 'user_confirmation';
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
@@ -231,6 +231,7 @@ sylius_mailer:
     templates:
         sylius.email.order_confirmation.name: SyliusWebBundle:Email:orderConfirmation.html.twig
         sylius.email.order_comment.name: SyliusWebBundle:Email:orderComment.html.twig
+        sylius.email.shipment_confirmation.name: SyliusWebBundle:Email:shipmentConfirmation.html.twig
         sylius.email.user_confirmation.name: SyliusWebBundle:Email:userConfirmation.html.twig
     sender:
         name: Example.com
@@ -242,6 +243,9 @@ sylius_mailer:
         order_comment:
             subject: sylius.emails.order_comment.subject
             template: SyliusWebBundle:Email:orderComment.html.twig
+        shipment_confirmation:
+            subject: sylius.emails.shipment_confirmation.subject
+            template: SyliusWebBundle:Email:shipmentConfirmation.html.twig
         user_confirmation:
             subject: sylius.emails.user_confirmation.subject
             template: SyliusWebBundle:Email:userConfirmation.html.twig

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/mailer.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/mailer.xml
@@ -24,6 +24,7 @@
         <service id="sylius.listener.mailer" class="%sylius.listener.mailer.class%">
             <argument type="service" id="sylius.email_sender" />
             <tag name="kernel.event_listener" event="sylius.checkout.finalize.complete" method="sendOrderConfirmationEmail" />
+            <tag name="kernel.event_listener" event="sylius.checkout.shipping.complete" method="sendShipmentConfirmationEmail" />
             <tag name="kernel.event_listener" event="fos_user.registration.completed" method="sendUserConfirmationEmail" />
             <tag name="kernel.event_listener" event="fos_user.registration.confirmed" method="sendUserConfirmationEmail" />
             <tag name="kernel.event_listener" event="sylius.comment.post_create" method="sendOrderCommentEmail" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/mailer.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/mailer.xml
@@ -24,7 +24,7 @@
         <service id="sylius.listener.mailer" class="%sylius.listener.mailer.class%">
             <argument type="service" id="sylius.email_sender" />
             <tag name="kernel.event_listener" event="sylius.checkout.finalize.complete" method="sendOrderConfirmationEmail" />
-            <tag name="kernel.event_listener" event="sylius.checkout.shipping.complete" method="sendShipmentConfirmationEmail" />
+            <tag name="kernel.event_listener" event="sylius.shipment.ship.success" method="sendShipmentConfirmationEmail" />
             <tag name="kernel.event_listener" event="fos_user.registration.completed" method="sendUserConfirmationEmail" />
             <tag name="kernel.event_listener" event="fos_user.registration.confirmed" method="sendUserConfirmationEmail" />
             <tag name="kernel.event_listener" event="sylius.comment.post_create" method="sendOrderCommentEmail" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/mailer.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/mailer.xml
@@ -24,7 +24,7 @@
         <service id="sylius.listener.mailer" class="%sylius.listener.mailer.class%">
             <argument type="service" id="sylius.email_sender" />
             <tag name="kernel.event_listener" event="sylius.checkout.finalize.complete" method="sendOrderConfirmationEmail" />
-            <tag name="kernel.event_listener" event="sylius.shipment.ship.success" method="sendShipmentConfirmationEmail" />
+            <tag name="kernel.event_listener" event="sylius.shipment.post_update" method="sendShipmentConfirmationEmail" />
             <tag name="kernel.event_listener" event="fos_user.registration.completed" method="sendUserConfirmationEmail" />
             <tag name="kernel.event_listener" event="fos_user.registration.confirmed" method="sendUserConfirmationEmail" />
             <tag name="kernel.event_listener" event="sylius.comment.post_create" method="sendOrderCommentEmail" />

--- a/src/Sylius/Bundle/ShippingBundle/Controller/ShipmentController.php
+++ b/src/Sylius/Bundle/ShippingBundle/Controller/ShipmentController.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\ShippingBundle\Controller;
 
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Component\Shipping\ShipmentTransitions;
+use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\Request;
 
 class ShipmentController extends ResourceController
@@ -32,6 +33,7 @@ class ShipmentController extends ResourceController
             $this->domainManager->update($shipment);
 
             $this->flashHelper->setFlash('success', 'sylius.shipment.ship.success');
+            $this->container->get('event_dispatcher')->dispatch('sylius.shipment.ship.success', new GenericEvent($shipment));
 
             return $this->redirectHandler->redirectTo($shipment);
         }

--- a/src/Sylius/Bundle/ShippingBundle/Controller/ShipmentController.php
+++ b/src/Sylius/Bundle/ShippingBundle/Controller/ShipmentController.php
@@ -13,7 +13,6 @@ namespace Sylius\Bundle\ShippingBundle\Controller;
 
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Component\Shipping\ShipmentTransitions;
-use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\Request;
 
 class ShipmentController extends ResourceController
@@ -33,7 +32,6 @@ class ShipmentController extends ResourceController
             $this->domainManager->update($shipment);
 
             $this->flashHelper->setFlash('success', 'sylius.shipment.ship.success');
-            $this->container->get('event_dispatcher')->dispatch('sylius.shipment.ship.success', new GenericEvent($shipment));
 
             return $this->redirectHandler->redirectTo($shipment);
         }

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
@@ -11,6 +11,10 @@ sylius:
             name: Order comment
             subject: New comment posted on order #{{ order.number }}
 
+        shipment_confirmation:
+            name: Shipment confirmation
+            subject: Your order has been shipped!
+
         user_confirmation:
             name: User confirmation
             subject: Welcome to our store!

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Email/shipmentConfirmation.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Email/shipmentConfirmation.html.twig
@@ -1,0 +1,7 @@
+{% block subject %}
+    {% autoescape false %}
+    {{ 'email.shipment_confirmation.subject'|trans }}
+    {% endautoescape %}
+{% endblock %}
+{% block body_text %}{% endblock %}
+{% block body_html %}{% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | [#413]
| License       | MIT
| Doc PR        | -

Hey ya! This triggers a shipping confirmation E-Mail once you click "Ship" on an order.