### PR TITLE
Fixed empty product slug bug

### DIFF
--- a/features/frontend/products.feature
+++ b/features/frontend/products.feature
@@ -59,3 +59,7 @@ Feature: Products
         Given I am on the store homepage
         Then I should see "Super T-Shirt"
         But I should not see "Black T-Shirt"
+
+    Scenario: Receiving exception while entering page for product with empty slug
+        Given I go to page for product with empty slug
+         Then the response status code should be 404

--- a/src/Sylius/Bundle/CoreBundle/Routing/RouteProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Routing/RouteProvider.php
@@ -134,9 +134,14 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
             ) {
                 $value = substr($path, strlen($this->routeConfigs[$className]['prefix']));
                 $value = trim($value, '/');
+
+                if (empty($value)) {
+                    continue;
+                }
+
                 $entity = $repository->findOneBy(array($this->routeConfigs[$className]['field'] => $value));
 
-                if (!$entity) {
+                if (null === $entity) {
                     continue;
                 }
 

--- a/src/Sylius/Bundle/WebBundle/Behat/WebContext.php
+++ b/src/Sylius/Bundle/WebBundle/Behat/WebContext.php
@@ -662,4 +662,12 @@ class WebContext extends BaseWebContext implements SnippetAcceptingContext
         $session->restart();
         $session->setCookie('REMEMBERME', $cookie);
     }
+
+    /**
+     * @Given /^I go to page for product with empty slug$/
+     */
+    public function iGoToPageForProductWithEmptySlug()
+    {
+        $this->visitPath('/p/');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #3011 
| License       | MIT
| Doc PR        |

After passing empty string as product slug, NonUniqueResultException was thrown, due to "findOneBy" method. Now it simply does not generate route, as for invalid slug.

However, it should be considered to generate some "invalidate product" page, rather than "No route found" exception :)