### PR TITLE
Replace dot with underscore in parameter name.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Context/CurrencyContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Context/CurrencyContext.php
@@ -26,7 +26,7 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
  */
 class CurrencyContext extends BaseCurrencyContext
 {
-    const STORAGE_KEY = '_sylius.currency.%s';
+    const STORAGE_KEY = '_sylius_currency_%s';
 
     protected $securityContext;
     protected $settingsManager;

--- a/src/Sylius/Bundle/FlowBundle/Storage/SessionFlowsBag.php
+++ b/src/Sylius/Bundle/FlowBundle/Storage/SessionFlowsBag.php
@@ -20,8 +20,8 @@ use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
  */
 class SessionFlowsBag extends NamespacedAttributeBag
 {
-    const STORAGE_KEY = 'sylius.flow.bag';
-    const NAME        = 'sylius.flow.bag';
+    const STORAGE_KEY = '_sylius_flow_bag';
+    const NAME        = '_sylius_flow_bag';
 
     /**
      * Constructor.

--- a/src/Sylius/Component/Core/Locale/LocaleContext.php
+++ b/src/Sylius/Component/Core/Locale/LocaleContext.php
@@ -20,7 +20,7 @@ use Sylius\Component\Storage\StorageInterface;
  */
 class LocaleContext implements LocaleContextInterface
 {
-    const STORAGE_KEY = '_sylius.locale.%s';
+    const STORAGE_KEY = '_sylius_locale_%s';
 
     /**
      * @var ChannelContextInterface


### PR DESCRIPTION
Bug fix: yes
BC break: no

Dots are replaced by underscores in PHP, so we should avoid using dot in parameter name. (ie: cookie name)

Without this fix, `CookieStorage` will not be able to retrieve what it set.

See more discussion in Symfony: https://github.com/symfony/symfony/issues/9009