### PR TITLE
WebBundle: using form variables that are available, not extra params

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/_item.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/_item.html.twig
@@ -1,19 +1,22 @@
-{% set product = item.variant.product %}
+{% set product = item.vars.value.variant.product %}
 <tr>
     <td class="col-md-1">{{ loop.index }}</td>
     <td>
-        {{ include('SyliusWebBundle:Frontend/Product:_variant.html.twig', {'variant': item.variant}) }}
+        {{ include(
+        'SyliusWebBundle:Frontend/Product:_variant.html.twig',
+        {'variant': item.vars.value.variant}
+        ) }}
     </td>
     <td class="col-md-2">
-        {{ form_row(form.items[loop.index0].quantity, {'label': false}) }}
+        {{ form_row(item.quantity, {'label': false}) }}
     </td>
     <td class="col-md-1">
-        <a href="{{ path('sylius_cart_item_remove', {'id': item.id}) }}" class="btn btn-danger"><i class="icon-trash icon-white"></i></a>
+        <a href="{{ path('sylius_cart_item_remove', {'id': item.vars.value.id}) }}" class="btn btn-danger"><i class="icon-trash icon-white"></i></a>
     </td>
     <td class="col-md-1">
-        {{ item.unitPrice|sylius_price }}
+        {{ item.vars.value.unitPrice|sylius_price }}
     </td>
     <td class="col-md-1" style="text-align: right">
-        {{ item.total|sylius_price }}
+        {{ item.vars.value.total|sylius_price }}
     </td>
 </tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
@@ -38,7 +38,7 @@
         </tr>
     </thead>
     <tbody>
-        {% for item in cart.items %}
+        {% for item in form.items %}
             {% include 'SyliusWebBundle:Frontend/Cart:_item.html.twig' %}
         {% endfor %}
     </tbody>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | [yes, possibly]
| New feature?  | [no]
| BC breaks?    | [no]
| Deprecations? | [no]
| License       | MIT

We were using cart.item's values rather than values that were available in the form itself. Strange looking loop.index0 in loop has been removed. I found this one while trying to add 'recalculate' on summary page. Error was:
```Key "1" in object with ArrayAccess of class "Symfony\Component\Form\FormView" does not exist in SyliusWebBundle:Frontend/Cart:_item.html.twig at line 8```
because cart items are not reindexed while recalculating.