### PR TITLE
[UserBundle] Modify CustomerRepository filter logic to support multi-term queries.

### DIFF
--- a/src/Sylius/Bundle/UserBundle/spec/Doctrine/ORM/CustomerRepositorySpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/Doctrine/ORM/CustomerRepositorySpec.php
@@ -83,11 +83,16 @@ class CustomerRepositorySpec extends ObjectBehavior
         $builder->setParameter('enabled', true)->shouldBeCalled()->willReturn($builder);
 
         // Query
-        $builder->where(Argument::type('Doctrine\ORM\Query\Expr'))->shouldBeCalled()->willReturn($builder);
-        $builder->orWhere(Argument::type('Doctrine\ORM\Query\Expr'))->shouldBeCalled()->willReturn($builder);
-        $builder->orWhere(Argument::type('Doctrine\ORM\Query\Expr'))->shouldBeCalled()->willReturn($builder);
-        $builder->orWhere(Argument::type('Doctrine\ORM\Query\Expr'))->shouldBeCalled()->willReturn($builder);
-        $builder->setParameter('query', '%arnaud%')->shouldBeCalled()->willReturn($builder);
+        $builder->andWhere(Argument::type('Doctrine\ORM\QueryBuilder'))->shouldBeCalled()->willReturn($builder);
+        $expr->orX(
+            Argument::type('Doctrine\ORM\Query\Expr'),
+            Argument::type('Doctrine\ORM\Query\Expr'),
+            Argument::type('Doctrine\ORM\Query\Expr'),
+            Argument::type('Doctrine\ORM\Query\Expr')
+        )->shouldBeCalled()->willReturn($builder);
+        $builder->setParameter('query0', '%arnaud%')->shouldBeCalled()->willReturn($builder);
+        $builder->setParameter('query1', '%middle%')->shouldBeCalled()->willReturn($builder);
+        $builder->setParameter('query2', '%last%')->shouldBeCalled()->willReturn($builder);
 
         // Sort
         $builder->addOrderBy('o.name', 'asc')->shouldBeCalled();
@@ -96,7 +101,7 @@ class CustomerRepositorySpec extends ObjectBehavior
         $this->createFilterPaginator(
             array(
                 'enabled' => true,
-                'query' => 'arnaud'
+                'query' => 'arnaud middle last'
             ),
             array('name' => 'asc'),
             true


### PR DESCRIPTION
For example, searching for "John Smith" would previously query for `LIKE
'%John Smith%'` against fields including first name, last name, email, etc.  Even with a customer named John Smith, this would find no matches since none of the fields alone contain his full name.

The new suggested logic tests 'John' against each field, AND tests 'Smith'
 against each field, AND tests further tokens against each field, and requires at least one match from each token to pass.
