### PR TITLE
[Flow] Allow ProcessValidator to access ProcessContext

### DIFF
--- a/src/Sylius/Bundle/FlowBundle/Process/Context/ProcessContext.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Context/ProcessContext.php
@@ -126,7 +126,7 @@ class ProcessContext implements ProcessContextInterface
         $validator = $this->process->getValidator();
 
         if (null !== $validator) {
-            return $validator->isValid();
+            return $validator->isValid($this);
         }
 
         $history = $this->getStepHistory();

--- a/src/Sylius/Bundle/FlowBundle/Validator/ProcessValidator.php
+++ b/src/Sylius/Bundle/FlowBundle/Validator/ProcessValidator.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\FlowBundle\Validator;
 
+use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Bundle\FlowBundle\Process\Step\StepInterface;
 
 /**
@@ -25,10 +26,12 @@ class ProcessValidator implements ProcessValidatorInterface
      * @var string|null
      */
     protected $message;
+
     /**
      * @var string|null
      */
     protected $stepName;
+
     /**
      * @var callable
      */
@@ -104,7 +107,7 @@ class ProcessValidator implements ProcessValidatorInterface
     /**
      * {@inheritdoc}
      */
-    public function isValid()
+    public function isValid(ProcessContextInterface $processContext)
     {
         return call_user_func($this->validation) ? true : false;
     }

--- a/src/Sylius/Bundle/FlowBundle/Validator/ProcessValidatorInterface.php
+++ b/src/Sylius/Bundle/FlowBundle/Validator/ProcessValidatorInterface.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\FlowBundle\Validator;
 
 use FOS\RestBundle\View\View;
+use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Bundle\FlowBundle\Process\Step\ActionResult;
 use Sylius\Bundle\FlowBundle\Process\Step\StepInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -59,9 +60,11 @@ interface ProcessValidatorInterface
     /**
      * Check validation.
      *
+     * @param ProcessContextInterface $processContext
+     *
      * @return bool
      */
-    public function isValid();
+    public function isValid(ProcessContextInterface $processContext);
 
     /**
      * @param StepInterface $step

--- a/src/Sylius/Bundle/FlowBundle/spec/Process/Context/ProcessContextSpec.php
+++ b/src/Sylius/Bundle/FlowBundle/spec/Process/Context/ProcessContextSpec.php
@@ -72,11 +72,11 @@ class ProcessContextSpec extends ObjectBehavior
         $this->initialize($process, $currentStep);
 
         $process->getValidator()->willReturn($processValidator);
-        $processValidator->isValid()->willReturn(false);
+        $processValidator->isValid($this)->willReturn(false);
         $this->isValid()->shouldReturn(false);
 
         $process->getValidator()->willReturn($processValidator);
-        $processValidator->isValid()->willReturn(true);
+        $processValidator->isValid($this)->willReturn(true);
 
         $process->getValidator()->willReturn(null);
         $currentStep->getName()->willReturn('current_step');

--- a/src/Sylius/Bundle/FlowBundle/spec/Validator/ProcessValidatorSpec.php
+++ b/src/Sylius/Bundle/FlowBundle/spec/Validator/ProcessValidatorSpec.php
@@ -13,6 +13,7 @@ namespace spec\Sylius\Bundle\FlowBundle\Validator;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Bundle\FlowBundle\Process\Step\StepInterface;
 
 class ProcessValidatorSpec extends ObjectBehavior
@@ -52,13 +53,13 @@ class ProcessValidatorSpec extends ObjectBehavior
         $this->getValidation()->shouldReturn($closure);
     }
 
-    function it_calls_validation_closure()
+    function it_calls_validation_closure(ProcessContextInterface $processContext)
     {
         $this->setValidation(function() {
             return true;
         });
 
-        $this->isValid()->shouldReturn(true);
+        $this->isValid($processContext)->shouldReturn(true);
     }
 
     function it_has_response(StepInterface $step)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

This can be useful when you want to implement some advanced process validation that need to be aware of the some process context data, such as current step.