### PR TITLE
Permit access to app_dev.php through system environment variable 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This chapter references the relevant changes done in 0.16 version.
 
 To get the diff between two versions, go to https://github.com/Sylius/Sylius/compare/v0.15.0...master
 
+ * feature #3709 Access to app_dev.php permitted through the use of SYLIUS_APP_DEV_PERMITTED environment variable (ideal for vagrant)
  * feature #3110 [BC BREAK] Bumped minimal versions, major changes: PHP >=5.5.9, Symfony ^2.7
  * bc break #3364 [BC BREAK] Renamed setDefaultOptions to configureOptions
  * bc break #3536 [BC BREAK] Renamed label to type on adjustment

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -15,13 +15,18 @@ use Symfony\Component\HttpFoundation\Request;
 /*
  * Sylius front controller.
  * Dev environment.
+ *
+ * To develop on Sylius in vagrant set the SYLIUS_APP_DEV_PERMITTED to a non zero value.
+ * e.g. in apache, through your vhost configuration file:
+ *
+ *   SetEnv SYLIUS_APP_DEV_PERMITTED 1
  */
-
-if (isset($_SERVER['HTTP_CLIENT_IP'])
+if (!getenv("SYLIUS_APP_DEV_PERMITTED") && (
+    isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
     || !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1', '113.0.0.1'))
         || php_sapi_name() === 'cli-server')
-) {
+)) {
     header('HTTP/1.0 403 Forbidden');
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

A few people have asked for this (although I can find any open issues to reference), a way of using sylius on Vagrant without having to comment out half of app_dev.php.