### PR TITLE
[FixturesBundle] Reverted loading fakers with the available locales

### DIFF
--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/DataFixture.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/DataFixture.php
@@ -73,19 +73,7 @@ abstract class DataFixture extends AbstractFixture implements ContainerAwareInte
             $this->faker = $this->fakers[$this->defaultLocale];
         }
 
-        foreach ($this->getLocales() as $local) {
-            $this->fakers[$local->getCode()] = FakerFactory::create($local->getCode());
-        }
-    }
-
-    /**
-     * Return locales available from the database
-     *
-     * @return mixed
-     */
-    public function getLocales()
-    {
-        return $this->getLocaleRepository()->findAll();
+        $this->fakers['es_ES'] = FakerFactory::create('es_ES');
     }
 
     public function __call($method, $arguments)

--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadLocalesData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadLocalesData.php
@@ -21,7 +21,7 @@ use Sylius\Bundle\FixturesBundle\DataFixtures\DataFixture;
  */
 class LoadLocalesData extends DataFixture
 {
-    protected $locales = array(
+    private $locales = array(
         'en_US' => true,
         'en_GB' => true,
         'es_ES' => true,
@@ -57,6 +57,6 @@ class LoadLocalesData extends DataFixture
      */
     public function getOrder()
     {
-        return 1;
+        return 10;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

I have discussed this problem with @pjedrzejewski and for now, I have reverted changes from #3531.

In future, we should consider a better solution for loading fakers locales in fixtures.