### PR TITLE
[Resource] Fix sorting bugs

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/EntityRepository.php
+++ b/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/EntityRepository.php
@@ -128,7 +128,7 @@ class EntityRepository extends BaseEntityRepository implements RepositoryInterfa
      */
     public function getPaginator(QueryBuilder $queryBuilder)
     {
-        return new Pagerfanta(new DoctrineORMAdapter($queryBuilder, true, false));
+        return new Pagerfanta(new DoctrineORMAdapter($queryBuilder, true, null));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #2892, #3004, #3027 
| License       | MIT
| Doc PR        |

Even by setting false, Paginator didn't use output walkers, because of comparing set value to ``null``.