### PR TITLE
Fee_calculator migration fix

### DIFF
--- a/app/migrations/Version20150629123648.php
+++ b/app/migrations/Version20150629123648.php
@@ -15,7 +15,7 @@ class Version20150629123648 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('ALTER TABLE sylius_payment_method CHANGE fee_calculator fee_calculator VARCHAR(255) DEFAULT NULL, CHANGE fee_calculator_configuration fee_calculator_configuration VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE sylius_payment_method ADD fee_calculator VARCHAR(255) DEFAULT NULL, ADD fee_calculator_configuration VARCHAR(255) DEFAULT NULL');
     }
 
     public function down(Schema $schema)
@@ -23,6 +23,6 @@ class Version20150629123648 extends AbstractMigration
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('ALTER TABLE sylius_payment_method CHANGE fee_calculator fee_calculator VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci, CHANGE fee_calculator_configuration fee_calculator_configuration VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci');
+        $this->addSql('ALTER TABLE sylius_payment_method DROP COLUMN fee_calculator, DROP COLUMN fee_calculator_configuration');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none
| License       | MIT
| Doc PR        | none

Changed the fee_calculator & fee_calculator_configuration `CHANGE` queries to `ADD`, since both columns do not exist at that point yet.