### PR TITLE
[Search] Allow override of price facet ranges

### DIFF
--- a/src/Sylius/Bundle/SearchBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/SearchBundle/DependencyInjection/Configuration.php
@@ -107,6 +107,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('type')->end()
                                     ->scalarNode('value')->end()
                                     ->arrayNode('values')
+                                        ->performNoDeepMerging()
                                         ->prototype('array')
                                             ->children()
                                                 ->scalarNode('from')->end()


### PR DESCRIPTION
Fixes #2742 

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #2742 
| License       | MIT
| Doc PR        | n/a

This is a potential BC-break as people may have been relying on the behaviour that has changed, e.g. they had added their own extra price ranges to the faceted search (on top of the provided ones). This would be relatively easy to fix in that they could just add the default ranges from the bundle to their own config.