### PR TITLE
[ResourceBundle] Include sylius_resource classes in metadatalistener

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
@@ -46,11 +46,11 @@ class SyliusResourceExtension extends AbstractExtension
 
         $this->createResourceServices($classes, $container);
 
-        $configClasses = array();
+        $configClasses = array('default' => $this->getClassesFromConfig($classes));
 
         if ($container->hasParameter('sylius.config.classes')) {
             $configClasses = array_merge_recursive(
-                array('default' => $classes),
+                $configClasses,
                 $container->getParameter('sylius.config.classes')
             );
         }
@@ -95,5 +95,20 @@ class SyliusResourceExtension extends AbstractExtension
                 )->load($config['classes']['translation']);
             }
         }
+    }
+
+    /**
+     * @param array $configs
+     * @return array
+     */
+    private function getClassesFromConfig($configs)
+    {
+        $classes = array();
+
+        foreach ($configs as $config) {
+            $classes[] = $config['classes'];
+        }
+
+        return $classes;
     }
 }


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | no
New feature?  | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

When using ResourceBundle standalone, the classes defined under `sylius_resource.resources` config are not added to the `sylius.config.classes` parameter (cf [SyliusResourceExtension.php#L49](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php#L49)).

But it is this parameter that is injected in the ORMMetadataListener, for assigning repository to their model in Doctrine for example (cf [LoadORMMetadataSubscriber.php#L76](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/ResourceBundle/EventListener/LoadORMMetadataSubscriber.php#L76)).

This PR fixes this :)