### PR TITLE
[Shipment] Fix join on ShipmentRepository for Shipment Admin page

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ShipmentRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ShipmentRepository.php
@@ -29,8 +29,8 @@ class ShipmentRepository extends EntityRepository
         $queryBuilder = $this->getCollectionQueryBuilder();
 
         $queryBuilder
-            ->leftJoin($this->getAlias().'.order', 'shipmentOrder')
-            ->leftJoin('shipmentOrder.shippingAddress', 'address')
+            ->innerJoin($this->getAlias().'.order', 'shipmentOrder')
+            ->innerJoin('shipmentOrder.shippingAddress', 'address')
             ->addSelect('shipmentOrder')
             ->addSelect('address')
         ;
@@ -78,6 +78,9 @@ class ShipmentRepository extends EntityRepository
         return $this->getPaginator($queryBuilder);
     }
 
+    /**
+     * @return string
+     */
     protected function getAlias()
     {
         return 's';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

It could be specific to our app that shipments are created before addresses sometimes, but there's no point in this query being a left-join anyway since the `Backend/Shipment/macros.html.twig` file requires an address (and an order) for displaying shipments:

https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/macros.html.twig#L33
