### PR TITLE
[Addressing] Country fixes

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Country.orm.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/Country.orm.xml
@@ -30,6 +30,9 @@
             <cascade>
                 <cascade-all/>
             </cascade>
+            <order-by>
+                <order-by-field name="name" direction="ASC" />
+            </order-by>
         </one-to-many>
     </mapped-superclass>
 

--- a/src/Sylius/Component/Addressing/Model/Country.php
+++ b/src/Sylius/Component/Addressing/Model/Country.php
@@ -50,11 +50,11 @@ class Country implements CountryInterface
     }
 
     /**
-     * @return null|string
+     * @return string
      */
     public function __toString()
     {
-        return $this->getName();
+        return $this->getName() ?: $this->getIsoName();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |
| License       | MIT
| Doc PR        | 

Provinces for a country ordered by name by default
Ensure __toString() won't break on Country. I may have an old DB, but some countries in my db couldn't retrieve a translation so blew up when used in a country dropdown.