### PR TITLE
[Resource] Fix ObjectToIdentifierTransformer bad implementation

### DIFF
--- a/features/frontend/checkout_shipping.feature
+++ b/features/frontend/checkout_shipping.feature
@@ -100,3 +100,12 @@ Feature: Checkout shipping
          When I press "Continue"
          Then I should be on the checkout addressing step
           And "We're sorry" should appear on the page
+
+    Scenario: Returning to shipping method page
+        Given I go to the checkout start page
+          And I fill in the shipping address to United States
+          And I press "Continue"
+         When I select the "FedEx" radio button
+          And I press "Continue"
+          And I click "Back"
+         Then I should see "FedEx"

--- a/src/Sylius/Bundle/ResourceBundle/Form/DataTransformer/ObjectToIdentifierTransformer.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/DataTransformer/ObjectToIdentifierTransformer.php
@@ -18,29 +18,22 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
- * Object to id transformer.
- *
  * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
 class ObjectToIdentifierTransformer implements DataTransformerInterface
 {
     /**
-     * Repository.
-     *
      * @var ObjectRepository
      */
     protected $repository;
 
     /**
-     * Identifier.
-     *
      * @var string
      */
     protected $identifier;
 
     /**
-     * Constructor.
-     *
      * @param ObjectRepository $repository
      * @param string           $identifier
      */
@@ -54,6 +47,26 @@ class ObjectToIdentifierTransformer implements DataTransformerInterface
      * {@inheritdoc}
      */
     public function transform($value)
+    {
+        if (null === $value) {
+            return '';
+        }
+
+        $class = $this->repository->getClassName();
+
+        if (!$value instanceof $class) {
+            throw new UnexpectedTypeException($value, $class);
+        }
+
+        $accessor = PropertyAccess::createPropertyAccessor();
+
+        return $accessor->getValue($value, $this->identifier);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reverseTransform($value)
     {
         if (!$value) {
             return null;
@@ -69,25 +82,5 @@ class ObjectToIdentifierTransformer implements DataTransformerInterface
         }
 
         return $entity;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function reverseTransform($value)
-    {
-        if (null === $value) {
-            return '';
-        }
-
-        $class = $this->repository->getClassName();
-
-        if (!$value instanceof $class) {
-            throw new UnexpectedTypeException($value, $class);
-        }
-
-        $accessor = PropertyAccess::createPropertyAccessor();
-
-        return $accessor->getValue($value, $this->identifier);
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Form/DataTransformer/ObjectToIdentifierTransformerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Form/DataTransformer/ObjectToIdentifierTransformerSpec.php
@@ -22,40 +22,36 @@ class ObjectToIdentifierTransformerSpec extends ObjectBehavior
         $this->shouldHaveType('Sylius\Bundle\ResourceBundle\Form\DataTransformer\ObjectToIdentifierTransformer');
     }
 
-    function it_does_not_transform_null_value(ObjectRepository $repository)
+    function it_does_not_reverse_null_value(ObjectRepository $repository)
     {
         $repository->findOneBy(Argument::any())->shouldNotBeCalled();
 
-        $this->transform(null)->shouldReturn(null);
+        $this->reverseTransform(null)->shouldReturn(null);
     }
 
     function it_throws_an_exception_on_non_existing_entity(ObjectRepository $repository)
     {
-        $value = 6;
+        $repository->findOneBy(array('id' => 6))->shouldBeCalled()->willReturn(null);
 
-        $repository->findOneBy(array('id' => $value))->shouldBeCalled()->willReturn(null);
-
-        $this->shouldThrow('Symfony\Component\Form\Exception\TransformationFailedException')->duringTransform($value);
+        $this->shouldThrow('Symfony\Component\Form\Exception\TransformationFailedException')->during('reverseTransform', array(6));
     }
 
-    function it_transforms_identifier_in_entity(ObjectRepository $repository, FakeEntity $entity)
+    function it_reverses_identifier_in_entity(ObjectRepository $repository, FakeEntity $entity)
     {
-        $value = 5;
+        $repository->findOneBy(array('id' => 5))->shouldBeCalled()->willReturn($entity);
 
-        $repository->findOneBy(array('id' => $value))->shouldBeCalled()->willReturn($entity);
-
-        $this->transform($value)->shouldReturn($entity);
+        $this->reverseTransform(5)->shouldReturn($entity);
     }
 
-    function it_does_not_reverse_null_value()
+    function it_does_not_transform_null_value()
     {
-        $this->reverseTransform(null)->shouldReturn('');
+        $this->transform(null)->shouldReturn('');
     }
 
-    function it_reverses_entity_in_identifier(FakeEntity $value)
+    function it_transforms_entity_in_identifier(FakeEntity $value)
     {
         $value->getId()->shouldBeCalled()->willReturn(6);
 
-        $this->reverseTransform($value)->shouldReturn(6);
+        $this->transform($value)->shouldReturn(6);
     }
 }

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\ShippingBundle\Form\Type;
 
+use Sylius\Bundle\ResourceBundle\Form\DataTransformer\ObjectToIdentifierTransformer;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Shipping\Calculator\Registry\CalculatorRegistryInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
@@ -73,9 +74,7 @@ class ShippingMethodChoiceType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if ($options['multiple']) {
-            $builder->addModelTransformer(new CollectionToArrayTransformer());
-        }
+        $builder->addModelTransformer($this->getProperTransformer($options));
     }
 
     /**
@@ -149,5 +148,19 @@ class ShippingMethodChoiceType extends AbstractType
     public function getName()
     {
         return 'sylius_shipping_method_choice';
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return ObjectToIdentifierTransformer|CollectionToArrayTransformer
+     */
+    private function getProperTransformer(array $options)
+    {
+        if ($options['multiple']) {
+            return new CollectionToArrayTransformer();
+        }
+
+        return new ObjectToIdentifierTransformer($this->repository);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | https://github.com/Sylius/Sylius/issues/2979
| License       | MIT
| Doc PR        |

While fixing https://github.com/Sylius/Sylius/issues/2979 I realized, that ``ObjectToIdentifierTransformer`` has inversely implemented methods! It caused mentioned bug, but also some others. There is open PR for this issue (https://github.com/Sylius/Sylius/pull/3085) with implemented custom transformer, but I think it will be not necessary after accepting this one ;)