### PR TITLE
CartBundle: fix for missing identifiers in cartContext

### DIFF
--- a/src/Sylius/Bundle/CartBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CartBundle/Resources/config/services.xml
@@ -88,6 +88,7 @@
             <argument type="service" id="sylius.factory.cart" />
             <argument type="service" id="sylius.repository.cart" />
             <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="sylius.manager.cart" />
         </service>
 
         <service id="sylius.listener.cart" class="%sylius.listener.cart.class%">

--- a/src/Sylius/Bundle/CartBundle/spec/Provider/CartProviderSpec.php
+++ b/src/Sylius/Bundle/CartBundle/spec/Provider/CartProviderSpec.php
@@ -11,6 +11,7 @@
 
 namespace spec\Sylius\Bundle\CartBundle\Provider;
 
+use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\CartBundle\Provider\CartProvider;
@@ -32,9 +33,16 @@ class CartProviderSpec extends ObjectBehavior
         CartContextInterface $cartContext,
         FactoryInterface $cartFactory,
         RepositoryInterface $cartRepository,
-        EventDispatcherInterface $eventDispatcher
+        EventDispatcherInterface $eventDispatcher,
+        ObjectManager $cartManager
     ) {
-        $this->beConstructedWith($cartContext, $cartFactory, $cartRepository, $eventDispatcher);
+        $this->beConstructedWith(
+            $cartContext,
+            $cartFactory,
+            $cartRepository,
+            $eventDispatcher,
+            $cartManager
+        );
     }
 
     function it_is_initializable()
@@ -57,8 +65,8 @@ class CartProviderSpec extends ObjectBehavior
         $cartRepository->find(3)->willReturn($cart);
         $eventDispatcher->dispatch(
             SyliusCartEvents::CART_INITIALIZE,
-            Argument::type(GenericEvent::class)
-        )->shouldBeCalled();
+            Argument::any()
+        )->shouldNotBeCalled();
 
         $cartContext->setCurrentCartIdentifier($cart)->shouldNotBeCalled();
 
@@ -70,7 +78,8 @@ class CartProviderSpec extends ObjectBehavior
         FactoryInterface $cartFactory,
         RepositoryInterface $cartRepository,
         EventDispatcherInterface $eventDispatcher,
-        CartInterface $cart
+        CartInterface $cart,
+        ObjectManager $cartManager
     ) {
         $cartContext->getCurrentCartIdentifier()->willReturn(null);
         $cartFactory->createNew()->willReturn($cart);
@@ -80,6 +89,9 @@ class CartProviderSpec extends ObjectBehavior
             SyliusCartEvents::CART_INITIALIZE,
             Argument::type(GenericEvent::class)
         )->shouldBeCalled();
+
+        $cartManager->persist($cart)->shouldBeCalled();
+        $cartManager->flush()->shouldBeCalled();
 
         $cartContext->setCurrentCartIdentifier($cart)->shouldBeCalled();
 

--- a/src/Sylius/Component/Cart/Context/CartContext.php
+++ b/src/Sylius/Component/Cart/Context/CartContext.php
@@ -13,6 +13,7 @@ namespace Sylius\Component\Cart\Context;
 
 use Sylius\Component\Cart\Model\CartInterface;
 use Sylius\Component\Storage\StorageInterface;
+use Symfony\Component\Config\Definition\Exception\Exception;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -45,6 +46,10 @@ class CartContext implements CartContextInterface
      */
     public function setCurrentCartIdentifier(CartInterface $cart)
     {
+        if (null === $cart->getIdentifier()) {
+            throw new \UnexpectedValueException('Identifier on cart does not exist - unable to save');
+        }
+
         $this->storage->setData(self::STORAGE_KEY, $cart->getIdentifier());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | [yes]
| New feature?  | [no]
| BC breaks?    | [no]
| Deprecations? | [no]
| License       | MIT

We were 'saving' carts even if there was no clear indication which cart has been saved because of non-persisted carts in that case we were creating plenty of instances of carts and overriding these by each other in CartContext. It is impossible now to save a cart in CartContext if there is no identifier.