### PR TITLE
[ProductBuilder] removed fluent interface for getters  in __call

### DIFF
--- a/src/Sylius/Component/Product/Builder/ProductBuilder.php
+++ b/src/Sylius/Component/Product/Builder/ProductBuilder.php
@@ -92,7 +92,11 @@ class ProductBuilder implements ProductBuilderInterface
             throw new \BadMethodCallException(sprintf('Product has no "%s()" method.', $method));
         }
 
-        call_user_func_array(array($this->product, $method), $arguments);
+        $result = call_user_func_array(array($this->product, $method), $arguments);
+
+        if(substr($method,0,3) === "get") {
+            return $result;
+        }
 
         return $this;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no  (just a slight improvement for debugging)
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #3113
| License       | MIT
| Doc PR        | 