### PR TITLE
generate function to return generated coupons

### DIFF
--- a/src/Sylius/Component/Promotion/Generator/CouponGenerator.php
+++ b/src/Sylius/Component/Promotion/Generator/CouponGenerator.php
@@ -43,16 +43,21 @@ class CouponGenerator implements CouponGeneratorInterface
      */
     public function generate(PromotionInterface $promotion, Instruction $instruction)
     {
+        $generatedCoupons = array();
         for ($i = 0, $amount = $instruction->getAmount(); $i < $amount; $i++) {
             $coupon = $this->repository->createNew();
             $coupon->setPromotion($promotion);
             $coupon->setCode($this->generateUniqueCode());
             $coupon->setUsageLimit($instruction->getUsageLimit());
+            
+            $generatedCoupons[] = $coupon;
 
             $this->manager->persist($coupon);
         }
 
         $this->manager->flush();
+        
+        return $generatedCoupons;
     }
 
     /**

--- a/src/Sylius/Component/Promotion/Generator/CouponGeneratorInterface.php
+++ b/src/Sylius/Component/Promotion/Generator/CouponGeneratorInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Promotion\Generator;
 
 use Sylius\Component\Promotion\Model\PromotionInterface;
+use Sylius\Component\Promotion\Model\CouponInterface;
 
 /**
  * Coupon generator interface.
@@ -25,6 +26,8 @@ interface CouponGeneratorInterface
      *
      * @param PromotionInterface $promotion
      * @param Instruction        $instruction
+     *
+     * @return CouponInterface[] $coupons
      */
     public function generate(PromotionInterface $promotion, Instruction $instruction);
 


### PR DESCRIPTION
Hello there,

I had to use coupon generator and afterwards send out an email with the generated codes.

Doesn't it make more sense to return a structure containing the coupons instead of having to query back the
db for those?

This change works great for me but maybe it affects sylius in a way I cannot see at the moment. Please let me 
know in case this can be achieved in any other way.

Cheers,
Argiris