### PR TITLE
[Rbac] Clear permissions cache on postUpdate fix

### DIFF
--- a/src/Sylius/Bundle/RbacBundle/EventListener/CacheListener.php
+++ b/src/Sylius/Bundle/RbacBundle/EventListener/CacheListener.php
@@ -53,6 +53,14 @@ class CacheListener
     /**
      * @param LifecycleEventArgs $args
      */
+    public function postUpdate(LifecycleEventArgs $args)
+    {
+        $this->clearCache($args);
+    }
+
+    /**
+     * @param LifecycleEventArgs $args
+     */
     protected function clearCache(LifecycleEventArgs $args)
     {
         if ($args->getObject() instanceof RoleInterface || $args->getObject() instanceof PermissionInterface) {

--- a/src/Sylius/Bundle/RbacBundle/Resources/config/driver/doctrine/orm.xml
+++ b/src/Sylius/Bundle/RbacBundle/Resources/config/driver/doctrine/orm.xml
@@ -29,6 +29,7 @@
     <services>
         <service id="sylius.listener.rbac_cache" class="%sylius.listener.rbac_cache.class%">
             <tag name="doctrine.event_listener" event="postPersist" />
+            <tag name="doctrine.event_listener" event="postUpdate" />
             <tag name="doctrine.event_listener" event="postRemove" />
             <argument type="service" id="doctrine_cache.providers.sylius_rbac" />
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 


Add postUpdate event to CacheListener to ensure that the cache is cleared when permissions are added to and removed from roles through the admin.