### PR TITLE
Fixes collection name deciding script causing item overwriting

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/public/js/form-collection.js
+++ b/src/Sylius/Bundle/WebBundle/Resources/public/js/form-collection.js
@@ -15,9 +15,17 @@
         $(document).on('click', 'a[data-collection-button="add"]', function(e) {
             e.preventDefault();
             var collectionContainer = $('#' + $(this).data('collection'));
-            var isArray = collectionContainer.data('is-php-array');
             var prototype = $('#' + $(this).data('prototype')).data('prototype');
-            var item = prototype.replace(/__name__/g, collectionContainer.children().length + (undefined == isArray ? 0 : 1));
+
+            // Check if an element with this ID already exists.
+            // If it does, increase the count by one and try again
+            var id = prototype.match(/input.*?id="(.*?)"/);
+            var count = 0;
+            while ($('#' + id[1].replace(/__name__/g, count)).length > 0) {
+                count++;
+            }
+
+            var item = prototype.replace(/__name__/g, count);
             collectionContainer.append(item);
         });
 

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_volume_based_config.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_volume_based_config.html.twig
@@ -30,7 +30,7 @@
         </tr>
         </thead>
         <tbody id="sylius-assortment-product-pricing-ranks" class="collection-container"
-               data-prototype="{{ _self.volume_based_prototype(form)|e }}" data-is-php-array="true">
+               data-prototype="{{ _self.volume_based_prototype(form)|e }}">
         {% for rank in form.masterVariant.pricingConfiguration.children %}
             <tr class="sylius-assortment-product-pricing-ranks-item">
                 <td>{{ form_widget(rank.children.min) }}</td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/Form/_volume_based_config.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/Form/_volume_based_config.html.twig
@@ -30,7 +30,7 @@
         </tr>
         </thead>
         <tbody id="sylius-assortment-product-pricing-ranks" class="collection-container"
-               data-prototype="{{ _self.volume_based_prototype(form)|e }}" data-is-php-array="true">
+               data-prototype="{{ _self.volume_based_prototype(form)|e }}">
         {% for rank in form.pricingConfiguration.children %}
             <tr class="sylius-assortment-product-pricing-ranks-item">
                 <td>{{ form_widget(rank.children.min) }}</td>


### PR DESCRIPTION
Getting an item's name from collection's children count is unreliable and caused data loss when items got deleted and shuffled around or when there were other child elements in the collection element. This fixes that issue by actually checking if the items are present.

Inspired by [Bootstrap's solution](https://github.com/braincrafted/bootstrap-bundle/blob/v2.1.2/Resources/js/bc-bootstrap-collection.js#L42-L50).

It's still very fast even with thousands of items in a collection.