### PR TITLE
[Behat] Changed the way of how the "I am on the page" assertion works

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Behat/DefaultContext.php
+++ b/src/Sylius/Bundle/ResourceBundle/Behat/DefaultContext.php
@@ -525,9 +525,9 @@ abstract class DefaultContext extends RawMinkContext implements Context, KernelA
     {
         $router = $this->getService('router');
 
-        $url = $this->getSession()->getCurrentUrl();
-        $path = str_replace(rtrim($this->getMinkParameter('base_url'), '/'), '', $url);
-        $match = $router->match($path);
+        $request = $this->getSession()->getDriver()->getClient()->getRequest();
+        //$path = str_replace(rtrim($this->getMinkParameter('base_url'), '/'), '', $url);
+        $match = $router->matchRequest($request);
 
         if (null === $match || !isset($match['_route'])) {
             throw new \Exception(sprintf('Route for URL "%s" not found!', $url));

--- a/src/Sylius/Bundle/ResourceBundle/Behat/DefaultContext.php
+++ b/src/Sylius/Bundle/ResourceBundle/Behat/DefaultContext.php
@@ -204,21 +204,40 @@ abstract class DefaultContext extends RawMinkContext implements Context, KernelA
             return $this->generateUrl($page, $parameters);
         }
 
-        $route  = str_replace(' ', '_', trim($page));
+        $route = $this->getPossibleRoutesForPage($page)->current();
+
+        return $this->generateUrl($route, $parameters);
+    }
+
+    /**
+     * @param string $page
+     *
+     * @return \Generator
+     */
+    protected function getPossibleRoutesForPage($page)
+    {
         $routes = $this->getContainer()->get('router')->getRouteCollection();
 
-        if (null === $routes->get($route)) {
-            $route = $this->applicationName.'_'.$route;
+        $route = str_replace(' ', '_', trim($page));
+        if (null !== $routes->get($route)) {
+            yield $route;
         }
 
-        if (null === $routes->get($route)) {
-            $route = str_replace($this->applicationName.'_', $this->applicationName.'_backend_', $route);
+        $route = $this->applicationName . '_' . $route;
+        if (null !== $routes->get($route)) {
+            yield $route;
+        }
+
+        $route = str_replace($this->applicationName . '_', $this->applicationName . '_backend_', $route);
+        if (null !== $routes->get($route)) {
+            yield $route;
         }
 
         $route = str_replace(array_keys($this->actions), array_values($this->actions), $route);
         $route = str_replace(' ', '_', $route);
-
-        return $this->generateUrl($route, $parameters);
+        if (null !== $routes->get($route)) {
+            yield $route;
+        }
     }
 
     /**
@@ -495,5 +514,25 @@ abstract class DefaultContext extends RawMinkContext implements Context, KernelA
         }
 
         return $code;
+    }
+
+    /**
+     * @return string
+     *
+     * @throws \Exception If route not found
+     */
+    protected function getCurrentPageRouteName()
+    {
+        $router = $this->getService('router');
+
+        $url = $this->getSession()->getCurrentUrl();
+        $path = str_replace(rtrim($this->getMinkParameter('base_url'), '/'), '', $url);
+        $match = $router->match($path);
+
+        if (null === $match || !isset($match['_route'])) {
+            throw new \Exception(sprintf('Route for URL "%s" not found!', $url));
+        }
+
+        return $match['_route'];
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/Behat/WebContext.php
+++ b/src/Sylius/Bundle/ResourceBundle/Behat/WebContext.php
@@ -35,7 +35,20 @@ class WebContext extends DefaultContext
      */
     public function iShouldBeOnThePage($page)
     {
-        $this->assertSession()->addressEquals($this->generatePageUrl($page));
+        $currentRoute = $this->getCurrentPageRouteName();
+
+        $route = null;
+        $passed = false;
+        foreach ($this->getPossibleRoutesForPage($page) as $route) {
+            if ($currentRoute === $route) {
+                $passed = true;
+                break;
+            }
+        }
+
+        if (false === $passed) {
+            throw new \Exception(sprintf('Current route is "%s", expected one was "%s"', $currentRoute, $route));
+        }
 
         try {
             $this->assertStatusCodeEquals(200);

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/frontend/checkout.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/frontend/checkout.yml
@@ -5,14 +5,6 @@ sylius_checkout_start:
     path: /
     defaults: { _controller: sylius.controller.process:startAction, scenarioAlias: 'sylius_checkout' }
 
-sylius_checkout_display:
-    path: /{stepName}
-    defaults: { _controller: sylius.controller.process:displayAction, scenarioAlias: 'sylius_checkout' }
-
-sylius_checkout_forward:
-    path: /{stepName}/forward
-    defaults: { _controller: sylius.controller.process:forwardAction, scenarioAlias: 'sylius_checkout' }
-
 sylius_checkout_security:
     path: /security
     defaults: { _controller: sylius.controller.process:displayAction, scenarioAlias: 'sylius_checkout', 'stepName': 'security' }
@@ -36,3 +28,11 @@ sylius_checkout_payment:
 sylius_checkout_finalize:
     path: /finalize
     defaults: { _controller: sylius.controller.process:displayAction, scenarioAlias: 'sylius_checkout', 'stepName': 'finalize' }
+
+sylius_checkout_display:
+    path: /{stepName}
+    defaults: { _controller: sylius.controller.process:displayAction, scenarioAlias: 'sylius_checkout' }
+
+sylius_checkout_forward:
+    path: /{stepName}/forward
+    defaults: { _controller: sylius.controller.process:forwardAction, scenarioAlias: 'sylius_checkout' }


### PR DESCRIPTION
Using PHP 5.5 generators (based on #3110), "I am on the (.+)? (page|step)" assertion compares current route with expected one, instead of comparing current address with expected address (generated from expected route). What it means - routes with parameters will work like a charm :)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT