### PR TITLE
Use unused parameter %sylius.state_machine.class%

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Kernel/Kernel.php
+++ b/src/Sylius/Bundle/CoreBundle/Kernel/Kernel.php
@@ -73,8 +73,8 @@ abstract class Kernel extends BaseKernel
 
             new \Sylius\Bundle\CoreBundle\SyliusCoreBundle(),
             new \Sylius\Bundle\WebBundle\SyliusWebBundle(),
-            new \winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new \Sylius\Bundle\ResourceBundle\SyliusResourceBundle(),
+            new \winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new \Sylius\Bundle\ApiBundle\SyliusApiBundle(),
 
             new \Sonata\BlockBundle\SonataBlockBundle(),

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/state-machine.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/state-machine.yml
@@ -3,7 +3,7 @@ winzou_state_machine:
         class:         %sylius.model.order.class%
         property_path: checkoutState
         graph:         sylius_order_checkout
-        state_machine_class: Sylius\Component\Resource\StateMachine\StateMachine
+        state_machine_class: %sylius.state_machine.class%
         states:
             cart: ~
             addressing: ~
@@ -32,7 +32,7 @@ winzou_state_machine:
         class:         %sylius.model.order.class%
         property_path: shippingState
         graph:         sylius_order_shipping
-        state_machine_class: Sylius\Component\Resource\StateMachine\StateMachine
+        state_machine_class: %sylius.state_machine.class%
         states:
             checkout:          ~
             onhold:            ~
@@ -66,7 +66,7 @@ winzou_state_machine:
         class:         %sylius.model.order.class%
         property_path: paymentState
         graph:         sylius_order_payment
-        state_machine_class: Sylius\Component\Resource\StateMachine\StateMachine
+        state_machine_class: %sylius.state_machine.class%
         states:
             new:        ~
             pending:    ~

--- a/src/Sylius/Bundle/InventoryBundle/Resources/config/state-machine.yml
+++ b/src/Sylius/Bundle/InventoryBundle/Resources/config/state-machine.yml
@@ -3,7 +3,7 @@ winzou_state_machine:
         class:         %sylius.model.inventory_unit.class%
         property_path: inventoryState
         graph:         sylius_inventory_unit
-        state_machine_class: Sylius\Component\Resource\StateMachine\StateMachine
+        state_machine_class: %sylius.state_machine.class%
         states:
             checkout:    ~
             onhold:      ~

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/state-machine.yml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/state-machine.yml
@@ -3,7 +3,7 @@ winzou_state_machine:
         class:         %sylius.model.order.class%
         property_path: state
         graph:         sylius_order
-        state_machine_class: Sylius\Component\Resource\StateMachine\StateMachine
+        state_machine_class: %sylius.state_machine.class%
         states:
             cart:        ~
             cart_locked: ~

--- a/src/Sylius/Bundle/PaymentBundle/Resources/config/state-machine.yml
+++ b/src/Sylius/Bundle/PaymentBundle/Resources/config/state-machine.yml
@@ -3,7 +3,7 @@ winzou_state_machine:
         class:         %sylius.model.payment.class%
         property_path: state
         graph:         sylius_payment
-        state_machine_class: Sylius\Component\Resource\StateMachine\StateMachine
+        state_machine_class: %sylius.state_machine.class%
         states:
             new:        ~
             unknown:    ~

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/state-machine.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/state-machine.yml
@@ -3,7 +3,7 @@ winzou_state_machine:
         class:         %sylius.model.shipment.class%
         property_path: state
         graph:         sylius_shipment
-        state_machine_class: Sylius\Component\Resource\StateMachine\StateMachine
+        state_machine_class: %sylius.state_machine.class%
         states:
             checkout:    ~
             pending:     ~
@@ -45,7 +45,7 @@ winzou_state_machine:
         class:         %sylius.model.shipment_item.class%
         property_path: shippingState
         graph:         sylius_shipment_item
-        state_machine_class: Sylius\Component\Resource\StateMachine\StateMachine
+        state_machine_class: %sylius.state_machine.class%
         states:
             checkout: ~
             onhold:      ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | refactor
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | no
| License       | MIT
| Doc PR        | -

But `SyliusResourceBundle` should be registered before `winzouStateMachineBundle`...