### PR TITLE
[SequenceBundle] Clear cached entities on postFlush

### DIFF
--- a/src/Sylius/Bundle/SequenceBundle/Doctrine/ORM/NumberListener.php
+++ b/src/Sylius/Bundle/SequenceBundle/Doctrine/ORM/NumberListener.php
@@ -91,6 +91,8 @@ class NumberListener
 
         if (!$this->listenerEnabled) {
             $this->eventManager->addEventListener(Events::preFlush, $this);
+            $this->eventManager->addEventListener(Events::postFlush, $this);
+
             $this->listenerEnabled = true;
         }
     }
@@ -129,6 +131,18 @@ class NumberListener
                 $event
             );
         }
+    }
+
+    /**
+     * Remove cached entities and sequences.
+     */
+    public function postFlush()
+    {
+        // Free memory to avoid memory leak.
+        $this->entitiesEnabled = array();
+
+        // Remove all cached sequences in order to get updated sequences on next use.
+        $this->sequences = array();
     }
 
     /**

--- a/src/Sylius/Bundle/SequenceBundle/spec/Doctrine/ORM/NumberListenerSpec.php
+++ b/src/Sylius/Bundle/SequenceBundle/spec/Doctrine/ORM/NumberListenerSpec.php
@@ -50,6 +50,11 @@ class NumberListenerSpec extends ObjectBehavior
             Argument::type('Sylius\Bundle\SequenceBundle\Doctrine\ORM\NumberListener')
         )->shouldBeCalled();
 
+        $eventManager->addEventListener(
+            Events::postFlush,
+            Argument::type('Sylius\Bundle\SequenceBundle\Doctrine\ORM\NumberListener')
+        )->shouldBeCalled();
+
         $this->enableEntity($subject);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

All cached entities caused a memory leak on flush batches. Cached sequences was used with old index counter on separated flush batches.