### PR TITLE
[Resource] Bundle resources can not be translated if they were not intended to

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDatabaseDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDatabaseDriver.php
@@ -73,7 +73,9 @@ abstract class AbstractDatabaseDriver implements DatabaseDriverInterface
 
         if (interface_exists($translatableRepositoryInterface) && $reflection->implementsInterface($translatableRepositoryInterface)) {
             $repositoryDefinition->addMethodCall('setLocaleProvider', array(new Reference('sylius.translation.locale_provider')));
-            $repositoryDefinition->addMethodCall('setTranslatableFields', array($classes['translation']['mapping']['fields']));
+            if (isset($classes['translation']['mapping']['fields'])) {
+                $repositoryDefinition->addMethodCall('setTranslatableFields', array($classes['translation']['mapping']['fields']));
+            }
         }
 
         $this->container->setDefinition(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Actually this is more of a workaround.
I ran into the issue while trying to make the `Order` entity translatable, but it actually applies to any sylius bundle exposing semantic configuration that contains untranslated resources.

The database driver adds method calls to `setLocaleProvider` and `setTranslatableFields` to any repository implementing `TranslatableResourceRepositoryInterface`.
However, a lot of sylius bundles include resources that are not initially translated.
For instance, `Order` comes from the `OrderBundle` and no `translation` can be added to the bundle config in `sylius.yml`. As a result, the call to `setTranslatableFields` fails.

This patch makes sure the app won't crash at container compilation time, but no translatable fields are set.
For now, I solved this by adding an additional compiler pass that sets the translatable fields from another bundle's configuration...