### PR TITLE
[WIP][CoreBundle] Add missing data_class to shipping method choice type

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/ShipmentType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/ShipmentType.php
@@ -52,6 +52,7 @@ class ShipmentType extends AbstractType
                 $shipment = $event->getData();
 
                 $form->add('method', 'sylius_shipping_method_choice', array(
+                    'data_class'  => 'Sylius\Component\Shipping\Model\ShippingMethodInterface',
                     'label'       => 'sylius.form.checkout.shipping_method',
                     'subject'     => $shipment,
                     'criteria'    => $criteria,


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | yes
New feature?  | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

The case is when user abandons the checkout process (I think after a `Shipment` entity is created for the `Order` and is stored on its `shipments` collection) and then that user tries to complete the checkout, `$order` contains a shipment in its `shipments` and its `$method` is a real object of selected `ShippingMethod` so when form tries to set the data it does not expect an object! Because it's a `choice`.

I don't know how can I cover this case in tests and also I don't know what other places are affected by this change.