### PR TITLE
[Behat] [DX] Added useful, developer-friendly steps, polished formatting

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -147,6 +147,7 @@ default:
         oauth:
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
+                - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\UserBundle\Behat\OAuthContext
                 - Sylius\Bundle\MoneyBundle\Behat\MoneyContext

--- a/features/backend/countries.feature
+++ b/features/backend/countries.feature
@@ -5,17 +5,13 @@ Feature: Countries and provinces
     I want to be able to manage countries and their provinces
 
     Background:
-        Given there is default currency configured
-        And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-        And there is default channel configured
-        And I am logged in as administrator
-        And there are following countries:
+        Given store has default configuration
+          And there are following countries:
             | name    | provinces                       |
             | France  | Lyon, Toulouse, Rennes, Nancy   |
             | China   |                                 |
             | Ukraine | Kiev, Odessa, Cherkasy, Kharkiv |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all countries
         Given I am on the dashboard page

--- a/features/backend/dashboard.feature
+++ b/features/backend/dashboard.feature
@@ -5,9 +5,7 @@ Feature: Store dashboard
     I need to be able to see sales info in backend dashboard
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And the following zones are defined:
             | name         | type    | members                       |
             | German lands | country | Germany, Austria, Switzerland |
@@ -19,13 +17,14 @@ Feature: Store dashboard
             | customer          | address                                                |
             | klaus@example.com | Klaus Schmitt, Heine-Straße 12, 99734, Berlin, Germany |
             | lars@example.com  | Lars Meine, Fun-Straße 1, 90032, Vienna, Austria       |
-        And order #000000001 has following items:
+          And order #000000001 has following items:
             | product | quantity |
             | Mug     | 2        |
-        And order #000000002 has following items:
+          And order #000000002 has following items:
             | product | quantity |
             | Mug     | 1        |
             | Sticker | 4        |
+          And I am logged in as administrator
 
     Scenario: Viewing the dashboard at website root
        Given I am on the dashboard page

--- a/features/backend/general_settings.feature
+++ b/features/backend/general_settings.feature
@@ -5,16 +5,15 @@ Feature: General settings
     I want to be able to edit general configuration
 
     Background:
-        Given there are following currencies configured:
-            | code | exchange rate | enabled |
-            | USD  | 0.76496       | yes     |
-            | GBP  | 1.16998       | no      |
-            | EUR  | 1.00000       | yes     |
-            | AUD  | 0.73986       | yes     |
-          And there is default channel configured
-          And channel "DEFAULT-WEB" has following configuration:
+        Given store has default configuration
+          And there are following currencies configured:
+            | code |
+            | EUR  |
+            | USD  |
+            | PLN  |
+          And the default channel has following configuration:
             | currencies    |
-            | USD, EUR, AUD |
+            | EUR, USD, PLN |
           And I am logged in as administrator
 
     Scenario: Accessing the settings form

--- a/features/backend/groups.feature
+++ b/features/backend/groups.feature
@@ -5,9 +5,7 @@ Feature: Customer groups management
     I want to be able to group them
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And the following zones are defined:
             | name         | type    | members                       |
             | German lands | country | Germany, Austria, Switzerland |
@@ -25,6 +23,7 @@ Feature: Customer groups management
             | martha@example.com | yes     | Retail Customers      |                                                        |
             | rick@example.com   | no      | Retail Customers      | Lars Meine, Fun-Straße 1, 90032, Vienna, Austria       |
             | dale@example.com   | yes     | Wholesale Customers   |                                                        |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all groups
         Given I am on the dashboard page

--- a/features/backend/inventory.feature
+++ b/features/backend/inventory.feature
@@ -5,9 +5,7 @@ Feature: Inventory tracking
     I want to be able to manage stock levels and availability
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And there are following options:
             | name          | presentation | values           |
             | T-Shirt color | Color        | Red, Blue, Green |
@@ -18,6 +16,7 @@ Feature: Inventory tracking
             | Black T-Shirt  | 19.99 | T-Shirt size                |
             | Mug            | 5.99  |                             |
             | Sticker        | 10.00 |                             |
+          And I am logged in as administrator
 
     Scenario: Seeing index of inventory
         Given I am on the dashboard page

--- a/features/backend/locales.feature
+++ b/features/backend/locales.feature
@@ -5,8 +5,7 @@ Feature: Managing locales
     I want to be able to configure locales
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
+        Given store has default configuration
           And there are following locales configured:
             | name                    | enabled |
             | German (Germany)        | yes     |

--- a/features/backend/orders.feature
+++ b/features/backend/orders.feature
@@ -5,9 +5,7 @@ Feature: Orders management
     I want to be able to list, view, edit and create orders
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And the following zones are defined:
             | name         | type    | members                       |
             | German lands | country | Germany, Austria, Switzerland |
@@ -25,13 +23,14 @@ Feature: Orders management
             | customer          | address                                                |
             | klaus@example.com | Klaus Schmitt, Heine-Straße 12, 99734, Berlin, Germany |
             | lars@example.com  | Lars Meine, Fun-Straße 1, 90032, Vienna, Austria       |
-        And order #000000001 has following items:
+          And order #000000001 has following items:
             | product | quantity |
             | Mug     | 2        |
-        And order #000000002 has following items:
+          And order #000000002 has following items:
             | product | quantity |
             | Mug     | 1        |
             | Sticker | 4        |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all orders
         Given I am on the dashboard page

--- a/features/backend/payment_methods.feature
+++ b/features/backend/payment_methods.feature
@@ -5,13 +5,12 @@ Feature: Payment methods
     I want to be able to manage payment methods
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And the following payment methods exist:
             | name        | gateway | calculator | calculator_configuration |
             | Credit Card | stripe  | fixed      | amount: 10               |
             | PayPal      | paypal  | percent    | percent: 5               |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all payment methods
         Given I am on the dashboard page

--- a/features/backend/product_archetypes.feature
+++ b/features/backend/product_archetypes.feature
@@ -5,13 +5,8 @@ Feature: Product archetypes
     I want to be able to create archetypes
 
     Background:
-        Given there is default currency configured
-        And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-        And there is default channel configured
-        And I am logged in as administrator
-        And there are following options:
+        Given store has default configuration
+          And there are following options:
             | name             | presentation | values                     |
             | T-Shirt color    | Color        | Red, Blue, Green           |
             | T-Shirt size     | Size         | S, M, L                    |
@@ -19,19 +14,20 @@ Feature: Product archetypes
             | Beverage size    | Size         | Tall, Grande, Venti        |
             | Beverage milk    | Milk         | None, Whole, Skinny, Soya  |
             | Coffee variety   | Variety      | Colombian, Ethiopian       |
-        And there are following attributes:
+          And there are following attributes:
             | name                  | presentation   |
             | T-Shirt collection    | Collection     |
             | T-Shirt fabric        | T-Shirt fabric |
             | Bag material          | Material       |
             | Beverage calories     | Calories       |
             | Coffee caffeine       | Caffeine       |
-        And there is archetype "T-Shirt" with following configuration:
+          And there is archetype "T-Shirt" with following configuration:
             | options    | T-Shirt color, T-Shirt size        |
             | attributes | T-Shirt collection, T-Shirt fabric |
-        And there is archetype "Beverage" with following configuration:
+          And there is archetype "Beverage" with following configuration:
             | options    | Beverage size, Beverage milk       |
             | attributes | Beverage calories                  |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all archetypes
         Given I am on the dashboard page

--- a/features/backend/product_archetypes_i18n.feature
+++ b/features/backend/product_archetypes_i18n.feature
@@ -5,13 +5,12 @@ Feature: Product archetype translations
     I want to be able to create archetypes with localised names
 
     Background:
-        Given there is default currency configured
-        And there is default channel configured
-        And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-            | es_ES | yes     |
-        And I am logged in as administrator
+        Given store has default configuration
+          And there are following locales configured:
+            | code  |
+            | en_US |
+            | es_ES |
+          And I am logged in as administrator
 
     Scenario: Creating a product archetype requires default translation fields
         Given I am on the product archetype creation page

--- a/features/backend/product_attributes.feature
+++ b/features/backend/product_attributes.feature
@@ -5,16 +5,12 @@ Feature: Product attributes
     I want to be able to configure product attributes
 
     Background:
-        Given there is default currency configured
-        And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-        And there is default channel configured
-        And I am logged in as administrator
-        And there are following attributes:
+        Given store has default configuration
+          And there are following attributes:
             | name               | presentation   |
             | T-Shirt collection | Collection     |
             | T-Shirt fabric     | T-Shirt fabric |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all attributes
         Given I am on the dashboard page

--- a/features/backend/product_options.feature
+++ b/features/backend/product_options.feature
@@ -5,16 +5,12 @@ Feature: Product options
     I want to be able to manage options
 
     Background:
-        Given there is default currency configured
-        And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-        And there is default channel configured
-        And I am logged in as administrator
-        And there are following options:
+        Given store has default configuration
+          And there are following options:
             | name          | presentation | values           |
             | T-Shirt color | Color        | Red, Blue, Green |
             | T-Shirt size  | Size         | S, M, L          |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all options
         Given I am on the dashboard page

--- a/features/backend/product_taxonomies.feature
+++ b/features/backend/product_taxonomies.feature
@@ -5,25 +5,24 @@ Feature: Browsing products by taxonomies
     I want to be able to view them by category
 
     Background:
-        Given there is default currency configured
-        And there is default channel configured
-        And I am logged in as administrator
-        And there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
             | Special  |
-        And taxonomy "Category" has following taxons:
+          And taxonomy "Category" has following taxons:
             | Clothing > T-Shirts |
             | Clothing > Shorts   |
-        And taxonomy "Special" has following taxons:
+          And taxonomy "Special" has following taxons:
             | Featured |
             | New      |
-        And the following products exist:
+          And the following products exist:
             | name          | price | taxons   |
             | Super T-Shirt | 19.99 | T-Shirts |
             | Black T-Shirt | 19.99 | T-Shirts |
             | Shorts        | 35.99 | Shorts   |
             | Bambi Shorts  | 35.00 | Shorts   |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all products for given taxonomy
         Given I am on the taxonomy index page

--- a/features/backend/product_variants.feature
+++ b/features/backend/product_variants.feature
@@ -5,24 +5,20 @@ Feature: Product variants
     I want to be able to manage product variants
 
     Background:
-        Given there is default currency configured
-        And there is default channel configured
-        And I am logged in as administrator
-        And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-        And there are following options:
+        Given store has default configuration
+          And there are following options:
             | name          | presentation | values           |
             | T-Shirt color | Color        | Red, Blue, Green |
             | T-Shirt size  | Size         | S, M, L          |
-        And the following products exist:
+          And the following products exist:
             | name           | price | options                     |
             | Super T-Shirt  | 19.99 | T-Shirt size, T-Shirt color |
             | Black T-Shirt  | 19.99 | T-Shirt size                |
             | Sylius T-Shirt | 12.99 | T-Shirt size, T-Shirt color |
             | Mug            | 5.99  |                             |
             | Sticker        | 10.00 |                             |
-        And product "Super T-Shirt" is available in all variations
+          And product "Super T-Shirt" is available in all variations
+          And I am logged in as administrator
 
     Scenario: Viewing a product without options
         Given I am on the product index page

--- a/features/backend/products.feature
+++ b/features/backend/products.feature
@@ -5,44 +5,40 @@ Feature: Products
     I want to be able to manage products
 
     Background:
-        Given there is default currency configured
-        And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-        And there is default channel configured
-        And I am logged in as administrator
-        And there are following options:
+        Given store has default configuration
+          And there are following options:
             | name          | presentation | values           |
             | T-Shirt color | Color        | Red, Blue, Green |
             | T-Shirt size  | Size         | S, M, L          |
-        And there are following attributes:
+          And there are following attributes:
             | name               | presentation      | type     | choices   |
             | T-Shirt fabric     | T-Shirt           | text     |           |
             | T-Shirt fare trade | Faretrade product | checkbox |           |
             | Color              | color             | choice   | red, blue |
             | Size               | size              | number   |           |
-        And the following products exist:
+          And the following products exist:
             | name          | price | options                     | attributes             |
             | Super T-Shirt | 19.99 | T-Shirt size, T-Shirt color | T-Shirt fabric: Wool   |
             | Black T-Shirt | 19.99 | T-Shirt size                | T-Shirt fabric: Cotton |
             | Mug           | 5.99  |                             |                        |
             | Sticker       | 10.00 |                             |                        |
-        And product "Super T-Shirt" is available in all variations
-        And there are following tax categories:
+          And product "Super T-Shirt" is available in all variations
+          And there are following tax categories:
             | name        |
             | Clothing    |
             | Electronics |
             | Print       |
-        And there are following taxonomies defined:
+          And there are following taxonomies defined:
             | name     |
             | Category |
             | Special  |
-        And taxonomy "Category" has following taxons:
+          And taxonomy "Category" has following taxons:
             | Clothing > T-Shirts         |
             | Clothing > Premium T-Shirts |
-        And taxonomy "Special" has following taxons:
+          And taxonomy "Special" has following taxons:
             | Featured |
             | New      |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all products with simple prices
         Given I am on the dashboard page
@@ -222,5 +218,5 @@ Feature: Products
 
     Scenario: Accessing the product details page from list
         Given I am on the product index page
-        When I click "details" near "Mug"
+        When I click "Mug"
         Then I should be on the page of product "Mug"

--- a/features/backend/products_filter.feature
+++ b/features/backend/products_filter.feature
@@ -5,17 +5,14 @@ Feature: Products filter
     I want to be able to filter list by name
 
     Background:
-        Given there is default currency configured
-        And there is default channel configured
-        And I am logged in as administrator
-        And the following products exist:
+        Given store has default configuration
+          And the following products exist:
             | name          | price | sku |
             | Super T-Shirt | 19.99 | 123 |
             | Black T-Shirt | 19.99 | 321 |
-            | Mug           | 5.99  | 136 |
             | Sticker       | 10.00 | 555 |
-            | Banana        | 10.00 | 999 |
             | Orange        | 10.00 | 124 |
+          And I am logged in as administrator
 
     Scenario: Filtering products by name
         Given I am on the product index page

--- a/features/backend/products_i18n.feature
+++ b/features/backend/products_i18n.feature
@@ -5,13 +5,12 @@ Feature: Products
     I want to be able to manage products
 
     Background:
-        Given there is default currency configured
-        And there is default channel configured
-        And I am logged in as administrator
-        And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-            | es_ES | yes     |
+        Given store has default configuration
+          And there are following locales configured:
+            | code  |
+            | en_US |
+            | es_ES |
+          And I am logged in as administrator
 
     Scenario: Creating a product requires default translation fields
         Given I am on the product creation page

--- a/features/backend/promotions.feature
+++ b/features/backend/promotions.feature
@@ -5,9 +5,7 @@ Feature: Promotions
     I want to be able to manage promotions
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And the following promotions exist:
             | name           | description                            | usage limit | used | starts     | ends       |
             | New Year       | New Year Sale for more than 3 items    | 0           | 0    | 2013-12-31 | 2014-01-03 |
@@ -39,6 +37,7 @@ Feature: Promotions
           And promotion "Free orders" has following actions defined:
             | type                | configuration   |
             | Percentage discount | Percentage: 100 |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all promotions
         Given I am on the dashboard page

--- a/features/backend/search.feature
+++ b/features/backend/search.feature
@@ -5,30 +5,26 @@ Feature: Orm indexer event listener
     I want to update the index when a product change occurs
 
     Background:
-        Given there is default currency configured
-        And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-        And there is default channel configured
-        And I am logged in as administrator
-        And there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
-        And taxonomy "Category" has following taxons:
+          And taxonomy "Category" has following taxons:
             | Clothing > T-Shirts     |
             | Clothing > PHP T-Shirts |
             | Clothing > Gloves       |
-        And the following products exist:
+          And the following products exist:
             | name             | price | taxons       | description             |
             | Super T-Shirt    | 19.99 | T-Shirts     | super black t-shirt     |
             | Black T-Shirt    | 18.99 | T-Shirts     | black t-shirt           |
             | Sylius Tee       | 12.99 | PHP T-Shirts | a very nice php t-shirt |
             | Symfony T-Shirt  | 15.00 | PHP T-Shirts | symfony t-shirt         |
             | Doctrine T-Shirt | 15.00 | PHP T-Shirts | doctrine t-shirt        |
-        And all products assigned to "DEFAULT-WEB" channel
-        And channel "DEFAULT-WEB" has following configuration:
+          And all products are assigned to the default channel
+          And the default channel has following configuration:
             | taxonomy |
             | Category |
+          And I am logged in as administrator
 
     Scenario: Creating simple product and indexing it
         Given I am on the product creation page

--- a/features/backend/shipments.feature
+++ b/features/backend/shipments.feature
@@ -5,28 +5,12 @@ Feature: Shipments
     I want to be able to list and view shipments
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And the following zones are defined:
             | name         | type    | members                       |
             | German lands | country | Germany, Austria, Switzerland |
             | UK + Poland  | country | United Kingdom, Poland        |
             | USA          | country | United States                 |
-          And there are following tax categories:
-            | name    |
-            | General |
-          And there are products:
-            | name          | price | tax category |
-            | Mug           | 5.99  | General      |
-            | Sticker       | 10.00 | General      |
-          And the following tax rates exist:
-            | category | zone         | name | amount |
-            | General  | German lands | VAT  | 23     |
-          And there are following shipping categories:
-            | name    |
-            | Regular |
-            | Heavy   |
           And the following shipping methods exist:
             | category | zone         | name        |
             | Regular  | USA          | FedEx       |
@@ -36,13 +20,7 @@ Feature: Shipments
             | customer          | address                                                | shipment |
             | klaus@example.com | Klaus Schmitt, Heine-Straße 12, 99734, Berlin, Germany | FedEx    |
             | lars@example.com  | Lars Meine, Fun-Straße 1, 90032, Vienna, Austria       | DHL      |
-        And order #000000001 has following items:
-            | product | quantity |
-            | Mug     | 2        |
-        And order #000000002 has following items:
-            | product | quantity |
-            | Mug     | 1        |
-            | Sticker | 4        |
+          And I am logged in as administratorzs
 
     Scenario: Seeing index of all shipments
         Given I am on the dashboard page
@@ -62,13 +40,6 @@ Feature: Shipments
           And I click "delete" from the confirmation modal
          Then I should be on the shipment index page
           And I should see "Shipment has been successfully deleted."
-
-    @javascript
-    Scenario: Deleted shipment disappears from the list
-        Given I am on the shipment page with method "DHL"
-         When I press "delete"
-          And I click "delete" from the confirmation modal
-         Then I should be on the shipment index page
           And I should not see shipment with name "DHL" in that list
 
     @javascript
@@ -77,8 +48,8 @@ Feature: Shipments
          When I click "delete" near "DHL"
           And I click "delete" from the confirmation modal
          Then I should still be on the shipment index page
-          And "Shipment has been successfully deleted." should appear on the page
-          But I should not see shipment with name "DHL" in that list
+          And I should see "Shipment has been successfully deleted."
+          And I should not see shipment with name "DHL" in that list
 
     Scenario: Accessing shipment details page via list
         Given I am on the shipment index page

--- a/features/backend/shipping_categories.feature
+++ b/features/backend/shipping_categories.feature
@@ -5,13 +5,12 @@ Feature: Shipping categories
     I want to be able to manage shipping categories
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And there are following shipping categories:
             | name    |
             | Regular |
             | Heavy   |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all shipping categories
         Given I am on the dashboard page
@@ -68,11 +67,4 @@ Feature: Shipping categories
           And I click "delete" from the confirmation modal
          Then I should be on the shipping category index page
           And I should see "Shipping category has been successfully deleted."
-
-    @javascript
-    Scenario: Deleted shipping category disappears from the list
-        Given I am on the shipping category index page
-         When I click "delete" near "Regular"
-          And I click "delete" from the confirmation modal
-         Then I should be on the shipping category index page
           And I should not see shipping category with name "Regular" in that list

--- a/features/backend/shipping_methods.feature
+++ b/features/backend/shipping_methods.feature
@@ -5,12 +5,7 @@ Feature: Shipping methods
     I want to be able to configure shipping methods
 
     Background:
-        Given there is default currency configured
-          And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And the following zones are defined:
             | name         | type    | members                 |
             | UK + Germany | country | United Kingdom, Germany |
@@ -31,6 +26,7 @@ Feature: Shipping methods
           And shipping method "TurboPackage" has following rules defined:
             | type   | configuration     |
             | Weight | Min: 10, Max: 500 |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all shipping methods
         Given I am on the dashboard page
@@ -130,11 +126,4 @@ Feature: Shipping methods
           And I click "delete" from the confirmation modal
          Then I should be on the shipping method index page
           And I should see "Shipping method has been successfully deleted."
-
-    @javascript
-    Scenario: Deleted shipping method disappears from the list
-        Given I am on the page of shipping method "FedEx"
-         When I press "delete"
-          And I click "delete" from the confirmation modal
-         Then I should be on the shipping method index page
           And I should not see shipping method with name "FedEx" in that list

--- a/features/backend/tax_categories.feature
+++ b/features/backend/tax_categories.feature
@@ -5,13 +5,12 @@ Feature: Tax categories
     I want to be able to manage tax categories
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And there are following tax categories:
             | name        |
             | Clothing    |
             | Electronics |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all tax categories
         Given I am on the dashboard page

--- a/features/backend/tax_rates.feature
+++ b/features/backend/tax_rates.feature
@@ -5,9 +5,7 @@ Feature: Tax rates
     I want to be able to configure tax rates
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And the following zones are defined:
             | name         | type    | members                 |
             | UK + Germany | country | United Kingdom, Germany |
@@ -23,6 +21,7 @@ Feature: Tax rates
             | Electronics | UK + Germany | UK+DE Electronics Tax | 23%    |
             | Clothing    | USA          | US Clothing Tax       | 8%     |
             | Electronics | USA          | US Electronics Tax    | 10%    |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all tax rates
         Given I am on the dashboard page

--- a/features/backend/taxation_settings.feature
+++ b/features/backend/taxation_settings.feature
@@ -5,13 +5,12 @@ Feature: Taxation settings
     I want to be able to edit taxation configuration
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And the following zones are defined:
             | name         | type    | members                       |
             | German lands | country | Germany, Austria, Switzerland |
             | USA          | country | United States                 |
+          And I am logged in as administrator
 
     Scenario: Accessing the settings form
         Given I am on the dashboard page

--- a/features/backend/taxonomies.feature
+++ b/features/backend/taxonomies.feature
@@ -5,12 +5,7 @@ Feature: taxonomies
     I want to be able to manage taxonomies
 
     Background:
-        Given there is default currency configured
-        And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And there are following taxonomies defined:
             | name     |
             | Category |
@@ -21,6 +16,7 @@ Feature: taxonomies
             | Electronics > Mac > MBP  |
             | Clothing > Gloves        |
             | Clothing > Hats          |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all taxonomies
         Given I am on the dashboard page

--- a/features/backend/taxonomies_i18n.feature
+++ b/features/backend/taxonomies_i18n.feature
@@ -1,21 +1,21 @@
 @i18n
-Feature: taxonomies
+Feature: Taxonomies internationalization
     In order to improve the store SEO
     As a store owner
     I want to be able to have localised permalinks
 
     Background:
-        Given there is default currency configured
-        And   there are following locales configured:
+        Given store has default configuration
+          And there are following locales configured:
             | code | enabled |
             | en   | yes     |
             | es   | yes     |
-        And   there are following taxonomies defined:
+          And there are following taxonomies defined:
             | name     |
             | Category |
-        And   taxonomy "Category" has following taxons:
+          And taxonomy "Category" has following taxons:
             | Clothing > Shirts > Long Sleeve |
-        And   the following taxon translations exist
+          And the following taxon translations exist
             | taxon       | name        | locale |
             | Category    | Categoria   | es     |
             | Clothing    | Ropa        | es     |
@@ -23,10 +23,10 @@ Feature: taxonomies
             | Long Sleeve | Manga Larga | es     |
 
     Scenario: Creating a taxon generates the proper permalink
-        Then  Taxon translation "Long Sleeve" should have permalink "category/clothing/shirts/long-sleeve"
-        And   Taxon translation "Manga Larga" should have permalink "categoria/ropa/camisas/manga-larga"
+        Then Taxon translation "Long Sleeve" should have permalink "category/clothing/shirts/long-sleeve"
+         And Taxon translation "Manga Larga" should have permalink "categoria/ropa/camisas/manga-larga"
 
     Scenario: Updating a taxon updates children permalinks only for the given locale
-        When  I change then name of taxon translation "Shirts" to "New Shirts"
-        Then  Taxon translation "Long Sleeve" should have permalink "category/clothing/new-shirts/long-sleeve"
-        And   Taxon translation "Manga Larga" should have permalink "categoria/ropa/camisas/manga-larga"
+        When I change then name of taxon translation "Shirts" to "New Shirts"
+        Then Taxon translation "Long Sleeve" should have permalink "category/clothing/new-shirts/long-sleeve"
+         And Taxon translation "Manga Larga" should have permalink "categoria/ropa/camisas/manga-larga"

--- a/features/backend/zones.feature
+++ b/features/backend/zones.feature
@@ -5,15 +5,14 @@ Feature: Zones
     In order to apply taxes and allow shipping to geographical areas
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And there are following zones:
             | name                      | type     | members                                       | scope      |
             | Baltic states             | country  | Lithuania, Latvia, Estonia                    | content    |
             | USA GMT-8                 | province | Washington, Oregon, Nevada, Idaho, California | shipping   |
             | Baltic states + USA GMT-8 | zone     | Baltic states, USA GMT-8                      |            |
             | Germany                   | country  | Germany                                       | price      |
+          And I am logged in as administrator
 
     Scenario: Seeing index of all zones
         Given I am on the dashboard page

--- a/features/channels/channel_management.feature
+++ b/features/channels/channel_management.feature
@@ -5,9 +5,7 @@ Feature: Channel management
     I want to configure channels
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And the following zones are defined:
             | name | type    | members                         |
             | USA  | country | United States                   |
@@ -42,6 +40,7 @@ Feature: Channel management
           And channel "WEB-EU" has following configuration:
             | shipping | payment                  |
             | DHL      | Credit Card (EU), PayPal |
+          And I am logged in as administrator
 
     Scenario: Browsing all configured channels
         Given I am on the dashboard page

--- a/features/contact/contact_request_management.feature
+++ b/features/contact/contact_request_management.feature
@@ -5,18 +5,17 @@ Feature: Contact requests management
     I want to manage contact requests
 
     Background:
-        Given there is default currency configured
-        And there is default channel configured
-        And there are following contact topics:
+        Given store has default configuration
+          And there are following contact topics:
             | title               |
             | Order return        |
             | Delivery            |
             | Product information |
-        And there are following contact requests:
+          And there are following contact requests:
             | topic               | firstName | lastName | email            | message                    |
             | Order return        | John      | Doe      | john@doe.com     | I want to return order     |
             | Delivery            | Joe       | Williams | joe@williams.com | What is my delivery status |
-        And I am logged in as administrator
+          And I am logged in as administrator
 
     Scenario: Browsing all contact requests
         Given I am on the dashboard page

--- a/features/contact/contact_requesting.feature
+++ b/features/contact/contact_requesting.feature
@@ -5,14 +5,13 @@ Feature: Contact requesting
     I want to send message to store owner
 
     Background:
-        Given there is default currency configured
-        And there is default channel configured
-        And there are following contact topics:
+        Given store has default configuration
+          And there are following contact topics:
             | title               |
             | Order return        |
             | Delivery            |
             | Product information |
-        And I am logged in as administrator
+          And I am logged in as administrator
 
     Scenario: Submitting the form without the required fields fails
         Given I am on the contact page

--- a/features/contact/contact_topic_management.feature
+++ b/features/contact/contact_topic_management.feature
@@ -5,14 +5,13 @@ Feature: Contact topics management
     I want to manage contact request topics
 
     Background:
-        Given there is default currency configured
-        And there is default channel configured
-        And there are following contact topics:
+        Given store has default configuration
+          And there are following contact topics:
             | title               |
             | Order return        |
             | Delivery            |
             | Product information |
-        And I am logged in as administrator
+          And I am logged in as administrator
 
     Scenario: Browsing all contact topics
         Given I am on the dashboard page

--- a/features/currencies/currency_management.feature
+++ b/features/currencies/currency_management.feature
@@ -5,13 +5,13 @@ Feature: Currency management
     I want to configure currencies and exchange rates
 
     Background:
-        Given there are following currencies configured:
+        Given store has default configuration
+          And there are following currencies configured:
             | code | exchange rate | enabled |
             | USD  | 0.76496       | yes     |
             | GBP  | 1.16998       | no      |
             | EUR  | 1.00000       | yes     |
             | AUD  | 0.73986       | yes     |
-          And there is default channel configured
           And I am logged in as administrator
 
     Scenario: Browsing all configured currencies

--- a/features/currencies/currency_switching.feature
+++ b/features/currencies/currency_switching.feature
@@ -6,24 +6,23 @@ Feature: Currency selection
 
     Background:
         Given there are following taxonomies defined:
-          | name     |
-          | Category |
-        And taxonomy "Category" has following taxons:
-          | Clothing > PHP T-Shirts |
-        And the following products exist:
-          | name          | price | taxons       |
-          | PHP Top       | 5.99  | PHP T-Shirts |
-        And there are following currencies configured:
-          | code | exchange rate | enabled |
-          | EUR  | 1.00000       | yes     |
-          | USD  | 0.76496       | yes     |
-          | GBP  | 1.13986       | yes     |
-          | PLN  | 1.01447       | no      |
-      And there are following channels configured:
-        | code        | name            | currencies    | locales  | url          |
-        | DEFAULT-WEB | Default Channel | EUR, GBP, USD | en_US    | localhost    |
-      And all products assigned to "DEFAULT-WEB" channel
-
+            | name     |
+            | Category |
+          And taxonomy "Category" has following taxons:
+            | Clothing > PHP T-Shirts |
+          And the following products exist:
+            | name          | price | taxons       |
+            | PHP Top       | 5.99  | PHP T-Shirts |
+          And there are following currencies configured:
+            | code | exchange rate | enabled |
+            | EUR  | 1.00000       | yes     |
+            | USD  | 0.76496       | yes     |
+            | GBP  | 1.13986       | yes     |
+            | PLN  | 1.01447       | no      |
+          And there are following channels configured:
+            | code        | name            | currencies    | locales  | url          |
+            | DEFAULT-WEB | Default Channel | EUR, GBP, USD | en_US    | localhost    |
+          And all products are assigned to the default channel
 
     Scenario: Only enabled currencies are visible to the user
         Given I am on the store homepage

--- a/features/email/email_management.feature
+++ b/features/email/email_management.feature
@@ -5,14 +5,13 @@ Feature: Managing emails
     I want to be able to configure them in backend
 
     Background:
-        Given there is default currency configured
-        And there is default channel configured
-        And there are following emails configured:
+        Given store has default configuration
+          And there are following emails configured:
             | code                  | subject                      | enabled |
             | user_confirmation     | Welcome!                     | yes     |
             | order_confirmation    | Thank you for your order!    | no      |
             | shipment_confirmation | Your shipment is on the way! | yes     |
-         And I am logged in as administrator
+          And I am logged in as administrator
 
     Scenario: Seeing index of all emails
         Given I am on the dashboard page

--- a/features/frontend/cart.feature
+++ b/features/frontend/cart.feature
@@ -5,7 +5,8 @@ Feature: Cart
     I want to be able to add products to cart
 
     Background:
-        Given there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
           And taxonomy "Category" has following taxons:
@@ -22,15 +23,11 @@ Feature: Cart
             | Git T-Shirt   | 29.99 | T-Shirt size                | PHP T-Shirts | match              |
             | PHP Top       | 5.99  |                             | PHP T-Shirts |                    |
             | iShirt        | 18.99 |                             | T-Shirts     |                    |
-          And product "Super T-Shirt" is available in all variations
-          And product "Git T-Shirt" is available in all variations
-          And product "Black T-Shirt" is available in all variations
-          And there is default currency configured
-          And there is default channel configured
-          And channel "DEFAULT-WEB" has following configuration:
-              | taxonomy |
-              | Category |
-          And all products assigned to "DEFAULT-WEB" channel
+          And all products are available in all variations
+          And all products are assigned to the default channel
+          And the default channel has following configuration:
+            | taxonomy |
+            | Category |
 
     Scenario: Seeing empty cart
         Given I am on the store homepage

--- a/features/frontend/cart_inclusive_tax.feature
+++ b/features/frontend/cart_inclusive_tax.feature
@@ -5,15 +5,14 @@ Feature: Tax included in price
     I want to apply taxes during checkout
 
     Background:
-        Given there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
           And taxonomy "Category" has following taxons:
             | Clothing > PHP T-Shirts |
-          And there is default currency configured
-          And there is default channel configured
           And the following zones are defined:
-            | name  | type    | members        |
+            | name    | type    | members        |
             | Germany | country | Germany        |
           And there are following tax categories:
             | name          |
@@ -24,10 +23,7 @@ Feature: Tax included in price
           And the following products exist:
             | name    | price | taxons       | tax category  |
             | PHP Top | 85    | PHP T-Shirts | Taxable Goods |
-          And all products assigned to "DEFAULT-WEB" channel
-          And channel "DEFAULT-WEB" has following configuration:
-            | taxonomy |
-            | Category |
+          And all products are assigned to the default channel
           And the default tax zone is "Germany"
 
     Scenario: Correct amounts are displayed for inclusive taxes

--- a/features/frontend/cart_maintenance.feature
+++ b/features/frontend/cart_maintenance.feature
@@ -5,23 +5,22 @@ Feature: Cart
     I want my cart to be maintained after I log in
 
     Background:
-          Given there are following users:
+          Given store has default configuration
+            And there are following users:
               | email       | password | enabled |
               | bar@foo.com | foo1     | yes     |
-          And there are following taxonomies defined:
+            And there are following taxonomies defined:
               | name     |
               | Category |
-          And taxonomy "Category" has following taxons:
+            And taxonomy "Category" has following taxons:
               | Clothing > PHP T-Shirts |
-          And the following products exist:
+            And the following products exist:
               | name    | price | taxons       |
               | PHP Top | 85    | PHP T-Shirts |
-          And there is default currency configured
-          And there is default channel configured
-          And channel "DEFAULT-WEB" has following configuration:
+            And all products are assigned to the default channel
+            And the default channel has following configuration:
               | taxonomy |
               | Category |
-          And all products assigned to "DEFAULT-WEB" channel
 
     Scenario: The cart is maintained after user log in
         Given I am on the store homepage

--- a/features/frontend/cart_promotions_complex.feature
+++ b/features/frontend/cart_promotions_complex.feature
@@ -5,34 +5,33 @@ Feature: Checkout promotions with multiple rules and actions
     I want to apply promotion discounts during checkout
 
     Background:
-        Given the following promotions exist:
-          | name              | description                                            |
-          | 150 EUR / 2 items | Discount for orders over 150 EUR with at least 2 items |
-        And promotion "150 EUR / 2 items" has following rules defined:
-          | type       | configuration        |
-          | Item total | Amount: 150          |
-          | Item count | Count: 2,Equal: true |
-        And promotion "150 EUR / 2 items" has following actions defined:
-          | type                | configuration |
-          | Fixed discount      | Amount: 20    |
-          | Percentage discount | Percentage: 5 |
-        And there are following taxonomies defined:
-          | name     |
-          | Category |
-        And taxonomy "Category" has following taxons:
-          | Clothing > Debian T-Shirts |
-        And the following products exist:
-          | name    | price | taxons          |
-          | Buzz    | 500   | Debian T-Shirts |
-          | Potato  | 200   | Debian T-Shirts |
-          | Woody   | 125   | Debian T-Shirts |
-          | Sarge   | 25    | Debian T-Shirts |
-          | Etch    | 20    | Debian T-Shirts |
-          | Lenny   | 15    | Debian T-Shirts |
-        And there is default currency configured
-        And there is default channel configured
-        And all products assigned to "DEFAULT-WEB" channel
-        And all promotions assigned to "DEFAULT-WEB" channel
+        Given store has default configuration
+          And the following promotions exist:
+            | name              | description                                            |
+            | 150 EUR / 2 items | Discount for orders over 150 EUR with at least 2 items |
+          And promotion "150 EUR / 2 items" has following rules defined:
+            | type       | configuration        |
+            | Item total | Amount: 150          |
+            | Item count | Count: 2,Equal: true |
+          And promotion "150 EUR / 2 items" has following actions defined:
+            | type                | configuration |
+            | Fixed discount      | Amount: 20    |
+            | Percentage discount | Percentage: 5 |
+          And there are following taxonomies defined:
+            | name     |
+            | Category |
+          And taxonomy "Category" has following taxons:
+            | Clothing > Debian T-Shirts |
+          And the following products exist:
+            | name    | price | taxons          |
+            | Buzz    | 500   | Debian T-Shirts |
+            | Potato  | 200   | Debian T-Shirts |
+            | Woody   | 125   | Debian T-Shirts |
+            | Sarge   | 25    | Debian T-Shirts |
+            | Etch    | 20    | Debian T-Shirts |
+            | Lenny   | 15    | Debian T-Shirts |
+          And all products are assigned to the default channel
+          And all promotions are assigned to the default channel
 
     Scenario: Several discounts are applied when a promotion has several
               actions and the cart fulfills all the rules

--- a/features/frontend/cart_promotions_coupons.feature
+++ b/features/frontend/cart_promotions_coupons.feature
@@ -5,45 +5,44 @@ Feature: Checkout coupon promotions
     I want to apply promotion discounts during checkout
 
     Background:
-        Given the following promotions exist:
-          | name                      | description            |
-          | Press campaign            | Coupon based promotion |
-          | New Year campaign         | Coupon based promotion |
-        And promotion "Press campaign" has following rules defined:
-          | type       | configuration |
-          | Item total | Amount: 100   |
-        And promotion "Press campaign" has following coupons:
-          | code   | usage limit | used |
-          | XD0001 | 1           | 0    |
-        And promotion "Press campaign" has following actions defined:
-          | type           | configuration |
-          | Fixed discount | Amount: 5     |
-        And promotion "New Year campaign" has following rules defined:
-          | type       | configuration |
-          | Item count | Count: 2      |
-        And promotion "New Year campaign" has following actions defined:
-          | type           | configuration |
-          | Fixed discount | Amount: 10    |
-        And promotion "New Year campaign" has following coupons:
-          | code   | usage limit | used |
-          | XD0002 | 1           | 1    |
-        And there are following taxonomies defined:
-          | name     |
-          | Category |
-        And taxonomy "Category" has following taxons:
-          | Clothing > Debian T-Shirts |
-        And the following products exist:
-          | name    | price | taxons          |
-          | Buzz    | 500   | Debian T-Shirts |
-          | Potato  | 200   | Debian T-Shirts |
-          | Woody   | 125   | Debian T-Shirts |
-          | Sarge   | 25    | Debian T-Shirts |
-          | Etch    | 20    | Debian T-Shirts |
-          | Lenny   | 1     | Debian T-Shirts |
-        And there is default currency configured
-        And there is default channel configured
-        And all products assigned to "DEFAULT-WEB" channel
-        And all promotions assigned to "DEFAULT-WEB" channel
+        Given store has default configuration
+          And the following promotions exist:
+            | name                      | description            |
+            | Press campaign            | Coupon based promotion |
+            | New Year campaign         | Coupon based promotion |
+          And promotion "Press campaign" has following rules defined:
+            | type       | configuration |
+            | Item total | Amount: 100   |
+          And promotion "Press campaign" has following coupons:
+            | code   | usage limit | used |
+            | XD0001 | 1           | 0    |
+          And promotion "Press campaign" has following actions defined:
+            | type           | configuration |
+            | Fixed discount | Amount: 5     |
+          And promotion "New Year campaign" has following rules defined:
+            | type       | configuration |
+            | Item count | Count: 2      |
+          And promotion "New Year campaign" has following actions defined:
+            | type           | configuration |
+            | Fixed discount | Amount: 10    |
+          And promotion "New Year campaign" has following coupons:
+            | code   | usage limit | used |
+            | XD0002 | 1           | 1    |
+          And there are following taxonomies defined:
+            | name     |
+            | Category |
+          And taxonomy "Category" has following taxons:
+            | Clothing > Debian T-Shirts |
+          And the following products exist:
+            | name    | price | taxons          |
+            | Buzz    | 500   | Debian T-Shirts |
+            | Potato  | 200   | Debian T-Shirts |
+            | Woody   | 125   | Debian T-Shirts |
+            | Sarge   | 25    | Debian T-Shirts |
+            | Etch    | 20    | Debian T-Shirts |
+            | Lenny   | 1     | Debian T-Shirts |
+          And all products are assigned to the default channel
+          And all promotions are assigned to the default channel
 
     Scenario: Promotion with coupons is applied when the customer
               has added a valid coupon

--- a/features/frontend/cart_promotions_dates.feature
+++ b/features/frontend/cart_promotions_dates.feature
@@ -5,37 +5,36 @@ Feature: Checkout limited time promotions
     I want to apply promotion discounts during checkout
 
     Background:
-        Given the following promotions exist:
-          | name     | description                   | starts     | ends       |
-          | Decade   | 20 EUR off for this decade    | 2013-01-01 | 2023-01-01 |
-          | Too late | too late to get this discount |            | 2013-01-01 |
-          | Too soon | too soon to get this discount | 2023-01-01 |            |
-        And promotion "Decade" has following actions defined:
-          | type           | configuration |
-          | Fixed discount | Amount: 20    |
-        And promotion "Too late" has following actions defined:
-          | type           | configuration |
-          | Fixed discount | Amount: 30    |
-        And promotion "Too soon" has following actions defined:
-          | type           | configuration |
-          | Fixed discount | Amount: 40    |
-        And there are following taxonomies defined:
-          | name     |
-          | Category |
-        And taxonomy "Category" has following taxons:
-          | Clothing > Debian T-Shirts |
-        And the following products exist:
-          | name    | price | taxons          |
-          | Buzz    | 500   | Debian T-Shirts |
-          | Potato  | 200   | Debian T-Shirts |
-          | Woody   | 125   | Debian T-Shirts |
-          | Sarge   | 25    | Debian T-Shirts |
-          | Etch    | 20    | Debian T-Shirts |
-          | Lenny   | 15    | Debian T-Shirts |
-        And there is default currency configured
-        And there is default channel configured
-        And all products assigned to "DEFAULT-WEB" channel
-        And all promotions assigned to "DEFAULT-WEB" channel
+        Given store has default configuration
+          And the following promotions exist:
+            | name     | description                   | starts     | ends       |
+            | Decade   | 20 EUR off for this decade    | 2013-01-01 | 2023-01-01 |
+            | Too late | too late to get this discount |            | 2013-01-01 |
+            | Too soon | too soon to get this discount | 2023-01-01 |            |
+          And promotion "Decade" has following actions defined:
+            | type           | configuration |
+            | Fixed discount | Amount: 20    |
+          And promotion "Too late" has following actions defined:
+            | type           | configuration |
+            | Fixed discount | Amount: 30    |
+          And promotion "Too soon" has following actions defined:
+            | type           | configuration |
+            | Fixed discount | Amount: 40    |
+          And there are following taxonomies defined:
+            | name     |
+            | Category |
+          And taxonomy "Category" has following taxons:
+            | Clothing > Debian T-Shirts |
+          And the following products exist:
+            | name    | price | taxons          |
+            | Buzz    | 500   | Debian T-Shirts |
+            | Potato  | 200   | Debian T-Shirts |
+            | Woody   | 125   | Debian T-Shirts |
+            | Sarge   | 25    | Debian T-Shirts |
+            | Etch    | 20    | Debian T-Shirts |
+            | Lenny   | 15    | Debian T-Shirts |
+          And all products are assigned to the default channel
+          And all promotions are assigned to the default channel
 
     Scenario: Promotion is applied when the order date corresponds
               with promotion dates

--- a/features/frontend/cart_promotions_fixed.feature
+++ b/features/frontend/cart_promotions_fixed.feature
@@ -5,9 +5,7 @@ Feature: Checkout fixed discount promotions
     I want to apply promotion discounts during checkout
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in as user "klaus@example.com"
+        Given store has default configuration
           And the following countries exist:
             | name    |
             | Germany |
@@ -34,8 +32,8 @@ Feature: Checkout fixed discount promotions
             | Shipping to Germany | Discount for orders with shipping country Germany |
             | Ubuntu T-Shirts     | Discount for Ubuntu T-Shirts                      |
             | 3rd order           | Discount for 3rd order                            |
-          And all products assigned to "DEFAULT-WEB" channel
-          And all promotions assigned to "DEFAULT-WEB" channel
+          And all products are assigned to the default channel
+          And all promotions are assigned to the default channel
           And promotion "3 items" has following rules defined:
             | type       | configuration        |
             | Item count | Count: 3,Equal: true |
@@ -49,13 +47,13 @@ Feature: Checkout fixed discount promotions
             | type           | configuration |
             | Fixed discount | Amount: 40    |
           And promotion "Shipping to Germany" has following rules defined:
-            | type       | configuration |
+            | type             | configuration |
             | Shipping country | Country: Germany |
           And promotion "Shipping to Germany" has following actions defined:
             | type           | configuration |
             | Fixed discount | Amount: 40    |
           And promotion "Ubuntu T-Shirts" has following rules defined:
-            | type     | configuration          |
+            | type     | configuration                      |
             | Taxonomy | Taxons: Ubuntu T-Shirts,Exclude: 0 |
           And promotion "Ubuntu T-Shirts" has following actions defined:
             | type           | configuration |
@@ -66,6 +64,7 @@ Feature: Checkout fixed discount promotions
           And promotion "3rd order" has following actions defined:
             | type           | configuration |
             | Fixed discount | Amount: 10    |
+          And I am logged in as user "klaus@example.com"
 
     Scenario: Fixed discount promotion is applied when the cart
               has the required amount

--- a/features/frontend/cart_promotions_percentage.feature
+++ b/features/frontend/cart_promotions_percentage.feature
@@ -5,39 +5,38 @@ Feature: Checkout percentage discount promotions
     I want to apply promotion discounts during checkout
 
     Background:
-        Given the following promotions exist:
-          | name              | description                               |
-          | 3 items           | Discount for orders with at least 3 items |
-          | 300 EUR           | Discount for orders over 300 EUR          |
-        And promotion "3 items" has following rules defined:
-          | type       | configuration        |
-          | Item count | Count: 3,Equal: true |
-        And promotion "3 items" has following actions defined:
-          | type                | configuration  |
-          | Percentage discount | Percentage: 15 |
-        And promotion "300 EUR" has following rules defined:
-          | type       | configuration |
-          | Item total | Amount: 300   |
-        And promotion "300 EUR" has following actions defined:
-          | type                | configuration |
-          | Percentage discount | Percentage: 8 |
-        And there are following taxonomies defined:
-          | name     |
-          | Category |
-        And taxonomy "Category" has following taxons:
-          | Clothing > Debian T-Shirts |
-        And the following products exist:
-          | name    | price | taxons          |
-          | Buzz    | 500   | Debian T-Shirts |
-          | Potato  | 200   | Debian T-Shirts |
-          | Woody   | 125   | Debian T-Shirts |
-          | Sarge   | 25    | Debian T-Shirts |
-          | Etch    | 20    | Debian T-Shirts |
-          | Lenny   | 15    | Debian T-Shirts |
-        And there is default currency configured
-        And there is default channel configured
-        And all products assigned to "DEFAULT-WEB" channel
-        And all promotions assigned to "DEFAULT-WEB" channel
+        Given store has default configuration
+          And the following promotions exist:
+            | name              | description                               |
+            | 3 items           | Discount for orders with at least 3 items |
+            | 300 EUR           | Discount for orders over 300 EUR          |
+          And promotion "3 items" has following rules defined:
+            | type       | configuration        |
+            | Item count | Count: 3,Equal: true |
+          And promotion "3 items" has following actions defined:
+            | type                | configuration  |
+            | Percentage discount | Percentage: 15 |
+          And promotion "300 EUR" has following rules defined:
+            | type       | configuration |
+            | Item total | Amount: 300   |
+          And promotion "300 EUR" has following actions defined:
+            | type                | configuration |
+            | Percentage discount | Percentage: 8 |
+          And there are following taxonomies defined:
+            | name     |
+            | Category |
+          And taxonomy "Category" has following taxons:
+            | Clothing > Debian T-Shirts |
+          And the following products exist:
+            | name    | price | taxons          |
+            | Buzz    | 500   | Debian T-Shirts |
+            | Potato  | 200   | Debian T-Shirts |
+            | Woody   | 125   | Debian T-Shirts |
+            | Sarge   | 25    | Debian T-Shirts |
+            | Etch    | 20    | Debian T-Shirts |
+            | Lenny   | 15    | Debian T-Shirts |
+          And all products are assigned to the default channel
+          And all promotions are assigned to the default channel
 
     Scenario: Fixed discount promotion is applied when the cart
               has the required amount

--- a/features/frontend/cart_promotions_product.feature
+++ b/features/frontend/cart_promotions_product.feature
@@ -5,28 +5,27 @@ Feature: Checkout product promotion
     I want to apply promotion discounts during checkout
 
     Background:
-        Given the following products exist:
-          | name   | price |
-          | Lenny  | 15    |
-          | Buzz   | 500   |
-          | Potato | 200   |
-          | Etch   | 20    |
-          | Woody  | 125   |
-          | Sarge  | 25    |
-          | Ubu    | 200   |
-        And the following promotions exist:
-          | name                | description                      |
-          | Free product        | Almost free product over 100 eur |
-        And promotion "Free product" has following rules defined:
-          | type       | configuration |
-          | Item total | Amount: 100   |
-        And promotion "Free product" has following actions defined:
-          | type        | configuration                     |
-          | Add product | variant:Ubu,quantity:1,price:10 |
-        And there is default currency configured
-        And there is default channel configured
-        And all products assigned to "DEFAULT-WEB" channel
-        And all promotions assigned to "DEFAULT-WEB" channel
+        Given store has default configuration
+          And the following products exist:
+            | name   | price |
+            | Lenny  | 15    |
+            | Buzz   | 500   |
+            | Potato | 200   |
+            | Etch   | 20    |
+            | Woody  | 125   |
+            | Sarge  | 25    |
+            | Ubu    | 200   |
+          And the following promotions exist:
+            | name                | description                      |
+            | Free product        | Almost free product over 100 eur |
+          And promotion "Free product" has following rules defined:
+            | type       | configuration |
+            | Item total | Amount: 100   |
+          And promotion "Free product" has following actions defined:
+            | type        | configuration                   |
+            | Add product | variant:Ubu,quantity:1,price:10 |
+          And all products are assigned to the default channel
+          And all promotions are assigned to the default channel
 
     Scenario: Free product is not applied when the cart
               has not the required amount

--- a/features/frontend/cart_promotions_usage_limit.feature
+++ b/features/frontend/cart_promotions_usage_limit.feature
@@ -5,39 +5,38 @@ Feature: Checkout usage limited promotions
     I want to apply promotion discounts during checkout
 
     Background:
-        Given the following promotions exist:
-          | name                             | description                                          | usage limit | used |
-          | 50% off over 200 EUR             | First 3 orders over 200 EUR have 50% discount!       | 3           | 0    |
-          | Free order with at least 3 items | First order with at least 3 items has 100% discount! | 1           | 1    |
-        And promotion "50% off over 200 EUR" has following rules defined:
-          | type       | configuration |
-          | Item total | Amount: 200   |
-        And promotion "50% off over 200 EUR" has following actions defined:
-          | type                | configuration  |
-          | Percentage discount | Percentage: 50 |
-        And promotion "Free order with at least 3 items" has following rules defined:
-          | type       | configuration        |
-          | Item count | Count: 3,Equal: true |
-        And promotion "Free order with at least 3 items" has following actions defined:
-          | type                | configuration   |
-          | Percentage discount | Percentage: 100 |
-        And there are following taxonomies defined:
-          | name     |
-          | Category |
-        And taxonomy "Category" has following taxons:
-          | Clothing > Debian T-Shirts |
-        And the following products exist:
-          | name    | price | taxons          |
-          | Buzz    | 500   | Debian T-Shirts |
-          | Potato  | 200   | Debian T-Shirts |
-          | Woody   | 125   | Debian T-Shirts |
-          | Sarge   | 25    | Debian T-Shirts |
-          | Etch    | 20    | Debian T-Shirts |
-          | Lenny   | 15    | Debian T-Shirts |
-        And there is default currency configured
-        And there is default channel configured
-        And all products assigned to "DEFAULT-WEB" channel
-        And all promotions assigned to "DEFAULT-WEB" channel
+        Given store has default configuration
+          And the following promotions exist:
+            | name                             | description                                          | usage limit | used |
+            | 50% off over 200 EUR             | First 3 orders over 200 EUR have 50% discount!       | 3           | 0    |
+            | Free order with at least 3 items | First order with at least 3 items has 100% discount! | 1           | 1    |
+          And promotion "50% off over 200 EUR" has following rules defined:
+            | type       | configuration |
+            | Item total | Amount: 200   |
+          And promotion "50% off over 200 EUR" has following actions defined:
+            | type                | configuration  |
+            | Percentage discount | Percentage: 50 |
+          And promotion "Free order with at least 3 items" has following rules defined:
+            | type       | configuration        |
+            | Item count | Count: 3,Equal: true |
+          And promotion "Free order with at least 3 items" has following actions defined:
+            | type                | configuration   |
+            | Percentage discount | Percentage: 100 |
+          And there are following taxonomies defined:
+            | name     |
+            | Category |
+          And taxonomy "Category" has following taxons:
+            | Clothing > Debian T-Shirts |
+          And the following products exist:
+            | name    | price | taxons          |
+            | Buzz    | 500   | Debian T-Shirts |
+            | Potato  | 200   | Debian T-Shirts |
+            | Woody   | 125   | Debian T-Shirts |
+            | Sarge   | 25    | Debian T-Shirts |
+            | Etch    | 20    | Debian T-Shirts |
+            | Lenny   | 15    | Debian T-Shirts |
+          And all products are assigned to the default channel
+          And all promotions are assigned to the default channel
 
     Scenario: Promotion with usage limit is applied when the
               number of usage is not reached

--- a/features/frontend/cart_tax_categories.feature
+++ b/features/frontend/cart_tax_categories.feature
@@ -5,7 +5,8 @@ Feature: Tax categories
     I want to apply taxes depending on the item cateogry
 
     Background:
-        Given there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
           And taxonomy "Category" has following taxons:
@@ -26,13 +27,8 @@ Feature: Tax categories
             | name         | price | taxons       | tax category |
             | PHP Top      | 50    | PHP T-Shirts | Clothing     |
             | Golden Apple | 120   | Food         | Food         |
-        And there is default currency configured
-        And there is default channel configured
-        And all products assigned to "DEFAULT-WEB" channel
-        And all promotions assigned to "DEFAULT-WEB" channel
-        And channel "DEFAULT-WEB" has following configuration:
-          | taxonomy |
-          | Category |
+          And all products are assigned to the default channel
+          And all promotions are assigned to the default channel
 
     Scenario: Correct taxes are applied for one item
         Given the default tax zone is "UK"

--- a/features/frontend/cart_taxation.feature
+++ b/features/frontend/cart_taxation.feature
@@ -5,13 +5,14 @@ Feature: Cart taxation
     I want to apply taxes during checkout
 
     Background:
-        Given there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
           And taxonomy "Category" has following taxons:
             | Clothing > PHP T-Shirts |
           And the following zones are defined:
-            | name  | type    | members        |
+            | name    | type    | members        |
             | UK      | country | United Kingdom |
             | Germany | country | Germany        |
           And there are following tax categories:
@@ -24,13 +25,7 @@ Feature: Cart taxation
           And the following products exist:
             | name    | price | taxons       | tax category  |
             | PHP Top | 50    | PHP T-Shirts | Taxable Goods |
-          And there is default currency configured
-          And there is default channel configured
-          And all products assigned to "DEFAULT-WEB" channel
-          And channel "DEFAULT-WEB" has following configuration:
-            | taxonomy |
-            | Category |
-
+          And all products are assigned to the default channel
 
     Scenario: No taxes are applied for unknown billing address
               when default tax zone is not configured

--- a/features/frontend/checkout_addressing.feature
+++ b/features/frontend/checkout_addressing.feature
@@ -5,7 +5,8 @@ Feature: Checkout addressing
     I want to proceed through addressing checkout step
 
     Background:
-        Given there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
           And taxonomy "Category" has following taxons:
@@ -31,9 +32,7 @@ Feature: Checkout addressing
             | zone         | name          | calculator | configuration |
             | UK + Germany | DHL Express   | Flat rate  | Amount: 5000  |
             | USA          | FedEx         | Flat rate  | Amount: 6500  |
-          And there is default currency configured
-          And there is default channel configured
-          And all products assigned to "DEFAULT-WEB" channel
+          And all products are assigned to the default channel
 
     Scenario: Filling the shipping address
         Given I am logged in user

--- a/features/frontend/checkout_addressing_i18n.feature
+++ b/features/frontend/checkout_addressing_i18n.feature
@@ -5,7 +5,8 @@ Feature: Checkout addressing in preferred language
     I want to see the country list in my preferred language
 
     Background:
-        Given there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
           And taxonomy "Category" has following taxons:
@@ -27,10 +28,8 @@ Feature: Checkout addressing in preferred language
             | zone         | name          | calculator | configuration |
             | UK + Germany | DHL Express   | Flat rate  | Amount: 5000  |
             | USA          | FedEx         | Flat rate  | Amount: 6500  |
-          And there is default currency configured
-          And there is default channel configured
-          And all products assigned to "DEFAULT-WEB" channel
-        And there are following locales configured:
+          And all products are assigned to the default channel
+          And there are following locales configured:
             | code  | enabled |
             | en_US | yes     |
             | de_DE | yes     |

--- a/features/frontend/checkout_finalize.feature
+++ b/features/frontend/checkout_finalize.feature
@@ -5,7 +5,8 @@ Feature: Checkout finalization
     I want to be able to complete the checkout process
 
     Background:
-        Given there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
           And taxonomy "Category" has following taxons:
@@ -22,10 +23,8 @@ Feature: Checkout finalization
           And the following payment methods exist:
             | name  | gateway | enabled | calculator | calculator_configuration |
             | Dummy | dummy   | yes     | fixed      | amount: 0                |
-          And there is default currency configured
-          And there is default channel configured
-          And all products assigned to "DEFAULT-WEB" channel
-          And channel "DEFAULT-WEB" has following configuration:
+          And all products are assigned to the default channel
+          And the default channel has following configuration:
             | taxonomy | payment | shipping    |
             | Category | Dummy   | DHL Express |
 

--- a/features/frontend/checkout_inventory.feature
+++ b/features/frontend/checkout_inventory.feature
@@ -5,7 +5,8 @@ Feature: Checkout inventory
     I need to see inventory changes after checkout
 
     Background:
-        Given there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
           And taxonomy "Category" has following taxons:
@@ -23,10 +24,8 @@ Feature: Checkout inventory
           And the following payment methods exist:
             | name        | gateway | enabled | calculator | calculator_configuration |
             | Credit Card | dummy   | yes     | fixed      | amount: 0                |
-          And there is default currency configured
-          And there is default channel configured
-          And all products assigned to "DEFAULT-WEB" channel
-          And channel "DEFAULT-WEB" has following configuration:
+          And all products are assigned to the default channel
+          And the default channel has following configuration:
             | taxonomy | payment       | shipping    |
             | Category | Credit Card   | DHL Express |
           And I am logged in as administrator

--- a/features/frontend/checkout_payment.feature
+++ b/features/frontend/checkout_payment.feature
@@ -5,9 +5,8 @@ Feature: Checkout Payment
     I want to be able to use checkout payment step
 
     Background:
-        Given there is default currency configured
-        And there is default channel configured
-        And there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
           And taxonomy "Category" has following taxons:
@@ -27,8 +26,8 @@ Feature: Checkout Payment
             | Credit Card PRO | stripe     | yes     | percent    | percent: 0               |
             | PayPal          | paypal     | yes     | fixed      | amount: 50               |
             | PayPal PRO      | paypal_pro | no      | percent    | percent: 10              |
-          And all products assigned to "DEFAULT-WEB" channel
-          And channel "DEFAULT-WEB" has following configuration:
+          And all products are assigned to the default channel
+          And the default channel has following configuration:
             | taxonomy | payment                                            | shipping    |
             | Category | PayPal, PayPal PRO, Credit Card, Credit Card PRO   | DHL Express |
           And I am logged in user

--- a/features/frontend/checkout_security.feature
+++ b/features/frontend/checkout_security.feature
@@ -5,8 +5,7 @@ Feature: Checkout security
     I want to login or register during checkout
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
+        Given store has default configuration
           And there are following taxonomies defined:
             | name     |
             | Category |
@@ -28,8 +27,8 @@ Feature: Checkout security
           And the following payment methods exist:
             | name  | gateway | enabled | calculator | calculator_configuration |
             | Dummy | dummy   | yes     | fixed      | amount: 0                |
-          And all products assigned to "DEFAULT-WEB" channel
-          And channel "DEFAULT-WEB" has following configuration:
+          And all products are assigned to the default channel
+          And the default channel has following configuration:
             | taxonomy | payment | shipping    |
             | Category | Dummy   | DHL Express |
           And I added product "PHP Top" to cart

--- a/features/frontend/checkout_shipping.feature
+++ b/features/frontend/checkout_shipping.feature
@@ -5,7 +5,8 @@ Feature: Checkout shipping
     I want to be able to use checkout shipping step
 
     Background:
-        Given there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
           And taxonomy "Category" has following taxons:
@@ -32,10 +33,8 @@ Feature: Checkout shipping
           And the following payment methods exist:
             | name  | gateway | enabled | calculator | calculator_configuration |
             | Dummy | dummy   | yes     | fixed      | amount: 0                |
-          And there is default currency configured
-          And there is default channel configured
-          And all products assigned to "DEFAULT-WEB" channel
-          And channel "DEFAULT-WEB" has following configuration:
+          And all products are assigned to the default channel
+          And the default channel has following configuration:
             | taxonomy | payment | shipping                                      |
             | Category | Dummy   | DHL Express, FedEx, FedEx Premium, UPS Ground |
           And I am logged in user

--- a/features/frontend/checkout_shipping_i18n.feature
+++ b/features/frontend/checkout_shipping_i18n.feature
@@ -5,7 +5,8 @@ Feature: Checkout shipping in preferred language
     I want to be able to see shipping methods in my preferred language
 
     Background:
-        Given there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
           And taxonomy "Category" has following taxons:
@@ -23,16 +24,14 @@ Feature: Checkout shipping in preferred language
             | United Kingdom |
             | Germany        |
           And the following shipping methods exist:
-            | zone         | name          | calculator | configuration | enabled |
-            | USA          | FedEx         | Flat rate  | Amount: 6500  | yes     |
-            | UK + Germany | UPS Ground    | Flat rate  | Amount: 20000 | yes     |
-          And there is default currency configured
-          And there is default channel configured
-          And all products assigned to "DEFAULT-WEB" channel
+            | zone         | name       | calculator | configuration | enabled |
+            | USA          | FedEx      | Flat rate  | Amount: 6500  | yes     |
+            | UK + Germany | UPS Ground | Flat rate  | Amount: 20000 | yes     |
+          And all products are assigned to the default channel
           And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-            | de_DE | yes     |
+            | code  |
+            | en_US |
+            | de_DE |
           And the shipping method translations exist
             | shipping_method | name        | locale |
             | UPS Ground      | UPS Land    | de     |

--- a/features/frontend/checkout_start.feature
+++ b/features/frontend/checkout_start.feature
@@ -5,7 +5,8 @@ Feature: Checkout starting
     I want to be able to use checkout process
 
     Background:
-        Given there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
           And taxonomy "Category" has following taxons:
@@ -19,9 +20,7 @@ Feature: Checkout starting
             | Super T-Shirt | 20.00 | T-Shirt color | T-Shirts     | match              |
             | PHP Top       | 5.99  |               | PHP T-Shirts |                    |
           And product "Super T-Shirt" is available in all variations
-          And there is default currency configured
-          And there is default channel configured
-          And all products assigned to "DEFAULT-WEB" channel
+          And all products are assigned to the default channel
 
     Scenario: There is no checkout for empty cart
         Given I am on the store homepage

--- a/features/frontend/checkout_taxation.feature
+++ b/features/frontend/checkout_taxation.feature
@@ -5,7 +5,8 @@ Feature: Checkout taxation
     I want to apply taxes during checkout
 
     Background:
-        Given there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
           And taxonomy "Category" has following taxons:
@@ -28,10 +29,8 @@ Feature: Checkout taxation
           And the following payment methods exist:
             | name  | gateway | enabled | calculator | calculator_configuration |
             | Dummy | dummy   | yes     | fixed      | amount: 0                |
-          And there is default currency configured
-          And there is default channel configured
-          And all products assigned to "DEFAULT-WEB" channel
-          And channel "DEFAULT-WEB" has following configuration:
+          And all products are assigned to the default channel
+          And the default channel has following configuration:
             | taxonomy | payment | shipping    |
             | Category | Dummy   | DHL Express |
           And I am logged in user

--- a/features/frontend/homepage.feature
+++ b/features/frontend/homepage.feature
@@ -5,8 +5,7 @@ Feature: Store homepage
     I want to be able to see the homepage
 
     Scenario: Viewing the homepage at website root
-        Given there is default currency configured
-          And there is default channel configured
+        Given store has default configuration
          When I go to the website root
          Then I should be on the homepage
           And I should see "Modern ecommerce for Symfony2"

--- a/features/frontend/products.feature
+++ b/features/frontend/products.feature
@@ -6,32 +6,32 @@ Feature: Products
 
     Background:
         Given there is default currency configured
-        And there are following taxonomies defined:
+          And there are following taxonomies defined:
             | name     |
             | Category |
-        And taxonomy "Category" has following taxons:
+          And taxonomy "Category" has following taxons:
             | Clothing > T-Shirts     |
             | Clothing > PHP T-Shirts |
             | Clothing > Gloves       |
-        And the following products exist:
+          And the following products exist:
             | name             | price | taxons       |
             | Super T-Shirt    | 19.99 | T-Shirts     |
             | Black T-Shirt    | 18.99 | T-Shirts     |
             | Sylius Tee       | 12.99 | PHP T-Shirts |
             | Symfony T-Shirt  | 15.00 | PHP T-Shirts |
             | Doctrine T-Shirt | 15.00 | PHP T-Shirts |
-        And there are following channels configured:
+          And there are following channels configured:
             | code   | name       | currencies | locales             | url          |
             | WEB-US | mystore.us | EUR, GBP   | en_US               |              |
             | WEB-EU | mystore.eu | USD        | en_GB, fr_FR, de_DE | localhost    |
-        And channel "WEB-EU" has following configuration:
+          And channel "WEB-EU" has following configuration:
             | taxonomy |
             | Category |
-        And channel "WEB-EU" has following products assigned:
+          And channel "WEB-EU" has following products assigned:
             | product         |
             | Super T-Shirt   |
             | Symfony T-Shirt |
-        And channel "WEB-US" has following products assigned:
+          And channel "WEB-US" has following products assigned:
             | product          |
             | Sylius Tee       |
             | Black T-Shirt    |

--- a/features/frontend/products_i18n.feature
+++ b/features/frontend/products_i18n.feature
@@ -5,46 +5,45 @@ Feature: Browse products, categories, attributes and options in preferred langua
     I want to be able to browse products in my preferred language
 
     Background:
-        Given there is default currency configured
-        And there is default channel configured
-        And there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
-        And taxonomy "Category" has following taxons:
+          And taxonomy "Category" has following taxons:
             | Clothing > T-Shirts     |
             | Clothing > PHP T-Shirts |
-        And there are following options:
+          And there are following options:
             | name          | presentation | values           |
             | T-Shirt color | Color        | Red, Blue, Green |
             | T-Shirt size  | Size         | S, M, L          |
-        And there are following attributes:
+          And there are following attributes:
             | name               | presentation      | type     | choices   |
             | T-Shirt fabric     | Fabric            | text     |           |
-        And the following products exist:
+          And the following products exist:
             | name          | price | options                     | attributes             | taxons       |
             | Super T-Shirt | 19.99 | T-Shirt size, T-Shirt color | T-Shirt fabric: Wool   | T-Shirts     |
-        And product "Super T-Shirt" is available in all variations
-        And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-            | es_ES | yes     |
-        And the following product translations exist:
+          And product "Super T-Shirt" is available in all variations
+          And there are following locales configured:
+            | code  |
+            | en_US |
+            | es_ES |
+          And the following product translations exist:
             | product       | name           | locale |
             | Super T-Shirt | Camiseta Super | es     |
-        And the following taxonomy translations exist
+          And the following taxonomy translations exist
             | taxonomy | name      | locale |
             | Category | Categoria | es     |
-        And the following taxon translations exist
+          And the following taxon translations exist
             | taxon    | name      | locale |
             | Clothing | Ropa      | es     |
             | T-Shirts | Camisetas | es     |
-        And the following attribute translations exist
+          And the following attribute translations exist
             | attribute      | presentation | locale |
             | T-Shirt fabric | Material     | es     |
-        And the following option translations exist
+          And the following option translations exist
             | option       | presentation | locale |
             | T-Shirt size | Talla        | es     |
-        And all products assigned to "DEFAULT-WEB" channel
+          And all products are assigned to the default channel
 
     Scenario: Seeing translated product, taxonomy and taxon name
         Given I am on the store homepage

--- a/features/frontend/search.feature
+++ b/features/frontend/search.feature
@@ -5,28 +5,26 @@ Feature: Search products
     I want to be able to search the products
 
     Background:
-        Given there is default currency configured
-        And there is default channel configured
-        And there are following taxonomies defined:
+        Given store has default configuration
+          And there are following taxonomies defined:
             | name     |
             | Category |
-        And taxonomy "Category" has following taxons:
+          And taxonomy "Category" has following taxons:
             | Clothing > T-Shirts     |
             | Clothing > PHP T-Shirts |
             | Clothing > Gloves       |
-        And the following products exist:
+          And the following products exist:
             | name             | price | taxons       | description             |
             | Super T-Shirt    | 19.99 | T-Shirts     | super black t-shirt     |
             | Black T-Shirt    | 18.99 | T-Shirts     | black t-shirt           |
             | Sylius Tee       | 12.99 | PHP T-Shirts | a very nice php t-shirt |
             | Symfony T-Shirt  | 15.00 | PHP T-Shirts | symfony t-shirt         |
             | Doctrine T-Shirt | 15.00 | PHP T-Shirts | doctrine t-shirt        |
-        And all products assigned to "DEFAULT-WEB" channel
-        And I populate the index
-        And channel "DEFAULT-WEB" has following configuration:
-          | taxonomy |
-          | Category |
-
+          And all products are assigned to the default channel
+          And the default channel has following configuration:
+            | taxonomy |
+            | Category |
+          And I populate the index
 
     Scenario: Search homepage is accessible
         Given I am on homepage

--- a/features/frontend/user_login_via_oauth.feature
+++ b/features/frontend/user_login_via_oauth.feature
@@ -5,10 +5,9 @@ Feature: Sign in to the store via OAuth
     I need to be able to log in to the store
 
     Background:
-        Given there is default currency configured
-        And there is default channel configured
-        And I am not logged in
-        And I am on the store homepage
+        Given store has default configuration
+          And I am not logged in
+          And I am on the store homepage
 
     Scenario Outline: Get to the OAuth login page
          When I follow "Login"

--- a/features/localization/locale_selection.feature
+++ b/features/localization/locale_selection.feature
@@ -5,13 +5,13 @@ Feature: Locale selection
     I want to to select my language in the storefront
 
     Background:
-        Given there are following locales configured:
+        Given there is default currency configured
+          And there are following locales configured:
             | code  | enabled |
             | de_DE | yes     |
             | en_US | yes     |
             | fr_FR | no      |
             | pl_PL | yes     |
-          And there is default currency configured
           And there are following channels configured:
             | code        | name            | currencies | locales                    | url       |
             | DEFAULT-WEB | Default Channel | EUR        | de_DE, en_US, fr_FR, pl_PL | localhost |

--- a/features/pricing/group_based_pricing.feature
+++ b/features/pricing/group_based_pricing.feature
@@ -5,8 +5,7 @@ Feature: Group based pricing
     I want to configure prices per customer group
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
+        Given store has default configuration
           And there are following taxonomies defined:
             | name     |
             | Category |
@@ -38,8 +37,8 @@ Feature: Group based pricing
             | group               | price |
             | Wholesale Customers | 39.49 |
             | Retail Customers    | 45.99 |
-          And all products assigned to "DEFAULT-WEB" channel
-          And channel "DEFAULT-WEB" has following configuration:
+          And all products are assigned to the default channel
+          And the default channel has following configuration:
             | taxonomy |
             | Category |
 

--- a/features/pricing/standard_pricing.feature
+++ b/features/pricing/standard_pricing.feature
@@ -5,8 +5,7 @@ Feature: Standard pricing
     I want to configure flat price for items
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
+        Given store has default configuration
           And there are following taxonomies defined:
             | name     |
             | Category |
@@ -26,8 +25,8 @@ Feature: Standard pricing
             | name        | price | taxons       | tax category  |
             | PHP Top     | 49.99 | PHP T-Shirts | Taxable Goods |
             | Symfony Tee | 69.00 | PHP T-Shirts | Taxable Goods |
-          And all products assigned to "DEFAULT-WEB" channel
-          And channel "DEFAULT-WEB" has following configuration:
+          And all products are assigned to the default channel
+          And the default channel has following configuration:
             | taxonomy |
             | Category |
 

--- a/features/pricing/volume_based_pricing.feature
+++ b/features/pricing/volume_based_pricing.feature
@@ -5,8 +5,7 @@ Feature: Volume based pricing
     I want to configure volume based pricing
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
+        Given store has default configuration
           And there are following taxonomies defined:
             | name     |
             | Category |
@@ -31,10 +30,7 @@ Feature: Volume based pricing
             | 10-19 | 65.00 |
             | 20-29 | 60.00 |
             | 30+   | 55.99 |
-          And all products assigned to "DEFAULT-WEB" channel
-          And channel "DEFAULT-WEB" has following configuration:
-            | taxonomy |
-            | Category |
+          And all products are assigned to the default channel
 
     Scenario: Volume-based pricing has priority over price attribute
         Given I am on the store homepage

--- a/features/reports/reports.feature
+++ b/features/reports/reports.feature
@@ -5,18 +5,17 @@ Feature: Reports
     I want to be able to manage reports
 
     Background:
-        Given there are following reports configured:
+        Given store has default configuration
+          And there are following reports configured:
             | name           | description | code             | renderer | renderer_configuration                                       | data_fetcher      | data_fetcher_configuration                   |
             | TableReport    | Lorem ipsum | table_report     | table    | Template:SyliusReportBundle:Table:default.html.twig          | user_registration | Period:day,Start:2010-01-01,End:2010-04-01   |
             | BarChartReport | Lorem ipsum | bar_chart_report | chart    | Type:bar,Template:SyliusReportBundle:Chart:default.html.twig | user_registration | Period:month,Start:2010-01-01,End:2010-04-01 |
-        And there is default currency configured
-        And there is default channel configured
-        And there are following users:
+          And there are following users:
             | email          | enabled  | created at          |
             | beth@foo.com   | yes      | 2010-01-02 12:00:00 |
             | martha@foo.com | yes      | 2010-01-02 13:00:00 |
             | rick@foo.com   | yes      | 2010-01-03 12:00:00 |
-        And I am logged in as administrator
+          And I am logged in as administrator
 
     Scenario: Seeing created reports it the list
         Given I am on the dashboard page
@@ -74,7 +73,7 @@ Feature: Reports
          When I fill in the following:
             | Name        | Report1           | 
             | Description | Lorem ipsum dolor |
-            | Code        | table report     |
+            | Code        | table report      |
           And I press "Create"
          Then I should still be on the report creation page
           And I should see "Report code should be a single word."

--- a/features/security/permission_management.feature
+++ b/features/security/permission_management.feature
@@ -5,33 +5,30 @@ Feature: Permissions management
     I want to be able to manage permissions
 
     Background:
-        Given there is default currency configured
-        And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-        And there is following permission hierarchy:
-            | code                        | parent         | description                   |
-            | sylius.catalog              |                | Manage products catalog       |
-            | sylius.product.show         | sylius.catalog | View single product           |
-            | sylius.product.index        | sylius.catalog | List all products             |
-            | sylius.product.create       | sylius.catalog | Add new products              |
-            | sylius.product.update       | sylius.catalog | Edit products                 |
-            | sylius.product.delete       | sylius.catalog | Delete products               |
-            | sylius.permission.show      |                | View single permission        |
-            | sylius.permission.index     |                | List all permissions          |
-            | sylius.permission.create    |                | Add new permissions           |
-            | sylius.permission.update    |                | Edit permissions              |
-            | sylius.permission.delete    |                | Delete permissions            |
-        And there is following role hierarchy:
-            | code                   | parent               | name            | security roles             |
-            | sylius.administrator   |                      | Administrator   | ROLE_ADMINISTRATION_ACCESS |
-        And role "Administrator" has the following permissions:
+        Given store has default configuration
+          And there is following permission hierarchy:
+            | code                     | parent         | description             |
+            | sylius.catalog           |                | Manage products catalog |
+            | sylius.product.show      | sylius.catalog | View single product     |
+            | sylius.product.index     | sylius.catalog | List all products       |
+            | sylius.product.create    | sylius.catalog | Add new products        |
+            | sylius.product.update    | sylius.catalog | Edit products           |
+            | sylius.product.delete    | sylius.catalog | Delete products         |
+            | sylius.permission.show   |                | View single permission  |
+            | sylius.permission.index  |                | List all permissions    |
+            | sylius.permission.create |                | Add new permissions     |
+            | sylius.permission.update |                | Edit permissions        |
+            | sylius.permission.delete |                | Delete permissions      |
+          And there is following role hierarchy:
+            | code                 | parent | name          | security roles             |
+            | sylius.administrator |        | Administrator | ROLE_ADMINISTRATION_ACCESS |
+          And role "Administrator" has the following permissions:
             | sylius.permission.show   |
             | sylius.permission.index  |
             | sylius.permission.create |
             | sylius.permission.update |
             | sylius.permission.delete |
-        And I am logged in as administrator
+          And I am logged in as administrator
 
     Scenario: Seeing index of all permissions
         Given I am on the dashboard page

--- a/features/security/role_based_access_control.feature
+++ b/features/security/role_based_access_control.feature
@@ -5,34 +5,31 @@ Feature: Hierarchical Role based access control (HRBAC)
   I want to be able to allow only certain roles to access backend
 
   Background:
-    Given there is default currency configured
-    And authorization checks are enabled
-    And there are following locales configured:
-      | code  | enabled |
-      | en_US | yes     |
-    And there is following permission hierarchy:
-      | code                  | parent         | description             |
-      | sylius.catalog        |                | Manage products catalog |
-      | sylius.product.show   | sylius.catalog | View single product     |
-      | sylius.product.index  | sylius.catalog | List all products       |
-      | sylius.product.create | sylius.catalog | Add new products        |
-      | sylius.product.update | sylius.catalog | Edit products           |
-      | sylius.product.delete | sylius.catalog | Delete products         |
-      | sylius.sales          |                | Manage products sales   |
-      | sylius.order.show     | sylius.sales   | View single order       |
-      | sylius.order.index    | sylius.sales   | List all orders         |
-      | sylius.order.create   | sylius.sales   | Add new orders          |
-      | sylius.order.update   | sylius.sales   | Edit orders             |
-      | sylius.order.delete   | sylius.sales   | Delete orders           |
-    And there is following role hierarchy:
-      | code                   | parent               | name            | security roles             |
-      | sylius.administrator   |                      | Administrator   | ROLE_ADMINISTRATION_ACCESS |
-      | sylius.catalog_manager | sylius.administrator | Catalog Manager | ROLE_ADMINISTRATION_ACCESS |
-      | sylius.sales_manager   | sylius.administrator | Sales Manager   | ROLE_ADMINISTRATION_ACCESS |
-    And role "Catalog Manager" has the following permissions:
-      | sylius.catalog |
-    And role "Sales Manager" has the following permissions:
-      | sylius.sales |
+    Given store has default configuration
+      And authorization checks are enabled
+      And there is following permission hierarchy:
+        | code                  | parent         | description             |
+        | sylius.catalog        |                | Manage products catalog |
+        | sylius.product.show   | sylius.catalog | View single product     |
+        | sylius.product.index  | sylius.catalog | List all products       |
+        | sylius.product.create | sylius.catalog | Add new products        |
+        | sylius.product.update | sylius.catalog | Edit products           |
+        | sylius.product.delete | sylius.catalog | Delete products         |
+        | sylius.sales          |                | Manage products sales   |
+        | sylius.order.show     | sylius.sales   | View single order       |
+        | sylius.order.index    | sylius.sales   | List all orders         |
+        | sylius.order.create   | sylius.sales   | Add new orders          |
+        | sylius.order.update   | sylius.sales   | Edit orders             |
+        | sylius.order.delete   | sylius.sales   | Delete orders           |
+      And there is following role hierarchy:
+        | code                   | parent               | name            | security roles             |
+        | sylius.administrator   |                      | Administrator   | ROLE_ADMINISTRATION_ACCESS |
+        | sylius.catalog_manager | sylius.administrator | Catalog Manager | ROLE_ADMINISTRATION_ACCESS |
+        | sylius.sales_manager   | sylius.administrator | Sales Manager   | ROLE_ADMINISTRATION_ACCESS |
+      And role "Catalog Manager" has the following permissions:
+        | sylius.catalog |
+      And role "Sales Manager" has the following permissions:
+        | sylius.sales |
 
   Scenario: Only selected menus are visible for Sales Manager
     Given I am logged in as "Sales Manager"

--- a/features/security/role_management.feature
+++ b/features/security/role_management.feature
@@ -5,11 +5,8 @@ Feature: Roles management
     I want to be able to manage user roles
 
     Background:
-        Given there is default currency configured
-        And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-        And there is following permission hierarchy:
+        Given store has default configuration
+          And there is following permission hierarchy:
             | code                  | parent         | description             |
             | sylius.catalog        |                | Manage products catalog |
             | sylius.product.show   | sylius.catalog | View single product     |
@@ -22,19 +19,19 @@ Feature: Roles management
             | sylius.role.create    |                | Add new roles           |
             | sylius.role.update    |                | Edit roles              |
             | sylius.role.delete    |                | Delete roles            |
-        And there is following role hierarchy:
+          And there is following role hierarchy:
             | code                   | parent               | name            | security roles             |
             | sylius.administrator   |                      | Administrator   | ROLE_ADMINISTRATION_ACCESS |
             | sylius.catalog_manager | sylius.administrator | Catalog Manager | ROLE_ADMINISTRATION_ACCESS |
-        And role "Administrator" has the following permissions:
+          And role "Administrator" has the following permissions:
             | sylius.role.show   |
             | sylius.role.index  |
             | sylius.role.create |
             | sylius.role.update |
             | sylius.role.delete |
-        And role "Catalog Manager" has the following permissions:
+          And role "Catalog Manager" has the following permissions:
             | sylius.catalog |
-        And I am logged in as administrator
+          And I am logged in as administrator
 
     Scenario: Seeing index of all roles
         Given I am on the dashboard page

--- a/features/user/account/account_addresses.feature
+++ b/features/user/account/account_addresses.feature
@@ -5,9 +5,7 @@ Feature: User account addresses page
     I want to be able to add, edit or delete my shipping and billing addresses
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in user
+        Given store has default configuration
           And the following countries exist:
             | name          | enabled |
             | Germany       | yes     |
@@ -21,6 +19,7 @@ Feature: User account addresses page
             | sylius@example.com | Jan Kowalski, Heine-Straße 12, 99734, Berlin, Germany |
             | sylius@example.com | Jan Kowalski, Fun-Straße 1, 90032, Vienna, Austria    |
             | sylius@example.com | Jan Kowalski, Wawel 5, 31-001, Kraków, Poland         |
+          And I am logged in user
           And I am on my account addresses page
 
     Scenario: Viewing my account addresses page

--- a/features/user/account/account_homepage.feature
+++ b/features/user/account/account_homepage.feature
@@ -5,8 +5,7 @@ Feature: User account homepage
     I want to be able to see my account homepage
 
     Background:
-        Given there is default currency configured
-        And there is default channel configured
+        Given store has default configuration
 
     Scenario: Displaying the my account section only to logged users
         Given I am on the store homepage

--- a/features/user/account/account_orders.feature
+++ b/features/user/account/account_orders.feature
@@ -5,151 +5,100 @@ Feature: User account orders page
   I want to be able to track and get an invoice of my sent orders
 
   Background:
-    Given there is default currency configured
-      And there is default channel configured
+    Given store has default configuration
       And I am logged in user
-      And I am on my account homepage
       And the following zones are defined:
-        | name         | type    | members                 |
-        | Scandinavia  | country | Norway, Sweden, Finland |
-        | France       | country | France                  |
-        | USA          | country | United States           |
+        | name        | type    | members                 |
+        | Scandinavia | country | Norway, Sweden, Finland |
+        | France      | country | France                  |
       And there are following shipping categories:
         | name    |
         | Regular |
         | Heavy   |
       And the following shipping methods exist:
-        | category | zone          | name  |
-        | Regular  | Scandinavia   | DHL   |
-        | Heavy    | USA           | FedEx |
-        |          | France        | UPS   |
+        | category | zone        | name |
+        | Regular  | Scandinavia | DHL  |
+        | Heavy    | France      | UPS  |
       And the following products exist:
-        | name          | price | sku |
-        | Mug           | 5.99  | 456 |
-        | Sticker       | 10.00 | 213 |
-        | Book          | 22.50 | 948 |
-      And all products assigned to "DEFAULT-WEB" channel
+        | name | price | sku |
+        | Mug  | 5.99  | 456 |
+        | Book | 22.50 | 948 |
+      And all products are assigned to the default channel
       And the following orders exist:
-        | customer                | shipment                 | address                                                                   |
-        | sylius@example.com      | UPS, shipped, DTBHH380HG | Théophile Morel, 17 avenue Jean Portalis, 33000, Bordeaux, France         |
-        | ianmurdock@debian.org   | FedEx                    | Ian Murdock, 3569 New York Avenue, CA 92801, San Francisco, United States |
-        | ianmurdock@debian.org   | FedEx                    | Ian Murdock, 3569 New York Avenue, CA 92801, San Francisco, United States |
-        | linustorvalds@linux.com | DHL                      | Linus Torvalds, Väätäjänniementie 59, 00440, Helsinki, Finland            |
-        | linustorvalds@linux.com | DHL                      | Linus Torvalds, Väätäjänniementie 59, 00440, Helsinki, Finland            |
-        | sylius@example.com      | UPS                      | Théophile Morel, 17 avenue Jean Portalis, 33000, Bordeaux, France         |
-        | sylius@example.com      | UPS                      | Théophile Morel, 17 avenue Jean Portalis, 33000, Bordeaux, France         |
-        | linustorvalds@linux.com | DHL                      | Linus Torvalds, Väätäjänniementie 59, 00440, Helsinki, Finland            |
-        | sylius@example.com      | UPS                      | Théophile Morel, 17 avenue Jean Portalis, 33000, Bordeaux, France         |
-        | sylius@example.com      | UPS                      | Théophile Morel, 17 avenue Jean Portalis, 33000, Bordeaux, France         |
-        | ianmurdock@debian.org   | FedEx                    | Ian Murdock, 3569 New York Avenue, CA 92801, San Francisco, United States |
+        | customer                | shipment                 | address                                                           |
+        | sylius@example.com      | UPS, shipped, DTBHH380HG | Théophile Morel, 17 avenue Jean Portalis, 33000, Bordeaux, France |
+        | linustorvalds@linux.com | DHL                      | Linus Torvalds, Väätäjänniementie 59, 00440, Helsinki, Finland    |
+        | sylius@example.com      | UPS                      | Théophile Morel, 17 avenue Jean Portalis, 33000, Bordeaux, France |
       And order #000000001 has following items:
-        | product  | quantity |
-        | Mug      | 2        |
-        | Sticker  | 4        |
-        | Book     | 1        |
-      And order #000000007 has following items:
-        | product  | quantity |
-        | Mug      | 5        |
-        | Sticker  | 1        |
+        | product | quantity |
+        | Mug     | 2        |
+        | Book    | 1        |
 
   Scenario: Viewing my account orders page
-    Given I follow "My orders / my invoices"
+    Given I am on my account homepage
+     When I follow "My orders / my invoices"
      Then I should be on my account orders page
 
-  Scenario Outline: Viewing my orders
-    Given I am on my account orders page
+  Scenario: Viewing my orders
+     When I am on my account orders page
      Then I should see "All your orders"
-      And I should see 5 orders in the list
-      And I should see "<myorder>"
-      And I should not see "<order>"
-    Examples:
-      | myorder    | order    |
-      | 000000001  | 000000002  |
-      | 000000006  | 000000003  |
-      | 000000007  | 000000004  |
-      | 000000009  | 000000005  |
-      | 000000010  | 000000008  |
-      | 000000010  | 000000011  |
+      And I should see 2 orders in the list
+      And I should see order with number "000000001" in the list
+      And I should not see order with number "000000002" in the list
 
-  Scenario Outline: Viewing the detail of an order
+  Scenario: Viewing the detail of an order
     Given I am on my account orders page
-      And I follow "order-<order>-details"
+     When I click "details" near "000000001"
      Then I should see "Details of your order"
-      And I should be on the order show page for <order>
-      And I should see <items> items in the list
+      And I should be on the order show page for 000000001
+      And I should see 2 items in the list
 
-    Examples:
-      | order      | items |
-      | 000000001  | 3     |
-      | 000000007  | 2     |
-
-  Scenario Outline: Trying to view the detail of an order which is not mine
-    Given I go to the order show page for <order>
+  Scenario: Trying to view the detail of an order which is not mine
+     When I go to the order show page for 000000002
      Then the response status code should be 403
-
-    Examples:
-      | order     |
-      | 000000002 |
-      | 000000003 |
-      | 000000004 |
-      | 000000005 |
-      | 000000008 |
-      | 000000011 |
 
   Scenario: Tracking an order that has been sent
-    Given I am on my account orders page
-     Then I should see "Tracking number DTBHH380HG" in the "#order-000000001" element
-      And I should see "Shipped" in the "#order-000000001" element
+     When I am on my account orders page
+     Then I should see the following rows:
+        | Number    | State                        |
+        | 000000001 | %Shipped%                    |
+        | 000000001 | %Tracking number DTBHH380HG% |
 
-  Scenario Outline: Trying to track an order that has not been sent
-    Given I am on my account orders page
-     Then I should not see "Tracking number" in the "#order-<order>" element
-      And I should see "<state>" in the "#order-<order>" element
-
-    Examples:
-      | order     | state       |
-      | 000000007 | Ready since |
+  Scenario: Trying to track an order that has not been sent
+     When I am on my account orders page
+     Then I should see the following row:
+        | Number    | State         |
+        | 000000003 | %Ready since% |
+      But I should not see the following row:
+        | Number    | State             |
+        | 000000003 | %Tracking number% |
 
   Scenario: Tracking an order that has been sent in its details page
-    Given I go to the order show page for 000000001
-     Then I should see "Tracking number DTBHH380HG" in the "#information" element
-      And I should see "Shipped" in the "#information" element
+     When I go to the order show page for 000000001
+     Then I should see "Tracking number DTBHH380HG"
+      And I should see "Shipped"
 
-  Scenario Outline: Trying to track an order that has not been sent in its details page
-    Given I go to the order show page for <order>
-     Then I should not see "Tracking number" in the "#information" element
-      And I should see "<state>" in the "#information" element
-
-    Examples:
-      | order     | state       |
-      | 000000007 | Ready since |
+  Scenario: Trying to track an order that has not been sent in its details page
+     When I go to the order show page for 000000003
+     Then I should see "Ready since"
+      But I should not see "Tracking number"
 
   Scenario: Checking that an invoice is available for an order that has been sent
-    Given I am on my account orders page
-     Then I should see an "#order-000000001-invoice" element
+     When I am on my account orders page
+     Then I should not see the following row:
+        | Number    | Invoice |
+        | 000000001 | -       |
 
   Scenario: Checking that an invoice is not available for an order that has not been sent
-    Given I am on my account orders page
-     Then I should not see an "#order-000000007-invoice" element
-
-#  @invoice
-#  Scenario: Generating an invoice for an order that has been sent
-#    Given I go to the order invoice page for 000000001
-#     Then the response status code should be 200
+     When I am on my account orders page
+     Then I should see the following row:
+        | Number    | Invoice |
+        | 000000003 | -       |
 
   Scenario: Trying to generate an invoice for an order that has not been sent
-    Given I go to the order invoice page for 000000007
+     When I go to the order invoice page for 000000003
      Then the response status code should be 404
 
-  Scenario Outline: Trying to generate an invoice of an order which is not mine
-    Given I go to the order invoice page for <order>
+  Scenario: Trying to generate an invoice of an order which is not mine
+     When I go to the order invoice page for 000000002
      Then the response status code should be 403
-
-    Examples:
-      | order     |
-      | 000000002 |
-      | 000000003 |
-      | 000000004 |
-      | 000000005 |
-      | 000000008 |
-      | 000000011 |

--- a/features/user/account/account_password.feature
+++ b/features/user/account/account_password.feature
@@ -5,8 +5,7 @@ Feature: User account password change
     I want to be able to change password
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
+        Given store has default configuration
           And I am logged in user
           And I am on my account homepage
 

--- a/features/user/account/account_profile.feature
+++ b/features/user/account/account_profile.feature
@@ -5,8 +5,7 @@ Feature: User account profile edition
     I want to be able to edit my name and my email
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
+        Given store has default configuration
           And I am logged in user
           And I am on my account homepage
 

--- a/features/user/user_login.feature
+++ b/features/user/user_login.feature
@@ -5,11 +5,10 @@ Feature: Sign in to the store
     I need to be able to log in to the store
 
     Background:
-        Given there are following users:
+        Given store has default configuration
+          And there are following users:
             | email       | password | enabled |
             | bar@foo.com | foo1     | yes     |
-        And there is default currency configured
-        And there is default channel configured
 
     Scenario: Log in with username and password
         Given I am on the store homepage

--- a/features/user/user_registration.feature
+++ b/features/user/user_registration.feature
@@ -5,7 +5,8 @@ Feature: User registration
     I need to be able to create an account in the store
 
     Background:
-        Given there are following users:
+        Given store has default configuration
+          And there are following users:
             | email       | password |
             | bar@bar.com | foo1     |
           And the following customers exist:
@@ -17,8 +18,6 @@ Feature: User registration
           And the following orders exist:
             | customer                | address                                        |
             | customer@email.com      | Jan Kowalski, Wawel 5 , 31-001, Kraków, Poland |
-          And there is default currency configured
-          And there is default channel configured
 
     Scenario: Successfully creating account in store
         Given I am on the store homepage

--- a/features/user/user_reset_password.feature
+++ b/features/user/user_reset_password.feature
@@ -5,11 +5,10 @@ Feature: Forgot password
     I need to be able to reset my password
 
     Background:
-        Given there are following users:
+        Given store has default configuration
+          And there are following users:
             | email       | password | enabled |
             | bar@foo.com | foo1     | yes     |
-        And there is default currency configured
-        And there is default channel configured
 
     Scenario: Reseting user password
         Given I am on the store homepage

--- a/features/user/users.feature
+++ b/features/user/users.feature
@@ -5,9 +5,7 @@ Feature: Customers management
     I want to be able to list all customers
 
     Background:
-        Given there is default currency configured
-          And there is default channel configured
-          And I am logged in as administrator
+        Given store has default configuration
           And there are products:
             | name | price |
             | Mug  | 5.99  |
@@ -35,6 +33,7 @@ Feature: Customers management
         And order #000000002 has following items:
             | product | quantity |
             | Mug     | 3        |
+        And I am logged in as administrator
 
     Scenario: Seeing index of all customers
         Given I am on the dashboard page

--- a/src/Sylius/Bundle/ChannelBundle/Behat/ChannelContext.php
+++ b/src/Sylius/Bundle/ChannelBundle/Behat/ChannelContext.php
@@ -20,7 +20,7 @@ use Sylius\Component\Core\Model\ProductInterface;
 class ChannelContext extends DefaultContext
 {
     /**
-     * @Given /^all products assigned to "([^""]*)" channel$/
+     * @Given /^all products are assigned to "([^""]*)" channel$/
      */
     public function assignChannelToProducts($code)
     {
@@ -33,6 +33,14 @@ class ChannelContext extends DefaultContext
         }
 
         $this->getEntityManager()->flush();
+    }
+
+    /**
+     * @Given all products are assigned to the default channel
+     */
+    public function allProductsAreAssignedToTheDefaultChannel()
+    {
+        $this->assignChannelToProducts('DEFAULT-WEB');
     }
 
     /**
@@ -54,7 +62,7 @@ class ChannelContext extends DefaultContext
     }
 
     /**
-     * @Given /^all promotions assigned to "([^""]*)" channel$/
+     * @Given /^all promotions are assigned to "([^""]*)" channel$/
      */
     public function assignChannelToPromotions($code)
     {
@@ -67,6 +75,14 @@ class ChannelContext extends DefaultContext
         }
 
         $this->getEntityManager()->flush();
+    }
+
+    /**
+     * @Given all promotions are assigned to the default channel
+     */
+    public function allPromotionsAreAssignedToDefaultChannel()
+    {
+        $this->assignChannelToPromotions('DEFAULT-WEB');
     }
 
     /**
@@ -117,6 +133,14 @@ class ChannelContext extends DefaultContext
         }
 
         $this->getEntityManager()->flush();
+    }
+
+    /**
+     * @Given the default channel has following configuration:
+     */
+    public function theDefaultChannelHasFollowingConfiguration(TableNode $table)
+    {
+        $this->channelHasFollowingConfiguration('DEFAULT-WEB', $table);
     }
 
     /**

--- a/src/Sylius/Bundle/MoneyBundle/Behat/MoneyContext.php
+++ b/src/Sylius/Bundle/MoneyBundle/Behat/MoneyContext.php
@@ -32,7 +32,10 @@ class MoneyContext extends DefaultContext
         $manager->clear();
 
         foreach ($table->getHash() as $data) {
-            $this->thereIsCurrency($data['code'], $data['exchange rate'], 'yes' === $data['enabled'], false);
+            $exchangeRate = isset($data['exchange rate']) ? $data['exchange rate'] : 1;
+            $enabled = isset($data['enabled']) ? 'yes' === $data['enabled'] : true;
+
+            $this->thereIsCurrency($data['code'], $exchangeRate, $enabled, false);
         }
 
         $manager->flush();

--- a/src/Sylius/Bundle/UserBundle/Behat/OAuthContext.php
+++ b/src/Sylius/Bundle/UserBundle/Behat/OAuthContext.php
@@ -14,20 +14,10 @@ namespace Sylius\Bundle\UserBundle\Behat;
 use Behat\MinkExtension\Context\RawMinkContext;
 
 /**
- * OAuth context.
- *
  * @author Fabian Kiss <fabian.kiss@ymc.ch>
  */
 class OAuthContext extends RawMinkContext
 {
-    /**
-     * @Given /^I am not logged in$/
-     */
-    public function iAmNotLoggedIn()
-    {
-        $this->getSession()->restart();
-    }
-
     /**
      * @Then /^I should see the connect with "([^""]*)" button$/
      */


### PR DESCRIPTION
Based on #3176.

Changes:
 - `Given there is default channel configured`, `Given there is default currency configured`, `Given there are locales: | en_US |` combined to one step **`Given store has default configuration`**
 - Removed unnecessary scenarios and steps, eg. Javascript's doubled delete scenarios or unused steps in `shipments.feature` background
 - Added:
    - **`Given all products are available in all variations`**
 - Renamed:
    - `Given all products assigned to [...] channel` to **`Given all products are assigned to [...] channel`**
    - `Given all promotions assigned to [...] channel` to **`Given all promotions are assigned to [...] channel`**
 - Bunch of aliases:
    - **`Given all products are assigned to the default channel`** instead of `Given all products assigned to "DEFAULT_WEB" channel`
    - **`Given all promotions are assigned to the default channel`** instead of `Given all promotions assigned to "DEFAULT_WEB" channel`
    - **`Given the default channel has following configuration`** instead of `Given channel "DEFAULT_WEB" has following configuration`
 - Moved `Given I am logged in as ...` step at the end of background, because usually it's the first step that slows down