### PR TITLE
fix for issue #2980 - using wrong total for the payment

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/config/services.xml
@@ -19,6 +19,7 @@
     <services>
         <!-- Generic -->
         <service id="sylius.payum.action.capture_payment" class="Sylius\Bundle\PayumBundle\Action\CapturePaymentAction">
+            <argument type="service" id="sylius.currency_converter" />
             <tag name="payum.action" all="true" alias="sylius.capture_payment" />
         </service>
         <service id="sylius.payum.action.execute_same_request_with_payment_details" class="Sylius\Bundle\PayumBundle\Action\ExecuteSameRequestWithPaymentDetailsAction">


### PR DESCRIPTION
Please test this.

Basically the issue for me was that using three currencies with GBP as the default, if someone was to checkout (using Stripe checkout JS), everything would look fine for the user in terms of the price, but the amount sent to stripe via SyliusPayumBundle was using the GBP value but in Euros.

I tested this myself using version 0.15 but I saw the same code is here in 0.16.
