### PR TITLE
[ResourceBundle] Search id or slug in request query strings

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -438,9 +438,9 @@ class ResourceController extends FOSRestController
      */
     public function findOr404(Request $request, array $criteria = array())
     {
-        if ($request->query->get('slug')) {
-            $default = array('slug' => $request->query->get('slug'));
-        } elseif ($request->get('id')) {
+        if ($request->attributes->has('slug') || $request->query->has('slug')) {
+            $default = array('slug' => $request->get('slug'));
+        } elseif ($request->attributes->has('id') || $request->query->has('id')) {
             $default = array('id' => $request->get('id'));
         } else {
             $default = array();

--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -438,8 +438,8 @@ class ResourceController extends FOSRestController
      */
     public function findOr404(Request $request, array $criteria = array())
     {
-        if ($request->get('slug')) {
-            $default = array('slug' => $request->get('slug'));
+        if ($request->query->get('slug')) {
+            $default = array('slug' => $request->query->get('slug'));
         } elseif ($request->get('id')) {
             $default = array('id' => $request->get('id'));
         } else {


### PR DESCRIPTION
A POST, PUT or PATCH request like this:
```
{
    "country_code": "FR",
    "first_name": "First name",
    "last_name": "Last name",
    "slug": "my-slug"
}
```
throws a 404 response because the slug became a default search criteria.