### PR TITLE
[UserBundle] Fix customer gender layout on backend admin form

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Form/Type/CustomerProfileType.php
+++ b/src/Sylius/Bundle/UserBundle/Form/Type/CustomerProfileType.php
@@ -39,7 +39,9 @@ class CustomerProfileType extends AbstractResourceType
                 'widget'   => 'single_text',
                 'required' => false,
             ))
-            ->add('gender', 'sylius_gender')
+            ->add('gender', 'sylius_gender', array(
+                'label'    => 'sylius.form.customer.gender'
+            ))
         ;
     }
 

--- a/src/Sylius/Bundle/UserBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/UserBundle/Resources/translations/messages.en.yml
@@ -37,6 +37,7 @@ sylius:
             groups: Groups
             last_name: Last name
             email: Email
+            gender: Gender
             birthday: Birthday
             billing_address: Billing address
             different_billing_address: Use different address for billing?

--- a/src/Sylius/Bundle/UserBundle/spec/Form/Type/CustomerProfileTypeSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/Form/Type/CustomerProfileTypeSpec.php
@@ -38,7 +38,7 @@ class CustomerProfileTypeSpec extends ObjectBehavior
         $builder->add('lastName', 'text', Argument::type('array'))->shouldbeCalled()->willReturn($builder);
         $builder->add('email', 'email', Argument::type('array'))->shouldbeCalled()->willReturn($builder);
         $builder->add('birthday', 'birthday', Argument::type('array'))->shouldbeCalled()->willReturn($builder);
-        $builder->add('gender', 'sylius_gender')->shouldbeCalled()->willReturn($builder);
+        $builder->add('gender', 'sylius_gender', Argument::type('array'))->shouldbeCalled()->willReturn($builder);
 
         $this->buildForm($builder);
     }


### PR DESCRIPTION
From:

<img width="1115" alt="screen shot 2015-10-31 at 09 00 36" src="https://cloud.githubusercontent.com/assets/7068515/10862784/032baf2a-7faf-11e5-9de0-982cceb18062.png">

To:

<img width="1107" alt="screen shot 2015-10-31 at 09 01 18" src="https://cloud.githubusercontent.com/assets/7068515/10862786/06479e30-7faf-11e5-8d89-df6acc400e9c.png">



NOTE: There's an underlying theme bug here which doesn't render 'default' labels properly. Ideally you shouldn't have to do this to make your widget render the same as every other, but it's still worth merging to make it consistent.

I will open a separate issue for this one, but don't have time to fix it right now.