### PR TITLE
[Order] OrderListener exception message fix

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderPricingListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderPricingListener.php
@@ -50,7 +50,7 @@ class OrderPricingListener
         $order = $event->getSubject();
 
         if (!$order instanceof OrderInterface) {
-            throw new UnexpectedTypeException($order, 'Sylius\Component\Order\Model\OrderInterface');
+            throw new UnexpectedTypeException($order, 'Sylius\Component\Core\Model\OrderInterface');
         }
 
         $context = array();

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/OrderPricingListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/OrderPricingListenerSpec.php
@@ -32,7 +32,7 @@ class OrderPricingListenerSpec extends ObjectBehavior
     function it_should_throw_an_exception_if_its_subjet_is_not_order_interface(GenericEvent $event)
     {
         $wrongOrderClass = new \stdClass();
-        $exception = new UnexpectedTypeException($wrongOrderClass, 'Sylius\Component\Order\Model\OrderInterface');
+        $exception = new UnexpectedTypeException($wrongOrderClass, 'Sylius\Component\Core\Model\OrderInterface');
 
         $event->getSubject()->shouldBeCalled()->willReturn($wrongOrderClass);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

In a condition we expect instance of `Sylius\Component\Core\Model\OrderInterface` but exception has message about  `Sylius\Component\`**Order**`\Model\OrderInterface`.