### PR TITLE
[API] Add customer show api path

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/customer.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/customer.yml
@@ -1,0 +1,8 @@
+# This file is part of the Sylius package.
+# (c) Paweł Jędrzejewski
+
+sylius_api_customer_show:
+    path: /{id}
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.customer:showAction

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/main.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/main.yml
@@ -103,6 +103,10 @@ sylius_api_user:
     resource: @SyliusApiBundle/Resources/config/routing/user.yml
     prefix: /users
 
+sylius_api_customer:
+    resource: @SyliusApiBundle/Resources/config/routing/customer.yml
+    prefix: /customers
+
 sylius_api_setting:
     resource: @SyliusApiBundle/Resources/config/routing/setting.yml
     prefix: /settings


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | [yes]
| New feature?  | [no]
| BC breaks?    | [no]
| Deprecations? | [no]
| Fixed tickets |  
| License       | MIT
| Doc PR        | 

`sylius_api_customer_show` route doesn't exist, should we create it or just use `sylius_api_user_show`?