### PR TITLE
Allow to overwrite TaxationProcessor

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OrderProcessing/TaxationProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderProcessing/TaxationProcessor.php
@@ -121,7 +121,7 @@ class TaxationProcessor implements TaxationProcessorInterface
         $order->calculateTotal();
     }
 
-    private function processTaxes(OrderInterface $order, $zone)
+    protected function processTaxes(OrderInterface $order, $zone)
     {
         $taxes = array();
         foreach ($order->getItems() as $item) {
@@ -147,7 +147,7 @@ class TaxationProcessor implements TaxationProcessorInterface
         return $taxes;
     }
 
-    private function addAdjustments(array $taxes, OrderInterface $order)
+    protected function addAdjustments(array $taxes, OrderInterface $order)
     {
         foreach ($taxes as $description => $tax) {
             $adjustment = $this->adjustmentRepository->createNew();


### PR DESCRIPTION
Methods processTaxes and addAdjustments are private.

This PR change the visibility of these methods to protected.