### PR TITLE
[User] Added missing unique indexes on customer.email and emailCanonical

### DIFF
--- a/app/migrations/Version20151024153713.php
+++ b/app/migrations/Version20151024153713.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20151024153713 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_7E82D5E6E7927C74 ON sylius_customer (email)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_7E82D5E6A0D96FBF ON sylius_customer (email_canonical)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX UNIQ_7E82D5E6E7927C74 ON sylius_customer');
+        $this->addSql('DROP INDEX UNIQ_7E82D5E6A0D96FBF ON sylius_customer');
+    }
+}

--- a/src/Sylius/Bundle/UserBundle/Resources/config/doctrine/model/Customer.orm.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/doctrine/model/Customer.orm.xml
@@ -22,8 +22,8 @@
             <generator strategy="AUTO" />
         </id>
 
-        <field name="email" column="email" type="string" nullable="false" />
-        <field name="emailCanonical" column="email_canonical" type="string" nullable="false" />
+        <field name="email" column="email" type="string" nullable="false" unique="true" />
+        <field name="emailCanonical" column="email_canonical" type="string" nullable="false" unique="true" />
 
         <field name="firstName" column="first_name" type="string" nullable="true" />
         <field name="lastName" column="last_name" type="string" nullable="true" />


### PR DESCRIPTION
Import a million users to your database and you'll really need this index...

user.username and usernameCanonical seem to be nullable? so I haven't added any to this, although customer.email will be where db queries are mainly run against anyway.