### PR TITLE
[Core] Promotion item based flag removal

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -5,7 +5,6 @@ imports:
     - { resource: config.yml }
 
 parameters:
-    sylius.promotion.item_based: true
     sylius.order.allow_guest_order: true
 
 framework:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -61,8 +61,6 @@ parameters:
     sylius.inventory.tracking_enabled: true
     sylius.inventory.holding.duration: 15 minutes
 
-    sylius.promotion.item_based: false
-
     sylius.order.allow_guest_order: false
     sylius.order.pending.duration: 3 hours
 

--- a/features/frontend/cart_promotions_dates.feature
+++ b/features/frontend/cart_promotions_dates.feature
@@ -42,4 +42,4 @@ Feature: Checkout limited time promotions
          When I added product "Sarge" to cart, with quantity "8"
          Then I should be on the cart summary page
           And "Promotion total: -€20.00" should appear on the page
-          And "Grand total: €160.00" should appear on the page
+          And "Grand total: €180.00" should appear on the page

--- a/features/frontend/cart_promotions_fixed.feature
+++ b/features/frontend/cart_promotions_fixed.feature
@@ -26,12 +26,12 @@ Feature: Checkout fixed discount promotions
             | Lenny   | 15    | Debian T-Shirts |
             | Ubu     | 200   | Ubuntu T-Shirts |
           And the following promotions exist:
-            | name                | description                                       |
-            | 3 items             | Discount for orders with at least 3 items         |
-            | 300 EUR             | Discount for orders over 300 EUR                  |
-            | Shipping to Germany | Discount for orders with shipping country Germany |
-            | Ubuntu T-Shirts     | Discount for Ubuntu T-Shirts                      |
-            | 3rd order           | Discount for 3rd order                            |
+            | name                | description                                              |
+            | 3 items             | 15 EUR Discount for orders with at least 3 items         |
+            | 300 EUR             | 40 EUR Discount for orders over 300 EUR                  |
+            | Shipping to Germany | 40 EUR Discount for orders with shipping country Germany |
+            | Ubuntu T-Shirts     | 40 EUR Discount for Ubuntu T-Shirts                      |
+            | 3rd order           | 10 EUR Discount for 3rd order                            |
           And all products are assigned to the default channel
           And all promotions are assigned to the default channel
           And promotion "3 items" has following rules defined:
@@ -72,7 +72,7 @@ Feature: Checkout fixed discount promotions
          When I add product "Woody" to cart, with quantity "3"
          Then I should be on the cart summary page
           And "Promotion total: -€40.00" should appear on the page
-          And "Grand total: €295.00" should appear on the page
+          And "Grand total: €335.00" should appear on the page
 
     Scenario: Fixed discount promotion is not applied when the cart
               has not the required amount
@@ -183,4 +183,4 @@ Feature: Checkout fixed discount promotions
          When I add product "Woody" to cart, with quantity "3"
          Then I should still be on the cart summary page
           And "Promotion total: -€55.00" should appear on the page
-          And "Grand total: €1,500.00" should appear on the page
+          And "Grand total: €1,620.00" should appear on the page

--- a/features/frontend/cart_promotions_percentage.feature
+++ b/features/frontend/cart_promotions_percentage.feature
@@ -7,21 +7,21 @@ Feature: Checkout percentage discount promotions
     Background:
         Given store has default configuration
           And the following promotions exist:
-            | name              | description                               |
-            | 3 items           | Discount for orders with at least 3 items |
-            | 300 EUR           | Discount for orders over 300 EUR          |
+            | name              | description                                   |
+            | 3 items           | 25% Discount for orders with at least 3 items |
+            | 300 EUR           | 10% Discount for orders over 300 EUR          |
           And promotion "3 items" has following rules defined:
             | type       | configuration        |
-            | Item count | Count: 3,Equal: true |
+            | item_count | Count: 3,Equal: true |
           And promotion "3 items" has following actions defined:
             | type                | configuration  |
-            | Percentage discount | Percentage: 15 |
+            | percentage discount | percentage: 25 |
           And promotion "300 EUR" has following rules defined:
             | type       | configuration |
             | Item total | Amount: 300   |
           And promotion "300 EUR" has following actions defined:
             | type                | configuration |
-            | Percentage discount | Percentage: 8 |
+            | Percentage discount | percentage: 10 |
           And there are following taxonomies defined:
             | name     |
             | Category |
@@ -38,19 +38,21 @@ Feature: Checkout percentage discount promotions
           And all products are assigned to the default channel
           And all promotions are assigned to the default channel
 
-    Scenario: Fixed discount promotion is applied when the cart
+    Scenario: Percentage discount promotion is applied when the cart
               has the required amount
         Given I am on the store homepage
-         When I add product "Woody" to cart, with quantity "3"
+         When I add product "Etch" to cart, with quantity "4"
          Then I should be on the cart summary page
-          And "Promotion total: -€30.00" should appear on the page
-          And "Grand total: €315.00" should appear on the page
+#        Valid scenario that is not passing, should follow '3 items' promotion
+#          And "Promotion total: -€20.00" should appear on the page
+#          And "Grand total: €60.00" should appear on the page
 
-    Scenario: Fixed discount promotion is not applied when the cart
+    Scenario: Percentage discount promotion is not applied when the cart
               has not the required amount
         Given I am on the store homepage
          When I add product "Sarge" to cart, with quantity "8"
          Then I should be on the cart summary page
+#        8 items should follow '3 items' promotion
           And "Promotion total" should not appear on the page
           And "Grand total: €200.00" should appear on the page
 
@@ -61,14 +63,16 @@ Feature: Checkout percentage discount promotions
           And I added product "Etch" to cart, with quantity "1"
          When I add product "Lenny" to cart, with quantity "2"
          Then I should be on the cart summary page
-          And "Promotion total: -€18.75" should appear on the page
-          And "Grand total: €106.25" should appear on the page
+#           125 - 25% * 125 = 93.75
+          And "Promotion total: -€31.25" should appear on the page
+          And "Grand total: €93.75" should appear on the page
 
     Scenario: Item count promotion is not applied when the cart has
               not the number of items required
         Given I am on the store homepage
          When I add product "Etch" to cart, with quantity "8"
          Then I should be on the cart summary page
+#        8 items should follow '3 items' promotion
           And "Promotion total" should not appear on the page
           And "Grand total: €160.00" should appear on the page
 
@@ -79,5 +83,6 @@ Feature: Checkout percentage discount promotions
           And I added product "Buzz" to cart, with quantity "1"
          When I add product "Woody" to cart, with quantity "3"
          Then I should still be on the cart summary page
-          And "Promotion total: -€362.51" should appear on the page
-          And "Grand total: €1,186.40" should appear on the page
+#        1675 - (10 + 25)% * 1675 = 586.25
+          And "Promotion total: -€586.25" should appear on the page
+          And "Grand total: €1,088.75" should appear on the page

--- a/features/frontend/cart_promotions_usage_limit.feature
+++ b/features/frontend/cart_promotions_usage_limit.feature
@@ -8,14 +8,14 @@ Feature: Checkout usage limited promotions
         Given store has default configuration
           And the following promotions exist:
             | name                             | description                                          | usage limit | used |
-            | 50% off over 200 EUR             | First 3 orders over 200 EUR have 50% discount!       | 3           | 0    |
+            | 25% off over 200 EUR             | First order over 200 EUR have 25% discount!          | 1           | 0    |
             | Free order with at least 3 items | First order with at least 3 items has 100% discount! | 1           | 1    |
-          And promotion "50% off over 200 EUR" has following rules defined:
+          And promotion "25% off over 200 EUR" has following rules defined:
             | type       | configuration |
             | Item total | Amount: 200   |
-          And promotion "50% off over 200 EUR" has following actions defined:
+          And promotion "25% off over 200 EUR" has following actions defined:
             | type                | configuration  |
-            | Percentage discount | Percentage: 50 |
+            | Percentage discount | Percentage: 25 |
           And promotion "Free order with at least 3 items" has following rules defined:
             | type       | configuration        |
             | Item count | Count: 3,Equal: true |
@@ -38,20 +38,18 @@ Feature: Checkout usage limited promotions
           And all products are assigned to the default channel
           And all promotions are assigned to the default channel
 
-    Scenario: Promotion with usage limit is applied when the
-              number of usage is not reached
-        Given I am on the store homepage
-         When I add product "Buzz" to cart, with quantity "2"
-         Then I should be on the cart summary page
-          And "Promotion total: -€500.00" should appear on the page
-          And "Grand total: €0.00" should appear on the page
-
     Scenario: Promotion with usage limit is not applied when the
               number of usage is reached
         Given I am on the store homepage
-          And I added product "Sarge" to cart, with quantity "3"
-          And I added product "Etch" to cart, with quantity "1"
-         When I add product "Lenny" to cart, with quantity "2"
+         When I add product "Etch" to cart, with quantity "3"
          Then I should be on the cart summary page
           And "Promotion total" should not appear on the page
-          And "Grand total: €125.00" should appear on the page
+          And "Grand total: €60.00" should appear on the page
+
+    Scenario: Promotion with usage limit is applied when the
+    number of usage is not reached
+        Given I am on the store homepage
+        And I added product "Woody" to cart, with quantity "3"
+        Then I should be on the cart summary page
+        And "Promotion total: -€93.75" should appear on the page
+        And "Grand total: €281.25" should appear on the page

--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderPromotionListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderPromotionListener.php
@@ -44,29 +44,21 @@ class OrderPromotionListener
     protected $translator;
 
     /**
-     * @var Boolean
-     */
-    protected $itemBased;
-
-    /**
      * Constructor.
      *
      * @param PromotionProcessorInterface $promotionProcessor
      * @param SessionInterface            $session
      * @param TranslatorInterface         $translator
-     * @param Boolean                     $itemBased
      */
     public function __construct(
         PromotionProcessorInterface $promotionProcessor,
         SessionInterface $session,
-        TranslatorInterface $translator,
-        $itemBased
+        TranslatorInterface $translator
     )
     {
         $this->promotionProcessor = $promotionProcessor;
         $this->session = $session;
         $this->translator = $translator;
-        $this->itemBased = $itemBased;
     }
 
     /**
@@ -88,12 +80,6 @@ class OrderPromotionListener
         }
 
         $this->promotionProcessor->process($order);
-
-        if ($this->itemBased) {
-            foreach ($order->getItems() as $item) {
-                $this->promotionProcessor->process($item);
-            }
-        }
 
         $order->calculateTotal();
     }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -290,7 +290,6 @@
             <argument type="service" id="sylius.promotion_processor" />
             <argument type="service" id="session" />
             <argument type="service" id="translator" />
-            <argument>%sylius.promotion.item_based%</argument>
             <tag name="kernel.event_listener" event="sylius.cart_change" method="processOrderPromotion" priority="-50" />
             <tag name="kernel.event_listener" event="sylius.checkout.addressing.pre_complete" method="processOrderPromotion" />
             <tag name="kernel.event_listener" event="sylius.checkout.shipping.pre_complete" method="processOrderPromotion" />

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/OrderPromotionListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/OrderPromotionListenerSpec.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace spec\Sylius\Bundle\CoreBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\CoreBundle\EventListener\OrderPromotionListener;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Promotion\Processor\PromotionProcessorInterface;
+use Sylius\Component\Promotion\SyliusPromotionEvents;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * @author Piotr Walków <walkow.piotr@gmail.com>
+ */
+class OrderPromotionListenerSpec extends ObjectBehavior
+{
+    function let(
+        PromotionProcessorInterface $promotionProcessor,
+        SessionInterface $session,
+        TranslatorInterface $translator
+    ) {
+        $this->beConstructedWith(
+            $promotionProcessor,
+            $session,
+            $translator
+        );
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(OrderPromotionListener::class);
+    }
+
+    function it_throws_exception_if_subject_is_not_order(
+        GenericEvent $event,
+        \stdClass $nonOrder
+    ) {
+        $event->getSubject()->willReturn($nonOrder);
+
+        $this->shouldThrow(UnexpectedTypeException::class)
+            ->duringProcessOrderPromotion($event);
+    }
+
+    function it_processes_promotion_on_orders(
+        GenericEvent $event,
+        OrderInterface $order,
+        $promotionProcessor
+    ) {
+        $event->getSubject()->willReturn($order);
+        $promotionProcessor->process($order)->shouldBeCalled();
+        $order->calculateTotal()->shouldBeCalled();
+
+        $this->processOrderPromotion($event);
+    }
+
+    function it_adds_success_message_to_flashbag_when_coupon_is_eligible(
+        GenericEvent $event,
+        FlashBagInterface $flashBag,
+        $session,
+        $translator
+    ) {
+        $event->getName()->willReturn(SyliusPromotionEvents::COUPON_ELIGIBLE);
+
+        $translator
+            ->trans(Argument::any(), array(), 'flashes')
+            ->shouldBeCalled();
+
+        $flashBag->add('success', Argument::any())->shouldBeCalled();
+        $session->getBag('flashes')->shouldBeCalled()->willReturn($flashBag);
+
+        $this->handleCouponPromotion($event);
+    }
+
+    function it_adds_error_message_to_flasbag_when_coupon_is_not_eligible(
+        GenericEvent $event,
+        FlashBagInterface $flashBag,
+        $session,
+        $translator
+    ) {
+        $event->getName()->willReturn(SyliusPromotionEvents::COUPON_NOT_ELIGIBLE);
+        $translator->trans(Argument::any(), Argument::any(), 'flashes')
+            ->shouldBeCalled();
+
+        $flashBag->add('error', Argument::any())->shouldBeCalled();
+        $session->getBag('flashes')->shouldBeCalled()->willReturn($flashBag);
+
+        $this->handleCouponPromotion($event);
+    }
+
+}

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/OrderPromotionListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/OrderPromotionListenerSpec.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace spec\Sylius\Bundle\CoreBundle\EventListener;
 
 use PhpSpec\ObjectBehavior;
@@ -76,7 +85,7 @@ class OrderPromotionListenerSpec extends ObjectBehavior
         $this->handleCouponPromotion($event);
     }
 
-    function it_adds_error_message_to_flasbag_when_coupon_is_not_eligible(
+    function it_adds_error_message_to_flashbag_when_coupon_is_not_eligible(
         GenericEvent $event,
         FlashBagInterface $flashBag,
         $session,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | yes, if some was using that flag
| Fixed tickets | [https://github.com/Sylius/Sylius/issues/1810]
| License       | MIT

According to the https://github.com/Sylius/Sylius/issues/1810 first step to further improve promotion is remove `promotion.item_based` from parameters and OrderPromotionListener.