### PR TITLE
Fixed bug in payment flow

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderPaymentListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderPaymentListener.php
@@ -71,6 +71,8 @@ class OrderPaymentListener
     {
         if (false === $this->getOrder($event)->getLastPayment()) {
             $this->paymentProcessor->createPayment($this->getOrder($event));
+        } else {
+            $this->getOrder($event)->getLastPayment()->setDetails(array());
         }
     }
 

--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderPaymentListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderPaymentListener.php
@@ -69,11 +69,7 @@ class OrderPaymentListener
      */
     public function createOrderPayment(GenericEvent $event)
     {
-        if (false === $this->getOrder($event)->getLastPayment()) {
-            $this->paymentProcessor->createPayment($this->getOrder($event));
-        } else {
-            $this->getOrder($event)->getLastPayment()->setDetails(array());
-        }
+        $this->paymentProcessor->createPayment($this->getOrder($event));
     }
 
     /**


### PR DESCRIPTION
I noticed that if you are using CreditCard for payment and if you change your mind on page where you need to enter your credit card, jump back to payment methods and pick something else for example offline that there is bug and you cannot complete payment. This PR fix it