### PR TITLE
[Resource] EntityHiddenType fix

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Form/Type/EntityHiddenType.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/Type/EntityHiddenType.php
@@ -49,10 +49,10 @@ class EntityHiddenType extends AbstractType
             ->addViewTransformer($transformer)
             ->setAttribute('data_class', $options['data_class'])
             ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($transformer) {
-                $event->setData($transformer->transform($event->getData()));
+                $event->setData($transformer->reverseTransform($event->getData()));
             })
             ->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) use ($transformer) {
-                $event->setData($transformer->transform($event->getData()));
+                $event->setData($transformer->reverseTransform($event->getData()));
             })
         ;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

#3406 PR fixed problem with reversed logic of `ObjectToIdentifierTransformer`. But unfortunately we forgot that *EntityHiddenType* use this transformer. I changed the name of method used by *EntityHiddenType* to avoid problems like this:
`Expected argument of type "AppBundle\Entity\ProductVariant", "string" given`