### PR TITLE
Fix: Object of class DateTime could not be converted to string

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -198,9 +198,9 @@ class OrderRepository extends CartRepository implements OrderRepositoryInterface
             ->innerJoin('o.promotionCoupons', 'coupons')
             ->andWhere('o.customer = :customer')
             ->andWhere('o.completedAt IS NOT NULL')
-            ->andWhere($queryBuilder->expr()->in('coupons', ':coupons'))
+            ->andWhere('coupons = :coupon')
             ->setParameter('customer', $customer)
-            ->setParameter('coupons', (array) $coupon)
+            ->setParameter('coupon', $coupon)
         ;
 
         $count = (int) $queryBuilder
@@ -318,7 +318,7 @@ class OrderRepository extends CartRepository implements OrderRepositoryInterface
 
 
     /**
-     * {@inheritdoc} 
+     * {@inheritdoc}
      */
     public function revenueBetweenDatesGroupByDate(array $configuration = array())
     {
@@ -344,7 +344,7 @@ class OrderRepository extends CartRepository implements OrderRepositoryInterface
     }
 
     /**
-     * {@inheritdoc} 
+     * {@inheritdoc}
      */
     public function ordersBetweenDatesGroupByDate(array $configuration = array())
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

When coupon has `expiresAt` date set, this error may occur:

```
Error: Object of class DateTime could not be converted to string

…//vendor/doctrine/dbal/lib/Doctrine/DBAL/
Connection.php (694)
…81352/vendor/doctrine/orm/lib/Doctrine/ORM/Query/Exec/
SingleSelectExecutor.php (50)
/vendor/doctrine/orm/lib/Doctrine/ORM/
Query.php (286)
…/vendor/doctrine/orm/lib/Doctrine/ORM/
AbstractQuery.php (794)
…/vendor/doctrine/orm/lib/Doctrine/ORM/
AbstractQuery.php (646)
…/vendor/doctrine/orm/lib/Doctrine/ORM/
AbstractQuery.php (674)
…or/sylius/sylius/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/
OrderRepository.php (198)
…us/src/Sylius/Component/Core/Promotion/Checker/
PromotionEligibilityChecker.php (102)
…us/src/Sylius/Component/Core/Promotion/Checker/
PromotionEligibilityChecker.php (97)
…us/src/Sylius/Component/Core/Promotion/Checker/
PromotionEligibilityChecker.php (67)
…/sylius/src/Sylius/Component/Promotion/Checker/
PromotionEligibilityChecker.php (90)
...
```

This happens because we cast coupon to array in order repository.