### PR TITLE
Fix translation for backend product undelete btn

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
@@ -765,7 +765,6 @@ sylius:
             qty_min: Qty min
             qty_max: Qty max
             price: Price
-        delete_revert: Undelete
     product_not_available_in_zone: Not available in your country
     promotion:
         actions: Actions
@@ -856,6 +855,7 @@ sylius:
         index_header: Reports
         no_data: There is no data to display.
         no_report: There is no report to display.
+    restore: Restore
     save_changes: Save changes
     search: Search
     security:

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/messages.lt.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/messages.lt.yml
@@ -751,7 +751,6 @@ sylius:
       qty_min: Kiekis min
       qty_max: Kiekis max
       price: Kaina
-    delete_revert: Atstatyti
   product_not_available_in_zone: Neprieinamas jūsų šalyje
   promotion:
     actions: Veiksmai

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/messages.sk.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/messages.sk.yml
@@ -751,7 +751,6 @@ sylius:
       qty_min: Min. množstvo
       qty_max: Max. množstvo
       price: Cena
-    delete_revert: Obnoviť
   product_not_available_in_zone: Nedostupné vo vašej krajine
   promotion:
     actions: Akcie

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/macros.html.twig
@@ -87,7 +87,7 @@
             </td>
             <td class="center-text">
                 {% if product.deleted %}
-                    {{ buttons.patch(path('sylius_backend_product_delete_restore', {'id': product.id}), 'sylius.product.delete_restore', null, 'btn btn-primary') }}
+                    {{ buttons.patch(path('sylius_backend_product_delete_restore', {'id': product.id}), 'sylius.restore'|trans, null, 'btn btn-primary') }}
                 {% else %}
                 {{ buttons.edit(path('sylius_backend_product_update', {'id': product.id})) }}
                 {{ buttons.delete(path('sylius_backend_product_delete', {'id': product.id})) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Fixes actions undelete button
http://demo.sylius.org/administration/products/?deleted=1

Let me know, if I should rename translation string from `sylius.product.delete_revert` to `sylius.product.delete_restore`.