### PR TITLE
[AttribtueBundle] Set correct value data on sylius_*_attribute_value form

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/Form/EventListener/BuildAttributeValueFormListener.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/EventListener/BuildAttributeValueFormListener.php
@@ -81,7 +81,11 @@ class BuildAttributeValueFormListener implements EventSubscriberInterface
             return;
         }
 
-        $options = array('label' => $attributeValue->getName(), 'auto_initialize' => false);
+        $options = array(
+            'label' => $attributeValue->getName(),
+            'auto_initialize' => false,
+            'property_path' => 'realValue'
+        );
 
         if (is_array($attributeValue->getConfiguration())) {
             $options = array_merge($options, $attributeValue->getConfiguration());

--- a/src/Sylius/Bundle/AttributeBundle/spec/Form/EventListener/BuildAttributeValueFormListenerSpec.php
+++ b/src/Sylius/Bundle/AttributeBundle/spec/Form/EventListener/BuildAttributeValueFormListenerSpec.php
@@ -63,7 +63,7 @@ class BuildAttributeValueFormListenerSpec extends ObjectBehavior
         $event->getData()->willReturn($productAttribute);
         $event->getForm()->willReturn($form);
 
-        $formFactory->createNamed('value', 'checkbox', null, array('label' => 'My name', 'auto_initialize' => false))->willReturn($valueField)->shouldBeCalled();
+        $formFactory->createNamed('value', 'checkbox', null, array('label' => 'My name', 'auto_initialize' => false, 'property_path' => 'realValue'))->willReturn($valueField)->shouldBeCalled();
 
         $form->remove('attribute')->shouldBeCalled()->willReturn($form);
         $form->add($valueField)->shouldBeCalled()->willReturn($form);
@@ -96,7 +96,7 @@ class BuildAttributeValueFormListenerSpec extends ObjectBehavior
                 'value',
                 'choice',
                 null,
-                array('label' => 'My name', 'auto_initialize' => false, 'choices' => array('red' => 'Red', 'blue' => 'Blue'))
+                array('label' => 'My name', 'auto_initialize' => false, 'property_path' => 'realValue', 'choices' => array('red' => 'Red', 'blue' => 'Blue'))
             )
             ->willReturn($valueField)
             ->shouldBeCalled()

--- a/src/Sylius/Component/Attribute/Model/AttributeValue.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeValue.php
@@ -120,6 +120,28 @@ class AttributeValue implements AttributeValueInterface
     /**
      * {@inheritdoc}
      */
+    public function getRealValue()
+    {
+        if ($this->attribute && AttributeTypes::CHECKBOX === $this->attribute->getType()) {
+            return (Boolean) $this->value;
+        }
+
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setRealValue($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setValue($value)
     {
         $this->value = $value;


### PR DESCRIPTION
Q | A
------------- | -------------
Bug fix? | yes
New feature? | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

Because of [this portion](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Component/Attribute/Model/AttributeValue.php#L110-L115) of the code, `value` field is going to be filled with choice's presentation (not index) which is the desired behavior for a lot of UI situations, but not when setting the form's data, which expects the real data. (Current choice's index) 

I don't like adding this new method, but is there any better way I'm missing?