### PR TITLE
[Travis] Added automatic way to invalidate MongoDB-based composer.lock cache

### DIFF
--- a/travis/prepare/prepare-mongodb
+++ b/travis/prepare/prepare-mongodb
@@ -1,11 +1,46 @@
 #!/bin/bash
-echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
-if [ -f $SYLIUS_CACHE_DIR/composer-mongodb.lock ]; then
-    cp $SYLIUS_CACHE_DIR/composer-mongodb.lock composer.lock
-else
-    composer require doctrine/mongodb-odm="1.0.*@dev" --no-update
-    composer require jmikola/geojson="~1.0" --no-update
-    composer update doctrine/mongodb-odm jmikola/geojson --prefer-source --no-interaction
+function main
+{
+    echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+
+    if is_cache_fresh; then
+        restore_composer_lock_from_cache
+    else
+        install_mongodb
+        store_composer_lock_in_cache
+    fi
+}
+
+function install_mongodb
+{
+    composer require doctrine/mongodb-odm="^1.0.2"
+}
+
+function store_composer_lock_in_cache
+{
     cp composer.lock $SYLIUS_CACHE_DIR/composer-mongodb.lock
-fi
+    file_md5sum 'composer.lock' > $SYLIUS_CACHE_DIR/composer.lock.md5sum
+}
+
+function restore_composer_lock_from_cache
+{
+    cp $SYLIUS_CACHE_DIR/composer-mongodb.lock composer.lock
+}
+
+function file_md5sum
+{
+    md5sum $1 | awk '{ print $1 }'
+}
+
+function is_cache_fresh
+{
+    if [ -f $SYLIUS_CACHE_DIR/composer-mongodb.lock ] && [ -f $SYLIUS_CACHE_DIR/composer.lock.md5sum ] && [ file_md5sum 'composer.lock' -eq `cat $SYLIUS_CACHE_DIR/composer.lock.md5sum` ];
+    then
+        return 0
+    else
+        return 1
+    fi
+}
+
+main


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Also:
 - set `doctrine/mongo-odm` version to `^1.0.2`
 - removed `jmikola/geojson` as it isn't required no more