### PR TITLE
[InstallerBundle] Add current migration versions to database on first installation

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Command/InstallDatabaseCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/InstallDatabaseCommand.php
@@ -84,6 +84,11 @@ EOT
         $commands[] = 'doctrine:phpcr:repository:init';
         $commands[] = 'sylius:search:index';
         $commands[] = 'sylius:rbac:initialize';
+        $commands['doctrine:migrations:version'] = array(
+            '--add' => true,
+            '--all' => true,
+            '--no-interaction' => true,
+        );
 
         $this->runCommands($commands, $input, $output);
 


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | yes
New feature?  | no
BC breaks? | no
Deprecations? | no
Fixed tickets | -
License | MIT
Doc PR | -

On first installation we need to add currently in-place migration files in migrations table to prevent them from running when new ones are available on a production site.