### PR TITLE
Zone Fixtures - Fix US being added to Rest of World zone

### DIFF
--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadZonesData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadZonesData.php
@@ -38,7 +38,7 @@ class LoadZonesData extends DataFixture
     {
         $restOfWorldCountries = array_diff(
             array_keys(Intl::getRegionBundle()->getCountryNames($this->container->getParameter('sylius.locale'))),
-            $this->euCountries + array('US')
+            array_merge($this->euCountries, ['US'])
         );
 
         $manager->persist($eu = $this->createZone('EU', ZoneInterface::TYPE_COUNTRY, $this->euCountries));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Fix for fixtures to prevent US being added to Rest of World zone as intended.

Currently you can't calculate Tax for the US with demo data because US addresses resolve to RoW