### PR TITLE
[FixturesBundle] - added missing taxonomies associations for channels sample data

### DIFF
--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadChannelData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadChannelData.php
@@ -28,10 +28,10 @@ class LoadChannelData extends DataFixture
     public function load(ObjectManager $manager)
     {
         $url = $this->container->getParameter('router.request_context.host');
-        $manager->persist($this->createChannel('WEB-UK', 'UK Webstore', $url, array('en_GB'), array('GBP'), array('DHL', 'UPS Ground'), array('Dummy', 'StripeCheckout')));
-        $manager->persist($this->createChannel('WEB-DE', 'Germany Webstore', null, array('de_DE'), array('EUR'), array('DHL', 'UPS Ground'), array('Dummy', 'StripeCheckout')));
-        $manager->persist($this->createChannel('WEB-US', 'United States Webstore', null, array('en_US'), array('USD'), array('FedEx', 'FedEx World Shipping'), array('Dummy', 'StripeCheckout')));
-        $manager->persist($this->createChannel('MOBILE', 'Mobile Store', null, array('en_GB', 'de_DE'), array('GBP', 'USD', 'EUR'), array('DHL', 'UPS Ground', 'FedEx'), array('Dummy', 'StripeCheckout')));
+        $manager->persist($this->createChannel('WEB-UK', 'UK Webstore', $url, array('en_GB'), array('GBP'), array('Category', 'Brand'), array('DHL', 'UPS Ground'), array('Dummy', 'StripeCheckout')));
+        $manager->persist($this->createChannel('WEB-DE', 'Germany Webstore', null, array('de_DE'), array('EUR'), array('Category', 'Brand'), array('DHL', 'UPS Ground'), array('Dummy', 'StripeCheckout')));
+        $manager->persist($this->createChannel('WEB-US', 'United States Webstore', null, array('en_US'), array('USD'), array('Category', 'Brand'), array('FedEx', 'FedEx World Shipping'), array('Dummy', 'StripeCheckout')));
+        $manager->persist($this->createChannel('MOBILE', 'Mobile Store', null, array('en_GB', 'de_DE'), array('GBP', 'USD', 'EUR'), array('Category', 'Brand'), array('DHL', 'UPS Ground', 'FedEx'), array('Dummy', 'StripeCheckout')));
 
         $manager->flush();
     }
@@ -45,15 +45,18 @@ class LoadChannelData extends DataFixture
     }
 
     /**
+     * @param string $code
      * @param string $name
+     * @param string $url
      * @param array  $locales
      * @param array  $currencies
+     * @param array  $taxonomies
      * @param array  $shippingMethods
      * @param array  $paymentMethods
      *
      * @return ChannelInterface
      */
-    protected function createChannel($code, $name, $url, array $locales = array(), array $currencies = array(), array $shippingMethods = array(), array $paymentMethods = array())
+    protected function createChannel($code, $name, $url, array $locales = array(), array $currencies = array(), array $taxonomies = array(), array $shippingMethods = array(), array $paymentMethods = array())
     {
         /** @var ChannelInterface $channel */
         $channel = $this->getChannelRepository()->createNew();
@@ -69,6 +72,9 @@ class LoadChannelData extends DataFixture
         }
         foreach ($currencies as $currency) {
             $channel->addCurrency($this->getReference('Sylius.Currency.'.$currency));
+        }
+        foreach ($taxonomies as $taxonomy) {
+            $channel->addTaxonomy($this->getReference('Sylius.Taxonomy.'.$taxonomy));
         }
         foreach ($shippingMethods as $shippingMethod) {
             $channel->addShippingMethod($this->getReference('Sylius.ShippingMethod.'.$shippingMethod));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

When executing doctrine:fixtures:load (or any superset like sylius:install), channels would be without any associated taxonomies.

This would result in missing taxonomies on frontend, and possibly other important places.

PR adds all taxonomies for all channels.

