### PR TITLE
Fix wrong transformer in LocaleChoiceType

### DIFF
--- a/src/Sylius/Bundle/LocaleBundle/Form/Type/LocaleChoiceType.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/Type/LocaleChoiceType.php
@@ -43,8 +43,6 @@ class LocaleChoiceType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         parent::buildForm($builder, $options);
-
-        $builder->addViewTransformer(new CollectionToArrayTransformer(), true);
     }
 
     /**


### PR DESCRIPTION
The `choice` field has `multiple` false by default, but the `sylius_locale_choice` was adding a wrong `CollectionToArray transformer`