### PR TITLE
Flush only payments in PaymentProcessor

### DIFF
--- a/src/Sylius/Component/Core/OrderProcessing/PaymentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/PaymentProcessor.php
@@ -73,9 +73,9 @@ class PaymentProcessor implements PaymentProcessorInterface
     {
         foreach ($order->getPayments() as $payment) {
             $this->cancelPaymentStateIfNotStarted($payment);
-        }
 
-        $this->paymentManager->flush();
+            $this->paymentManager->flush($payment);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| License | MIT |

While I find it wrong to flush in `PaymentProcessor`, I find it even worse to flush everything.
I know it is not optimal to flush them one by one, but at least I am preventing `PaymentProcessor` to flush what shouldn't be flushed.
