### PR TITLE
[ReportBundle] Remove wrong translation

### DIFF
--- a/src/Sylius/Bundle/ReportBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/ReportBundle/Resources/translations/messages.en.yml
@@ -1,12 +1,5 @@
 sylius:
     form:
-        rule:
-            item_count_configuration:
-                count: sylius.form.rule.item_count_configuration.count   # FIXME
-                equal: sylius.form.rule.item_count_configuration.equal   # FIXME
-
-            type: sylius.form.rule.type   # FIXME
-
         report:
             name: Name
             description: Description


### PR DESCRIPTION
Hi,

Remove wrong translation from report bundle.
It's promotion bundle ones, but they already exists in this bundle.

So I remove them.