### PR TITLE
[LocaleBundle] Add traditional calendars support

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/date.html.twig
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/date.html.twig
@@ -1,5 +1,5 @@
 {% if attribute.attribute.configuration['format'] is defined %}
-    <td>{{ attribute.value|date(attribute.attribute.configuration['format']) }}</td>
+    <td>{{ attribute.value|sylius_localized_date(attribute.attribute.configuration['format']) }}</td>
 {% else %}
-    <td>{{ attribute.value|date }}</td>
+    <td>{{ attribute.value|sylius_localized_date }}</td>
 {% endif %}

--- a/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/datetime.html.twig
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/datetime.html.twig
@@ -1,5 +1,5 @@
 {% if attribute.attribute.configuration['format'] is defined %}
-    <td>{{ attribute.value|date(attribute.attribute.configuration['format']) }}</td>
+    <td>{{ attribute.value|sylius_localized_date(attribute.attribute.configuration['format']) }}</td>
 {% else %}
-    <td>{{ attribute.value|date }}</td>
+    <td>{{ attribute.value|sylius_localized_date }}</td>
 {% endif %}

--- a/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/ArrayGregorianToCalendarSystemTransformer.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/ArrayGregorianToCalendarSystemTransformer.php
@@ -49,6 +49,10 @@ class ArrayGregorianToCalendarSystemTransformer implements DataTransformerInterf
             return $date;
         }
 
+        if (empty($date['year']) || empty($date['month']) || empty($date['day'])) {
+            return $date;
+        }
+
         $dateTime = \DateTime::createFromFormat('Y-m-d', $date['year'].'-'.$date['month'].'-'.$date['day']);
         $translatedDate = $this->localeHelper->formatDate($dateTime, 'Y-m-d');
 
@@ -75,6 +79,10 @@ class ArrayGregorianToCalendarSystemTransformer implements DataTransformerInterf
         }
 
         if (Calendars::GREGORIAN === $this->localeHelper->getCurrentCalendar()) {
+            return $value;
+        }
+
+        if (empty($value['year']) || empty($value['month']) || empty($value['day'])) {
             return $value;
         }
 

--- a/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/ArrayGregorianToCalendarSystemTransformer.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/ArrayGregorianToCalendarSystemTransformer.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\LocaleBundle\Form\DataTransformer;
+
+use Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelper;
+use Sylius\Component\Locale\Calendars;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+/**
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
+ */
+class ArrayGregorianToCalendarSystemTransformer implements DataTransformerInterface
+{
+    /**
+     * @var LocaleHelper
+     */
+    private $localeHelper;
+
+    /**
+     * @param $localeHelper
+     */
+    public function __construct(LocaleHelper $localeHelper)
+    {
+        $this->localeHelper = $localeHelper;
+    }
+
+    /**
+     * @param array $date Normalized date array.
+     *
+     * @return array Localized calendar-aware date array.
+     */
+    public function transform($date)
+    {
+        if (!is_array($date)) {
+            throw new TransformationFailedException('Expected an array.');
+        }
+
+        if (Calendars::GREGORIAN === $this->localeHelper->getCurrentCalendar()) {
+            return $date;
+        }
+
+        $dateTime = \DateTime::createFromFormat('Y-m-d', $date['year'].'-'.$date['month'].'-'.$date['day']);
+        $translatedDate = $this->localeHelper->formatDate($dateTime, 'Y-m-d');
+
+        list($year, $month, $day) = explode('-', $translatedDate);
+
+        return [
+            'year' => $year,
+            'month' => $month,
+            'day' => $day,
+        ];
+    }
+
+    /**
+     * @param array $value Localized calendar-aware date array
+     *
+     * @return array Normalized date
+     *
+     * @throws TransformationFailedException If the given value is not an array.
+     */
+    public function reverseTransform($value)
+    {
+        if (!is_array($value)) {
+            throw new TransformationFailedException('Expected an array.');
+        }
+
+        if (Calendars::GREGORIAN === $this->localeHelper->getCurrentCalendar()) {
+            return $value;
+        }
+
+        // Use helper method `parseDate()` to translate the whole date
+        // stored inside the array to its corresponding localized version.
+        $dateTime = $this->localeHelper->parseDate($value['year'].'-'.$value['month'].'-'.$value['day'], 'Y-m-d');
+        list($year, $month, $day) = explode('-', $dateTime->format('Y-m-d'));
+
+        return [
+            'year' => $year,
+            'month' => $month,
+            'day' => $day,
+        ];
+    }
+}

--- a/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/StringGregorianToCalendarSystemTransformer.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/DataTransformer/StringGregorianToCalendarSystemTransformer.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\LocaleBundle\Form\DataTransformer;
+
+use Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelper;
+use Sylius\Component\Locale\Calendars;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
+ */
+class StringGregorianToCalendarSystemTransformer implements DataTransformerInterface
+{
+    /**
+     * @var string PHP-compatible date format
+     */
+    private $format;
+
+    /**
+     * @var LocaleHelper
+     */
+    private $localeHelper;
+
+    /**
+     * @param string       $format       PHP-compatible date format
+     * @param LocaleHelper $localeHelper
+     */
+    public function __construct($format, LocaleHelper $localeHelper)
+    {
+        $this->format = $format;
+        $this->localeHelper = $localeHelper;
+    }
+
+    /**
+     * @param string $date Normalized date.
+     *
+     * @return string Localized calendar-aware date.
+     */
+    public function transform($date)
+    {
+        if (Calendars::GREGORIAN === $this->localeHelper->getCurrentCalendar()) {
+            return $date;
+        }
+
+        // Since Symfony's default DateType is using \IntlDateFormatter
+        // but not correctly (Only sets locale and not calendar system)
+        // we need to use a IntlDateFormatter similar to one DateType used
+        // to change back everything to the original \DateTime that was used.
+        //
+        // For example when you set locale to `persian` it converts 2014
+        // to it's persian character (۲۰۱۴) representation.
+        // So we need to change it back to latin characters.
+        $originalFormatter = new \IntlDateFormatter(
+            \Locale::getDefault(),
+            null,
+            null,
+            'UTC',
+            \IntlDateFormatter::GREGORIAN,
+            LocaleHelper::convertDatePhpToIcu($this->format)
+        );
+
+        $dateTime = new \DateTime();
+        $dateTime->setTimestamp($originalFormatter->parse($date));
+
+        $translatedDate = $this->localeHelper->formatDate($dateTime, $this->format);
+
+        return $translatedDate;
+    }
+
+    /**
+     * @param string $value Localized calendar-aware date.
+     *
+     * @return string Normalized date.
+     */
+    public function reverseTransform($value)
+    {
+        if (Calendars::GREGORIAN === $this->localeHelper->getCurrentCalendar()) {
+            return $value;
+        }
+
+        $dateTime = $this->localeHelper->parseDate($value, $this->format);
+
+        return $dateTime->format($this->format);
+    }
+}

--- a/src/Sylius/Bundle/LocaleBundle/Form/Extension/DateExtension.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/Extension/DateExtension.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\LocaleBundle\Form\Extension;
+
+use Sylius\Bundle\LocaleBundle\Form\DataTransformer\ArrayGregorianToCalendarSystemTransformer;
+use Sylius\Bundle\LocaleBundle\Form\DataTransformer\StringGregorianToCalendarSystemTransformer;
+use Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelper;
+use Sylius\Component\Locale\Calendars;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+
+/**
+ * Extension for Symfony's DateType for a localized calendar-aware date.
+ *
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
+ */
+class DateExtension extends AbstractTypeExtension
+{
+    /**
+     * @var LocaleHelper
+     */
+    protected $localeHelper;
+
+    /**
+     * @param LocaleHelper $helper
+     */
+    public function __construct(LocaleHelper $helper)
+    {
+        $this->localeHelper = $helper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        if (Calendars::GREGORIAN === $this->localeHelper->getCurrentCalendar()) {
+            // We only need to alter default behaviour when
+            // we're having a traditional calendar system.
+            return;
+        }
+
+        if ('single_text' === $options['widget']) {
+            $builder->addViewTransformer(new StringGregorianToCalendarSystemTransformer(
+                'Y-m-d',
+                $this->localeHelper
+            ));
+        } elseif ('array' === $options['input']) {
+            $builder->addViewTransformer(new ArrayGregorianToCalendarSystemTransformer(
+                $this->localeHelper
+            ));
+        }
+
+        if ('choice' === $options['widget']) {
+            $this->translateChoices($builder, 'year', 'Y');
+            $this->translateChoices($builder, 'month', 'm');
+            $this->translateChoices($builder, 'day', 'd');
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function finishView(FormView $view, FormInterface $form, array $options)
+    {
+        if ('single_text' === $options['widget'] &&
+            Calendars::GREGORIAN !== $this->localeHelper->getCurrentCalendar()) {
+            // Native browsers do not support different calendar systems
+            // so we have to use "text" type instead of "date" for the input.
+            // We only need to alter default behaviour when
+            // we're having a traditional calendar system.
+            $view->vars['type'] = 'text';
+        }
+    }
+
+    /**
+     * A helper method to translate choices of a date-related field
+     * to their localized version.
+     *
+     * e.g. For a year field it should translate 2014 (gregorian) choice to to 1393 (persian)
+     *
+     * @param FormBuilderInterface $builder
+     * @param string               $fieldName
+     * @param string               $format    PHP-compatible date format
+     */
+    private function translateChoices(FormBuilderInterface $builder, $fieldName, $format)
+    {
+        $field = $builder->get($fieldName);
+        $options = $field->getOptions();
+        $type = $field->getType()->getName();
+
+        if (isset($options['choices'])) {
+            $newValues = [];
+            $values = $options['choices'];
+
+            foreach ($values as $presentation => $value) {
+                $newVal = $this->localeHelper->formatDate(\DateTime::createFromFormat($format, $value), $format);
+                $newValues[$newVal] = $newVal;
+            }
+
+            $options['choices'] = $newValues;
+        }
+
+        unset($options['choice_list']);
+
+        // Replace the field
+        $builder->add($fieldName, $type, $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedType()
+    {
+        return 'date';
+    }
+}

--- a/src/Sylius/Bundle/LocaleBundle/Form/Extension/DateExtension.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/Extension/DateExtension.php
@@ -109,6 +109,9 @@ class DateExtension extends AbstractTypeExtension
                 $newValues[$newVal] = $newVal;
             }
 
+            $collator = new \Collator($this->localeHelper->getCurrentLocale());
+            $collator->asort($newValues, \Collator::SORT_STRING);
+
             $options['choices'] = $newValues;
         }
 

--- a/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
@@ -20,6 +20,7 @@
         <parameter key="sylius.locale_provider.class">Sylius\Component\Locale\Provider\LocaleProvider</parameter>
         <parameter key="sylius.event_subscriber.locale.class">Sylius\Bundle\LocaleBundle\EventListener\LocaleSubscriber</parameter>
         <parameter key="sylius.context.locale.class">Sylius\Component\Locale\Context\LocaleContext</parameter>
+        <parameter key="sylius.locale.form.date_extension.class">Sylius\Bundle\LocaleBundle\Form\Extension\DateExtension</parameter>
     </parameters>
 
     <services>
@@ -36,6 +37,11 @@
             <argument type="service" id="sylius.context.locale" />
 
             <tag name="kernel.event_subscriber" />
+        </service>
+
+        <service id="sylius.locale.form.date_extension" class="%sylius.locale.form.date_extension.class%">
+            <argument type="service" id="sylius.templating.helper.locale" />
+            <tag name="form.type_extension" alias="date" />
         </service>
     </services>
 

--- a/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
+++ b/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
@@ -11,11 +11,13 @@
 
 namespace Sylius\Bundle\LocaleBundle\Templating\Helper;
 
+use Sylius\Component\Locale\Calendars;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
 use Symfony\Component\Templating\Helper\Helper;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
  */
 class LocaleHelper extends Helper
 {
@@ -38,6 +40,202 @@ class LocaleHelper extends Helper
     public function getCurrentLocale()
     {
         return $this->localeContext->getCurrentLocale();
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentCalendar()
+    {
+        return $this->localeContext->getCurrentCalendar();
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentDirection()
+    {
+        return $this->localeContext->getCurrentDirection();
+    }
+
+    /**
+     * @param string|\DateTimeInterface $date
+     * @param string                    $format   PHP-compatible date format
+     * @param string|\DateTimeZone      $timezone
+     * @param string                    $locale
+     * @param string                    $calendar
+     *
+     * @return bool|string
+     */
+    public function formatDate($date, $format = null, $timezone = null, $locale = null, $calendar = null)
+    {
+        $dateTime = $this->getDateTime($date, $timezone);
+
+        $locale = $locale ?: $this->localeContext->getCurrentLocale();
+        $calendar = $calendar ?: $this->localeContext->getCurrentCalendar();
+
+        if (Calendars::GREGORIAN === $calendar) {
+            return $dateTime->format($format);
+        }
+
+        $dateFormatter = new \IntlDateFormatter(
+            "$locale@calendar=$calendar",
+            null,
+            null,
+            $timezone,
+            \IntlDateFormatter::TRADITIONAL,
+            self::convertDatePhpToIcu($format)
+        );
+
+        return $dateFormatter->format($dateTime);
+    }
+
+    /**
+     * @param string               $date
+     * @param string               $format   PHP-compatible date format
+     * @param string|\DateTimeZone $timezone
+     * @param string               $locale
+     * @param string               $calendar
+     *
+     * @return \DateTimeInterface
+     */
+    public function parseDate($date, $format, $timezone = null, $locale = null, $calendar = null)
+    {
+        if (!$timezone) {
+            $timezone = date_default_timezone_get();
+        }
+
+        if (!$timezone instanceof \DateTimeZone) {
+            $timezone = new \DateTimeZone($timezone);
+        }
+
+        $locale = $locale ?: $this->localeContext->getCurrentLocale();
+        $calendar = $calendar ?: $this->localeContext->getCurrentCalendar();
+
+        $dateTime = new \DateTime(null, $timezone);
+
+        if (Calendars::GREGORIAN === $calendar) {
+            $dateTime->setTimestamp(strtotime($date));
+        } else {
+            $dateFormatter = new \IntlDateFormatter(
+                "$locale@calendar=$calendar",
+                null,
+                null,
+                $timezone,
+                \IntlDateFormatter::TRADITIONAL,
+                self::convertDatePhpToIcu($format)
+            );
+            $dateTime->setTimestamp($dateFormatter->parse($date));
+        }
+
+        return $dateTime;
+    }
+
+    /**
+     * @param string|\DateTimeInterface $date
+     * @param null                      $timezone
+     *
+     * @return \DateTimeInterface
+     */
+    private function getDateTime($date, $timezone = null)
+    {
+        if (null === $timezone) {
+            $timezone = date_default_timezone_get();
+        }
+
+        if (!$timezone instanceof \DateTimeZone) {
+            $timezone = new \DateTimeZone($timezone);
+        }
+
+        if ($date instanceof \DateTime) {
+            $date = clone $date;
+
+            if (false !== $timezone) {
+                $date->setTimezone($timezone);
+            }
+        } else {
+            // If $date's string representation is somehow numeric,
+            // we'll assume it's a timestamp then prepend an @ and pass it to \DateTime.
+            $asString = (string) $date;
+            if (ctype_digit($asString) || (!empty($asString) && '-' === $asString[0] && ctype_digit(substr($asString, 1)))) {
+                $date = '@'.$date;
+            }
+
+            $date = new \DateTime($date, $timezone);
+        }
+
+        return $date;
+    }
+
+    /**
+     * The method below is borrowed from Yii Project
+     * (https://github.com/yiisoft/yii2/blob/master/framework/helpers/BaseFormatConverter.php#L241).
+     *
+     * Converts a date format pattern from [php date() function format][] to [ICU format][].
+     *
+     * The conversion is limited to date patterns that do not use escaped characters.
+     * Patterns like `jS \o\f F Y` which will result in a date like `1st of December 2014` may not be converted correctly
+     * because of the use of escaped characters.
+     *
+     * Pattern constructs that are not supported by the ICU format will be removed.
+     *
+     * [php date() function format]: http://php.net/manual/en/function.date.php
+     * [ICU format]: http://userguide.icu-project.org/formatparse/datetime#TOC-Date-Time-Format-Syntax
+     *
+     * @param string $pattern date format pattern in php date()-function format.
+     *
+     * @return string The converted date format pattern.
+     */
+    public static function convertDatePhpToIcu($pattern)
+    {
+        // Translation from PHP DateTime to UCI pattern
+        // http://php.net/manual/en/function.date.php
+        return strtr($pattern, [
+            // Day
+            'd' => 'dd',    // Day of the month, 2 digits with leading zeros 	01 to 31
+            'D' => 'eee',   // A textual representation of a day, three letters 	Mon through Sun
+            'j' => 'd',     // Day of the month without leading zeros 	1 to 31
+            'l' => 'eeee',  // A full textual representation of the day of the week 	Sunday through Saturday
+            'N' => 'e',     // ISO-8601 numeric representation of the day of the week, 1 (for Monday) through 7 (for Sunday)
+            'S' => '',      // English ordinal suffix for the day of the month, 2 characters 	st, nd, rd or th. Works well with j
+            'w' => '',      // Numeric representation of the day of the week 	0 (for Sunday) through 6 (for Saturday)
+            'z' => 'D',     // The day of the year (starting from 0) 	0 through 365
+            // Week
+            'W' => 'w',     // ISO-8601 week number of year, weeks starting on Monday (added in PHP 4.1.0) 	Example: 42 (the 42nd week in the year)
+            // Month
+            'F' => 'MMMM',  // A full textual representation of a month, January through December
+            'm' => 'MM',    // Numeric representation of a month, with leading zeros 	01 through 12
+            'M' => 'MMM',   // A short textual representation of a month, three letters 	Jan through Dec
+            'n' => 'M',     // Numeric representation of a month, without leading zeros 	1 through 12, not supported by ICU but we fallback to "with leading zero"
+            't' => '',      // Number of days in the given month 	28 through 31
+            // Year
+            'L' => '',      // Whether it's a leap year, 1 if it is a leap year, 0 otherwise.
+            'o' => 'Y',     // ISO-8601 year number. This has the same value as Y, except that if the ISO week number (W) belongs to the previous or next year, that year is used instead.
+            'Y' => 'yyyy',  // A full numeric representation of a year, 4 digits 	Examples: 1999 or 2003
+            'y' => 'yy',    // A two digit representation of a year 	Examples: 99 or 03
+            // Time
+            'a' => 'a',     // Lowercase Ante meridiem and Post meridiem, am or pm
+            'A' => 'a',     // Uppercase Ante meridiem and Post meridiem, AM or PM, not supported by ICU but we fallback to lowercase
+            'B' => '',      // Swatch Internet time 	000 through 999
+            'g' => 'h',     // 12-hour format of an hour without leading zeros 	1 through 12
+            'G' => 'H',     // 24-hour format of an hour without leading zeros 0 to 23h
+            'h' => 'hh',    // 12-hour format of an hour with leading zeros, 01 to 12 h
+            'H' => 'HH',    // 24-hour format of an hour with leading zeros, 00 to 23 h
+            'i' => 'mm',    // Minutes with leading zeros 	00 to 59
+            's' => 'ss',    // Seconds, with leading zeros 	00 through 59
+            'u' => '',      // Microseconds. Example: 654321
+            // Timezone
+            'e' => 'VV',    // Timezone identifier. Examples: UTC, GMT, Atlantic/Azores
+            'I' => '',      // Whether or not the date is in daylight saving time, 1 if Daylight Saving Time, 0 otherwise.
+            'O' => 'xx',    // Difference to Greenwich time (GMT) in hours, Example: +0200
+            'P' => 'xxx',   // Difference to Greenwich time (GMT) with colon between hours and minutes, Example: +02:00
+            'T' => 'zzz',   // Timezone abbreviation, Examples: EST, MDT ...
+            'Z' => '',    // Timezone offset in seconds. The offset for timezones west of UTC is always negative, and for those east of UTC is always positive. -43200 through 50400
+            // Full Date/Time
+            'c' => 'yyyy-MM-dd\'T\'HH:mm:ssxxx', // ISO 8601 date, e.g. 2004-02-12T15:19:21+00:00
+            'r' => 'eee, dd MMM yyyy HH:mm:ss xx', // RFC 2822 formatted date, Example: Thu, 21 Dec 2000 16:01:07 +0200
+            'U' => '',      // Seconds since the Unix Epoch (January 1 1970 00:00:00 GMT)
+        ]);
     }
 
     /**

--- a/src/Sylius/Bundle/LocaleBundle/Twig/LocaleExtension.php
+++ b/src/Sylius/Bundle/LocaleBundle/Twig/LocaleExtension.php
@@ -12,9 +12,11 @@
 namespace Sylius\Bundle\LocaleBundle\Twig;
 
 use Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelper;
+use Symfony\Component\Intl\Intl;
 
 /**
  * @author Paweł Jędrzejewski <pjedrzejewski@diweb.pl>
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
  */
 class LocaleExtension extends \Twig_Extension
 {
@@ -34,11 +36,51 @@ class LocaleExtension extends \Twig_Extension
     /**
      * {@inheritdoc}
      */
+    public function getFilters()
+    {
+        return [
+            new \Twig_SimpleFilter(
+                'sylius_localized_date', [$this, 'filterLocalizedDate'], ['needs_environment' => true]
+            ),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getFunctions()
     {
         return [
             new \Twig_SimpleFunction('sylius_locale', [$this, 'getCurrentLocale']),
+            new \Twig_SimpleFunction('sylius_direction', [$this, 'getCurrentDirection']),
+            new \Twig_SimpleFunction('sylius_calendar', [$this, 'getCurrentCalendar']),
+            new \Twig_SimpleFunction('sylius_language', [$this, 'getLanguage']),
+            new \Twig_SimpleFunction('sylius_rtl', [$this, 'isRtl']),
         ];
+    }
+
+    /**
+     * Returns translated language and country name of a locale.
+     *
+     * @param string|null $locale If not passed will use current locale.
+     *
+     * @return string
+     */
+    public function getLanguage($locale = null)
+    {
+        if (null === $locale) {
+            $locale = $this->helper->getCurrentLocale();
+        }
+
+        return Intl::getLocaleBundle()->getLocaleName($locale);
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentCalendar()
+    {
+        return $this->helper->getCurrentCalendar();
     }
 
     /**
@@ -47,6 +89,46 @@ class LocaleExtension extends \Twig_Extension
     public function getCurrentLocale()
     {
         return $this->helper->getCurrentLocale();
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentDirection()
+    {
+        return $this->helper->getCurrentDirection();
+    }
+
+    /**
+     * @return bool True if language direction is RTL
+     */
+    public function isRtl()
+    {
+        return 'rtl' === $this->helper->getCurrentDirection();
+    }
+
+    /**
+     * Filter to format date to a localized calendar-aware date.
+     *
+     * @param \Twig_Environment $env
+     * @param string $date PHP-compatible date format
+     * @param string $timezone
+     * @param string $format
+     *
+     * @return bool|string
+     *
+     * @throws \Twig_Error_Runtime
+     */
+    public function filterLocalizedDate(\Twig_Environment $env, $date, $format = null, $timezone = null)
+    {
+        if (null === $format) {
+            $formats = $env->getExtension('core')->getDateFormat();
+            $format = $date instanceof \DateInterval ? $formats[1] : $formats[0];
+        }
+
+        $timezone = $timezone ?: $env->getExtension('core')->getTimezone();
+
+        return $this->helper->formatDate($date, $format, $timezone);
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/views/layout.html.twig
@@ -47,7 +47,7 @@
             {% endblock %}
             <hr>
             <footer>
-                <p>&copy; <a href="http://Sylius.org">Sylius.org</a>, 2011 - {{ 'now'|date('Y') }}.</p>
+                <p>&copy; <a href="http://Sylius.org">Sylius.org</a>, 2011 - {{ 'now'|sylius_localized_date('Y') }}.</p>
             </footer>
         </div>
         {% block sylius_javascripts %}

--- a/src/Sylius/Bundle/UserBundle/Resources/views/Customer/showProfile.html.twig
+++ b/src/Sylius/Bundle/UserBundle/Resources/views/Customer/showProfile.html.twig
@@ -4,5 +4,5 @@
     <strong>{{ customer.fullName|upper }}</strong><br>
     {{ 'sylius.ui.customer_id'|trans }}: {{ app.user.id }}<br>
     {{ 'sylius.ui.email'|trans }}: {{ customer.email }}<br>
-    {{ 'sylius.ui.customer_since'|trans }} {{ app.user.createdAt|date() }}
+    {{ 'sylius.ui.customer_since'|trans }} {{ app.user.createdAt|sylius_localized_date }}
 {% endblock %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Channel/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Channel/macros.html.twig
@@ -28,7 +28,7 @@
                     <td>{% if channel.defaultCurrency is not null %}{{ channel.defaultCurrency.code }}{% endif %}</td>
                     <td>{{ channel.theme.title|default('') }}</td>
                     <td>{{ misc.state_label(channel.enabled) }}</td>
-                    <td>{{ channel.updatedAt|date }}</td>
+                    <td>{{ channel.updatedAt|sylius_localized_date }}</td>
                     <td>
                         <div class="pull-right">
                             {{ buttons.edit(path('sylius_backend_channel_update', {'id': channel.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/Imagine/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/Imagine/macros.html.twig
@@ -27,9 +27,9 @@
                         {{ block.publishable ? 'sylius.ui.yes'|trans : 'sylius.ui.no'|trans }}
                     </span>
                 </td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.updatedAt|date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_imagine_block_update', {'id': block.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/Simple/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/Simple/macros.html.twig
@@ -27,9 +27,9 @@
                         {{ block.publishable ? 'sylius.ui.yes'|trans : 'sylius.ui.no'|trans }}
                     </span>
                 </td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.updatedAt|date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_simple_block_update', {'id': block.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/Slideshow/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/Slideshow/macros.html.twig
@@ -27,9 +27,9 @@
                         {{ block.publishable ? 'sylius.ui.yes'|trans : 'sylius.ui.no'|trans }}
                     </span>
                 </td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.updatedAt|date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_slideshow_block_update', {'id': block.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/String/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Block/String/macros.html.twig
@@ -27,9 +27,9 @@
                         {{ block.publishable ? 'sylius.ui.yes'|trans : 'sylius.ui.no'|trans }}
                     </span>
                 </td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|date }}</td>
-                <td>{{ block.updatedAt|date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.publishStartDate is empty ? '-' : block.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ block.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_string_block_update', {'id': block.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Menu/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/Menu/macros.html.twig
@@ -26,8 +26,8 @@
                         {{ menu.publishable ? 'sylius.ui.yes'|trans : 'sylius.ui.no'|trans }}
                     </span>
                 </td>
-                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|date }}</td>
-                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|date }}</td>
+                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_menu_update', {'id': menu.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/MenuNode/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/MenuNode/macros.html.twig
@@ -27,8 +27,8 @@
                         {{ menu.publishable ? 'sylius.ui.yes'|trans : 'sylius.ui.no'|trans }}
                     </span>
                 </td>
-                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|date }}</td>
-                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|date }}</td>
+                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ menu.publishStartDate is empty ? '-' : menu.publishStartDate|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_menu_node_update', {'id': menu.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/StaticContent/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Content/StaticContent/macros.html.twig
@@ -27,8 +27,8 @@
                         {{ page.publishable ? 'sylius.ui.yes'|trans : 'sylius.ui.no'|trans }}
                     </span>
                 </td>
-                <td>{{ page.publishStartDate is empty ? '-' : page.publishStartDate|date }}</td>
-                <td>{{ page.publishStartDate is empty ? '-' : page.publishStartDate|date }}</td>
+                <td>{{ page.publishStartDate is empty ? '-' : page.publishStartDate|sylius_localized_date }}</td>
+                <td>{{ page.publishStartDate is empty ? '-' : page.publishStartDate|sylius_localized_date }}</td>
                 <td>
                     {% if page.routes is not empty %}
                         <ul>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Coupon/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Coupon/macros.html.twig
@@ -41,7 +41,7 @@
                     {{ promotion_coupon.used }}
                 </span>
             </td>
-            <td>{{ promotion_coupon.expiresAt is null ? '-' : promotion_coupon.expiresAt|date }}</td>
+            <td>{{ promotion_coupon.expiresAt is null ? '-' : promotion_coupon.expiresAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_promotion_coupon_update', {'promotionId': promotion.id, 'id': promotion_coupon.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Currency/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Currency/macros.html.twig
@@ -26,7 +26,7 @@
                     {{ currency.enabled ? 'sylius.ui.yes'|trans : 'sylius.ui.no'|trans }}
                 </span>
             </td>
-            <td>{{ currency.updatedAt|date }}</td>
+            <td>{{ currency.updatedAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                 {{ buttons.edit(path('sylius_backend_currency_update', {'id': currency.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/macros.html.twig
@@ -26,7 +26,7 @@
             <td><a href="{{ path('sylius_backend_customer_show', {'id': customer.id}) }}">{{ customer.email }}</a></td>
             <td>
                 {% if customer.user is not null %}
-                    {{ customer.user.createdAt|date('d-m-Y H:i') }}
+                    {{ customer.user.createdAt|sylius_localized_date('d-m-Y H:i') }}
                 {% endif %}
             </td>
             <td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/show.html.twig
@@ -80,7 +80,7 @@
             {% if customer.user is not null and customer.user.lastLogin %}
                 <tr>
                     <td><strong>{{ 'sylius.ui.last_login'|trans }}</strong></td>
-                    <td>{{ customer.user.lastLogin|date }}</td>
+                    <td>{{ customer.user.lastLogin|sylius_localized_date }}</td>
                 </tr>
             {% endif %}
             <tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Email/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Email/macros.html.twig
@@ -23,7 +23,7 @@
                 <td>
                     {{ misc.state_label(email.enabled) }}
                 </td>
-                <td>{{ email.updatedAt|date }}</td>
+                <td>{{ email.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_email_update', {'id': email.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Inventory/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Inventory/macros.html.twig
@@ -68,7 +68,7 @@
                             {% for variant in product.variants %}
                                 <tr>
                                     <td>{{ variant.id }}</td>
-                                    <td><span class="label label-{{ variant.available ? 'success' : 'danger' }}">{{ variant.availableOn|date }}</span></td>
+                                    <td><span class="label label-{{ variant.available ? 'success' : 'danger' }}">{{ variant.availableOn|sylius_localized_date }}</span></td>
                                     <td>
                                         <ul>
                                         {% for option in variant.options %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
@@ -30,7 +30,7 @@
         <div class="list-group">
             <div class="list-group-item">
                 <h4 class="list-group-item-heading">{{ 'sylius.ui.creation_time'|trans }}</h4>
-                <div class="list-group-item-text">{{ order.createdAt|date }}</div>
+                <div class="list-group-item-text">{{ order.createdAt|sylius_localized_date }}</div>
             </div>
             <div class="list-group-item">
                 <h4 class="list-group-item-heading">{{ 'sylius.ui.order_state'|trans }}</h4>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/macros.html.twig
@@ -26,7 +26,7 @@
         {% for order in orders %}
         <tr id="{{ order.id }}">
             <td class="center-text"><input type="checkbox" value="{{ order.id }}" /></td>
-            <td>{{ order.createdAt|date }}</td>
+            <td>{{ order.createdAt|sylius_localized_date }}</td>
             <td>
                 <span {%- if order.channel.color -%} style="color: {{ order.channel.color }};"{%- endif -%}>{{ order.channel.code }}</span>
             </td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
@@ -48,7 +48,7 @@
         <h4>Order Details</h4>
         <dl>
             <dt>{{ 'sylius.ui.creation_time'|trans }}</dt>
-            <dd>{{ order.createdAt|date }}</dd>
+            <dd>{{ order.createdAt|sylius_localized_date }}</dd>
             <dt>Email</dt>
             <dd>
                 {% if order.customer %}
@@ -229,7 +229,7 @@
                             {{ (comment.notifyCustomer ? 'sylius.order.comment.customer.notified' : 'sylius.order.comment.customer.not_notified')|trans }}
                         </span>
                     </td>
-                    <td>{{ comment.createdAt|date }}</td>
+                    <td>{{ comment.createdAt|sylius_localized_date }}</td>
                 </tr>
             {% endfor %}
                 <tr>
@@ -263,8 +263,8 @@
                     <td>{{ unit.inventoryName }}</td>
                     <td>{{ unit.inventoryState|humanize }}</td>
                     <td>{{ unit.shippingState|humanize }}</td>
-                    <td>{{ unit.createdAt|date }}</td>
-                    <td>{{ unit.updatedAt|date }}</td>
+                    <td>{{ unit.createdAt|sylius_localized_date }}</td>
+                    <td>{{ unit.updatedAt|sylius_localized_date }}</td>
                     <td>
                         {% for transition in ['backorder', 'sell', 'return'] if sm_can(unit, transition, 'sylius_inventory_unit') %}
                             <form action="{{ path('sylius_backend_inventory_unit_update_state', {'id': unit.id, 'transition': transition}) }}" method="post">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Payment/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Payment/macros.html.twig
@@ -34,7 +34,7 @@
                 {{ payment.amount|sylius_price(payment.currency) }}
             </td>
             <td>{{ misc.state_label(payment.state, 'payment') }}</td>
-            <td>{{ payment.createdAt|date }}</td>
+            <td>{{ payment.createdAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_payment_update', {'id': payment.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/PaymentMethod/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/PaymentMethod/macros.html.twig
@@ -31,7 +31,7 @@
                     {{ payment_method.enabled ? 'sylius.ui.yes'|trans : 'sylius.ui.no'|trans }}
                 </span>
             </td>
-            <td>{{ payment_method.updatedAt|date }}</td>
+            <td>{{ payment_method.updatedAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                 {{ buttons.edit(path('sylius_backend_payment_method_update', {'id': payment_method.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Permission/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Permission/macros.html.twig
@@ -21,7 +21,7 @@
                     <strong>{{ permission.description }}</strong> <i>({{ permission.code }})</i>
                     </span>
                 </td>
-                <td>{{ permission.updatedAt|date }}</td>
+                <td>{{ permission.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_permission_update', {'id': permission.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/macros.html.twig
@@ -90,7 +90,7 @@
             {% endif %}
 
             <td class="updated-at">
-                {{ product.updatedAt|date('Y/m/d') }}
+                {{ product.updatedAt|sylius_localized_date('Y/m/d') }}
             </td>
             <td class="center-text">
                 <a href="{{ path('sylius_backend_metadata_container_customize', { 'id': product.metadataIdentifier }) }}" class="btn btn-default">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
@@ -78,12 +78,12 @@
                 </tr>
                 <tr>
                     <td>{{ 'sylius.ui.available_on'|trans }}</td>
-                    <td><span class="label label-{{ product.available ? 'success' : 'danger' }}">{{ product.availableOn|date }}</span></td>
+                    <td><span class="label label-{{ product.available ? 'success' : 'danger' }}">{{ product.availableOn|sylius_localized_date }}</span></td>
                 </tr>
                 {% if product.availableUntil %}
                 <tr>
                     <td>{{ 'sylius.ui.available_until'|trans }}</td>
-                    <td><span class="label label-{{ product.available ? 'success' : 'danger' }}">{{ product.availableUntil|date }}</span></td>
+                    <td><span class="label label-{{ product.available ? 'success' : 'danger' }}">{{ product.availableUntil|sylius_localized_date }}</span></td>
                 </tr>
                 {% endif %}
                 <tr>
@@ -222,7 +222,7 @@
                 <tr>
                     <td><strong>{{ attribute.name }}</strong></td>
                     {% if attribute.value.timestamp is defined %}
-                        <td>{{ attribute.value|date('Y/m/d H:i:s') }}</td>
+                        <td>{{ attribute.value|sylius_localized_date('Y/m/d H:i:s') }}</td>
                     {% else %}
                         <td>{{ attribute.value }}</td>
                     {% endif %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductArchetype/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductArchetype/macros.html.twig
@@ -37,7 +37,7 @@
                     {% endfor %}
                 </ul>
             </td>
-            <td>{{ archetype.updatedAt|date }}</td>
+            <td>{{ archetype.updatedAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                 {{ buttons.generic(path('sylius_backend_product_archetype_code_product_index', {'code': archetype.code}), 'sylius.ui.browse_products'|trans) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductAttribute/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductAttribute/macros.html.twig
@@ -22,7 +22,7 @@
                 <td>{{ attribute.code }}</td>
                 <td>{{ attribute.name }}</td>
                 <td><span class="label label-primary">{{ attribute.type|upper }}</span></td>
-                <td>{{ attribute.updatedAt|date }}</td>
+                <td>{{ attribute.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_product_attribute_update', {'id': attribute.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductOption/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductOption/macros.html.twig
@@ -28,7 +28,7 @@
                         {% endfor %}
                     </ul>
                 </td>
-                <td>{{ option.updatedAt|date }}</td>
+                <td>{{ option.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_product_option_update', {'id': option.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/macros.html.twig
@@ -30,8 +30,8 @@
                 <img class="img-polaroid" src="{{ variant.images.offsetGet(0).path|imagine_filter('sylius_small') }}" />
             {% endif %}
             </td>
-            <td><span class="label label-{{ variant.available ? 'success' : 'important' }}">{{ variant.availableOn|date }}</span></td>
-            <td>{{ product.updatedAt|date }}</td>
+            <td><span class="label label-{{ variant.available ? 'success' : 'important' }}">{{ variant.availableOn|sylius_localized_date }}</span></td>
+            <td>{{ product.updatedAt|sylius_localized_date }}</td>
             <td>
                 <ul>
                 {% for option in variant.options %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Promotion/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Promotion/macros.html.twig
@@ -52,8 +52,8 @@
                     </span>
                 </td>
                 <td>{{ promotion.priority }}</td>
-                <td>{{ promotion.startsAt is empty ? '-' : promotion.startsAt|date }}</td>
-                <td>{{ promotion.endsAt is empty ? '-' : promotion.endsAt|date }}</td>
+                <td>{{ promotion.startsAt is empty ? '-' : promotion.startsAt|sylius_localized_date }}</td>
+                <td>{{ promotion.endsAt is empty ? '-' : promotion.endsAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                         {{ buttons.move(path('sylius_backend_promotion_move_up', {'id': promotion.id}), 'up', loop.first and not promotions.hasPreviousPage, loop.last and not promotions.hasNextPage) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Promotion/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Promotion/show.html.twig
@@ -57,11 +57,11 @@
                 </tr>
                 <tr>
                     <td><strong>{{ 'sylius.ui.starts_at'|trans }}</strong></td>
-                    <td>{{ promotion.startsAt is empty ? '-' : promotion.startsAt|date }}</td>
+                    <td>{{ promotion.startsAt is empty ? '-' : promotion.startsAt|sylius_localized_date }}</td>
                 </tr>
                 <tr>
                     <td><strong>{{ 'sylius.ui.ends_at'|trans }}</strong></td>
-                    <td>{{ promotion.endsAt is empty ? '-' : promotion.endsAt|date }}</td>
+                    <td>{{ promotion.endsAt is empty ? '-' : promotion.endsAt|sylius_localized_date }}</td>
                 </tr>
                 <tr>
                     <td><strong>{{ 'sylius.ui.usage_limit'|trans }}</strong></td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Role/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Role/macros.html.twig
@@ -25,7 +25,7 @@
                 <td>
                     {{ role.description }}
                 </td>
-                <td>{{ role.updatedAt|date }}</td>
+                <td>{{ role.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_role_update', {'id': role.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/macros.html.twig
@@ -32,7 +32,7 @@
             <td>{{ misc.shipment_state(shipment.state) }}</td>
             <td>{{ address.firstname }} {{ address.lastname }} ({{ address.city }}, {{ address.countryCode|sylius_country_name }})</td>
             <td class="text-center">{{ shipment.units|length }}</td>
-            <td>{{ shipment.createdAt|date }}</td>
+            <td>{{ shipment.createdAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                     {{ buttons.show(path('sylius_backend_shipment_show', {'id': shipment.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/show.html.twig
@@ -79,7 +79,7 @@
                 </tr>
                 <tr>
                     <td><strong>{{ 'sylius.ui.creation_time'|trans }}</strong></td>
-                    <td>{{ order.createdAt|date }}</td>
+                    <td>{{ order.createdAt|sylius_localized_date }}</td>
                 </tr>
             </tbody>
         </table>
@@ -122,8 +122,8 @@
                 <td>{{ item.inventoryName }}</td>
                 <td><span class="label label-success">{{ item.shippingState }}</span></td>
                 <td><span class="label label-{{ item.sold ? 'success' : 'important' }}">{{ item.inventoryState }}</span></td>
-                <td>{{ item.createdAt|date }}</td>
-                <td>{{ item.updatedAt|date }}</td>
+                <td>{{ item.createdAt|sylius_localized_date }}</td>
+                <td>{{ item.updatedAt|sylius_localized_date }}</td>
             </tr>
         {% endfor %}
         </tbody>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ShippingCategory/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ShippingCategory/macros.html.twig
@@ -20,7 +20,7 @@
                 <td>{{ shipping_category.id }}</td>
                 <td>{{ shipping_category.code }}</td>
                 <td>{{ shipping_category.name }}</td>
-                <td>{{ shipping_category.updatedAt|date }}</td>
+                <td>{{ shipping_category.updatedAt|sylius_localized_date }}</td>
                 <td>
                     <div class="pull-right">
                         {{ buttons.edit(path('sylius_backend_shipping_category_update', {'id': shipping_category.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ShippingMethod/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ShippingMethod/show.html.twig
@@ -42,7 +42,7 @@
                 </span>
             </td>
             <td><span class="label label-info">{{ shipping_method.calculator|humanize }}</span></td>
-            <td>{{ shipping_method.updatedAt|date }}</td>
+            <td>{{ shipping_method.updatedAt|sylius_localized_date }}</td>
         </tr>
         </tbody>
     </table>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/TaxCategory/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/TaxCategory/macros.html.twig
@@ -22,7 +22,7 @@
             <td>{{ tax_category.code }}</td>
             <td>{{ tax_category.name }}</td>
             <td>{{ tax_category.description|default('sylius.ui.no_description'|trans) }}</td>
-            <td>{{ tax_category.updatedAt|date }}</td>
+            <td>{{ tax_category.updatedAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_tax_category_update', {'id': tax_category.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/TaxRate/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/TaxRate/macros.html.twig
@@ -33,7 +33,7 @@
                 {{ misc.state_label(tax_rate.includedInPrice) }}
             </td>
             <td><span class="label label-primary">{{ tax_rate.calculator|humanize|upper }}</span></td>
-            <td>{{ tax_rate.updatedAt|date }}</td>
+            <td>{{ tax_rate.updatedAt|sylius_localized_date }}</td>
             <td>
                 <div class="pull-right">
                 {{ buttons.show(path('sylius_backend_tax_rate_show', {'id': tax_rate.id})) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/_history_table.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/_history_table.html.twig
@@ -1,6 +1,6 @@
 {% macro formatValue(key, value) %}
 {% if value.timestamp is defined %}
-    {{ value|date() }}
+    {{ value|sylius_localized_date }}
 {% elseif key == 'price' or key == 'unitPrice' %}
     {{ value|sylius_price() }}
 {% elseif value is empty %}
@@ -28,7 +28,7 @@
     {% for log in logs %}
         <tr>
             <td><span class="label label-{{ log.action == 'danger' ? 'warning' : (log.action == 'update' ? 'success' : 'primary') }}">{{ log.action|upper }}</span></td>
-            <td>{{ log.loggedAt|date }} (#{{ log.version }})</td>
+            <td>{{ log.loggedAt|sylius_localized_date }} (#{{ log.version }})</td>
             <td>
                 {% if log.data is not empty %}
                 <ul>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/layout.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/layout.html.twig
@@ -63,7 +63,7 @@
                     {% include 'SyliusWebBundle::confirm-modal.html.twig' %}
 
                     <footer>
-                        <p>&copy; <a href="http://Sylius.org">Sylius</a>, 2011 - {{ 'now'|date('Y') }}.</p>
+                        <p>&copy; <a href="http://Sylius.org">Sylius</a>, 2011 - {{ 'now'|sylius_localized_date('Y') }}.</p>
                     </footer>
                 </div>
             </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Common/forms.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Common/forms.html.twig
@@ -47,6 +47,11 @@
         <label for="{{ id }}" class="btn-primary btn-lg file-overlay"><i class="glyphicon glyphicon-folder-open"></i>&nbsp; {{ 'sylius.ui.choose_file'|trans }}</label>
         &nbsp;
     {% endif %}
+
+    {% if 'datepicker' in attr.class %}
+        {% set attr = attr|merge({'data-locale': sylius_locale(), 'data-direction': sylius_direction()}) %}
+    {% endif %}
+
     {{ parent() }}
 {% endspaceless %}
 {% endblock form_widget_simple %}
@@ -90,6 +95,7 @@
 {% block date_widget %}
 {% spaceless %}
     {% if widget == 'single_text' %}
+        {% set attr = attr|merge({'data-calendar': sylius_calendar()}) %}
         {{ block('form_widget_simple') }}
     {% else %}
             {{ '{{ year }} / {{ month }} / {{ day }}'|replace({

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
@@ -4,7 +4,7 @@
 
 <div class="row well well-sm" id="information">
     <div class="col-md-6">
-        <strong>{{ 'sylius.ui.placed_at'|trans }} {{ order.createdAt|date() }}</strong><br><br>
+        <strong>{{ 'sylius.ui.placed_at'|trans }} {{ order.createdAt|sylius_localized_date }}</strong><br><br>
         {#{{ 'sylius.ui.shipment_mode'|trans }} <strong>TODO</strong><br>#}
         {#{{ 'sylius.ui.payment_mode'|trans }} <strong>TODO</strong><br>#}
     </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_list.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_list.html.twig
@@ -18,7 +18,7 @@
             <tbody>
             {% for order in orders %}
                 <tr class="order" id="order-{{ order.number }}">
-                    <td>{{ order.createdAt|date }}</td>
+                    <td>{{ order.createdAt|sylius_localized_date }}</td>
                     <td>{{ order.number }}</td>
                     <td>{{ order.total|sylius_money(order.currency) }}</td>
                     <td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_state.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_state.html.twig
@@ -1,11 +1,11 @@
 {% set shipment = order.lastShipment %}
 {% if shipment %}
-    {{ ('sylius.account.order.shipment.' ~ shipment.state) |trans({'%at%': shipment.updatedAt|date}) }}
+    {{ ('sylius.account.order.shipment.' ~ shipment.state) |trans({'%at%': shipment.updatedAt|sylius_localized_date}) }}
     {% if shipment.tracking %}
         <br>
         {{ 'sylius.ui.tracking_number'|trans}}
         {{ shipment.tracking }}
     {% endif %}
 {% else %}
-    {{ 'sylius.account.order.placed_at'|trans({'%at%': order.createdAt|date}) }}
+    {{ 'sylius.account.order.placed_at'|trans({'%at%': order.createdAt|sylius_localized_date}) }}
 {% endif %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Profile/index.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Profile/index.html.twig
@@ -1,0 +1,26 @@
+{% extends 'SyliusWebBundle:Frontend/Account:layout.html.twig' %}
+
+{% import 'SyliusWebBundle:Frontend/Macros:buttons.html.twig' as buttons %}
+{% from 'SyliusWebBundle:Backend/Macros:misc.html.twig' import pagination %}
+{% from 'SyliusWebBundle:Backend/Order:macros.html.twig' import simple_list %}
+
+{% block content %}
+
+    <h4>{{ 'sylius.account.home.welcome'|trans }}</h4>
+    <br>
+
+    <div class="row">
+        <div class="col-md-7">{{ 'sylius.account.home.outline'|trans }} </div>
+        <div class="col-md-5">
+            <strong>{{ user.lastName|upper }} {{ user.firstName }}</strong><br><br>
+            {{ 'sylius.account.home.id'|trans }} {{ user.id }} <br>
+            {{ 'sylius.account.home.email'|trans }} {{ user.email }}<br>
+            {{ 'sylius.account.home.since'|trans }} {{ user.createdAt|sylius_localized_date }}
+        </div>
+    </div>
+
+    <h4>{{ 'sylius.account.home.last5orders'|trans|raw }}</h4>
+
+    {% include "SyliusWebBundle:Frontend/Account:Order/_list.html.twig" %}
+
+{% endblock %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Customer/showProfile.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Customer/showProfile.html.twig
@@ -11,7 +11,7 @@
             <strong>{{ customer.lastName|upper }} {{ customer.firstName }}</strong><br><br>
             {{ 'sylius.ui.customer_id'|trans }} {{ app.user.id }} <br>
             {{ 'sylius.ui.email'|trans }} {{ customer.email }}<br>
-            {{ 'sylius.ui.you_are_customer_since'|trans }} {{ app.user.createdAt|date() }}
+            {{ 'sylius.ui.you_are_customer_since'|trans }} {{ app.user.createdAt|sylius_localized_date }}
         </div>
     </div>
 

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/layout.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/layout.html.twig
@@ -136,7 +136,7 @@
         {% block footer %}
             <div class="footer">
                 <p class="text-muted">
-                    &copy; Sylius, 2011 - {{ 'now'|date('Y') }}.
+                    Powered by <a href="http://sylius.org/" title="Sylius is a modern ecommerce solution for PHP, easily customizable and based on the Symfony2 framework.">Sylius</a>
                 </p>
                 {{ knp_menu_render('sylius.frontend.social', {'template': 'SyliusWebBundle:Frontend:menu.html.twig'}) }}
             </div>

--- a/src/Sylius/Component/Locale/Calendars.php
+++ b/src/Sylius/Component/Locale/Calendars.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Locale;
+
+/**
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
+ */
+class Calendars
+{
+    const GREGORIAN = 'gregorian';
+    const PERSIAN = 'persian';
+    const ISLAMIC = 'islamic';
+    const HEBREW = 'hebrew';
+    const JAPANESE = 'japanese';
+    const BUDDHIST = 'buddhist';
+    const CHINESE = 'chinese';
+    const INDIAN = 'indian';
+    const COPTIC = 'coptic';
+    const ETHIOPIC = 'ethiopic';
+}

--- a/src/Sylius/Component/Locale/Context/LocaleContext.php
+++ b/src/Sylius/Component/Locale/Context/LocaleContext.php
@@ -11,11 +11,13 @@
 
 namespace Sylius\Component\Locale\Context;
 
+use Sylius\Component\Locale\Calendars;
 use Sylius\Component\Storage\StorageInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Joseph Bielawski <stloyd@gmail.com>
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
  */
 class LocaleContext implements LocaleContextInterface
 {
@@ -31,6 +33,60 @@ class LocaleContext implements LocaleContextInterface
      * @var StorageInterface
      */
     protected $storage;
+
+    /**
+     * Meta data for special languages,
+     * by default we assume that all languages are LTR, and calendar is gregorian,
+     * except mentioned otherwise below.
+     *
+     * TODO Should be completed and extracted to an external library!
+     *
+     * @var array
+     */
+    protected static $localeMetaData = [
+        'fa' => [
+            'direction' => 'rtl',
+            'calendar' => Calendars::PERSIAN,
+        ],
+        'fa_IR' => [
+            'direction' => 'rtl',
+            'calendar' => Calendars::PERSIAN,
+        ],
+        'fa_AF' => [
+            'direction' => 'rtl',
+            'calendar' => Calendars::PERSIAN,
+        ],
+        'ar' => [
+            'direction' => 'rtl',
+            'calendar' => Calendars::ISLAMIC,
+        ],
+        'ckb' => [
+            'direction' => 'rtl',
+            'calendar' => Calendars::PERSIAN,
+        ],
+        'he_IL' => [
+            'direction' => 'rtl',
+            'calendar' => Calendars::HEBREW,
+        ],
+        'ug_CN' => [
+            'direction' => 'rtl',
+        ],
+        'dv' => [
+            'direction' => 'rtl',
+        ],
+        'ha' => [
+            'direction' => 'rtl',
+        ],
+        'ps' => [
+            'direction' => 'rtl',
+        ],
+        'uz_UZ' => [
+            'direction' => 'rtl',
+        ],
+        'yi' => [
+            'direction' => 'rtl',
+        ],
+    ];
 
     public function __construct(StorageInterface $storage, $defaultLocale)
     {
@@ -60,5 +116,33 @@ class LocaleContext implements LocaleContextInterface
     public function setCurrentLocale($locale)
     {
         return $this->storage->setData(self::STORAGE_KEY, $locale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCurrentCalendar()
+    {
+        $code = $this->getCurrentLocale();
+
+        if (isset(self::$localeMetaData[$code]) && isset(self::$localeMetaData[$code]['calendar'])) {
+            return self::$localeMetaData[$code]['calendar'];
+        }
+
+        return Calendars::GREGORIAN;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCurrentDirection()
+    {
+        $code = $this->getCurrentLocale();
+
+        if (isset(self::$localeMetaData[$code]) && isset(self::$localeMetaData[$code]['calendar'])) {
+            return self::$localeMetaData[$code]['direction'];
+        }
+
+        return 'ltr';
     }
 }

--- a/src/Sylius/Component/Locale/Context/LocaleContextInterface.php
+++ b/src/Sylius/Component/Locale/Context/LocaleContextInterface.php
@@ -16,6 +16,7 @@ namespace Sylius\Component\Locale\Context;
  * locale.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Aram Alipoor <aram.alipoor@gmail.com>
  */
 interface LocaleContextInterface
 {
@@ -33,4 +34,16 @@ interface LocaleContextInterface
      * @param string $locale
      */
     public function setCurrentLocale($locale);
+
+    /**
+     * @return string `rtl` or `ltr`
+     */
+    public function getCurrentDirection();
+
+    /**
+     * @return string
+     *
+     * @see \Sylius\Component\Locale\Calendars
+     */
+    public function getCurrentCalendar();
 }

--- a/src/Sylius/Component/Locale/Model/LocalesAwareInterface.php
+++ b/src/Sylius/Component/Locale/Model/LocalesAwareInterface.php
@@ -14,7 +14,7 @@ namespace Sylius\Component\Locale\Model;
 use Doctrine\Common\Collections\Collection;
 
 /**
- * Interface implemented by objects related to multiple locales
+ * Interface implemented by objects related to multiple locales.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */


### PR DESCRIPTION
Based on #2275.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Here is a list of twig filters/functions I've added:
- [x] `sylius_localized_date([date], [format], [timezone])` Twig date filter with calendar-aware conversion, based on current locale.
- [x] `sylius_language([code])` Returns localized language name of current (or provided) locale code.
- [x] `sylius_rtl()` Returns true if current locale code is of an RTL-type language. e.g  If current locale is RTL so that we can load RTL stylesheets and whatnot.
- [x] `sylius_direction()` Returns current locale language direction. (`rtl`, `ltr`)
- [x] `sylius_calendar()` Returns current locale calendar system. (`gregorian`, `persian`, `hebrew`, `islamic`, etc)
- I've created a TypeExtension for Symfony's `date` FormType to support calendar-aware dates.
  - [x] Simple `<select>` tags picker
  - [ ] jQuery date picker widget
