### PR TITLE
Removed oauthAccounts since it is already defined in user bundle

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/User.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/User.orm.xml
@@ -18,11 +18,6 @@
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <mapped-superclass name="Sylius\Component\Core\Model\User" table="sylius_user">
-        <one-to-many field="oauthAccounts" target-entity="Sylius\Component\Core\Model\UserOAuthInterface" mapped-by="user">
-            <cascade>
-                <cascade-all />
-            </cascade>
-        </one-to-many>
 
         <many-to-many field="authorizationRoles" target-entity="Sylius\Component\Rbac\Model\RoleInterface">
             <join-table name="sylius_user_role">


### PR DESCRIPTION
I was getting:

```
MappingException: Property "oauthAccounts" in "Sylius\Component\Core\Model\User" was already declared, but it must be declared only once
```

Does not belong to this model, already defined in [User.orm.xml#L55](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/UserBundle/Resources/config/doctrine/model/User.orm.xml#L55).

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT
