### PR TITLE
[Report] Decouple from Symfony FrameworkBundle; fix typos and docblocks

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/DataFetcher/NumberOfOrdersDataFetcher.php
+++ b/src/Sylius/Bundle/CoreBundle/DataFetcher/NumberOfOrdersDataFetcher.php
@@ -27,6 +27,9 @@ class NumberOfOrdersDataFetcher extends TimePeriod
      */
     private $orderRepository;
 
+    /**
+     * @param OrderRepositoryInterface $orderRepository
+     */
     public function __construct(OrderRepositoryInterface $orderRepository)
     {
         $this->orderRepository = $orderRepository;

--- a/src/Sylius/Bundle/CoreBundle/DataFetcher/SalesTotalDataFetcher.php
+++ b/src/Sylius/Bundle/CoreBundle/DataFetcher/SalesTotalDataFetcher.php
@@ -27,6 +27,9 @@ class SalesTotalDataFetcher extends TimePeriod
      */
     private $orderRepository;
 
+    /**
+     * @param OrderRepositoryInterface $orderRepository
+     */
     public function __construct(OrderRepositoryInterface $orderRepository)
     {
         $this->orderRepository = $orderRepository;

--- a/src/Sylius/Bundle/CoreBundle/DataFetcher/UserRegistrationDataFetcher.php
+++ b/src/Sylius/Bundle/CoreBundle/DataFetcher/UserRegistrationDataFetcher.php
@@ -18,6 +18,9 @@ class UserRegistrationDataFetcher extends TimePeriod
      */
     private $userRepository;
 
+    /**
+     * @param UserRepository $userRepository
+     */
     public function __construct(UserRepository $userRepository)
     {
         $this->userRepository = $userRepository;

--- a/src/Sylius/Bundle/ReportBundle/DataFetcher/TimePeriod.php
+++ b/src/Sylius/Bundle/ReportBundle/DataFetcher/TimePeriod.php
@@ -26,7 +26,7 @@ abstract class TimePeriod implements DataFetcherInterface
     const PERIOD_YEAR   = 'year';
 
     /**
-     * {@inheritdoc}
+     * @return array
      */
     public static function getPeriodChoices()
     {
@@ -74,7 +74,7 @@ abstract class TimePeriod implements DataFetcherInterface
         $fetched = array();
 
         if ($configuration['empty_records']) {
-            $fetched = $this->fillEmptyRecodrs($fetched, $configuration);
+            $fetched = $this->fillEmptyRecords($fetched, $configuration);
         }
         foreach ($rawData as $row) {
             $date = new \DateTime($row[$labels[0]]);
@@ -87,10 +87,12 @@ abstract class TimePeriod implements DataFetcherInterface
     }
 
     /**
-     * Method responsible for providing raw data to fetch.
-     * It returns the configuration (start date, end date, time period, empty records flag, interval, period format, presentation format, group by).
+     * Responsible for providing raw data to fetch, from the configuration (ie: start date, end date, time period,
+     * empty records flag, interval, period format, presentation format, group by).
      *
-     * @param Array
+     * @param array $configuration
+     *
+     * @return array
      */
     abstract protected function getData(array $configuration = array());
 
@@ -120,15 +122,15 @@ abstract class TimePeriod implements DataFetcherInterface
      *
      * @return array
      */
-    private function fillEmptyRecodrs(array $fetched, array $configuration)
+    private function fillEmptyRecords(array $fetched, array $configuration)
     {
         $date = $configuration['start'];
         $dateInterval = new \DateInterval($configuration['interval']);
 
         $numberOfPeriods = $configuration['start']->diff($configuration['end']);
-        $formatednumberOfPeriods = $numberOfPeriods->format($configuration['periodFormat']);
+        $formattedNumberOfPeriods = $numberOfPeriods->format($configuration['periodFormat']);
 
-        for ($i = 0; $i <= $formatednumberOfPeriods; $i++) {
+        for ($i = 0; $i <= $formattedNumberOfPeriods; $i++) {
             $fetched[$date->format($configuration['presentationFormat'])] = 0;
             $date = $date->add($dateInterval);
         }

--- a/src/Sylius/Bundle/ReportBundle/Renderer/ChartRenderer.php
+++ b/src/Sylius/Bundle/ReportBundle/Renderer/ChartRenderer.php
@@ -14,8 +14,8 @@ namespace Sylius\Bundle\ReportBundle\Renderer;
 use Sylius\Component\Report\DataFetcher\Data;
 use Sylius\Component\Report\Model\ReportInterface;
 use Sylius\Component\Report\Renderer\RendererInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Sylius\Component\Report\Renderer\DefaultRenderers;
+use Symfony\Component\Templating\EngineInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -35,6 +35,9 @@ class ChartRenderer implements RendererInterface
      */
     private $templating;
 
+    /**
+     * @param EngineInterface $templating
+     */
     public function __construct(EngineInterface $templating)
     {
         $this->templating = $templating;
@@ -54,13 +57,13 @@ class ChartRenderer implements RendererInterface
 
             $rendererConfiguration = $report->getRendererConfiguration();
 
-            return $this->templating->renderResponse($rendererConfiguration["template"], array(
+            return $this->templating->render($rendererConfiguration["template"], array(
                 'data' => $rendererData,
                 'configuration' => $rendererConfiguration,
             ));
         }
 
-        return $this->templating->renderResponse("SyliusReportBundle::noDataTemplate.html.twig", array(
+        return $this->templating->render("SyliusReportBundle::noDataTemplate.html.twig", array(
             'report' => $report,
         ));
     }

--- a/src/Sylius/Bundle/ReportBundle/Renderer/TableRenderer.php
+++ b/src/Sylius/Bundle/ReportBundle/Renderer/TableRenderer.php
@@ -14,8 +14,8 @@ namespace Sylius\Bundle\ReportBundle\Renderer;
 use Sylius\Component\Report\DataFetcher\Data;
 use Sylius\Component\Report\Model\ReportInterface;
 use Sylius\Component\Report\Renderer\RendererInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Sylius\Component\Report\Renderer\DefaultRenderers;
+use Symfony\Component\Templating\EngineInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -28,6 +28,9 @@ class TableRenderer implements RendererInterface
      */
     private $templating;
 
+    /**
+     * @param EngineInterface $templating
+     */
     public function __construct(EngineInterface $templating)
     {
         $this->templating = $templating;
@@ -48,13 +51,13 @@ class TableRenderer implements RendererInterface
 
             $rendererConfiguration = $report->getRendererConfiguration();
 
-            return $this->templating->renderResponse($rendererConfiguration["template"], array(
+            return $this->templating->render($rendererConfiguration["template"], array(
                 'data' => $data,
                 'configuration' => $rendererConfiguration,
             ));
         }
 
-        return $this->templating->renderResponse("SyliusReportBundle::noDataTemplate.html.twig", array(
+        return $this->templating->render("SyliusReportBundle::noDataTemplate.html.twig", array(
             'report' => $report,
         ));
     }

--- a/src/Sylius/Bundle/ReportBundle/spec/Renderer/ChartRendererSpec.php
+++ b/src/Sylius/Bundle/ReportBundle/spec/Renderer/ChartRendererSpec.php
@@ -12,9 +12,8 @@
 namespace spec\Sylius\Bundle\ReportBundle\Renderer;
 
 use PhpSpec\ObjectBehavior;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Templating\EngineInterface;
 use Sylius\Component\Report\Model\ReportInterface;
-use Symfony\Component\HttpFoundation\Response;
 use Sylius\Component\Report\DataFetcher\Data;
 use Sylius\Component\Report\Renderer\DefaultRenderers;
 
@@ -39,7 +38,7 @@ class ChartRendererSpec extends ObjectBehavior
         $this->shouldImplement('Sylius\Component\Report\Renderer\RendererInterface');
     }
 
-    function it_renders_data_with_given_configuration(ReportInterface $report, Response $response, Data $reportData, $templating)
+    function it_renders_data_with_given_configuration(ReportInterface $report, Data $reportData, $templating)
     {
         $reportData->getData()->willReturn(array('month1' => '50', 'month2' => '40'));
 
@@ -51,15 +50,15 @@ class ChartRendererSpec extends ObjectBehavior
 
         $report->getRendererConfiguration()->willReturn(array('template' => 'SyliusReportBundle:Chart:default.html.twig'));
 
-        $templating->renderResponse('SyliusReportBundle:Chart:default.html.twig', array(
+        $templating->render('SyliusReportBundle:Chart:default.html.twig', array(
             'data' => $renderData,
             'configuration' => array('template' => 'SyliusReportBundle:Chart:default.html.twig'),
-        ))->willReturn($response);
+        ))->willReturn('<div>Chart Report</div>');
 
-        $this->render($report, $reportData)->shouldReturn($response);
+        $this->render($report, $reportData)->shouldReturn('<div>Chart Report</div>');
     }
 
-    function it_has_type()
+    function it_is_a_chart_type()
     {
         $this->getType()->shouldReturn(DefaultRenderers::CHART);
     }

--- a/src/Sylius/Bundle/ReportBundle/spec/Renderer/TableRendererSpec.php
+++ b/src/Sylius/Bundle/ReportBundle/spec/Renderer/TableRendererSpec.php
@@ -12,9 +12,8 @@
 namespace spec\Sylius\Bundle\ReportBundle\Renderer;
 
 use PhpSpec\ObjectBehavior;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Templating\EngineInterface;
 use Sylius\Component\Report\Model\ReportInterface;
-use Symfony\Component\HttpFoundation\Response;
 use Sylius\Component\Report\DataFetcher\Data;
 use Sylius\Component\Report\Renderer\DefaultRenderers;
 
@@ -39,7 +38,7 @@ class TableRendererSpec extends ObjectBehavior
         $this->shouldImplement('Sylius\Component\Report\Renderer\RendererInterface');
     }
 
-    function it_renders_data_with_given_configuration(ReportInterface $report, Response $response, Data $reportData, $templating)
+    function it_renders_data_with_given_configuration(ReportInterface $report, Data $reportData, $templating)
     {
         $reportData->getLabels()->willReturn(array('month', 'user_total'));
         $reportData->getData()->willReturn(array('month1' => '50', 'month2' => '40'));
@@ -53,15 +52,15 @@ class TableRendererSpec extends ObjectBehavior
 
         $report->getRendererConfiguration()->willReturn(array('template' => 'SyliusReportBundle:Table:default.html.twig'));
 
-        $templating->renderResponse('SyliusReportBundle:Table:default.html.twig', array(
+        $templating->render('SyliusReportBundle:Table:default.html.twig', array(
             'data' => $renderData,
             'configuration' => array('template' => 'SyliusReportBundle:Table:default.html.twig'),
-        ))->willReturn($response);
+        ))->willReturn('<div>Table Report</div>');
 
-        $this->render($report, $reportData)->shouldReturn($response);
+        $this->render($report, $reportData)->shouldReturn('<div>Table Report</div>');
     }
 
-    function it_has_type()
+    function it_is_a_table_type()
     {
         $this->getType()->shouldReturn(DefaultRenderers::TABLE);
     }

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Dashboard/main.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Dashboard/main.html.twig
@@ -22,7 +22,7 @@
         <br>
     </div>
     <div class="col-md-6">
-        {{ render(controller('sylius.controller.report:embeddAction', {'report': 'ReportCode'})) }}
+        {{ render(controller('sylius.controller.report:embedAction', {'report': 'ReportCode'})) }}
     </div>
 </div>
 

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Report/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Report/show.html.twig
@@ -28,7 +28,7 @@
     <br>
     </form>
     {{ report.description }}
-    {{ render(controller('sylius.controller.report:embeddAction', {'report': report, 'configuration' : configuration})) }}
+    {{ render(controller('sylius.controller.report:embedAction', {'report': report, 'configuration' : configuration})) }}
 {% endblock %}
 
 {% block stylesheets %}

--- a/src/Sylius/Component/Report/DataFetcher/DataFetcherInterface.php
+++ b/src/Sylius/Component/Report/DataFetcher/DataFetcherInterface.php
@@ -17,8 +17,6 @@ namespace Sylius\Component\Report\DataFetcher;
 interface DataFetcherInterface
 {
     /**
-     * Fetching data from data base
-     *
      * @param array $configuration
      *
      * @return Data $data
@@ -26,7 +24,7 @@ interface DataFetcherInterface
     public function fetch(array $configuration);
 
     /**
-     * @return Type of data
+     * @return string
      */
     public function getType();
 }

--- a/src/Sylius/Component/Report/DataFetcher/DelegatingDataFetcher.php
+++ b/src/Sylius/Component/Report/DataFetcher/DelegatingDataFetcher.php
@@ -29,8 +29,6 @@ class DelegatingDataFetcher implements DelegatingDataFetcherInterface
     protected $registry;
 
     /**
-     * Constructor.
-     *
      * @param ServiceRegistryInterface $registry
      */
     public function __construct(ServiceRegistryInterface $registry)
@@ -40,6 +38,8 @@ class DelegatingDataFetcher implements DelegatingDataFetcherInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \InvalidArgumentException If the report does not have a data fetcher.
      */
     public function fetch(ReportInterface $report, array $configuration = array())
     {

--- a/src/Sylius/Component/Report/DataFetcher/DelegatingDataFetcherInterface.php
+++ b/src/Sylius/Component/Report/DataFetcher/DelegatingDataFetcherInterface.php
@@ -21,12 +21,12 @@ use Sylius\Component\Report\Model\ReportInterface;
 interface DelegatingDataFetcherInterface
 {
     /**
-    * Fetch data for given config.
-    *
-    * @param ReportInterface $report
-    * @param array $configuration
-    *
-    * @return array
-    */
+     * Fetch data for given config.
+     *
+     * @param ReportInterface $report
+     * @param array           $configuration
+     *
+     * @return array
+     */
     public function fetch(ReportInterface $report, array $configuration = array());
 }

--- a/src/Sylius/Component/Report/Model/Report.php
+++ b/src/Sylius/Component/Report/Model/Report.php
@@ -18,7 +18,6 @@ use Sylius\Component\Report\Renderer\DefaultRenderers;
  * @author Łukasz Chruściel <lchrusciel@gmail.com>
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-
 class Report implements ReportInterface
 {
     /**
@@ -49,8 +48,6 @@ class Report implements ReportInterface
     private $renderer = DefaultRenderers::TABLE;
 
     /**
-     * Renderer configuration.
-     *
      * @var array
      */
     private $rendererConfiguration = array();
@@ -68,9 +65,7 @@ class Report implements ReportInterface
     private $dataFetcherConfiguration = array();
 
     /**
-     * Gets the value of id.
-     *
-     * @return integer
+     * {@inheritdoc}
      */
     public function getId()
     {
@@ -78,9 +73,7 @@ class Report implements ReportInterface
     }
 
     /**
-     * Gets the value of name.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getName()
     {
@@ -88,23 +81,15 @@ class Report implements ReportInterface
     }
 
     /**
-     * Sets the value of name.
-     *
-     * @param string $name the name
-     *
-     * @return self
+     * {@inheritdoc}
      */
     public function setName($name)
     {
         $this->name = $name;
-
-        return $this;
     }
 
     /**
-     * Gets the value of description.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getDescription()
     {
@@ -112,22 +97,14 @@ class Report implements ReportInterface
     }
 
     /**
-     * Sets the value of description.
-     *
-     * @param string $description the description
-     *
-     * @return self
+     * {@inheritdoc}
      */
     public function setDescription($description)
     {
         $this->description = $description;
-
-        return $this;
     }
 
     /**
-     * Gets the value of code.
-     *
      * @return string
      */
     public function getCode()
@@ -136,23 +113,15 @@ class Report implements ReportInterface
     }
 
     /**
-     * Sets the value of code.
-     *
-     * @param string $code the code
-     *
-     * @return self
+     * @param string $code
      */
     public function setCode($code)
     {
         $this->code = $code;
-
-        return $this;
     }
 
     /**
-     * Gets the dataFetcher name.
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getDataFetcher()
     {
@@ -160,22 +129,14 @@ class Report implements ReportInterface
     }
 
     /**
-     * Sets the value of dataFetcher.
-     *
-     * @param string $dataFetcher the data fetcher
-     *
-     * @return self
+     * {@inheritdoc}
      */
     public function setDataFetcher($dataFetcher)
     {
         $this->dataFetcher = $dataFetcher;
-
-        return $this;
     }
 
     /**
-     * Gets the Renderer name.
-     *
      * @return string
      */
     public function getRenderer()
@@ -184,23 +145,15 @@ class Report implements ReportInterface
     }
 
     /**
-     * Sets the Renderer name.
-     *
-     * @param string $renderer the renderer
-     *
-     * @return self
+     * {@inheritdoc}
      */
     public function setRenderer($renderer)
     {
         $this->renderer = $renderer;
-
-        return $this;
     }
 
     /**
-     * Gets the value of dataFetcherConfiguration.
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getDataFetcherConfiguration()
     {
@@ -208,23 +161,15 @@ class Report implements ReportInterface
     }
 
     /**
-     * Sets the value of dataFetcherConfiguration.
-     *
-     * @param array $dataFetcherConfiguration the data fetcher configuration
-     *
-     * @return self
+     * {@inheritdoc}
      */
     public function setDataFetcherConfiguration(array $dataFetcherConfiguration)
     {
         $this->dataFetcherConfiguration = $dataFetcherConfiguration;
-
-        return $this;
     }
 
     /**
-     * Gets the Renderers configuration.
-     *
-     * @return array
+     * {@inheritdoc}
      */
     public function getRendererConfiguration()
     {
@@ -232,16 +177,10 @@ class Report implements ReportInterface
     }
 
     /**
-     * Sets the Renderers configuration.
-     *
-     * @param array $rendererConfiguration the renderer configuration
-     *
-     * @return self
+     * {@inheritdoc}
      */
-    public function setRendererConfiguration($rendererConfiguration)
+    public function setRendererConfiguration(array $rendererConfiguration)
     {
         $this->rendererConfiguration = $rendererConfiguration;
-
-        return $this;
     }
 }

--- a/src/Sylius/Component/Report/Model/ReportInterface.php
+++ b/src/Sylius/Component/Report/Model/ReportInterface.php
@@ -13,17 +13,68 @@ namespace Sylius\Component\Report\Model;
 
 interface ReportInterface
 {
+    /**
+     * @return mixed
+     */
     public function getId();
+
+    /**
+     * @return string
+     */
     public function getName();
+
+    /**
+     * @param string $name
+     */
     public function setName($name);
+
+    /**
+     * @return string
+     */
     public function getDescription();
+
+    /**
+     * @param string $description
+     */
     public function setDescription($description);
+
+    /**
+     * @return string
+     */
     public function getRenderer();
+
+    /**
+     * @param string $renderer
+     */
     public function setRenderer($renderer);
+
+    /**
+     * @return array
+     */
     public function getRendererConfiguration();
-    public function setRendererConfiguration($rendererConfiguration);
+
+    /**
+     * @param array $rendererConfiguration
+     */
+    public function setRendererConfiguration(array $rendererConfiguration);
+
+    /**
+     * @return string
+     */
     public function getDataFetcher();
+
+    /**
+     * @param string $dataFetcher
+     */
     public function setDataFetcher($dataFetcher);
+
+    /**
+     * @return array
+     */
     public function getDataFetcherConfiguration();
+
+    /**
+     * @param array $dataFetcherConfiguration
+     */
     public function setDataFetcherConfiguration(array $dataFetcherConfiguration);
 }

--- a/src/Sylius/Component/Report/Renderer/DelegatingRenderer.php
+++ b/src/Sylius/Component/Report/Renderer/DelegatingRenderer.php
@@ -28,8 +28,6 @@ class DelegatingRenderer implements DelegatingRendererInterface
     protected $registry;
 
     /**
-     * Contructor
-     *
      * @param ServiceRegistryInterface $registry
      */
     public function __construct(ServiceRegistryInterface $registry)
@@ -37,6 +35,11 @@ class DelegatingRenderer implements DelegatingRendererInterface
         $this->registry = $registry;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \InvalidArgumentException If the report subject does not have a renderer.
+     */
     public function render(ReportInterface $subject, Data $data)
     {
         if (null === $type = $subject->getRenderer()) {

--- a/src/Sylius/Component/Report/Renderer/DelegatingRendererInterface.php
+++ b/src/Sylius/Component/Report/Renderer/DelegatingRendererInterface.php
@@ -20,7 +20,6 @@ use Sylius\Component\Report\DataFetcher\Data;
 interface DelegatingRendererInterface
 {
     /**
-     *
      * @param ReportInterface $subject
      * @param Data            $data
      *

--- a/src/Sylius/Component/Report/Renderer/RendererInterface.php
+++ b/src/Sylius/Component/Report/Renderer/RendererInterface.php
@@ -18,7 +18,7 @@ interface RendererInterface
 {
     /**
      * @param ReportInterface $report
-     * @param Data $data
+     * @param Data            $data
      *
      * @return string
      */

--- a/src/Sylius/Component/Report/composer.json
+++ b/src/Sylius/Component/Report/composer.json
@@ -33,6 +33,9 @@
     "require-dev": {
         "phpspec/phpspec": "~2.1"
     },
+    "suggest": {
+        "symfony/templating": "~2.3"
+    },
     "autoload": {
         "psr-4": { "Sylius\\Component\\Report\\": "" }
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | n/a

Changeset:

 * Fixed typo in method ReportController::embed**d**Action - BC Break
 * Fixed typo in method TimePeriod::fillEmptyReco**dr**s
 * Dependency for `TableRenderer` and `ChartRenderer` is lowered from Symfony FrameworkBundle to Symfony Templating. These renderers could be moved from the ReportBundle to the Report component.
 * Added docblocks that were missing and fixed incorrect ones.