### PR TITLE
[SettingsBundle] Use find() in ObjectToIdentifierTransformer

### DIFF
--- a/src/Sylius/Bundle/SettingsBundle/Transformer/ObjectToIdentifierTransformer.php
+++ b/src/Sylius/Bundle/SettingsBundle/Transformer/ObjectToIdentifierTransformer.php
@@ -42,6 +42,10 @@ class ObjectToIdentifierTransformer extends BaseTransformer implements Parameter
             return;
         }
 
+        if ('id' === $this->identifier) {
+            return $this->repository->find($value);
+        }
+
         return $this->repository->findOneBy([$this->identifier => $value]);
     }
 }


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | yes
New feature?  | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

In Phpcr document repository `findOneBy` will look for properties and not document `id` or `path`. So if `ObjectToIdentifierTransformer`'s job is find the object by real document/entity (not user provided) identifier it's more universal to use `find()` method.

Anyway right now `ObjectToIdentifierTransformer` does not work with [Phpcr document repository](https://github.com/doctrine/phpcr-odm/blob/master/lib/Doctrine/ODM/PHPCR/DocumentRepository.php).