### PR TITLE
CoreBundle: checker for promotion coupons added

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/CartType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/CartType.php
@@ -58,9 +58,11 @@ class CartType extends BaseCartType
                     return;
                 }
 
-                $data->addPromotionCoupon(
-                    $this->couponFactory->createNew()
-                );
+                if ($event->getForm()->has('promotionCoupons')) {
+                    $data->addPromotionCoupon(
+                        $this->couponFactory->createNew()
+                    );
+                }
             })
         ;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | ~
| License       | MIT

Allows to use form extension to modify 'sylius_cart' if promotion coupons are removed from the form itself. It is throwing 'A new entity was found through the relationship' because we are having detached entity from form.