### PR TITLE
fixes API routes for product_variant actions

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/product_variant.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/product_variant.yml
@@ -27,9 +27,8 @@ sylius_api_product_variant_update:
         _controller: sylius.controller.product_variant:updateAction
         _sylius:
             criteria:
-                id:      $id
-                product: $productId
-                master:  false
+                object: $productId
+                master: false
 
 sylius_api_product_variant_delete:
     path: /{id}
@@ -38,9 +37,8 @@ sylius_api_product_variant_delete:
         _controller: sylius.controller.product_variant:deleteAction
         _sylius:
             criteria:
-                id:      $id
-                product: $productId
-                master:  false
+                object: $productId
+                master: false
 
 sylius_api_product_variant_show:
     path: /{id}
@@ -49,6 +47,5 @@ sylius_api_product_variant_show:
         _controller: sylius.controller.product_variant:showAction
         _sylius:
             criteria:
-                id:      $id
-                product: $productId
-                master:  false
+                object: $productId
+                master: false


### PR DESCRIPTION
ProductVariant has no field "product" - it has "object". The "id"
criteria was useless since it is ignored by the API route controller
which takes the parameter directly.

Fixes this error:

    [Semantical Error] line 0, col 112 near 'product = :product': Error: Class ...\ProductVariant has no field or association named product

It appeared when accessing `/api/products/<productId>/variants/<variantId>`.