### PR TITLE
Made ChannelContext-related computations lazy-loaded

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -436,7 +436,7 @@
 
         <service id="sylius.context.channel" class="%sylius.context.channel.class%">
             <argument type="service" id="sylius.channel_resolver" />
-            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="50" />
+            <argument type="service" id="request_stack" />
         </service>
 
         <service id="sylius.channel_resolver" class="Sylius\Component\Core\Channel\ChannelResolver">


### PR DESCRIPTION
The app was crashing if there were Sylius bundles loaded whereas there was no channel in the database. Made `ChannelContext`-related computations lazy-loaded.