### PR TITLE
Fix password reset forms

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Resources/views/User/resetPassword.html.twig
+++ b/src/Sylius/Bundle/UserBundle/Resources/views/User/resetPassword.html.twig
@@ -8,8 +8,8 @@
 
 <form action="{{ path('sylius_user_password_reset', { 'token' : user.confirmationToken}) }}" {{ form_enctype(form) }} method="POST">
     <fieldset>
-        {{ form_row(form.newPassword.first, {'label': 'sylius.form.user_reset_password.new'|trans}) }}
-        {{ form_row(form.newPassword.second, {'label': 'sylius.form.user_reset_password.confirmation'|trans}) }}
+        {{ form_row(form.password.first, {'label': 'sylius.form.user_reset_password.new'|trans}) }}
+        {{ form_row(form.password.second, {'label': 'sylius.form.user_reset_password.confirmation'|trans}) }}
     </fieldset>
     {{ form_rest(form) }}
     {{ update() }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/User/resetPassword.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/User/resetPassword.html.twig
@@ -10,8 +10,8 @@
 
 <form action="{{ path('sylius_user_password_reset', { 'token' : user.confirmationToken}) }}" {{ form_enctype(form) }} method="POST" class="form-horizontal">
     <fieldset>
-        {{ form_row(form.newPassword.first, {'label': 'sylius.form.frontend.password.new'|trans}) }}
-        {{ form_row(form.newPassword.second, {'label': 'sylius.form.frontend.password.confirmation'|trans}) }}
+        {{ form_row(form.password.first, {'label': 'sylius.form.frontend.password.new'|trans}) }}
+        {{ form_row(form.password.second, {'label': 'sylius.form.frontend.password.confirmation'|trans}) }}
     </fieldset>
     {{ form_rest(form) }}
     {{ update() }}


### PR DESCRIPTION
The reset password page was referring to 'newPassword' which was never defined anywhere.

This should probably be tested, but I am not very familiar with Behat / BDD yet. Perhaps if I get some time tonight I'll try taking a stab at it.