### PR TITLE
[WebBundle] Change $.fn.datepicker format to yyyy-mm-dd.

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/public/js/backend.js
+++ b/src/Sylius/Bundle/WebBundle/Resources/public/js/backend.js
@@ -14,6 +14,8 @@
             $(this).toggleClass('glyphicon-chevron-down glyphicon-chevron-up');
             $(this).parent().parent().find('table tbody').toggle();
         });
-        $('.datepicker').datepicker({});
+        $('.datepicker').datepicker({
+            format: 'yyyy-mm-dd'
+        });
     });
 })( jQuery );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no (I think)
| Deprecations? | no
| Fixed tickets | [comma separated list of tickets fixed by the PR]
| License       | MIT
| Doc PR        | [The reference to the documentation PR if any]

The motivation here is to allow the datetime comparison operators in the
database layer to was done so that native database comparisons can do
their job.