### PR TITLE
[Composer] Added explicit dependency symfony/proxy-manager-bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ matrix:
 before_install:
     - mkdir -p $SYLIUS_CACHE_DIR
 
+    - composer self-update
+
     - if [ $TRAVIS_PHP_VERSION == "7.0" ]; then travis/prepare/prepare-php7-memcached; fi
     - if [ $TRAVIS_PHP_VERSION != "7.0" ]; then travis/prepare/prepare-mongodb; fi
 
@@ -41,19 +43,19 @@ before_install:
     - echo "" > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
     - echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
-    - composer self-update
     - composer install --no-interaction --prefer-dist --no-scripts
     - composer run-script travis-build --no-interaction
 
 before_script:
     - app/console doctrine:database:create --env=test_cached
-    - app/console doctrine:schema:create --env=test_cached
-    - app/console doctrine:phpcr:repository:init --env=test_cached
 
     - app/console cache:warmup --env=test_cached --no-debug
 
-    - app/console assetic:dump --env=test_cached --no-debug &
-    - app/console assets:install --env=test_cached --no-debug &
+    - app/console doctrine:schema:create --env=test_cached
+    - app/console doctrine:phpcr:repository:init --env=test_cached
+
+    - app/console assets:install --env=test_cached --no-debug
+    - app/console assetic:dump --env=test_cached --no-debug
 
     - php -v
     - php -i

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,8 @@
         "white-october/pagerfanta-bundle": "~1.0",
         "willdurand/hateoas-bundle": "~0.4",
         "winzou/state-machine-bundle": "~0.2",
-        "ocramius/proxy-manager": "^1.0"
+        "ocramius/proxy-manager": "^1.0",
+        "symfony/proxy-manager-bridge": "^2.7"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "99f81c36d8c00b6947e099bf072dbba2",
-    "content-hash": "7d89b8cecb431278edf7bb3dc2571c42",
+    "hash": "24597d6ea3ad3642e0410bbbed909604",
+    "content-hash": "b51b53820b874bceb59a0fb4667426b9",
     "packages": [
         {
             "name": "a2lix/translation-form-bundle",
@@ -1674,16 +1674,16 @@
         },
         {
             "name": "gedmo/doctrine-extensions",
-            "version": "v2.4.8",
+            "version": "v2.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Atlantic18/DoctrineExtensions.git",
-                "reference": "096ed89496f8adab9a57aaf0e3624c3407f64d4f"
+                "reference": "04ac4d1cdbdc610816562344c7ed74aecf2cd1ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Atlantic18/DoctrineExtensions/zipball/096ed89496f8adab9a57aaf0e3624c3407f64d4f",
-                "reference": "096ed89496f8adab9a57aaf0e3624c3407f64d4f",
+                "url": "https://api.github.com/repos/Atlantic18/DoctrineExtensions/zipball/04ac4d1cdbdc610816562344c7ed74aecf2cd1ca",
+                "reference": "04ac4d1cdbdc610816562344c7ed74aecf2cd1ca",
                 "shasum": ""
             },
             "require": {
@@ -1749,7 +1749,7 @@
                 "tree",
                 "uploadable"
             ],
-            "time": "2015-11-25 05:46:30"
+            "time": "2015-11-30 18:58:48"
         },
         {
             "name": "guzzle/guzzle",


### PR DESCRIPTION
It looks like Symfony 2.8 does not include `symfony/proxy-manager-bridge` and changes made in #3643 related to lazy `cache:warmup` aren't working in that case.

Also moved `cache:warmup` above creating schema in Travis, to ensure that cache warming up does not require database schema.