### PR TITLE
[ResourceBundle] Turning on back softdeleteable filter just after necessary operations

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -292,6 +292,8 @@ class ResourceController extends FOSRestController
     {
         $this->get('doctrine')->getManager()->getFilters()->disable('softdeleteable');
         $resource = $this->findOr404($request);
+        $this->get('doctrine')->getManager()->getFilters()->enable('softdeleteable');
+        
         $resource->setDeletedAt(null);
 
         $this->domainManager->update($resource, 'restore_deleted');


### PR DESCRIPTION
Removed side effect.

| Q             | A
| ------------- | ---
| Bug fix?      | yes (a little bit)
| New feature?  | no
| BC breaks?    | yes (event listeners will get Doctrine with enabled  `softdeleteable` filter)
| Deprecations? | no
| License       | MIT