### PR TITLE
[RFC][Rbac] Use a finite default ttl in CachedPermissionMap.

### DIFF
--- a/src/Sylius/Component/Rbac/Authorization/CachedPermissionMap.php
+++ b/src/Sylius/Component/Rbac/Authorization/CachedPermissionMap.php
@@ -21,6 +21,8 @@ use Sylius\Component\Rbac\Model\RoleInterface;
  */
 class CachedPermissionMap implements PermissionMapInterface
 {
+    const DEFAULT_TTL = 60;
+
     /**
      * @var PermissionMapInterface
      */
@@ -41,7 +43,7 @@ class CachedPermissionMap implements PermissionMapInterface
      * @param Cache $cache
      * @param int $ttl
      */
-    public function __construct(PermissionMapInterface $map, Cache $cache, $ttl = null)
+    public function __construct(PermissionMapInterface $map, Cache $cache, $ttl = self::DEFAULT_TTL)
     {
         $this->map = $map;
         $this->cache = $cache;


### PR DESCRIPTION
Caching infinitely requires invalidating the cache entries whenever
roles or permissions are modified.  We could use a "sane" default TTL,
or make it configurable, or figure out an invalidation strategy, or...
But I think infinite by default is pretty unexpected behavior.