### PR TITLE
[Core] Redirect customer to order tracking page after checkout completion

### DIFF
--- a/features/frontend/checkout_finalize.feature
+++ b/features/frontend/checkout_finalize.feature
@@ -42,12 +42,8 @@ Feature: Checkout finalization
           And I select the "Dummy" radio button
           And I press "Continue"
          When I click "Place order"
-         Then I should be on the store homepage
+         Then I should be on the order tracking page for 000000001
           And I should see "Thank you for your order!"
-          And I am on my account orders page
-          And I should see "All your orders"
-          And I should see 1 orders in the list
-          And I should see "000000001"
 
     Scenario: Placing the order as Guest without email address
         Given I am not logged in
@@ -85,5 +81,5 @@ Feature: Checkout finalization
           And I select the "Dummy" radio button
           And I press "Continue"
          When I click "Place order"
-         Then I should be on the store homepage
+         Then I should be on the order tracking page for 000000001
           And I should see "Thank you for your order!"

--- a/features/frontend/checkout_security.feature
+++ b/features/frontend/checkout_security.feature
@@ -74,7 +74,7 @@ Feature: Checkout security
           And I select the "Dummy" radio button
           And I press "Continue"
           And I click "Place order"
-         Then I should be on the store homepage
+         Then I should be on the order tracking page for 000000001
           And I should see "Thank you for your order!"
 
     Scenario: Creating account without first and last name

--- a/src/Sylius/Bundle/CoreBundle/Checkout/CheckoutProcessScenario.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/CheckoutProcessScenario.php
@@ -59,7 +59,10 @@ class CheckoutProcessScenario implements ProcessScenarioInterface
         $builder
             ->setDisplayRoute('sylius_checkout_display')
             ->setForwardRoute('sylius_checkout_forward')
-            ->setRedirect('sylius_homepage')
+            ->setRedirect('sylius_order_track')
+            ->setRedirectParams(array(
+                'number' => $cart->getNumber()
+            ))
             ->validate(function () use ($cart) {
                 return !$cart->isEmpty();
             })

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -22,6 +22,7 @@
         <parameter key="sylius.settings_schema.security.class">Sylius\Bundle\CoreBundle\Settings\SecuritySettingsSchema</parameter>
 
         <parameter key="sylius.context.currency.class">Sylius\Bundle\CoreBundle\Context\CurrencyContext</parameter>
+        <parameter key="sylius.listener.customer_context.class">Sylius\Bundle\UserBundle\EventListener\CustomerContextListener</parameter>
 
         <parameter key="sylius.checkout_scenario.class">Sylius\Bundle\CoreBundle\Checkout\CheckoutProcessScenario</parameter>
         <parameter key="sylius.checkout_step.security.class">Sylius\Bundle\CoreBundle\Checkout\Step\SecurityStep</parameter>
@@ -327,6 +328,10 @@
         </service>
         <service id="sylius.listener.checkout_addressing" class="%sylius.listener.checkout_addressing.class%">
             <tag name="kernel.event_listener" event="sylius.checkout.addressing.pre_complete" method="setCustomerAddressing" />
+        </service>
+        <service id="sylius.listener.customer_context" class="%sylius.listener.customer_context.class%">
+            <argument type="service" id="sylius.context.customer" />
+            <tag name="kernel.event_listener" event="sylius.checkout.security.pre_complete" method="setCustomerContextFromSubject" />
         </service>
         <service id="sylius.listener.insufficient_stock_exception" class="%sylius.listener.insufficient_stock_exception.class%">
             <argument type="service" id="router" />

--- a/src/Sylius/Bundle/CoreBundle/spec/Checkout/CheckoutProcessScenarioSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Checkout/CheckoutProcessScenarioSpec.php
@@ -39,20 +39,25 @@ class CheckoutProcessScenarioSpec extends ObjectBehavior
         $this->shouldImplement('Sylius\Bundle\FlowBundle\Process\Scenario\ProcessScenarioInterface');
     }
 
-    function it_builds_checkout_process_with_proper_steps(ProcessBuilderInterface $builder)
+    function it_builds_checkout_process_with_proper_steps(ProcessBuilderInterface $builder, CartInterface $cart)
     {
-        $builder->add('security', 'sylius_checkout_security')->willReturn($builder)->shouldBeCalled();
-        $builder->add('addressing', 'sylius_checkout_addressing')->willReturn($builder)->shouldBeCalled();
-        $builder->add('shipping', 'sylius_checkout_shipping')->willReturn($builder)->shouldBeCalled();
-        $builder->add('payment', 'sylius_checkout_payment')->willReturn($builder)->shouldBeCalled();
-        $builder->add('finalize', 'sylius_checkout_finalize')->willReturn($builder)->shouldBeCalled();
-        $builder->add("purchase", "sylius_checkout_purchase")->willReturn($builder)->shouldBeCalled();
+        $cart->getNumber()->willReturn('000000001');
 
-        $builder->setDisplayRoute('sylius_checkout_display')->willReturn($builder)->shouldBeCalled();
-        $builder->setForwardRoute('sylius_checkout_forward')->willReturn($builder)->shouldBeCalled();
+        $builder->add('security', 'sylius_checkout_security')->willReturn($builder);
+        $builder->add('addressing', 'sylius_checkout_addressing')->willReturn($builder);
+        $builder->add('shipping', 'sylius_checkout_shipping')->willReturn($builder);
+        $builder->add('payment', 'sylius_checkout_payment')->willReturn($builder);
+        $builder->add('finalize', 'sylius_checkout_finalize')->willReturn($builder);
+        $builder->add('purchase', 'sylius_checkout_purchase')->willReturn($builder);
 
-        $builder->setRedirect('sylius_homepage')->willReturn($builder)->shouldBeCalled();
-        $builder->validate(Argument::any())->willReturn($builder)->shouldBeCalled();
+        $builder->setDisplayRoute('sylius_checkout_display')->willReturn($builder);
+        $builder->setForwardRoute('sylius_checkout_forward')->willReturn($builder);
+
+        $builder->setRedirect('sylius_order_track')->willReturn($builder);
+        $builder->setRedirectParams(array(
+            'number' => '000000001'
+        ))->willReturn($builder);
+        $builder->validate(Argument::any())->willReturn($builder);
 
         $this->build($builder);
     }

--- a/src/Sylius/Bundle/UserBundle/EventListener/CustomerContextListener.php
+++ b/src/Sylius/Bundle/UserBundle/EventListener/CustomerContextListener.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\UserBundle\EventListener;
+
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
+use Sylius\Component\User\Context\CustomerContextInterface;
+use Sylius\Component\User\Model\CustomerAwareInterface;
+use Sylius\Component\User\Model\CustomerInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * Sets customer in context from a customer-aware Event subject.
+ *
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
+ */
+class CustomerContextListener
+{
+    /**
+     * @var CustomerContextInterface
+     */
+    protected $customerContext;
+
+    /**
+     * @param CustomerContextInterface $customerContext
+     */
+    public function __construct(CustomerContextInterface $customerContext)
+    {
+        $this->customerContext = $customerContext;
+    }
+
+    /**
+     * @param GenericEvent $event
+     */
+    public function setCustomerContextFromSubject(GenericEvent $event)
+    {
+        $subject = $event->getSubject();
+
+        if (!$subject instanceof CustomerAwareInterface) {
+            throw new UnexpectedTypeException(
+                $subject,
+                'Sylius\Component\User\Model\CustomerAwareInterface'
+            );
+        }
+
+        /** @var CustomerInterface $customer */
+        if (null === $customer = $subject->getCustomer()) {
+            return;
+        }
+
+        $this->customerContext->setCustomer($customer);
+    }
+}

--- a/src/Sylius/Bundle/UserBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/services.xml
@@ -57,7 +57,9 @@
     <services>
         <!-- Customer context -->
         <service id="sylius.context.customer" class="%sylius.context.customer.class%">
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="security.authorization_checker" />
+            <argument type="service" id="session" />
         </service>
 
         <!-- Controllers -->

--- a/src/Sylius/Bundle/UserBundle/spec/Context/CustomerContextSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/Context/CustomerContextSpec.php
@@ -14,7 +14,10 @@ namespace spec\Sylius\Bundle\UserBundle\Context;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\User\Model\CustomerInterface;
 use Sylius\Component\User\Model\UserInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
@@ -22,9 +25,16 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
  */
 class CustomerContextSpec extends ObjectBehavior
 {
-    function let(SecurityContextInterface $securityContext)
-    {
-        $this->beConstructedWith($securityContext);
+    function let(
+        TokenStorageInterface $tokenStorage,
+        AuthorizationCheckerInterface $authorizationChecker,
+        SessionInterface $session
+    ) {
+        $this->beConstructedWith(
+            $tokenStorage,
+            $authorizationChecker,
+            $session
+        );
     }
 
     function it_is_initializable()
@@ -32,20 +42,60 @@ class CustomerContextSpec extends ObjectBehavior
         $this->shouldHaveType('Sylius\Bundle\UserBundle\Context\CustomerContext');
     }
 
-    function it_gets_customer_from_currently_logged_user($securityContext, TokenInterface $token, UserInterface $user, CustomerInterface $customer)
-    {
-        $securityContext->getToken()->willReturn($token);
-        $securityContext->isGranted('IS_AUTHENTICATED_REMEMBERED')->willReturn(true);
+    function it_gets_customer_from_currently_logged_in_user(
+        TokenStorageInterface $tokenStorage,
+        AuthorizationCheckerInterface $authorizationChecker,
+        TokenInterface $token,
+        UserInterface $user,
+        CustomerInterface $customer
+    ) {
+        $tokenStorage->getToken()->willReturn($token);
+        $authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')->willReturn(true);
+
         $token->getUser()->willReturn($user);
         $user->getCustomer()->willReturn($customer);
 
         $this->getCustomer()->shouldReturn($customer);
     }
 
-    function it_returns_null_if_user_is_not_logged_in($securityContext)
+    function it_stores_customer_in_session($session, CustomerInterface $customer)
     {
-        $securityContext->getToken()->willReturn(null);
+        $session->set('customer', $customer)->shouldBeCalled();
+        $this->setCustomer($customer);
+    }
 
-        $this->getCustomer()->shouldReturn(null);
+    function it_returns_previously_set_customer_from_session_if_user_is_not_logged_in(
+        TokenStorageInterface $tokenStorage,
+        SessionInterface $session,
+        CustomerInterface $customer
+    ) {
+        $tokenStorage->getToken()->willReturn(null);
+        $session->set('customer', $customer)->shouldBeCalled();
+        $session->get('customer')->willReturn($customer);
+
+        $this->setCustomer($customer);
+        $this->getCustomer()->shouldReturn($customer);
+    }
+
+    function it_returns_customer_from_logged_in_user_even_if_customer_is_previously_set_in_session(
+        TokenStorageInterface $tokenStorage,
+        AuthorizationCheckerInterface $authorizationChecker,
+        CustomerInterface $customerOfUser,
+        CustomerInterface $customerInSession,
+        TokenInterface $token,
+        UserInterface $user
+    ) {
+        $tokenStorage->getToken()->willReturn($token);
+        $authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')->willReturn(true);
+        $token->getUser()->willReturn($user);
+        $user->getCustomer()->willReturn($customerOfUser);
+
+        $this->setCustomer($customerInSession);
+        $this->getCustomer()->shouldReturn($customerOfUser);
+    }
+
+    function it_returns_null_if_user_is_not_logged_in_and_customer_not_set_in_session(TokenStorageInterface $tokenStorage) {
+        $tokenStorage->getToken()->willReturn(null);
+        $this->getCustomer();
     }
 }

--- a/src/Sylius/Bundle/UserBundle/spec/EventListener/CustomerContextListenerSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/EventListener/CustomerContextListenerSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\UserBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\UserBundle\Context\CustomerContext;
+use Sylius\Component\User\Model\CustomerAwareInterface;
+use Sylius\Component\User\Model\CustomerInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class CustomerContextListenerSpec extends ObjectBehavior
+{
+    function let(CustomerContext $customerContext)
+    {
+        $this->beConstructedWith($customerContext);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\UserBundle\EventListener\CustomerContextListener');
+    }
+
+    function it_sets_subjects_customer_in_context(
+        $customerContext,
+        GenericEvent $event,
+        CustomerAwareInterface $subject,
+        CustomerInterface $customer
+    ) {
+        $event->getSubject()->willReturn($subject);
+        $subject->getCustomer()->willReturn($customer);
+        $customerContext->setCustomer($customer)->shouldBeCalled();
+
+        $this->setCustomerContextFromSubject($event);
+    }
+
+    function it_throws_exception_if_event_subject_is_not_a_customer_aware(GenericEvent $event)
+    {
+        $event->getSubject()->willReturn(new \stdClass());
+
+        $this
+            ->shouldThrow('Sylius\Component\Resource\Exception\UnexpectedTypeException')
+            ->duringSetCustomerContextFromSubject($event)
+        ;
+    }
+}

--- a/src/Sylius/Bundle/WebBundle/Behat/WebContext.php
+++ b/src/Sylius/Bundle/WebBundle/Behat/WebContext.php
@@ -462,7 +462,13 @@ class WebContext extends BaseWebContext implements SnippetAcceptingContext
     {
         $order = $this->findOneBy('order', array('number' => $number));
 
-        $this->getSession()->visit($this->generatePageUrl('sylius_account_order_'.$action, array('number' => $order->getNumber())));
+        if ('tracking' === $action) {
+            $route = 'sylius_order_track';
+        } else {
+            $route = 'sylius_account_order_'.$action;
+        }
+
+        $this->getSession()->visit($this->generatePageUrl($route, array('number' => $order->getNumber())));
     }
 
     /**
@@ -471,7 +477,13 @@ class WebContext extends BaseWebContext implements SnippetAcceptingContext
      */
     public function iShouldBeOnTheOrderPage($action, $number)
     {
-        $this->assertSession()->addressEquals($this->generatePageUrl('sylius_account_order_'.$action, array('number' => $number)));
+        if ('tracking' === $action) {
+            $route = 'sylius_order_track';
+        } else {
+            $route = 'sylius_account_order_'.$action;
+        }
+
+        $this->assertSession()->addressEquals($this->generatePageUrl($route, array('number' => $number)));
     }
 
     /**

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/frontend/main.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/frontend/main.yml
@@ -33,6 +33,12 @@ sylius_cart:
     resource: @SyliusCartBundle/Resources/config/routing.yml
     prefix: /cart
 
+sylius_order_track:
+    path: /track/{number}
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.frontend.account.order:showAction
+
 sylius_cart_summary:
     path: /cart
     defaults:

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
@@ -2,6 +2,7 @@
 # (c) Paweł Jędrzejewski
 
 sylius:
+    back_to_shop: Back to shop
     emails:
         order_confirmation:
             name: Order confirmation

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/layout.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/layout.html.twig
@@ -12,5 +12,12 @@
 {% endblock %}
 
 {% block sidebar %}
-{{ knp_menu_render('sylius.frontend.account', {'template': 'SyliusWebBundle:Frontend:menu.html.twig'}) }}
+    {% if is_granted('IS_AUTHENTICATED_REMEMBERED') %}
+        {{ knp_menu_render('sylius.frontend.account', {'template': 'SyliusWebBundle:Frontend:menu.html.twig'}) }}
+    {% else %}
+        <a href="{{ path('sylius_homepage') }}" class="btn btn-default">
+            <i class="icon-arrow-left icon-large"></i>&nbsp;
+            <span>{{ 'sylius.back_to_shop'|trans }}</span>
+        </a>
+    {% endif %}
 {% endblock sidebar %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | no |
| License | MIT |
| Doc PR | - |

I wanted to redirect customer to a thank you page after order is placed successfully. With a quick overview I thought maybe we can redirect him to an Order Tracking (`order/track/{number}`) page.

Note that for now I had to [set buying _customer_ into current context](https://github.com/Sylius/Sylius/pull/3230/files#diff-79357f2667866d43b41932fa092a9746R43), so that I could check their authentication when doing _guest checkout_.

BTW If we generate order numbers using [hash generator](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Component/Sequence/Number/HashGenerator.php) we can offer **order tracking without authentication** feature.

Related to #2224
