### PR TITLE
using ContainerAwareTrait

### DIFF
--- a/src/Sylius/Bundle/FlowBundle/Process/Step/AbstractContainerAwareStep.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Step/AbstractContainerAwareStep.php
@@ -12,7 +12,7 @@
 namespace Sylius\Bundle\FlowBundle\Process\Step;
 
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * Container aware step.
@@ -22,18 +22,5 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 abstract class AbstractContainerAwareStep extends AbstractStep implements ContainerAwareInterface
 {
-    /**
-     * Container.
-     *
-     * @var ContainerInterface
-     */
-    protected $container;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
-    }
+    use ContainerAwareTrait;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | [no]
| New feature?  | [no]
| BC breaks?    | [no]
| Deprecations? | [yes]
| Fixed tickets | [#3698]
| License       | MIT
| Doc PR        | [n/a]

What bothers me is that even if I remove "implements ContainerAwareInterface" from Sylius\Bundle\FlowBundle\Process\Step\AbstractContainerAwareStep phpspec still tells me everything is fine.

Is this the expected behaviour?