### PR TITLE
[AttributeBundle] Product attribute value is not API friendly

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/Form/EventListener/BuildAttributeValueFormListener.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/EventListener/BuildAttributeValueFormListener.php
@@ -89,9 +89,7 @@ class BuildAttributeValueFormListener implements EventSubscriberInterface
 
         $this->verifyValue($attributeValue);
 
-        // If we're editing the attribute value, let's just render the value field, not full selection.
         $form
-            ->remove('attribute')
             ->add($this->factory->createNamed('value', $attributeValue->getType(), null, $options))
         ;
     }

--- a/src/Sylius/Bundle/AttributeBundle/spec/Form/EventListener/BuildAttributeValueFormListenerSpec.php
+++ b/src/Sylius/Bundle/AttributeBundle/spec/Form/EventListener/BuildAttributeValueFormListenerSpec.php
@@ -65,7 +65,6 @@ class BuildAttributeValueFormListenerSpec extends ObjectBehavior
 
         $formFactory->createNamed('value', 'checkbox', null, array('label' => 'My name', 'auto_initialize' => false))->willReturn($valueField)->shouldBeCalled();
 
-        $form->remove('attribute')->shouldBeCalled()->willReturn($form);
         $form->add($valueField)->shouldBeCalled()->willReturn($form);
 
         $this->buildForm($event);
@@ -102,7 +101,6 @@ class BuildAttributeValueFormListenerSpec extends ObjectBehavior
             ->shouldBeCalled()
         ;
 
-        $form->remove('attribute')->shouldBeCalled()->willReturn($form);
         $form->add($valueField)->shouldBeCalled()->willReturn($form);
 
         $this->buildForm($event);


### PR DESCRIPTION
Q | A
------------- | -------------
Bug fix? | yes
New feature? | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

In product attribute value form, there an event listener which tries to remove `attribute` field. But when we're using this form in APIs removing this field is going to raise some issues. (Form serialization, extra fields, etc)

So if removing this field is only for a better view, IMO it's better to keep than make the form unsable in some situations.

What do you think?