### PR TITLE
[SearchBundle] Behat/SearchContext is portable

### DIFF
--- a/src/Sylius/Bundle/SearchBundle/Behat/SearchContext.php
+++ b/src/Sylius/Bundle/SearchBundle/Behat/SearchContext.php
@@ -12,8 +12,10 @@
 namespace Sylius\Bundle\SearchBundle\Behat;
 
 use Sylius\Bundle\ResourceBundle\Behat\DefaultContext;
+use Sylius\Bundle\SearchBundle\Command\IndexCommand;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\DomCrawler\Crawler;
-use Symfony\Component\Process\Process;
 
 /**
  * @author Argyrios Gounaris <agounaris@gmail.com>
@@ -25,15 +27,13 @@ class SearchContext extends DefaultContext
      */
     public function iPopulateTheIndex()
     {
-        $command = $this->kernel->getRootDir() . "/console sylius:search:index --env=test";
-        $process = new Process($command);
-        $process->run();
+        $command = new IndexCommand();
+        $command->setContainer($this->kernel->getContainer());
 
-        if (!$process->isSuccessful()) {
-            throw new \RuntimeException($process->getErrorOutput());
+        $output = new BufferedOutput();
+        if ($command->run(new ArgvInput(['env' => 'test']), $output)) { //return code is not zero
+            throw new \RuntimeException($output->fetch());
         }
-
-        print $process->getOutput();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none, related to #3501
| License       | MIT
| Doc PR        | none

`Behat/SearchContext` executes the SearchBundle - `IndexCommand`
When the code was ran on Windows, the app/console did not exists:
   `'app/console' is not recognized as an internal or external command...`

This change makes the code portable, so it runs on Linux and Windows