### PR TITLE
Fixed Bad Refactor in transliterate

### DIFF
--- a/src/Sylius/Bundle/TranslationBundle/GedmoHandler/TranslationSlugHandler.php
+++ b/src/Sylius/Bundle/TranslationBundle/GedmoHandler/TranslationSlugHandler.php
@@ -190,7 +190,7 @@ class TranslationSlugHandler implements SlugHandlerInterface
      */
     public function transliterate($text, $separator, $object)
     {
-        if ('' !== $this->parentSlug) {
+        if (!empty($this->parentSlug)) {
             $text = $this->parentSlug.$this->usedPathSeparator.$text.$this->suffix;
         } else {
             // if no parentSlug, apply our prefix


### PR DESCRIPTION
`empty()` is a safer check in the case that somehow the `$this->parentSlug` got set to NULL.