### PR TITLE
[ResourceBundle] check translations are possible before configuration them

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration.php
@@ -80,7 +80,6 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->arrayNode('translation')
-                                ->addDefaultsIfNotSet()
                                 ->children()
                                     ->arrayNode('classes')
                                         ->isRequired()

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
@@ -54,7 +54,7 @@ class SyliusResourceExtension extends Extension
 
             DriverProvider::get($metadata)->load($container, $metadata);
 
-            if (isset($resourceConfig['translation'])) {
+            if (isset($resourceConfig['translation']) && class_exists('Sylius\Bundle\TranslationBundle\SyliusTranslationBundle')) {
                 $alias = $alias.'_translation';
                 $resourceConfig = array_merge(array('driver' => $resourceConfig['driver']), $resourceConfig['translation']);
 

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
@@ -54,7 +54,7 @@ class SyliusResourceExtension extends Extension
 
             DriverProvider::get($metadata)->load($container, $metadata);
 
-            if (isset($resourceConfig['translation']) && class_exists('Sylius\Bundle\TranslationBundle\SyliusTranslationBundle')) {
+            if ($metadata->hasParameter('translation') && class_exists('Sylius\Bundle\TranslationBundle\SyliusTranslationBundle')) {
                 $alias = $alias.'_translation';
                 $resourceConfig = array_merge(array('driver' => $resourceConfig['driver']), $resourceConfig['translation']);
 


### PR DESCRIPTION
I am not using translations in my application, and an error is thrown here as I've not configured translations for my resources.
This was introduced by https://github.com/Sylius/Sylius/pull/3721.

Also, it seems it is not not possible to disable translations per resource, see [here](https://github.com/Sylius/Sylius/pull/3721/files#r48045552).