### PR TITLE
[Travis] Composer-related performance optimzations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
     directories:
         - bin
         - vendor
-        - $HOME/.composer/cache
         - $SYLIUS_CACHE_DIR
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,10 @@ before_install:
 
     - composer self-update
 
-    - |
-        if [ $TRAVIS_PHP_VERSION != "7.0" ] && [ $TEST_SUITE = "no-javascript" ]; then
-            travis/prepare/prepare-mongodb
-        else
-            composer install --prefer-dist --no-interaction
-        fi
+    - if [ $TRAVIS_PHP_VERSION != "7.0" ] && [ $TEST_SUITE = "no-javascript" ]; then travis/prepare/prepare-mongodb; fi
+
+    - composer install --no-interaction --prefer-dist --no-scripts
+    - composer run-script "travis-$TEST_SUITE-build" --no-interaction
 
     - cat travis/prepare/opcache.ini >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 

--- a/composer.json
+++ b/composer.json
@@ -157,6 +157,14 @@
         "sylius/web-bundle":         "self.version"
     },
     "scripts": {
+        "travis-no-javascript-build": [
+            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap"
+        ],
+        "travis-javascript-build": [
+            "@travis-no-javascript-build",
+            "Symfony\\Cmf\\Bundle\\CreateBundle\\Composer\\ScriptHandler::downloadCreateAndCkeditor"
+        ],
         "post-install-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",

--- a/travis/prepare/mongodb/1-before
+++ b/travis/prepare/mongodb/1-before
@@ -1,3 +1,5 @@
 #!/bin/bash
 
 echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+
+composer require --no-interaction --no-update doctrine/mongodb-odm="^1.0.2"

--- a/travis/prepare/mongodb/2-rebuild-cache
+++ b/travis/prepare/mongodb/2-rebuild-cache
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-composer require --prefer-dist doctrine/mongodb-odm="^1.0.2"
+composer update --no-interaction --no-scripts --prefer-dist --lock doctrine/mongodb-odm

--- a/travis/prepare/prepare-cached-composer
+++ b/travis/prepare/prepare-cached-composer
@@ -3,11 +3,13 @@
 # Argument 1: Dir with scripts
 function main
 {
-    UNIQUE_KEY=$( text_md5sum $1 )
+    UNIQUE_KEY=`text_md5sum '$1'`
+
+    echo "Preparing cached composer, unique key: $UNIQUE_KEY"
 
     before_hook $1
 
-    if is_cache_fresh $UNIQUE_KEY; then
+    if is_cache_fresh "$UNIQUE_KEY"; then
         restore_composer_lock_from_cache $UNIQUE_KEY
     else
         rebuild_cache_hook $1
@@ -20,21 +22,36 @@ function main
 # Argument 1: Cache unique key
 function store_composer_lock_in_cache
 {
+    echo "Storing composer-$1.lock in cache"
+
     cp composer.lock $SYLIUS_CACHE_DIR/composer-$1.lock
-    file_md5sum 'composer.lock' > $SYLIUS_CACHE_DIR/composer-$1.lock.md5sum
+    file_md5sum composer.json > $SYLIUS_CACHE_DIR/composer-$1.json.md5sum
 }
 
-# Argument 1: Cache unique key
+# Argument 1: Cacheunique key
 function restore_composer_lock_from_cache
 {
+    echo "Restoring composer-$1.lock from cache"
+
     cp $SYLIUS_CACHE_DIR/composer-$1.lock composer.lock
 }
 
 # Argument 1: Cache unique key
 function is_cache_fresh
 {
-    if [ -f "$SYLIUS_CACHE_DIR/composer-$1.lock" ] && [ -f "$SYLIUS_CACHE_DIR/composer-$1.lock.md5sum" ] && [ file_md5sum 'composer.lock' -eq "`cat $SYLIUS_CACHE_DIR/composer-$1.lock.md5sum`" ]; then
-        return 0
+    if [ -f "$SYLIUS_CACHE_DIR/composer-$1.lock" ] \
+    && [ -f "$SYLIUS_CACHE_DIR/composer-$1.json.md5sum" ]; then
+        current_md5sum=`file_md5sum composer.json`
+        previous_md5sum=`cat $SYLIUS_CACHE_DIR/composer-$1.json.md5sum`
+
+        echo "Found previous cache"
+        echo "Previous composer.json md5sum: $current_md5sum"
+        echo "Current composer.json md5sum: $previous_md5sum"
+        if [ $current_md5sum = $previous_md5sum ]; then
+            return 0
+        else
+            return 1
+        fi
     else
         return 1
     fi
@@ -49,30 +66,33 @@ function text_md5sum
 # Argument 1: File to hash
 function file_md5sum
 {
-    md5sum $1 | awk '{ print $1 }'
+    cat $1 | md5sum | awk '{ print $1 }'
 }
 
 # Argument 1: Dir with scripts
 function before_hook
 {
-    if [ -f $1/1-before ]; then
-        bash $1/1-before
+    if [ -f "$1/1-before" ]; then
+        echo "Executing before_hook"
+        bash "$1/1-before"
     fi
 }
 
 # Argument 1: Dir with scripts
 function rebuild_cache_hook
 {
-    if [ -f $1/2-rebuild-cache ]; then
-        bash $1/2-rebuild-cache
+    if [ -f "$1/2-rebuild-cache" ]; then
+        echo "Executing rebuild_cache_hook"
+        bash "$1/2-rebuild-cache"
     fi
 }
 
 # Argument 1: Dir with scripts
 function after_hook
 {
-    if [ -f $1/3-after ]; then
-        bash $1/3-after
+    if [ -f "$1/3-after" ]; then
+        echo "Executing after_hook"
+        bash "$1/3-after"
     fi
 }
 
@@ -81,4 +101,4 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-main $1
+main "$1"


### PR DESCRIPTION
- Travis now does not implicitly run `cache:clear` / `assets:install`  while installing packages by Composer
- Fixed composer.lock caching (while requiring `doctrine/mongodb-odm`)
- Removed `~/.composer` from Travis cache

Doing these things makes that every build, that does not change `composer.json` or `composer.lock`, will not have to upload new cache archive, which usually takes about 40-60s. Moreover, cache archives will be smaller so we will save another second or two here.