### PR TITLE
Remove unnessary softdeleteable in CoreBundle User mappings

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/User.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/User.orm.xml
@@ -35,7 +35,6 @@
             </join-table>
         </many-to-many>
 
-        <gedmo:soft-deleteable field-name="deletedAt" />
     </mapped-superclass>
 
 </doctrine-mapping>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        |

While not exactly a bug, it have a great chance to become one. :)

Note that CoreBundle:Customer.orm.xml is correct and doesn't have softdeleteable duplication of mapping.