### PR TITLE
Use submit on forms instead of handleRequest

### DIFF
--- a/src/Sylius/Bundle/CartBundle/Controller/CartController.php
+++ b/src/Sylius/Bundle/CartBundle/Controller/CartController.php
@@ -67,7 +67,7 @@ class CartController extends Controller
         $cart = $this->getCurrentCart();
         $form = $this->createForm('sylius_cart', $cart);
 
-        if ($form->handleRequest($request)->isValid()) {
+        if ($form->submit($request)->isValid()) {
             $event = new CartEvent($cart);
             $event->isFresh(true);
 

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
@@ -49,7 +49,7 @@ class AddressingStep extends CheckoutStep
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::ADDRESSING_INITIALIZE, $order);
         $form = $this->createCheckoutAddressingForm($order, $this->getCustomer());
 
-        if ($form->handleRequest($request)->isValid()) {
+        if ($form->submit($request)->isValid()) {
             $this->dispatchCheckoutEvent(SyliusCheckoutEvents::ADDRESSING_PRE_COMPLETE, $order);
 
             $this->getManager()->persist($order);

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
@@ -49,7 +49,7 @@ class PaymentStep extends CheckoutStep
 
         $form = $this->createCheckoutPaymentForm($order);
 
-        if ($form->handleRequest($request)->isValid()) {
+        if ($form->submit($request)->isValid()) {
             $this->dispatchCheckoutEvent(SyliusCheckoutEvents::PAYMENT_PRE_COMPLETE, $order);
 
             $this->getManager()->persist($order);

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
@@ -61,7 +61,7 @@ class ShippingStep extends CheckoutStep
 
         $form = $this->createCheckoutShippingForm($order);
 
-        if ($form->handleRequest($request)->isValid()) {
+        if ($form->submit($request)->isValid()) {
             $this->dispatchCheckoutEvent(SyliusCheckoutEvents::SHIPPING_PRE_COMPLETE, $order);
 
             $this->getManager()->persist($order);

--- a/src/Sylius/Bundle/FlowBundle/README.md
+++ b/src/Sylius/Bundle/FlowBundle/README.md
@@ -85,7 +85,7 @@ class DeliveryStep extends ContainerAwareStep
         $request = $context->getRequest();
         $form = $this->createAddressForm();
 
-        if ($form->handleRequest($request)->isValid()) {
+        if ($form->submit($request)->isValid()) {
             $context->getStorage()->set('delivery.address', $form->getData());
             $context->complete(); // Complete step, user will be redirected to next step.
 

--- a/src/Sylius/Bundle/InstallerBundle/Process/Step/ConfigureStep.php
+++ b/src/Sylius/Bundle/InstallerBundle/Process/Step/ConfigureStep.php
@@ -35,7 +35,7 @@ class ConfigureStep extends AbstractControllerStep
         $request = $this->getRequest();
         $form = $this->createConfigurationForm();
 
-        if ($form->handleRequest($request)->isValid()) {
+        if ($form->submit($request)->isValid()) {
             $this->get('sylius.installer.yaml_persister')->dump($form->getData());
 
             return $this->complete();

--- a/src/Sylius/Bundle/InstallerBundle/Process/Step/SetupStep.php
+++ b/src/Sylius/Bundle/InstallerBundle/Process/Step/SetupStep.php
@@ -41,7 +41,7 @@ class SetupStep extends AbstractControllerStep
         $form = $this->createForm('sylius_setup');
         $em = $this->getDoctrine()->getManager();
 
-        if ($form->handleRequest($request)->isValid()) {
+        if ($form->submit($request)->isValid()) {
             $params = $this->get('doctrine')->getConnection()->getParams();
             $dbname = $params['dbname'];
             unset($params['dbname']);

--- a/src/Sylius/Bundle/PromotionBundle/Controller/CouponController.php
+++ b/src/Sylius/Bundle/PromotionBundle/Controller/CouponController.php
@@ -43,7 +43,7 @@ class CouponController extends ResourceController
 
         $form = $this->createForm('sylius_promotion_coupon_generate_instruction');
 
-        if ($form->handleRequest($request)->isValid()) {
+        if ($form->submit($request)->isValid()) {
             $this->getGenerator()->generate($promotion, $form->getData());
             $this->flashHelper->setFlash('success', 'generate');
 

--- a/src/Sylius/Bundle/SettingsBundle/Controller/SettingsController.php
+++ b/src/Sylius/Bundle/SettingsBundle/Controller/SettingsController.php
@@ -46,7 +46,7 @@ class SettingsController extends FOSRestController
             ->create($namespace, $settings, $isApiRequest ? array('csrf_protection' => false) : array())
         ;
 
-        if ($form->handleRequest($request)->isValid()) {
+        if ($form->submit($request)->isValid()) {
             $messageType = 'success';
             try {
                 $manager->saveSettings($namespace, $form->getData());

--- a/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/AddressController.php
+++ b/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/AddressController.php
@@ -55,7 +55,7 @@ class AddressController extends FOSRestController
         $address = $this->getAddressRepository()->createNew();
         $form = $this->getAddressForm($address);
 
-        if ($form->handleRequest($request)->isValid()) {
+        if ($form->submit($request)->isValid()) {
             $customer->addAddress($address);
 
             $manager = $this->getCustomerManager();
@@ -88,7 +88,7 @@ class AddressController extends FOSRestController
         $address = $this->findUserAddressOr404($id);
         $form = $this->getAddressForm($address);
 
-        if ($form->handleRequest($request)->isValid()) {
+        if ($form->submit($request)->isValid()) {
             $manager = $this->getCustomerManager();
             $manager->persist($customer);
             $manager->flush();


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | yes
New feature?  | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

Sometimes when you use `handleRequest` form will not be valid. (`isValid()` returns false)