### PR TITLE
[FixturesBundle] Fixed problem with not existing payment method

### DIFF
--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadPaymentMethodsData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadPaymentMethodsData.php
@@ -32,6 +32,7 @@ class LoadPaymentMethodsData extends DataFixture
         $manager->persist($this->createPaymentMethod('Be2bill', 'be2bill_direct', 'fixed', array('amount' => 100)));
         $manager->persist($this->createPaymentMethod('Be2billOffsite', 'be2bill_offsite', 'percent', array('percent' => 7)));
         $manager->persist($this->createPaymentMethod('StripeCheckout', 'stripe_checkout', 'percent', array('percent' => 5)));
+        $manager->persist($this->createPaymentMethod('Offline', 'offline', 'fixed', array('amount' => 500)));
 
         $manager->flush();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

This line was removed in PR associated with upgrading Payum (#3380). I am not sure what the idea was, but this payment method is used in loaded by fixtures channels.