### PR TITLE
[Behat] Missing security suite added, ordered alphabetically

### DIFF
--- a/features/security/permission_management.feature
+++ b/features/security/permission_management.feature
@@ -58,7 +58,7 @@ Feature: Permissions management
         Then I should be on the permission index page
         And I should see "Permission has been successfully created."
         And I should see 13 permissions in the list
-        And I should see permission with code "sylius.product.display_sales_stats" in that list
+        And I should see permission with code containing "sylius.product.display_sales_stats" in that list
 
     Scenario: Cannot edit the parent of root node
         Given I am on the permission index page
@@ -80,4 +80,4 @@ Feature: Permissions management
         When I click "delete" near "Edit product"
         Then I should be on the permission index page
         And I should see "Permission has been successfully deleted."
-        And I should not see permission with code "sylius.product.edit" in the list
+        And I should not see permission with code containing "sylius.product.edit" in the list

--- a/features/security/role_management.feature
+++ b/features/security/role_management.feature
@@ -62,7 +62,7 @@ Feature: Roles management
         Then I should be on the role index page
         And I should see "Role has been successfully created."
         And I should see 4 roles in the list
-        And I should see role with code "sylius.salesman" in that list
+        And I should see role with name "Salesman" in that list
 
     Scenario: Cannot edit the parent of root node
         Given I am on the role index page
@@ -83,4 +83,4 @@ Feature: Roles management
         When I click "delete" near "sylius.catalog_manager"
         Then I should be on the role index page
         And I should see "Role has been successfully deleted."
-        And I should not see role with code "sylius.catalog_manager" in the list
+        And I should not see role with name "Catalog Manager" in the list

--- a/travis/suites/suite-javascript
+++ b/travis/suites/suite-javascript
@@ -1,12 +1,12 @@
 #!/bin/bash
-bin/behat --strict -f progress -p javascript_cached -s channels
-bin/behat --strict -f progress -p javascript_cached -s users
-bin/behat --strict -f progress -p javascript_cached -s taxonomies
-bin/behat --strict -f progress -p javascript_cached -s taxation
-bin/behat --strict -f progress -p javascript_cached -s shipping
-bin/behat --strict -f progress -p javascript_cached -s promotions
-bin/behat --strict -f progress -p javascript_cached -s products
-bin/behat --strict -f progress -p javascript_cached -s payments
-bin/behat --strict -f progress -p javascript_cached -s orders
-bin/behat --strict -f progress -p javascript_cached -s addressing
 bin/behat --strict -f progress -p javascript_cached -s account
+bin/behat --strict -f progress -p javascript_cached -s addressing
+bin/behat --strict -f progress -p javascript_cached -s channels
+bin/behat --strict -f progress -p javascript_cached -s orders
+bin/behat --strict -f progress -p javascript_cached -s payments
+bin/behat --strict -f progress -p javascript_cached -s products
+bin/behat --strict -f progress -p javascript_cached -s promotions
+bin/behat --strict -f progress -p javascript_cached -s shipping
+bin/behat --strict -f progress -p javascript_cached -s taxation
+bin/behat --strict -f progress -p javascript_cached -s taxonomies
+bin/behat --strict -f progress -p javascript_cached -s users

--- a/travis/suites/suite-no-javascript
+++ b/travis/suites/suite-no-javascript
@@ -2,27 +2,29 @@
 bin/phpspec run -f dot
 
 bin/behat --strict -f progress -p cached -s account
-bin/behat --strict -f progress -p cached -s cart 
-bin/behat --strict -f progress -p cached -s currencies 
-bin/behat --strict -f progress -p cached -s dashboard 
-bin/behat --strict -f progress -p cached -s homepage 
-bin/behat --strict -f progress -p cached -s inventory 
-bin/behat --strict -f progress -p cached -s localization 
-bin/behat --strict -f progress -p cached -s oauth 
-bin/behat --strict -f progress -p cached -s reports 
-bin/behat --strict -f progress -p cached -s taxonomies 
-bin/behat --strict -f progress -p cached -s users 
-bin/behat --strict -f progress -p cached -s search
-bin/behat --strict -f progress -p cached -s checkout
 bin/behat --strict -f progress -p cached -s addressing
+bin/behat --strict -f progress -p cached -s cart
+bin/behat --strict -f progress -p cached -s channels
+bin/behat --strict -f progress -p cached -s checkout
+#bin/behat --strict -f progress -p cached -s contact (waiting for #3164)
+bin/behat --strict -f progress -p cached -s currencies
+bin/behat --strict -f progress -p cached -s dashboard
 bin/behat --strict -f progress -p cached -s emails
+bin/behat --strict -f progress -p cached -s homepage
+bin/behat --strict -f progress -p cached -s i18n
+bin/behat --strict -f progress -p cached -s inventory
+bin/behat --strict -f progress -p cached -s localization
+bin/behat --strict -f progress -p cached -s oauth
 bin/behat --strict -f progress -p cached -s orders
 bin/behat --strict -f progress -p cached -s payments
 bin/behat --strict -f progress -p cached -s pricing
+bin/behat --strict -f progress -p cached -s products
+bin/behat --strict -f progress -p cached -s promotions
+bin/behat --strict -f progress -p cached -s reports
+bin/behat --strict -f progress -p cached -s search
+bin/behat --strict -f progress -p cached -s security
 bin/behat --strict -f progress -p cached -s settings
 bin/behat --strict -f progress -p cached -s shipping
 bin/behat --strict -f progress -p cached -s taxation
-bin/behat --strict -f progress -p cached -s i18n
-bin/behat --strict -f progress -p cached -s channels
-bin/behat --strict -f progress -p cached -s products
-bin/behat --strict -f progress -p cached -s promotions
+bin/behat --strict -f progress -p cached -s taxonomies
+bin/behat --strict -f progress -p cached -s users


### PR DESCRIPTION
- Added `security` suite, which was missing
- Updated `security` scenarios (new table matching)
- Ordered Behat suites in `travis/suites/*` alphabetically