### PR TITLE
[WebBundle] Fixed showing ProductAttribute choices

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductAttribute/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductAttribute/_form.html.twig
@@ -4,7 +4,7 @@
     {{ form_row(form.name, {'attr': {'class': 'input-lg'}}) }}
     {{ form_row(form.translations, {'attr': {'class': 'input-lg'}}) }}
     {{ form_row(form.type, {'attr': {'class': 'input-lg'}}) }}
-    <div id="sylius_form_choice_container" class="hide">
+    <div id="sylius_form_choice_container">
         {% if form.choices is defined %}
             {{ form_row(form.choices) }}
         {% endif %}


### PR DESCRIPTION
Fixed setting choices for product attribute by removing bootstrap "hide" class which does not work with jQuery show(). Visibility is now handled by JS only.

Also .hide class is deprecated.