### PR TITLE
Tweak serialization configs for all image aware resources

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.ProductVariant.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.ProductVariant.yml
@@ -23,3 +23,5 @@ Sylius\Component\Core\Model\ProductVariant:
         depth:
             expose: true
             type: float
+        images:
+            expose: true

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.ProductVariantImage.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.ProductVariantImage.yml
@@ -1,0 +1,9 @@
+Sylius\Component\Core\Model\ProductVariantImage:
+    exclusion_policy: ALL
+    xml_root_name: image
+    properties:
+        id:
+            expose: true
+            type: integer
+        path:
+            expose: true

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.Taxon.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.Taxon.yml
@@ -1,2 +1,6 @@
 Sylius\Component\Core\Model\Taxon:
     exclusion_policy: ALL
+    properites:
+        path:
+            expose: true
+            type: string

--- a/src/Sylius/Bundle/TaxonomyBundle/Resources/config/serializer/Model.Taxon.yml
+++ b/src/Sylius/Bundle/TaxonomyBundle/Resources/config/serializer/Model.Taxon.yml
@@ -9,6 +9,9 @@ Sylius\Component\Taxonomy\Model\Taxon:
         name:
             expose: true
             type: string
+        path:
+            expose: true
+            type: string
         children:
             expose: true
     relations:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Fixed wrong serialization config and expose image paths in the config. Useful when you need to get the images via API. :)