### PR TITLE
fixes flash message in overriding template

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/layout.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/layout.html.twig
@@ -1,9 +1,9 @@
 {% extends 'SyliusWebBundle:Frontend:layout.html.twig' %}
 
 {% block flashes %}
-    {% for name, flashes in app.session.flashbag.all if name in ['success', 'error', 'fos_user_success'] %}
-        {% for flash in flashes %}
-            <div class="alert alert-{{ name == 'fos_user_success' ? 'success' : name == 'error' ? 'danger' : name }}">
+    {% for type in ['success', 'error', 'fos_user_success', 'notice'] %}
+        {% for flash in app.session.flashbag.get(type) %}
+            <div class="alert alert-{{ type == 'fos_user_success' ? 'success' : type == 'error' ? 'danger' : type == 'notice' ? 'warning' : type }}">
                 <a class="close" data-dismiss="alert" href="#">×</a>
                 {{ flash|trans({}, 'FOSUserBundle') }}
             </div>


### PR DESCRIPTION
This applies essentially the same patch as ffdf42d0 to a template that they forgot to patch in PR #1229.

This fixes an issue where flash messages would be displayed inconsistently (in our experience the *success* messages after successful payment didn't show up while the *error* ones did).