### PR TITLE
Add optional $options parameters to getForm method

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -382,10 +382,11 @@ class ResourceController extends FOSRestController
 
     /**
      * @param object|null $resource
+     * @param array       $options
      *
      * @return FormInterface
      */
-    public function getForm($resource = null)
+    public function getForm($resource = null, array $options = array())
     {
         $type = $this->config->getFormType();
 
@@ -399,10 +400,10 @@ class ResourceController extends FOSRestController
         }
 
         if ($this->config->isApiRequest()) {
-            return $this->container->get('form.factory')->createNamed('', $type, $resource, array('csrf_protection' => false));
+            return $this->container->get('form.factory')->createNamed('', $type, $resource, array_merge($options, array('csrf_protection' => false)));
         }
 
-        return $this->createForm($type, $resource);
+        return $this->createForm($type, $resource, $options);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | kind of
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Just add the ability to pass options when creating form from ResourceController.