### PR TITLE
[PHP7 Compatibility] Fixed doubled arguments in some specifications

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/spec/Checker/RestrictedZoneCheckerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Checker/RestrictedZoneCheckerSpec.php
@@ -44,8 +44,8 @@ class RestrictedZoneCheckerSpec extends ObjectBehavior
     }
 
     function it_is_not_restricted_if_customer_have_no_shipping_address(
-        ProductInterface $product,
         $customerContext,
+        ProductInterface $product,
         CustomerInterface $customer
     ) {
         $customerContext->getCustomer()->shouldBeCalled()->willReturn($customer);
@@ -55,7 +55,6 @@ class RestrictedZoneCheckerSpec extends ObjectBehavior
     }
 
     function it_is_not_restricted_if_product_have_no_restricted_zone(
-        ProductInterface $product,
         $customerContext,
         CustomerInterface $customer,
         AddressInterface $address,
@@ -69,7 +68,6 @@ class RestrictedZoneCheckerSpec extends ObjectBehavior
     }
 
     function it_is_not_restricted_if_zone_matcher_does_not_match_customers_shipping_address(
-        ProductInterface $product,
         $customerContext,
         $zoneMatcher,
         CustomerInterface $customer,
@@ -86,7 +84,6 @@ class RestrictedZoneCheckerSpec extends ObjectBehavior
     }
 
     function it_is_restricted_if_zone_matcher_match_customers_shipping_address(
-        ProductInterface $product,
         $customerContext,
         $zoneMatcher,
         CustomerInterface $customer,

--- a/src/Sylius/Bundle/PayumBundle/spec/Payum/Action/PaymentStatusActionSpec.php
+++ b/src/Sylius/Bundle/PayumBundle/spec/Payum/Action/PaymentStatusActionSpec.php
@@ -73,9 +73,8 @@ class PaymentStatusActionSpec extends ObjectBehavior
     }
 
     function it_should_do_status_subrequest_with_payment_details_as_model(
-        PaymentInterface $payment,
-        GetStatusInterface $statusRequest,
-        PayumPaymentInterface $payment
+        PayumPaymentInterface $payment,
+        GetStatusInterface $statusRequest
     ) {
         $details = array('foo' => 'foo', 'bar' => 'baz');
 

--- a/src/Sylius/Bundle/RbacBundle/spec/Doctrine/ORM/PermissionRepositorySpec.php
+++ b/src/Sylius/Bundle/RbacBundle/spec/Doctrine/ORM/PermissionRepositorySpec.php
@@ -35,9 +35,8 @@ class PermissionRepositorySpec extends ObjectBehavior
         $this->shouldHaveType('Sylius\Bundle\RbacBundle\Doctrine\ORM\PermissionRepository');
     }
 
-    function it_gets_chield_permission(
+    function it_gets_child_permission(
         $em,
-        $builder,
         PermissionInterface $permission,
         QueryBuilder $builder,
         AbstractQuery $query,

--- a/src/Sylius/Bundle/RbacBundle/spec/Doctrine/ORM/RoleRepositorySpec.php
+++ b/src/Sylius/Bundle/RbacBundle/spec/Doctrine/ORM/RoleRepositorySpec.php
@@ -37,7 +37,6 @@ class RoleRepositorySpec extends ObjectBehavior
 
     function it_gets_chield_roles(
         $em,
-        $builder,
         RoleInterface $role,
         QueryBuilder $builder,
         AbstractQuery $query,

--- a/src/Sylius/Bundle/ResourceBundle/spec/Twig/ResourceExtensionSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Twig/ResourceExtensionSpec.php
@@ -123,8 +123,7 @@ class ResourceExtensionSpec extends ObjectBehavior
         GetResponseEvent $event,
         RouterInterface $router,
         \Twig_Environment $twig,
-        $parameters,
-        Request $request
+        $parameters
     ) {
         $parameters->get('parameter_name')->willReturn(array());
         $parameters->get('sortable')->willReturn(true);


### PR DESCRIPTION
While checking out for PHP7 compatibility (unfortunately PhpSpec isn't ready yet :(), found some doubled declarations in some methods in specifications.