### PR TITLE
Fixing Type Error when Order has ShippingMethod

### DIFF
--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
@@ -74,6 +74,8 @@ class ShippingMethodChoiceType extends AbstractType
     {
         if ($options['multiple']) {
             $builder->addModelTransformer(new CollectionToArrayTransformer());
+        } else {
+            $builder->addModelTransformer(new ObjectToIdentifierTransformer($this->repository));
         }
     }
 
@@ -97,7 +99,6 @@ class ShippingMethodChoiceType extends AbstractType
 
         $resolver
             ->setDefaults(array(
-                'data_class' => 'Sylius\Component\Shipping\Model\ShippingMethodInterface',
                 'choice_list' => $choiceList,
                 'criteria'    => array(),
             ))

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
@@ -97,6 +97,7 @@ class ShippingMethodChoiceType extends AbstractType
 
         $resolver
             ->setDefaults(array(
+                'data_class' => 'Sylius\Component\Shipping\Model\ShippingMethodInterface',
                 'choice_list' => $choiceList,
                 'criteria'    => array(),
             ))


### PR DESCRIPTION
This fixes the error "The form's view data is expected to be of type scalar, array or an instance of \ArrayAccess, but is an instance of class Proxies\__CG__\Sylius\Component\Core\Model\ShippingMethod" that occurs when viewing the shipping form with either only one option available, or when going back from checkout.

Fixes issue #2979