### PR TITLE
[WebBundle] Form theming fix for when no label is explicitly specified 

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Common/forms.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Common/forms.html.twig
@@ -116,7 +116,7 @@
 {% spaceless %}
     <div class="form-group{% if errors|length > 0 %} has-error{% endif %}">
         {{ form_label(form) }}
-        <div {% if label %}class="col-lg-10"{% endif %}>
+        <div {% if label is not same as(false) %}class="col-lg-10"{% endif %}>
         {{ form_widget(form) }}
         {% for error in errors %}
             <span class="help-block form-error">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 3512
| License       | MIT

Affects label placement on large resolutions.

Use the correct check for whether a label is not being used as per the default form_label block rather than checking only for a user-entered label.

Fixes #3512 

BEFORE:

![image](https://cloud.githubusercontent.com/assets/7068515/11209748/11807280-8d1b-11e5-9087-96d896fee363.png)

AFTER:

![image](https://cloud.githubusercontent.com/assets/7068515/11209749/177a73fc-8d1b-11e5-8d53-da47b9f39d31.png)

