### PR TITLE
[BugFix][PHPCR] Fix criteria "name" for DocumentRepository

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Doctrine/ODM/PHPCR/DocumentRepository.php
+++ b/src/Sylius/Bundle/ResourceBundle/Doctrine/ODM/PHPCR/DocumentRepository.php
@@ -83,13 +83,22 @@ class DocumentRepository extends BaseDocumentRepository implements RepositoryInt
      */
     protected function applyCriteria(QueryBuilder $queryBuilder, array $criteria = array())
     {
+        $metadata = $this->getClassMetadata();
         foreach ($criteria as $property => $value) {
             if (!empty($value)) {
-                $queryBuilder
-                    ->andWhere()
-                        ->eq()
-                            ->field($this->getPropertyName($property))
-                            ->literal($value);
+                if ($property === $metadata->nodename) {
+                    $queryBuilder
+                        ->andWhere()
+                            ->eq()
+                                ->localName($this->getAlias())
+                                ->literal($value);
+                } else {
+                    $queryBuilder
+                        ->andWhere()
+                            ->eq()
+                                ->field($this->getPropertyName($property))
+                                ->literal($value);
+                }
             }
         }
     }


### PR DESCRIPTION
Fix bug where you could not select phpcr documents with criteria "name" (it would throw: `Cannot use nodename property "name" of class "Xyz" as a dynamic operand use "localname()"` instead.)