### PR TITLE
[WebBundle] Fixed showing static content by route sylius_static_content_show

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/StaticContent/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/StaticContent/show.html.twig
@@ -1,7 +1,7 @@
 {% extends 'SyliusWebBundle:Frontend:layout.html.twig' %}
 
 {% block content %}
-{% createphp cmfMainContent as='rdf' noautotag %}
+{% createphp static_content as='rdf' noautotag %}
 <div {{ createphp_attributes(rdf) }}>
     <div class="page-header">
         <h1 class="page-title" {{ createphp_attributes(rdf.title) }}>{{ createphp_content(rdf.title) }}</h1>


### PR DESCRIPTION
No BC breaks, bug fixed. Variable named `cmfMainContent` did not exist in that template.