### PR TITLE
Add required PHP extensions to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "require": {
         "php":                                  ">=5.5.9",
         "ext-exif":                             "*",
+        "ext-gd":                               "*",
         "a2lix/translation-form-bundle":        "~2.0",
         "doctrine/collections":                 "~1.2",
         "doctrine/common":                      "~2.5",

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     ],
     "require": {
         "php":                                  ">=5.5.9",
+        "ext-exif":                             "*",
         "a2lix/translation-form-bundle":        "~2.0",
         "doctrine/collections":                 "~1.2",
         "doctrine/common":                      "~2.5",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "require": {
         "php":                                  ">=5.5.9",
         "ext-exif":                             "*",
+        "ext-fileinfo":                         "*",
         "ext-gd":                               "*",
         "a2lix/translation-form-bundle":        "~2.0",
         "doctrine/collections":                 "~1.2",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "ext-exif":                             "*",
         "ext-fileinfo":                         "*",
         "ext-gd":                               "*",
+        "ext-intl":                             "*",
         "a2lix/translation-form-bundle":        "~2.0",
         "doctrine/collections":                 "~1.2",
         "doctrine/common":                      "~2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c699acf695b7b696a336648d48c263e7",
-    "content-hash": "561dff1a9131f476264e787f627cb463",
+    "hash": "5705cfba9ca8d72f471ad2b643631386",
+    "content-hash": "e790afb1c83817899790db274ee1e51d",
     "packages": [
         {
             "name": "a2lix/translation-form-bundle",
@@ -9314,7 +9314,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=5.5.9",
-        "ext-exif": "*"
+        "ext-exif": "*",
+        "ext-gd": "*"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "5705cfba9ca8d72f471ad2b643631386",
-    "content-hash": "e790afb1c83817899790db274ee1e51d",
+    "hash": "577aee9aac00cf186185e5d2b5f44e98",
+    "content-hash": "b83dc7ecc5a7059fbd6978f90cdc3c5d",
     "packages": [
         {
             "name": "a2lix/translation-form-bundle",
@@ -9315,6 +9315,7 @@
     "platform": {
         "php": ">=5.5.9",
         "ext-exif": "*",
+        "ext-fileinfo": "*",
         "ext-gd": "*"
     },
     "platform-dev": []

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f45642c2c8997291516f7c2ad78c9ac5",
+    "hash": "c699acf695b7b696a336648d48c263e7",
+    "content-hash": "561dff1a9131f476264e787f627cb463",
     "packages": [
         {
             "name": "a2lix/translation-form-bundle",
@@ -3262,61 +3263,6 @@
                 "imagine"
             ],
             "time": "2015-08-27 11:27:33"
-        },
-        {
-            "name": "mathiasverraes/money",
-            "version": "1.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mathiasverraes/money.git",
-                "reference": "b9e258119041fed20e4704f72e3ebb94ed10bea2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mathiasverraes/money/zipball/b9e258119041fed20e4704f72e3ebb94ed10bea2",
-                "reference": "b9e258119041fed20e4704f72e3ebb94ed10bea2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "3.7.*"
-            },
-            "suggest": {
-                "Sylius/SyliusMoneyBundle": "Sylius' Symfony2 integration with Money library",
-                "TheBigBrainsCompany/TbbcMoneyBundle": "Very complete Symfony2 bundle with support for Twig, Doctrine, Forms, ...",
-                "pink-tie/money-bundle": "Pink-Tie's Symfony2 integration with Money library"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Money": "lib"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mathias Verraes",
-                    "email": "mathias@verraes.net"
-                }
-            ],
-            "description": "PHP implementation of Fowler's Money pattern",
-            "homepage": "http://verraes.net/2011/04/fowler-money-pattern-in-php/",
-            "keywords": [
-                "Generic Sub-domain",
-                "Value Object",
-                "money"
-            ],
-            "time": "2014-10-07 12:54:10"
         },
         {
             "name": "midgard/createphp",
@@ -6834,12 +6780,12 @@
             "version": "v2.7.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/AsseticBundle.git",
+                "url": "https://github.com/symfony/assetic-bundle.git",
                 "reference": "3ae5c8ca3079b6e0033cc9fbfb6500e2bc964da5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/AsseticBundle/zipball/3ae5c8ca3079b6e0033cc9fbfb6500e2bc964da5",
+                "url": "https://api.github.com/repos/symfony/assetic-bundle/zipball/3ae5c8ca3079b6e0033cc9fbfb6500e2bc964da5",
                 "reference": "3ae5c8ca3079b6e0033cc9fbfb6500e2bc964da5",
                 "shasum": ""
             },
@@ -6904,12 +6850,12 @@
             "version": "v2.7.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/MonologBundle.git",
+                "url": "https://github.com/symfony/monolog-bundle.git",
                 "reference": "9320b6863404c70ebe111e9040dab96f251de7ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/MonologBundle/zipball/9320b6863404c70ebe111e9040dab96f251de7ac",
+                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/9320b6863404c70ebe111e9040dab96f251de7ac",
                 "reference": "9320b6863404c70ebe111e9040dab96f251de7ac",
                 "shasum": ""
             },
@@ -6963,12 +6909,12 @@
             "version": "v2.3.8",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/SwiftmailerBundle.git",
+                "url": "https://github.com/symfony/swiftmailer-bundle.git",
                 "reference": "970b13d01871207e81d17b17ddda025e7e21e797"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/SwiftmailerBundle/zipball/970b13d01871207e81d17b17ddda025e7e21e797",
+                "url": "https://api.github.com/repos/symfony/swiftmailer-bundle/zipball/970b13d01871207e81d17b17ddda025e7e21e797",
                 "reference": "970b13d01871207e81d17b17ddda025e7e21e797",
                 "shasum": ""
             },
@@ -9367,7 +9313,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5.9"
+        "php": ">=5.5.9",
+        "ext-exif": "*"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "577aee9aac00cf186185e5d2b5f44e98",
-    "content-hash": "b83dc7ecc5a7059fbd6978f90cdc3c5d",
+    "hash": "fa499db8e84ad7dd3fa87ac8d0c48158",
+    "content-hash": "15985684ec87461d9de572d29c50b53a",
     "packages": [
         {
             "name": "a2lix/translation-form-bundle",
@@ -9316,7 +9316,8 @@
         "php": ">=5.5.9",
         "ext-exif": "*",
         "ext-fileinfo": "*",
-        "ext-gd": "*"
+        "ext-gd": "*",
+        "ext-intl": "*"
     },
     "platform-dev": []
 }

--- a/src/Sylius/Bundle/InstallerBundle/Requirement/ExtensionsRequirements.php
+++ b/src/Sylius/Bundle/InstallerBundle/Requirement/ExtensionsRequirements.php
@@ -176,7 +176,7 @@ class ExtensionsRequirements extends RequirementCollection
                 $status = defined('GD_VERSION'),
                 $on,
                 $status ? $on : $off,
-                false,
+                true,
                 $translator->trans('sylius.extensions.help', array('%extension%' => 'gd'), 'requirements')
             ))
         ;

--- a/src/Sylius/Bundle/InstallerBundle/Requirement/ExtensionsRequirements.php
+++ b/src/Sylius/Bundle/InstallerBundle/Requirement/ExtensionsRequirements.php
@@ -122,6 +122,14 @@ class ExtensionsRequirements extends RequirementCollection
                 false,
                 $translator->trans('sylius.extensions.help', array('%extension%' => 'intl'), 'requirements')
             ))
+            ->add(new Requirement(
+                $translator->trans('sylius.extensions.fileinfo', array(), 'requirements'),
+                $status = extension_loaded('fileinfo'),
+                $on,
+                $status ? $on : $off,
+                true,
+                $translator->trans('sylius.extensions.help', array('%extension%' => 'fileinfo'), 'requirements')
+            ))
         ;
 
         if (extension_loaded('intl')) {

--- a/src/Sylius/Bundle/InstallerBundle/Requirement/ExtensionsRequirements.php
+++ b/src/Sylius/Bundle/InstallerBundle/Requirement/ExtensionsRequirements.php
@@ -119,7 +119,7 @@ class ExtensionsRequirements extends RequirementCollection
                 $status = extension_loaded('intl'),
                 $on,
                 $status ? $on : $off,
-                false,
+                true,
                 $translator->trans('sylius.extensions.help', array('%extension%' => 'intl'), 'requirements')
             ))
             ->add(new Requirement(

--- a/src/Sylius/Bundle/InstallerBundle/Resources/translations/requirements.en.yml
+++ b/src/Sylius/Bundle/InstallerBundle/Resources/translations/requirements.en.yml
@@ -13,6 +13,7 @@ sylius:
         help: Install and enable the %extension% extension.
         iconv: Iconv
         exif: Exif
+        fileinfo: Fileinfo
         icu: ICU
         intl: Intl
         json_encode: JSON


### PR DESCRIPTION
Some extensions (so far I've discoverd: `exif`, `fileinfo`, `gd`, `intl`) are necessary for tests to run, so they should be listed in the `require-dev` part of the `composer.json`

They gave me hard time during #3501 because every build takes a few minutes because of the Composer dependencies :clock1: 