### PR TITLE
[CoreBundle] Fix shipment confirmation email to correctly get email

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/MailerListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/MailerListener.php
@@ -71,8 +71,10 @@ class MailerListener
                 'Sylius\Component\Shipping\Model\ShipmentInterface'
             );
         }
+
+        /** @var OrderInterface $order */
         $order = $shipment->getOrder();
-        $this->emailSender->send(Emails::SHIPMENT_CONFIRMATION, array($order->getEmail()), array(
+        $this->emailSender->send(Emails::SHIPMENT_CONFIRMATION, array($order->getCustomer()->getEmail()), array(
             'shipment' => $shipment,
             'order' => $order
         ));


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | yes
New feature?  | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

Is it correct to get email from customer model? Because there's no `getEmail()` method on `Order` model.