### PR TITLE
[ReportBundle] Remove bi-directional dependency on the CoreBundle

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -92,12 +92,9 @@
         <parameter key="sylius.callback.complete_order.class">Sylius\Bundle\CoreBundle\StateMachineCallback\CompleteOrderCallback</parameter>
 
         <!-- Data fetchers -->
-        <parameter key="sylius.registry.report.class">Sylius\Component\Registry\ServiceRegistry</parameter>
         <parameter key="sylius.form.type.data_fetcher.number_of_orders.class">Sylius\Bundle\CoreBundle\Form\Type\DataFetcher\NumberOfOrdersType</parameter>
         <parameter key="sylius.form.type.data_fetcher.sales_total.class">Sylius\Bundle\CoreBundle\Form\Type\DataFetcher\SalesTotalType</parameter>
         <parameter key="sylius.form.type.data_fetcher.user_registration.class">Sylius\Bundle\CoreBundle\Form\Type\DataFetcher\UserRegistrationType</parameter>
-        <parameter key="sylius.form.type.data_fetcher_choice.class">Sylius\Bundle\CoreBundle\Form\Type\DataFetcher\DataFetcherChoiceType</parameter>
-        <parameter key="sylius.report.data_fetcher.class">Sylius\Component\Report\DataFetcher\DelegatingDataFetcher</parameter>
 
         <parameter key="sylius.authorization_checker.toggleable.class">Sylius\Bundle\CoreBundle\Authorization\ToggleableAuthorizationChecker</parameter>
         <parameter key="sylius.translation.locale_provider.contextual.class">Sylius\Bundle\CoreBundle\Locale\TranslationLocaleProvider</parameter>
@@ -509,17 +506,6 @@
         </service>
 
         <!-- Data fetchers -->
-        <service id="sylius.registry.report.data_fetcher" class="%sylius.registry.report.class%">
-            <argument>Sylius\Component\Report\DataFetcher\DataFetcherInterface</argument>
-        </service>
-        <service id="sylius.report.data_fetcher" class="%sylius.report.data_fetcher.class%">
-            <argument type="service" id="sylius.registry.report.data_fetcher" />
-        </service>
-        <service id="sylius.form.type.data_fetcher_choice" class="%sylius.form.type.data_fetcher_choice.class%">
-            <argument>%sylius.report.data_fetchers%</argument>
-            <tag name="form.type" alias="sylius_data_fetcher_choice" />
-        </service>
-
         <service id="sylius.form.type.data_fetcher.user_registration" class="%sylius.form.type.data_fetcher.user_registration.class%">
             <tag name="form.type" alias="sylius_data_fetcher_user_registration" />
         </service>

--- a/src/Sylius/Bundle/ReportBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ReportBundle/Resources/config/services.xml
@@ -19,21 +19,53 @@
     <parameters>
         <parameter key="sylius.registry.report.class">Sylius\Component\Registry\ServiceRegistry</parameter>
 
+        <parameter key="sylius.report.data_fetcher.class">Sylius\Component\Report\DataFetcher\DelegatingDataFetcher</parameter>
+        <parameter key="sylius.report.renderer.class">Sylius\Component\Report\Renderer\DelegatingRenderer</parameter>
+
+        <parameter key="sylius.form.type.data_fetcher_choice.class">Sylius\Bundle\CoreBundle\Form\Type\DataFetcher\DataFetcherChoiceType</parameter>
         <parameter key="sylius.form.type.renderer.chart.class">Sylius\Bundle\ReportBundle\Renderer\ChartRenderer</parameter>
         <parameter key="sylius.form.type.renderer.table.class">Sylius\Bundle\ReportBundle\Renderer\TableRenderer</parameter>
         <parameter key="sylius.form.type.renderer_choice.class">Sylius\Bundle\ReportBundle\Form\Type\Renderer\RendererChoiceType</parameter>
         <parameter key="sylius.form.type.report.renderer.chart_configuration.class">Sylius\Bundle\ReportBundle\Form\Type\Renderer\ChartConfigurationType</parameter>
         <parameter key="sylius.form.type.report.renderer.table_configuration.class">Sylius\Bundle\ReportBundle\Form\Type\Renderer\TableConfigurationType</parameter>
-        <parameter key="sylius.report.renderer.class">Sylius\Component\Report\Renderer\DelegatingRenderer</parameter>
     </parameters>
 
     <services>
+        <!-- Registry -->
+
+        <service id="sylius.registry.report.data_fetcher" class="%sylius.registry.report.class%">
+            <argument>Sylius\Component\Report\DataFetcher\DataFetcherInterface</argument>
+        </service>
+
         <service id="sylius.registry.report.renderer" class="%sylius.registry.report.class%">
             <argument>Sylius\Component\Report\Renderer\RendererInterface</argument>
         </service>
 
+        <!-- Report -->
+
+        <service id="sylius.report.data_fetcher" class="%sylius.report.data_fetcher.class%">
+            <argument type="service" id="sylius.registry.report.data_fetcher" />
+        </service>
+
         <service id="sylius.report.renderer" class="%sylius.report.renderer.class%">
             <argument type="service" id="sylius.registry.report.renderer" />
+        </service>
+
+        <!-- Form -->
+
+        <service id="sylius.form.type.data_fetcher_choice" class="%sylius.form.type.data_fetcher_choice.class%">
+            <argument>%sylius.report.data_fetchers%</argument>
+            <tag name="form.type" alias="sylius_data_fetcher_choice" />
+        </service>
+
+        <service id="sylius.form.type.renderer.chart" class="%sylius.form.type.renderer.chart.class%">
+            <argument type="service" id="templating" />
+            <tag name="sylius.report.renderer" renderer="chart" label="Chart renderer" />
+        </service>
+
+        <service id="sylius.form.type.renderer.table" class="%sylius.form.type.renderer.table.class%">
+            <argument type="service" id="templating" />
+            <tag name="sylius.report.renderer" renderer="table" label="Table renderer" />
         </service>
 
         <service id="sylius.form.type.renderer_choice" class="%sylius.form.type.renderer_choice.class%">
@@ -41,21 +73,14 @@
             <tag name="form.type" alias="sylius_renderer_choice" />
         </service>
 
-        <service id="sylius.form.type.renderer.table" class="%sylius.form.type.renderer.table.class%">
-            <argument type="service" id="templating" />
-            <tag name="sylius.report.renderer" renderer="table" label="Table renderer" />
+        <service id="sylius.form.type.report.renderer.chart_configuration" class="%sylius.form.type.report.renderer.chart_configuration.class%">
+            <tag name="form.type" alias="sylius_renderer_chart" />
         </service>
+
         <service id="sylius.form.type.report.renderer.table_configuration" class="%sylius.form.type.report.renderer.table_configuration.class%">
             <tag name="form.type" alias="sylius_renderer_table" />
         </service>
 
-        <service id="sylius.form.type.renderer.chart" class="%sylius.form.type.renderer.chart.class%">
-            <argument type="service" id="templating" />
-            <tag name="sylius.report.renderer" renderer="chart" label="Chart renderer" />
-        </service>
-        <service id="sylius.form.type.report.renderer.chart_configuration" class="%sylius.form.type.report.renderer.chart_configuration.class%">
-            <tag name="form.type" alias="sylius_renderer_chart" />
-        </service>
     </services>
 
 </container>

--- a/src/Sylius/Bundle/ReportBundle/composer.json
+++ b/src/Sylius/Bundle/ReportBundle/composer.json
@@ -34,6 +34,7 @@
         "stof/doctrine-extensions-bundle": "~1.1",
         "sylius/resource-bundle":          "0.16.*",
         "sylius/money-bundle":             "0.16.*",
+        "sylius/registry":                 "0.16.*",
         "sylius/report":                   "0.16.*"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | n/a

Thanks for merging the [other pull request](https://github.com/Sylius/Sylius/pull/3212), now the real issue - The ReportBundle is completely unusable because of the following error:

 > Fatal error: Uncaught exception 'Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException' with message 'The service "sylius.form.type.report" has a dependency on a non-existent service "sylius.registry.report.data_fetcher"

These missing services are registered by the CoreBundle, so I've moved them to the ReportBundle.

Additionally, I've grouped and sorted the service definitions in alphabetical order (it was getting really confusing otherwise).

Don't merge yet, though, I need to do some more work. Cheers.