### PR TITLE
[UserBundle] Fix flash messages on UserController

### DIFF
--- a/features/user/user_reset_password.feature
+++ b/features/user/user_reset_password.feature
@@ -17,7 +17,7 @@ Feature: Forgot password
          When I fill in "Email" with "bar@foo.com"
           And I press "Reset"
          Then I should be redirected to user login page
-          And I should see "Your password has been reset successfully!"
+          And I should see "We send you an email with instructions to reset your password!"
 
     Scenario: Trying to reset password without email
         Given I am on the sylius user request password reset token page

--- a/src/Sylius/Bundle/UserBundle/Controller/UserController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/UserController.php
@@ -128,7 +128,6 @@ class UserController extends ResourceController
             }
 
             $this->addFlash('error', 'sylius.user.email.not_exist');
-            $this->addFlash('error', 'sylius.user.password.request.failed');
         }
 
         if ($this->config->isApiRequest()) {

--- a/src/Sylius/Bundle/UserBundle/Controller/UserController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/UserController.php
@@ -128,7 +128,7 @@ class UserController extends ResourceController
             }
 
             $this->addFlash('error', 'sylius.user.email.not_exist');
-            $this->addFlash('error', 'sylius.user.password.reset.failed');
+            $this->addFlash('error', 'sylius.user.password.request.failed');
         }
 
         if ($this->config->isApiRequest()) {
@@ -194,7 +194,7 @@ class UserController extends ResourceController
         $user->setConfirmationToken($generator->generateUniqueToken());
         $user->setPasswordRequestedAt(new \DateTime());
 
-        $this->domainManager->update($user);
+        $this->domainManager->update($user, 'sylius.user.password.request.success');
 
         $dispatcher = $this->get('event_dispatcher');
         $dispatcher->dispatch($senderEvent, new GenericEvent($user));
@@ -202,8 +202,6 @@ class UserController extends ResourceController
         if ($this->config->isApiRequest()) {
             return $this->handleView($this->view($user, 204));
         }
-
-        $this->addFlash('success', 'sylius.user.password.reset.success');
 
         return new RedirectResponse($this->generateUrl('sylius_user_security_login'));
     }
@@ -223,14 +221,13 @@ class UserController extends ResourceController
         $dispatcher = $this->get('event_dispatcher');
         $dispatcher->dispatch(UserEvents::PRE_PASSWORD_RESET, new GenericEvent($user));
 
-        $this->domainManager->update($user);
+        $this->domainManager->update($user, 'sylius.user.password.reset.success');
 
         $dispatcher->dispatch(UserEvents::POST_PASSWORD_RESET, new GenericEvent($user));
 
         if ($this->config->isApiRequest()) {
             return $this->handleView($this->view($user, 204));
         }
-        $this->addFlash('success', 'sylius.user.password.change.success');
 
         return new RedirectResponse($this->generateUrl('sylius_user_security_login'));
     }
@@ -248,14 +245,13 @@ class UserController extends ResourceController
         $dispatcher = $this->get('event_dispatcher');
         $dispatcher->dispatch(UserEvents::PRE_PASSWORD_CHANGE, new GenericEvent($user));
 
-        $this->domainManager->update($user);
+        $this->domainManager->update($user, 'sylius.user.password.change.success');
 
         $dispatcher->dispatch(UserEvents::POST_PASSWORD_CHANGE, new GenericEvent($user));
-        
+
         if ($this->config->isApiRequest()) {
             return $this->handleView($this->view($user, 204));
         }
-        $this->addFlash('success', 'sylius.user.password.change.success');
 
         return new RedirectResponse($this->generateUrl('sylius_account_profile_show'));
     }

--- a/src/Sylius/Bundle/UserBundle/Form/EventListener/CustomerRegistrationFormListener.php
+++ b/src/Sylius/Bundle/UserBundle/Form/EventListener/CustomerRegistrationFormListener.php
@@ -26,7 +26,7 @@ class CustomerRegistrationFormListener implements EventSubscriberInterface
     /**
      * @var RepositoryInterface
      */
-    private $customerRepository;
+    protected $customerRepository;
 
     /**
      * @param RepositoryInterface $customerRepository

--- a/src/Sylius/Bundle/UserBundle/Resources/translations/flashes.en.yml
+++ b/src/Sylius/Bundle/UserBundle/Resources/translations/flashes.en.yml
@@ -6,7 +6,6 @@ sylius:
             invalid: Wrong current password.
             request:
                 success: We send you an email with instructions to reset your password!
-                failed: Failed to request password.
             reset:
                 success: Your password has been reset successfully!
             change:

--- a/src/Sylius/Bundle/UserBundle/Resources/translations/flashes.en.yml
+++ b/src/Sylius/Bundle/UserBundle/Resources/translations/flashes.en.yml
@@ -4,8 +4,10 @@ sylius:
             not_exist: User with this email does not exist.
         password:
             invalid: Wrong current password.
+            request:
+                success: We send you an email with instructions to reset your password!
+                failed: Failed to request password.
             reset:
                 success: Your password has been reset successfully!
-                failed: Failed to reset password.
             change:
                 success: Your password has been changed successfully!

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/frontend/user.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/frontend/user.yml
@@ -7,8 +7,10 @@ sylius_user_registration:
             form: sylius_customer_registration
             event: register
             template: SyliusWebBundle:Frontend/User:register.html.twig
-            redirect: sylius_homepage
             permission: false
+            redirect:
+                route: sylius_homepage
+                parameters: { email: resource.email }
 
 sylius_login:
     resource: @SyliusUserBundle/Resources/config/routing/security.yml


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Hi, this PR fix some issues when user change, request or reset password.

Now, two flash messages are shown, <code>User has been successfully updated</code> and another message depending of the action, this PR avoid the apparition of the first message and change some translations related to these actions.