### PR TITLE
Add missing default value for PaymentMethod configuration

### DIFF
--- a/src/Sylius/Bundle/PaymentBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/PaymentBundle/DependencyInjection/Configuration.php
@@ -68,7 +68,7 @@ class Configuration implements ConfigurationInterface
                             ->children()
                                 ->scalarNode('model')->defaultValue('Sylius\Component\Payment\Model\PaymentMethod')->end()
                                 ->scalarNode('controller')->defaultValue('Sylius\Bundle\ResourceBundle\Controller\ResourceController')->end()
-                                ->scalarNode('repository')->end()
+                                ->scalarNode('repository')->defaultValue('Sylius\Bundle\PaymentBundle\Doctrine\ORM\PaymentMethodRepository')->end()
                                 ->arrayNode('form')
                                     ->addDefaultsIfNotSet()
                                     ->children()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| License | MIT |

`sylius_payment_method_choice` uses method from this repository, which renders configuration defaults to be broken.
