### PR TITLE
[InstallerBundle] fix 'no-interaction' default param

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Command/CommandExecutor.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/CommandExecutor.php
@@ -99,8 +99,8 @@ class CommandExecutor
             $defaultParameters['--env'] = $this->input->hasOption('env') ? $this->input->getOption('env') : Kernel::ENV_DEV;
         }
         
-        if ($this->input->hasOption('no-interaction')) {
-            $defaultParameters['--no-interaction'] = $this->input->getOption('no-interaction');
+        if ($this->input->hasOption('no-interaction') && true === $this->input->getOption('no-interaction')) {
+            $defaultParameters['--no-interaction'] = true;
         }
 
         if ($this->input->hasOption('verbose') && true === $this->input->getOption('verbose')) {

--- a/src/Sylius/Bundle/InstallerBundle/spec/Command/CommandExecutorSpec.php
+++ b/src/Sylius/Bundle/InstallerBundle/spec/Command/CommandExecutorSpec.php
@@ -42,7 +42,6 @@ class CommandExecutorSpec extends ObjectBehavior
                 'command' => 'command',
                 '--no-debug' => true,
                 '--env' => 'dev',
-                '--no-interaction' => false,
                 '--verbose' => true,
             )
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2762
| License       | MIT
| Doc PR        | -

`--no-interaction` default param must be absent if input option value !== `true`.

Otherwise the `sylius:install` sub-commands are non-interactive, the questions get skipped and it ends up in the endless while loop trying to validate the non-present user input.

This is because `--no-intercation` is a `InputOption::VALUE_NONE` option which does not require a value. If the `--no-interaction` key is present in Sylius default parameters (even if value is `false`!), then the subcommands are always non-interactive, skipping the questions, see `Symfony\Component\Console\Application::configureIO()` – it does NOT check the value, only the presence of the parameter:

       ....
        if (true === $input->hasParameterOption(array('--no-interaction', '-n'))) {
            $input->setInteractive(false);
        }
        ....

Without the fix I'm currently not able to install Sylius interactively.