### PR TITLE
[Behat] Renamed build path

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -399,7 +399,7 @@ default:
 
     extensions:
         Lakion\Behat\MinkDebugExtension:
-            directory: travis/build-output
+            directory: etc/build
         Behat\MinkExtension:
             sessions:
                 default:


### PR DESCRIPTION
Introduced by #3711, causes errors while handling errors :)

Failed builds looks like: https://travis-ci.org/Sylius/Sylius/jobs/96761126