### PR TITLE
[User] Decoupled password encoders and updaters from UserInterface

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Security/UserPasswordEncoder.php
+++ b/src/Sylius/Bundle/UserBundle/Security/UserPasswordEncoder.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\UserBundle\Security;
 
+use Sylius\Component\User\Model\CredentialingInterface;
 use Sylius\Component\User\Model\UserInterface;
 use Sylius\Component\User\Security\UserPasswordEncoderInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
@@ -36,7 +37,7 @@ class UserPasswordEncoder implements UserPasswordEncoderInterface
     /**
      * {@inheritdoc}
      */
-    public function encode(UserInterface $user)
+    public function encode(CredentialingInterface $user)
     {
         $encoder = $this->encoderFactory->getEncoder($user);
 

--- a/src/Sylius/Bundle/UserBundle/Security/UserPasswordEncoder.php
+++ b/src/Sylius/Bundle/UserBundle/Security/UserPasswordEncoder.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\UserBundle\Security;
 
-use Sylius\Component\User\Model\CredentialingInterface;
+use Sylius\Component\User\Model\CredentialsHolderInterface;
 use Sylius\Component\User\Security\UserPasswordEncoderInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
@@ -36,7 +36,7 @@ class UserPasswordEncoder implements UserPasswordEncoderInterface
     /**
      * {@inheritdoc}
      */
-    public function encode(CredentialingInterface $user)
+    public function encode(CredentialsHolderInterface $user)
     {
         $encoder = $this->encoderFactory->getEncoder(get_class($user));
 

--- a/src/Sylius/Bundle/UserBundle/Security/UserPasswordEncoder.php
+++ b/src/Sylius/Bundle/UserBundle/Security/UserPasswordEncoder.php
@@ -12,7 +12,6 @@
 namespace Sylius\Bundle\UserBundle\Security;
 
 use Sylius\Component\User\Model\CredentialingInterface;
-use Sylius\Component\User\Model\UserInterface;
 use Sylius\Component\User\Security\UserPasswordEncoderInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
@@ -39,7 +38,7 @@ class UserPasswordEncoder implements UserPasswordEncoderInterface
      */
     public function encode(CredentialingInterface $user)
     {
-        $encoder = $this->encoderFactory->getEncoder($user);
+        $encoder = $this->encoderFactory->getEncoder(get_class($user));
 
         return $encoder->encodePassword($user->getPlainPassword(), $user->getSalt());
     }

--- a/src/Sylius/Bundle/UserBundle/spec/Security/UserPasswordEncoderSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/Security/UserPasswordEncoderSpec.php
@@ -13,7 +13,7 @@ namespace spec\Sylius\Bundle\UserBundle\Security;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Sylius\Component\User\Model\CredentialingInterface;
+use Sylius\Component\User\Model\CredentialsHolderInterface;
 use Sylius\Component\User\Model\UserInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
@@ -38,7 +38,7 @@ class UserPasswordEncoderSpec extends ObjectBehavior
         $this->shouldImplement('Sylius\Component\User\Security\UserPasswordEncoderInterface');
     }
 
-    function it_encodes_password(EncoderFactoryInterface $encoderFactory, PasswordEncoderInterface $passwordEncoder, CredentialingInterface $user)
+    function it_encodes_password(EncoderFactoryInterface $encoderFactory, PasswordEncoderInterface $passwordEncoder, CredentialsHolderInterface $user)
     {
         $user->getPlainPassword()->willReturn('topSecretPlainPassword');
         $user->getSalt()->willReturn('typicalSalt');

--- a/src/Sylius/Bundle/UserBundle/spec/Security/UserPasswordEncoderSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/Security/UserPasswordEncoderSpec.php
@@ -13,6 +13,7 @@ namespace spec\Sylius\Bundle\UserBundle\Security;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Sylius\Component\User\Model\CredentialingInterface;
 use Sylius\Component\User\Model\UserInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
@@ -37,11 +38,11 @@ class UserPasswordEncoderSpec extends ObjectBehavior
         $this->shouldImplement('Sylius\Component\User\Security\UserPasswordEncoderInterface');
     }
 
-    function it_encodes_password(EncoderFactoryInterface $encoderFactory, PasswordEncoderInterface $passwordEncoder, UserInterface $user)
+    function it_encodes_password(EncoderFactoryInterface $encoderFactory, PasswordEncoderInterface $passwordEncoder, CredentialingInterface $user)
     {
         $user->getPlainPassword()->willReturn('topSecretPlainPassword');
         $user->getSalt()->willReturn('typicalSalt');
-        $encoderFactory->getEncoder($user)->willReturn($passwordEncoder);
+        $encoderFactory->getEncoder(get_class($user->getWrappedObject()))->willReturn($passwordEncoder);
         $passwordEncoder->encodePassword('topSecretPlainPassword', 'typicalSalt')->willReturn('topSecretEncodedPassword');
 
         $this->encode($user)->shouldReturn('topSecretEncodedPassword');

--- a/src/Sylius/Component/User/Model/CredentialingInterface.php
+++ b/src/Sylius/Component/User/Model/CredentialingInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Sylius\Component\User\Model;
+
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+interface CredentialingInterface
+{
+    /**
+     * @return string
+     */
+    public function getPlainPassword();
+
+    /**
+     * @param string $plainPassword
+     */
+    public function setPlainPassword($plainPassword);
+
+    /**
+     * Returns the password used to authenticate the user.
+     *
+     * This should be the encoded password. On authentication, a plain-text
+     * password will be salted, encoded, and then compared to this value.
+     *
+     * @return string
+     */
+    public function getPassword();
+
+    /**
+     * @param string $encodedPassword
+     */
+    public function setPassword($encodedPassword);
+
+    /**
+     * Returns the salt that was originally used to encode the password.
+     *
+     * This can return null if the password was not encoded using a salt.
+     *
+     * @return string|null
+     */
+    public function getSalt();
+
+    /**
+     * Removes sensitive data from the user.
+     *
+     * This is important if, at any given point, sensitive information like
+     * the plain-text password is stored on this object.
+     */
+    public function eraseCredentials();
+}

--- a/src/Sylius/Component/User/Model/CredentialsHolderInterface.php
+++ b/src/Sylius/Component/User/Model/CredentialsHolderInterface.php
@@ -5,7 +5,7 @@ namespace Sylius\Component\User\Model;
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-interface CredentialingInterface
+interface CredentialsHolderInterface
 {
     /**
      * @return string

--- a/src/Sylius/Component/User/Model/UserInterface.php
+++ b/src/Sylius/Component/User/Model/UserInterface.php
@@ -81,23 +81,6 @@ interface UserInterface extends AdvancedUserInterface, CredentialingInterface, \
     public function setUsernameCanonical($usernameCanonical);
 
     /**
-     * @return string
-     */
-    public function getPlainPassword();
-
-    /**
-     * @param string $password
-     */
-    public function setPlainPassword($password);
-
-    /**
-     * Sets the hashed password.
-     *
-     * @param string $password
-     */
-    public function setPassword($password);
-
-    /**
      * @param boolean $enabled
      */
     public function setEnabled($enabled);

--- a/src/Sylius/Component/User/Model/UserInterface.php
+++ b/src/Sylius/Component/User/Model/UserInterface.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Core\User\AdvancedUserInterface;
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
  */
-interface UserInterface extends AdvancedUserInterface, \Serializable, TimestampableInterface, SoftDeletableInterface
+interface UserInterface extends AdvancedUserInterface, CredentialingInterface, \Serializable, TimestampableInterface, SoftDeletableInterface
 {
     const DEFAULT_ROLE = 'ROLE_USER';
     /**

--- a/src/Sylius/Component/User/Model/UserInterface.php
+++ b/src/Sylius/Component/User/Model/UserInterface.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Core\User\AdvancedUserInterface;
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
  */
-interface UserInterface extends AdvancedUserInterface, CredentialingInterface, \Serializable, TimestampableInterface, SoftDeletableInterface
+interface UserInterface extends AdvancedUserInterface, CredentialsHolderInterface, \Serializable, TimestampableInterface, SoftDeletableInterface
 {
     const DEFAULT_ROLE = 'ROLE_USER';
     /**

--- a/src/Sylius/Component/User/Security/PasswordUpdater.php
+++ b/src/Sylius/Component/User/Security/PasswordUpdater.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Component\User\Security;
 
-use Sylius\Component\User\Model\CredentialingInterface;
+use Sylius\Component\User\Model\CredentialsHolderInterface;
 
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
@@ -32,7 +32,7 @@ class PasswordUpdater implements PasswordUpdaterInterface
     /**
      * {@inheritDoc}
      */
-    public function updatePassword(CredentialingInterface $user)
+    public function updatePassword(CredentialsHolderInterface $user)
     {
         if (0 !== strlen($password = $user->getPlainPassword())) {
             $user->setPassword($this->userPasswordEncoder->encode($user));

--- a/src/Sylius/Component/User/Security/PasswordUpdater.php
+++ b/src/Sylius/Component/User/Security/PasswordUpdater.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Component\User\Security;
 
-use Sylius\Component\User\Model\UserInterface;
+use Sylius\Component\User\Model\CredentialingInterface;
 
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
@@ -32,7 +32,7 @@ class PasswordUpdater implements PasswordUpdaterInterface
     /**
      * {@inheritDoc}
      */
-    public function updatePassword(UserInterface $user)
+    public function updatePassword(CredentialingInterface $user)
     {
         if (0 !== strlen($password = $user->getPlainPassword())) {
             $user->setPassword($this->userPasswordEncoder->encode($user));

--- a/src/Sylius/Component/User/Security/PasswordUpdaterInterface.php
+++ b/src/Sylius/Component/User/Security/PasswordUpdaterInterface.php
@@ -11,12 +11,12 @@
 
 namespace Sylius\Component\User\Security;
 
-use Sylius\Component\User\Model\CredentialingInterface;
+use Sylius\Component\User\Model\CredentialsHolderInterface;
 
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
 interface PasswordUpdaterInterface
 {
-    public function updatePassword(CredentialingInterface $user);
+    public function updatePassword(CredentialsHolderInterface $user);
 }

--- a/src/Sylius/Component/User/Security/PasswordUpdaterInterface.php
+++ b/src/Sylius/Component/User/Security/PasswordUpdaterInterface.php
@@ -11,12 +11,12 @@
 
 namespace Sylius\Component\User\Security;
 
-use Sylius\Component\User\Model\UserInterface;
+use Sylius\Component\User\Model\CredentialingInterface;
 
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
 interface PasswordUpdaterInterface
 {
-    public function updatePassword(UserInterface $user);
+    public function updatePassword(CredentialingInterface $user);
 }

--- a/src/Sylius/Component/User/Security/UserPasswordEncoderInterface.php
+++ b/src/Sylius/Component/User/Security/UserPasswordEncoderInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\User\Security;
 
+use Sylius\Component\User\Model\CredentialingInterface;
 use Sylius\Component\User\Model\UserInterface;
 
 /**
@@ -21,9 +22,9 @@ interface UserPasswordEncoderInterface
     /**
      * Encodes the user plain password.
      *
-     * @param UserInterface $user
+     * @param CredentialingInterface $user
      *
      * @return string The encoded password
      */
-    public function encode(UserInterface $user);
+    public function encode(CredentialingInterface $user);
 }

--- a/src/Sylius/Component/User/Security/UserPasswordEncoderInterface.php
+++ b/src/Sylius/Component/User/Security/UserPasswordEncoderInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Component\User\Security;
 
-use Sylius\Component\User\Model\CredentialingInterface;
+use Sylius\Component\User\Model\CredentialsHolderInterface;
 use Sylius\Component\User\Model\UserInterface;
 
 /**
@@ -22,9 +22,9 @@ interface UserPasswordEncoderInterface
     /**
      * Encodes the user plain password.
      *
-     * @param CredentialingInterface $user
+     * @param CredentialsHolderInterface $user
      *
      * @return string The encoded password
      */
-    public function encode(CredentialingInterface $user);
+    public function encode(CredentialsHolderInterface $user);
 }

--- a/src/Sylius/Component/User/Security/UserPbkdf2PasswordEncoder.php
+++ b/src/Sylius/Component/User/Security/UserPbkdf2PasswordEncoder.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Component\User\Security;
 
-use Sylius\Component\User\Model\UserInterface;
+use Sylius\Component\User\Model\CredentialingInterface;
 
 /**
  * Pbkdf2PasswordEncoder uses the PBKDF2 (Password-Based Key Derivation Function 2).
@@ -70,7 +70,7 @@ class UserPbkdf2PasswordEncoder implements UserPasswordEncoderInterface
      *
      * @throws \LogicException when the algorithm is not supported
      */
-    public function encode(UserInterface $user)
+    public function encode(CredentialingInterface $user)
     {
         return $this->encodePassword($user->getPlainPassword(), $user->getSalt());
     }

--- a/src/Sylius/Component/User/Security/UserPbkdf2PasswordEncoder.php
+++ b/src/Sylius/Component/User/Security/UserPbkdf2PasswordEncoder.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Component\User\Security;
 
-use Sylius\Component\User\Model\CredentialingInterface;
+use Sylius\Component\User\Model\CredentialsHolderInterface;
 
 /**
  * Pbkdf2PasswordEncoder uses the PBKDF2 (Password-Based Key Derivation Function 2).
@@ -70,7 +70,7 @@ class UserPbkdf2PasswordEncoder implements UserPasswordEncoderInterface
      *
      * @throws \LogicException when the algorithm is not supported
      */
-    public function encode(CredentialingInterface $user)
+    public function encode(CredentialsHolderInterface $user)
     {
         return $this->encodePassword($user->getPlainPassword(), $user->getSalt());
     }

--- a/src/Sylius/Component/User/spec/Security/PasswordUpdaterSpec.php
+++ b/src/Sylius/Component/User/spec/Security/PasswordUpdaterSpec.php
@@ -13,7 +13,7 @@ namespace spec\Sylius\Component\User\Security;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Sylius\Component\User\Model\CredentialingInterface;
+use Sylius\Component\User\Model\CredentialsHolderInterface;
 use Sylius\Component\User\Security\UserPasswordEncoderInterface;
 
 /**
@@ -36,7 +36,7 @@ class PasswordUpdaterSpec extends ObjectBehavior
         $this->shouldImplement('Sylius\Component\User\Security\PasswordUpdaterInterface');
     }
 
-    function it_updates_user_profile_with_encoded_password(UserPasswordEncoderInterface $userPasswordEncoder, CredentialingInterface $user)
+    function it_updates_user_profile_with_encoded_password(UserPasswordEncoderInterface $userPasswordEncoder, CredentialsHolderInterface $user)
     {
         $user->getPlainPassword()->willReturn('topSecretPlainPassword');
 
@@ -48,7 +48,7 @@ class PasswordUpdaterSpec extends ObjectBehavior
         $this->updatePassword($user);
     }
 
-    function it_does_nothing_if_plain_password_is_empty(UserPasswordEncoderInterface $userPasswordEncoder, CredentialingInterface $user)
+    function it_does_nothing_if_plain_password_is_empty(UserPasswordEncoderInterface $userPasswordEncoder, CredentialsHolderInterface $user)
     {
         $user->getPlainPassword()->willReturn('');
 

--- a/src/Sylius/Component/User/spec/Security/PasswordUpdaterSpec.php
+++ b/src/Sylius/Component/User/spec/Security/PasswordUpdaterSpec.php
@@ -13,7 +13,7 @@ namespace spec\Sylius\Component\User\Security;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Sylius\Component\User\Model\UserInterface;
+use Sylius\Component\User\Model\CredentialingInterface;
 use Sylius\Component\User\Security\UserPasswordEncoderInterface;
 
 /**
@@ -36,7 +36,7 @@ class PasswordUpdaterSpec extends ObjectBehavior
         $this->shouldImplement('Sylius\Component\User\Security\PasswordUpdaterInterface');
     }
 
-    function it_updates_user_profile_with_encoded_password(UserPasswordEncoderInterface $userPasswordEncoder, UserInterface $user)
+    function it_updates_user_profile_with_encoded_password(UserPasswordEncoderInterface $userPasswordEncoder, CredentialingInterface $user)
     {
         $user->getPlainPassword()->willReturn('topSecretPlainPassword');
 
@@ -48,7 +48,7 @@ class PasswordUpdaterSpec extends ObjectBehavior
         $this->updatePassword($user);
     }
 
-    function it_does_nothing_if_plain_password_is_empty(UserPasswordEncoderInterface $userPasswordEncoder, UserInterface $user)
+    function it_does_nothing_if_plain_password_is_empty(UserPasswordEncoderInterface $userPasswordEncoder, CredentialingInterface $user)
     {
         $user->getPlainPassword()->willReturn('');
 

--- a/src/Sylius/Component/User/spec/Security/UserPbkdf2PasswordEncoderSpec.php
+++ b/src/Sylius/Component/User/spec/Security/UserPbkdf2PasswordEncoderSpec.php
@@ -13,7 +13,7 @@ namespace spec\Sylius\Component\User\Security;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Sylius\Component\User\Model\UserInterface;
+use Sylius\Component\User\Model\CredentialingInterface;
 
 /**
  * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
@@ -30,7 +30,7 @@ class UserPbkdf2PasswordEncoderSpec extends ObjectBehavior
         $this->shouldImplement('Sylius\Component\User\Security\UserPasswordEncoderInterface');
     }
 
-    function it_encodes_password(UserInterface $user)
+    function it_encodes_password(CredentialingInterface $user)
     {
         $user->getPlainPassword()->willReturn('myPassword');
         $user->getSalt()->willReturn('typicalSalt');

--- a/src/Sylius/Component/User/spec/Security/UserPbkdf2PasswordEncoderSpec.php
+++ b/src/Sylius/Component/User/spec/Security/UserPbkdf2PasswordEncoderSpec.php
@@ -13,7 +13,7 @@ namespace spec\Sylius\Component\User\Security;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Sylius\Component\User\Model\CredentialingInterface;
+use Sylius\Component\User\Model\CredentialsHolderInterface;
 
 /**
  * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
@@ -30,7 +30,7 @@ class UserPbkdf2PasswordEncoderSpec extends ObjectBehavior
         $this->shouldImplement('Sylius\Component\User\Security\UserPasswordEncoderInterface');
     }
 
-    function it_encodes_password(CredentialingInterface $user)
+    function it_encodes_password(CredentialsHolderInterface $user)
     {
         $user->getPlainPassword()->willReturn('myPassword');
         $user->getSalt()->willReturn('typicalSalt');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Introduced `CredentialingInterface` which implementation needs to be passed to password encoders and updaters instead of `UserInterface` with methods like `setCustomer()` etc.