### PR TITLE
[User] Add temporary required dependency

### DIFF
--- a/src/Sylius/Component/User/composer.json
+++ b/src/Sylius/Component/User/composer.json
@@ -30,8 +30,9 @@
     "require": {
         "php": ">=5.3.3",
 
-        "sylius/resource": "0.15.*@dev",
-        "sylius/storage":  "0.15.*@dev"
+        "sylius/resource":  "0.15.*@dev",
+        "sylius/storage":   "0.15.*@dev",
+        "symfony/security": "~2.3"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.1"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |
| License       | MIT

Unfortunately we have to add this, because of `Symfony\Component\Security\Core\User\AdvancedUserInterface` dependency and PHP 5.3 limitations...