### PR TITLE
[InstallerBundle] Fixed setup command

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Command/SetupCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/SetupCommand.php
@@ -61,11 +61,14 @@ EOT
 
         $userManager = $this->get('sylius.manager.user');
         $userRepository = $this->get('sylius.repository.user');
+        $customerRepository = $this->get('sylius.repository.customer');
 
         $rbacInitializer = $this->get('sylius.rbac.initializer');
         $rbacInitializer->initialize();
 
         $user = $userRepository->createNew();
+        $customer = $customerRepository->createNew();
+        $user->setCustomer($customer);
 
         if ($input->getOption('no-interaction')) {
             $exists = null !== $userRepository->findOneByEmail('sylius@example.com');
@@ -74,13 +77,13 @@ EOT
                 return 0;
             }
 
-            $user->setFirstname('Sylius');
-            $user->setLastname('Admin');
+            $customer->setFirstname('Sylius');
+            $customer->setLastname('Admin');
             $user->setEmail('sylius@example.com');
             $user->setPlainPassword('sylius');
         } else {
-            $user->setFirstname($this->ask($output, 'Your firstname:', array(new NotBlank())));
-            $user->setLastname($this->ask($output, 'Lastname:', array(new NotBlank())));
+            $customer->setFirstname($this->ask($output, 'Your firstname:', array(new NotBlank())));
+            $customer->setLastname($this->ask($output, 'Lastname:', array(new NotBlank())));
 
             do {
                 $email = $this->ask($output, 'E-Mail:', array(new NotBlank(), new Email()));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This fixes an issue when running php app/console sylius:install:setup
```
Please enter list of locale codes, separated by commas or just hit ENTER to use "en_US". For example "en_US, de_DE".
In which language your customers can browse the store?
Adding English (United States).
Please enter list of currency codes, separated by commas or just hit ENTER to use "USD". For example "USD, EUR, GBP".
In which currency your customers can buy goods?
Adding US Dollar.
Please enter list of country codes, separated by commas or just hit ENTER to use "US". For example "US, PL, DE".
To which countries you are going to sell your goods?
Adding United States.
Create your administrator account.
PHP Fatal error:  Call to undefined method Sylius\Component\Core\Model\User::setFirstname() in /path/to/Sylius/src/Sylius/Bundle/InstallerBundle/Command/SetupCommand.php on line 82
...
```