### PR TITLE
Missing menu translations and alphabetized

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/translations/menu.en.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/menu.en.yml
@@ -5,19 +5,28 @@ sylius:
     backend:
         menu:
             main:
+                api_clients: API clients
+                archetypes: Product archetypes
                 assortment: Assortment
+                attributes: Configure attributes
                 blocks: Blocks
-                configuration: Configuration
-                countries: Countries
-                customer: Customer
-                content: Content
                 channels: Channels
-                dashboard: Dashboard
+                configuration: Configuration
+                contact_requests: Contact Requests
+                contact_topics: Configure Topics
+                content: Content
+                countries: Countries
                 currencies: Currencies
+                customer: Customer
+                customers: Customers
+                dashboard: Dashboard
+                emails: Emails
                 general_settings: General settings
                 groups: Groups
                 homepage: Your store
                 locales: Locales
+                marketing: Marketing
+                menus: Menus
                 new_order: Add new order
                 new_promotion: Add new promotion
                 options: Manage product options
@@ -25,55 +34,12 @@ sylius:
                 pages: Pages
                 payment_methods: Payment methods
                 payments: Payments
-                products: Products
-                promotions: Promotions
-                attributes: Configure attributes
-                archetypes: Product archetypes
-                sales: Orders
-                shipments: Shipments
-                shipping_categories: Shipping categories
-                shipping_methods: Shipping methods
-                stockables: Inventory levels
-                tax_categories: Taxation categories
-                tax_rates: Tax rates
-                taxation_settings: Taxation settings
-                taxonomies: Categorization
-                customers: Customers
-                zones: Zones
-                emails: Emails
-                roles: Roles
                 permissions: Permissions
-                report: Reports
-            sidebar:
-                api_clients: API clients
-                assortment: Assortment
-                blocks: Blocks
-                configuration: Configuration
-                content: Content
-                countries: Countries
-                channels: Channels
-                customer: Customer
-                dashboard: Dashboard
-                currencies: Currencies
-                general_settings: General settings
-                groups: Groups
-                homepage: Back to frontend
-                locales: Locales
-                new_order: Add new order
-                new_promotion: Add new promotion
-                options: Manage options
-                orders: Current orders
-                pages: Pages
-                routes: Routes
-                redirects: Redirects
-                menus: Menus
-                payment_methods: Payment methods
-                payments: Payments
                 products: Products
                 promotions: Promotions
                 report: Reports
-                attributes: Configure attributes
-                archetypes: Product archetypes
+                roles: Roles
+                routes: Routes
                 sales: Orders
                 security_settings: Security settings
                 shipments: Shipments
@@ -81,19 +47,62 @@ sylius:
                 shipping_methods: Shipping methods
                 slideshow: Slideshow
                 stockables: Inventory levels
+                support: Support
+                taxation_settings: Taxation settings
+                taxonomies: Categorization
+                tax_categories: Taxation categories
+                tax_rates: Tax rates
+                zones: Zones
+            sidebar:
+                api_clients: API clients
+                archetypes: Product archetypes
+                assortment: Assortment
+                attributes: Configure attributes
+                blocks: Blocks
+                channels: Channels
+                configuration: Configuration
+                contact_requests: Requests
+                contact_topics: Configure Topics
+                content: Content
+                countries: Countries
+                currencies: Currencies
+                customer: Customer
+                customers: Customers
+                dashboard: Dashboard
+                emails: Emails
+                general_settings: General settings
+                groups: Groups
+                homepage: Back to frontend
+                locales: Locales
+                marketing: Marketing
+                menus: Menus
+                new_order: Add new order
+                new_promotion: Add new promotion
+                options: Manage options
+                orders: Current orders
+                pages: Pages
+                payments: Payments
+                payment_methods: Payment methods
+                permissions: Permissions
+                products: Products
+                promotions: Promotions
+                redirects: Redirects
+                report: Reports
+                roles: Roles
+                routes: Routes
+                sales: Orders
+                security_settings: Security settings
+                shipments: Shipments
+                shipping_categories: Shipping categories
+                shipping_methods: Shipping methods
+                slideshow: Slideshow
+                stockables: Inventory levels
+                support: Support
                 tax_categories: Taxation categories
                 tax_rates: Tax rates
                 taxation_settings: Taxation settings
                 taxonomies: Categorization
-                customers: Customers
                 zones: Zones
-                emails: Emails
-                roles: Roles
-                permissions: Permissions
-                marketing: Marketing
-                support: Support
-                contact_requests: Requests
-                contact_topics: Configure Topics
     frontend:
         menu:
             account:


### PR DESCRIPTION
There's another issue here of double-translations because translate() is called in the MenuBuilder (for separation of messages into menu domain) and also when it's rendered, so you get a lot of translation errors on the backend.

I might look at this again soon but here's the missing messages to start with.