### PR TITLE
[UserBundle] Fix invalid serialization type 'int' to 'integer'.

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Resources/config/serializer/Model.User.yml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/serializer/Model.User.yml
@@ -4,7 +4,7 @@ Sylius\Component\User\Model\User:
     properties:
         id:
             expose: true
-            type: int
+            type: integer
         username:
             expose: true
             type: string


### PR DESCRIPTION
The title nearly says it all.  `int` simply isn't a valid JMS serialization type, it should be `integer`.