### PR TITLE
Api order type fix

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Api/OrderType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Api/OrderType.php
@@ -28,7 +28,7 @@ class OrderType extends BaseOrderType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('user', 'sylius_user_choice', array(
+            ->add('user', 'sylius_customer_choice', array(
                 'constraints' => array(
                     new NotBlank()
                 )

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.ProductVariant.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.ProductVariant.yml
@@ -5,3 +5,21 @@ Sylius\Component\Core\Model\ProductVariant:
         sku:
             expose: true
             type: string
+        price:
+            expose: true
+            type: integer
+        onHold:
+            expose: true
+            type: integer
+        availableOnDemand:
+            expose: true
+            type: boolean
+        width:
+            expose: true
+            type: float
+        height:
+            expose: true
+            type: float
+        depth:
+            expose: true
+            type: float

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.Product.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.Product.yml
@@ -15,6 +15,9 @@ Sylius\Component\Product\Model\Product:
         options:
             expose: true
             max_depth: 1
+        variants:
+            expose: true
+            max_depth: 1
         attributes:
             expose: true
             max_depth: 1

--- a/src/Sylius/Bundle/UserBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/UserBundle/DependencyInjection/Configuration.php
@@ -155,6 +155,7 @@ class Configuration implements ConfigurationInterface
                                         ->scalarNode('registration')->defaultValue('Sylius\Bundle\UserBundle\Form\Type\CustomerRegistrationType')->end()
                                         ->scalarNode('simple_registration')->defaultValue('Sylius\Bundle\UserBundle\Form\Type\CustomerSimpleRegistrationType')->end()
                                         ->scalarNode('guest')->defaultValue('Sylius\Bundle\UserBundle\Form\Type\CustomerGuestType')->end()
+                                        ->scalarNode('choice')->defaultValue('%sylius.form.type.resource_choice.class%')->end()
                                     ->end()
                                 ->end()
                             ->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

Added new line in UserBundle configuration to auto generate customer choice type and Api OrderType fix.
Depends on #3332