### PR TITLE
Cascade persist translatables

### DIFF
--- a/src/Sylius/Bundle/TranslationBundle/EventListener/ORMTranslatableListener.php
+++ b/src/Sylius/Bundle/TranslationBundle/EventListener/ORMTranslatableListener.php
@@ -101,6 +101,7 @@ class ORMTranslatableListener extends AbstractTranslatableListener implements Ev
             'fieldName'    => 'translatable' ,
             'targetEntity' => $this->configs[$metadata->name]['model'],
             'inversedBy'   => 'translations' ,
+            'cascade'      => array('persist', 'merge', 'remove'),
             'joinColumns'  => array(array(
                 'name'                 => 'translatable_id',
                 'referencedColumnName' => 'id',


### PR DESCRIPTION
In our app (where we override a lot of Sylius stuff) I was getting this error during CLI install:

```
$ ./app/console sylius:install
Installing Sylius...

Step 1 of 4. Checking system requirements.
+--------------------+----------------+
| Issue              | Recommendation |
+--------------------+----------------+
| short_open_tag     |                |
| session.auto_start |                |
+--------------------+----------------+
Success! Your system can run Sylius properly.

Step 2 of 4. Setting up the database.
Creating Sylius database for environment dev.
It appears that your database already exists. Would you like to reset it? (y/N) y
 7/7 [||||||||||||||||||||||||||||] 100%
Warning! This will erase your database. Your current environment is dev.
Load sample data? (y/N) y
Loading sample data...
 3/4 [||||||||||||||||||||||      ]  75%PHP Fatal error:  Uncaught exception 'Doctrine\ORM\ORMInvalidArgumentException' with message 'A new entity was found through the relationship 'Sylius\Component\Core\Model\ProductTranslation#translatable' that was not configured to cascade persist operations for entity: Hypebeast\Bundle\CoreBundle\Entity\Product@000000003d7399dd0000000049429139. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist  this association in the mapping for example @ManyToOne(..,cascade={"persist"}). If you cannot find out which entity causes the problem implement 'Hypebeast\Bundle\CoreBundle\Entity\Product#__toString()' to get a clue.' in vendor/doctrine/orm/lib/Doctrine/ORM/ORMInvalidArgumentException.php:91
Stack trace:
#0 vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php(797): Doctrine\ORM\ORMInvalidArgumentException::newEntityFoundThroughRelationship(Array, Object(Hypebeast\Bundle\CoreBundle\Entity\Produ in vendor/doctrine/orm/lib/Doctrine/ORM/ORMInvalidArgumentException.php on line 91
```

After submitted fix, the error is gone.

May it be we are missing something? Or this cascade is really missing? Any idea @gonzalovilaseca?