### PR TITLE
[ResourceBundle] Configurable form actions in ResourceController

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/Configuration.php
@@ -251,6 +251,27 @@ class Configuration
         return $parameters;
     }
 
+    public function getTargetRoute($default = null)
+    {
+        $target = $this->parameters->get('target', array('route' => $default));
+
+        return is_array($target) ? $target['route'] : $target;
+    }
+
+    public function getTargetParameters(array $default = array())
+    {
+        $target = $this->parameters->get('target', array());
+
+        return isset($target['parameters']) ? $target['parameters'] : $default;
+    }
+
+    public function getTargetMethod($default = null)
+    {
+        $target = $this->parameters->get('target', array());
+
+        return isset($target['method']) ? $target['method'] : $default;
+    }
+
     public function isLimited()
     {
         return (bool) $this->parameters->get('limit', $this->settings['limit']);

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/taxon.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/taxon.yml
@@ -1,9 +1,22 @@
 # This file is part of the Sylius package.
 # (c) Paweł Jędrzejewski
 #
-sylius_backend_taxon_create:
+sylius_backend_taxon_new:
     path: /new
     methods: [GET, POST]
+    defaults:
+        _controller: sylius.controller.taxon:newAction
+        _sylius:
+            template: SyliusWebBundle:Backend/Taxon:create.html.twig
+            redirect:
+                route: sylius_backend_taxonomy_show
+                parameters: {'id': $taxonomyId}
+            target:
+                route: sylius_backend_taxon_create
+
+sylius_backend_taxon_create:
+    path: /
+    methods: [POST]
     defaults:
         _controller: sylius.controller.taxon:createAction
         _sylius:

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/create.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/create.html.twig
@@ -17,9 +17,8 @@
 </div>
 
 {{ form_errors(form) }}
-
-<form action="{{ path('sylius_backend_taxon_create', {'taxonomyId': taxon.taxonomy.id}) }}" method="post" class="form-horizontal" {{ form_enctype(form) }} novalidate>
-    {% include 'SyliusWebBundle:Backend/Taxon:_form.html.twig' %}
-    {{ create() }}
-</form>
+{{ form_start(form, {'attr': {'class': 'form-horizontal', 'novalidate': ''}}) }}
+{% include 'SyliusWebBundle:Backend/Taxon:_form.html.twig' %}
+{{ create() }}
+{{ form_end(form) }}
 {% endblock %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/macros.html.twig
@@ -38,9 +38,19 @@
     </td>
     <td>
         <div class="pull-right">
-        {{ buttons.generic(path('sylius_backend_taxon_product_index', {'taxonomyId': taxonomy.id, 'id': taxon.id}), 'sylius.browse_products'|trans) }}
-        {{ buttons.edit(path('sylius_backend_taxon_update', {'taxonomyId': taxonomy.id, 'id': taxon.id})) }}
-        {{ buttons.delete(path('sylius_backend_taxon_delete', {'taxonomyId': taxonomy.id, 'id': taxon.id})) }}
+            {#<form action="{{ path('sylius_backend_taxon_new', {'taxonomyId': taxonomy.id}) }}" method="post"
+                              class="delete-action-form" novalidate>
+                            <input type="hidden" name="sylius_taxon[parent]" value="{{ taxon.id }}">
+                            <input type="hidden" name="sylius_taxon[_token]" value="{{ }}">
+                            <button class="btn btn-{{ button|default('success') }}" type="submit">
+                                <i class="glyphicon glyphicon-plus-sign"></i>
+                                <span>{{ 'sylius.taxon.create_child'|trans }}</span>
+                            </button>
+                        </form>#}
+            {{ buttons.create(path('sylius_backend_taxon_new', {'taxonomyId': taxonomy.id, 'sylius_taxon': {'parent': taxon.id, '_token': csrf_token("sylius_taxon")}}), 'sylius.taxon.create_child'|trans) }}
+            {{ buttons.generic(path('sylius_backend_taxon_product_index', {'taxonomyId': taxonomy.id, 'id': taxon.id}), 'sylius.browse_products'|trans) }}
+            {{ buttons.edit(path('sylius_backend_taxon_update', {'taxonomyId': taxonomy.id, 'id': taxon.id})) }}
+            {{ buttons.delete(path('sylius_backend_taxon_delete', {'taxonomyId': taxonomy.id, 'id': taxon.id})) }}
         </div>
     </td>
 </tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/productIndex.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/productIndex.html.twig
@@ -19,7 +19,7 @@
 {% block content %}
 <div class="page-header">
     <div class="actions-menu">
-        {{ buttons.create(path('sylius_backend_taxon_create', {'taxonomyId': taxonomy.id}), 'sylius.taxon.create'|trans) }}
+        {{ buttons.create(path('sylius_backend_taxon_new', {'taxonomyId': taxonomy.id}), 'sylius.taxon.create'|trans) }}
         {{ buttons.manage(path('sylius_backend_taxonomy_index'), 'sylius.taxonomy.manage'|trans) }}
     </div>
     <h1><i class="glyphicon glyphicon-tags"></i> {{ 'sylius.taxon.product_index_header'|trans({'%name%': taxon.name})|raw }}</h1>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/update.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/update.html.twig
@@ -19,9 +19,8 @@
 
 {{ form_errors(form) }}
 
-<form action="{{ path('sylius_backend_taxon_update', {'taxonomyId': taxon.taxonomy.id, 'id': taxon.id}) }}" method="post"  class="form-horizontal" {{ form_enctype(form) }}novalidate>
-    <input type="hidden" name="_method" value="PUT">
-    {% include 'SyliusWebBundle:Backend/Taxon:_form.html.twig' %}
-    {{ update() }}
-</form>
+{{ form_start(form, {'attr': {'class': 'form-horizontal', 'novalidate': ''}}) }}
+{% include 'SyliusWebBundle:Backend/Taxon:_form.html.twig' %}
+{{ update() }}
+{{ form_end(form) }}
 {% endblock %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxonomy/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxonomy/macros.html.twig
@@ -31,7 +31,7 @@
             </td>
             <td>
                 <div class="pull-right">
-                    {{ buttons.create(path('sylius_backend_taxon_create', {'taxonomyId': taxonomy.id}), 'sylius.taxon.create'|trans)|raw }}
+                    {{ buttons.create(path('sylius_backend_taxon_new', {'taxonomyId': taxonomy.id}), 'sylius.taxon.create'|trans)|raw }}
                     {{ buttons.edit(path('sylius_backend_taxonomy_update', {'id': taxonomy.id})) }}
                     {{ buttons.delete(path('sylius_backend_taxonomy_delete', {'id': taxonomy.id})) }}
                 </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxonomy/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxonomy/show.html.twig
@@ -14,7 +14,7 @@
 {% block content %}
 <div class="page-header">
     <div class="actions-menu">
-        {{ buttons.create(path('sylius_backend_taxon_create', {'taxonomyId': taxonomy.id}), 'sylius.taxon.create'|trans) }}
+        {{ buttons.create(path('sylius_backend_taxon_new', {'taxonomyId': taxonomy.id}), 'sylius.taxon.create'|trans) }}
         {{ buttons.manage(path('sylius_backend_taxonomy_index'), 'sylius.taxonomy.manage'|trans) }}
     </div>
     <h1><i class="glyphicon glyphicon-tags"></i> {{ 'sylius.taxonomy.show_header'|trans({'%name%': taxonomy.name})|raw }}</h1>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Two features:
1) Set form `action` and `method` attributes in ResourceController and remove this attributes from view templates (Now its possible create FormExtenson than add attribute 'novalidate' for all forms).
2) New `newAction` and `editAction` of ResourceController. They render resource form and with some data from request. Its usefull for creating some dynamic forms.  For i.e. now user go to taxon create form with selected parent taxon by direct link (or by button).

Waiting for feedback...