### PR TITLE
[Settings] Cache parameters after fetching as well as saving.

### DIFF
--- a/src/Sylius/Bundle/SettingsBundle/Manager/SettingsManager.php
+++ b/src/Sylius/Bundle/SettingsBundle/Manager/SettingsManager.php
@@ -101,6 +101,7 @@ class SettingsManager implements SettingsManagerInterface
             $parameters = $this->cache->fetch($namespace);
         } else {
             $parameters = $this->getParameters($namespace);
+            $this->cache->save($namespace, $parameters);
         }
 
         $schema = $this->schemaRegistry->getSchema($namespace);


### PR DESCRIPTION
I tried to find any previous issues / PRs regarding this. Is this not something you guys wanted to do? The only issue I could see with this is if someone is using `file_system` cache or another persistent cache in dev mode that default value changes to their schemas wouldn't be reflected (Edit: actually maybe not, this only caches parameters from the database, so default values would change). This could easily be solved by using `array` cache in dev mode. As I see it right now the settings only get cached when saved but if you clear caches you'd have to go to your settings after warmup and save them again to benefit from any caching. 