### PR TITLE
Stop registering PHPCR ORM annotations in autoload

### DIFF
--- a/app/autoload.php
+++ b/app/autoload.php
@@ -18,7 +18,6 @@ if (!function_exists('intl_get_error_code')) {
     require_once __DIR__.'/../vendor/symfony/symfony/src/Symfony/Component/Locale/Resources/stubs/functions.php';
 }
 
-AnnotationRegistry::registerFile(__DIR__.'/../vendor/doctrine/phpcr-odm/lib/Doctrine/ODM/PHPCR/Mapping/Annotations/DoctrineAnnotations.php');
 AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
 
 return $loader;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I tried running Sylius with PHP7 last weekend, and I had issues getting it to run. After reading https://github.com/doctrine/phpcr-odm/pull/412, it seems like this line is no longer necessary, and it will stop including the String class.

This should probably stop the PHP7 travis tests from breaking where it does now.

A separate pull request is also required for the Sylis/Standard, as it's autoload also has the same line.