### PR TITLE
[CoreBundle] Decouple original locale provider and channel-aware locale provider

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Controller/LocaleController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/LocaleController.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Controller;
+
+use Sylius\Bundle\CoreBundle\Locale\ChannelAwareLocaleProvider;
+use Sylius\Bundle\LocaleBundle\Controller\LocaleController as BaseLocaleController;
+
+/**
+ * Locale controller which is Channel aware.
+ *
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
+ */
+class LocaleController extends BaseLocaleController
+{
+    /**
+     * @return ChannelAwareLocaleProvider
+     */
+    protected function getLocaleProvider()
+    {
+        return $this->get('sylius.channel_aware_locale_provider');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
@@ -24,7 +24,10 @@ sylius_money:
     currency: %sylius.currency%
     locale: %sylius.locale%
 
-sylius_locale: ~
+sylius_locale:
+    classes:
+        locale:
+            controller: Sylius\Bundle\CoreBundle\Controller\LocaleController
 
 sylius_currency: ~
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -73,7 +73,7 @@
         <parameter key="sylius.currency_context.class">Sylius\Bundle\CoreBundle\Context\CurrencyContext</parameter>
         <parameter key="sylius.currency_provider.class">Sylius\Component\Core\Currency\ChannelAwareCurrencyProvider</parameter>
         <parameter key="sylius.context.channel.class">Sylius\Bundle\CoreBundle\Context\ChannelContext</parameter>
-        <parameter key="sylius.locale_provider.class">Sylius\Bundle\CoreBundle\Locale\ChannelAwareLocaleProvider</parameter>
+        <parameter key="sylius.channel_aware_locale_provider.class">Sylius\Bundle\CoreBundle\Locale\ChannelAwareLocaleProvider</parameter>
         <parameter key="sylius.cart_item_resolver.default.class">Sylius\Bundle\CoreBundle\Cart\ItemResolver</parameter>
         <parameter key="sylius.checker.restricted_zone.class">Sylius\Bundle\CoreBundle\Checker\RestrictedZoneChecker</parameter>
         <parameter key="sylius.price_calculator.channel_based.class">Sylius\Component\Core\Pricing\ChannelBasedCalculator</parameter>
@@ -433,7 +433,7 @@
             <argument type="service" id="sylius.context.channel" />
         </service>
 
-        <service id="sylius.locale_provider" class="%sylius.locale_provider.class%">
+        <service id="sylius.channel_aware_locale_provider" class="%sylius.channel_aware_locale_provider.class%">
             <argument type="service" id="sylius.context.channel" />
             <argument>%sylius.locale%</argument>
         </service>

--- a/src/Sylius/Bundle/LocaleBundle/Controller/LocaleController.php
+++ b/src/Sylius/Bundle/LocaleBundle/Controller/LocaleController.php
@@ -11,12 +11,12 @@
 
 namespace Sylius\Bundle\LocaleBundle\Controller;
 
-use Sylius\Bundle\CoreBundle\Locale\ChannelAwareLocaleProvider;
-use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
-use Sylius\Component\Locale\Context\LocaleContext;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Sylius\Component\Locale\Provider\LocaleProviderInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 
 /**
  * Locale controller.
@@ -53,7 +53,7 @@ class LocaleController extends ResourceController
     }
 
     /**
-     * @return LocaleContext
+     * @return LocaleContextInterface
      */
     protected function getLocaleContext()
     {
@@ -61,7 +61,7 @@ class LocaleController extends ResourceController
     }
 
     /**
-     * @return ChannelAwareLocaleProvider
+     * @return LocaleProviderInterface
      */
     protected function getLocaleProvider()
     {

--- a/src/Sylius/Bundle/WebBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/services.xml
@@ -104,7 +104,7 @@
             <argument type="service" id="security.context" />
             <argument type="service" id="translator" />
             <argument type="service" id="event_dispatcher" />
-            <argument type="service" id="sylius.locale_provider" />
+            <argument type="service" id="sylius.channel_aware_locale_provider" />
             <argument type="service" id="sylius.authorization_checker" />
             <call method="setRequest">
                 <argument type="service" id="request" on-invalid="null" strict="false" />


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | no
New feature?  | no
BC breaks? | no
Deprecations? | no
Fixed tickets | Fixes #2944
License | MIT
Doc PR | -

This change allows the admin to see all enabled locales (not only current channel available ones) when editing translations. 

Translations form type is using [LocaleBundle provider](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/CoreBundle/Resources/config/app/main.yml#L160) so it selects all enabled locales.