### PR TITLE
Enable header redirection in RedirectHandler

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
@@ -383,4 +383,15 @@ class Configuration
     {
         return $this->parameters->get('permission', $default);
     }
+
+    public function isHeaderRedirection()
+    {
+        $redirect = $this->parameters->get('redirect');
+
+        if (!is_array($redirect) || !isset($redirect['header'])) {
+            return false;
+        }
+
+        return (bool) $redirect['header'];
+    }
 }

--- a/src/Sylius/Bundle/ResourceBundle/Controller/RedirectHandler.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/RedirectHandler.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\ResourceBundle\Controller;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -83,6 +84,12 @@ class RedirectHandler
      */
     public function redirect($url, $status = 302)
     {
+        if ($this->config->isHeaderRedirection()) {
+            return new Response('', 200, array(
+                'X-SYLIUS-LOCATION' => $url.$this->config->getRedirectHash(),
+            ));
+        }
+
         return new RedirectResponse($url.$this->config->getRedirectHash(), $status);
     }
 

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/RedirectHandlerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/RedirectHandlerSpec.php
@@ -27,6 +27,7 @@ class RedirectHandlerSpec extends ObjectBehavior
         $config->getRedirectRoute('show')->willReturn('my_route');
         $router->generate('my_route', array())->willReturn('http://myurl.com');
         $config->getRedirectHash()->willReturn(null);
+        $config->isHeaderRedirection()->willReturn(false);
 
         $this->redirectTo('resource')->shouldHaveType('Symfony\Component\HttpFoundation\RedirectResponse');
     }
@@ -37,6 +38,7 @@ class RedirectHandlerSpec extends ObjectBehavior
         $config->getRedirectParameters()->willReturn(array());
         $router->generate('my_route', array())->willReturn('http://myurl.com');
         $config->getRedirectHash()->willReturn(null);
+        $config->isHeaderRedirection()->willReturn(false);
 
         $this->redirectToIndex()->shouldHaveType('Symfony\Component\HttpFoundation\RedirectResponse');
     }
@@ -52,6 +54,7 @@ class RedirectHandlerSpec extends ObjectBehavior
     function it_redirects($config)
     {
         $config->getRedirectHash()->willReturn(null);
+        $config->isHeaderRedirection()->willReturn(false);
         $this->redirect('http://myurl.com')->shouldHaveType('Symfony\Component\HttpFoundation\RedirectResponse');
     }
 
@@ -63,7 +66,16 @@ class RedirectHandlerSpec extends ObjectBehavior
         $config->getRequest()->willreturn($request);
         $config->getRedirectHash()->willReturn(null);
         $config->getRedirectReferer()->willreturn('http://myurl.com');
+        $config->isHeaderRedirection()->willReturn(false);
 
         $this->redirectToReferer()->shouldHaveType('Symfony\Component\HttpFoundation\RedirectResponse');
+    }
+
+    function it_redirects_with_header($config)
+    {
+        $config->getRedirectHash()->willReturn(null);
+        $config->isHeaderRedirection()->willReturn(true);
+
+        $this->redirect('http://myurl.com')->shouldHaveType('Symfony\Component\HttpFoundation\Response');
     }
 }


### PR DESCRIPTION
Q | A
------------- | -------------
Bug fix? | no
New feature? | kind of
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

Add the ability to intercept a redirection. Use case: an xhr request. In javascript it is not possible to catch a redirection, so this way enable the JS to get this HTTP 200 response, and read the defined `X-SYLIUS-LOCATION` header, so that it can decide to redirect or not.