### PR TITLE
[InstallerBundle] - fixed recommended version of php lower then required

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Requirement/SettingsRequirements.php
+++ b/src/Sylius/Bundle/InstallerBundle/Requirement/SettingsRequirements.php
@@ -17,6 +17,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 class SettingsRequirements extends RequirementCollection
 {
     const REQUIRED_PHP_VERSION = '5.5.9';
+    const RECOMMENDED_PHP_VERSION = '5.6.13';
 
     public function __construct(TranslatorInterface $translator)
     {
@@ -34,8 +35,8 @@ class SettingsRequirements extends RequirementCollection
             ))
             ->add(new Requirement(
                 $translator->trans('sylius.settings.version_recommanded', array(), 'requirements'),
-                version_compare(phpversion(), '5.3.8', '>='),
-                '>=5.3.8',
+                version_compare(phpversion(), self::RECOMMENDED_PHP_VERSION, '>='),
+                '>='.self::RECOMMENDED_PHP_VERSION,
                 phpversion(),
                 false
             ))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Recommended version of was php lower then required,
required -> 5.5.9 
recommended -> 5.3.8

Also added constant for php recommended version RECOMMENDED_PHP_VERSION
set to 5.6.13, just because its current.

If anyone got suggestion what the recommended version should be, drop it here and I'll change it.