### PR TITLE
[ResourceBundle] Make ResourceController format agnostic

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
@@ -154,7 +154,21 @@ class Configuration
 
     public function getTemplateName($name)
     {
-        return sprintf('%s:%s.%s', $this->templateNamespace ?: ':', $name, $this->templatingEngine);
+        //For BC, prefer usage $this->config->getTemplate('index') instead of $this->config->getTemplate('index.html')
+        if (preg_match('/^(\S+)\.(\S+)$/', $name, $m)) {
+            $name = $m[1];
+            $format = $m[2];
+        } else {
+            $format = null;
+        }
+
+        return sprintf(
+            '%s:%s.%s.%s',
+            $this->templateNamespace ?: ':',
+            $name,
+            $format ?: $this->request->getRequestFormat(),
+            $this->templatingEngine
+        );
     }
 
     public function getTemplate($name)

--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -111,7 +111,7 @@ class ResourceController extends FOSRestController
 
         $view = $this
             ->view()
-            ->setTemplate($this->config->getTemplate('show.html'))
+            ->setTemplate($this->config->getTemplate('show'))
             ->setTemplateVar($this->config->getResourceName())
             ->setData($this->findOr404($request))
         ;
@@ -161,7 +161,7 @@ class ResourceController extends FOSRestController
 
         $view = $this
             ->view()
-            ->setTemplate($this->config->getTemplate('index.html'))
+            ->setTemplate($this->config->getTemplate('index'))
             ->setTemplateVar($this->config->getPluralResourceName())
             ->setData($resources)
         ;
@@ -205,7 +205,7 @@ class ResourceController extends FOSRestController
 
         $view = $this
             ->view()
-            ->setTemplate($this->config->getTemplate('create.html'))
+            ->setTemplate($this->config->getTemplate('create'))
             ->setData(array(
                 $this->config->getResourceName() => $resource,
                 'form'                           => $form->createView(),
@@ -251,7 +251,7 @@ class ResourceController extends FOSRestController
 
         $view = $this
             ->view()
-            ->setTemplate($this->config->getTemplate('update.html'))
+            ->setTemplate($this->config->getTemplate('update'))
             ->setData(array(
                 $this->config->getResourceName() => $resource,
                 'form'                           => $form->createView(),

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ConfigurationSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ConfigurationSpec.php
@@ -122,9 +122,21 @@ class ConfigurationSpec extends ObjectBehavior
     {
         $this->getTemplateName('index.html')->shouldReturn('SyliusWebBundle:Product:index.html.twig');
         $this->getTemplateName('show.html')->shouldReturn('SyliusWebBundle:Product:show.html.twig');
+        $this->getTemplateName('show.pdf')->shouldReturn('SyliusWebBundle:Product:show.pdf.twig');
         $this->getTemplateName('create.html')->shouldReturn('SyliusWebBundle:Product:create.html.twig');
         $this->getTemplateName('update.html')->shouldReturn('SyliusWebBundle:Product:update.html.twig');
         $this->getTemplateName('custom.html')->shouldReturn('SyliusWebBundle:Product:custom.html.twig');
+    }
+
+    function it_generates_template_names_based_on_request_format(Request $request)
+    {
+        $this->setRequest($request);
+
+        $request->getRequestFormat()->willReturn('html');
+        $this->getTemplateName('show')->shouldReturn('SyliusWebBundle:Product:show.html.twig');
+
+        $request->getRequestFormat()->willReturn('pdf');
+        $this->getTemplateName('show')->shouldReturn('SyliusWebBundle:Product:show.pdf.twig');
     }
 
     function it_generates_view_template(Parameters $parameters)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | no |
| License | MIT |
| Doc PR | - |

Allow ResourceController working with other then `html` formats requiring templating.
