### PR TITLE
Allow vagrant users to access app_dev.php from host IP

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1', '113.0.0.1'))
+    || !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1', '113.0.0.1', '10.0.0.1'))
         || php_sapi_name() === 'cli-server')
 ) {
     header('HTTP/1.0 403 Forbidden');

--- a/web/app_test.php
+++ b/web/app_test.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1', '113.0.0.1'))
+    || !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1', '113.0.0.1', '10.0.0.1'))
         || php_sapi_name() === 'cli-server')
 ) {
     header('HTTP/1.0 403 Forbidden');


### PR DESCRIPTION
After using the supplied vagrant box and trying to access 'http://sylius.dev/app_dev.php' I got the error that I was not allowed to access that file. This change adds the host IP to allow for that on vagrant usage.