### PR TITLE
Made attribute bundle configuration methods protected

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/AttributeBundle/DependencyInjection/Configuration.php
@@ -52,7 +52,7 @@ class Configuration implements ConfigurationInterface
      *
      * @param ArrayNodeDefinition $node
      */
-    private function addValidationGroupsSection(ArrayNodeDefinition $node)
+    protected function addValidationGroupsSection(ArrayNodeDefinition $node)
     {
         $node
             ->children()
@@ -84,7 +84,7 @@ class Configuration implements ConfigurationInterface
      *
      * @param ArrayNodeDefinition $node
      */
-    private function addClassesSection(ArrayNodeDefinition $node)
+    protected function addClassesSection(ArrayNodeDefinition $node)
     {
         $node
             ->children()


### PR DESCRIPTION
The goal is to override them in extended classes.

I want to implement AttributeValueTranslation and avoid code duplication (continue to use the validation from parent, and just append 'translation' under 'attribute_value' key)