### PR TITLE
[UserBundle] Fix mistype in registration route

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Resources/config/routing/registration.yml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/routing/registration.yml
@@ -7,5 +7,5 @@ sylius_user_registration:
             form: sylius_customer_registration
             event: register
             template: SyliusUserBundle::register.html.twig
-            redirect: referrer
+            redirect: referer
             permission: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

It went unnoticed, because SyliusWebBundle rewrites registration route.
