### PR TITLE
[Travis] OPCache optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ before_install:
 
     - if [ $TRAVIS_PHP_VERSION == "7.0" ]; then travis/prepare/prepare-php7-memcached; fi
 
+    - cat travis/prepare/opcache.ini >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+
     - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
     - echo "" > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
     - echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
@@ -50,8 +52,6 @@ before_install:
 
     - composer install --no-interaction --prefer-dist --no-scripts
     - composer run-script "travis-$TEST_SUITE-build" --no-interaction
-
-    - cat travis/prepare/opcache.ini >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 before_script:
     - app/console doctrine:database:create --env=test_cached

--- a/travis/prepare/opcache.ini
+++ b/travis/prepare/opcache.ini
@@ -3,8 +3,9 @@
 opcache.enable = 1
 opcache.enable_cli = 1
 
-opcache.memory_consumption = 128
-opcache.max_accelerated_files = 4000
-opcache.revalidate_freq = 60
+opcache.memory_consumption = 256
+opcache.max_accelerated_files = 32531
+opcache.interned_strings_buffer = 8
+opcache.validate_timestamps = 0
 opcache.save_comments = 1
-opcache.fast_shutdown = 1
+opcache.fast_shutdown = 0


### PR DESCRIPTION
This should prevent `zend_mm_heap corrupted` errors happening sometimes while running `phpspec` and `composer`.