### PR TITLE
Install command fails for 0.14.x-dev

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Command/CommandExecutor.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/CommandExecutor.php
@@ -99,8 +99,8 @@ class CommandExecutor
             $defaultParameters['--env'] = $this->input->hasOption('env') ? $this->input->getOption('env') : Kernel::ENV_DEV;
         }
         
-        if ($this->input->hasOption('no-interaction')) {
-            $defaultParameters['--no-interaction'] = $this->input->getOption('no-interaction');
+        if ($this->input->hasOption('no-interaction') && true === $this->input->getOption('no-interaction')) {
+            $defaultParameters['--no-interaction'] = true;
         }
 
         if ($this->input->hasOption('verbose') && true === $this->input->getOption('verbose')) {


### PR DESCRIPTION
When installing Sylius Standard 0.14.x-dev with `sylius:install` command, no interaction mode is turned on unintentionally and the install fails with "This value should not be blank" error message which is displayed in infinite loop.

The problem lies in `CommandExecutor::getDefaultParameters` method that wrongly checks for existence of `--no-interaction` option with `$this->input->hasOption()`. It turns out that if not specified in command line, the option EXISTS, but it's value is set to `false`.

So, instead of only checking if `no-interaction` option exists, the value of the option should be checked just like `verbose` option is checked.

I don't have the time currently to fix the tests if this fails, but I can do it next week if required.