### PR TITLE
[SettingsBundle] fix for fix default to file_system cache

### DIFF
--- a/src/Sylius/Bundle/SettingsBundle/DependencyInjection/SyliusSettingsExtension.php
+++ b/src/Sylius/Bundle/SettingsBundle/DependencyInjection/SyliusSettingsExtension.php
@@ -62,7 +62,7 @@ class SyliusSettingsExtension extends AbstractResourceExtension implements Prepe
         }
         
         if (!$container->hasParameter('sylius.cache')) {
-            $container->setParameter('sylius.cache', 'file_system');
+            $container->setParameter('sylius.cache', array('type' => 'file_system'));
         }
 
         $container->prependExtensionConfig('doctrine_cache', array(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Now it cause exception:
```
 [Symfony\Component\Debug\Exception\ContextErrorException]                    
  Catchable Fatal Error: Argument 1 passed to Doctrine\Bundle\DoctrineCacheBu  
  ndle\DependencyInjection\Configuration::resolveNodeType() must be of the ty  
  pe array, string given
```