### PR TITLE
Fixing Type Error when Order has ShippingMethod

### DIFF
--- a/src/Sylius/Bundle/ShippingBundle/Form/Transformer/ObjectToIdentifierTransformer.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Transformer/ObjectToIdentifierTransformer.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ShippingBundle\Form\Transformer;
+
+use Sylius\Bundle\ResourceBundle\Form\DataTransformer\ObjectToIdentifierTransformer as BaseTransformer;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+/**
+ * Object to identifier transformer.
+ *
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+class ObjectToIdentifierTransformer extends BaseTransformer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($value)
+    {
+        if (!is_object($value)) {
+            return null;
+        }
+
+        $accessor = PropertyAccess::createPropertyAccessor();
+
+        return $accessor->getValue($value, $this->identifier);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reverseTransform($value)
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        return $this->repository->findOneBy(array($this->identifier => $value));
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
@@ -24,6 +24,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Sylius\Bundle\ShippingBundle\Form\Transformer\ObjectToIdentifierTransformer;
 
 /**
  * A select form which allows the user to select
@@ -74,6 +75,8 @@ class ShippingMethodChoiceType extends AbstractType
     {
         if ($options['multiple']) {
             $builder->addModelTransformer(new CollectionToArrayTransformer());
+        } else {
+            $builder->addModelTransformer(new ObjectToIdentifierTransformer($this->repository));
         }
     }
 


### PR DESCRIPTION
This fixes the error "The form's view data is expected to be of type
scalar, array or an instance of \ArrayAccess, but is an instance of
class Proxies\__CG__\Sylius\Component\Core\Model\ShippingMethod" that
occurs when viewing the shipping form with either only one option
available, or when going back from checkout.



Fixes issue #2979