### PR TITLE
[Payment] Missing payment state added

### DIFF
--- a/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentType.php
+++ b/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentType.php
@@ -42,6 +42,7 @@ class PaymentType extends AbstractResourceType
                     PaymentInterface::STATE_FAILED     => 'sylius.form.payment.state.failed',
                     PaymentInterface::STATE_VOID       => 'sylius.form.payment.state.void',
                     PaymentInterface::STATE_COMPLETED  => 'sylius.form.payment.state.completed',
+                    PaymentInterface::STATE_AUTHORIZED => 'sylius.form.payment.state.authorized',
                     PaymentInterface::STATE_NEW        => 'sylius.form.payment.state.new',
                     PaymentInterface::STATE_CANCELLED  => 'sylius.form.payment.state.cancelled',
                     PaymentInterface::STATE_REFUNDED   => 'sylius.form.payment.state.refunded',

--- a/src/Sylius/Bundle/PaymentBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/PaymentBundle/Resources/translations/messages.en.yml
@@ -18,6 +18,7 @@ sylius:
                 header: Payment state
                 checkout: Checkout
                 completed: Completed
+                authorized: Authorized
                 failed: Failed
                 new: New
                 pending: Pending


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

Payment has [authorization state](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Component/Payment/Model/PaymentInterface.php#L27) which was not reachable from [PaymentFormType](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentType.php#L39). I have added this state to form type choices. 