### PR TITLE
[Taxonomy] [RFC] Constructor for the Taxonomy model

### DIFF
--- a/src/Sylius/Bundle/TaxonomyBundle/Behat/TaxonomyContext.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Behat/TaxonomyContext.php
@@ -35,8 +35,8 @@ class TaxonomyContext extends DefaultContext
     public function thereIsTaxonomy($name, $code, $flush = true)
     {
         $taxonomy = $this->getFactory('taxonomy')->createNew();
-        $taxonomy->setName($name);
         $taxonomy->getRoot()->setCode($code);
+        $taxonomy->setName($name);
 
         if (null === $taxonomy->getCurrentLocale()) {
             $taxonomy->setCurrentLocale('en_US');

--- a/src/Sylius/Bundle/TaxonomyBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\TaxonomyBundle\DependencyInjection;
 
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Sylius\Component\Resource\Factory\Factory;
+use Sylius\Component\Taxonomy\Factory\TaxonomyFactory;
 use Sylius\Component\Translation\Factory\TranslatableFactory;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Bundle\ResourceBundle\Form\Type\ResourceChoiceType;
@@ -82,7 +83,7 @@ class Configuration implements ConfigurationInterface
                                         ->scalarNode('interface')->defaultValue(TaxonomyInterface::class)->cannotBeEmpty()->end()
                                         ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
                                         ->scalarNode('repository')->cannotBeEmpty()->end()
-                                        ->scalarNode('factory')->defaultValue(TranslatableFactory::class)->end()
+                                        ->scalarNode('factory')->defaultValue(TaxonomyFactory::class)->end()
                                         ->arrayNode('form')
                                             ->addDefaultsIfNotSet()
                                             ->children()

--- a/src/Sylius/Bundle/TaxonomyBundle/DependencyInjection/SyliusTaxonomyExtension.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/DependencyInjection/SyliusTaxonomyExtension.php
@@ -15,6 +15,8 @@ use Sylius\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractResourceE
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Parameter;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Taxonomy extension.
@@ -42,5 +44,11 @@ class SyliusTaxonomyExtension extends AbstractResourceExtension
         foreach ($configFiles as $configFile) {
             $loader->load($configFile);
         }
+
+        $container
+            ->getDefinition('sylius.factory.taxonomy')
+            ->addArgument(new Reference('sylius.factory.taxon'))
+            ->addArgument(new Parameter('sylius.model.taxonomy.class'))
+        ;
     }
 }

--- a/src/Sylius/Bundle/TaxonomyBundle/DependencyInjection/SyliusTaxonomyExtension.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/DependencyInjection/SyliusTaxonomyExtension.php
@@ -15,8 +15,11 @@ use Sylius\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractResourceE
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\DependencyInjection\Parameter;
+use Sylius\Component\Resource\Factory\Factory;
+use Sylius\Component\Translation\Factory\TranslatableFactory;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Parameter;
 
 /**
  * Taxonomy extension.
@@ -45,10 +48,31 @@ class SyliusTaxonomyExtension extends AbstractResourceExtension
             $loader->load($configFile);
         }
 
-        $container
-            ->getDefinition('sylius.factory.taxonomy')
-            ->addArgument(new Reference('sylius.factory.taxon'))
-            ->addArgument(new Parameter('sylius.model.taxonomy.class'))
-        ;
+        $factoryDefinition = new Definition(Factory::class);
+        $factoryDefinition->setArguments(
+            array(
+                new Parameter('sylius.model.taxonomy.class')
+            )
+        );
+
+        $translatableFactoryDefinition = $container->getDefinition('sylius.factory.taxonomy');
+        $taxonomyFactoryClass = $translatableFactoryDefinition->getClass();
+        $translatableFactoryDefinition->setClass(TranslatableFactory::class);
+        $translatableFactoryDefinition->setArguments(
+            array(
+                $factoryDefinition,
+                new Reference('sylius.translation.locale_provider')
+            )
+        );
+
+        $decoratedTaxonomyFactoryDefinition = new Definition($taxonomyFactoryClass);
+        $decoratedTaxonomyFactoryDefinition->setArguments(
+            array(
+                $translatableFactoryDefinition,
+                new Reference('sylius.factory.taxon')
+            )
+        );
+
+        $container->setDefinition('sylius.factory.taxonomy', $decoratedTaxonomyFactoryDefinition);
     }
 }

--- a/src/Sylius/Bundle/TaxonomyBundle/SyliusTaxonomyBundle.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/SyliusTaxonomyBundle.php
@@ -11,10 +11,12 @@
 
 namespace Sylius\Bundle\TaxonomyBundle;
 
+use Sylius\Bundle\TaxonomyBundle\DependencyInjection\Compiler\ServicesPass;
 use Sylius\Bundle\ResourceBundle\AbstractResourceBundle;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Sylius\Component\Taxonomy\Model\TaxonInterface;
 use Sylius\Component\Taxonomy\Model\TaxonomyInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Flexible categorization system.

--- a/src/Sylius/Component/Core/Model/Taxonomy.php
+++ b/src/Sylius/Component/Core/Model/Taxonomy.php
@@ -22,8 +22,6 @@ class Taxonomy extends BaseTaxonomy
     public function __construct()
     {
         parent::__construct();
-
-        $this->setRoot(new Taxon());
     }
 
     /**

--- a/src/Sylius/Component/Core/spec/Model/TaxonomySpec.php
+++ b/src/Sylius/Component/Core/spec/Model/TaxonomySpec.php
@@ -13,6 +13,7 @@ namespace spec\Sylius\Component\Core\Model;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Taxonomy\Model\TaxonomyInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
 
 class TaxonomySpec extends ObjectBehavior
 {
@@ -24,10 +25,5 @@ class TaxonomySpec extends ObjectBehavior
     function it_is_Sylius_Taxonomy()
     {
         $this->shouldImplement(TaxonomyInterface::class);
-    }
-
-    function it_should_not_path_defined_by_default()
-    {
-        $this->getRoot()->getPath()->shouldReturn(null);
     }
 }

--- a/src/Sylius/Component/Taxonomy/Factory/TaxonomyFactory.php
+++ b/src/Sylius/Component/Taxonomy/Factory/TaxonomyFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Taxonomy\Factory;
+
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\Component\Taxonomy\Model\TaxonomyInterface;
+use Sylius\Component\Translation\Factory\TranslatableFactory;
+use Sylius\Component\Translation\Provider\LocaleProviderInterface;
+
+/**
+ * @author Magdalena Banasiak <magdalena.banasiak@lakion.com>
+ */
+class TaxonomyFactory extends TranslatableFactory implements FactoryInterface
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $taxonFactory;
+
+    /**
+     * @var string
+     */
+    private $className;
+
+    /**
+     * @param FactoryInterface $taxonFactory
+     */
+    public function __construct(
+        FactoryInterface $translatableResourceFactory,
+        LocaleProviderInterface $localeProvider,
+        FactoryInterface $taxonFactory,
+        $className
+    ) {
+        $this->taxonFactory = $taxonFactory;
+        $this->className = $className;
+
+        parent::__construct($translatableResourceFactory, $localeProvider);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createNew()
+    {
+        $taxon = $this->taxonFactory->createNew();
+
+        $taxonomy = parent::createNew();
+        $taxonomy->setRoot($taxon);
+
+        return $taxonomy;
+    }
+}

--- a/src/Sylius/Component/Taxonomy/Factory/TaxonomyFactory.php
+++ b/src/Sylius/Component/Taxonomy/Factory/TaxonomyFactory.php
@@ -12,14 +12,11 @@
 namespace Sylius\Component\Taxonomy\Factory;
 
 use Sylius\Component\Resource\Factory\FactoryInterface;
-use Sylius\Component\Taxonomy\Model\TaxonomyInterface;
-use Sylius\Component\Translation\Factory\TranslatableFactory;
-use Sylius\Component\Translation\Provider\LocaleProviderInterface;
 
 /**
  * @author Magdalena Banasiak <magdalena.banasiak@lakion.com>
  */
-class TaxonomyFactory extends TranslatableFactory implements FactoryInterface
+class TaxonomyFactory implements FactoryInterface
 {
     /**
      * @var FactoryInterface
@@ -27,23 +24,19 @@ class TaxonomyFactory extends TranslatableFactory implements FactoryInterface
     private $taxonFactory;
 
     /**
-     * @var string
+     * @var FactoryInterface
      */
-    private $className;
+    private $translatableFactory;
 
     /**
      * @param FactoryInterface $taxonFactory
      */
     public function __construct(
-        FactoryInterface $translatableResourceFactory,
-        LocaleProviderInterface $localeProvider,
-        FactoryInterface $taxonFactory,
-        $className
+        FactoryInterface $translatableFactory,
+        FactoryInterface $taxonFactory
     ) {
+        $this->translatableFactory = $translatableFactory;
         $this->taxonFactory = $taxonFactory;
-        $this->className = $className;
-
-        parent::__construct($translatableResourceFactory, $localeProvider);
     }
 
     /**
@@ -53,7 +46,7 @@ class TaxonomyFactory extends TranslatableFactory implements FactoryInterface
     {
         $taxon = $this->taxonFactory->createNew();
 
-        $taxonomy = parent::createNew();
+        $taxonomy = $this->translatableFactory->createNew();
         $taxonomy->setRoot($taxon);
 
         return $taxonomy;

--- a/src/Sylius/Component/Taxonomy/Model/Taxonomy.php
+++ b/src/Sylius/Component/Taxonomy/Model/Taxonomy.php
@@ -32,6 +32,18 @@ class Taxonomy extends AbstractTranslatable implements TaxonomyInterface
     protected $root;
 
     /**
+     * @param TaxonInterface $root
+     */
+    public function __construct(TaxonInterface $root = null)
+    {
+        parent::__construct();
+
+        if (null !== $root) {
+            $this->setRoot($root);
+        }
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function __toString()

--- a/src/Sylius/Component/Taxonomy/Model/Taxonomy.php
+++ b/src/Sylius/Component/Taxonomy/Model/Taxonomy.php
@@ -32,18 +32,6 @@ class Taxonomy extends AbstractTranslatable implements TaxonomyInterface
     protected $root;
 
     /**
-     * @param TaxonInterface $root
-     */
-    public function __construct(TaxonInterface $root = null)
-    {
-        parent::__construct();
-
-        if (null !== $root) {
-            $this->setRoot($root);
-        }
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function __toString()

--- a/src/Sylius/Component/Taxonomy/spec/Factory/TaxonomyFactorySpec.php
+++ b/src/Sylius/Component/Taxonomy/spec/Factory/TaxonomyFactorySpec.php
@@ -16,16 +16,15 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Taxonomy\Model\TaxonInterface;
 use Sylius\Component\Taxonomy\Model\TaxonomyInterface;
 use Sylius\Component\Translation\Factory\TranslatableFactoryInterface;
-use Sylius\Component\Translation\Provider\LocaleProviderInterface;
 
 /**
  * @author Magdalena Banasiak <magdalena.banasiak@lakion.com>
  */
 class TaxonomyFactorySpec extends ObjectBehavior
 {
-    function let(FactoryInterface $taxonFactory, FactoryInterface $factory, LocaleProviderInterface $localeProvider)
+    function let(TranslatableFactoryInterface $translatableFactory, FactoryInterface $taxonFactory)
     {
-        $this->beConstructedWith($factory, $localeProvider, $taxonFactory, 'Sylius\Component\Taxonomy\Model\Taxonomy');
+        $this->beConstructedWith($translatableFactory, $taxonFactory);
     }
 
     function it_is_initializable()
@@ -36,5 +35,19 @@ class TaxonomyFactorySpec extends ObjectBehavior
     function it_implements_factory_interface()
     {
         $this->shouldImplement(FactoryInterface::class);
+    }
+    
+    function it_creates_new_taxonomy_with_root(
+        TaxonInterface $taxon,
+        TaxonomyInterface $taxonomy,
+        FactoryInterface $taxonFactory,
+        TranslatableFactoryInterface $translatableFactory
+    ) {
+        $taxonFactory->createNew()->shouldBeCalled()->willReturn($taxon);
+        
+        $translatableFactory->createNew()->shouldBeCalled()->willReturn($taxonomy);
+        $taxonomy->setRoot($taxon)->shouldBeCalled();
+        
+        $this->createNew()->shouldReturn($taxonomy);
     }
 }

--- a/src/Sylius/Component/Taxonomy/spec/Factory/TaxonomyFactorySpec.php
+++ b/src/Sylius/Component/Taxonomy/spec/Factory/TaxonomyFactorySpec.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Taxonomy\Factory;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\Component\Taxonomy\Model\TaxonInterface;
+use Sylius\Component\Taxonomy\Model\TaxonomyInterface;
+use Sylius\Component\Translation\Factory\TranslatableFactoryInterface;
+use Sylius\Component\Translation\Provider\LocaleProviderInterface;
+
+/**
+ * @author Magdalena Banasiak <magdalena.banasiak@lakion.com>
+ */
+class TaxonomyFactorySpec extends ObjectBehavior
+{
+    function let(FactoryInterface $taxonFactory, FactoryInterface $factory, LocaleProviderInterface $localeProvider)
+    {
+        $this->beConstructedWith($factory, $localeProvider, $taxonFactory, 'Sylius\Component\Taxonomy\Model\Taxonomy');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Taxonomy\Factory\TaxonomyFactory');
+    }
+
+    function it_implements_factory_interface()
+    {
+        $this->shouldImplement(FactoryInterface::class);
+    }
+}


### PR DESCRIPTION
| Q                    | A
| -------------       | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #2884 #2557 
| License       | MIT

While using component independently, if we wanted to use ``$taxonomy = new Taxonomy()`` we would get an error, because we are not setting the root taxon while creating a new Taxonomy. Therefore I suppose we need a constructor.
