### PR TITLE
[ArchetypeBundle] Add ON DELETE CASCADE constraint on archetype

### DIFF
--- a/src/Sylius/Bundle/ArchetypeBundle/EventListener/LoadMetadataSubscriber.php
+++ b/src/Sylius/Bundle/ArchetypeBundle/EventListener/LoadMetadataSubscriber.php
@@ -60,7 +60,7 @@ class LoadMetadataSubscriber implements EventSubscriber
                 continue;
             }
 
-            $this->mapVariations($metadata, $class, $subject);
+            $this->mapOptions($metadata, $class, $subject);
             $this->mapAttributes($metadata, $class, $subject);
             $this->mapParent($metadata, $class);
         }
@@ -85,12 +85,14 @@ class LoadMetadataSubscriber implements EventSubscriber
                     'referencedColumnName' => 'id',
                     'nullable'             => false,
                     'unique'               => false,
+                    'onDelete'             => 'CASCADE',
                 )),
                 'inverseJoinColumns'   => array(array(
                     'name'                 => 'attribute_id',
                     'referencedColumnName' => 'id',
                     'nullable'             => false,
                     'unique'               => false,
+                    'onDelete'             => 'CASCADE',
                 ))
             ),
         );
@@ -103,7 +105,7 @@ class LoadMetadataSubscriber implements EventSubscriber
      * @param array                           $class
      * @param string                          $subject
      */
-    private function mapVariations(ClassMetadataInfo $metadata, array $class, $subject)
+    private function mapOptions(ClassMetadataInfo $metadata, array $class, $subject)
     {
         $optionMapping = array(
             'fieldName'    => 'options',
@@ -116,12 +118,14 @@ class LoadMetadataSubscriber implements EventSubscriber
                     'referencedColumnName' => 'id',
                     'nullable'             => false,
                     'unique'               => false,
+                    'onDelete'             => 'CASCADE',
                 )),
                 'inverseJoinColumns'   => array(array(
                     'name'                 => 'option_id',
                     'referencedColumnName' => 'id',
                     'nullable'             => false,
                     'unique'               => false,
+                    'onDelete'             => 'CASCADE',
                 ))
             ),
         );

--- a/src/Sylius/Bundle/ArchetypeBundle/spec/EventListener/LoadMetadataSubscriberSpec.php
+++ b/src/Sylius/Bundle/ArchetypeBundle/spec/EventListener/LoadMetadataSubscriberSpec.php
@@ -78,12 +78,14 @@ class LoadMetadataSubscriberSpec extends ObjectBehavior
                     'referencedColumnName' => 'id',
                     'nullable'             => false,
                     'unique'               => false,
+                    'onDelete'             => 'CASCADE',
                 )),
                 'inverseJoinColumns'   => array(array(
                     'name'                 => 'attribute_id', // or `product_attribute_id` ?
                     'referencedColumnName' => 'id',
                     'nullable'             => false,
                     'unique'               => false,
+                    'onDelete'             => 'CASCADE',
                 ))
             ),
         );
@@ -99,12 +101,14 @@ class LoadMetadataSubscriberSpec extends ObjectBehavior
                     'referencedColumnName' => 'id',
                     'nullable'             => false,
                     'unique'               => false,
+                    'onDelete'             => 'CASCADE',
                 )),
                 'inverseJoinColumns'   => array(array(
                     'name'                 => 'option_id',
                     'referencedColumnName' => 'id',
                     'nullable'             => false,
                     'unique'               => false,
+                    'onDelete'             => 'CASCADE',
                 ))
             ),
         );


### PR DESCRIPTION
Q | A
------------- | -------------
Bug fix? | yes
New feature? | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

When I want to delete a product option, because of the foreign key constraint of `CASCADE` all related records will also get deleted from tables below:
- sylius_product_option
- sylius_product_option_translation
- sylius_product_option_value

but product option relation to product archetype (`sylius_product_archetype_option`) does not have a `CASCADE` constraint (It's currently `RESTRICT`) so a constraint violation occurs.

Is it correct to add `CASCADE ON DELETE` relation constraint?