### PR TITLE
[Travis] Added missing Behat tests to Travis

### DIFF
--- a/features/backend/product_archetypes_i18n.feature
+++ b/features/backend/product_archetypes_i18n.feature
@@ -6,7 +6,7 @@ Feature: Product archetype translations
 
     Background:
         Given store has default configuration
-          And there are following locales configured:
+          And there are following locales configured and assigned to the default channel:
             | code  |
             | en_US |
             | es_ES |
@@ -14,20 +14,20 @@ Feature: Product archetype translations
 
     Scenario: Creating a product archetype requires default translation fields
         Given I am on the product archetype creation page
-        And I fill in the following:
-            | Code                                          | Shirt    |
-            | sylius_product_archetype_translations_es_name | Camiseta |
-        When I press "Create"
-        Then I should still be on the product archetype creation page
-        And  I should see "Please enter archetype name."
+          And I fill in the following:
+            | Code                                             | Shirt    |
+            | sylius_product_archetype_translations_es_ES_name | Camiseta |
+         When I press "Create"
+         Then I should still be on the product archetype creation page
+          And I should see "Please enter archetype name"
 
     Scenario: Creating a product in archetype specific locale
         Given I am on the product archetype creation page
-        And I fill in the following:
-            | Code                                          | Shirt    |
-            | sylius_product_archetype_translations_es_name | Camiseta |
-            | sylius_product_archetype_translations_en_name | Shirt    |
-        When I press "Create"
-        Then "Product archetype has been successfully created." should appear on the page
-        And "es" translation for product archetype "Camiseta" should exist
-        And "en" translation for product archetype "Shirt" should exist
+          And I fill in the following:
+            | Code                                             | Shirt    |
+            | sylius_product_archetype_translations_es_ES_name | Camiseta |
+            | sylius_product_archetype_translations_en_US_name | Shirt    |
+         When I press "Create"
+         Then "Product archetype has been successfully created" should appear on the page
+          And "es_ES" translation for product archetype "Camiseta" should exist
+          And "en_US" translation for product archetype "Shirt" should exist

--- a/features/backend/products_i18n.feature
+++ b/features/backend/products_i18n.feature
@@ -6,7 +6,7 @@ Feature: Products
 
     Background:
         Given store has default configuration
-          And there are following locales configured:
+          And there are following locales configured and assigned to the default channel:
             | code  |
             | en_US |
             | es_ES |
@@ -15,22 +15,22 @@ Feature: Products
     Scenario: Creating a product requires default translation fields
         Given I am on the product creation page
         And I fill in the following:
-            | Price                                      | 29.99                    |
-            | sylius_product_translations_es_name        | Soy i18n                 |
-            | sylius_product_translations_es_description | Conmemorando el dia i18n |
+            | Price                                         | 29.99                    |
+            | sylius_product_translations_es_ES_name        | Soy i18n                 |
+            | sylius_product_translations_es_ES_description | Conmemorando el dia i18n |
         When I press "Create"
         Then I should still be on the product creation page
-        And  I should see "Please enter product name."
+        And  I should see "Please enter product name"
 
     Scenario: Creating a product in specific locale
         Given I am on the product creation page
         And I fill in the following:
-            | Price                                      | 29.99                    |
-            | sylius_product_translations_es_name        | Soy i18n                 |
-            | sylius_product_translations_es_description | Conmemorando el dia i18n |
-            | sylius_product_translations_en_name        | I am i18n                 |
-            | sylius_product_translations_en_description | Finally i18n |
+            | Price                                         | 29.99                    |
+            | sylius_product_translations_es_ES_name        | Soy i18n                 |
+            | sylius_product_translations_es_ES_description | Conmemorando el dia i18n |
+            | sylius_product_translations_en_US_name        | I am i18n                |
+            | sylius_product_translations_en_US_description | Finally i18n             |
         When I press "Create"
-        Then "Product has been successfully created." should appear on the page
-        And "es" translation for product "Soy i18n" should exist
-        And "en" translation for product "I am i18n" should exist
+        Then "Product has been successfully created" should appear on the page
+        And "es_ES" translation for product "Soy i18n" should exist
+        And "en_US" translation for product "I am i18n" should exist

--- a/features/backend/taxonomies_i18n.feature
+++ b/features/backend/taxonomies_i18n.feature
@@ -6,27 +6,27 @@ Feature: Taxonomies internationalization
 
     Background:
         Given store has default configuration
-          And there are following locales configured:
-            | code | enabled |
-            | en   | yes     |
-            | es   | yes     |
+          And there are following locales configured and assigned to the default channel:
+            | code  |
+            | en_US |
+            | es_ES |
           And there are following taxonomies defined:
             | name     |
             | Category |
           And taxonomy "Category" has following taxons:
             | Clothing > Shirts > Long Sleeve |
-          And the following taxon translations exist
+          And the following taxon translations exist:
             | taxon       | name        | locale |
-            | Category    | Categoria   | es     |
-            | Clothing    | Ropa        | es     |
-            | Shirts      | Camisas     | es     |
-            | Long Sleeve | Manga Larga | es     |
+            | Category    | Categoria   | es_ES  |
+            | Clothing    | Ropa        | es_ES  |
+            | Shirts      | Camisas     | es_ES  |
+            | Long Sleeve | Manga Larga | es_ES  |
 
     Scenario: Creating a taxon generates the proper permalink
-        Then Taxon translation "Long Sleeve" should have permalink "category/clothing/shirts/long-sleeve"
-         And Taxon translation "Manga Larga" should have permalink "categoria/ropa/camisas/manga-larga"
+        Then taxon translation "Long Sleeve" should have permalink "category/clothing/shirts/long-sleeve"
+         And taxon translation "Manga Larga" should have permalink "categoria/ropa/camisas/manga-larga"
 
     Scenario: Updating a taxon updates children permalinks only for the given locale
         When I change then name of taxon translation "Shirts" to "New Shirts"
-        Then Taxon translation "Long Sleeve" should have permalink "category/clothing/new-shirts/long-sleeve"
-         And Taxon translation "Manga Larga" should have permalink "categoria/ropa/camisas/manga-larga"
+        Then taxon translation "Long Sleeve" should have permalink "category/clothing/new-shirts/long-sleeve"
+         And taxon translation "Manga Larga" should have permalink "categoria/ropa/camisas/manga-larga"

--- a/features/channels/channel_management.feature
+++ b/features/channels/channel_management.feature
@@ -7,20 +7,18 @@ Feature: Channel management
     Background:
         Given store has default configuration
           And the following zones are defined:
-            | name | type    | members                         |
-            | USA  | country | United States                   |
-            | EU   | country | Germany, United Kingdom, France |
+            | name | type    | members         |
+            | USA  | country | United States   |
+            | EU   | country | Germany, France |
           And there are following currencies configured:
-            | code | exchange rate | enabled |
-            | USD  | 0.76496       | yes     |
-            | GBP  | 1.16998       | yes     |
-            | EUR  | 1.00000       | yes     |
+            | code |
+            | USD  |
+            | EUR  |
           And there are following locales configured:
-            | code  | activated |
-            | en_US | yes       |
-            | en_GB | yes       |
-            | fr_FR | yes       |
-            | de_DE | yes       |
+            | code  |
+            | en_US |
+            | fr_FR |
+            | de_DE |
           And the following payment methods exist:
             | name             | gateway |
             | Credit Card (US) | stripe  |
@@ -31,9 +29,9 @@ Feature: Channel management
             | USA  | FedEx |
             | EU   | DHL   |
           And there are following channels configured:
-            | code   | name       | currencies | locales             |
-            | WEB-US | mystore.us | EUR, GBP   | en_US               |
-            | WEB-EU | mystore.eu | USD        | en_GB, fr_FR, de_DE |
+            | code   | name       | currencies | locales      |
+            | WEB-US | mystore.us | USD        | en_US        |
+            | WEB-EU | mystore.eu | EUR, GBP   | fr_FR, de_DE |
           And channel "WEB-US" has following configuration:
             | shipping | payment                  |
             | FedEx    | Credit Card (US), PayPal |
@@ -54,11 +52,6 @@ Feature: Channel management
          Then I should be on the channel index page
           And I should see channel with code "WEB-US" in the list
 
-    Scenario: Seeing empty index of channels
-        Given there are no channels
-         When I am on the channel index page
-         Then I should see "There are no channels configured."
-
     Scenario: Accessing the channel creation form
         Given I am on the dashboard page
          When I follow "Channels"
@@ -75,7 +68,7 @@ Feature: Channel management
           And I select "FedEx" from "Shipping Methods"
          When I press "Create"
          Then I should be on the channel index page
-          And I should see "Channel has been successfully created."
+          And I should see "Channel has been successfully created"
 
     Scenario: Accessing the channel edit form
         Given I am on the channel index page
@@ -93,7 +86,7 @@ Feature: Channel management
     Scenario: Deleting a channel
         Given I am on the channel index page
          When I press "delete" near "WEB-EU"
-          And I confirm the deletion action
+          And I click "delete" from the confirmation modal
          Then I should still be on the channel index page
-          And I should see "Channel has been successfully deleted."
+          And I should see "Channel has been successfully deleted"
           And I should not see channel with name "mystore.eu" in the list

--- a/features/frontend/cart_inclusive_tax.feature
+++ b/features/frontend/cart_inclusive_tax.feature
@@ -24,6 +24,9 @@ Feature: Tax included in price
             | name    | price | taxons       | tax category  |
             | PHP Top | 85    | PHP T-Shirts | Taxable Goods |
           And all products are assigned to the default channel
+          And the default channel has following configuration:
+            | taxonomy |
+            | Category |
           And the default tax zone is "Germany"
 
     Scenario: Correct amounts are displayed for inclusive taxes

--- a/features/frontend/cart_tax_categories.feature
+++ b/features/frontend/cart_tax_categories.feature
@@ -28,7 +28,9 @@ Feature: Tax categories
             | PHP Top      | 50    | PHP T-Shirts | Clothing     |
             | Golden Apple | 120   | Food         | Food         |
           And all products are assigned to the default channel
-          And all promotions are assigned to the default channel
+          And the default channel has following configuration:
+            | taxonomy |
+            | Category |
 
     Scenario: Correct taxes are applied for one item
         Given the default tax zone is "UK"

--- a/features/frontend/cart_taxation.feature
+++ b/features/frontend/cart_taxation.feature
@@ -26,6 +26,9 @@ Feature: Cart taxation
             | name    | price | taxons       | tax category  |
             | PHP Top | 50    | PHP T-Shirts | Taxable Goods |
           And all products are assigned to the default channel
+          And the default channel has following configuration:
+            | taxonomy |
+            | Category |
 
     Scenario: No taxes are applied for unknown billing address
               when default tax zone is not configured

--- a/features/frontend/checkout_addressing_i18n.feature
+++ b/features/frontend/checkout_addressing_i18n.feature
@@ -12,27 +12,25 @@ Feature: Checkout addressing in preferred language
           And taxonomy "Category" has following taxons:
             | Clothing > PHP T-Shirts |
           And the following products exist:
-            | name          | price | taxons       |
-            | PHP Top       | 5.99  | PHP T-Shirts |
+            | name    | price | taxons       |
+            | PHP Top | 5.99  | PHP T-Shirts |
           And the following zones are defined:
-            | name         | type    | members                 |
-            | UK + Germany | country | United Kingdom, Germany |
-            | USA          | country | United States           |
+            | name    | type    | members       |
+            | Germany | country | Germany       |
+            | USA     | country | United States |
           And there are following countries:
             | name           |
-            | USA            |
-            | United Kingdom |
-            | Poland         |
+            | United States  |
             | Germany        |
           And the following shipping methods exist:
-            | zone         | name          | calculator | configuration |
-            | UK + Germany | DHL Express   | Flat rate  | Amount: 5000  |
-            | USA          | FedEx         | Flat rate  | Amount: 6500  |
+            | zone    | name        |
+            | Germany | DHL Express |
+            | USA     | FedEx       |
           And all products are assigned to the default channel
-          And there are following locales configured:
-            | code  | enabled |
-            | en_US | yes     |
-            | de_DE | yes     |
+          And there are following locales configured and assigned to the default channel:
+            | code  |
+            | en_US |
+            | de_DE |
 
     Scenario: Seeing country in preferred language
         Given I am not logged in
@@ -40,5 +38,5 @@ Feature: Checkout addressing in preferred language
          When I go to the checkout start page
           And I fill in guest email with "example@example.com"
           And I press "Proceed with your order"
-          And I change the locale to "German"
+          And I change the locale to "German (Germany)"
          Then I select "Deutschland" from "Land"

--- a/features/frontend/checkout_shipping_i18n.feature
+++ b/features/frontend/checkout_shipping_i18n.feature
@@ -12,29 +12,31 @@ Feature: Checkout shipping in preferred language
           And taxonomy "Category" has following taxons:
             | Clothing > PHP T-Shirts |
           And the following products exist:
-            | name          | price | taxons       |
-            | PHP Top       | 5.99  | PHP T-Shirts |
+            | name    | price | taxons       |
+            | PHP Top | 5.99  | PHP T-Shirts |
           And the following zones are defined:
-            | name         | type    | members                 |
-            | UK + Germany | country | United Kingdom, Germany |
-            | USA          | country | United States           |
+            | name    | type    | members       |
+            | Germany | country | Germany       |
+            | USA     | country | United States |
           And there are following countries:
-            | name           |
-            | USA            |
-            | United Kingdom |
-            | Germany        |
+            | name          |
+            | United States |
+            | Germany       |
           And the following shipping methods exist:
-            | zone         | name       | calculator | configuration | enabled |
-            | USA          | FedEx      | Flat rate  | Amount: 6500  | yes     |
-            | UK + Germany | UPS Ground | Flat rate  | Amount: 20000 | yes     |
+            | zone    | name       |
+            | USA     | FedEx      |
+            | Germany | UPS Ground |
           And all products are assigned to the default channel
-          And there are following locales configured:
+          And there are following locales configured and assigned to the default channel:
             | code  |
             | en_US |
             | de_DE |
-          And the shipping method translations exist
-            | shipping_method | name        | locale |
-            | UPS Ground      | UPS Land    | de     |
+          And the shipping method translations exist:
+            | shipping method | name     | locale |
+            | UPS Ground      | UPS Land | de_DE  |
+          And the default channel has following configuration:
+            | taxonomy | shipping          |
+            | Category | FedEx, UPS Ground |
           And I am logged in user
           And I added product "PHP Top" to cart
 
@@ -42,7 +44,7 @@ Feature: Checkout shipping in preferred language
         Given I go to the checkout start page
           And I fill in the shipping address to Germany
          When I press "Continue"
-          And I change the locale to "German"
+          And I change the locale to "German (Germany)"
          Then I should be on the checkout shipping step
           And I should see "UPS Land"
           And I should not see "UPS Ground"

--- a/features/frontend/products_i18n.feature
+++ b/features/frontend/products_i18n.feature
@@ -17,44 +17,37 @@ Feature: Browse products, categories, attributes and options in preferred langua
             | T-Shirt color | Color        | Red, Blue, Green |
             | T-Shirt size  | Size         | S, M, L          |
           And there are following attributes:
-            | name               | presentation      | type     | choices   |
-            | T-Shirt fabric     | Fabric            | text     |           |
+            | name           | presentation | type | choices |
+            | T-Shirt fabric | Fabric       | text |         |
           And the following products exist:
-            | name          | price | options                     | attributes             | taxons       |
-            | Super T-Shirt | 19.99 | T-Shirt size, T-Shirt color | T-Shirt fabric: Wool   | T-Shirts     |
+            | name          | price | options                     | attributes           | taxons   |
+            | Super T-Shirt | 19.99 | T-Shirt size, T-Shirt color | T-Shirt fabric: Wool | T-Shirts |
           And product "Super T-Shirt" is available in all variations
-          And there are following locales configured:
+          And there are following locales configured and assigned to the default channel:
             | code  |
             | en_US |
             | es_ES |
           And the following product translations exist:
             | product       | name           | locale |
-            | Super T-Shirt | Camiseta Super | es     |
-          And the following taxonomy translations exist
+            | Super T-Shirt | Camiseta Super | es_ES   |
+          And the following taxonomy translations exist:
             | taxonomy | name      | locale |
-            | Category | Categoria | es     |
-          And the following taxon translations exist
+            | Category | Categoria | es_ES  |
+          And the following taxon translations exist:
             | taxon    | name      | locale |
-            | Clothing | Ropa      | es     |
-            | T-Shirts | Camisetas | es     |
-          And the following attribute translations exist
+            | Clothing | Ropa      | es_ES  |
+            | T-Shirts | Camisetas | es_ES  |
+          And the following attribute translations exist:
             | attribute      | presentation | locale |
-            | T-Shirt fabric | Material     | es     |
-          And the following option translations exist
+            | T-Shirt fabric | Material     | es_ES  |
+          And the following option translations exist:
             | option       | presentation | locale |
-            | T-Shirt size | Talla        | es     |
+            | T-Shirt size | Talla        | es_ES  |
           And all products are assigned to the default channel
 
-    Scenario: Seeing translated product, taxonomy and taxon name
+    Scenario: Seeing translated product name, options and attributes
         Given I am on the store homepage
-        When I change the locale to "Spanish"
-        Then I should see "Camiseta Super"
-        And I should see "Categoria"
-        And I should see "Camisetas"
-
-    Scenario: Seeing translated product options and attributes
-        Given I am on the store homepage
-        When I change the locale to "Spanish"
-        And I follow "Camiseta Super"
-        Then I should see "Material"
-        And I should see "Talla"
+         When I change the locale to "Spanish (Spain)"
+          And I follow "Camiseta Super"
+         Then I should see "Material"
+          And I should see "Talla"

--- a/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
@@ -494,6 +494,27 @@ class CoreContext extends DefaultContext
     }
 
     /**
+     * @Given /^there are following locales configured and assigned to the default channel:$/
+     */
+    public function thereAreLocalesAssignedToDefaultChannel(TableNode $table)
+    {
+        $this->thereAreLocales($table);
+
+        /** @var ChannelInterface $defaultChannel */
+        $defaultChannel = $this->getRepository('channel')->findOneBy(array('code' => 'DEFAULT-WEB'));
+
+        /** @var LocaleInterface[] $locales */
+        $locales = $this->getRepository('locale')->findAll();
+        foreach ($locales as $locale) {
+            $defaultChannel->addLocale($locale);
+        }
+
+        $em = $this->getEntityManager();
+        //$em->persist($defaultChannel);
+        $em->flush();
+    }
+
+    /**
      * @Given /^product "([^""]*)" is available in all variations$/
      */
     public function productIsAvailableInAllVariations($productName)

--- a/src/Sylius/Bundle/PaymentBundle/Behat/PaymentContext.php
+++ b/src/Sylius/Bundle/PaymentBundle/Behat/PaymentContext.php
@@ -28,6 +28,11 @@ class PaymentContext extends DefaultContext
         $repository = $this->getRepository('payment_method');
 
         foreach ($table->getHash() as $data) {
+            if (!isset($data['calculator'], $data['calculator_configuration'])) {
+                $data['calculator'] = 'fixed';
+                $data['calculator_configuration'] = 'amount: 0';
+            }
+
             /* @var $method PaymentMethodInterface */
             $method = $repository->createNew();
             $method->setName(trim($data['name']));
@@ -35,13 +40,7 @@ class PaymentContext extends DefaultContext
             $method->setFeeCalculator($data['calculator']);
             $method->setFeeCalculatorConfiguration($this->getConfiguration($data['calculator_configuration']));
 
-            $enabled = true;
-
-            if (isset($data['enabled'])) {
-                $enabled = 'yes' === trim($data['enabled']);
-            }
-
-            $method->setEnabled($enabled);
+            $method->setEnabled(isset($data['enabled']) ? 'yes' === trim($data['enabled']) : true);
 
             $manager->persist($method);
         }

--- a/src/Sylius/Bundle/ProductBundle/Behat/ProductContext.php
+++ b/src/Sylius/Bundle/ProductBundle/Behat/ProductContext.php
@@ -233,11 +233,13 @@ class ProductContext extends DefaultContext
 
         foreach ($table->getHash() as $data) {
             $productTranslation = $this->findOneByName('product_translation', $data['product']);
+
             $product = $productTranslation->getTranslatable();
             $product->setCurrentLocale($data['locale']);
-            $product
-                ->setName($data['name'])
-                ->setDescription('...');
+            $product->setFallbackLocale($data['locale']);
+
+            $product->setName($data['name']);
+            $product->setDescription('...');
         }
 
         $manager->flush();
@@ -256,7 +258,7 @@ class ProductContext extends DefaultContext
     }
 
     /**
-     * @Given the following attribute translations exist
+     * @Given the following attribute translations exist:
      */
     public function theFollowingAttributeTranslationsExist(TableNode $table)
     {
@@ -264,16 +266,17 @@ class ProductContext extends DefaultContext
 
         foreach ($table->getHash() as $data) {
             $attribute = $this->findOneByName('product_attribute', $data['attribute']);
-            $attribute
-                ->setCurrentLocale($data['locale'])
-                ->setPresentation($data['presentation']);
+            $attribute->setCurrentLocale($data['locale']);
+            $attribute->setFallbackLocale($data['locale']);
+
+            $attribute->setPresentation($data['presentation']);
         }
 
         $manager->flush();
     }
 
     /**
-     * @Given the following option translations exist
+     * @Given the following option translations exist:
      */
     public function theFollowingOptionTranslationsExist(TableNode $table)
     {
@@ -281,9 +284,10 @@ class ProductContext extends DefaultContext
 
         foreach ($table->getHash() as $data) {
             $option = $this->findOneByName('product_option', $data['option']);
-            $option
-                ->setCurrentLocale($data['locale'])
-                ->setPresentation($data['presentation']);
+            $option->setCurrentLocale($data['locale']);
+            $option->setFallbackLocale($data['locale']);
+
+            $option->setPresentation($data['presentation']);
         }
 
         $manager->flush();

--- a/src/Sylius/Bundle/ShippingBundle/Behat/ShippingContext.php
+++ b/src/Sylius/Bundle/ShippingBundle/Behat/ShippingContext.php
@@ -76,18 +76,20 @@ class ShippingContext extends DefaultContext
     }
 
     /**
-     * @Given the shipping method translations exist
+     * @Given the shipping method translations exist:
      */
     public function theShippingMethodTranslationsExist(TableNode $table)
     {
         $manager = $this->getEntityManager();
 
         foreach ($table->getHash() as $data) {
-            $countryTranslation = $this->findOneByName('shipping_method_translation', $data['shipping_method']);
-            $country = $countryTranslation->getTranslatable();
-            $country
-                ->setCurrentLocale($data['locale'])
-                ->setName($data['name']);
+            $shippingMethodTranslation = $this->findOneByName('shipping_method_translation', $data['shipping method']);
+
+            $shippingMethod = $shippingMethodTranslation->getTranslatable();
+            $shippingMethod->setCurrentLocale($data['locale']);
+            $shippingMethod->setFallbackLocale($data['locale']);
+
+            $shippingMethod->setName($data['name']);
         }
 
         $manager->flush();

--- a/src/Sylius/Bundle/TaxonomyBundle/Behat/TaxonomyContext.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Behat/TaxonomyContext.php
@@ -89,7 +89,7 @@ class TaxonomyContext extends DefaultContext
     }
 
     /**
-     * @Given the following taxonomy translations exist
+     * @Given the following taxonomy translations exist:
      */
     public function theFollowingTaxonomyTranslationsExist(TableNode $table)
     {
@@ -97,33 +97,37 @@ class TaxonomyContext extends DefaultContext
 
         foreach ($table->getHash() as $data) {
             $taxonomyTranslation = $this->findOneByName('taxonomy_translation', $data['taxonomy']);
+
             $taxonomy = $taxonomyTranslation->getTranslatable();
-            $taxonomy
-                ->setCurrentLocale($data['locale'])
-                ->setName($data['name']);
+            $taxonomy->setCurrentLocale($data['locale']);
+            $taxonomy->setFallbackLocale($data['locale']);
+
+            $taxonomy->setName($data['name']);
         }
 
         $manager->flush();
     }
 
     /**
-     * @Given the following taxon translations exist
+     * @Given the following taxon translations exist:
      */
     public function theFollowingTaxonTranslationsExist(TableNode $table)
     {
         foreach ($table->getHash() as $data) {
             $taxonTranslation = $this->findOneByName('taxon_translation', $data['taxon']);
+
             $taxon = $taxonTranslation->getTranslatable();
-            $taxon
-                ->setCurrentLocale($data['locale'])
-                ->setName($data['name']);
+            $taxon->setCurrentLocale($data['locale']);
+            $taxon->setFallbackLocale($data['locale']);
+
+            $taxon->setName($data['name']);
         }
 
         $this->getEntityManager()->flush();
     }
 
     /**
-     * @Then Taxon translation :taxonName should have permalink :expectedPermalink
+     * @Then taxon translation :taxonName should have permalink :expectedPermalink
      */
     public function taxonForLocaleShouldHavePermalink($taxonName, $expectedPermalink)
     {

--- a/travis/suites/suite-1
+++ b/travis/suites/suite-1
@@ -14,6 +14,7 @@ bin/behat -s reports -f progress
 bin/behat -s taxonomies -f progress
 bin/behat -s users -f progress
 bin/behat -s search -f progress
+bin/behat -s search_orm_only -f progress
 
 bin/behat -s checkout -f progress features/frontend/checkout_addressing.feature
 bin/behat -s checkout -f progress features/frontend/checkout_finalize.feature
@@ -23,3 +24,6 @@ bin/behat -s checkout -f progress features/frontend/checkout_security.feature
 bin/behat -s checkout -f progress features/frontend/checkout_shipping.feature
 bin/behat -s checkout -f progress features/frontend/checkout_start.feature
 bin/behat -s checkout -f progress features/frontend/checkout_taxation.feature
+bin/behat -s checkout -f progress features/frontend/cart_taxation.feature
+bin/behat -s checkout -f progress features/frontend/cart_tax_categories.feature
+bin/behat -s checkout -f progress features/frontend/cart_inclusive_tax.feature

--- a/travis/suites/suite-2
+++ b/travis/suites/suite-2
@@ -6,6 +6,8 @@ bin/behat -s pricing -f progress
 bin/behat -s settings -f progress
 bin/behat -s shipping -f progress
 bin/behat -s taxation -f progress
+bin/behat -s i18n -f progress
+bin/behat -s channels -f progress
 
 bin/behat -s products -f progress features/backend/products.feature
 bin/behat -s products -f progress features/backend/product_attributes.feature


### PR DESCRIPTION
There were 4 suites missing: `i18n`, `channels`, `search_orm_only` and `contact`. Added only three of them, because `contact` is currently under refactoring by @GSadee in #3164.

There were also 3 feature missing in `checkout` suite: `features/frontend/cart_taxation.feature`, `cart_tax_categories.feature` and `features/frontend/cart_inclusive_tax.feature`.