### PR TITLE
[Product][Core] Moved ProductAccessor from Product to Core

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
@@ -216,7 +216,7 @@ sylius_search:
                 id: ~
                 name: ~
                 description: ~
-    custom_accessor: Sylius\Component\Product\Accessor\ProductAccessor
+    custom_accessor: Sylius\Component\Core\Accessor\ProductAccessor
     filters:
         pre_search_filter:
             enabled: true

--- a/src/Sylius/Component/Core/Accessor/ProductAccessor.php
+++ b/src/Sylius/Component/Core/Accessor/ProductAccessor.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Component\Product\Accessor;
+namespace Sylius\Component\Core\Accessor;
 
 use Sylius\Component\Core\Model\ProductInterface;
 use Symfony\Component\PropertyAccess\Exception;

--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -50,7 +50,8 @@
     },
     "require-dev": {
         "phpspec/phpspec":              "~2.1",
-        "friendsofsymfony/user-bundle": "2.0.*@dev"
+        "friendsofsymfony/user-bundle": "2.0.*@dev",
+        "symfony/property-access":      "~2.3"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Sylius/Component/Product/composer.json
+++ b/src/Sylius/Component/Product/composer.json
@@ -29,9 +29,7 @@
         "sylius/translation": "0.16.*"
     },
     "require-dev": {
-        "phpspec/phpspec":         "~2.1",
-
-        "symfony/property-access": "~2.3"
+        "phpspec/phpspec":         "~2.1"
     },
     "autoload": {
         "psr-4": { "Sylius\\Component\\Product\\": "" }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

ProductAccessor class is located in the Product component, but it doesn't have any connection to it. Although it uses the ProductInterface it's not the one from Product component, but from Core.