### PR TITLE
[CoreBundle] Fix findExpired orders method query

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -391,7 +391,7 @@ class OrderRepository extends CartRepository implements OrderRepositoryInterface
         $queryBuilder = $this->getQueryBuilder();
 
         $queryBuilder
-            ->andWhere($queryBuilder->expr()->lt($this->getAlias().'.updatedAt', ':expiresAt'))
+            ->andWhere($queryBuilder->expr()->lt($this->getAlias().'.expiresAt', ':expiresAt'))
             ->andWhere($this->getAlias().'.state = :state')
             ->setParameter('expiresAt', $expiresAt)
             ->setParameter('state', $state)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes, if users are currently anticipating the bug and changing behavior to work around
| Deprecations? | no
| Fixed tickets | #3122 
| License       | MIT
| Doc PR        | -

It was using the updatedAt column instead of the expiresAt column.  Big difference!