### PR TITLE
[Travis] Javascript suites on every PHP version, lazy cache:warmup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,9 @@ before_script:
 script:
     - travis/run-tests default
 
+before_cache:
+    - yes 'Y' | rm -fr vendor/symfony-cmf/create-bundle/Resources/public/vendor/*
+
 after_failure:
     - export IMGUR_API_KEY=4907fcd89e761c6b07eeb8292d5a9b2a
     - vendor/lakion/mink-debug-extension/travis/tools/upload-textfiles "$SYLIUS_BUILD_DIR/*.log"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,21 +13,20 @@ cache:
 
 sudo: false
 
+addons:
+    apt:
+        sources:
+            - google-chrome
+        packages:
+            - google-chrome-stable
+
 matrix:
     include:
         - php: 5.6
-          env: TEST_SUITE=no-javascript
           services: [memcached, mongodb]
-        - php: 5.6
-          env: TEST_SUITE=javascript
-          services: [memcached]
-          sudo: required
-
         - php: 7.0
-          env: TEST_SUITE=no-javascript
           services: [memcached]
         - php: 5.5
-          env: TEST_SUITE=no-javascript
           services: [memcached, mongodb]
 
     fast_finish: true
@@ -39,6 +38,7 @@ before_install:
     - mkdir -p $SYLIUS_CACHE_DIR
 
     - if [ $TRAVIS_PHP_VERSION == "7.0" ]; then travis/prepare/prepare-php7-memcached; fi
+    - if [ $TRAVIS_PHP_VERSION != "7.0" ]; then travis/prepare/prepare-mongodb; fi
 
     - cat travis/prepare/opcache.ini >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
@@ -47,11 +47,8 @@ before_install:
     - echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
     - composer self-update
-
-    - if [ $TRAVIS_PHP_VERSION != "7.0" ] && [ $TEST_SUITE = "no-javascript" ]; then travis/prepare/prepare-mongodb; fi
-
     - composer install --no-interaction --prefer-dist --no-scripts
-    - composer run-script "travis-$TEST_SUITE-build" --no-interaction
+    - composer run-script travis-build --no-interaction
 
 before_script:
     - app/console doctrine:database:create --env=test_cached
@@ -60,18 +57,14 @@ before_script:
 
     - app/console cache:warmup --env=test_cached --no-debug
 
-    - |
-        if [ $TEST_SUITE = "javascript" ]; then
-            travis/prepare/prepare-javascript
-            app/console assets:install --env=test_cached --no-debug
-            app/console assetic:dump --env=test_cached --no-debug
-        fi
+    - app/console assetic:dump --env=test_cached --no-debug &
+    - app/console assets:install --env=test_cached --no-debug &
 
     - php -v
     - php -i
 
 script:
-    - travis/run-tests $TEST_SUITE
+    - travis/run-tests default
 
 after_failure:
     - export IMGUR_API_KEY=4907fcd89e761c6b07eeb8292d5a9b2a

--- a/composer.json
+++ b/composer.json
@@ -157,12 +157,9 @@
         "sylius/web-bundle":         "self.version"
     },
     "scripts": {
-        "travis-no-javascript-build": [
+        "travis-build": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap"
-        ],
-        "travis-javascript-build": [
-            "@travis-no-javascript-build",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Symfony\\Cmf\\Bundle\\CreateBundle\\Composer\\ScriptHandler::downloadCreateAndCkeditor"
         ],
         "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,8 @@
         "twig/twig": "~1.11",
         "white-october/pagerfanta-bundle": "~1.0",
         "willdurand/hateoas-bundle": "~0.4",
-        "winzou/state-machine-bundle": "~0.2"
+        "winzou/state-machine-bundle": "~0.2",
+        "ocramius/proxy-manager": "^1.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.4@rc",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "3ec6953b2602942fe53c77f3f79484e9",
-    "content-hash": "0e40d5264883ec72d508116ae96501d0",
+    "hash": "f7d51288bb8ab0287bc6e8cbe010c017",
+    "content-hash": "086bcf76758b6ffb085bdc3e7a5fe18f",
     "packages": [
         {
             "name": "a2lix/translation-form-bundle",
@@ -3499,6 +3499,69 @@
                 "php"
             ],
             "time": "2012-04-23 22:52:11"
+        },
+        {
+            "name": "ocramius/proxy-manager",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/ProxyManager.git",
+                "reference": "57e9272ec0e8deccf09421596e0e2252df440e11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/57e9272ec0e8deccf09421596e0e2252df440e11",
+                "reference": "57e9272ec0e8deccf09421596e0e2252df440e11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "zendframework/zend-code": ">2.2.5,<3.0"
+            },
+            "require-dev": {
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "1.5.*"
+            },
+            "suggest": {
+                "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects",
+                "zendframework/zend-json": "To have the JsonRpc adapter (Remote Object feature)",
+                "zendframework/zend-soap": "To have the Soap adapter (Remote Object feature)",
+                "zendframework/zend-stdlib": "To use the hydrator proxy",
+                "zendframework/zend-xmlrpc": "To have the XmlRpc adapter (Remote Object feature)"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "ProxyManager\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A library providing utilities to generate, instantiate and generally operate with Object Proxies",
+            "homepage": "https://github.com/Ocramius/ProxyManager",
+            "keywords": [
+                "aop",
+                "lazy loading",
+                "proxy",
+                "proxy pattern",
+                "service proxies"
+            ],
+            "time": "2015-08-09 04:28:19"
         },
         {
             "name": "omnipay/2checkout",
@@ -7630,6 +7693,217 @@
                 "symfony"
             ],
             "time": "2014-11-27 05:49:41"
+        },
+        {
+            "name": "zendframework/zend-code",
+            "version": "2.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-code.git",
+                "reference": "2a69bd42bddf9a955f3747af9e06b6d26e7c41ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/2a69bd42bddf9a955f3747af9e06b6d26e7c41ba",
+                "reference": "2a69bd42bddf9a955f3747af9e06b6d26e7c41ba",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "zendframework/zend-eventmanager": "~2.5"
+            },
+            "require-dev": {
+                "doctrine/common": ">=2.1",
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-stdlib": "~2.5"
+            },
+            "suggest": {
+                "doctrine/common": "Doctrine\\Common >=2.1 for annotation features",
+                "zendframework/zend-stdlib": "Zend\\Stdlib component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Code\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides facilities to generate arbitrary code using an object oriented interface",
+            "homepage": "https://github.com/zendframework/zend-code",
+            "keywords": [
+                "code",
+                "zf2"
+            ],
+            "time": "2015-11-18 18:22:37"
+        },
+        {
+            "name": "zendframework/zend-eventmanager",
+            "version": "2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-eventmanager.git",
+                "reference": "135af03d07fd048c322259aab6611d2be290475c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/135af03d07fd048c322259aab6611d2be290475c",
+                "reference": "135af03d07fd048c322259aab6611d2be290475c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "zendframework/zend-stdlib": "~2.5"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-eventmanager",
+            "keywords": [
+                "eventmanager",
+                "zf2"
+            ],
+            "time": "2015-07-16 19:00:49"
+        },
+        {
+            "name": "zendframework/zend-hydrator",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-hydrator.git",
+                "reference": "f3ed8b833355140350bbed98d8a7b8b66875903f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-hydrator/zipball/f3ed8b833355140350bbed98d8a7b8b66875903f",
+                "reference": "f3ed8b833355140350bbed98d8a7b8b66875903f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "zendframework/zend-stdlib": "^2.5.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "^2.0@dev",
+                "zendframework/zend-eventmanager": "^2.5.1",
+                "zendframework/zend-filter": "^2.5.1",
+                "zendframework/zend-inputfilter": "^2.5.1",
+                "zendframework/zend-serializer": "^2.5.1",
+                "zendframework/zend-servicemanager": "^2.5.1"
+            },
+            "suggest": {
+                "zendframework/zend-eventmanager": "^2.5.1, to support aggregate hydrator usage",
+                "zendframework/zend-filter": "^2.5.1, to support naming strategy hydrator usage",
+                "zendframework/zend-serializer": "^2.5.1, to use the SerializableStrategy",
+                "zendframework/zend-servicemanager": "^2.5.1, to support hydrator plugin manager usage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev",
+                    "dev-develop": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Hydrator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-hydrator",
+            "keywords": [
+                "hydrator",
+                "zf2"
+            ],
+            "time": "2015-09-17 14:06:43"
+        },
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "2.7.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "cae029346a33663b998507f94962eb27de060683"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/cae029346a33663b998507f94962eb27de060683",
+                "reference": "cae029346a33663b998507f94962eb27de060683",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "zendframework/zend-hydrator": "~1.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1",
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-config": "~2.5",
+                "zendframework/zend-eventmanager": "~2.5",
+                "zendframework/zend-filter": "~2.5",
+                "zendframework/zend-inputfilter": "~2.5",
+                "zendframework/zend-serializer": "~2.5",
+                "zendframework/zend-servicemanager": "~2.5"
+            },
+            "suggest": {
+                "zendframework/zend-eventmanager": "To support aggregate hydrator usage",
+                "zendframework/zend-filter": "To support naming strategy hydrator usage",
+                "zendframework/zend-serializer": "Zend\\Serializer component",
+                "zendframework/zend-servicemanager": "To support hydrator plugin manager usage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev",
+                    "dev-develop": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-stdlib",
+            "keywords": [
+                "stdlib",
+                "zf2"
+            ],
+            "time": "2015-10-15 15:57:32"
         }
     ],
     "packages-dev": [

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/LazyCacheWarmupPass.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/LazyCacheWarmupPass.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Sylius\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+class LazyCacheWarmupPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->markServiceAsLazy($container, 'cmf_core.templating.helper');
+        $this->markServiceAsLazy($container, 'cmf_create.rdf_type_factory');
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param $id
+     */
+    private function markServiceAsLazy(ContainerBuilder $container, $id)
+    {
+        if ($container->hasDefinition($id)) {
+            $definition = $container->findDefinition($id);
+            $definition->setLazy(true);
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/templating.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/templating.xml
@@ -27,7 +27,7 @@
             <tag name="templating.helper" alias="sylius_restricted_zone" />
         </service>
 
-        <service id="sylius.templating.helper.money" class="%sylius.templating.helper.money.class%">
+        <service id="sylius.templating.helper.money" class="%sylius.templating.helper.money.class%" lazy="true">
             <argument type="service" id="sylius.context.locale" />
             <argument type="service" id="sylius.context.currency" />
             <tag name="templating.helper" alias="sylius_money" />

--- a/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
+++ b/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\CoreBundle;
 
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\DoctrineSluggablePass;
+use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\LazyCacheWarmupPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\RoutingRepositoryPass;
 use Sylius\Bundle\ResourceBundle\AbstractResourceBundle;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
@@ -44,6 +45,7 @@ class SyliusCoreBundle extends AbstractResourceBundle
 
         $container->addCompilerPass(new DoctrineSluggablePass());
         $container->addCompilerPass(new RoutingRepositoryPass());
+        $container->addCompilerPass(new LazyCacheWarmupPass());
     }
 
     /**

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/templating.xml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/templating.xml
@@ -22,13 +22,13 @@
     </parameters>
 
     <services>
-        <service id="sylius.templating.helper.currency" class="%sylius.templating.helper.currency.class%">
+        <service id="sylius.templating.helper.currency" class="%sylius.templating.helper.currency.class%" lazy="true">
             <argument type="service" id="sylius.context.currency" />
             <argument type="service" id="sylius.currency_converter" />
             <argument type="service" id="sylius.templating.helper.money" />
             <tag name="templating.helper" alias="sylius_currency" />
         </service>
-        <service id="sylius.templating.helper.money" class="%sylius.templating.helper.money.class%">
+        <service id="sylius.templating.helper.money" class="%sylius.templating.helper.money.class%" lazy="true">
             <argument>%sylius.money.locale%</argument>
             <argument type="service" id="sylius.context.currency" />
             <tag name="templating.helper" alias="sylius_money" />

--- a/src/Sylius/Bundle/MoneyBundle/Resources/config/templating.xml
+++ b/src/Sylius/Bundle/MoneyBundle/Resources/config/templating.xml
@@ -21,7 +21,7 @@
     </parameters>
 
     <services>
-        <service id="sylius.templating.helper.money" class="%sylius.templating.helper.money.class%">
+        <service id="sylius.templating.helper.money" class="%sylius.templating.helper.money.class%" lazy="true">
             <argument>%sylius.money.locale%</argument>
             <argument>%sylius.money.currency%</argument>
             <tag name="templating.helper" alias="sylius_money" />

--- a/travis/prepare/prepare-javascript
+++ b/travis/prepare/prepare-javascript
@@ -3,14 +3,6 @@
 /sbin/start-stop-daemon --start --quiet --pidfile /tmp/xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1680x1050x16
 export DISPLAY=:99
 
-# Installing google-chrome
-if [ ! -f $SYLIUS_CACHE_DIR/google-chrome.deb ]; then
-    curl https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb > $SYLIUS_CACHE_DIR/google-chrome.deb
-fi
-
-sudo dpkg -i $SYLIUS_CACHE_DIR/google-chrome.deb
-sudo apt-get -f install
-
 # Downloading and configuring Selenium & ChromeDriver
 if [ ! -f $SYLIUS_CACHE_DIR/selenium.jar ]; then
     curl http://selenium-release.storage.googleapis.com/2.47/selenium-server-standalone-2.47.1.jar > $SYLIUS_CACHE_DIR/selenium.jar
@@ -22,10 +14,11 @@ if [ ! -f $SYLIUS_CACHE_DIR/chromedriver ]; then
     mv chromedriver $SYLIUS_CACHE_DIR
 fi
 
-# Running Selenium with ChromeDriver
-java -jar $SYLIUS_CACHE_DIR/selenium.jar -Dwebdriver.chrome.driver=$SYLIUS_CACHE_DIR/chromedriver > $SYLIUS_BUILD_DIR/selenium.log 2>&1 &
-vendor/lakion/mink-debug-extension/travis/tools/wait-for-port 4444
-
 # Running webserver
 app/console server:run 127.0.0.1:8080 --env=test_cached --router=app/config/router_test_cached.php --no-debug > $SYLIUS_BUILD_DIR/webserver.log 2>&1 &
+
+# Running Selenium with ChromeDriver
+java -jar $SYLIUS_CACHE_DIR/selenium.jar -Dwebdriver.chrome.driver=$SYLIUS_CACHE_DIR/chromedriver > $SYLIUS_BUILD_DIR/selenium.log 2>&1 &
+
 vendor/lakion/mink-debug-extension/travis/tools/wait-for-port 8080
+vendor/lakion/mink-debug-extension/travis/tools/wait-for-port 4444

--- a/travis/suites/suite-default
+++ b/travis/suites/suite-default
@@ -1,0 +1,8 @@
+#!/bin/bash
+bin/phpspec run -f dot
+
+bin/behat --strict -f progress -p cached
+
+travis/prepare/prepare-javascript
+
+bin/behat --strict -f progress -p javascript_cached

--- a/travis/suites/suite-javascript
+++ b/travis/suites/suite-javascript
@@ -1,2 +1,0 @@
-#!/bin/bash
-bin/behat --strict -f progress -p javascript_cached

--- a/travis/suites/suite-no-javascript
+++ b/travis/suites/suite-no-javascript
@@ -1,4 +1,0 @@
-#!/bin/bash
-bin/phpspec run -f dot
-
-bin/behat --strict -f progress -p cached


### PR DESCRIPTION
No BC breaks :)

 - [x] Deleted PHP 5.6 Javascript job on Travis
 - [x] Added Javascript Behat suites on every PHP version
 - [x] Made `cache:warmup` command not to require database schema
 - [x] Solved issue with storing new cache on every build