### PR TITLE
[Core] Extract path generation logic from ImageUploader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,6 +98,7 @@
         "pamil/prophecy-common": "^0.1",
         "pamil/phpspec-generator-extension": "^0.3",
         "phpspec/phpspec": "^2.4",
+        "phpspec/prophecy": "^1.6",
         "phpunit/phpunit": "~4.1",
         "se/selenium-server-standalone": "^2.52"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c146d059e81a758b4c3fae5bbae7e244",
-    "content-hash": "4428c9cc3d8aa00241751656a74b7310",
+    "hash": "36c709990b5529f8c61cc9ddf6c1a390",
+    "content-hash": "e878856f6e84a310a0273b9e07e097d5",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -2975,7 +2975,7 @@
                     "email": "stof@notk.org"
                 },
                 {
-                    "name": "Knplabs",
+                    "name": "KnpLabs",
                     "homepage": "http://knplabs.com"
                 },
                 {
@@ -7086,12 +7086,12 @@
             "version": "1.2.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony-cmf/CreateBundle.git",
+                "url": "https://github.com/symfony-cmf/create-bundle.git",
                 "reference": "86a3ade0210bc30b304f9d992ff21c403681d7f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony-cmf/CreateBundle/zipball/86a3ade0210bc30b304f9d992ff21c403681d7f3",
+                "url": "https://api.github.com/repos/symfony-cmf/create-bundle/zipball/86a3ade0210bc30b304f9d992ff21c403681d7f3",
                 "reference": "86a3ade0210bc30b304f9d992ff21c403681d7f3",
                 "shasum": ""
             },
@@ -7312,7 +7312,7 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony CMF Community",
+                    "name": "Symfony CMF community",
                     "homepage": "https://github.com/symfony-cmf/Routing/contributors"
                 }
             ],
@@ -10008,12 +10008,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Lakion/ApiTestCase.git",
-                "reference": "c4d37eccbaa49f06a317d22198649517627ed599"
+                "reference": "ec152e9d55d3e4a05eb7192c522661ec7620b5e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Lakion/ApiTestCase/zipball/c4d37eccbaa49f06a317d22198649517627ed599",
-                "reference": "c4d37eccbaa49f06a317d22198649517627ed599",
+                "url": "https://api.github.com/repos/Lakion/ApiTestCase/zipball/ec152e9d55d3e4a05eb7192c522661ec7620b5e3",
+                "reference": "ec152e9d55d3e4a05eb7192c522661ec7620b5e3",
                 "shasum": ""
             },
             "require": {
@@ -10078,7 +10078,7 @@
                 "testcase",
                 "xml"
             ],
-            "time": "2016-03-26 13:06:40"
+            "time": "2016-06-06 12:52:07"
         },
         {
             "name": "lakion/mink-debug-extension",

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -456,8 +456,22 @@
 
         <service id="sylius.image_uploader" class="%sylius.image_uploader.class%">
             <argument type="service">
-                <service class="Gaufrette\Filesystem" factory-service="knp_gaufrette.filesystem_map" factory-method="get">
+                <service class="Gaufrette\Filesystem">
                     <argument>%sylius.uploader.filesystem%</argument>
+                    <factory service="knp_gaufrette.filesystem_map" method="get" />
+                </service>
+            </argument>
+            <argument type="service" id="sylius.image_uploader.path_provider" />
+        </service>
+
+        <service id="sylius.image_uploader.path_provider" class="Sylius\Component\Core\Uploader\GeneratorBasedPathProvider">
+            <argument type="service">
+                <service class="Sylius\Component\Core\Uploader\ChunkingPathGenerator">
+                    <argument type="service">
+                        <service class="Sylius\Component\Core\Uploader\NonrandomPathGenerator" />
+                    </argument>
+                    <argument>2</argument>
+                    <argument>2</argument>
                 </service>
             </argument>
         </service>

--- a/src/Sylius/Component/Core/Uploader/ChunkingPathGenerator.php
+++ b/src/Sylius/Component/Core/Uploader/ChunkingPathGenerator.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Uploader;
+
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+final class ChunkingPathGenerator implements PathGeneratorInterface
+{
+    /**
+     * @var PathGeneratorInterface
+     */
+    private $decoratedPathGenerator;
+
+    /**
+     * @var int
+     */
+    private $numberOfChunks;
+
+    /**
+     * @var int
+     */
+    private $chunkLength;
+
+    /**
+     * @param PathGeneratorInterface $decoratedPathGenerator
+     * @param int $numberOfChunks
+     * @param int $chunkLength
+     */
+    public function __construct(PathGeneratorInterface $decoratedPathGenerator, $numberOfChunks, $chunkLength)
+    {
+        $this->decoratedPathGenerator = $decoratedPathGenerator;
+        $this->numberOfChunks = $numberOfChunks;
+        $this->chunkLength = $chunkLength;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(\SplFileInfo $file)
+    {
+        foreach ($this->decoratedPathGenerator->generate($file) as $path) {
+            yield $this->getChunkedPath($path);
+        }
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return string
+     */
+    private function getChunkedPath($path)
+    {
+        for ($i = 1; $i <= $this->numberOfChunks; ++$i) {
+            $cutAt = $i * 2 + ($i - 1);
+
+            $path = substr($path, 0, $cutAt) . '/' . substr($path, $cutAt);
+        }
+
+        return $path;
+    }
+}

--- a/src/Sylius/Component/Core/Uploader/GeneratorBasedPathProvider.php
+++ b/src/Sylius/Component/Core/Uploader/GeneratorBasedPathProvider.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Uploader;
+
+use Gaufrette\Filesystem;
+
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+final class GeneratorBasedPathProvider implements PathProviderInterface
+{
+    /**
+     * @var PathGeneratorInterface
+     */
+    private $pathGenerator;
+
+    /**
+     * @param PathGeneratorInterface $pathGenerator
+     */
+    public function __construct(PathGeneratorInterface $pathGenerator)
+    {
+        $this->pathGenerator = $pathGenerator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function provide(Filesystem $filesystem, \SplFileInfo $file)
+    {
+        $uniquePath = null;
+        foreach ($this->pathGenerator->generate($file) as $generatedPath) {
+            if (!$filesystem->has($generatedPath)) {
+                $uniquePath = $generatedPath;
+
+                break;
+            }
+        }
+
+        if (null === $uniquePath) {
+            throw new \RuntimeException('Could not generate path for given file');
+        }
+
+        return $uniquePath;
+    }
+}

--- a/src/Sylius/Component/Core/Uploader/ImageUploader.php
+++ b/src/Sylius/Component/Core/Uploader/ImageUploader.php
@@ -44,7 +44,7 @@ final class ImageUploader implements ImageUploaderInterface
      */
     public function upload(ImageInterface $image)
     {
-        if (false === $image->hasFile()) {
+        if (!$image->hasFile()) {
             return;
         }
 

--- a/src/Sylius/Component/Core/Uploader/ImageUploader.php
+++ b/src/Sylius/Component/Core/Uploader/ImageUploader.php
@@ -14,19 +14,29 @@ namespace Sylius\Component\Core\Uploader;
 use Gaufrette\Filesystem;
 use Sylius\Component\Core\Model\ImageInterface;
 
-class ImageUploader implements ImageUploaderInterface
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+final class ImageUploader implements ImageUploaderInterface
 {
     /**
      * @var Filesystem
      */
-    protected $filesystem;
+    private $filesystem;
+
+    /**
+     * @var PathProviderInterface
+     */
+    private $pathProvider;
 
     /**
      * @param Filesystem $filesystem
+     * @param PathProviderInterface $pathProvider
      */
-    public function __construct(Filesystem $filesystem)
+    public function __construct(Filesystem $filesystem, PathProviderInterface $pathProvider)
     {
         $this->filesystem = $filesystem;
+        $this->pathProvider = $pathProvider;
     }
 
     /**
@@ -34,47 +44,27 @@ class ImageUploader implements ImageUploaderInterface
      */
     public function upload(ImageInterface $image)
     {
-        if (!$image->hasFile()) {
+        if (false === $image->hasFile()) {
             return;
         }
 
-        if (null !== $image->getPath()) {
-            $this->remove($image->getPath());
+        $newFilePath = $this->pathProvider->provide($this->filesystem, $image->getFile());
+
+        $openedFile = $image->getFile()->openFile();
+        $this->filesystem->write($newFilePath, $openedFile->fread($openedFile->getSize()));
+
+        $this->deleteOverwrittenImageIfExists($image);
+        $image->setPath($newFilePath);
+    }
+
+    /**
+     * @param ImageInterface $image
+     */
+    private function deleteOverwrittenImageIfExists(ImageInterface $image)
+    {
+        $oldFilePath = $image->getPath();
+        if (null !== $oldFilePath) {
+            $this->filesystem->delete($oldFilePath);
         }
-
-        do {
-            $hash = md5(uniqid(mt_rand(), true));
-            $path = $this->expandPath($hash.'.'.$image->getFile()->guessExtension());
-        } while ($this->filesystem->has($path));
-
-        $image->setPath($path);
-
-        $this->filesystem->write(
-            $image->getPath(),
-            file_get_contents($image->getFile()->getPathname())
-        );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function remove($path)
-    {
-        return $this->filesystem->delete($path);
-    }
-
-    /**
-     * @param string $path
-     *
-     * @return string
-     */
-    private function expandPath($path)
-    {
-        return sprintf(
-            '%s/%s/%s',
-            substr($path, 0, 2),
-            substr($path, 2, 2),
-            substr($path, 4)
-        );
     }
 }

--- a/src/Sylius/Component/Core/Uploader/MicrotimeBasedPathGenerator.php
+++ b/src/Sylius/Component/Core/Uploader/MicrotimeBasedPathGenerator.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Uploader;
+
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+final class MicrotimeBasedPathGenerator implements PathGeneratorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(\SplFileInfo $file)
+    {
+        while (true) {
+            yield md5(sprintf('%s.%s.%d', $file->getFilename(), $file->getMTime(), microtime())) . '.' . $file->getExtension();
+        }
+    }
+}

--- a/src/Sylius/Component/Core/Uploader/NonrandomPathGenerator.php
+++ b/src/Sylius/Component/Core/Uploader/NonrandomPathGenerator.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Uploader;
+
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+final class NonrandomPathGenerator implements PathGeneratorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function generate(\SplFileInfo $file)
+    {
+        for ($i = 0; true; ++$i) {
+            yield md5(sprintf('%s.%s.%d', $file->getFilename(), $file->getMTime(), $i)) . '.' . $file->getExtension();
+        }
+    }
+}

--- a/src/Sylius/Component/Core/Uploader/PathGeneratorInterface.php
+++ b/src/Sylius/Component/Core/Uploader/PathGeneratorInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Uploader;
+
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+interface PathGeneratorInterface
+{
+    /**
+     * @param \SplFileInfo $file
+     *
+     * @return \Generator
+     */
+    public function generate(\SplFileInfo $file);
+}

--- a/src/Sylius/Component/Core/Uploader/PathProviderInterface.php
+++ b/src/Sylius/Component/Core/Uploader/PathProviderInterface.php
@@ -11,15 +11,18 @@
 
 namespace Sylius\Component\Core\Uploader;
 
-use Sylius\Component\Core\Model\ImageInterface;
+use Gaufrette\Filesystem;
 
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-interface ImageUploaderInterface
+interface PathProviderInterface
 {
     /**
-     * @param ImageInterface $image
+     * @param Filesystem $filesystem
+     * @param \SplFileInfo $file
+     *
+     * @return string
      */
-    public function upload(ImageInterface $image);
+    public function provide(Filesystem $filesystem, \SplFileInfo $file);
 }

--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -55,7 +55,9 @@
         "zendframework/zend-stdlib": "^2.0|^3.0"
     },
     "require-dev": {
+        "pamil/phpspec-generator-extension": "^0.1",
         "phpspec/phpspec": "^2.4",
+        "phpspec/prophecy": "^1.6",
         "symfony/property-access": "^2.8"
     },
     "config": {

--- a/src/Sylius/Component/Core/phpspec.yml.dist
+++ b/src/Sylius/Component/Core/phpspec.yml.dist
@@ -3,3 +3,6 @@ suites:
         namespace: Sylius\Component\Core
         psr4_prefix: Sylius\Component\Core
         src_path: .
+
+extensions:
+    - Pamil\PhpSpecGeneratorExtension\Extension

--- a/src/Sylius/Component/Core/spec/Uploader/ChunkingPathGeneratorSpec.php
+++ b/src/Sylius/Component/Core/spec/Uploader/ChunkingPathGeneratorSpec.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Core\Uploader;
+
+use Gaufrette\Filesystem;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Core\Uploader\ChunkingPathGenerator;
+use Sylius\Component\Core\Uploader\PathGeneratorInterface;
+
+/**
+ * @mixin ChunkingPathGenerator
+ *
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+final class ChunkingPathGeneratorSpec extends ObjectBehavior
+{
+    function let(PathGeneratorInterface $decoratedPathGenerator)
+    {
+        $numberOfChunks = 3;
+        $chunkLength = 2;
+
+        $this->beConstructedWith($decoratedPathGenerator, $numberOfChunks, $chunkLength);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Core\Uploader\ChunkingPathGenerator');
+    }
+
+    function it_implements_path_generator_interface()
+    {
+        $this->shouldImplement(PathGeneratorInterface::class);
+    }
+
+    function it_chunks_a_path(PathGeneratorInterface $decoratedPathGenerator, \SplFileInfo $file)
+    {
+        $decoratedPathGenerator->generate($file)->willReturn(new \ArrayIterator(['deadbeef.jpg']));
+
+        $this->generate($file)->shouldGenerate(['de/ad/be/ef.jpg']);
+    }
+}

--- a/src/Sylius/Component/Core/spec/Uploader/GeneratorBasedPathProviderSpec.php
+++ b/src/Sylius/Component/Core/spec/Uploader/GeneratorBasedPathProviderSpec.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Core\Uploader;
+
+use Gaufrette\Filesystem;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Core\Uploader\GeneratorBasedPathProvider;
+use Sylius\Component\Core\Uploader\PathGeneratorInterface;
+use Sylius\Component\Core\Uploader\PathProviderInterface;
+
+/**
+ * @mixin GeneratorBasedPathProvider
+ *
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+final class GeneratorBasedPathProviderSpec extends ObjectBehavior
+{
+    function let(PathGeneratorInterface $pathGenerator)
+    {
+        $this->beConstructedWith($pathGenerator);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Core\Uploader\GeneratorBasedPathProvider');
+    }
+
+    function it_implements_path_provider_interface()
+    {
+        $this->shouldImplement(PathProviderInterface::class);
+    }
+
+    function it_returns_first_unique_path_that_was_generated(
+        PathGeneratorInterface $pathGenerator,
+        Filesystem $filesystem,
+        \SplFileInfo $file
+    ) {
+        $pathGenerator->generate($file)->willReturn(new \ArrayIterator([
+            'non/unique/path',
+            'first/unique/path',
+            'second/unique/path',
+        ]));
+
+        $filesystem->has('non/unique/path')->willReturn(true);
+        $filesystem->has('first/unique/path')->willReturn(false);
+        $filesystem->has('second/unique/path')->willReturn(false);
+
+        $this->provide($filesystem, $file)->shouldReturn('first/unique/path');
+    }
+
+    function it_throws_an_exception_if_generator_is_empty(
+        PathGeneratorInterface $pathGenerator,
+        Filesystem $filesystem,
+        \SplFileInfo $file
+    ) {
+        $pathGenerator->generate($file)->willReturn(new \ArrayIterator([]));
+
+        $this->shouldThrow(\RuntimeException::class)->during('provide', [$filesystem, $file]);
+    }
+
+    function it_throws_an_exception_if_generation_cannot_be_done(
+        PathGeneratorInterface $pathGenerator,
+        Filesystem $filesystem,
+        \SplFileInfo $file
+    ) {
+        $pathGenerator->generate($file)->willReturn(new \ArrayIterator(['non/unique/path1', 'non/unique/path2']));
+
+        $filesystem->has('non/unique/path1')->willReturn(true);
+        $filesystem->has('non/unique/path2')->willReturn(true);
+
+        $this->shouldThrow(\RuntimeException::class)->during('provide', [$filesystem, $file]);
+    }
+}

--- a/src/Sylius/Component/Core/spec/Uploader/ImageUploaderSpec.php
+++ b/src/Sylius/Component/Core/spec/Uploader/ImageUploaderSpec.php
@@ -15,24 +15,26 @@ use Gaufrette\Filesystem;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Component\Core\Model\ImageInterface;
+use Sylius\Component\Core\Uploader\ImageUploader;
 use Sylius\Component\Core\Uploader\ImageUploaderInterface;
-use Symfony\Component\HttpFoundation\File\File;
+use Sylius\Component\Core\Uploader\PathGeneratorInterface;
+use Sylius\Component\Core\Uploader\PathProviderInterface;
 
+/**
+ * @mixin ImageUploader
+ *
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
 class ImageUploaderSpec extends ObjectBehavior
 {
-    function let(Filesystem $filesystem, ImageInterface $image)
+    function let(Filesystem $filesystem, PathProviderInterface $pathProvider)
     {
-        $filesystem->has(Argument::any())->willReturn(false);
-
-        $file = new File(__FILE__, 'img.jpg');
-        $image->getFile()->willReturn($file);
-
-        $this->beConstructedWith($filesystem);
+        $this->beConstructedWith($filesystem, $pathProvider);
     }
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Component\Core\Uploader\ImageUploader');
+        $this->shouldHaveType(ImageUploader::class);
     }
 
     function it_is_Sylius_image_uploader()
@@ -40,15 +42,88 @@ class ImageUploaderSpec extends ObjectBehavior
         $this->shouldImplement(ImageUploaderInterface::class);
     }
 
-    function it_uploads_image($filesystem, $image)
+    function it_does_not_upload_image_if_there_is_no_file_attached(ImageInterface $image)
     {
+        $image->hasFile()->willReturn(false);
+        $image->getFile()->shouldNotBeCalled();
+
+        $this->upload($image);
+    }
+
+    function it_uploads_an_image(
+        Filesystem $filesystem,
+        PathProviderInterface $pathProvider,
+        ImageInterface $image,
+        \SplFileInfo $fileInfo,
+        \SplFileObject $fileObject
+    ) {
         $image->hasFile()->willReturn(true);
-        $image->getPath()->willReturn('foo.jpg');
+        $image->getFile()->willReturn($fileInfo);
 
-        $filesystem->delete(Argument::any())->shouldBeCalled();
-        $filesystem->write(Argument::any(), Argument::any())->shouldBeCalled();
+        $fileInfo->openFile(Argument::cetera())->willReturn($fileObject);
 
-        $image->setPath(Argument::any())->shouldBeCalled();
+        $pathProvider->provide($filesystem, $fileInfo)->willReturn('path/to/file');
+
+        $fileObject->getSize()->willReturn(42);
+        $fileObject->fread(42)->willReturn('File contents');
+
+        $image->getPath()->willReturn(null);
+        $filesystem->delete(Argument::any())->shouldNotBeCalled();
+
+        $filesystem->write('path/to/file', 'File contents')->shouldBeCalled();
+        $image->setPath('path/to/file')->shouldBeCalled();
+
+        $this->upload($image);
+    }
+
+    function it_replaces_existing_images_while_uploading_a_new_one(
+        Filesystem $filesystem,
+        PathProviderInterface $pathProvider,
+        ImageInterface $image,
+        \SplFileInfo $fileInfo,
+        \SplFileObject $fileObject
+    ) {
+        $image->hasFile()->willReturn(true);
+        $image->getFile()->willReturn($fileInfo);
+
+        $fileInfo->openFile(Argument::cetera())->willReturn($fileObject);
+
+        $pathProvider->provide($filesystem, $fileInfo)->willReturn('path/to/file');
+
+        $fileObject->getSize()->willReturn(42);
+        $fileObject->fread(42)->willReturn('File contents');
+
+        $image->getPath()->willReturn('path/to/existing-file');
+        $filesystem->delete('path/to/existing-file')->shouldBeCalled();
+
+        $filesystem->write('path/to/file', 'File contents')->shouldBeCalled();
+        $image->setPath('path/to/file')->shouldBeCalled();
+
+        $this->upload($image);
+    }
+
+    function it_generates_a_name_for_an_image_until_it_is_unique(
+        Filesystem $filesystem,
+        PathProviderInterface $pathProvider,
+        ImageInterface $image,
+        \SplFileInfo $fileInfo,
+        \SplFileObject $fileObject
+    ) {
+        $image->hasFile()->willReturn(true);
+        $image->getFile()->willReturn($fileInfo);
+
+        $fileInfo->openFile(Argument::cetera())->willReturn($fileObject);
+
+        $pathProvider->provide($filesystem, $fileInfo)->willReturn('path/to/file');
+
+        $fileObject->getSize()->willReturn(42);
+        $fileObject->fread(42)->willReturn('File contents');
+
+        $image->getPath()->willReturn(null);
+        $filesystem->delete(Argument::any())->shouldNotBeCalled();
+
+        $filesystem->write('path/to/file', 'File contents')->shouldBeCalled();
+        $image->setPath('path/to/file')->shouldBeCalled();
 
         $this->upload($image);
     }

--- a/src/Sylius/Component/Core/spec/Uploader/NonrandomPathGeneratorSpec.php
+++ b/src/Sylius/Component/Core/spec/Uploader/NonrandomPathGeneratorSpec.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Core\Uploader;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Core\Uploader\NonrandomPathGenerator;
+use Sylius\Component\Core\Uploader\PathGeneratorInterface;
+
+/**
+ * @mixin NonrandomPathGenerator
+ *
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+class NonrandomPathGeneratorSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(NonrandomPathGenerator::class);
+    }
+
+    function it_implements_Sylius_uploader_path_generator_interface()
+    {
+        $this->shouldImplement(PathGeneratorInterface::class);
+    }
+
+    function it_creates_unique_nonexistent_path_for_file(\SplFileInfo $file)
+    {
+        $file->getFilename()->willReturn('FILENAME');
+        $file->getMTime()->willReturn('MTIME');
+        $file->getExtension()->willReturn('jpg');
+
+        $firstGeneratedPath = md5('FILENAME.MTIME.0') . '.jpg';
+        $secondGeneratedPath = md5('FILENAME.MTIME.1') . '.jpg';
+
+        $this->generate($file)->shouldGenerate([$firstGeneratedPath, $secondGeneratedPath]);
+    }
+}


### PR DESCRIPTION
Brand new `ImageUploader` allows us to change the way paths are generated without modifying or copying it. You just need to implement `PathGeneratorInterface` and inject it to `sylius.image_uploader` service as second argument.

Anyway, the specifications of new classes uses some not-merged-yet features of Prophecy: phpspec/prophecy#237 and phpspec/prophecy#238.

TODO:
 - [x] Add a decorator for `PathGeneratorInterface` that put uploaded files into nested directories (eg. `deadbeef.png` becomes `de/ad/beef.png`
 - [x] Create an easy way to switch between path generators