### PR TITLE
[Product] added availableTo parameter

### DIFF
--- a/app/migrations/Version20151221084137.php
+++ b/app/migrations/Version20151221084137.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20151221084137 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_product_variant ADD available_until DATETIME DEFAULT NULL');
+        $this->addSql('ALTER TABLE sylius_product ADD available_until DATETIME DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_product DROP available_until');
+        $this->addSql('ALTER TABLE sylius_product_variant DROP available_until');
+    }
+}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/VariantType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/VariantType.php
@@ -35,6 +35,13 @@ class VariantType extends BaseVariantType
                 'time_widget' => 'text',
                 'label'       => 'sylius.form.product_variant.available_on'
             ))
+            ->add('availableUntil', 'datetime', array(
+                'date_format' => 'y-M-d',
+                'date_widget' => 'choice',
+                'time_widget' => 'text',
+                'required'    => false,
+                'label'       => 'sylius.form.product_variant.available_until'
+            ))
         ;
     }
 }

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Product.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Product.orm.xml
@@ -23,6 +23,10 @@
             <gedmo:versioned />
         </field>
 
+        <field name="availableUntil" column="available_until" type="datetime" nullable="true">
+            <gedmo:versioned />
+        </field>
+
         <many-to-one field="archetype" target-entity="Sylius\Component\Product\Model\ArchetypeInterface">
             <join-column name="archetype_id" referenced-column-name="id" nullable="true" />
         </many-to-one>

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Variant.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Variant.orm.xml
@@ -18,6 +18,7 @@
 
     <mapped-superclass name="Sylius\Component\Product\Model\Variant" table="sylius_product_variant">
         <field name="availableOn" column="available_on" type="datetime" nullable="true" />
+        <field name="availableUntil" column="available_until" type="datetime" nullable="true" />
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Bundle/ProductBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/translations/messages.en.yml
@@ -9,6 +9,7 @@ sylius:
       meta_description: Meta description
     product_variant:
       available_on: Available on
+      available_until: Available until
     product_archetype:
       name: Name
       parent: Parent

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
@@ -714,6 +714,7 @@ sylius:
     product:
         add_attribute: Add attribute
         available_on: Available on
+        available_until: Available until
         available_on_demand: Available on demand
         categorization: Categorization
         contain_variants: Contain Variants

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_main.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/Form/_main.html.twig
@@ -8,8 +8,11 @@
         <div class="col-md-6">
             {{ form_label(form.masterVariant.availableOn) }}
             {{ form_widget(form.masterVariant.availableOn, {'label': false}) }}
+            {{ form_label(form.masterVariant.availableUntil) }}
+            {{ form_widget(form.masterVariant.availableUntil, {'label': false}) }}
             {{ form_row(form.masterVariant.availableOnDemand) }}
             {{ form_row(form.masterVariant.onHand) }}
+
             <hr />
             {{ form_row(form.masterVariant.price) }}
             {{ form_row(form.masterVariant.pricingCalculator) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
@@ -77,6 +77,12 @@
                     <td>{{ 'sylius.product.available_on'|trans }}</td>
                     <td><span class="label label-{{ product.available ? 'success' : 'danger' }}">{{ product.availableOn|date }}</span></td>
                 </tr>
+                {% if product.availableUntil %}
+                <tr>
+                    <td>{{ 'sylius.product.available_until'|trans }}</td>
+                    <td><span class="label label-{{ product.available ? 'success' : 'danger' }}">{{ product.availableUntil|date }}</span></td>
+                </tr>
+                {% endif %}
                 <tr>
                     <td>{{ 'sylius.product.options'|trans }}</td>
                     <td>

--- a/src/Sylius/Component/Product/Model/DateRange.php
+++ b/src/Sylius/Component/Product/Model/DateRange.php
@@ -1,0 +1,86 @@
+<?php
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Product\Model;
+
+/**
+ * @author Krzysztof Wędrowicz <krzysztof@wedrowicz.me>
+ */
+class DateRange
+{
+    /**
+     * @var \DateTime
+     */
+    private $start;
+
+    /**
+     * @var \DateTime
+     */
+    private $end;
+
+    /**
+     * @param \DateTime $start
+     * @param \DateTime $end
+     */
+    public function __construct(\DateTime $start = null,\DateTime $end = null)
+    {
+        $this->start = $start;
+        $this->end = $end;
+    }
+
+    /**
+     * Checks whether current datetime meets two requirements:
+     * is greater than $start or equal,
+     * is smaller than $end or equal.
+     * Checks only these conditions which values ($start, $end) are not null.
+     *
+     * @return bool
+     */
+    public function isInRange()
+    {
+        if($this->start > new \DateTime() || ($this->end !== null && $this->end < new \DateTime())){
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @param \DateTime $start
+     */
+    public function setStart($start)
+    {
+        $this->start = $start;
+    }
+
+    /**
+     * @param \DateTime $end
+     */
+    public function setEnd($end)
+    {
+        $this->end = $end;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getStart()
+    {
+        return $this->start;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getEnd()
+    {
+        return $this->end;
+    }
+}
+

--- a/src/Sylius/Component/Product/Model/DateRange.php
+++ b/src/Sylius/Component/Product/Model/DateRange.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sylius package.
  *
@@ -13,7 +14,7 @@ namespace Sylius\Component\Product\Model;
 /**
  * @author Krzysztof Wędrowicz <krzysztof@wedrowicz.me>
  */
-class DateRange
+final class DateRange
 {
     /**
      * @var \DateTime
@@ -29,7 +30,7 @@ class DateRange
      * @param \DateTime $start
      * @param \DateTime $end
      */
-    public function __construct(\DateTime $start = null,\DateTime $end = null)
+    public function __construct(\DateTime $start = null, \DateTime $end = null)
     {
         $this->start = $start;
         $this->end = $end;
@@ -54,7 +55,7 @@ class DateRange
     /**
      * @param \DateTime $start
      */
-    public function setStart($start)
+    public function setStart(\DateTime $start = null)
     {
         $this->start = $start;
     }
@@ -62,7 +63,7 @@ class DateRange
     /**
      * @param \DateTime $end
      */
-    public function setEnd($end)
+    public function setEnd(\DateTime $end = null)
     {
         $this->end = $end;
     }

--- a/src/Sylius/Component/Product/Model/Product.php
+++ b/src/Sylius/Component/Product/Model/Product.php
@@ -41,6 +41,11 @@ class Product extends AbstractTranslatable implements ProductInterface
     protected $availableOn;
 
     /**
+     * @var \DateTime
+     */
+    protected $availableUntil;
+
+    /**
      * @var Collection|BaseAttributeValueInterface[]
      */
     protected $attributes;
@@ -189,7 +194,7 @@ class Product extends AbstractTranslatable implements ProductInterface
      */
     public function isAvailable()
     {
-        return new \DateTime() >= $this->availableOn;
+        return (new DateRange($this->availableOn, $this->availableUntil))->isInRange();
     }
 
     /**
@@ -206,6 +211,22 @@ class Product extends AbstractTranslatable implements ProductInterface
     public function setAvailableOn(\DateTime $availableOn = null)
     {
         $this->availableOn = $availableOn;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAvailableUntil()
+    {
+        return $this->availableUntil;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAvailableUntil(\DateTime $availableUntil = null)
+    {
+        $this->availableUntil = $availableUntil;
     }
 
     /**

--- a/src/Sylius/Component/Product/Model/ProductInterface.php
+++ b/src/Sylius/Component/Product/Model/ProductInterface.php
@@ -51,6 +51,4 @@ interface ProductInterface extends
      * @param null|\DateTime $availableUntil
      */
     public function setAvailableUntil(\DateTime $availableUntil = null);
-
-
 }

--- a/src/Sylius/Component/Product/Model/ProductInterface.php
+++ b/src/Sylius/Component/Product/Model/ProductInterface.php
@@ -41,4 +41,16 @@ interface ProductInterface extends
      * @param null|\DateTime $availableOn
      */
     public function setAvailableOn(\DateTime $availableOn = null);
+
+    /**
+     * @return \DateTime
+     */
+    public function getAvailableUntil();
+
+    /**
+     * @param null|\DateTime $availableUntil
+     */
+    public function setAvailableUntil(\DateTime $availableUntil = null);
+
+
 }

--- a/src/Sylius/Component/Product/Model/Variant.php
+++ b/src/Sylius/Component/Product/Model/Variant.php
@@ -24,6 +24,11 @@ class Variant extends BaseVariant implements VariantInterface
      */
     protected $availableOn;
 
+    /**
+     * @var \DateTime
+     */
+    protected $availableUntil;
+
     public function __construct()
     {
         parent::__construct();
@@ -52,7 +57,7 @@ class Variant extends BaseVariant implements VariantInterface
      */
     public function isAvailable()
     {
-        return new \DateTime() >= $this->availableOn;
+        return (new DateRange($this->availableOn, $this->availableUntil))->isInRange();
     }
 
     /**
@@ -72,6 +77,26 @@ class Variant extends BaseVariant implements VariantInterface
 
         if ($this->isMaster() && null !== $this->object) {
             $this->getProduct()->setAvailableOn($availableOn);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAvailableUntil()
+    {
+        return $this->availableUntil;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAvailableUntil(\DateTime $availableUntil = null)
+    {
+        $this->availableUntil = $availableUntil;
+
+        if ($this->isMaster() && null !== $this->object) {
+            $this->getProduct()->setAvailableUntil($availableUntil);
         }
     }
 

--- a/src/Sylius/Component/Product/Model/VariantInterface.php
+++ b/src/Sylius/Component/Product/Model/VariantInterface.php
@@ -42,4 +42,14 @@ interface VariantInterface extends BaseVariantInterface
      * @param null|\DateTime $availableOn
      */
     public function setAvailableOn(\DateTime $availableOn = null);
+
+    /**
+     * @return \DateTime
+     */
+    public function getAvailableUntil();
+
+    /**
+     * @param null|\DateTime $availableUntil
+     */
+    public function setAvailableUntil(\DateTime $availableUntil = null);
 }

--- a/src/Sylius/Component/Product/spec/Model/DateRangeSpec.php
+++ b/src/Sylius/Component/Product/spec/Model/DateRangeSpec.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Product\Model;
+
+use Faker\Provider\tr_TR\DateTime;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class DateRangeSpec extends ObjectBehavior
+{
+    function let(\DateTime $start, \DateTime $end)
+    {
+        $this->beConstructedWith($start, $end);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Product\Model\DateRange');
+    }
+
+    function its_start_date_is_mutable()
+    {
+        $date = new \DateTime('last year');
+
+        $this->setStart($date);
+        $this->getStart()->shouldReturn($date);
+    }
+
+    function its_end_date_is_mutable()
+    {
+        $date = new \DateTime('next year');
+
+        $this->setEnd($date);
+        $this->getEnd()->shouldReturn($date);
+    }
+
+    function it_checks_whether_current_datetime_is_in_range_of_start_and_end()
+    {
+        $start = new \DateTime('last year');
+        $end = new \DateTime('next year');
+        $this->setStart($start);
+        $this->setEnd($end);
+        $this->isInRange()->shouldReturn(true);
+
+        $this->setStart(null);
+        $this->isInRange()->shouldReturn(true);
+
+        $this->setEnd(null);
+        $this->isInRange()->shouldReturn(true);
+
+        $this->setStart($end);
+        $this->isInRange()->shouldReturn(false);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Sometimes except availableOn product parameter we need also availableTo one. This is especially usefull when You selling something like concert or training tickets which events take place at particular day and it is useless to selling them after that day. When You leave this parameter blank nothing new happens but when You set a date, Sylius will validate it with availableOn in isAvailable method.

This is my first bigger commit to Sylius so any tips how to improve my code are highly appreciated. Hope it will be usefull for community.