### PR TITLE
[Product] Add a crossed price 

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -4,7 +4,7 @@
 imports:
     - { resource: parameters.yml }
     - { resource: security.yml }
-    - { resource: migrations.yml }    
+    - { resource: migrations.yml }
     - { resource: @SyliusCoreBundle/Resources/config/app/main.yml }
 
 framework:

--- a/app/migrations/Version20150922153417.php
+++ b/app/migrations/Version20150922153417.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20150922153417 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql("ALTER TABLE sylius_product_variant ADD original_price INT NULL;");
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql("ALTER TABLE sylius_product_variant DROP COLUMN original_price;");
+    }
+}

--- a/features/backend/product_variants.feature
+++ b/features/backend/product_variants.feature
@@ -51,6 +51,13 @@ Feature: Product variants
         And I press "Create"
         Then I should see "Price must not be negative"
 
+    Scenario: Trying to create product variant with invalid original price
+        Given I am creating variant of "Black T-Shirt"
+        When I fill in "Price" with "1.00"
+        And I fill in "Original price" with "-0.01"
+        And I press "Create"
+        Then I should see "Original price must not be negative"
+
     Scenario: Displaying the "Generate variants" button
               only for products with options
         Given I am viewing product "Mug"

--- a/src/Sylius/Bundle/CoreBundle/Controller/ProductController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/ProductController.php
@@ -223,12 +223,13 @@ class ProductController extends BaseProductController
         $helper   = $this->get('sylius.templating.helper.currency');
         foreach ($products as $product) {
             $results[] = array(
-                'id'        => $product->getMasterVariant()->getId(),
-                'name'      => $product->getName(),
-                'image'     => $product->getImage()->getPath(),
-                'price'     => $helper->convertAndFormatAmount($product->getMasterVariant()->getPrice()),
-                'raw_price' => $helper->convertAndFormatAmount($product->getMasterVariant()->getPrice(), null, true),
-                'desc'      => $product->getShortDescription(),
+                'id'            => $product->getMasterVariant()->getId(),
+                'name'          => $product->getName(),
+                'image'         => $product->getImage()->getPath(),
+                'price'         => $helper->convertAndFormatAmount($product->getMasterVariant()->getPrice()),
+                'original_price' => $helper->convertAndFormatAmount($product->getMasterVariant()->getOriginalPrice()),
+                'raw_price'     => $helper->convertAndFormatAmount($product->getMasterVariant()->getPrice(), null, true),
+                'desc'          => $product->getShortDescription(),
             );
         }
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/ProductVariantType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/ProductVariantType.php
@@ -35,6 +35,9 @@ class ProductVariantType extends BaseVariantType
             ->add('price', 'sylius_money', array(
                 'label' => 'sylius.form.variant.price'
             ))
+            ->add('originalPrice', 'sylius_money', array(
+                'label' => 'sylius.form.variant.original_price'
+            ))
             ->add('availableOnDemand', 'checkbox', array(
                 'label' => 'sylius.form.variant.available_on_demand'
             ))

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductVariant.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductVariant.orm.xml
@@ -35,6 +35,9 @@
         <field name="price" column="price" type="integer">
             <gedmo:versioned />
         </field>
+        <field name="originalPrice" column="original_price" type="integer" nullable="true">
+            <gedmo:versioned />
+        </field>
         <field name="pricingCalculator" column="pricing_calculator" type="string">
             <gedmo:versioned/>
         </field>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation.xml
@@ -42,6 +42,13 @@
                 <option name="groups">sylius</option>
             </constraint>
         </property>
+        <property name="originalPrice">
+            <constraint name="Range">
+                <option name="min">0.00</option>
+                <option name="minMessage">sylius.product_variant.original_price.min</option>
+                <option name="groups">sylius</option>
+            </constraint>
+        </property>
         <property name="onHand">
             <constraint name="NotBlank">
                 <option name="message">sylius.product_variant.onHand.not_blank</option>
@@ -71,7 +78,7 @@
                 <option name="groups">sylius</option>
             </constraint>
         </property>
-    </class>    
+    </class>
     <class name="Sylius\Component\Cart\Model\CartItem">
         <constraint name="Sylius\Bundle\InventoryBundle\Validator\Constraints\InStock">
             <option name="stockablePath">variant</option>

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
@@ -109,6 +109,7 @@ sylius:
             images: Images
             on_hand: Current stock
             price: Price
+            original_price: Original price
             sku: SKU
             weight: Weight
             width: Width

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/validators.en.yml
@@ -10,6 +10,8 @@ sylius:
         price:
             min: Price must not be negative.
             not_blank: Please enter the price.
+        original_price:
+            min: Original price must not be negative.
     product_translation:
         short_description:
             max: Short description must not be longer then {{ limit }} characters.

--- a/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
@@ -41,7 +41,6 @@ class CurrencyExtension extends \Twig_Extension
         return array(
             new \Twig_SimpleFilter('sylius_currency', array($this, 'convertAmount')),
             new \Twig_SimpleFilter('sylius_price', array($this, 'convertAndFormatAmount')),
-            new \Twig_SimpleFilter('sylius_original_price', array($this, 'convertAndFormatAmount')),
         );
     }
 

--- a/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
@@ -41,6 +41,7 @@ class CurrencyExtension extends \Twig_Extension
         return array(
             new \Twig_SimpleFilter('sylius_currency', array($this, 'convertAmount')),
             new \Twig_SimpleFilter('sylius_price', array($this, 'convertAndFormatAmount')),
+            new \Twig_SimpleFilter('sylius_original_price', array($this, 'convertAndFormatAmount')),
         );
     }
 

--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -313,7 +313,7 @@ class ResourceController extends FOSRestController
         $this->get('doctrine')->getManager()->getFilters()->disable('softdeleteable');
         $resource = $this->findOr404($request);
         $this->get('doctrine')->getManager()->getFilters()->enable('softdeleteable');
-        
+
         $resource->setDeletedAt(null);
 
         $this->domainManager->update($resource, 'restore_deleted');

--- a/src/Sylius/Bundle/WebBundle/Resources/public/css/backend.css
+++ b/src/Sylius/Bundle/WebBundle/Resources/public/css/backend.css
@@ -493,11 +493,13 @@ form.form-signin .btn-success:hover {
 .sylius-products-table .id,
 .sylius-products-table .stock,
 .sylius-products-table .retail-price,
+.sylius-products-table .original-price,
 .sylius-products-table .updated-at {
     text-align: center;
 }
 .sylius-products-table .stock,
 .sylius-products-table .retail-price,
+.sylius-products-table .original-price,
 .sylius-products-table .updated-at {
     width: 150px;
 }
@@ -618,7 +620,7 @@ form.form-signin .btn-success:hover {
 
 /** Content. **/
 .content-block-overview {
-	
+
 }
 
 .content-block-overview i {

--- a/src/Sylius/Bundle/WebBundle/Resources/public/css/frontend.css
+++ b/src/Sylius/Bundle/WebBundle/Resources/public/css/frontend.css
@@ -220,4 +220,3 @@ a.create-ui-toggle {
 .label-originalprice {
     margin-right: 0.3em;
 }
->>>>>>> Added a field 'original_price'

--- a/src/Sylius/Bundle/WebBundle/Resources/public/css/frontend.css
+++ b/src/Sylius/Bundle/WebBundle/Resources/public/css/frontend.css
@@ -162,7 +162,7 @@ a.oauth-login:hover {
     background-color: #333 !important;
 }
 .create-ui-toolbar-wrapper.editing {
-    background: rgba(0, 0, 0, 0.7) !important;
+	background: rgba(0, 0, 0, 0.7) !important;
 }
 
 a.create-ui-toggle {
@@ -211,3 +211,13 @@ a.create-ui-toggle {
     box-shadow: 0px 0px;
     background: none;
 }
+
+/* Specific rules */
+.crossed {
+    text-decoration: line-through;
+}
+
+.label-originalprice {
+    margin-right: 0.3em;
+}
+>>>>>>> Added a field 'original_price'

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
@@ -737,6 +737,7 @@ sylius:
         options: Options
         variants: Variants
         price: Retail price
+        original_price: Original price
         attributes: Attributes
         restricted_zone: Restricted zone
         remove_attribute: Remove attribute
@@ -1020,6 +1021,7 @@ sylius:
         no_results: There are no variants to display.
         options: Options
         price: Price
+        original_price: Original price
         sku: SKU
         stock: Current stock
         update_header: Editing variant

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_main.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_main.html.twig
@@ -12,6 +12,7 @@
             {{ form_row(form.masterVariant.onHand) }}
             <hr />
             {{ form_row(form.masterVariant.price) }}
+            {{ form_row(form.masterVariant.originalPrice) }}
             {{ form_row(form.masterVariant.pricingCalculator) }}
 
             {% if form.masterVariant.pricingConfiguration is defined %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/macros.html.twig
@@ -78,7 +78,7 @@
                     {{ product.masterVariant.price|sylius_price }}
                 </td>
                 <td class="original-price">
-                    {{ product.masterVariant.originalPrice|sylius_original_price }}
+                    {{ product.masterVariant.originalPrice|sylius_price }}
                 </td>
             {% else %}
                 <td class="retail-price text-muted">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/macros.html.twig
@@ -12,6 +12,7 @@
             <th class="info">{{ sylius_resource_sort('name', 'sylius.product.name'|trans) }}</th>
             <th class="stock">{{ 'sylius.product.stock'|trans }}</th>
             <th class="retail-price">{{ 'sylius.product.price'|trans }}</th>
+            <th class="original-price">{{ 'sylius.product.original_price'|trans }}</th>
             <th class="updated-at">{{ sylius_resource_sort('updatedAt', 'Updated At') }}</th>
             <th></th>
         </tr>
@@ -76,8 +77,14 @@
                 <td class="retail-price">
                     {{ product.masterVariant.price|sylius_price }}
                 </td>
+                <td class="original-price">
+                    {{ product.masterVariant.originalPrice|sylius_original_price }}
+                </td>
             {% else %}
                 <td class="retail-price text-muted">
+                    <em>{{ 'sylius.na'|trans }}</em>
+                </td>
+                <td class="original-price text-muted">
                     <em>{{ 'sylius.na'|trans }}</em>
                 </td>
             {% endif %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
@@ -141,7 +141,7 @@
                 </tr>
                 <tr>
                     <td>{{ 'sylius.product.original_price'|trans }}</td>
-                    <td>{{ product.masterVariant.originalPrice|sylius_original_price }}</td>
+                    <td>{{ product.masterVariant.originalPrice|sylius_price }}</td>
                 </tr>
                 {% if product.masterVariant.pricingCalculator == 'volume_based' %}
                 <tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
@@ -139,6 +139,10 @@
                     <td>{{ 'sylius.product.price'|trans }}</td>
                     <td>{{ product.masterVariant.price|sylius_price }}</td>
                 </tr>
+                <tr>
+                    <td>{{ 'sylius.product.original_price'|trans }}</td>
+                    <td>{{ product.masterVariant.originalPrice|sylius_original_price }}</td>
+                </tr>
                 {% if product.masterVariant.pricingCalculator == 'volume_based' %}
                 <tr>
                     <td>{{ 'sylius.product.volume_price'|trans }}</td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/_form.html.twig
@@ -18,6 +18,7 @@
             </div>
         </div>
         {{ form_row(form.price) }}
+        {{ form_row(form.originalPrice) }}
         {{ form_row(form.pricingCalculator) }}
         {% if form.pricingConfiguration is defined %}
             {% if form.pricingCalculator.vars.value == 'volume_based' %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/macros.html.twig
@@ -16,6 +16,7 @@
             <th>{{ 'sylius.variant.available_on_demand'|trans }}</th>
             <th>{{ 'sylius.variant.stock'|trans }}</th>
             <th>{{ 'sylius.variant.price'|trans }}</th>
+            <th>{{ 'sylius.variant.original_price'|trans }}</th>
             <th></th>
         </tr>
     </thead>
@@ -45,6 +46,7 @@
             </td>
             <td><span class="label label-{{ variant.inStock ? 'success' : 'important' }}">{{ variant.onHand }}</span></td>
             <td>{{ variant.price|sylius_price }}</td>
+            <td>{{ variant.originalPrice|sylius_original_price }}</td>
             <td>
                 <div class="pull-right">
                 {% if not variant.deleted %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/macros.html.twig
@@ -46,7 +46,7 @@
             </td>
             <td><span class="label label-{{ variant.inStock ? 'success' : 'important' }}">{{ variant.onHand }}</span></td>
             <td>{{ variant.price|sylius_price }}</td>
-            <td>{{ variant.originalPrice|sylius_original_price }}</td>
+            <td>{{ variant.originalPrice|sylius_price }}</td>
             <td>
                 <div class="pull-right">
                 {% if not variant.deleted %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_singleBox.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_singleBox.html.twig
@@ -1,7 +1,9 @@
+{% from 'SyliusWebBundle:Frontend/Product:macros.html.twig' import price %}
 <div class="product-box">
     <a href="{{ path(product) }}"><h4>{{ product.name|truncate(18) }}</h4></a>
     <a href="{{ path(product) }}">
         <img class="img-rounded img-responsive" src="{{ product.image ? product.image.path|imagine_filter('sylius_medium') : 'http://placehold.it/262x255' }}" alt="{{ product.name }}" />
+        {{ price(product.masterVariant, ['label-primary']) }}
         <span class="label label-primary">{{ sylius_calculate_price(product.masterVariant)|sylius_price }}</span>
         <button class="btn btn-success btn-xs pull-right"><i class="icon-shopping-cart icon-white"></i> {{ 'sylius.add_to_cart'|trans }}</button>
     </a>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_singleBox.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_singleBox.html.twig
@@ -1,10 +1,9 @@
-{% from 'SyliusWebBundle:Frontend/Product:macros.html.twig' import price %}
+{% from 'SyliusWebBundle:Frontend/Product:macros.html.twig' import sylius_display_price_with_original %}
 <div class="product-box">
     <a href="{{ path(product) }}"><h4>{{ product.name|truncate(18) }}</h4></a>
     <a href="{{ path(product) }}">
         <img class="img-rounded img-responsive" src="{{ product.image ? product.image.path|imagine_filter('sylius_medium') : 'http://placehold.it/262x255' }}" alt="{{ product.name }}" />
-        {{ price(product.masterVariant, ['label-primary']) }}
-        <span class="label label-primary">{{ sylius_calculate_price(product.masterVariant)|sylius_price }}</span>
+        {{ sylius_display_price_with_original(product.masterVariant) }}
         <button class="btn btn-success btn-xs pull-right"><i class="icon-shopping-cart icon-white"></i> {{ 'sylius.add_to_cart'|trans }}</button>
     </a>
 </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/macros.html.twig
@@ -33,8 +33,9 @@
 
 {% endmacro %}
 
-{% macro price(variant, classes) %}
-{% if (variant.originalprice > variant.price) %}
-    <span class="label crossed {% for class in classes %} {{ class }} {% endfor %}">{{ variant.originalPrice|sylius_price }}</span>
-{% endif %}
+{% macro sylius_display_price_with_original(variant) %}
+    {% if (variant.isReduced) %}
+        <span class='label label-success crossed'>{{ variant.originalPrice|sylius_price }}</span>
+    {% endif %}
+    <span class='label label-success'>{{variant.price|sylius_price }}</span>
 {% endmacro %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/macros.html.twig
@@ -32,3 +32,9 @@
 </div>
 
 {% endmacro %}
+
+{% macro price(variant, classes) %}
+{% if (variant.originalprice > variant.price) %}
+    <span class="label crossed {% for class in classes %} {{ class }} {% endfor %}">{{ variant.originalPrice|sylius_price }}</span>
+{% endif %}
+{% endmacro %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
@@ -1,7 +1,7 @@
 {% extends 'SyliusWebBundle:Frontend:layout.html.twig' %}
 
 {% set form = sylius_cart_form({'product': product}) %}
-{% from 'SyliusWebBundle:Frontend/Product:macros.html.twig' import price %}
+{% from 'SyliusWebBundle:Frontend/Product:macros.html.twig' import sylius_display_price_with_original %}
 
 {% block content %}
 <div class="row">
@@ -80,8 +80,7 @@
                             {% endif %}
                         </td>
                         <td>
-                            {{ price(variant, ['label-success', 'label-originalprice']) }}
-                            <span class="label label-success">{{ sylius_calculate_price(variant)|sylius_price }}</span>
+                            {{ sylius_display_price_with_original(variant) }}
                         </td>
                         <td>
                         {% if sylius_inventory_is_available(variant) %}
@@ -101,8 +100,9 @@
             {% endif %}
         {% else %}
             <h4>
-                <span class="label label-success pull-right">{{ sylius_calculate_price(product.masterVariant)|sylius_price }}</span>
-                {{ price(product.masterVariant, ['label-success', 'label-originalprice', 'pull-right']) }}
+                <span class="pull-right">
+                    {{ sylius_display_price_with_original(product.masterVariant) }}
+                </span>
                 {{ 'sylius.variant.price'|trans }}
             </h4>
         {% endif %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
@@ -1,6 +1,7 @@
 {% extends 'SyliusWebBundle:Frontend:layout.html.twig' %}
 
 {% set form = sylius_cart_form({'product': product}) %}
+{% from 'SyliusWebBundle:Frontend/Product:macros.html.twig' import price %}
 
 {% block content %}
 <div class="row">
@@ -79,6 +80,7 @@
                             {% endif %}
                         </td>
                         <td>
+                            {{ price(variant, ['label-success', 'label-originalprice']) }}
                             <span class="label label-success">{{ sylius_calculate_price(variant)|sylius_price }}</span>
                         </td>
                         <td>
@@ -100,6 +102,7 @@
         {% else %}
             <h4>
                 <span class="label label-success pull-right">{{ sylius_calculate_price(product.masterVariant)|sylius_price }}</span>
+                {{ price(product.masterVariant, ['label-success', 'label-originalprice', 'pull-right']) }}
                 {{ 'sylius.variant.price'|trans }}
             </h4>
         {% endif %}

--- a/src/Sylius/Component/Core/Model/ProductVariant.php
+++ b/src/Sylius/Component/Core/Model/ProductVariant.php
@@ -39,6 +39,13 @@ class ProductVariant extends BaseVariant implements ProductVariantInterface
     protected $price;
 
     /**
+     * The variant original price.
+     *
+     * @var int
+     */
+    protected $originalPrice;
+
+    /**
      * The pricing calculator.
      *
      * @var string
@@ -177,6 +184,27 @@ class ProductVariant extends BaseVariant implements ProductVariantInterface
             throw new \InvalidArgumentException('Price must be an integer.');
         }
         $this->price = $price;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOriginalPrice()
+    {
+        return $this->originalPrice;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOriginalPrice($originalPrice)
+    {
+        if (!is_int($originalPrice)) {
+            throw new \InvalidArgumentException('Original price must be an integer.');
+        }
+        $this->originalPrice = $originalPrice;
 
         return $this;
     }

--- a/src/Sylius/Component/Core/Model/ProductVariant.php
+++ b/src/Sylius/Component/Core/Model/ProductVariant.php
@@ -520,4 +520,13 @@ class ProductVariant extends BaseVariant implements ProductVariantInterface
     {
         return $this->depth * $this->height * $this->width;
     }
+
+    public function isReduced()
+    {
+        if ($this->originalPrice > $this->price) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/src/Sylius/Component/Core/spec/Model/ProductVariantSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ProductVariantSpec.php
@@ -41,6 +41,11 @@ class ProductVariantSpec extends ObjectBehavior
         $this->getPrice()->shouldReturn(null);
     }
 
+    function it_should_not_have_original_price_by_default()
+    {
+        $this->getOriginalPrice()->shouldReturn(null);
+    }
+
     function it_initializes_image_collection_by_default()
     {
         $this->getImages()->shouldHaveType('Doctrine\Common\Collections\Collection');
@@ -51,6 +56,11 @@ class ProductVariantSpec extends ObjectBehavior
         $this->setPrice(499)->getPrice()->shouldReturn(499);
     }
 
+    function its_original_price_should_be_mutable()
+    {
+        $this->setOriginalPrice(399)->getOriginalPrice()->shouldReturn(399);
+    }
+
     function its_price_should_accept_only_integer()
     {
         $this->setPrice(410)->getPrice()->shouldBeInteger();
@@ -59,6 +69,16 @@ class ProductVariantSpec extends ObjectBehavior
         $this->shouldThrow('\InvalidArgumentException')->duringSetPrice(round(4.1 * 100));
         $this->shouldThrow('\InvalidArgumentException')->duringSetPrice(array(410));
         $this->shouldThrow('\InvalidArgumentException')->duringSetPrice(new \stdClass());
+    }
+
+    function its_original_price_should_accept_only_integer()
+    {
+        $this->setOriginalPrice(310)->getOriginalPrice()->shouldBeInteger();
+        $this->shouldThrow('\InvalidArgumentException')->duringSetOriginalPrice(3.1 * 100);
+        $this->shouldThrow('\InvalidArgumentException')->duringSetOriginalPrice('310');
+        $this->shouldThrow('\InvalidArgumentException')->duringSetOriginalPrice(round(3.1 * 100));
+        $this->shouldThrow('\InvalidArgumentException')->duringSetOriginalPrice(array(310));
+        $this->shouldThrow('\InvalidArgumentException')->duringSetOriginalPrice(new \stdClass());
     }
 
     function it_should_inherit_price_from_master_variant(ProductVariantInterface $masterVariant)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | 
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Added a crossed price attribute on every variant.

It works as amazon system price :
- the crossed one is overpriced
- the real one is normal

- [x] Add Field in DB
- [x] Add Backend display and fonctions
- [x] Add Frontend display and fonctions
- [x] Add Behat test
- [x] Add Phpspec test

**This development was sponsorised by Store Factory**