### PR TITLE
[FixturesBundle] Allow access to resources for api user on fixtures load

### DIFF
--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadApiData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadApiData.php
@@ -37,6 +37,7 @@ class LoadApiData extends DataFixture
             true,
             array('ROLE_API')
         );
+        $user->addAuthorizationRole($this->get('sylius.repository.role')->findOneBy(array('code' => 'administrator')));
 
         $manager->persist($user);
         $manager->flush();


### PR DESCRIPTION
In order to have access to resources we should have proper authorization role assigned.