### PR TITLE
[WebBundle] Changed the way of displaying product variant's options

### DIFF
--- a/features/backend/inventory.feature
+++ b/features/backend/inventory.feature
@@ -46,7 +46,7 @@ Feature: Inventory tracking
     Scenario: Updating variant stock level
         Given product "Black T-Shirt" is available in all variations
           And I am on the page of product "Black T-Shirt"
-         When I click "edit" near "T-Shirt size: L"
+         When I click "edit" near "Size: L"
           And I fill in "Current stock" with "10"
           And I press "Save changes"
          Then I should be on the page of product "Black T-Shirt"
@@ -55,7 +55,7 @@ Feature: Inventory tracking
     Scenario: Making variant not available on demand
         Given product "Black T-Shirt" is available in all variations
           And I am on the page of product "Black T-Shirt"
-         When I click "edit" near "T-Shirt size: L"
+         When I click "edit" near "Size: L"
           And I uncheck "Available on demand"
           And I press "Save changes"
          Then I should be on the page of product "Black T-Shirt"

--- a/features/backend/product_variants.feature
+++ b/features/backend/product_variants.feature
@@ -66,7 +66,7 @@ Feature: Product variants
     Scenario: Generating only missing variants of product
         Given I am creating variant of "Black T-Shirt"
         When I fill in "Price" with "19.99"
-        And I select "L" from "T-Shirt size"
+        And I select "L" from "Size"
         And I press "Create"
         And I press "Generate variants"
         Then I should still be on the page of product with name "Black T-Shirt"
@@ -83,8 +83,8 @@ Feature: Product variants
     Scenario: Generating only missing variants of product with multiple options
         Given I am creating variant of "Sylius T-Shirt"
         When I fill in "Price" with "19.99"
-        And I select "L" from "T-Shirt size"
-        And I select "Red" from "T-Shirt color"
+        And I select "L" from "Size"
+        And I select "Red" from "Color"
         And I press "Create"
         And I press "Generate variants"
         Then I should still be on the page of product with name "Sylius T-Shirt"
@@ -94,7 +94,7 @@ Feature: Product variants
     Scenario: Creating a product variant by selecting option
         Given I am creating variant of "Black T-Shirt"
         When I fill in "Price" with "19.99"
-        And I select "L" from "T-Shirt size"
+        And I select "L" from "Size"
         And I press "Create"
         Then I should be on the page of product "Black T-Shirt"
         And I should see "Variant has been successfully created."
@@ -102,8 +102,8 @@ Feature: Product variants
     Scenario: Creating a product variant by selecting multiple options
         Given I am creating variant of "Sylius T-Shirt"
         When I fill in "Price" with "19.99"
-        And I select "L" from "T-Shirt size"
-        And I select "Red" from "T-Shirt color"
+        And I select "L" from "Size"
+        And I select "Red" from "Color"
         And I press "Create"
         Then I should be on the page of product "Sylius T-Shirt"
         And I should see "Variant has been successfully created."
@@ -111,7 +111,7 @@ Feature: Product variants
     Scenario: Updating the variant price
         Given product "Black T-Shirt" is available in all variations
         And I am on the page of product "Black T-Shirt"
-        When I click "edit" near "T-Shirt size: L"
+        When I click "edit" near "Size: L"
         And I fill in "Price" with "33.99"
         And I press "Save changes"
         Then I should be on the page of product "Black T-Shirt"
@@ -121,7 +121,7 @@ Feature: Product variants
     Scenario: Deleting product variant
         Given product "Black T-Shirt" is available in all variations
         And I am on the page of product "Black T-Shirt"
-        When I click "delete" near "T-Shirt size: L"
+        When I click "delete" near "Size: L"
         And I click "delete" from the confirmation modal
         Then I should be on the page of product "Black T-Shirt"
         And I should see "Variant has been successfully deleted."

--- a/src/Sylius/Bundle/VariationBundle/Form/Type/OptionValueCollectionType.php
+++ b/src/Sylius/Bundle/VariationBundle/Form/Type/OptionValueCollectionType.php
@@ -64,7 +64,7 @@ class OptionValueCollectionType extends AbstractType
             }
 
             $builder->add((string) $option->getId(), sprintf('sylius_%s_option_value_choice', $this->variableName), array(
-                'label'         => $option->getName(),
+                'label'         => $option->getPresentation() ?: $option->getName(),
                 'option'        => $option,
                 'property_path' => '['.$i.']',
             ));

--- a/src/Sylius/Bundle/VariationBundle/spec/Form/Type/OptionValueCollectionTypeSpec.php
+++ b/src/Sylius/Bundle/VariationBundle/spec/Form/Type/OptionValueCollectionTypeSpec.php
@@ -34,13 +34,36 @@ class OptionValueCollectionTypeSpec extends ObjectBehavior
         $this->shouldImplement('Symfony\Component\Form\FormTypeInterface');
     }
 
-    function it_builds_a_form(FormBuilderInterface $builder, OptionInterface $option)
-    {
+    function it_builds_a_form_using_option_presenation_as_label_if_possible(
+        FormBuilderInterface $builder,
+        OptionInterface $option
+    ) {
         $option->getId()->shouldBeCalled()->willReturn(3);
+        $option->getPresentation()->shouldBeCalled()->willReturn(null);
         $option->getName()->shouldBeCalled()->willReturn('option_name');
 
         $builder->add('3', 'sylius_varibale_name_option_value_choice', array(
             'label'         => 'option_name',
+            'option'        => $option,
+            'property_path' => '[0]'
+        ))->shouldBeCalled();
+
+        $this->buildForm($builder, array(
+            'options' => array($option)
+        ));
+    }
+
+    function it_builds_a_form_using_option_name_as_label_if_presentation_is_empty(
+        FormBuilderInterface $builder,
+        OptionInterface $option
+    ) {
+        $option->getId()->shouldBeCalled()->willReturn(3);
+        $option->getPresentation()->shouldBeCalled()->willReturn('option_presentation');
+        $option->getName()->shouldNotBeCalled();
+
+
+        $builder->add('3', 'sylius_varibale_name_option_value_choice', array(
+            'label'         => 'option_presentation',
             'option'        => $option,
             'property_path' => '[0]'
         ))->shouldBeCalled();

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/macros.html.twig
@@ -34,7 +34,7 @@
             <td>
                 <ul>
                 {% for option in variant.options %}
-                    <li><strong>{{ option.name }}</strong>: {{ option.value }}</li>
+                    <li><strong>{{ option.presentation|default(option.name) }}</strong>: {{ option.value }}</li>
                 {% endfor %}
                 </ul>
             </td>


### PR DESCRIPTION
Using option's presentation instead of name while displaying product variant on the list.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT