### PR TITLE
[Coupon] Add missing expiration date in the view

### DIFF
--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CouponGenerateInstructionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CouponGenerateInstructionType.php
@@ -21,6 +21,9 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class CouponGenerateInstructionType extends AbstractResourceType
 {
+    /**
+     * {@inheritdoc}
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
@@ -30,9 +33,16 @@ class CouponGenerateInstructionType extends AbstractResourceType
             ->add('usageLimit', 'integer', array(
                 'label' => 'sylius.form.coupon_generate_instruction.usage_limit'
             ))
+            ->add('expiresAt', 'date', array(
+                'label' => 'sylius.form.coupon_generate_instruction.expires_at',
+                'empty_value' => /** @Ignore */ array('year' => '-', 'month' => '-', 'day' => '-'),
+            ))
         ;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return 'sylius_promotion_coupon_generate_instruction';

--- a/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.en.yml
@@ -1,6 +1,5 @@
 # This file is part of the Sylius package.
 # (c) Paweł Jędrzejewski
-
 sylius:
     form:
         action:
@@ -45,6 +44,7 @@ sylius:
         coupon_generate_instruction:
             amount: Amount
             usage_limit: Usage limit
+            expires_at: Expires at
         promotion:
             actions: Actions
             coupon_based: Coupon based

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Coupon/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Coupon/_form.html.twig
@@ -4,5 +4,6 @@
     {{ form_row(form.code) }}
     {{ form_row(form.usageLimit) }}
     {{ form_row(form.perCustomerUsageLimit) }}
+    {{ form_row(form.expiresAt) }}
     {{ form_widget(form._token) }}
 </fieldset>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Coupon/_generateForm.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Coupon/_generateForm.html.twig
@@ -3,5 +3,6 @@
 <fieldset>
     {{ form_row(form.amount) }}
     {{ form_row(form.usageLimit) }}
+    {{ form_row(form.expiresAt) }}
     {{ form_widget(form._token) }}
 </fieldset>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Coupon/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Coupon/macros.html.twig
@@ -41,7 +41,7 @@
                     {{ promotion_coupon.used }}
                 </span>
             </td>
-            <td>{{ promotion_coupon.expiresAt|date }}</td>
+            <td>{{ promotion_coupon.expiresAt is null ? '-' : promotion_coupon.expiresAt|date }}</td>
             <td>
                 <div class="pull-right">
                     {{ buttons.edit(path('sylius_backend_promotion_coupon_update', {'promotionId': promotion.id, 'id': promotion_coupon.id})) }}

--- a/src/Sylius/Component/Promotion/Generator/CouponGenerator.php
+++ b/src/Sylius/Component/Promotion/Generator/CouponGenerator.php
@@ -32,6 +32,10 @@ class CouponGenerator implements CouponGeneratorInterface
      */
     protected $manager;
 
+    /**
+     * @param RepositoryInterface    $repository
+     * @param EntityManagerInterface $manager
+     */
     public function __construct(RepositoryInterface $repository, EntityManagerInterface $manager)
     {
         $this->repository = $repository;
@@ -49,14 +53,15 @@ class CouponGenerator implements CouponGeneratorInterface
             $coupon->setPromotion($promotion);
             $coupon->setCode($this->generateUniqueCode());
             $coupon->setUsageLimit($instruction->getUsageLimit());
-            
+            $coupon->setExpiresAt($instruction->getExpiresAt());
+
             $generatedCoupons[] = $coupon;
 
             $this->manager->persist($coupon);
         }
 
         $this->manager->flush();
-        
+
         return $generatedCoupons;
     }
 

--- a/src/Sylius/Component/Promotion/Generator/Instruction.php
+++ b/src/Sylius/Component/Promotion/Generator/Instruction.php
@@ -20,6 +20,7 @@ class Instruction
 {
     protected $amount;
     protected $usageLimit;
+    protected $expiresAt;
 
     public function __construct()
     {
@@ -48,5 +49,15 @@ class Instruction
         $this->usageLimit = $usageLimit;
 
         return $this;
+    }
+
+    public function getExpiresAt()
+    {
+        return $this->expiresAt;
+    }
+
+    public function setExpiresAt(\DateTime $expiresAt = null)
+    {
+        $this->expiresAt = $expiresAt;
     }
 }

--- a/src/Sylius/Component/Promotion/spec/Generator/CouponGeneratorSpec.php
+++ b/src/Sylius/Component/Promotion/spec/Generator/CouponGeneratorSpec.php
@@ -50,6 +50,7 @@ class CouponGeneratorSpec extends ObjectBehavior
     ) {
         $instruction->getAmount()->willReturn(1);
         $instruction->getUsageLimit()->willReturn(null);
+        $instruction->getExpiresAt()->willReturn(null);
 
         $repository->createNew()->willReturn($coupon);
         $repository->findOneBy(Argument::any())->willReturn(null);
@@ -57,6 +58,7 @@ class CouponGeneratorSpec extends ObjectBehavior
         $coupon->setPromotion($promotion)->shouldBeCalled();
         $coupon->setCode(Argument::any())->shouldBeCalled();
         $coupon->setUsageLimit(null)->shouldBeCalled();
+        $coupon->setExpiresAt(null)->shouldBeCalled();
 
         $manager->getFilters()->shouldBeCalled()->willReturn($filters);
         $filters->disable('softdeleteable')->shouldBeCalled();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #3302
| License       | MIT
| Doc PR        | 
 
- [x] Field `expiresAt` is now displayed on manual coupon form
- [x] Field `expiresAt` is now displayed on generated coupon form
- [x] Fixed some docblocks and whitespaces
- [x] Updated PHPSpec test




I wasn't able to reproduce the fact that a newly created coupon cannot be used with the error message "coupon alread expired". 