### PR TITLE
Status field not set on offline gateway

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Payum/Offline/Action/CapturePaymentAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Payum/Offline/Action/CapturePaymentAction.php
@@ -36,6 +36,7 @@ class CapturePaymentAction extends GenericCapturePaymentAction
 
         $payment->setDetails(array(
             Constants::FIELD_PAID => false,
+            Constants::FIELD_STATUS => Constants::STATUS_PENDING
         ));
     }
 }


### PR DESCRIPTION
Status field is not set which results in a cancelled order when processing an order with the offline gateway