### PR TITLE
[WebBundle] Configurable templates for frontend and backend controllers

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/product.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/product.yml
@@ -7,7 +7,6 @@ sylius_api_product_index:
     defaults:
         _controller: sylius.controller.product:indexAction
         _sylius:
-            template:  SyliusWebBundle:Backend/Product:index.html.twig
             repository:
                 method:    createFilterPaginator
                 arguments: [$criteria, $sorting]

--- a/src/Sylius/Bundle/UserBundle/Controller/CustomerController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/CustomerController.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\UserBundle\Controller;
 
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Sylius\Component\User\Model\CustomerInterface;
@@ -47,12 +48,33 @@ class CustomerController extends ResourceController
         }
 
         return $this->render(
-            'SyliusWebBundle:Frontend/Account:Profile/edit.html.twig',
+            $this->getTemplate('frontend_profile_edit'),
             array(
                 $this->config->getResourceName() => $customer,
                 'form'                           => $form->createView(),
             )
         );
+    }
+
+    /**
+     * Returns a template name based on bundle's configuration.
+     *
+     * @param string $name Template name
+     *
+     * @param null|string $default Optional default value if no template found with that name.
+     *
+     * @return string Template path
+     */
+    protected function getTemplate($name, $default = null) {
+        try {
+            return $this->container->getParameter(sprintf('sylius.template.%s', $name));
+        } catch (InvalidArgumentException $e) {
+            if (null !== $default) {
+                return $default;
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/Sylius/Bundle/UserBundle/Controller/SecurityController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/SecurityController.php
@@ -11,18 +11,18 @@
 
 namespace Sylius\Bundle\UserBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Sylius\Bundle\WebBundle\Controller\WebController;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class SecurityController extends Controller
+class SecurityController extends WebController
 {
     /**
      * Login form action.
      */
-    public function loginAction(Request $request)
+    public function loginAction()
     {
         $authenticationUtils = $this->get('security.authentication_utils');
         $error = $authenticationUtils->getLastAuthenticationError();
@@ -39,7 +39,7 @@ class SecurityController extends Controller
     /**
      * Login check action. This action should never be called.
      */
-    public function checkAction(Request $request)
+    public function checkAction()
     {
         throw new \RuntimeException('You must configure the check path to be handled by the firewall.');
     }
@@ -47,7 +47,7 @@ class SecurityController extends Controller
     /**
      * Logout action. This action should never be called.
      */
-    public function logoutAction(Request $request)
+    public function logoutAction()
     {
         throw new \RuntimeException('You must configure the check path to be handled by the firewall.');
     }
@@ -62,6 +62,6 @@ class SecurityController extends Controller
      */
     protected function renderLogin(array $data)
     {
-        return $this->render('SyliusWebBundle:Frontend/User:login.html.twig', $data);
+        return $this->render($this->getTemplate('frontend_user_login'), $data);
     }
 }

--- a/src/Sylius/Bundle/UserBundle/Controller/UserController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/UserController.php
@@ -20,6 +20,7 @@ use Sylius\Bundle\UserBundle\Form\Type\UserResetPasswordType;
 use Sylius\Bundle\UserBundle\UserEvents;
 use Sylius\Component\User\Model\UserInterface;
 use Sylius\Component\User\Security\TokenProviderInterface;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -61,7 +62,7 @@ class UserController extends ResourceController
         }
 
         return $this->render(
-            'SyliusWebBundle:Frontend/Account:changePassword.html.twig',
+            $this->getTemplate('frontend_user_change_password'),
             array(
                 'form'  => $form->createView(),
             )
@@ -103,7 +104,7 @@ class UserController extends ResourceController
         }
 
         return $this->render(
-            'SyliusWebBundle:Frontend/Account:resetPassword.html.twig',
+            $this->getTemplate('frontend_user_reset_password'),
             array(
                 'form' => $form->createView(),
                 'user' => $user,
@@ -131,7 +132,7 @@ class UserController extends ResourceController
         }
 
         return $this->render(
-            'SyliusWebBundle:Frontend/Account:requestPasswordReset.html.twig',
+            $this->getTemplate('frontend_user_request_password_reset'),
             array(
                 'form'  => $form->createView(),
             )
@@ -277,5 +278,27 @@ class UserController extends ResourceController
         }
 
         return $user;
+    }
+
+
+    /**
+     * Returns a template name based on bundle's configuration.
+     *
+     * @param string $name Template name
+     *
+     * @param null|string $default Optional default value if no template found with that name.
+     *
+     * @return string Template path
+     */
+    protected function getTemplate($name, $default = null) {
+        try {
+            return $this->container->getParameter(sprintf('sylius.template.%s', $name));
+        } catch (InvalidArgumentException $e) {
+            if (null !== $default) {
+                return $default;
+            }
+
+            throw $e;
+        }
     }
 }

--- a/src/Sylius/Bundle/UserBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/UserBundle/DependencyInjection/Configuration.php
@@ -67,6 +67,7 @@ class Configuration implements ConfigurationInterface
 
         $this->addValidationGroupsSection($rootNode);
         $this->addClassesSection($rootNode);
+        $this->addTemplatesSection($rootNode);
 
         return $treeBuilder;
     }
@@ -179,6 +180,30 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * Adds `templates` section.
+     *
+     * @param ArrayNodeDefinition $node
+     */
+    private function addTemplatesSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('templates')
+                    ->addDefaultsIfNotSet()
+                    ->info('Templates used in the user bundle')
+                    ->children()
+                        ->scalarNode('frontend_user_login')->defaultValue('SyliusWebBundle:Frontend/User:login.html.twig')->end()
+                        ->scalarNode('frontend_profile_edit')->defaultValue('SyliusWebBundle:Frontend/Account:Profile/edit.html.twig')->end()
+                        ->scalarNode('frontend_user_change_password')->defaultValue('SyliusWebBundle:Frontend/Account:changePassword.html.twig')->end()
+                        ->scalarNode('frontend_user_reset_password')->defaultValue('SyliusWebBundle:Frontend/Account:resetPassword.html.twig')->end()
+                        ->scalarNode('frontend_user_request_password_reset')->defaultValue('SyliusWebBundle:Frontend/Account:requestPasswordReset.html.twig')->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Sylius/Bundle/UserBundle/DependencyInjection/SyliusUserExtension.php
+++ b/src/Sylius/Bundle/UserBundle/DependencyInjection/SyliusUserExtension.php
@@ -41,5 +41,9 @@ class SyliusUserExtension extends AbstractResourceExtension
         $container->setParameter('sylius.user.resetting.token_ttl', $config['resetting']['token']['ttl']);
         $container->setParameter('sylius.user.resetting.token_length', $config['resetting']['token']['length']);
         $container->setParameter('sylius.user.resetting.pin_length', $config['resetting']['pin']['length']);
+
+        foreach ($config['templates'] as $name => $template) {
+            $container->setParameter(sprintf('sylius.template.%s', $name), $template);
+        }
     }
 }

--- a/src/Sylius/Bundle/WebBundle/Controller/Backend/DashboardController.php
+++ b/src/Sylius/Bundle/WebBundle/Controller/Backend/DashboardController.php
@@ -11,15 +11,15 @@
 
 namespace Sylius\Bundle\WebBundle\Controller\Backend;
 
+use Sylius\Bundle\WebBundle\Controller\WebController;
 use Sylius\Component\Order\Model\OrderInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 /**
  * Backend dashboard controller.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class DashboardController extends Controller
+class DashboardController extends WebController
 {
     /**
      * Backend dashboard display action.
@@ -30,7 +30,7 @@ class DashboardController extends Controller
         $customerRepository  = $this->get('sylius.repository.customer');
         $userRepository  = $this->get('sylius.repository.user');
 
-        return $this->render('SyliusWebBundle:Backend/Dashboard:main.html.twig', array(
+        return $this->render($this->getTemplate('backend_dashboard'), array(
             'orders_count'        => $orderRepository->countBetweenDates(new \DateTime('1 month ago'), new \DateTime()),
             'orders'              => $orderRepository->findBy(array(), array('updatedAt' => 'desc'), 5),
             'customers'           => $customerRepository->findBy(array(), array('id' => 'desc'), 5),

--- a/src/Sylius/Bundle/WebBundle/Controller/Backend/SecurityController.php
+++ b/src/Sylius/Bundle/WebBundle/Controller/Backend/SecurityController.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\WebBundle\Controller\Backend;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Sylius\Bundle\WebBundle\Controller\WebController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Core\SecurityContext;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class SecurityController extends Controller
+class SecurityController extends WebController
 {
     /**
      * Target action for _switch_user=_exit, redirects admin back to impersonated user
@@ -48,7 +48,9 @@ class SecurityController extends Controller
             throw new NotFoundHttpException(sprintf('User with username %s does not exist.', $username));
         }
 
-        return $this->redirect($this->generateUrl('sylius_backend_customer_show', array('id' => $user->getCustomer()->getId())));
+        return $this->redirect(
+            $this->generateUrl('sylius_backend_customer_show', array('id' => $user->getCustomer()->getId()))
+        );
     }
 
     /**
@@ -79,7 +81,7 @@ class SecurityController extends Controller
             ->generateCsrfToken('authenticate')
         ;
 
-        return $this->render('SyliusWebBundle:Backend/Security:login.html.twig', array(
+        return $this->render($this->getTemplate('backend_login'), array(
             'last_username' => $lastUsername,
             'error'         => $error,
             'token'         => $csrfToken,

--- a/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/AccountController.php
+++ b/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/AccountController.php
@@ -11,19 +11,22 @@
 
 namespace Sylius\Bundle\WebBundle\Controller\Frontend\Account;
 
+use Sylius\Bundle\WebBundle\Controller\WebController;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\Request;
 use Sylius\Component\User\Model\UserInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * User account address controller.
  *
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class AccountController extends Controller
+class AccountController extends WebController
 {
-    public function indexAction(Request $request)
+    /**
+     * @return Response
+     */
+    public function indexAction()
     {
         $user = $this->getUser();
 
@@ -34,7 +37,7 @@ class AccountController extends Controller
             );
         }
 
-        return $this->render('SyliusWebBundle:Frontend/Account:show.html.twig', array(
+        return $this->render($this->getTemplate('frontend_account'), array(
             'user' => $user
         ));
     }

--- a/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/AddressController.php
+++ b/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/AddressController.php
@@ -13,12 +13,14 @@ namespace Sylius\Bundle\WebBundle\Controller\Frontend\Account;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use FOS\RestBundle\Controller\FOSRestController;
+use Sylius\Bundle\WebBundle\Controller\WebController;
 use Sylius\Component\Addressing\Model\AddressInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
@@ -27,16 +29,18 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  *
  * @author Julien Janvier <j.janvier@gmail.com>
  */
-class AddressController extends FOSRestController
+class AddressController extends WebController
 {
     /**
      * Get collection of customer's addresses.
+     *
+     * @return Response
      */
     public function indexAction()
     {
         $view = $this
             ->view()
-            ->setTemplate('SyliusWebBundle:Frontend/Account:Address/index.html.twig')
+            ->setTemplate($this->getTemplate('frontend_address_index'))
             ->setData(array(
                 'customer'  => $this->getCustomer(),
                 'addresses' => $this->getCustomer()->getAddresses(),
@@ -48,6 +52,10 @@ class AddressController extends FOSRestController
 
     /**
      * Create new customer address.
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse|Response
      */
     public function createAction(Request $request)
     {
@@ -69,7 +77,7 @@ class AddressController extends FOSRestController
 
         $view = $this
             ->view()
-            ->setTemplate('SyliusWebBundle:Frontend/Account:Address/create.html.twig')
+            ->setTemplate($this->getTemplate('frontend_address_create'))
             ->setData(array(
                 'customer' => $this->getCustomer(),
                 'form' => $form->createView()
@@ -81,9 +89,14 @@ class AddressController extends FOSRestController
 
     /**
      * Update existing user address.
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse|Response
      */
-    public function updateAction(Request $request, $id)
+    public function updateAction(Request $request)
     {
+        $id = $request->get('id');
         $customer = $this->getCustomer();
         $address = $this->findUserAddressOr404($id);
         $form = $this->getAddressForm($address);
@@ -100,7 +113,7 @@ class AddressController extends FOSRestController
 
         $view = $this
             ->view()
-            ->setTemplate('SyliusWebBundle:Frontend/Account:Address/update.html.twig')
+            ->setTemplate($this->getTemplate('frontend_address_update'))
             ->setData(array(
                 'customer'    => $this->getCustomer(),
                 'address' => $address,
@@ -113,6 +126,10 @@ class AddressController extends FOSRestController
 
     /**
      * Delete user address.
+     *
+     * @param $id
+     *
+     * @return RedirectResponse
      */
     public function deleteAction($id)
     {
@@ -165,12 +182,6 @@ class AddressController extends FOSRestController
         return $this->redirectToIndex();
     }
 
-    protected function addFlash($type, $message)
-    {
-        $translator = $this->get('translator');
-        $this->get('session')->getFlashBag()->add($type, $translator->trans($message, array(), 'flashes'));
-    }
-
     /**
      * @param AddressInterface $address
      *
@@ -197,11 +208,6 @@ class AddressController extends FOSRestController
         return $this->get('sylius.repository.address');
     }
 
-    protected function redirectToIndex()
-    {
-        return $this->redirect($this->generateUrl('sylius_account_address_index'));
-    }
-
     /**
      * Accesses address or throws 403/404
      *
@@ -223,13 +229,5 @@ class AddressController extends FOSRestController
         }
 
         return $address;
-    }
-
-    /**
-     * @return CustomerInterface
-     */
-    protected function getCustomer()
-    {
-        return $this->get('sylius.context.customer')->getCustomer();
     }
 }

--- a/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/OrderController.php
+++ b/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/OrderController.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\WebBundle\Controller\Frontend\Account;
 
-use FOS\RestBundle\Controller\FOSRestController;
+use Sylius\Bundle\WebBundle\Controller\WebController;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Order\Repository\OrderRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  *
  * @author Julien Janvier <j.janvier@gmail.com>
  */
-class OrderController extends FOSRestController
+class OrderController extends WebController
 {
     /**
      * List orders of the current customer.
@@ -37,7 +37,7 @@ class OrderController extends FOSRestController
 
         $view = $this
             ->view()
-            ->setTemplate('SyliusWebBundle:Frontend/Account:Order/index.html.twig')
+            ->setTemplate($this->getTemplate('frontend_order_index'))
             ->setData(array(
                 'orders' => $orders,
             ))
@@ -49,20 +49,18 @@ class OrderController extends FOSRestController
     /**
      * Get single order of the current customer.
      *
-     * @param string $number
+     * @param Request $request
      *
      * @return Response
-     *
-     * @throws NotFoundHttpException
-     * @throws AccessDeniedException
      */
-    public function showAction($number)
+    public function showAction(Request $request)
     {
+        $number = $request->get('number');
         $order = $this->findOrderOr404($number);
 
         $view = $this
             ->view()
-            ->setTemplate('SyliusWebBundle:Frontend/Account:Order/show.html.twig')
+            ->setTemplate($this->getTemplate('frontend_order_show'))
             ->setData(array(
                 'order' => $order,
             ))
@@ -75,21 +73,22 @@ class OrderController extends FOSRestController
      * Renders an invoice as PDF.
      *
      * @param Request $request
-     * @param string  $number
      *
      * @return Response
+     *
      * @throws NotFoundHttpException
      * @throws AccessDeniedException
      */
-    public function renderInvoiceAction(Request $request, $number)
+    public function renderInvoiceAction(Request $request)
     {
+        $number = $request->get('number');
         $order = $this->findOrderOr404($number);
 
         if (!$order->isInvoiceAvailable()) {
             throw $this->createNotFoundException('The invoice can not yet be generated.');
         }
 
-        $html = $this->renderView('SyliusWebBundle:Frontend/Account:Order/invoice.html.twig', array(
+        $html = $this->renderView($this->getTemplate('frontend_order_invoice'), array(
             'order' => $order
         ));
 

--- a/src/Sylius/Bundle/WebBundle/Controller/Frontend/HomepageController.php
+++ b/src/Sylius/Bundle/WebBundle/Controller/Frontend/HomepageController.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\WebBundle\Controller\Frontend;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Sylius\Bundle\WebBundle\Controller\WebController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class HomepageController extends Controller
+class HomepageController extends WebController
 {
     /**
      * Store front page.
@@ -28,6 +28,6 @@ class HomepageController extends Controller
      */
     public function mainAction()
     {
-        return $this->render('SyliusWebBundle:Frontend/Homepage:main.html.twig');
+        return $this->render($this->getTemplate('frontend_homepage'));
     }
 }

--- a/src/Sylius/Bundle/WebBundle/Controller/WebController.php
+++ b/src/Sylius/Bundle/WebBundle/Controller/WebController.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\WebBundle\Controller;
+
+use FOS\RestBundle\Controller\FOSRestController;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+/**
+ * An abstract controller that WebBundle controllers may extend.
+ *
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
+ */
+class WebController extends FOSRestController {
+
+    /**
+     * Returns a template name based on bundle's configuration.
+     *
+     * @param string $name Template name
+     *
+     * @param null|string $default Optional default value if no template found with that name.
+     *
+     * @return string Template path
+     */
+    protected function getTemplate($name, $default = null) {
+        try {
+            return $this->container->getParameter(sprintf('sylius.template.%s', $name));
+        } catch (InvalidArgumentException $e) {
+            if (null !== $default) {
+                return $default;
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @return CustomerInterface
+     */
+    protected function getCustomer()
+    {
+        return $this->get('sylius.context.customer')->getCustomer();
+    }
+
+    /**
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     */
+    protected function redirectToIndex()
+    {
+        return $this->redirect($this->generateUrl('sylius_account_address_index'));
+    }
+
+    /**
+     * @param string $type
+     * @param string $message
+     */
+    protected function addFlash($type, $message)
+    {
+        $translator = $this->get('translator');
+        $this->get('session')->getFlashBag()->add($type, $translator->trans($message, array(), 'flashes'));
+    }
+}

--- a/src/Sylius/Bundle/WebBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/WebBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\WebBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('sylius_web');
+
+        $this->addTemplatesSection($rootNode);
+
+        return $treeBuilder;
+    }
+
+    /**
+     * Adds `templates` section.
+     *
+     * @param ArrayNodeDefinition $node
+     */
+    private function addTemplatesSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('templates')
+                    ->addDefaultsIfNotSet()
+                    ->info('Templates used in the web bundle')
+                    ->children()
+
+                        // Frontend Templates
+                        ->scalarNode('frontend_homepage')->defaultValue('SyliusWebBundle:Frontend/Homepage:main.html.twig')->end()
+                        ->scalarNode('frontend_cart_summary')->defaultValue('SyliusWebBundle:Frontend/Cart:summary.html.twig')->end()
+                        ->scalarNode('frontend_account')->defaultValue('SyliusWebBundle:Frontend/Account:show.html.twig')->end()
+                        ->scalarNode('frontend_address_index')->defaultValue('SyliusWebBundle:Frontend/Account:Address/index.html.twig')->end()
+                        ->scalarNode('frontend_address_create')->defaultValue('SyliusWebBundle:Frontend/Account:Address/create.html.twig')->end()
+                        ->scalarNode('frontend_address_update')->defaultValue('SyliusWebBundle:Frontend/Account:Address/update.html.twig')->end()
+                        ->scalarNode('frontend_order_index')->defaultValue('SyliusWebBundle:Frontend/Account:Order/index.html.twig')->end()
+                        ->scalarNode('frontend_order_show')->defaultValue('SyliusWebBundle:Frontend/Account:Order/show.html.twig')->end()
+                        ->scalarNode('frontend_order_invoice')->defaultValue('SyliusWebBundle:Frontend/Account:Order/invoice.html.twig')->end()
+
+                        // Backend Templates
+                        ->scalarNode('backend_dashboard')->defaultValue('SyliusWebBundle:Backend/Dashboard:main.html.twig')->end()
+                        ->scalarNode('backend_login')->defaultValue('SyliusWebBundle:Backend/Security:login.html.twig')->end()
+
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+}

--- a/src/Sylius/Bundle/WebBundle/DependencyInjection/SyliusWebExtension.php
+++ b/src/Sylius/Bundle/WebBundle/DependencyInjection/SyliusWebExtension.php
@@ -26,10 +26,17 @@ class SyliusWebExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $config, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container)
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
         $loader->load('twig.xml');
+
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+
+        foreach ($config['templates'] as $name => $template) {
+            $container->setParameter(sprintf('sylius.template.%s', $name), $template);
+        }
     }
 }


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | no
New feature?  | yes
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

When you want to use Sylius `WebBundle` sometimes you want change only the templates. With this PR you do not need to override the whole controller instead easily put this configuration in `config.yml`:

```yml
sylius_web:
   templates:
      backend_dashboard: "SyliusWebBundle:Backend/Dashboard:main.html.twig"
      backend_login: "SyliusWebBundle:Backend/Security:login.html.twig"
      frontend_homepage: "SyliusWebBundle:Frontend/Homepage:main.html.twig"
      frontend_cart_summary: "SyliusWebBundle:Frontend/Cart:summary.html.twig"
      frontend_account: "SyliusWebBundle:Frontend/Account:show.html.twig"
      frontend_address_index: "SyliusWebBundle:Frontend/Account:Address/index.html.twig"
      frontend_address_create: "SyliusWebBundle:Frontend/Account:Address/create.html.twig"
      frontend_address_update: "SyliusWebBundle:Frontend/Account:Address/update.html.twig"
      frontend_order_index: "SyliusWebBundle:Frontend/Account:Order/index.html.twig"
      frontend_order_show: "SyliusWebBundle:Frontend/Account:Order/show.html.twig"
      frontend_order_invoice: "SyliusWebBundle:Frontend/Account:Order/invoice.html.twig"
```

\cc @stloyd 