### PR TITLE
[Travis] Improved waiting for port while executing JS scenarios

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8730,16 +8730,16 @@
         },
         {
             "name": "lakion/mink-debug-extension",
-            "version": "v1.0.1",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Lakion/MinkDebugExtension.git",
-                "reference": "e811211da7c67db9b05405d31704d3e9037cac08"
+                "reference": "c93dacd50d6fda9334b1f234d98240aea2cfa323"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Lakion/MinkDebugExtension/zipball/e811211da7c67db9b05405d31704d3e9037cac08",
-                "reference": "e811211da7c67db9b05405d31704d3e9037cac08",
+                "url": "https://api.github.com/repos/Lakion/MinkDebugExtension/zipball/c93dacd50d6fda9334b1f234d98240aea2cfa323",
+                "reference": "c93dacd50d6fda9334b1f234d98240aea2cfa323",
                 "shasum": ""
             },
             "require": {
@@ -8782,7 +8782,7 @@
                 "debug",
                 "logging"
             ],
-            "time": "2015-09-15 13:59:32"
+            "time": "2015-12-03 09:34:37"
         },
         {
             "name": "openlss/lib-array2xml",

--- a/travis/prepare/prepare-javascript
+++ b/travis/prepare/prepare-javascript
@@ -14,11 +14,13 @@ if [ ! -f $SYLIUS_CACHE_DIR/chromedriver ]; then
     mv chromedriver $SYLIUS_CACHE_DIR
 fi
 
-# Running webserver
-app/console server:run 127.0.0.1:8080 --env=test_cached --router=app/config/router_test_cached.php --no-debug > $SYLIUS_BUILD_DIR/webserver.log 2>&1 &
-
 # Running Selenium with ChromeDriver
 java -jar $SYLIUS_CACHE_DIR/selenium.jar -Dwebdriver.chrome.driver=$SYLIUS_CACHE_DIR/chromedriver > $SYLIUS_BUILD_DIR/selenium.log 2>&1 &
 
-vendor/lakion/mink-debug-extension/travis/tools/wait-for-port 8080
-vendor/lakion/mink-debug-extension/travis/tools/wait-for-port 4444
+vendor/lakion/mink-debug-extension/travis/tools/wait-for-port 9515 # Chromedriver port
+vendor/lakion/mink-debug-extension/travis/tools/wait-for-port 4444 # Selenium2 port
+
+# Running webserver
+app/console server:run 127.0.0.1:8080 --env=test_cached --router=app/config/router_test_cached.php --no-debug > $SYLIUS_BUILD_DIR/webserver.log 2>&1 &
+
+vendor/lakion/mink-debug-extension/travis/tools/wait-for-port 8080 # Webserver port


### PR DESCRIPTION
Prevents failing on the first scenarios, while Selenium2 is unavailable (added waiting for Chromedriver's port 9515).
![screen shot 2015-12-03 at 10 45 14](https://cloud.githubusercontent.com/assets/1897953/11557080/10177cc6-99ab-11e5-911b-6d578e8a1ee7.png)
.