### PR TITLE
Remove FOS extension from UserInterface

### DIFF
--- a/src/Sylius/Component/Core/Model/UserInterface.php
+++ b/src/Sylius/Component/Core/Model/UserInterface.php
@@ -13,11 +13,10 @@ namespace Sylius\Component\Core\Model;
 
 use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Rbac\Model\IdentityInterface;
-use Sylius\Component\User\Model\UserInterface as BaseUserInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface UserInterface extends BaseUserInterface, IdentityInterface
+interface UserInterface extends IdentityInterface
 {
 }


### PR DESCRIPTION
Fixes #2795 

This change should be pretty safe, since the FOS BaseUser that the Sylius User model extends also implements this interface.