### PR TITLE
[RbacBundle] Teach the RbacInitializer to append new permissions

### DIFF
--- a/src/Sylius/Bundle/RbacBundle/Doctrine/RbacInitializer.php
+++ b/src/Sylius/Bundle/RbacBundle/Doctrine/RbacInitializer.php
@@ -133,19 +133,27 @@ class RbacInitializer
                 $role->setName($data['name']);
                 $role->setDescription($data['description']);
                 $role->setParent($root);
-
-                foreach ($data['permissions'] as $permission) {
-                    $role->addPermission($this->permissionsByCode[$permission]);
-                }
-
-                $role->setSecurityRoles($data['security_roles']);
-
-                $this->roleManager->persist($role);
-
                 if ($output) {
                     $output->writeln(sprintf('Adding role "<comment>%s</comment>". (<info>%s</info>)', $data['name'], $code));
                 }
             }
+
+            foreach ($data['permissions'] as $permission) {
+                if (!$role->hasPermission($this->permissionsByCode[$permission])) {
+                    $role->addPermission($this->permissionsByCode[$permission]);
+                    if ($output) {
+                        $output->writeln(sprintf('Adding role:permission <info>%s</info>:<comment>%s</comment>',
+                            $role->getCode(),
+                            $permission
+                        ));
+                    }
+                }
+            }
+
+            $role->setSecurityRoles($data['security_roles']);
+
+            $this->roleManager->persist($role);
+
 
             $rolesByCode[$code] = $role;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | unlikely
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Previously, you could basically only use the RbacInitializer once, to
create roles with their permissions. If you add new permissions to
existing roles (e.g. via configuration like rbac.yml) these won't be
added by the initializer.

This commit makes the initializer always try to add new permissions to
roles, new or old, and updates the console output a bit to reflect the
behavior.