### PR TITLE
[WebBundle] Rework the common address "show" template

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Common/Address/_show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Common/Address/_show.html.twig
@@ -1,13 +1,20 @@
-<address>
-    <strong>{{ address.firstName }} {{ address.lastName }}</strong><br/>
+<div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+    <strong itemprop="name">{{ address.firstName }} {{ address.lastName }}</strong><br/>
     {% if address.company %}
         {{ address.company }}<br/>
     {% endif %}
-    {{ address.phoneNumber }}<br/>
-    {{ address.street }}<br/>
-    {{ address.city }}<br/>
+    <span itemprop="streetAddress">{{ address.street }}</span><br/>
+    <span itemprop="addressLocality">{{ address.city }}</span><br/>
     {% if address.province %}
-        {{ address.province }}<br/>
+        <span itemprop="addressRegion">{{ address.province }}</span><br/>
     {% endif %}
-    {{ address.country|upper }} {{ address.postcode }}
-</address>
+    <span>
+        <span itemprop="addressCountry">{{ address.country.isoName|upper }}</span>
+        <span itemprop="postalCode">{{ address.postcode }}</span>
+        <em>({{ address.country.name }})</em>
+    </span>
+    <br/>
+    {% if address.phoneNumber %}
+        <span itemprop="telephone">{{ address.phoneNumber }}</span><br/>
+    {% endif %}
+</div>


### PR DESCRIPTION
I don't believe this commit has much impact, nor is it particularly
important, but more of a "why not?" consideration.  So if there are no
strong oppositions, why not?

Changes:
1. Remove `<address>` element.  Most opinionated google results will claim
   the element shouldn't be used for mailing addresses, so I've
   changed this to use a [schema.org microdata format](http://schema.org/PostalAddress).  I'm far from savvy
   in this area but it does seem like schema.org is the trending microdata
   dictionary if one should be adopted at all.
2. Moved phone number to the bottom, on the assumption this is more
   common across the world.  It's definitely the common format here in USA.
3. Use country ISO code, with full country name noted on the side.  The
   motivation here is that most workers managing customer information won't
   have all the ISO codes memorized, but displaying the ISO code is still
   useful.
- Before: http://i.imgur.com/CkwGHUy.png
- After: http://i.imgur.com/HffrXXO.png
