### PR TITLE
[ResourceBundle] fix merging request and config sorting parameters

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
@@ -302,7 +302,15 @@ class Configuration
         $defaultSorting = array_merge($this->parameters->get('sorting', array()), $sorting);
 
         if ($this->isSortable()) {
-            return $this->getRequestParameter('sorting', $defaultSorting);
+            $sorting = $this->getRequestParameter('sorting');
+            foreach ($defaultSorting as $key => $value) {
+                //do not override request parameters by $defaultSorting values
+                if (!isset($sorting[$key])){
+                    $sorting[$key] = $value;
+                }
+            }
+
+            return $sorting;
         }
 
         return $defaultSorting;

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ConfigurationSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ConfigurationSpec.php
@@ -321,7 +321,7 @@ class ConfigurationSpec extends ObjectBehavior
     {
         $sorting = array('property' => 'desc');
         $overriddenSorting = array('other_property' => 'asc');
-        $combinedSorting = array('property' => 'desc', 'other_property' => 'asc');
+        $combinedSorting = array('other_property' => 'asc', 'property' => 'desc');
 
         $parameters->get('sortable', false)->willReturn(true);
         $parameters->get('sorting', array())->willReturn($sorting);
@@ -330,7 +330,7 @@ class ConfigurationSpec extends ObjectBehavior
         $this->getSorting()->shouldReturn($combinedSorting);
 
         $defaultSorting = array('foo' => 'bar');
-        $combinedDefaultSorting = array('property' => 'desc', 'foo' => 'bar', 'other_property' => 'asc');
+        $combinedDefaultSorting = array('other_property' => 'asc', 'property' => 'desc', 'foo' => 'bar');
 
         $parameters->get('sortable', false)->willReturn(true);
         $parameters->get('sorting', Argument::any())->willReturn($sorting);

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/country.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/country.yml
@@ -10,6 +10,8 @@ sylius_backend_country_index:
             template: SyliusWebBundle:Backend/Country:index.html.twig
             sortable: true
             paginate: 50
+            sorting:
+                name: asc
 
 sylius_backend_country_create:
     path: /new


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

If specify default sorting order in config:
```yml
sylius_backend_country_index:
    path: /
    methods: [GET]
    defaults:
        _controller: sylius.controller.country:indexAction
        _sylius:
            template: SyliusWebBundle:Backend/Country:index.html.twig
            sortable: true
            paginate: 50
            sorting:
                name: asc
```
and trying sort table manually GET /administration/countries/?sorting%5BisoName%5D=asc
Query will contain:
```SQL
ORDER BY o.name ASC, o.isoName ASC
```
but should be
```SQL
ORDER BY o.isoName ASC, o.name ASC
```