### PR TITLE
Add xhr option to header redirection

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
@@ -392,6 +392,10 @@ class Configuration
             return false;
         }
 
+        if ('xhr' === $redirect['header']) {
+            return $this->getRequest()->isXmlHttpRequest();
+        }
+
         return (bool) $redirect['header'];
     }
 }


### PR DESCRIPTION
Q | A
------------- | -------------
Bug fix? | no
New feature? | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

So that with the same route, you can choose to have an header redirection only when the request is done by XmlHttpRequest. Very useful!

I was wondering if this should be the default behavior, but at the end with these values (true, false or 'xhr') we can let the developer choose.