### PR TITLE
Form theming fix for sublabels on expanded compound widgets 

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Promotion/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Promotion/_form.html.twig
@@ -7,14 +7,7 @@
         {{ form_row(form.endsAt) }}
         {{ form_row(form.couponBased) }}
         {{ form_row(form.exclusive) }}
-        <div class="form-group">
-        {{ form_errors(form.channels) }}
-        {{ form_label(form.channels) }}
-        {% for channelForm in form.channels %}
-            {{ form_row(channelForm) }}
-        {% endfor %}
-        </div>
-
+        {{ form_row(form.channels) }}
         {{ form_widget(form._token) }}
     </div>
     <div class="row">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Common/forms.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Common/forms.html.twig
@@ -5,6 +5,33 @@
 {{ parent() }}
 {% endblock choice_widget_collapsed %}
 
+{%- block choice_widget_expanded -%}
+    <div {{ block('widget_container_attributes') }}>
+        {% set widget_class = multiple ? ' checkbox-inline' : ' radio-inline' %}
+        {%- for child in form %}
+            {% set child_label = child.vars.label %}
+            {% if child_label is not sameas(false) %}
+                {% set child_label_attr = child.vars.label_attr|merge({'class' : widget_class}) %}
+                {% if not child.vars.compound %}
+                    {% set child_label_attr = child_label_attr|merge({'for': child.vars.id}) %}
+                {% endif %}
+                {% if child.vars.required %}
+                    {% set child_label_attr = child_label_attr|merge({'class': (child_label_attr.class|default('') ~ ' required')|trim}) %}
+                {% endif %}
+                <label{% for attrname, attrvalue in child_label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+            {% endif %}
+            {{ form_widget(child) }}
+            {% if child_label is not sameas(false) %}
+                {% if child_label is empty %}
+                    {% set child_label = name|humanize %}
+                {% endif %}
+                {{ child_label|trans({}, translation_domain) }}
+                </label>
+            {% endif %}
+        {% endfor -%}
+    </div>
+{%- endblock choice_widget_expanded -%}
+
 {% block textarea_widget %}
 {% set attr = attr|merge({'class': attr.class|default('') ~ ' form-control'}) %}
 {{ parent() }}


### PR DESCRIPTION
This fixes the layout for checkboxs and radio buttons as part of a compound form widget as per the bootstrap spec: http://getbootstrap.com/css/#forms

Eventually it might be worth looking at the official symfony bootstrap theme (http://symfony.com/blog/new-in-symfony-2-6-bootstrap-form-theme), but for now this fix helps:

Also fixed use on promo form with channels

BEFORE:

![image](https://cloud.githubusercontent.com/assets/7068515/10895108/466ca7d8-81aa-11e5-9859-8517482a5f9b.png)

AFTER:

![image](https://cloud.githubusercontent.com/assets/7068515/10895111/4f2e4ad4-81aa-11e5-9489-a177f4683325.png)

Also fine on smaller breakpoints:

![image](https://cloud.githubusercontent.com/assets/7068515/10895114/545a999a-81aa-11e5-8be6-09145e8b54c0.png)

