### PR TITLE
[DB] Allow orders to be deleted directly through DB with correct onDelete=CASCADEs

### DIFF
--- a/app/migrations/Version20151129155421.php
+++ b/app/migrations/Version20151129155421.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20151129155421 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_adjustment DROP FOREIGN KEY FK_ACA6E0F28D9F6D38');
+        $this->addSql('ALTER TABLE sylius_adjustment DROP FOREIGN KEY FK_ACA6E0F2E415FB15');
+        $this->addSql('ALTER TABLE sylius_adjustment ADD CONSTRAINT FK_ACA6E0F28D9F6D38 FOREIGN KEY (order_id) REFERENCES sylius_order (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sylius_adjustment ADD CONSTRAINT FK_ACA6E0F2E415FB15 FOREIGN KEY (order_item_id) REFERENCES sylius_order_item (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sylius_inventory_unit DROP FOREIGN KEY FK_4A276986E415FB15');
+        $this->addSql('ALTER TABLE sylius_inventory_unit ADD CONSTRAINT FK_4A276986E415FB15 FOREIGN KEY (order_item_id) REFERENCES sylius_order_item (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sylius_promotion_order DROP FOREIGN KEY FK_BF9CF6FB8D9F6D38');
+        $this->addSql('ALTER TABLE sylius_promotion_order ADD CONSTRAINT FK_BF9CF6FB8D9F6D38 FOREIGN KEY (order_id) REFERENCES sylius_order (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sylius_order_item DROP FOREIGN KEY FK_77B587ED8D9F6D38');
+        $this->addSql('ALTER TABLE sylius_order_item ADD CONSTRAINT FK_77B587ED8D9F6D38 FOREIGN KEY (order_id) REFERENCES sylius_order (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sylius_promotion_order_item DROP FOREIGN KEY FK_49838ED1E415FB15');
+        $this->addSql('ALTER TABLE sylius_promotion_order_item ADD CONSTRAINT FK_49838ED1E415FB15 FOREIGN KEY (order_item_id) REFERENCES sylius_order_item (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sylius_payment DROP FOREIGN KEY FK_D9191BD48D9F6D38');
+        $this->addSql('ALTER TABLE sylius_payment ADD CONSTRAINT FK_D9191BD48D9F6D38 FOREIGN KEY (order_id) REFERENCES sylius_order (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sylius_shipment DROP FOREIGN KEY FK_FD707B338D9F6D38');
+        $this->addSql('ALTER TABLE sylius_shipment ADD CONSTRAINT FK_FD707B338D9F6D38 FOREIGN KEY (order_id) REFERENCES sylius_order (id) ON DELETE CASCADE');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_adjustment DROP FOREIGN KEY FK_ACA6E0F28D9F6D38');
+        $this->addSql('ALTER TABLE sylius_adjustment DROP FOREIGN KEY FK_ACA6E0F2E415FB15');
+        $this->addSql('ALTER TABLE sylius_adjustment ADD CONSTRAINT FK_ACA6E0F28D9F6D38 FOREIGN KEY (order_id) REFERENCES sylius_order (id)');
+        $this->addSql('ALTER TABLE sylius_adjustment ADD CONSTRAINT FK_ACA6E0F2E415FB15 FOREIGN KEY (order_item_id) REFERENCES sylius_order_item (id)');
+        $this->addSql('ALTER TABLE sylius_inventory_unit DROP FOREIGN KEY FK_4A276986E415FB15');
+        $this->addSql('ALTER TABLE sylius_inventory_unit ADD CONSTRAINT FK_4A276986E415FB15 FOREIGN KEY (order_item_id) REFERENCES sylius_order_item (id)');
+        $this->addSql('ALTER TABLE sylius_order_item DROP FOREIGN KEY FK_77B587ED8D9F6D38');
+        $this->addSql('ALTER TABLE sylius_order_item ADD CONSTRAINT FK_77B587ED8D9F6D38 FOREIGN KEY (order_id) REFERENCES sylius_order (id)');
+        $this->addSql('ALTER TABLE sylius_payment DROP FOREIGN KEY FK_D9191BD48D9F6D38');
+        $this->addSql('ALTER TABLE sylius_payment ADD CONSTRAINT FK_D9191BD48D9F6D38 FOREIGN KEY (order_id) REFERENCES sylius_order (id)');
+        $this->addSql('ALTER TABLE sylius_promotion_order DROP FOREIGN KEY FK_BF9CF6FB8D9F6D38');
+        $this->addSql('ALTER TABLE sylius_promotion_order ADD CONSTRAINT FK_BF9CF6FB8D9F6D38 FOREIGN KEY (order_id) REFERENCES sylius_order (id)');
+        $this->addSql('ALTER TABLE sylius_promotion_order_item DROP FOREIGN KEY FK_49838ED1E415FB15');
+        $this->addSql('ALTER TABLE sylius_promotion_order_item ADD CONSTRAINT FK_49838ED1E415FB15 FOREIGN KEY (order_item_id) REFERENCES sylius_order_item (id)');
+        $this->addSql('ALTER TABLE sylius_shipment DROP FOREIGN KEY FK_FD707B338D9F6D38');
+        $this->addSql('ALTER TABLE sylius_shipment ADD CONSTRAINT FK_FD707B338D9F6D38 FOREIGN KEY (order_id) REFERENCES sylius_order (id)');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/InventoryUnit.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/InventoryUnit.orm.xml
@@ -7,7 +7,7 @@
 
     <mapped-superclass name="Sylius\Component\Core\Model\InventoryUnit" table="sylius_inventory_unit">
         <many-to-one field="orderItem" target-entity="Sylius\Component\Order\Model\OrderItemInterface" inversed-by="inventoryUnits">
-            <join-column name="order_item_id" referenced-column-name="id" nullable="false" />
+            <join-column name="order_item_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
         </many-to-one>
 
         <field name="shippingState" column="shipping_state" type="string" nullable="false" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Order.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Order.orm.xml
@@ -70,7 +70,7 @@
         <many-to-many field="promotions" target-entity="Sylius\Component\Promotion\Model\PromotionInterface">
             <join-table name="sylius_promotion_order">
                 <join-columns>
-                    <join-column name="order_id" referenced-column-name="id" />
+                    <join-column name="order_id" referenced-column-name="id" on-delete="CASCADE" />
                 </join-columns>
                 <inverse-join-columns>
                     <join-column name="promotion_id" referenced-column-name="id" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/OrderItem.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/OrderItem.orm.xml
@@ -31,7 +31,7 @@
         <many-to-many field="promotions" target-entity="Sylius\Component\Promotion\Model\PromotionInterface">
             <join-table name="sylius_promotion_order_item">
                 <join-columns>
-                    <join-column name="order_item_id" referenced-column-name="id" />
+                    <join-column name="order_item_id" referenced-column-name="id" on-delete="CASCADE" />
                 </join-columns>
                 <inverse-join-columns>
                     <join-column name="promotion_id" referenced-column-name="id" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Payment.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Payment.orm.xml
@@ -18,7 +18,7 @@
 
     <mapped-superclass name="Sylius\Component\Core\Model\Payment" table="sylius_payment">
         <many-to-one field="order" target-entity="Sylius\Component\Order\Model\OrderInterface" inversed-by="payments">
-            <join-column name="order_id" referenced-column-name="id" nullable="false" />
+            <join-column name="order_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
         </many-to-one>
     </mapped-superclass>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Shipment.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Shipment.orm.xml
@@ -18,7 +18,7 @@
 
     <mapped-superclass name="Sylius\Component\Core\Model\Shipment" table="sylius_shipment">
         <many-to-one field="order" target-entity="Sylius\Component\Order\Model\OrderInterface" inversed-by="shipments">
-            <join-column name="order_id" referenced-column-name="id" nullable="false" />
+            <join-column name="order_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
         </many-to-one>
     </mapped-superclass>
 

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Adjustment.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Adjustment.orm.xml
@@ -39,11 +39,11 @@
         </field>
 
         <many-to-one field="order" target-entity="Sylius\Component\Order\Model\OrderInterface" inversed-by="adjustments">
-            <join-column name="order_id" referenced-column-name="id" nullable="true" />
+            <join-column name="order_id" referenced-column-name="id" nullable="true" on-delete="CASCADE"/>
         </many-to-one>
 
         <many-to-one field="orderItem" target-entity="Sylius\Component\Order\Model\OrderItemInterface" inversed-by="adjustments">
-            <join-column name="order_item_id" referenced-column-name="id" nullable="true" />
+            <join-column name="order_item_id" referenced-column-name="id" nullable="true" on-delete="CASCADE"/>
         </many-to-one>
     </mapped-superclass>
 

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItem.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItem.orm.xml
@@ -33,7 +33,7 @@
         <field name="immutable" column="is_immutable" type="boolean" />
 
         <many-to-one field="order" target-entity="Sylius\Component\Order\Model\OrderInterface" inversed-by="items">
-            <join-column name="order_id" referenced-column-name="id" nullable="false" />
+            <join-column name="order_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
         </many-to-one>
 
         <one-to-many field="adjustments" target-entity="Sylius\Component\Order\Model\AdjustmentInterface" mapped-by="orderItem" orphan-removal="true">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Setup onDelete=CASCADE foreign keys for Order and OrderItem relations so that orders can be deleted directly in the DB along with their relevant relations:
* Order => OrderItem
* Order => Payment
* Order => Shipment
* Order => InventoryUnit
* Order => Adjustment
* Order => OrderPromotion (m2m)
* OrderItem => OrderItemPromotion (m2m)
* OrderItem => InventoryUnit
* OrderItem => Adjustment