### PR TITLE
[Flow] Go to last valid step if forward not found

### DIFF
--- a/src/Sylius/Bundle/FlowBundle/Process/Coordinator/Coordinator.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Coordinator/Coordinator.php
@@ -104,23 +104,7 @@ class Coordinator implements CoordinatorInterface
         try {
             $this->context->rewindHistory();
         } catch (NotFoundHttpException $e) {
-            // The step we are supposed to display was not found in the history.
-            if (null === $this->context->getPreviousStep()) {
-                // There is no previous step go to start
-                return $this->start($scenarioAlias, $queryParameters);
-            }
-
-            // We will go back to previous step...
-            $history = $this->context->getStepHistory();
-            if (empty($history)) {
-                // There is no history
-                return $this->start($scenarioAlias);
-            }
-            $step = $process->getStepByName(end($history));
-
-            $this->context->initialize($process, $step);
-
-            return $this->redirectToStepDisplayAction($process, $step);
+            return $this->goToLastValidStep($process, $scenarioAlias);
         }
 
         return $this->processStepResult(
@@ -138,7 +122,12 @@ class Coordinator implements CoordinatorInterface
         $step = $process->getStepByName($stepName);
 
         $this->context->initialize($process, $step);
-        $this->context->rewindHistory();
+
+        try {
+            $this->context->rewindHistory();
+        } catch (NotFoundHttpException $e) {
+            return $this->goToLastValidStep($process, $scenarioAlias);
+        }
 
         return $this->processStepResult(
             $process,
@@ -247,6 +236,33 @@ class Coordinator implements CoordinatorInterface
         return new RedirectResponse(
             $this->router->generate('sylius_flow_display', $routeParameters)
         );
+    }
+
+    /**
+     * @param ProcessInterface $process
+     * @param string           $scenarioAlias
+     *
+     * @return RedirectResponse
+     */
+    protected function goToLastValidStep(ProcessInterface $process, $scenarioAlias)
+    {
+        //the step we are supposed to display was not found in the history.
+        if (null === $this->context->getPreviousStep()) {
+            //there is no previous step go to start
+            return $this->start($scenarioAlias);
+        }
+
+        //we will go back to previous step...
+        $history = $this->context->getStepHistory();
+        if (empty($history)) {
+            //there is no history
+            return $this->start($scenarioAlias);
+        }
+        $step = $process->getStepByName(end($history));
+
+        $this->context->initialize($process, $step);
+
+        return $this->redirectToStepDisplayAction($process, $step);
     }
 
     /**


### PR DESCRIPTION
In case when one directly navigate to forward step instead of 404 it is being redirected to last valid step. Forward action is now consistent with display action.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT