### PR TITLE
[Core] Fix problem authenticating with facebook

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/main.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/main.yml
@@ -88,6 +88,7 @@ hwi_oauth:
             client_id:     %sylius.oauth.facebook.clientid%
             client_secret: %sylius.oauth.facebook.clientsecret%
             scope:         "email"
+            infos_url:     "https://graph.facebook.com/me?fields=id,name,email"
             options:
                 display: popup
         google:


### PR DESCRIPTION
If you don't ask for the field "email" on facebook graph, sylius will crash trying to "INSERT INTO sylius_customer" with an empty e-mail where the field is required.