### PR TITLE
Remove flashHelper dependency from domainManager

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Controller/OrderController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/OrderController.php
@@ -73,7 +73,16 @@ class OrderController extends ResourceController
             ->apply(OrderTransitions::SYLIUS_RELEASE)
         ;
 
-        $this->domainManager->update($order);
+        try {
+            $this->domainManager->update($order);
+            $this->flashHelper->setFlash('success', 'update');
+        } catch (DomainException $e) {
+            $this->flashHelper->setFlash(
+                $e->getType(),
+                $e->getMessage(),
+                $e->getParameters()
+            );
+        }
 
         return $this->redirectHandler->redirectToReferer();
     }

--- a/src/Sylius/Bundle/OrderBundle/Controller/AdjustmentController.php
+++ b/src/Sylius/Bundle/OrderBundle/Controller/AdjustmentController.php
@@ -49,7 +49,16 @@ class AdjustmentController extends ResourceController
             }
         }
 
-        $this->domainManager->update($order);
+        try {
+            $this->domainManager->update($order);
+            $this->flashHelper->setFlash('success', 'update');
+        } catch (DomainException $e) {
+            $this->flashHelper->setFlash(
+                $e->getType(),
+                $e->getMessage(),
+                $e->getParameters()
+            );
+        }
 
         return $this->redirectHandler->redirectTo($order);
     }

--- a/src/Sylius/Bundle/OrderBundle/Controller/CommentController.php
+++ b/src/Sylius/Bundle/OrderBundle/Controller/CommentController.php
@@ -39,7 +39,16 @@ class CommentController extends ResourceController
             $resource->setOrder($order);
             $resource->setAuthor($this->getUser()->getEmail());
 
-            $this->domainManager->create($resource);
+            try {
+                $this->domainManager->create($resource);
+                $this->flashHelper->setFlash('success', 'create');
+            } catch (DomainException $e) {
+                $this->flashHelper->setFlash(
+                    $e->getType(),
+                    $e->getMessage(),
+                    $e->getParameters()
+                );
+            }
 
             return $this->redirect($this->generateUrl('sylius_backend_order_show', array('id' => $order->getId())));
         }

--- a/src/Sylius/Bundle/ResourceBundle/Exception/DomainException.php
+++ b/src/Sylius/Bundle/ResourceBundle/Exception/DomainException.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\Exception;
+
+class DomainException extends \Exception
+{
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var array
+     */
+    protected $parameters = array();
+
+    public function __construct($type, $message, $code, array $parameters = array())
+    {
+        $this->type       = $type;
+        $this->message    = $message;
+        $this->code       = $code;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/Controller/ShipmentController.php
+++ b/src/Sylius/Bundle/ShippingBundle/Controller/ShipmentController.php
@@ -29,9 +29,16 @@ class ShipmentController extends ResourceController
                 ->apply(ShipmentTransitions::SYLIUS_SHIP)
             ;
 
-            $this->domainManager->update($shipment);
-
-            $this->flashHelper->setFlash('success', 'sylius.shipment.ship.success');
+            try {
+                $this->domainManager->update($shipment);
+                $this->flashHelper->setFlash('success', 'sylius.shipment.ship.success');
+            } catch (DomainException $e) {
+                $this->flashHelper->setFlash(
+                    $e->getType(),
+                    $e->getMessage(),
+                    $e->getParameters()
+                );
+            }
 
             return $this->redirectHandler->redirectTo($shipment);
         }

--- a/src/Sylius/Bundle/UserBundle/Controller/CustomerController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/CustomerController.php
@@ -34,11 +34,23 @@ class CustomerController extends ResourceController
         $form     = $this->getForm($customer);
 
         if (in_array($request->getMethod(), array('POST', 'PUT', 'PATCH')) && $form->submit($request, !$request->isMethod('PATCH'))->isValid()) {
-            $this->domainManager->update($customer);
+            try {
+                $this->domainManager->update($customer);
+            } catch (DomainException $e) {
+                if (!$this->config->isApiRequest()) {
+                    $this->flashHelper->setFlash(
+                        $e->getType(),
+                        $e->getMessage(),
+                        $e->getParameters()
+                    );
+                }
+            }
 
             if ($this->config->isApiRequest()) {
                 return $this->handleView($this->view($customer, 204));
             }
+
+            $this->flashHelper->setFlash('success', 'update');
 
             return $this->redirectHandler->redirectTo($customer);
         }

--- a/src/Sylius/Bundle/UserBundle/Controller/UserController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/UserController.php
@@ -164,7 +164,17 @@ class UserController extends ResourceController
         $user->setConfirmationToken(null);
         $user->setPasswordRequestedAt(null);
 
-        $this->domainManager->update($user);
+        try {
+            $this->domainManager->update($user);
+        } catch (DomainException $e) {
+            if (!$this->config->isApiRequest()) {
+                $this->flashHelper->setFlash(
+                    $e->getType(),
+                    $e->getMessage(),
+                    $e->getParameters()
+                );
+            }
+        }
 
         if ($this->config->isApiRequest()) {
             return $this->handleView($this->view($user, 400));
@@ -189,7 +199,17 @@ class UserController extends ResourceController
         $user->setConfirmationToken($generator->generateUniqueToken());
         $user->setPasswordRequestedAt(new \DateTime());
 
-        $this->domainManager->update($user);
+        try {
+            $this->domainManager->update($user);
+        } catch (DomainException $e) {
+            if (!$this->config->isApiRequest()) {
+                $this->flashHelper->setFlash(
+                    $e->getType(),
+                    $e->getMessage(),
+                    $e->getParameters()
+                );
+            }
+        }
 
         $dispatcher = $this->get('event_dispatcher');
         $dispatcher->dispatch($senderEvent, new GenericEvent($user));
@@ -215,7 +235,17 @@ class UserController extends ResourceController
         $user->setConfirmationToken(null);
         $user->setPasswordRequestedAt(null);
 
-        $this->domainManager->update($user);
+        try {
+            $this->domainManager->update($user);
+        } catch (DomainException $e) {
+            if (!$this->config->isApiRequest()) {
+                $this->flashHelper->setFlash(
+                    $e->getType(),
+                    $e->getMessage(),
+                    $e->getParameters()
+                );
+            }
+        }
 
         $dispatcher = $this->get('event_dispatcher');
         $dispatcher->dispatch(UserEvents::PASSWORD_RESET_SUCCESS, new GenericEvent($user));
@@ -238,7 +268,17 @@ class UserController extends ResourceController
     {
         $user->setPlainPassword($newPassword);
 
-        $this->domainManager->update($user);
+        try {
+            $this->domainManager->update($user);
+        } catch (DomainException $e) {
+            if (!$this->config->isApiRequest()) {
+                $this->flashHelper->setFlash(
+                    $e->getType(),
+                    $e->getMessage(),
+                    $e->getParameters()
+                );
+            }
+        }
 
         $dispatcher = $this->get('event_dispatcher');
         $dispatcher->dispatch(UserEvents::PASSWORD_RESET_SUCCESS, new GenericEvent($user));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes, DomainManager now throws DomainException
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Remove the ugly flashHelper dependency from DomainManager. Make it return a resource everytime (instead of a mix resource/event).
If there are flashes to define, it must be done from the controller.
Solve the cases where multiple flashes were defined (UserController for example).
Improve usability of ResourceBundle standalone.