### PR TITLE
[Sylius] - register DebugBundle by default in appKernel dev/test

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -28,6 +28,7 @@ class AppKernel extends Kernel
         );
 
         if (in_array($this->environment, array('dev', 'test'))) {
+            $bundles[] = new \Symfony\Bundle\DebugBundle\DebugBundle();
             $bundles[] = new \Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Enable debugBundle for dev/test environment by default
Many SF developers are used for the shorthand dump() function provided by debugBundle, and will register the bundle anyway.

This makes the DX better, as people will be able to use what they are used to.
