### PR TITLE
Avoid flushing only a single resource when not required

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
@@ -188,7 +188,7 @@ class SecurityStep extends CheckoutStep
     protected function saveResource($resource)
     {
         $this->getManager()->persist($resource);
-        $this->getManager()->flush($resource);
+        $this->getManager()->flush();
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/EventListener/CartBlamerListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/CartBlamerListener.php
@@ -62,7 +62,7 @@ class CartBlamerListener
         $cart->setCustomer($customer);
 
         $this->cartManager->persist($cart);
-        $this->cartManager->flush($cart);
+        $this->cartManager->flush();
     }
 
     /**
@@ -88,6 +88,6 @@ class CartBlamerListener
         $cart->setCustomer($user->getCustomer());
 
         $this->cartManager->persist($cart);
-        $this->cartManager->flush($cart);
+        $this->cartManager->flush();
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/CartBlamerListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/CartBlamerListenerSpec.php
@@ -41,7 +41,7 @@ class CartBlamerListenerSpec extends ObjectBehavior
         $cartProvider->getCart()->willReturn($cart);
 
         $cartManager->persist($cart)->shouldNotBeCalled();
-        $cartManager->flush($cart)->shouldNotBeCalled();
+        $cartManager->flush()->shouldNotBeCalled();
 
         $this->shouldThrow('Sylius\Component\Resource\Exception\UnexpectedTypeException')->during('blame', array($userEvent));
     }
@@ -55,7 +55,7 @@ class CartBlamerListenerSpec extends ObjectBehavior
 
         $cart->setCustomer($customer)->shouldBeCalled();
         $cartManager->persist($cart)->shouldBeCalled();
-        $cartManager->flush($cart)->shouldBeCalled();
+        $cartManager->flush()->shouldBeCalled();
 
         $this->blame($userEvent);
     }

--- a/src/Sylius/Bundle/UserBundle/EventListener/UserLastLoginSubscriber.php
+++ b/src/Sylius/Bundle/UserBundle/EventListener/UserLastLoginSubscriber.php
@@ -72,6 +72,6 @@ class UserLastLoginSubscriber implements EventSubscriberInterface
     {
         $user->setLastLogin(new \DateTime());
         $this->userManager->persist($user);
-        $this->userManager->flush($user);
+        $this->userManager->flush();
     }
 }

--- a/src/Sylius/Bundle/UserBundle/spec/EventListener/UserLastLoginSubscriberSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/EventListener/UserLastLoginSubscriberSpec.php
@@ -56,7 +56,7 @@ class UserLastLoginSubscriberSpec extends ObjectBehavior
         $token->getUser()->shouldBeCalled()->willReturn($user);
 
         $userManager->persist($user)->shouldBeCalled();
-        $userManager->flush($user)->shouldBeCalled();
+        $userManager->flush()->shouldBeCalled();
 
         $this->onSecurityInteractiveLogin($event);
     }
@@ -66,7 +66,7 @@ class UserLastLoginSubscriberSpec extends ObjectBehavior
         $event->getUser()->shouldBeCalled()->willReturn($user);
 
         $userManager->persist($user)->shouldBeCalled();
-        $userManager->flush($user)->shouldBeCalled();
+        $userManager->flush()->shouldBeCalled();
 
         $this->onImplicitLogin($event);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

If you only flush a single resource it's possible that you can lose other important entity flushes - especially as Sylius uses Sequences called on preFlush.

We just had an issue where a Customer Sequence was not being flushed in checkout because only the single Customer resource was being flushed. The sequence therefore didn't change and it was impossible to register because the sequence had not incremented and the value was not unique next time around...

Unless there's a really particular reason not to flush everything, I think we always should.