### PR TITLE
[Permissions] Fixed permission for emails back-end menu item

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Menu/BackendMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/BackendMenuBuilder.php
@@ -232,7 +232,7 @@ class BackendMenuBuilder extends MenuBuilder
                 'labelAttributes' => array('icon' => 'glyphicon glyphicon-plus-sign'),
             ))->setLabel($this->translate(sprintf('sylius.backend.menu.%s.new_promotion', $section)));
         }
-        if ($this->authorizationChecker->isGranted('sylius.promotion.index')) {
+        if ($this->authorizationChecker->isGranted('sylius.manage.email')) {
             $child->addChild('emails', array(
                 'route' => 'sylius_backend_email_index',
                 'labelAttributes' => array('icon' => 'glyphicon glyphicon-envelope'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

User see emails menu item in back-end even if he hasn't permission (sylius.manage.email) for it. This happens due to wrong isGranted parameter in BackendMenuBuilder.