### PR TITLE
[Behat] [Travis] Investigating failing JS builds

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
@@ -655,9 +655,7 @@ class CoreContext extends DefaultContext
         $session->set('_security_user', serialize($token));
         $session->save();
 
-        if ($this->getSession()->getDriver() instanceof Selenium2Driver) {
-            $this->visitPath('/');
-        }
+        $this->prepareSessionIfNeeded();
 
         $this->getSession()->setCookie($session->getName(), $session->getId());
         $this->getService('security.token_storage')->setToken($token);
@@ -781,5 +779,18 @@ class CoreContext extends DefaultContext
         }
 
         $this->getEntityManager()->persist($product);
+    }
+
+    private function prepareSessionIfNeeded()
+    {
+        if (!$this->getSession()->getDriver() instanceof Selenium2Driver) {
+            return;
+        }
+
+        if (false !== strpos($this->getSession()->getCurrentUrl(), $this->getMinkParameter('base_url'))) {
+            return;
+        }
+
+        $this->visitPath('/');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Behat/HookContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Behat/HookContext.php
@@ -10,10 +10,9 @@
 
 namespace Sylius\Bundle\CoreBundle\Behat;
 
-use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
-use Behat\Symfony2Extension\Context\KernelAwareContext;
-use Doctrine\Common\DataFixtures\Purger\ORMPurger;
+use Behat\Behat\Hook\Scope\BeforeStepScope;
+use Behat\Mink\Driver\Selenium2Driver;
 use Doctrine\Common\DataFixtures\Purger\PurgerInterface;
 use Doctrine\DBAL\Driver\PDOMySql\Driver as PDOMySqlDriver;
 use Sylius\Bundle\ResourceBundle\Behat\DefaultContext;
@@ -41,6 +40,17 @@ class HookContext extends DefaultContext
     public function setKernel(KernelInterface $kernel)
     {
         $this->kernel = $kernel;
+    }
+
+    /**
+     * @BeforeStep
+     */
+    public function setTimeouts(BeforeStepScope $scope)
+    {
+        $driver = $this->getMink()->getSession()->getDriver();
+        if ($driver instanceof Selenium2Driver) {
+            $driver->setTimeouts(['page load' => 30000]);
+        }
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/Behat/DefaultContext.php
+++ b/src/Sylius/Bundle/ResourceBundle/Behat/DefaultContext.php
@@ -470,7 +470,7 @@ abstract class DefaultContext extends RawMinkContext implements Context, KernelA
      *
      * @throws \RuntimeException If timeout was reached
      */
-    protected function waitFor(callable $callback, $limit = 10, $delay = 100)
+    protected function waitFor(callable $callback, $limit = 30, $delay = 100)
     {
         for ($i = 0; $i < $limit; ++$i) {
             $payload = $callback();


### PR DESCRIPTION
- Longer timeouts for accessing database (half of fails, timeout was set to 1s, increased to 3s)
- Shorter timeouts for loading page by Selenium (another half of fails, timeout was set to 10min [equal to Travis no-output timeout :/], decreased to 30s)

I hope the second change will give us insight about the issue and help to fix it.