### PR TITLE
Register state machine configs in bundle extensions

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/main.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/main.yml
@@ -2,10 +2,6 @@ imports:
     - { resource: @SyliusCoreBundle/Resources/config/app/sylius.yml }
     - { resource: @SyliusCoreBundle/Resources/config/app/payum.yml }
     - { resource: @SyliusCoreBundle/Resources/config/app/cmf.yml }
-    - { resource: @SyliusPaymentBundle/Resources/config/state-machine.yml }
-    - { resource: @SyliusShippingBundle/Resources/config/state-machine.yml }
-    - { resource: @SyliusOrderBundle/Resources/config/state-machine.yml }
-    - { resource: @SyliusInventoryBundle/Resources/config/state-machine.yml }
     - { resource: @SyliusCoreBundle/Resources/config/state-machine.yml }
 
 twig:

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -11,8 +11,8 @@
 
 -->
 
-<container xmlns="http://symfony.com/schema/dic/services"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://symfony.com/schema/dic/services"
            xsi:schemaLocation="http://symfony.com/schema/dic/services
                                http://symfony.com/schema/dic/services/services-1.0.xsd">
 
@@ -85,8 +85,6 @@
         <parameter key="sylius.generator.class">Sylius\Bundle\CoreBundle\Routing\SyliusAwareGenerator</parameter>
         <parameter key="sylius.route_provider.class">Sylius\Bundle\CoreBundle\Routing\RouteProvider</parameter>
         <parameter key="sylius.a2lix_locale_provider.class">Sylius\Bundle\CoreBundle\Locale\A2lixTranslationLocaleProvider</parameter>
-
-        <parameter key="sylius.callback.complete_order.class">Sylius\Bundle\CoreBundle\StateMachineCallback\CompleteOrderCallback</parameter>
 
         <!-- Data fetchers -->
         <parameter key="sylius.registry.report.class">Sylius\Component\Registry\ServiceRegistry</parameter>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/state_machine.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/state_machine.xml
@@ -11,8 +11,8 @@
 
 -->
 
-<container xmlns="http://symfony.com/schema/dic/services"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://symfony.com/schema/dic/services"
            xsi:schemaLocation="http://symfony.com/schema/dic/services
                                http://symfony.com/schema/dic/services/services-1.0.xsd">
 
@@ -23,6 +23,8 @@
         <parameter key="sylius.callback.coupon_usage.class">Sylius\Bundle\CoreBundle\StateMachineCallback\CouponUsageCallback</parameter>
         <parameter key="sylius.callback.promotion_usage.class">Sylius\Bundle\CoreBundle\StateMachineCallback\PromotionUsageCallback</parameter>
         <parameter key="sylius.callback.order_shipment.class">Sylius\Bundle\CoreBundle\StateMachineCallback\OrderShipmentCallback</parameter>
+
+        <parameter key="sylius.callback.complete_order.class">Sylius\Bundle\CoreBundle\StateMachineCallback\CompleteOrderCallback</parameter>
     </parameters>
 
     <services>

--- a/src/Sylius/Bundle/InventoryBundle/DependencyInjection/SyliusInventoryExtension.php
+++ b/src/Sylius/Bundle/InventoryBundle/DependencyInjection/SyliusInventoryExtension.php
@@ -13,6 +13,8 @@ namespace Sylius\Bundle\InventoryBundle\DependencyInjection;
 
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractResourceExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\Yaml\Parser;
 
 /**
  * Inventory extension.
@@ -20,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class SyliusInventoryExtension extends AbstractResourceExtension
+class SyliusInventoryExtension extends AbstractResourceExtension implements PrependExtensionInterface
 {
     protected $configFiles = array(
         'services.xml',
@@ -68,5 +70,18 @@ class SyliusInventoryExtension extends AbstractResourceExtension
                 );
             }
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        if (!$container->hasExtension('winzou_state_machine')) {
+            throw new \RuntimeException('winzouStateMachineBundle must be registered!');
+        }
+        $parser = new Parser();
+        $config = $parser->parse(file_get_contents($this->getDefinitionPath($container).'/state-machine.yml'));
+        $container->prependExtensionConfig('winzou_state_machine', $config['winzou_state_machine']);
     }
 }

--- a/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
+++ b/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
@@ -13,13 +13,15 @@ namespace Sylius\Bundle\OrderBundle\DependencyInjection;
 
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractResourceExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\Yaml\Parser;
 
 /**
  * Order extension.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class SyliusOrderExtension extends AbstractResourceExtension
+class SyliusOrderExtension extends AbstractResourceExtension implements PrependExtensionInterface
 {
     /**
      * {@inheritdoc}
@@ -34,5 +36,18 @@ class SyliusOrderExtension extends AbstractResourceExtension
         );
 
         $container->setParameter('sylius.order.allow_guest_order', $config['guest_order']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        if (!$container->hasExtension('winzou_state_machine')) {
+            throw new \RuntimeException('winzouStateMachineBundle must be registered!');
+        }
+        $parser = new Parser();
+        $config = $parser->parse(file_get_contents($this->getDefinitionPath($container).'/state-machine.yml'));
+        $container->prependExtensionConfig('winzou_state_machine', $config['winzou_state_machine']);
     }
 }

--- a/src/Sylius/Bundle/PaymentBundle/DependencyInjection/SyliusPaymentExtension.php
+++ b/src/Sylius/Bundle/PaymentBundle/DependencyInjection/SyliusPaymentExtension.php
@@ -14,13 +14,15 @@ namespace Sylius\Bundle\PaymentBundle\DependencyInjection;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractResourceExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\Yaml\Parser;
 
 /**
  * Payments extension.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class SyliusPaymentExtension extends AbstractResourceExtension
+class SyliusPaymentExtension extends AbstractResourceExtension implements PrependExtensionInterface
 {
     /**
      * {@inheritdoc}
@@ -46,5 +48,18 @@ class SyliusPaymentExtension extends AbstractResourceExtension
             ->addArgument(new Reference('sylius.registry.payment.fee_calculator'))
             ->addArgument(new Reference('sylius.repository.payment'))
         ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        if (!$container->hasExtension('winzou_state_machine')) {
+            throw new \RuntimeException('winzouStateMachineBundle must be registered!');
+        }
+        $parser = new Parser();
+        $config = $parser->parse(file_get_contents($this->getDefinitionPath($container).'/state-machine.yml'));
+        $container->prependExtensionConfig('winzou_state_machine', $config['winzou_state_machine']);
     }
 }

--- a/src/Sylius/Bundle/ShippingBundle/DependencyInjection/SyliusShippingExtension.php
+++ b/src/Sylius/Bundle/ShippingBundle/DependencyInjection/SyliusShippingExtension.php
@@ -13,14 +13,16 @@ namespace Sylius\Bundle\ShippingBundle\DependencyInjection;
 
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractResourceExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Yaml\Parser;
 
 /**
  * Shipping extension.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class SyliusShippingExtension extends AbstractResourceExtension
+class SyliusShippingExtension extends AbstractResourceExtension implements PrependExtensionInterface
 {
     /**
      * {@inheritdoc}
@@ -40,5 +42,18 @@ class SyliusShippingExtension extends AbstractResourceExtension
 
         $shippingMethod = $container->getDefinition('sylius.form.type.shipping_method_rule');
         $shippingMethod->addArgument(new Reference('sylius.shipping_rule_checker_registry'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        if (!$container->hasExtension('winzou_state_machine')) {
+            throw new \RuntimeException('winzouStateMachineBundle must be registered!');
+        }
+        $parser = new Parser();
+        $config = $parser->parse(file_get_contents($this->getDefinitionPath($container).'/state-machine.yml'));
+        $container->prependExtensionConfig('winzou_state_machine', $config['winzou_state_machine']);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | refactor |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | no |
| License | MIT |
| Doc PR | - |

Some questions:
1) Should `SyliusPaymentBundle`, `SyliusOrderBundle` etc work without StateMachineBundle?
2) Which bundle should have dependency in composer.json from `winzou/state-machine-bundle`: `ResourceBundle` or `SyliusPaymentBundle`, `SyliusOrderBundle`?..
3) I keep same structure of state-machine.yml files for BC, right?
