### PR TITLE
Add check to customer context

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Context/CustomerContext.php
+++ b/src/Sylius/Bundle/UserBundle/Context/CustomerContext.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\UserBundle\Context;
 
 use Sylius\Component\User\Context\CustomerContextInterface;
 use Sylius\Component\User\Model\CustomerInterface;
+use Sylius\Component\User\Model\UserInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
@@ -41,7 +42,7 @@ class CustomerContext implements CustomerContextInterface
     public function getCustomer()
     {
         if ($this->securityContext->getToken() && $this->securityContext->isGranted('IS_AUTHENTICATED_REMEMBERED')
-            && $this->securityContext->getToken()->getUser()
+            && $this->securityContext->getToken()->getUser() instanceof UserInterface
         ) {
             return $this->securityContext->getToken()->getUser()->getCustomer();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

In one part of our site we don't need sylius autentication, just basic http with a generic username and password (which by default uses a Symfony user), so the Customer context fails when calling `->getCustomer()`.
Adding this check allows us to use basic http autentication.