### PR TITLE
Return default locale if request has not been injected (Fixes #2748)

### DIFF
--- a/src/Sylius/Bundle/TranslationBundle/Provider/RequestLocaleProvider.php
+++ b/src/Sylius/Bundle/TranslationBundle/Provider/RequestLocaleProvider.php
@@ -65,7 +65,7 @@ class RequestLocaleProvider implements LocaleProviderInterface, EventSubscriberI
     public function getCurrentLocale()
     {
         if (null === $this->request) {
-            throw new \RuntimeException('Request must be defined.');
+            return $this->getFallbackLocale();
         }
 
         return $this->request->getLocale();


### PR DESCRIPTION
Implements the solution proposed by @pjedrzejewski in #2748.