### PR TITLE
[CoreBundle] Use state machine for order and shipment email confirmation

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
@@ -63,7 +63,7 @@ class SyliusCoreExtension extends AbstractResourceExtension implements PrependEx
         'templating.xml',
         'twig.xml',
         'reports.xml',
-        'mailer.xml',
+        'email.xml',
     );
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/EmailManager/OrderEmailManager.php
+++ b/src/Sylius/Bundle/CoreBundle/EmailManager/OrderEmailManager.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\EmailManager;
+
+use Sylius\Bundle\CoreBundle\Mailer\Emails;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Mailer\Sender\SenderInterface;
+
+/**
+ * Sends the order confirmation email.
+ *
+ * @author Hussein Jafferjee <hussein@jafferjee.ca>
+ */
+class OrderEmailManager
+{
+    /** @var SenderInterface */
+    protected $emailSender;
+
+    /**
+     * @param SenderInterface $emailSender
+     */
+    public function __construct(SenderInterface $emailSender)
+    {
+        $this->emailSender = $emailSender;
+    }
+
+    /**
+     * @param OrderInterface $order
+     */
+    public function sendConfirmationEmail(OrderInterface $order)
+    {
+        $this->emailSender->send(Emails::ORDER_CONFIRMATION, array($order->getCustomer()->getEmail()), array('order' => $order));
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/EmailManager/ShipmentEmailManager.php
+++ b/src/Sylius/Bundle/CoreBundle/EmailManager/ShipmentEmailManager.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\EmailManager;
+
+use Sylius\Bundle\CoreBundle\Mailer\Emails;
+use Sylius\Component\Mailer\Sender\SenderInterface;
+use Sylius\Component\Shipping\Model\ShipmentInterface;
+
+/**
+ * Sends the shipment confirmation email.
+ *
+ * @author Hussein Jafferjee <hussein@jafferjee.ca>
+ */
+class ShipmentEmailManager
+{
+    /** @var SenderInterface */
+    protected $emailSender;
+
+    /**
+     * @param SenderInterface $emailSender
+     */
+    public function __construct(SenderInterface $emailSender)
+    {
+        $this->emailSender = $emailSender;
+    }
+
+    /**
+     * @param ShipmentInterface $shipment
+     */
+    public function sendConfirmationEmail(ShipmentInterface $shipment)
+    {
+        /** @var \Sylius\Component\Core\Model\OrderInterface $order */
+        $order = $shipment->getOrder();
+
+        $this->emailSender->send(Emails::SHIPMENT_CONFIRMATION, array($order->getCustomer()->getEmail()), array(
+            'shipment' => $shipment,
+            'order' => $order
+        ));
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/EventListener/MailerListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/MailerListener.php
@@ -42,49 +42,6 @@ class MailerListener
      *
      * @throws UnexpectedTypeException
      */
-    public function sendOrderConfirmationEmail(GenericEvent $event)
-    {
-        $order = $event->getSubject();
-
-        if (!$order instanceof OrderInterface) {
-            throw new UnexpectedTypeException(
-                $order,
-                'Sylius\Component\Core\Model\OrderInterface'
-            );
-        }
-
-        $this->emailSender->send(Emails::ORDER_CONFIRMATION, array($order->getCustomer()->getEmail()), array('order' => $order));
-    }
-
-    /**
-     * @param GenericEvent $event
-     *
-     * @throws UnexpectedTypeException
-     */
-    public function sendShipmentConfirmationEmail(GenericEvent $event)
-    {
-        $shipment = $event->getSubject();
-
-        if (!$shipment instanceof ShipmentInterface) {
-            throw new UnexpectedTypeException(
-                $shipment,
-                'Sylius\Component\Shipping\Model\ShipmentInterface'
-            );
-        }
-
-        /** @var OrderInterface $order */
-        $order = $shipment->getOrder();
-        $this->emailSender->send(Emails::SHIPMENT_CONFIRMATION, array($order->getCustomer()->getEmail()), array(
-            'shipment' => $shipment,
-            'order' => $order
-        ));
-    }
-
-    /**
-     * @param GenericEvent $event
-     *
-     * @throws UnexpectedTypeException
-     */
     public function sendUserConfirmationEmail(GenericEvent $event)
     {
         $customer = $event->getSubject();

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/email.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/email.xml
@@ -18,16 +18,24 @@
 
     <parameters>
         <parameter key="sylius.listener.mailer.class">Sylius\Bundle\CoreBundle\EventListener\MailerListener</parameter>
+        <parameter key="sylius.email_manager.order.class">Sylius\Bundle\CoreBundle\EmailManager\OrderEmailManager</parameter>
+        <parameter key="sylius.email_manager.shipment.class">Sylius\Bundle\CoreBundle\EmailManager\ShipmentEmailManager</parameter>
     </parameters>
 
     <services>
         <service id="sylius.listener.mailer" class="%sylius.listener.mailer.class%">
             <argument type="service" id="sylius.email_sender" />
-            <tag name="kernel.event_listener" event="sylius.checkout.finalize.complete" method="sendOrderConfirmationEmail" />
-            <tag name="kernel.event_listener" event="sylius.shipment.post_update" method="sendShipmentConfirmationEmail" />
             <tag name="kernel.event_listener" event="sylius.customer.post_create" method="sendUserConfirmationEmail" />
             <tag name="kernel.event_listener" event="sylius.customer.post_register" method="sendUserConfirmationEmail" />
             <tag name="kernel.event_listener" event="sylius.comment.post_create" method="sendOrderCommentEmail" />
+        </service>
+
+        <service id="sylius.email_manager.order" class="%sylius.email_manager.order.class%">
+            <argument type="service" id="sylius.email_sender" />
+        </service>
+
+        <service id="sylius.email_manager.shipment" class="%sylius.email_manager.shipment.class%">
+            <argument type="service" id="sylius.email_sender" />
         </service>
     </services>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/state-machine.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/state-machine.yml
@@ -119,7 +119,10 @@ winzou_state_machine:
                     on:   'confirm'
                     do:   [@sylius.callback.coupon_usage, 'incrementCouponUsage']
                     args: ['object']
-
+                sylius_order_confirmation_email:
+                    on:   ['confirm']
+                    do:   [@sylius.email_manager.order, 'sendConfirmationEmail']
+                    args: ['object']
                 sylius_release_inventory:
                     on:   'release'
                     do:   [@sylius.order_processing.inventory_handler, 'releaseInventory']
@@ -164,3 +167,7 @@ winzou_state_machine:
                     to:   'shipped'
                     do:   [@sylius.callback.order_shipment, 'updateOrderShippingState']
                     args: ['object.getOrder()']
+                sylius_shipping_confirmation_email:
+                    to:   'shipped'
+                    do:   [@sylius.email_manager.shipment, 'sendConfirmationEmail']
+                    args: ['object']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | https://github.com/Sylius/Sylius/issues/2915, https://github.com/Sylius/Sylius/issues/2514
| License       | MIT
| Doc PR        | 

Pretty simple PR, just moves the order and shipment confirmation email listeners to use the state machine instead of the event listener. In that process, it also fixes a bug. (Order email confirmation listener was bound to the wrong event).