### PR TITLE
Update Search Repository to retain ordering

### DIFF
--- a/src/Sylius/Bundle/SearchBundle/Doctrine/ORM/SearchIndexRepository.php
+++ b/src/Sylius/Bundle/SearchBundle/Doctrine/ORM/SearchIndexRepository.php
@@ -111,9 +111,12 @@ class SearchIndexRepository extends EntityRepository
             ;
 
             foreach ($queryBuilder->getQuery()->getResult() as $object) {
-                $results[] = $object;
+                $pos = array_search($object->getId(), $ids);
+                $results[$pos] = $object;
             }
         }
+        
+        ksort($results);
 
         return $results;
     }


### PR DESCRIPTION
The order that the results are returned from the search engine are important. Don't throw the order away when getting the entities from the database.

This assumes that every entity that is searchable will also have a getId() method - which is correct for products, I'm not sure about other entities.