### PR TITLE
Fix country sorting

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/country.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/country.yml
@@ -11,7 +11,7 @@ sylius_backend_country_index:
             sortable: true
             paginate: 50
             sorting:
-                name: asc
+                isoName: asc
 
 sylius_backend_country_create:
     path: /new


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Fix the exception on `sylius_backend_country_index` page:

    RuntimeException: Cannot select distinct identifiers from query with LIMIT and ORDER BY
    on a column from a fetch joined to-many association. Use output walkers.

cf. http://demo.sylius.org/administration/countries/