### PR TITLE
[Installer] Check cache permissions to avoid exception

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Command/AbstractInstallCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/AbstractInstallCommand.php
@@ -19,6 +19,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
 
 abstract class AbstractInstallCommand extends ContainerAwareCommand
 {
+    const APP_CACHE                 = 'app/cache/';
     const WEB_ASSETS_DIRECTORY      = 'web/assets/';
     const WEB_BUNDLES_DIRECTORY     = 'web/bundles/';
     const WEB_MEDIA_DIRECTORY       = 'web/media/';

--- a/src/Sylius/Bundle/InstallerBundle/Command/InstallCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/InstallCommand.php
@@ -68,6 +68,8 @@ EOT
         $output->writeln('<info>Installing Sylius...</info>');
         $output->writeln('');
 
+        $this->ensureDirectoryExistsAndIsWritable(self::APP_CACHE, $output);
+
         foreach ($this->commands as $step => $command) {
             try {
                 $output->writeln(sprintf('<comment>Step %d of %d.</comment> <info>%s</info>', $step+1, count($this->commands), $command['message']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |
| License       | MIT
| Doc PR        |

It uses previously implemented service to check ``app/cache`` permissions - unwritable cache caused fatal error.