### PR TITLE
[Settings] Add API routes for SettingsController and some improvements

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/main.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/main.yml
@@ -96,3 +96,7 @@ sylius_api_zone:
 sylius_api_user:
     resource: @SyliusApiBundle/Resources/config/routing/user.yml
     prefix: /users
+
+sylius_api_setting:
+    resource: @SyliusApiBundle/Resources/config/routing/setting.yml
+    prefix: /settings

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/setting.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/setting.yml
@@ -1,0 +1,14 @@
+# This file is part of the Sylius package.
+# (c) Paweł Jędrzejewski
+
+sylius_api_setting_show:
+    path: /{namespace}
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.settings:showAction
+
+sylius_api_setting_update:
+    path: /{namespace}
+    methods: [PUT, PATCH]
+    defaults:
+        _controller: sylius.controller.settings:updateAction


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | yes
New feature?  | yes
BC breaks? | no
Deprecations? | no
Fixed tickets | no
License | MIT
Doc PR | -

* Add showAction for Settings schema's for API consumers. `/api/settings/{namespace}`
* `showAction` and `updateAction` now will not throw `MissingOptions` exception which is annoying when it's the first to read/update a Settings schema through an API call. (If there's a better way than ignoring this exception that'd be nice to guide me on that)
