### PR TITLE
2736 fix issues with command parameters

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Command/CommandExecutor.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/CommandExecutor.php
@@ -100,7 +100,7 @@ class CommandExecutor
         }
         
         if ($this->input->hasOption('no-interaction')) {
-            $defaultParameters['--no-interaction'] = true;
+            $defaultParameters['--no-interaction'] = $this->input->getOption('no-interaction');
         }
 
         if ($this->input->hasOption('verbose') && true === $this->input->getOption('verbose')) {

--- a/src/Sylius/Bundle/InstallerBundle/Command/CommandExecutor.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/CommandExecutor.php
@@ -66,8 +66,8 @@ class CommandExecutor
     {
         $parameters = array_merge(
             array('command' => $command),
-            $parameters,
-            $this->getDefaultParameters()
+            $this->getDefaultParameters(),
+            $parameters
         );
 
         $this->application->setAutoExit(false);

--- a/src/Sylius/Bundle/InstallerBundle/spec/Command/CommandExecutorSpec.php
+++ b/src/Sylius/Bundle/InstallerBundle/spec/Command/CommandExecutorSpec.php
@@ -38,18 +38,18 @@ class CommandExecutorSpec extends ObjectBehavior
         $input->getOption('verbose')
             ->willReturn(true);
         $arrayInput = new ArrayInput(
-            [
+            array(
                 'command' => 'command',
                 '--no-debug' => true,
                 '--env' => 'dev',
                 '--no-interaction' => false,
                 '--verbose' => true,
-            ]
+            )
         );
         $application->setAutoExit(false)->shouldBeCalled();
         $application->run($arrayInput, new NullOutput())->willReturn(0);
 
-        $this->runCommand('command', []);
+        $this->runCommand('command', array());
     }
 
     function it_should_use_passed_options_rather_than_default_params(InputInterface $input, Application $application)
@@ -67,17 +67,17 @@ class CommandExecutorSpec extends ObjectBehavior
         $input->getOption('verbose')
             ->willReturn(true);
         $arrayInput = new ArrayInput(
-            [
+            array(
                 'command' => 'command',
                 '--no-debug' => true,
                 '--env' => 'dev',
                 '--no-interaction' => true,
                 '--verbose' => true,
-            ]
+            )
         );
         $application->setAutoExit(false)->shouldBeCalled();
         $application->run($arrayInput, new NullOutput())->willReturn(0);
 
-        $this->runCommand('command', [ '--no-interaction' => true]);
+        $this->runCommand('command', array('--no-interaction' => true));
     }
 }

--- a/src/Sylius/Bundle/InstallerBundle/spec/Command/CommandExecutorSpec.php
+++ b/src/Sylius/Bundle/InstallerBundle/spec/Command/CommandExecutorSpec.php
@@ -51,4 +51,33 @@ class CommandExecutorSpec extends ObjectBehavior
 
         $this->runCommand('command', []);
     }
+
+    function it_should_use_passed_options_rather_than_default_params(InputInterface $input, Application $application)
+    {
+        $input->hasOption('no-interaction')
+            ->willReturn(true);
+        $input->getOption('no-interaction')
+            ->willReturn(false);
+        $input->hasOption('env')
+            ->willReturn(true);
+        $input->getOption('env')
+            ->willReturn('dev');
+        $input->hasOption('verbose')
+            ->willReturn(true);
+        $input->getOption('verbose')
+            ->willReturn(true);
+        $arrayInput = new ArrayInput(
+            [
+                'command' => 'command',
+                '--no-debug' => true,
+                '--env' => 'dev',
+                '--no-interaction' => true,
+                '--verbose' => true,
+            ]
+        );
+        $application->setAutoExit(false)->shouldBeCalled();
+        $application->run($arrayInput, new NullOutput())->willReturn(0);
+
+        $this->runCommand('command', [ '--no-interaction' => true]);
+    }
 }

--- a/src/Sylius/Bundle/InstallerBundle/spec/Command/CommandExecutorSpec.php
+++ b/src/Sylius/Bundle/InstallerBundle/spec/Command/CommandExecutorSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace spec\Sylius\Bundle\InstallerBundle\Command;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Application;
+
+class CommandExecutorSpec extends ObjectBehavior
+{
+
+    function let(InputInterface $input, OutputInterface $output, Application $application)
+    {
+        $this->beConstructedWith($input, $output, $application);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\InstallerBundle\Command\CommandExecutor');
+    }
+
+    function it_should_preserve_the_current_value_of_interactive_option(InputInterface $input, Application $application)
+    {
+        $input->hasOption('no-interaction')
+            ->willReturn(true);
+        $input->getOption('no-interaction')
+            ->willReturn(false);
+        $input->hasOption('env')
+            ->willReturn(true);
+        $input->getOption('env')
+            ->willReturn('dev');
+        $input->hasOption('verbose')
+            ->willReturn(true);
+        $input->getOption('verbose')
+            ->willReturn(true);
+        $arrayInput = new ArrayInput(
+            [
+                'command' => 'command',
+                '--no-debug' => true,
+                '--env' => 'dev',
+                '--no-interaction' => false,
+                '--verbose' => true,
+            ]
+        );
+        $application->setAutoExit(false)->shouldBeCalled();
+        $application->run($arrayInput, new NullOutput())->willReturn(0);
+
+        $this->runCommand('command', []);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #2736 
| License       | MIT
| Doc PR        | n/a

There are no BC breaks in the class API but as this does change behaviour it's possible people are relying on the existing (broken) behaviour which could cause a BC break. 