### PR TITLE
[Shipping] Allow prepare transition from backordered state to ready state

### DIFF
--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/state-machine.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/state-machine.yml
@@ -24,7 +24,7 @@ winzou_state_machine:
                 from: [checkout, onhold]
                 to:   backordered
             prepare:
-                from: [checkout, onhold]
+                from: [checkout, onhold, backordered]
                 to:   ready
             ship:
                 from: [ready]
@@ -65,7 +65,7 @@ winzou_state_machine:
                 from: [checkout, onhold]
                 to:   backordered
             prepare:
-                from: [checkout, onhold]
+                from: [checkout, onhold, backordered]
                 to:   ready
             ship:
                 from: [ready]


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | no
New feature?  | yes
BC breaks? | no
Deprecations? | no
Fixed tickets | no
License | MIT
Doc PR | -

I'm not very familiar with how state machines work, is this a correct way to add this transition?