### PR TITLE
[Behat] Steps for checking whether row contains given value (not starts with)

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Behat/DefaultContext.php
+++ b/src/Sylius/Bundle/ResourceBundle/Behat/DefaultContext.php
@@ -408,7 +408,15 @@ abstract class DefaultContext extends RawMinkContext implements Context, KernelA
                     throw new \InvalidArgumentException(sprintf('There is no column with index %d', $index));
                 }
 
-                if (0 !== stripos(trim($columns[$index]->getText()), trim($searchedValue))) {
+                $containing = false;
+                $searchedValue = trim($searchedValue);
+                if (0 === strpos($searchedValue, '%') && (strlen($searchedValue) - 1) === strrpos($searchedValue, '%')) {
+                    $searchedValue = substr($searchedValue, 1, strlen($searchedValue) - 2);
+                    $containing = true;
+                }
+
+                $position = stripos(trim($columns[$index]->getText()), $searchedValue);
+                if (($containing && false === $position) || (!$containing && 0 !== $position)) {
                     $found = false;
 
                     break;

--- a/src/Sylius/Bundle/ResourceBundle/Behat/WebContext.php
+++ b/src/Sylius/Bundle/ResourceBundle/Behat/WebContext.php
@@ -42,7 +42,6 @@ class WebContext extends DefaultContext
         }
     }
 
-
     /**
      * @Given /^I am on the page of ([^""]*) with ([^""]*) "([^""]*)"$/
      * @Given /^I go to the page of ([^""]*) with ([^""]*) "([^""]*)"$/
@@ -92,6 +91,7 @@ class WebContext extends DefaultContext
         $this->assertSession()->addressEquals($this->generatePageUrl(
             sprintf('%s_show', $type), array('id' => $resource->getId())
         ));
+
         $this->assertStatusCodeEquals(200);
     }
 
@@ -249,7 +249,7 @@ class WebContext extends DefaultContext
     /**
      * For example: I should see product with name "Wine X" in that list.
      *
-     * @Then /^I should see (?:(?!enabled|disabled)[\w\s]+) with ([\w\s]+) "([^""]*)" in (?:that|the) list$/
+     * @Then /^I should see (?:(?!enabled|disabled)[\w\s]+) with ((?:(?![\w\s]+ containing))[\w\s]+) "([^""]*)" in (?:that|the) list$/
      */
     public function iShouldSeeResourceWithValueInThatList($columnName, $value)
     {
@@ -264,13 +264,43 @@ class WebContext extends DefaultContext
     /**
      * For example: I should not see product with name "Wine X" in that list.
      *
-     * @Then /^I should not see [\w\s]+ with ([\w\s]+) "([^""]*)" in (?:that|the) list$/
+     * @Then /^I should not see [\w\s]+ with ((?:(?![\w\s]+ containing))[\w\s]+) "([^""]*)" in (?:that|the) list$/
      */
     public function iShouldNotSeeResourceWithValueInThatList($columnName, $value)
     {
         $tableNode = new TableNode(array(
             array(trim($columnName)),
             array(trim($value)),
+        ));
+
+        $this->iShouldNotSeeTheFollowingRow($tableNode);
+    }
+
+    /**
+     * For example: I should see product with name containing "Wine X" in that list.
+     *
+     * @Then /^I should see (?:(?!enabled|disabled)[\w\s]+) with ([\w\s]+) containing "([^""]*)" in (?:that|the) list$/
+     */
+    public function iShouldSeeResourceWithValueContainingInThatList($columnName, $value)
+    {
+        $tableNode = new TableNode(array(
+            array(trim($columnName)),
+            array(trim('%' . $value . '%')),
+        ));
+
+        $this->iShouldSeeTheFollowingRow($tableNode);
+    }
+
+    /**
+     * For example: I should not see product with name containing "Wine X" in that list.
+     *
+     * @Then /^I should not see [\w\s]+ with ([\w\s]+) containing "([^""]*)" in (?:that|the) list$/
+     */
+    public function iShouldNotSeeResourceWithValueContainingInThatList($columnName, $value)
+    {
+        $tableNode = new TableNode(array(
+            array(trim($columnName)),
+            array(trim('%' . $value . '%')),
         ));
 
         $this->iShouldNotSeeTheFollowingRow($tableNode);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

**TL;DR**: You can add `%` at the beginning and the end of searched string and it will work just like SQL `LIKE` statement (no support for one-side `%` yet).

- `I should see resource with name containing "value"` is equal to `I should see resource with name "%value%"` (same comes with negation)
- `I should see the following rows: | name | %value% |` (same comes with negation)