### PR TITLE
[CMF Integration] StaticContent/show template can be used with both ContentController and ResourceController

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/StaticContent/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/StaticContent/show.html.twig
@@ -1,7 +1,11 @@
 {% extends 'SyliusWebBundle:Frontend:layout.html.twig' %}
 
+{% if cmfMainContent is not defined %}
+    {% set cmfMainContent = static_content %}
+{% endif %}
+
 {% block content %}
-{% createphp static_content as='rdf' noautotag %}
+{% createphp cmfMainContent as='rdf' noautotag %}
 <div {{ createphp_attributes(rdf) }}>
     <div class="page-header">
         <h1 class="page-title" {{ createphp_attributes(rdf.title) }}>{{ createphp_content(rdf.title) }}</h1>


### PR DESCRIPTION
As @psyray noticed in #3664, we have two endpoints that can show static content. In that PR I wasn't aware of `ContentController` and it resulted in BC change, this one reverts it and adds compatibility layer. Possibly related to #3672.