### PR TITLE
[Settings] Missing parameters issues in twig templates and settings loading

### DIFF
--- a/src/Sylius/Bundle/SettingsBundle/Manager/SettingsManager.php
+++ b/src/Sylius/Bundle/SettingsBundle/Manager/SettingsManager.php
@@ -101,7 +101,7 @@ class SettingsManager implements SettingsManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function loadSettings($namespace)
+    public function loadSettings($namespace, $ignoreUnknown = true)
     {
         if (isset($this->resolvedSettings[$namespace])) {
             return $this->resolvedSettings[$namespace];
@@ -118,6 +118,15 @@ class SettingsManager implements SettingsManagerInterface
 
         $settingsBuilder = new SettingsBuilder();
         $schema->buildSettings($settingsBuilder);
+
+        // Remove unknown settings' parameters (e.g. From a previous version of the settings schema)
+        if (true === $ignoreUnknown) {
+            foreach ($parameters as $name => $value) {
+                if (!$settingsBuilder->isKnown($name)) {
+                    unset($parameters[$name]);
+                }
+            }
+        }
 
         $parameters = $this->transformParameters($settingsBuilder, $parameters);
         $parameters = $settingsBuilder->resolve($parameters);

--- a/src/Sylius/Bundle/SettingsBundle/Templating/Helper/SettingsHelper.php
+++ b/src/Sylius/Bundle/SettingsBundle/Templating/Helper/SettingsHelper.php
@@ -60,6 +60,26 @@ class SettingsHelper extends Helper
     }
 
     /**
+     * Checks if settings parameter for given namespace and name exists.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasSettingsParameter($name)
+    {
+        if (false === strpos($name, '.')) {
+            throw new \InvalidArgumentException(sprintf('Parameter must be in format "namespace.name", "%s" given.', $name));
+        }
+
+        list($namespace, $name) = explode('.', $name);
+
+        $settings = $this->settingsManager->loadSettings($namespace);
+
+        return $settings->has($name);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getName()

--- a/src/Sylius/Bundle/SettingsBundle/Twig/SettingsExtension.php
+++ b/src/Sylius/Bundle/SettingsBundle/Twig/SettingsExtension.php
@@ -41,6 +41,7 @@ class SettingsExtension extends \Twig_Extension
         return array(
              new \Twig_SimpleFunction('sylius_settings_all', array($this, 'getSettings')),
              new \Twig_SimpleFunction('sylius_settings_get', array($this, 'getSettingsParameter')),
+             new \Twig_SimpleFunction('sylius_settings_has', array($this, 'hasSettingsParameter')),
         );
     }
 
@@ -62,6 +63,18 @@ class SettingsExtension extends \Twig_Extension
     public function getSettingsParameter($name)
     {
         return $this->helper->getSettingsParameter($name);
+    }
+
+    /**
+     * Checks if settings parameter for given namespace and name exists.
+     *
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function hasSettingsParameter($name)
+    {
+        return $this->helper->hasSettingsParameter($name);
     }
 
     /**


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | yes
New feature?  | no
BC breaks? | no
Deprecations? | no
Fixed tickets | no
License | MIT
Doc PR | -

There are a lot of times and loading a settings schema fails because we had a previous deprecated value in the database which we didn't want anymore and since it's not easy to create migrations for settings schema's I thought maybe it's safe to ignore missing options **ONLY** when loading from database.