### PR TITLE
[TranslationBundle] TranslatableResourceRepository->find() yield incorrect counts on multilang setups

### DIFF
--- a/src/Sylius/Bundle/TranslationBundle/Doctrine/ORM/TranslatableResourceRepository.php
+++ b/src/Sylius/Bundle/TranslationBundle/Doctrine/ORM/TranslatableResourceRepository.php
@@ -43,6 +43,8 @@ class TranslatableResourceRepository extends EntityRepository implements Transla
         $queryBuilder
             ->addSelect('translation')
             ->leftJoin($this->getAlias().'.translations', 'translation')
+            ->andWhere('translation.locale = :locale')
+            ->setParameter('locale', $this->localeProvider->getCurrentLocale())
         ;
 
         return $queryBuilder;
@@ -58,6 +60,8 @@ class TranslatableResourceRepository extends EntityRepository implements Transla
         $queryBuilder
             ->addSelect('translation')
             ->leftJoin($this->getAlias().'.translations', 'translation')
+            ->andWhere('translation.locale = :locale')
+            ->setParameter('locale', $this->localeProvider->getCurrentLocale())
         ;
 
         return $queryBuilder;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes (partial fix) |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

`TranslatableResourceRepository` selects all translations instead of one, thus reducing offer counts. See attached screenshots for front page "productRepo->findLatest(9)" call (cleaned up doctrine):

before fix:
<img width="586" alt="screenshot 2015-07-05 20 55 31" src="https://cloud.githubusercontent.com/assets/1804210/8512711/6297874e-2358-11e5-9409-de05ae2e4684.png">

after fix:
<img width="593" alt="screenshot 2015-07-05 21 05 53" src="https://cloud.githubusercontent.com/assets/1804210/8512737/9e5d1bda-2359-11e5-8265-81f999e4c8b2.png">

Problem - does not respect `fallback` locale.
