### PR TITLE
[RFC][ProductBundle] When finding products in a given taxon, consider the whole tree.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -39,8 +39,13 @@ class ProductRepository extends BaseProductRepository
         $queryBuilder = $this->getCollectionQueryBuilder();
         $queryBuilder
             ->innerJoin('product.taxons', 'taxon')
-            ->andWhere('taxon = :taxon')
+            ->andWhere($queryBuilder->expr()->orX(
+                'taxon = :taxon',
+                ':left < taxon.left AND taxon.right < :right'
+            ))
             ->setParameter('taxon', $taxon)
+            ->setParameter('left', $taxon->getLeft())
+            ->setParameter('right', $taxon->getRight())
         ;
 
         $this->applyCriteria($queryBuilder, $criteria);


### PR DESCRIPTION
When asking for items in a group, I believe it makes sense to consider the group's hierarchy at the same time and return a list that includes implicitly-included items.

Would be nice if we could extend the [NestedTreeRepository](https://github.com/Atlantic18/DoctrineExtensions/blob/master/lib/Gedmo/Tree/Entity/Repository/NestedTreeRepository.php) as it has some methods already to deal with this, but I don't see a way to hack that in  since it already must extend the ResourceRepository.

As a less flexible but simpler compromise, I'm interested to hear any thoughts on whether we could do something like the example in this PR.