### PR TITLE
[WIP] Rework promotion rule checkers to allow promotion repeating

### DIFF
--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Rule/ItemCountConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Rule/ItemCountConfigurationType.php
@@ -44,12 +44,16 @@ class ItemCountConfigurationType extends AbstractType
                     new Type(array('type' => 'numeric')),
                 ),
             ))
-            ->add('equal', 'checkbox', array(
+            ->add('equal', 'choice', [
                 'label' => 'sylius.form.rule.item_count_configuration.equal',
-                'constraints' => array(
-                    new Type(array('type' => 'bool')),
-                ),
-            ))
+                'choices' => [
+                    'sylius.form.rule.item_count_configuration.equal_or_more' => 'equal',
+                    'sylius.form.rule.item_count_configuration.more_than' => 'more_than',
+                    'sylius.form.rule.item_count_configuration.exactly' => 'exactly',
+                    'sylius.form.rule.item_count_configuration.repeatable' => 'modulo',
+                ],
+                'choices_as_values' => true,
+            ])
         ;
     }
 

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Rule/ItemTotalConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Rule/ItemTotalConfigurationType.php
@@ -44,12 +44,15 @@ class ItemTotalConfigurationType extends AbstractType
                     new Type(array('type' => 'numeric')),
                 ),
             ))
-            ->add('equal', 'checkbox', array(
+            ->add('equal', 'choice', [
                 'label' => 'sylius.form.rule.item_total_configuration.equal',
-                'constraints' => array(
-                    new Type(array('type' => 'bool')),
-                ),
-            ))
+                'choices' => [
+                    'sylius.form.rule.item_total_configuration.equal_or_more' => 'equal',
+                    'sylius.form.rule.item_total_configuration.more_than' => 'more_than',
+                    'sylius.form.rule.item_total_configuration.exactly' => 'exactly',
+                ],
+                'choices_as_values' => true,
+            ])
         ;
     }
 

--- a/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.en.yml
@@ -20,9 +20,16 @@ sylius:
             item_count_configuration:
                 count: Count
                 equal: Equal
+                equal_or_more: Equal or more
+                more_than: More than
+                exactly: Exactly
             item_total_configuration:
                 amount: Amount
                 equal: Equal
+                equal_or_more: Equal or more
+                more_than: More than
+                exactly: Exactly
+                repeatable: Repeatable?
             nth_order_configuration:
                 nth: Nth
             customer_loyalty_configuration:

--- a/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Rule/ItemCountConfigurationTypeSpec.php
+++ b/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Rule/ItemCountConfigurationTypeSpec.php
@@ -43,7 +43,7 @@ class ItemCountConfigurationTypeSpec extends ObjectBehavior
         ;
 
         $builder
-            ->add('equal', 'checkbox', Argument::any())
+            ->add('equal', 'choice', Argument::any())
             ->willReturn($builder)
         ;
 

--- a/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Rule/ItemTotalConfigurationTypeSpec.php
+++ b/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Rule/ItemTotalConfigurationTypeSpec.php
@@ -43,7 +43,7 @@ class ItemTotalConfigurationTypeSpec extends ObjectBehavior
         ;
 
         $builder
-            ->add('equal', 'checkbox', Argument::any())
+            ->add('equal', 'choice', Argument::any())
             ->willReturn($builder)
         ;
 

--- a/src/Sylius/Component/Promotion/Action/PromotionActionInterface.php
+++ b/src/Sylius/Component/Promotion/Action/PromotionActionInterface.php
@@ -27,8 +27,6 @@ interface PromotionActionInterface
      * @param PromotionSubjectInterface $subject
      * @param array                     $configuration
      * @param PromotionInterface        $promotion
-     *
-     * @return mixed
      */
     public function execute(PromotionSubjectInterface $subject, array $configuration, PromotionInterface $promotion);
 
@@ -38,8 +36,6 @@ interface PromotionActionInterface
      * @param PromotionSubjectInterface $subject
      * @param array                     $configuration
      * @param PromotionInterface        $promotion
-     *
-     * @return mixed
      */
     public function revert(PromotionSubjectInterface $subject, array $configuration, PromotionInterface $promotion);
 

--- a/src/Sylius/Component/Promotion/Checker/ItemTotalRuleChecker.php
+++ b/src/Sylius/Component/Promotion/Checker/ItemTotalRuleChecker.php
@@ -14,9 +14,10 @@ namespace Sylius\Component\Promotion\Checker;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
 
 /**
- * Checks if subject’s total exceeds (or at least equal) to the configured amount.
+ * Checks if subject’s total is equal, exactly same, or more than to the configured amount.
  *
  * @author Saša Stamenković <umpirsky@gmail.com>
+ * @author Joseph Bielawski <stloyd@gmail.com>
  */
 class ItemTotalRuleChecker implements RuleCheckerInterface
 {
@@ -25,11 +26,33 @@ class ItemTotalRuleChecker implements RuleCheckerInterface
      */
     public function isEligible(PromotionSubjectInterface $subject, array $configuration)
     {
-        if (isset($configuration['equal']) && $configuration['equal']) {
-            return $subject->getPromotionSubjectTotal() >= $configuration['amount'];
+        if (!isset($configuration['equal'])) {
+            $configuration['equal'] = 'equal';
+        } elseif (is_bool($configuration['equal'])) {
+            $configuration['equal'] = $configuration['equal'] ? 'equal' : 'more_than';
         }
 
-        return $subject->getPromotionSubjectTotal() > $configuration['amount'];
+        $total = (int) $subject->getPromotionSubjectTotal();
+        switch ($configuration['equal']) {
+            default;
+            case 'equal':
+                $result = $total >= $configuration['amount'];
+
+                break;
+
+            case 'more_than':
+                $result = $total > $configuration['amount'];
+
+                break;
+
+            case 'exactly':
+                $result = $total === $configuration['amount'];
+
+                break;
+        }
+
+
+        return (int) $result;
     }
 
     /**

--- a/src/Sylius/Component/Promotion/Checker/PromotionEligibilityCheckerInterface.php
+++ b/src/Sylius/Component/Promotion/Checker/PromotionEligibilityCheckerInterface.php
@@ -25,7 +25,7 @@ interface PromotionEligibilityCheckerInterface
      * @param PromotionSubjectInterface $subject
      * @param PromotionInterface        $promotion
      *
-     * @return Boolean
+     * @return int
      */
     public function isEligible(PromotionSubjectInterface $subject, PromotionInterface $promotion);
 }

--- a/src/Sylius/Component/Promotion/Checker/RuleCheckerInterface.php
+++ b/src/Sylius/Component/Promotion/Checker/RuleCheckerInterface.php
@@ -24,7 +24,7 @@ interface RuleCheckerInterface
      * @param PromotionSubjectInterface $subject
      * @param array                     $configuration
      *
-     * @return Boolean
+     * @return int
      */
     public function isEligible(PromotionSubjectInterface $subject, array $configuration);
 

--- a/src/Sylius/Component/Promotion/Model/Promotion.php
+++ b/src/Sylius/Component/Promotion/Model/Promotion.php
@@ -103,6 +103,13 @@ class Promotion implements PromotionInterface
      */
     protected $deletedAt;
 
+    /**
+     * Virtual property used by promotion processors.
+     *
+     * @var int
+     */
+    protected $repeatable = 1;
+
     public function __construct()
     {
         $this->coupons = new ArrayCollection();
@@ -457,5 +464,21 @@ class Promotion implements PromotionInterface
     public function setDeletedAt(\DateTime $deletedAt = null)
     {
         $this->deletedAt = $deletedAt;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRepeatable()
+    {
+        return $this->repeatable;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setRepeatable($repeat)
+    {
+        $this->repeatable = $repeat;
     }
 }

--- a/src/Sylius/Component/Promotion/Model/PromotionInterface.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionInterface.php
@@ -197,4 +197,14 @@ interface PromotionInterface extends SoftDeletableInterface, TimestampableInterf
      * @param ActionInterface $action
      */
     public function removeAction(ActionInterface $action);
+
+    /**
+     * @return int
+     */
+    public function getRepeatable();
+
+    /**
+     * @param int $repeat
+     */
+    public function setRepeatable($repeat);
 }

--- a/src/Sylius/Component/Promotion/Processor/PromotionProcessor.php
+++ b/src/Sylius/Component/Promotion/Processor/PromotionProcessor.php
@@ -30,8 +30,11 @@ class PromotionProcessor implements PromotionProcessorInterface
     protected $applicator;
     protected $promotions;
 
-    public function __construct(PromotionRepositoryInterface $repository, PromotionEligibilityCheckerInterface $checker, PromotionApplicatorInterface $applicator)
-    {
+    public function __construct(
+        PromotionRepositoryInterface $repository,
+        PromotionEligibilityCheckerInterface $checker,
+        PromotionApplicatorInterface $applicator
+    ) {
         $this->repository = $repository;
         $this->checker = $checker;
         $this->applicator = $applicator;
@@ -43,15 +46,17 @@ class PromotionProcessor implements PromotionProcessorInterface
             $this->applicator->revert($subject, $promotion);
         }
 
-        $eligiblePromotions = array();
-
+        $eligiblePromotions = [];
         foreach ($this->getActivePromotions() as $promotion) {
-            if (!$this->checker->isEligible($subject, $promotion)) {
+            if (0 === $eligibleCount = $this->checker->isEligible($subject, $promotion)) {
                 continue;
             }
 
+            $promotion->setRepeatable($eligibleCount);
             if ($promotion->isExclusive()) {
-                return $this->applicator->apply($subject, $promotion);
+                $this->applicator->apply($subject, $promotion);
+
+                return;
             }
 
             $eligiblePromotions[] = $promotion;

--- a/src/Sylius/Component/Promotion/spec/Checker/ItemCountRuleCheckerSpec.php
+++ b/src/Sylius/Component/Promotion/spec/Checker/ItemCountRuleCheckerSpec.php
@@ -31,34 +31,43 @@ class ItemCountRuleCheckerSpec extends ObjectBehavior
 
     function it_should_recognize_empty_subject_as_not_eligible(PromotionCountableSubjectInterface $subject)
     {
-        $subject->getPromotionSubjectCount()->shouldBeCalled()->willReturn(0);
+        $subject->getPromotionSubjectCount()->willReturn(0);
 
-        $this->isEligible($subject, array('count' => 10, 'equal' => false))->shouldReturn(false);
+        $this->isEligible($subject, array('count' => 10, 'equal' => false))->shouldReturn(0);
     }
 
     function it_should_recognize_subject_as_not_eligible_if_item_count_is_less_then_configured(
         PromotionCountableSubjectInterface $subject
     ) {
-        $subject->getPromotionSubjectCount()->shouldBeCalled()->willReturn(7);
+        $subject->getPromotionSubjectCount()->willReturn(7);
 
-        $this->isEligible($subject, array('count' => 10, 'equal' => false))->shouldReturn(false);
+        $this->isEligible($subject, array('count' => 10, 'equal' => false))->shouldReturn(0);
     }
 
     function it_should_recognize_subject_as_eligible_if_item_count_is_greater_then_configured(
         PromotionCountableSubjectInterface $subject
     ) {
-        $subject->getPromotionSubjectCount()->shouldBeCalled()->willReturn(12);
+        $subject->getPromotionSubjectCount()->willReturn(12);
 
-        $this->isEligible($subject, array('count' => 10, 'equal' => false))->shouldReturn(true);
+        $this->isEligible($subject, array('count' => 10, 'equal' => false))->shouldReturn(1);
     }
 
     function it_should_recognize_subject_as_eligible_if_item_count_is_equal_with_configured_depending_on_equal_setting(
         PromotionCountableSubjectInterface $subject
     ) {
-        $subject->getPromotionSubjectCount()->shouldBeCalled()->willReturn(10);
+        $subject->getPromotionSubjectCount()->willReturn(10);
 
-        $this->isEligible($subject, array('count' => 10, 'equal' => false))->shouldReturn(false);
-        $this->isEligible($subject, array('count' => 10, 'equal' => true))->shouldReturn(true);
+        $this->isEligible($subject, array('count' => 10, 'equal' => 'more_than'))->shouldReturn(0);
+        $this->isEligible($subject, array('count' => 10, 'equal' => 'equal'))->shouldReturn(1);
+    }
+
+    function it_should_recognize_subject_as_eligible_if_item_count_is_more_than_with_configured_count_and_modulo_is_allowed(
+        PromotionCountableSubjectInterface $subject
+    ) {
+        $subject->getPromotionSubjectCount()->willReturn(100);
+
+        $this->isEligible($subject, array('count' => 10, 'equal' => 'modulo'))->shouldReturn(10);
+        $this->isEligible($subject, array('count' => 50, 'equal' => 'modulo'))->shouldReturn(2);
     }
 
     function it_should_return_item_count_configuration_form_type()

--- a/src/Sylius/Component/Promotion/spec/Checker/ItemTotalRuleCheckerSpec.php
+++ b/src/Sylius/Component/Promotion/spec/Checker/ItemTotalRuleCheckerSpec.php
@@ -31,34 +31,34 @@ class ItemTotalRuleCheckerSpec extends ObjectBehavior
 
     function it_should_recognize_empty_subject_as_not_eligible(PromotionSubjectInterface $subject)
     {
-        $subject->getPromotionSubjectTotal()->shouldBeCalled()->willReturn(0);
+        $subject->getPromotionSubjectTotal()->willReturn(0);
 
-        $this->isEligible($subject, array('amount' => 500, 'equal' => false))->shouldReturn(false);
+        $this->isEligible($subject, array('amount' => 500, 'equal' => false))->shouldReturn(0);
     }
 
     function it_should_recognize_subject_as_not_eligible_if_subject_total_is_less_then_configured(
         PromotionSubjectInterface $subject
     ) {
-        $subject->getPromotionSubjectTotal()->shouldBeCalled()->willReturn(400);
+        $subject->getPromotionSubjectTotal()->willReturn(400);
 
-        $this->isEligible($subject, array('amount' => 500, 'equal' => false))->shouldReturn(false);
+        $this->isEligible($subject, array('amount' => 500, 'equal' => false))->shouldReturn(0);
     }
 
     function it_should_recognize_subject_as_eligible_if_subject_total_is_greater_then_configured(
         PromotionSubjectInterface $subject
     ) {
-        $subject->getPromotionSubjectTotal()->shouldBeCalled()->willReturn(600);
+        $subject->getPromotionSubjectTotal()->willReturn(600);
 
-        $this->isEligible($subject, array('amount' => 500, 'equal' => false))->shouldReturn(true);
+        $this->isEligible($subject, array('amount' => 500, 'equal' => false))->shouldReturn(1);
     }
 
     function it_should_recognize_subject_as_eligible_if_subject_total_is_equal_with_configured_depending_on_equal_setting(
         PromotionSubjectInterface $subject
     ) {
-        $subject->getPromotionSubjectTotal()->shouldBeCalled()->willReturn(500);
+        $subject->getPromotionSubjectTotal()->willReturn(500);
 
-        $this->isEligible($subject, array('amount' => 500, 'equal' => false))->shouldReturn(false);
-        $this->isEligible($subject, array('amount' => 500, 'equal' => true))->shouldReturn(true);
+        $this->isEligible($subject, array('amount' => 500, 'equal' => false))->shouldReturn(0);
+        $this->isEligible($subject, array('amount' => 500, 'equal' => true))->shouldReturn(1);
     }
 
     function it_should_return_subject_total_configuration_form_type()

--- a/src/Sylius/Component/Promotion/spec/Processor/PromotionProcessorSpec.php
+++ b/src/Sylius/Component/Promotion/spec/Processor/PromotionProcessorSpec.php
@@ -47,11 +47,12 @@ class PromotionProcessorSpec extends ObjectBehavior
         $applicator,
         PromotionSubjectInterface $subject,
         PromotionInterface $promotion
-    )
-    {
-        $subject->getPromotions()->shouldBeCalled()->willReturn(array());
-        $repository->findActive()->shouldBeCalled()->willReturn(array($promotion));
-        $checker->isEligible($subject, $promotion)->shouldBeCalled()->willReturn(false);
+    ) {
+        $subject->getPromotions()->willReturn(array());
+        $repository->findActive()->willReturn(array($promotion));
+
+        $checker->isEligible($subject, $promotion)->willReturn(0);
+
         $applicator->apply($subject, $promotion)->shouldNotBeCalled();
         $applicator->revert($subject, $promotion)->shouldNotBeCalled();
 
@@ -65,9 +66,11 @@ class PromotionProcessorSpec extends ObjectBehavior
         PromotionSubjectInterface $subject,
         PromotionInterface $promotion
     ) {
-        $subject->getPromotions()->shouldBeCalled()->willReturn(array());
-        $repository->findActive()->shouldBeCalled()->willReturn(array($promotion));
-        $checker->isEligible($subject, $promotion)->shouldBeCalled()->willReturn(true);
+        $subject->getPromotions()->willReturn(array());
+        $repository->findActive()->willReturn(array($promotion));
+
+        $checker->isEligible($subject, $promotion)->willReturn(1);
+
         $applicator->apply($subject, $promotion)->shouldBeCalled();
         $applicator->revert($subject, $promotion)->shouldNotBeCalled();
 
@@ -80,17 +83,24 @@ class PromotionProcessorSpec extends ObjectBehavior
         $applicator,
         PromotionSubjectInterface $subject,
         PromotionInterface $promotion,
-        PromotionInterface $exlusivePromotion
+        PromotionInterface $exclusivePromotion
     ) {
-        $subject->getPromotions()->shouldBeCalled()->willReturn(array());
-        $repository->findActive()->shouldBeCalled()->willReturn(array($promotion, $exlusivePromotion));
-        $exlusivePromotion->isExclusive()->shouldBeCalled()->willReturn(true);
-        $checker->isEligible($subject, $promotion)->shouldBeCalled()->willReturn(true);
-        $checker->isEligible($subject, $exlusivePromotion)->shouldBeCalled()->willReturn(true);
-        $applicator->apply($subject, $exlusivePromotion)->shouldBeCalled();
+        $subject->getPromotions()->willReturn(array());
+        $repository->findActive()->willReturn(array($promotion, $exclusivePromotion));
+
+        $promotion->isExclusive()->willReturn(false);
+        $exclusivePromotion->isExclusive()->willReturn(true);
+
+        $checker->isEligible($subject, $promotion)->willReturn(1);
+        $checker->isEligible($subject, $exclusivePromotion)->willReturn(1);
+
+        $promotion->setRepeatable(1)->shouldBeCalled();
+        $exclusivePromotion->setRepeatable(1)->shouldBeCalled();
+
+        $applicator->apply($subject, $exclusivePromotion)->shouldBeCalled();
         $applicator->apply($subject, $promotion)->shouldNotBeCalled();
         $applicator->revert($subject, $promotion)->shouldNotBeCalled();
-        $applicator->revert($subject, $exlusivePromotion)->shouldNotBeCalled();
+        $applicator->revert($subject, $exclusivePromotion)->shouldNotBeCalled();
 
         $this->process($subject);
     }
@@ -102,9 +112,10 @@ class PromotionProcessorSpec extends ObjectBehavior
         PromotionSubjectInterface $subject,
         PromotionInterface $promotion
     ) {
-        $subject->getPromotions()->shouldBeCalled()->willReturn(array($promotion));
-        $repository->findActive()->shouldBeCalled()->willReturn(array($promotion));
-        $checker->isEligible($subject, $promotion)->shouldBeCalled()->willReturn(false);
+        $subject->getPromotions()->willReturn(array($promotion));
+        $repository->findActive()->willReturn(array($promotion));
+
+        $checker->isEligible($subject, $promotion)->willReturn(0);
 
         $applicator->apply($subject, $promotion)->shouldNotBeCalled();
         $applicator->revert($subject, $promotion)->shouldBeCalled();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | kinda* |
| Deprecations? | yes |
| License | MIT |

The only BC break in current state is that `isEliglibe()` will no longer return `bool` value.
