### PR TITLE
Compatibility with PHP7 beta (Uniform Variable Syntax issue)

### DIFF
--- a/src/Sylius/Bundle/TranslationBundle/GedmoHandler/TranslationSlugHandler.php
+++ b/src/Sylius/Bundle/TranslationBundle/GedmoHandler/TranslationSlugHandler.php
@@ -117,7 +117,7 @@ class TranslationSlugHandler implements SlugHandlerInterface
 
             $translation = call_user_func_array(array($parent,$options['translate']), array($locale));
 
-            $this->parentSlug = $translation->$options['parentFieldMethod']();
+            $this->parentSlug = $translation->{$options['parentFieldMethod']}();
 
             // if needed, remove suffix from parentSlug, so we can use it to prepend it to our slug
             if(isset($options['suffix'])) {


### PR DESCRIPTION
This fixes some backward compability issues with PHP7. See https://wiki.php.net/rfc/uniform_variable_syntax for more info.