### PR TITLE
Fix FormType options not being passed when using symfony 2.7

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Form/Type/AbstractResourceType.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/Type/AbstractResourceType.php
@@ -12,7 +12,7 @@
 namespace Sylius\Bundle\ResourceBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Arnaud Langlade <arn0d.dev@gmail.com>
@@ -42,7 +42,7 @@ abstract class AbstractResourceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => $this->dataClass,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | yes
| Fixed tickets | https://github.com/Sylius/Sylius/issues/2985
| License       | MIT
| Doc PR        | 

Fixes the options after upgrading to Symfony 2.7. Currently the options can not be used.