### PR TITLE
ShippingMethodChoiceType is not channel aware

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/ShipmentType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/ShipmentType.php
@@ -56,7 +56,6 @@ class ShipmentType extends AbstractType
                     'label'       => 'sylius.form.checkout.shipping_method',
                     'subject'     => $shipment,
                     'criteria'    => $criteria,
-                    'channel'     => $channel,
                     'expanded'    => true,
                     'constraints' => array(
                         $notBlank


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

I used to get:

```
The option "channel" does not exist. Known options are: "action", "attr", "auto_initialize", "block_name", "by_reference", "cascade_validation", "choice_list", "choices", "compound", "constraints", "criteria", "csrf_field_name", "csrf_message", "csrf_protection", "csrf_provider", "data", "data_class", "delete_button_render", "disabled", "empty_data", "empty_value", "error_bubbling", "error_mapping", "expanded", "extra_fields_message", "inherit_data", "intention", "invalid_message", "invalid_message_parameters", "label", "label_attr", "label_render", "mapped", "max_length", "method", "multiple", "pattern", "post_max_size_message", "preferred_choices", "property_path", "prototype_name", "read_only", "required", "subject", "translation_domain", "trim", "validation_groups", "virtual"
500 Internal Server Error - InvalidOptionsException
```