### PR TITLE
[Order,Core,Web] Rename of label on adjustment to type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ To get the diff between two versions, go to https://github.com/Sylius/Sylius/com
 
  * feature #3110 [BC BREAK] Bumped minimal versions, major changes: PHP >=5.5.9, Symfony ^2.7
  * bc break #3364 [BC BREAK] Renamed setDefaultOptions to configureOptions
+ * bc break #3536 [BC BREAK] Renamed label to type on adjustment
 
 ## v0.15 (2015-09-08)
 

--- a/app/migrations/Version20151019160305.php
+++ b/app/migrations/Version20151019160305.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20151019160305 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_adjustment CHANGE label type VARCHAR(255) NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_adjustment CHANGE type label VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/OrderProcessing/TaxationProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderProcessing/TaxationProcessor.php
@@ -150,7 +150,7 @@ class TaxationProcessor implements TaxationProcessorInterface
     {
         foreach ($taxes as $description => $tax) {
             $adjustment = $this->adjustmentRepository->createNew();
-            $adjustment->setLabel(AdjustmentInterface::TAX_ADJUSTMENT);
+            $adjustment->setType(AdjustmentInterface::TAX_ADJUSTMENT);
             $adjustment->setAmount($tax['amount']);
             $adjustment->setDescription($description);
             $adjustment->setNeutral($tax['included']);

--- a/src/Sylius/Bundle/OrderBundle/Form/Type/AdjustmentType.php
+++ b/src/Sylius/Bundle/OrderBundle/Form/Type/AdjustmentType.php
@@ -27,8 +27,8 @@ class AdjustmentType extends AbstractResourceType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('label', 'text', array(
-                'label' => 'sylius.form.adjustment.label'
+            ->add('type', 'text', array(
+                'label' => 'sylius.form.adjustment.type'
             ))
             ->add('description', 'text', array(
                 'label'    => 'sylius.form.adjustment.description',

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Adjustment.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Adjustment.orm.xml
@@ -22,7 +22,7 @@
             <generator strategy="AUTO" />
         </id>
 
-        <field name="label" column="label" type="string" />
+        <field name="type" column="type" type="string" />
         <field name="description" column="description" type="string" nullable="true" />
         <field name="amount" column="amount" type="integer" />
         <field name="neutral" column="is_neutral" type="boolean" />

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/validation.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/validation.xml
@@ -42,9 +42,9 @@
     </class>
 
     <class name="Sylius\Component\Order\Model\Adjustment">
-        <property name="label">
+        <property name="type">
             <constraint name="NotBlank">
-                <option name="message">sylius.adjustment.label.not_blank</option>
+                <option name="message">sylius.adjustment.type.not_blank</option>
                 <option name="groups">sylius</option>
             </constraint>
         </property>

--- a/src/Sylius/Bundle/OrderBundle/spec/Form/Type/AdjustmentTypeSpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Form/Type/AdjustmentTypeSpec.php
@@ -39,7 +39,7 @@ class AdjustmentTypeSpec extends ObjectBehavior
     function it_builds_form_with_proper_fields(FormBuilderInterface $builder)
     {
         $builder
-            ->add('label', 'text', Argument::any())
+            ->add('type', 'text', Argument::any())
             ->willReturn($builder)
         ;
 

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
@@ -578,7 +578,7 @@ sylius:
         no_promotion: No coupons were used.order:
         adjustments:
             manage: Manage adjustments
-            label: Label
+            type: Type
             description: Description
             amount: Amount
             locked: Locked?

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/adjustments.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/adjustments.html.twig
@@ -38,7 +38,7 @@
 <table class="table">
     <thead>
         <tr>
-            <th>{{ 'sylius.order.adjustments.label'|trans }}</th>
+            <th>{{ 'sylius.order.adjustments.type'|trans }}</th>
             <th>{{ 'sylius.order.adjustments.description'|trans }}</th>
             <th>{{ 'sylius.order.adjustments.amount'|trans }}</th>
             <th>{{ 'sylius.order.adjustments.locked'|trans }}</th>
@@ -49,7 +49,7 @@
     {% for adjustment in order.adjustments %}
         <tr>
             <td>
-                {{ adjustment.label }}
+                {{ adjustment.type }}
             </td>
             <td>
                 {{ adjustment.description }}

--- a/src/Sylius/Component/Core/OrderProcessing/PaymentChargesProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/PaymentChargesProcessor.php
@@ -78,7 +78,7 @@ class PaymentChargesProcessor implements PaymentChargesProcessorInterface
     private function prepareAdjustmentForOrder(PaymentSubjectInterface $payment)
     {
         $adjustment = $this->adjustmentRepository->createNew();
-        $adjustment->setLabel(AdjustmentInterface::PAYMENT_ADJUSTMENT);
+        $adjustment->setType(AdjustmentInterface::PAYMENT_ADJUSTMENT);
         $adjustment->setAmount($this->feeCalculator->calculate($payment));
         $adjustment->setDescription($payment->getMethod()->getName());
 

--- a/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php
@@ -61,7 +61,7 @@ class ShippingChargesProcessor implements ShippingChargesProcessorInterface
             $shippingCharge = $this->calculator->calculate($shipment);
 
             $adjustment = $this->adjustmentRepository->createNew();
-            $adjustment->setLabel(AdjustmentInterface::SHIPPING_ADJUSTMENT);
+            $adjustment->setType(AdjustmentInterface::SHIPPING_ADJUSTMENT);
             $adjustment->setAmount($shippingCharge);
             $adjustment->setDescription($shipment->getMethod()->getName());
 

--- a/src/Sylius/Component/Core/Promotion/Action/DiscountAction.php
+++ b/src/Sylius/Component/Core/Promotion/Action/DiscountAction.php
@@ -64,7 +64,7 @@ abstract class DiscountAction implements PromotionActionInterface
     protected function createAdjustment(PromotionInterface $promotion)
     {
         $adjustment = $this->adjustmentRepository->createNew();
-        $adjustment->setLabel(AdjustmentInterface::PROMOTION_ADJUSTMENT);
+        $adjustment->setType(AdjustmentInterface::PROMOTION_ADJUSTMENT);
         $adjustment->setDescription($promotion->getDescription());
 
         $this->originator->setOrigin($adjustment, $promotion);

--- a/src/Sylius/Component/Core/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderSpec.php
@@ -110,10 +110,10 @@ class OrderSpec extends ObjectBehavior
         AdjustmentInterface $shippingAdjustment,
         AdjustmentInterface $taxAdjustment
     ) {
-        $shippingAdjustment->getLabel()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
+        $shippingAdjustment->getType()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
         $shippingAdjustment->setAdjustable($this)->shouldBeCalled();
 
-        $taxAdjustment->getLabel()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $taxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
         $taxAdjustment->setAdjustable($this)->shouldBeCalled();
 
         $this->addAdjustment($shippingAdjustment);
@@ -130,10 +130,10 @@ class OrderSpec extends ObjectBehavior
         AdjustmentInterface $shippingAdjustment,
         AdjustmentInterface $taxAdjustment
     ) {
-        $shippingAdjustment->getLabel()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
+        $shippingAdjustment->getType()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
         $shippingAdjustment->setAdjustable($this)->shouldBeCalled();
 
-        $taxAdjustment->getLabel()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $taxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
         $taxAdjustment->setAdjustable($this)->shouldBeCalled();
 
         $this->addAdjustment($shippingAdjustment);
@@ -153,10 +153,10 @@ class OrderSpec extends ObjectBehavior
         AdjustmentInterface $shippingAdjustment,
         AdjustmentInterface $taxAdjustment
     ) {
-        $shippingAdjustment->getLabel()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
+        $shippingAdjustment->getType()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
         $shippingAdjustment->setAdjustable($this)->shouldBeCalled();
 
-        $taxAdjustment->getLabel()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $taxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
         $taxAdjustment->setAdjustable($this)->shouldBeCalled();
 
         $this->addAdjustment($shippingAdjustment);
@@ -173,10 +173,10 @@ class OrderSpec extends ObjectBehavior
         AdjustmentInterface $shippingAdjustment,
         AdjustmentInterface $taxAdjustment
     ) {
-        $shippingAdjustment->getLabel()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
+        $shippingAdjustment->getType()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
         $shippingAdjustment->setAdjustable($this)->shouldBeCalled();
 
-        $taxAdjustment->getLabel()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $taxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
         $taxAdjustment->setAdjustable($this)->shouldBeCalled();
 
         $this->addAdjustment($shippingAdjustment);

--- a/src/Sylius/Component/Core/spec/OrderProcessing/PaymentChargesProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/PaymentChargesProcessorSpec.php
@@ -59,7 +59,7 @@ class PaymentChargesProcessorSpec extends ObjectBehavior
         $delegatingFeeCalculator->calculate($payment)->willReturn(50);
 
         $adjustmentRepository->createNew()->willReturn($adjustment)->shouldBeCalled();
-        $adjustment->setLabel('payment')->shouldBeCalled();
+        $adjustment->setType('payment')->shouldBeCalled();
         $adjustment->setAmount(50)->shouldBeCalled();
         $adjustment->setDescription('testPaymentMethod')->shouldBeCalled();
 

--- a/src/Sylius/Component/Core/spec/OrderProcessing/ShippingChargesProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/ShippingChargesProcessorSpec.php
@@ -81,7 +81,7 @@ class ShippingChargesProcessorSpec extends ObjectBehavior
         $shippingMethod->getName()->willReturn('FedEx');
 
         $adjustment->setAmount(450)->shouldBeCalled();
-        $adjustment->setLabel(AdjustmentInterface::SHIPPING_ADJUSTMENT)->shouldBeCalled();
+        $adjustment->setType(AdjustmentInterface::SHIPPING_ADJUSTMENT)->shouldBeCalled();
         $adjustment->setDescription('FedEx')->shouldBeCalled();
 
         $order->removeAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->shouldBeCalled();

--- a/src/Sylius/Component/Core/spec/Promotion/Action/FixedDiscountActionSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/FixedDiscountActionSpec.php
@@ -50,7 +50,7 @@ class FixedDiscountActionSpec extends ObjectBehavior
         $promotion->getDescription()->willReturn('promotion description');
 
         $adjustment->setAmount(-500)->shouldBeCalled();
-        $adjustment->setLabel(AdjustmentInterface::PROMOTION_ADJUSTMENT)->shouldBeCalled();
+        $adjustment->setType(AdjustmentInterface::PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $adjustment->setDescription('promotion description')->shouldBeCalled();
 
         $originator->setOrigin($adjustment, $promotion)->shouldBeCalled();

--- a/src/Sylius/Component/Core/spec/Promotion/Action/PercentageDiscountActionSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/PercentageDiscountActionSpec.php
@@ -51,7 +51,7 @@ class PercentageDiscountActionSpec extends ObjectBehavior
         $promotion->getDescription()->willReturn('promotion description');
 
         $adjustment->setAmount(-2500)->shouldBeCalled();
-        $adjustment->setLabel(AdjustmentInterface::PROMOTION_ADJUSTMENT)->shouldBeCalled();
+        $adjustment->setType(AdjustmentInterface::PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $adjustment->setDescription('promotion description')->shouldBeCalled();
 
         $originator->setOrigin($adjustment, $promotion)->shouldBeCalled();

--- a/src/Sylius/Component/Order/Model/Adjustment.php
+++ b/src/Sylius/Component/Order/Model/Adjustment.php
@@ -34,7 +34,7 @@ class Adjustment implements AdjustmentInterface
     /**
      * @var string
      */
-    protected $label;
+    protected $type;
 
     /**
      * @var string
@@ -127,17 +127,17 @@ class Adjustment implements AdjustmentInterface
     /**
      * {@inheritdoc}
      */
-    public function getLabel()
+    public function getType()
     {
-        return $this->label;
+        return $this->type;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function setLabel($label)
+    public function setType($type)
     {
-        $this->label = $label;
+        $this->type = $type;
     }
 
     /**

--- a/src/Sylius/Component/Order/Model/AdjustmentInterface.php
+++ b/src/Sylius/Component/Order/Model/AdjustmentInterface.php
@@ -32,12 +32,12 @@ interface AdjustmentInterface extends TimestampableInterface, OriginAwareInterfa
     /**
      * @return string
      */
-    public function getLabel();
+    public function getType();
 
     /**
-     * @param string $label
+     * @param string $type
      */
-    public function setLabel($label);
+    public function setType($type);
 
     /**
      * @return string

--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -282,7 +282,7 @@ class Order implements OrderInterface
         }
 
         return $this->adjustments->filter(function (AdjustmentInterface $adjustment) use ($type) {
-            return $type === $adjustment->getLabel();
+            return $type === $adjustment->getType();
         });
     }
 

--- a/src/Sylius/Component/Order/Model/OrderItem.php
+++ b/src/Sylius/Component/Order/Model/OrderItem.php
@@ -144,7 +144,7 @@ class OrderItem implements OrderItemInterface
         }
 
         return $this->adjustments->filter(function (AdjustmentInterface $adjustment) use ($type) {
-            return $type === $adjustment->getLabel();
+            return $type === $adjustment->getType();
         });
     }
 

--- a/src/Sylius/Component/Order/spec/Model/AdjustmentSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/AdjustmentSpec.php
@@ -65,15 +65,15 @@ class AdjustmentSpec extends ObjectBehavior
         $this->getAdjustable()->shouldReturn(null);
     }
 
-    function it_has_no_label_by_default()
+    function it_has_no_type_by_default()
     {
-        $this->getLabel()->shouldReturn(null);
+        $this->getType()->shouldReturn(null);
     }
 
-    function its_label_is_mutable()
+    function its_type_is_mutable()
     {
-        $this->setLabel('Shipping Fee');
-        $this->getLabel()->shouldReturn('Shipping Fee');
+        $this->setType('some type');
+        $this->getType()->shouldReturn('some type');
     }
 
     function it_has_no_description_by_default()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | [no]
| New feature?  | [no]
| BC breaks?    | [yes]
| Deprecations? | [yes, if someone was extending adjustments]
| License       | MIT
| Doc PR        | [https://github.com/Sylius/Sylius-Docs/pull/356]

This 'label' field is using type of adjustments specified in 'Sylius\Component\Core\Model\AdjustmentInterface', so I've renamed it to the type.