### PR TITLE
[Taxonomy] Cast Taxon::__toString() to string to prevent Monolog exception

### DIFF
--- a/src/Sylius/Component/Taxonomy/Model/Taxon.php
+++ b/src/Sylius/Component/Taxonomy/Model/Taxon.php
@@ -77,7 +77,7 @@ class Taxon extends AbstractTranslatable implements TaxonInterface
      */
     public function __toString()
     {
-        return $this->translate()->__toString();
+        return (string) $this->translate()->__toString();
     }
 
     /**


### PR DESCRIPTION
Q  | A
------------- | -------------
Bug fix?  | yes
New feature?  | no
BC breaks? | no
Deprecations? | no
Fixed tickets | no
License | MIT
Doc PR | -

We an issue with our version of Monolog I suppose.