### PR TITLE
Fix translation keys for backend customer macro

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/macros.html.twig
@@ -9,8 +9,8 @@
     <thead>
         <tr>
             <th>{{ sylius_resource_sort('id', 'sylius.customer.id'|trans) }}</th>
-            <th>{{ sylius_resource_sort('firstName', 'sylius.address.firstname'|trans) }}</th>
-            <th>{{ sylius_resource_sort('lastName', 'sylius.address.lastname'|trans) }}</th>
+            <th>{{ sylius_resource_sort('firstName', 'sylius.customer.first_name'|trans) }}</th>
+            <th>{{ sylius_resource_sort('lastName', 'sylius.customer.last_name'|trans) }}</th>
             <th>{{ sylius_resource_sort('email', 'sylius.customer.email'|trans) }}</th>
             <th>{{ sylius_resource_sort('user.createdAt', 'sylius.user.registration_date'|trans) }}</th>
             <th>{{ sylius_resource_sort('user.enabled', 'sylius.user.enabled'|trans) }}</th>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        |

Correct keys available at https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml#L972