### PR TITLE
[SearchBundle] OrmIndexer minor patch

### DIFF
--- a/src/Sylius/Bundle/SearchBundle/Indexer/OrmIndexer.php
+++ b/src/Sylius/Bundle/SearchBundle/Indexer/OrmIndexer.php
@@ -242,7 +242,10 @@ class OrmIndexer implements IndexerInterface
         $content = '';
         foreach (array_keys(array_slice($fields, 1)) as $field) {
             $func = 'get' . ucfirst($field);
-            $content .= $element->$func() . self::SPACER;
+            
+            if (method_exists($element, $func)) {
+               $content .= $element->$func() . self::SPACER;
+            }
         }
 
         return $content;


### PR DESCRIPTION
| Q | A |
|-----|-----|
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets |	none, related to #2305 |
| License | MIT |
| Doc PR | none |

Prevent indexer from throwing the "Attempted to call an undefined method named "get0" of class ..." error when extending classes. This behaviour also truncates entire search index table in the database.