### PR TITLE
Add extension point to add template data

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "308a982c7cd2939d2ae9d778a0e87a21",
+    "hash": "b6d17dfe5edbd8dd93885622a0c0af64",
     "packages": [
         {
             "name": "a2lix/translation-form-bundle",
@@ -1538,50 +1538,56 @@
         },
         {
             "name": "friendsofsymfony/rest-bundle",
-            "version": "1.5.0",
+            "version": "1.7.1",
             "target-dir": "FOS/RestBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfSymfony/FOSRestBundle.git",
-                "reference": "a9377f6a05fb516423d6adf9079c6e5fb41e4799"
+                "reference": "3fb2d30c58cde59213dbddd031bc36171b8b68b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSRestBundle/zipball/a9377f6a05fb516423d6adf9079c6e5fb41e4799",
-                "reference": "a9377f6a05fb516423d6adf9079c6e5fb41e4799",
+                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSRestBundle/zipball/3fb2d30c58cde59213dbddd031bc36171b8b68b6",
+                "reference": "3fb2d30c58cde59213dbddd031bc36171b8b68b6",
                 "shasum": ""
             },
             "require": {
                 "doctrine/inflector": "~1.0",
                 "php": ">=5.3.9",
                 "psr/log": "~1.0",
-                "symfony/framework-bundle": "~2.2",
+                "symfony/framework-bundle": "~2.3",
+                "symfony/http-kernel": "~2.3,>=2.3.24",
                 "willdurand/jsonp-callback-validator": "~1.0",
                 "willdurand/negotiation": "~1.2"
             },
             "conflict": {
                 "jms/serializer": "<0.12",
-                "jms/serializer-bundle": "<0.11"
+                "jms/serializer-bundle": "<0.11",
+                "symfony/validator": ">=2.5.0,<2.5.5"
             },
             "require-dev": {
+                "jms/serializer": "~0.13",
                 "jms/serializer-bundle": "~0.12",
-                "sensio/framework-extra-bundle": "~2.2",
-                "symfony/form": "~2.2",
-                "symfony/security": "~2.2",
-                "symfony/serializer": "~2.2",
-                "symfony/validator": "~2.2",
-                "symfony/yaml": "~2.2"
+                "phpoption/phpoption": "~1.1.0",
+                "sensio/framework-extra-bundle": "~3.0",
+                "symfony/browser-kit": "~2.3",
+                "symfony/dependency-injection": "~2.3",
+                "symfony/form": "~2.3",
+                "symfony/security": "~2.3",
+                "symfony/serializer": "~2.3",
+                "symfony/validator": "~2.3",
+                "symfony/yaml": "~2.3"
             },
             "suggest": {
                 "jms/serializer-bundle": "Add support for advanced serialization capabilities, recommended, requires ~0.12",
-                "sensio/framework-extra-bundle": "Add support for route annotations and the view response listener",
-                "symfony/serializer": "Add support for basic serialization capabilities and xml decoding, requires ~2.2",
-                "symfony/validator": "Add support for validation capabilities in the ParamFetcher, requires ~2.2"
+                "sensio/framework-extra-bundle": "Add support for route annotations and the view response listener, requires ~3.0",
+                "symfony/serializer": "Add support for basic serialization capabilities and xml decoding, requires ~2.3",
+                "symfony/validator": "Add support for validation capabilities in the ParamFetcher, requires ~2.3"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.7-dev"
                 }
             },
             "autoload": {

--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -109,11 +109,14 @@ class ResourceController extends FOSRestController
     {
         $this->isGrantedOr403('show');
 
+        $resource = $this->findOr404($request);
+
         $view = $this
             ->view()
             ->setTemplate($this->config->getTemplate('show.html'))
             ->setTemplateVar($this->config->getResourceName())
-            ->setData($this->findOr404($request))
+            ->setData($resource)
+            ->setTemplateData($this->getTemplateData($resource, 'show'))
         ;
 
         return $this->handleView($view);
@@ -164,6 +167,7 @@ class ResourceController extends FOSRestController
             ->setTemplate($this->config->getTemplate('index.html'))
             ->setTemplateVar($this->config->getPluralResourceName())
             ->setData($resources)
+            ->setTemplateData($this->getTemplateData($resources, 'index'))
         ;
 
         return $this->handleView($view);
@@ -210,6 +214,7 @@ class ResourceController extends FOSRestController
                 $this->config->getResourceName() => $resource,
                 'form'                           => $form->createView(),
             ))
+            ->setTemplateData($this->getTemplateData($resource, 'create'))
         ;
 
         return $this->handleView($view);
@@ -256,6 +261,7 @@ class ResourceController extends FOSRestController
                 $this->config->getResourceName() => $resource,
                 'form'                           => $form->createView(),
             ))
+            ->setTemplateData($this->getTemplateData($resource, 'update'))
         ;
 
         return $this->handleView($view);
@@ -507,5 +513,10 @@ class ResourceController extends FOSRestController
                 throw new AccessDeniedException(sprintf('Access denied to "%s" for "%s".', $grant, $this->getUser() ? $this->getUser()->getUsername() : 'anon.'));
             }
         }
+    }
+
+    protected function getTemplateData($resource, $action = 'show')
+    {
+        return array();
     }
 }


### PR DESCRIPTION
Q | A
------------- | -------------
Bug fix? | no
New feature? | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

Update FOSRestBundle to have the setTemplateData method, and add an extension point to add template data without overriding the whole action in ResourceController.

Side modification: in create/update action, do not set the form template data as it is automatically added by the ViewHandler cf [ViewHandler.php#L384-385](https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/View/ViewHandler.php#L384-385)