### PR TITLE
[ResourceBundle] check if requested paginate on allowed paginate array

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
@@ -273,7 +273,12 @@ class Configuration
 
     public function getPaginationMaxPerPage()
     {
-        return (int) $this->parameters->get('paginate', $this->settings['default_page_size']);
+        $paginate = (int)$this->parameters->get('paginate', $this->settings['default_page_size']);
+        $allowedPaginate = $this->parameters->get('allowed_paginate', $this->settings['allowed_paginate']);
+
+        return in_array($paginate, $allowedPaginate)
+            ? $paginate
+            : $this->settings['default_page_size'];
     }
 
     public function isFilterable()

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ConfigurationSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ConfigurationSpec.php
@@ -229,6 +229,19 @@ class ConfigurationSpec extends ObjectBehavior
         $this->getPaginationMaxPerPage()->shouldReturn(10);
     }
 
+    function it_should_return_default_page_size_if_not_allowed_paginate_size(Parameters $parameters)
+    {
+        $allowedPaginate = array(10, 20, 30);
+
+        $parameters->get('paginate', 10)->willReturn(10000);
+        $parameters->get('allowed_paginate',  Argument::any())->willReturn($allowedPaginate);
+        $this->getPaginationMaxPerPage()->shouldReturn(10);
+
+        $parameters->get('paginate', 10)->willReturn(15);
+        $parameters->get('allowed_paginate',  Argument::any())->willReturn($allowedPaginate);
+        $this->getPaginationMaxPerPage()->shouldReturn(10);
+    }
+
     function it_checks_if_the_resource_is_filterable(Parameters $parameters)
     {
         $parameters->get('filterable', Argument::any())->willReturn(true);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | improvement |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

If we enable custom pagination size by setting `paginate: $paginate` user can request exstra large data by `paginate=10000`. But we can chech if `paginate` is in array `allowed_paginate`.
