### PR TITLE
[Installer] Fixed directory permission checks and improved DX

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Command/AbstractInstallCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/AbstractInstallCommand.php
@@ -19,8 +19,8 @@ use Symfony\Component\Validator\ConstraintViolationList;
 
 abstract class AbstractInstallCommand extends ContainerAwareCommand
 {
-    const WEB_ASSETS_DIRECTORY      = 'web/assets/*';
-    const WEB_BUNDLES_DIRECTORY     = 'web/bundles/*';
+    const WEB_ASSETS_DIRECTORY      = 'web/assets/';
+    const WEB_BUNDLES_DIRECTORY     = 'web/bundles/';
     const WEB_MEDIA_DIRECTORY       = 'web/media/';
     const WEB_MEDIA_IMAGE_DIRECTORY = 'web/media/image/';
 
@@ -188,27 +188,6 @@ abstract class AbstractInstallCommand extends ContainerAwareCommand
     }
 
     /**
-     * @param string $directory
-     *
-     * @return bool
-     */
-    protected function isDirectoryWritable($directory)
-    {
-        return is_writable($directory);
-    }
-
-    /**
-     * @param string $directory
-     * @param string $command
-     *
-     * @return string
-     */
-    protected function createBadPermissionsMessage($directory, $command)
-    {
-        return '<error>Cannot run command due to bad directory permissions.</error>'.PHP_EOL.'Set '.$directory.' writable and run command'.PHP_EOL.'<comment>'.$command.'</comment>';
-    }
-
-    /**
      * @param OutputInterface $output
      * @param string          $question
      * @param array           $constraints
@@ -254,5 +233,75 @@ abstract class AbstractInstallCommand extends ContainerAwareCommand
         }
 
         return $dialog->askHiddenResponse($output, sprintf('<question>%s</question> ', $question));
+    }
+
+    /**
+     * @param string $directory
+     * @param OutputInterface $output
+     */
+    protected function ensureDirectoryExistsAndIsWritable($directory, OutputInterface $output)
+    {
+        $this->ensureDirectoryExists($directory, $output);
+        $this->ensureDirectoryIsWritable($directory, $output);
+    }
+
+    /**
+     * @param string $directory
+     * @param OutputInterface $output
+     */
+    private function ensureDirectoryExists($directory, OutputInterface $output)
+    {
+        if (!is_dir($directory)) {
+            if (!mkdir($directory, 0755, true)) {
+                $output->writeln($this->createUnexisitingDirectoryMessage($directory));
+
+                throw new \RuntimeException("Failed while trying to create directory.");
+            }
+
+            $output->writeln(sprintf('<comment>Created "%s" directory.</comment>', $directory));
+        }
+    }
+
+    /**
+     * @param string $directory
+     *
+     * @return string
+     */
+    protected function createUnexisitingDirectoryMessage($directory)
+    {
+        return
+            '<error>Cannot run command due to unexisting directory (tried to create it automatically, failed).</error>' . PHP_EOL .
+            sprintf('Create directory "%s" and run command "<comment>%s</comment>"', $directory, $this->getName())
+            ;
+    }
+
+    /**
+     * @param string $directory
+     * @param OutputInterface $output
+     */
+    protected function ensureDirectoryIsWritable($directory, OutputInterface $output)
+    {
+        if (!is_writable($directory)) {
+            if (!chmod($directory, 0755)) {
+                $output->writeln($this->createBadPermissionsMessage($directory));
+
+                throw new \RuntimeException("Failed while trying to change directory permissions.");
+            }
+
+            $output->writeln(sprintf('<comment>Changed "%s" permissions to 0755.</comment>', $directory));
+        }
+    }
+
+    /**
+     * @param string $directory
+     *
+     * @return string
+     */
+    protected function createBadPermissionsMessage($directory)
+    {
+        return
+            '<error>Cannot run command due to bad directory permissions (tried to change permissions to 0755).</error>' . PHP_EOL .
+            sprintf('Set directory "%s" writable and run command "<comment>%s</comment>"', $directory, $this->getName())
+            ;
     }
 }

--- a/src/Sylius/Bundle/InstallerBundle/Command/InstallAssetsCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/InstallAssetsCommand.php
@@ -29,15 +29,10 @@ EOT
     {
         $output->writeln(sprintf('Installing Sylius assets for environment <info>%s</info>.', $this->getEnvironment()));
 
-        if (!$this->isDirectoryWritable(self::WEB_ASSETS_DIRECTORY)) {
-            $output->writeln($this->createBadPermissionsMessage(self::WEB_ASSETS_DIRECTORY, 'sylius:install:assets'));
-
-            return 1;
-        }
-
-        if (!$this->isDirectoryWritable(self::WEB_BUNDLES_DIRECTORY)) {
-            $output->writeln($this->createBadPermissionsMessage(self::WEB_BUNDLES_DIRECTORY, 'sylius:install:assets'));
-
+        try {
+            $this->ensureDirectoryExistsAndIsWritable(self::WEB_ASSETS_DIRECTORY, $output);
+            $this->ensureDirectoryExistsAndIsWritable(self::WEB_BUNDLES_DIRECTORY, $output);
+        } catch (\RuntimeException $exception) {
             return 1;
         }
 

--- a/src/Sylius/Bundle/InstallerBundle/Command/InstallSampleDataCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/InstallSampleDataCommand.php
@@ -51,15 +51,10 @@ EOT
 
         $output->writeln('Loading sample data...');
 
-        if (!$this->isDirectoryWritable(self::WEB_MEDIA_DIRECTORY)) {
-            $output->writeln($this->createBadPermissionsMessage(self::WEB_MEDIA_DIRECTORY, 'sylius:install:sample-data'));
-
-            return 1;
-        }
-
-        if (!$this->isDirectoryWritable(self::WEB_MEDIA_IMAGE_DIRECTORY)) {
-            $output->writeln($this->createBadPermissionsMessage(self::WEB_MEDIA_IMAGE_DIRECTORY, 'sylius:install:sample-data'));
-
+        try {
+            $this->ensureDirectoryExistsAndIsWritable(self::WEB_MEDIA_DIRECTORY, $output);
+            $this->ensureDirectoryExistsAndIsWritable(self::WEB_MEDIA_IMAGE_DIRECTORY, $output);
+        } catch (\RuntimeException $exception) {
             return 1;
         }
 


### PR DESCRIPTION
 - Fixed critical error (checking permissions for unexisting file/directory `web/assets/*`, it stopped `sylius:install:assets` before anything can happen)
 - Developer experience:
   - Better messages (one for unexisting directory, one for bad permissions)
   - Trying to create directory or set permissions on its own