### PR TITLE
[Taxonomy] Set root taxon locale based on current taxonomy locale

### DIFF
--- a/src/Sylius/Component/Taxonomy/Model/Taxonomy.php
+++ b/src/Sylius/Component/Taxonomy/Model/Taxonomy.php
@@ -66,13 +66,33 @@ class Taxonomy extends AbstractTranslatable implements TaxonomyInterface
     public function setName($name)
     {
         $this->translate()->setName($name);
-
-        $this->root->setCurrentLocale($this->getCurrentLocale());
-        $this->root->setFallbackLocale($this->getFallbackLocale());
-
         $this->root->setName($name);
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCurrentLocale($currentLocale)
+    {
+        if (null !== $this->root) {
+            $this->root->setCurrentLocale($currentLocale);
+        }
+
+        return parent::setCurrentLocale($currentLocale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setFallbackLocale($fallbackLocale)
+    {
+        if (null !== $this->root) {
+            $this->root->setFallbackLocale($fallbackLocale);
+        }
+
+        return parent::setFallbackLocale($fallbackLocale);
     }
 
     /**
@@ -89,6 +109,8 @@ class Taxonomy extends AbstractTranslatable implements TaxonomyInterface
     public function setRoot(TaxonInterface $root)
     {
         $root->setTaxonomy($this);
+        $root->setCurrentLocale($this->getCurrentLocale());
+        $root->setFallbackLocale($this->getFallbackLocale());
 
         $this->root = $root;
 

--- a/src/Sylius/Component/Taxonomy/spec/Model/TaxonomySpec.php
+++ b/src/Sylius/Component/Taxonomy/spec/Model/TaxonomySpec.php
@@ -70,11 +70,22 @@ class TaxonomySpec extends ObjectBehavior
         $this->getName()->shouldReturn(null);
     }
 
+    function it_delegates_current_and_fallback_locale_to_root_taxon(Taxon $taxon)
+    {
+        $taxon->setCurrentLocale('en_US')->shouldBeCalled();
+        $taxon->setFallbackLocale('en_US')->shouldBeCalled();
+        $taxon->setTaxonomy($this)->shouldBeCalled();
+
+        $this->setRoot($taxon);
+
+        $this->setCurrentLocale('en_US');
+        $this->setFallbackLocale('en_US');
+    }
+
     function its_name_is_mutable(Taxon $taxon)
     {
         $taxon->setName('Brand')->shouldBeCalled();
         $taxon->setTaxonomy($this)->shouldBeCalled();
-
         $taxon->setCurrentLocale('en_US')->shouldBeCalled();
         $taxon->setFallbackLocale('en_US')->shouldBeCalled();
 
@@ -86,11 +97,10 @@ class TaxonomySpec extends ObjectBehavior
 
     function it_also_sets_name_on_the_root_taxon(Taxon $taxon)
     {
-        $taxon->setName('Category')->shouldBeCalled();
-        $taxon->setTaxonomy($this)->shouldBeCalled();
-
         $taxon->setCurrentLocale('en_US')->shouldBeCalled();
         $taxon->setFallbackLocale('en_US')->shouldBeCalled();
+        $taxon->setName('Category')->shouldBeCalled();
+        $taxon->setTaxonomy($this)->shouldBeCalled();
 
         $this->setRoot($taxon);
 


### PR DESCRIPTION
Q | A
------------- | -------------
Bug fix? | yes
New feature? | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

Sometimes (e.g. submitting forms) entity's `Translation`s current locale is not set so we need to set it manually. 

Our current issue is that after creating `Taxonomy` from API `$resource` is going to be serialized for the response, because `$currentLocale` on root Taxon is not set we're going to have a `No current locale` exception.