### PR TITLE
[Order] Implementation of OrderItemQuantityModifier

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -14,6 +14,10 @@ UPGRADE
 
 * Introduced ``OrderItemUnit``, which represents every single unit in ``Order``;
 * Replaced ``InventoryUnit`` with ``OrderItemUnit`` in the core. This entity will be used as ``InventoryUnit`` and ``ShipmentItem``;
+* Removed ``setQuantity()`` method from ``OrderItem``
+* Introduced ``OrderItemUnitFactory`` creating unit for specific ``OrderItem`` by ``createForItem()`` method
+* Introduced ``OrderItemQuantityModifier`` that is used to control ``OrderItem`` quantity and units
+* Introduced ``OrderItemQuantityDataMapper``, which attached to ``OrderItemType`` uses proper service to modify ``OrderItem`` quantity
 
 ## From 0.15.0 to 0.16.x
 

--- a/app/migrations/Version20151230142358.php
+++ b/app/migrations/Version20151230142358.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20151230142358 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_order_item ADD units_total INT NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_order_item DROP units_total');
+    }
+}

--- a/app/migrations/Version20151231002659.php
+++ b/app/migrations/Version20151231002659.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Schema\Schema;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-class Version20151230142358 extends AbstractMigration
+class Version20151231002659 extends AbstractMigration
 {
     /**
      * @param Schema $schema
@@ -19,6 +19,7 @@ class Version20151230142358 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_order_item ADD units_total INT NOT NULL');
+        $this->addSql('ALTER TABLE sylius_order_item_unit DROP total');
     }
 
     /**
@@ -30,5 +31,6 @@ class Version20151230142358 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_order_item DROP units_total');
+        $this->addSql('ALTER TABLE sylius_order_item_unit ADD total INT NOT NULL');
     }
 }

--- a/src/Sylius/Bundle/CartBundle/Form/Type/CartItemType.php
+++ b/src/Sylius/Bundle/CartBundle/Form/Type/CartItemType.php
@@ -28,7 +28,10 @@ class CartItemType extends AbstractResourceType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('quantity', 'integer', array('attr' => array('min' => 1)))
+            ->add('quantity', 'integer', array(
+                'attr' => array('min' => 1),
+                'data' => 1,
+            ))
         ;
     }
 

--- a/src/Sylius/Bundle/CartBundle/Form/Type/CartItemType.php
+++ b/src/Sylius/Bundle/CartBundle/Form/Type/CartItemType.php
@@ -44,8 +44,7 @@ class CartItemType extends AbstractResourceType
     {
         $builder
             ->add('quantity', 'integer', array(
-                'attr' => array('min' => 1),
-                'data' => 1,
+                'attr' => array('min' => 1)
             ))
             ->setDataMapper($this->orderItemQuantityDataMapper);
         ;

--- a/src/Sylius/Bundle/CartBundle/Form/Type/CartItemType.php
+++ b/src/Sylius/Bundle/CartBundle/Form/Type/CartItemType.php
@@ -12,16 +12,31 @@
 namespace Sylius\Bundle\CartBundle\Form\Type;
 
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
+use Symfony\Component\Form\DataMapperInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- * Cart item type.
- * It includes only quantity form field by default.
- *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
 class CartItemType extends AbstractResourceType
 {
+    /**
+     * @var DataMapperInterface
+     */
+    protected $orderItemQuantityDataMapper;
+
+    /**
+     * @param string $dataClass
+     * @param array $validationGroups
+     * @param DataMapperInterface $orderItemQuantityDataMapper
+     */
+    public function __construct($dataClass, array $validationGroups = array(), DataMapperInterface $orderItemQuantityDataMapper)
+    {
+        parent::__construct($dataClass, $validationGroups);
+
+        $this->orderItemQuantityDataMapper = $orderItemQuantityDataMapper;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -32,6 +47,7 @@ class CartItemType extends AbstractResourceType
                 'attr' => array('min' => 1),
                 'data' => 1,
             ))
+            ->setDataMapper($this->orderItemQuantityDataMapper);
         ;
     }
 

--- a/src/Sylius/Bundle/CartBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CartBundle/Resources/config/services.xml
@@ -67,7 +67,7 @@
         <service id="sylius.form.type.cart_item" class="%sylius.form.type.cart_item.class%">
             <argument>%sylius.model.cart_item.class%</argument>
             <argument>%sylius.validation_groups.cart_item%</argument>
-            <argument type="service" id="sylius.data_mapper.order_item_quantity" />
+            <argument type="service" id="sylius.form.data_mapper.order_item_quantity" />
             <tag name="form.type" alias="sylius_cart_item" />
         </service>
 
@@ -87,7 +87,7 @@
             <argument type="service" id="sylius.manager.cart" />
             <argument type="service" id="validator" />
             <argument type="service" id="sylius.cart_provider" />
-            <argument type="service" id="sylius.modifier.order_item_quantity" />
+            <argument type="service" id="sylius.order_item_quantity_modifier" />
         </service>
 
         <service id="sylius.listener.cart_flash" class="%sylius.listener.cart_flash.class%">

--- a/src/Sylius/Bundle/CartBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CartBundle/Resources/config/services.xml
@@ -87,6 +87,7 @@
             <argument type="service" id="sylius.manager.cart" />
             <argument type="service" id="validator" />
             <argument type="service" id="sylius.cart_provider" />
+            <argument type="service" id="sylius.modifier.order_item_quantity" />
         </service>
 
         <service id="sylius.listener.cart_flash" class="%sylius.listener.cart_flash.class%">

--- a/src/Sylius/Bundle/CartBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CartBundle/Resources/config/services.xml
@@ -67,6 +67,7 @@
         <service id="sylius.form.type.cart_item" class="%sylius.form.type.cart_item.class%">
             <argument>%sylius.model.cart_item.class%</argument>
             <argument>%sylius.validation_groups.cart_item%</argument>
+            <argument type="service" id="sylius.data_mapper.order_item_quantity" />
             <tag name="form.type" alias="sylius_cart_item" />
         </service>
 

--- a/src/Sylius/Bundle/CartBundle/Resources/config/templating.xml
+++ b/src/Sylius/Bundle/CartBundle/Resources/config/templating.xml
@@ -25,6 +25,7 @@
             <argument type="service" id="sylius.cart_provider" />
             <argument type="service" id="sylius.factory.cart_item" />
             <argument type="service" id="form.factory" />
+            <argument type="service" id="sylius.modifier.order_item_quantity" />
             <tag name="templating.helper" alias="sylius_cart" />
         </service>
     </services>

--- a/src/Sylius/Bundle/CartBundle/Resources/config/templating.xml
+++ b/src/Sylius/Bundle/CartBundle/Resources/config/templating.xml
@@ -25,7 +25,7 @@
             <argument type="service" id="sylius.cart_provider" />
             <argument type="service" id="sylius.factory.cart_item" />
             <argument type="service" id="form.factory" />
-            <argument type="service" id="sylius.modifier.order_item_quantity" />
+            <argument type="service" id="sylius.order_item_quantity_modifier" />
             <tag name="templating.helper" alias="sylius_cart" />
         </service>
     </services>

--- a/src/Sylius/Bundle/CartBundle/Templating/Helper/CartHelper.php
+++ b/src/Sylius/Bundle/CartBundle/Templating/Helper/CartHelper.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\CartBundle\Templating\Helper;
 
+use Sylius\Bundle\OrderBundle\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Component\Cart\Model\CartInterface;
 use Sylius\Component\Cart\Provider\CartProviderInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
@@ -21,44 +22,41 @@ use Symfony\Component\Templating\Helper\Helper;
 class CartHelper extends Helper
 {
     /**
-     * Cart provider.
-     *
      * @var CartProviderInterface
      */
     protected $cartProvider;
 
     /**
-     * Cart item manager.
-     *
      * @var FactoryInterface
      */
     protected $cartItemFactory;
 
     /**
-     * Form factory.
-     *
      * @var FormFactoryInterface
      */
     protected $formFactory;
 
     /**
-     * Constructor.
-     *
-     * @param CartProviderInterface $cartProvider
-     * @param FactoryInterface   $cartItemFactory
-     * @param FormFactoryInterface  $formFactory
+     * @var OrderItemQuantityModifierInterface
      */
-    public function __construct(CartProviderInterface $cartProvider, FactoryInterface $cartItemFactory, FormFactoryInterface $formFactory)
+    protected $orderItemQuantityModifier;
+
+    /**
+     * @param CartProviderInterface $cartProvider
+     * @param FactoryInterface $cartItemFactory
+     * @param FormFactoryInterface $formFactory
+     * @param OrderItemQuantityModifierInterface $orderItemQuantityModifier
+     */
+    public function __construct(CartProviderInterface $cartProvider, FactoryInterface $cartItemFactory, FormFactoryInterface $formFactory, OrderItemQuantityModifierInterface $orderItemQuantityModifier)
     {
         $this->cartProvider = $cartProvider;
         $this->cartItemFactory = $cartItemFactory;
         $this->formFactory = $formFactory;
+        $this->orderItemQuantityModifier = $orderItemQuantityModifier;
     }
 
     /**
-     * Returns current cart.
-     *
-     * @return null|CartInterface
+     * @return CartInterface|null
      */
     public function getCurrentCart()
     {
@@ -66,9 +64,7 @@ class CartHelper extends Helper
     }
 
     /**
-     * Check if a cart exists.
-     *
-     * @return Boolean
+     * @return bool
      */
     public function hasCart()
     {
@@ -76,15 +72,16 @@ class CartHelper extends Helper
     }
 
     /**
-     * Returns cart item form view.
-     *
      * @param array $options
      *
      * @return FormView
      */
     public function getItemFormView(array $options = array())
     {
-        $form = $this->formFactory->create('sylius_cart_item', $this->cartItemFactory->createNew(), $options);
+        $cartItem = $this->cartItemFactory->createNew();
+        $this->orderItemQuantityModifier->modify($cartItem, 1);
+
+        $form = $this->formFactory->create('sylius_cart_item', $cartItem, $options);
 
         return $form->createView();
     }

--- a/src/Sylius/Bundle/CartBundle/spec/EventListener/CartSubscriberSpec.php
+++ b/src/Sylius/Bundle/CartBundle/spec/EventListener/CartSubscriberSpec.php
@@ -40,7 +40,7 @@ class CartSubscriberSpec extends ObjectBehavior
         $this->shouldHaveType('Sylius\Bundle\CartBundle\EventListener\CartSubscriber');
     }
 
-    function it_adds_a_item_to_a_cart_from_event_if_not_already_exist(
+    function it_adds_an_item_to_a_cart_from_event_if_does_not_already_exist(
         CartItemEvent $event,
         CartInterface $cart,
         CartItemInterface $cartItem,

--- a/src/Sylius/Bundle/CartBundle/spec/EventListener/CartSubscriberSpec.php
+++ b/src/Sylius/Bundle/CartBundle/spec/EventListener/CartSubscriberSpec.php
@@ -11,13 +11,16 @@
 
 namespace spec\Sylius\Bundle\CartBundle\EventListener;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\OrderBundle\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Component\Cart\Event\CartEvent;
 use Sylius\Component\Cart\Event\CartItemEvent;
 use Sylius\Component\Cart\Model\CartInterface;
 use Sylius\Component\Cart\Model\CartItemInterface;
 use Sylius\Component\Cart\Provider\CartProviderInterface;
+use Sylius\Component\Order\Model\OrderItemInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\ValidatorInterface;
 
@@ -27,9 +30,9 @@ use Symfony\Component\Validator\ValidatorInterface;
  */
 class CartSubscriberSpec extends ObjectBehavior
 {
-    function let(ObjectManager $manager, ValidatorInterface $validator, CartProviderInterface $provider)
+    function let(ObjectManager $manager, ValidatorInterface $validator, CartProviderInterface $provider, OrderItemQuantityModifierInterface $orderItemQuantityModifier)
     {
-        $this->beConstructedWith($manager, $validator, $provider);
+        $this->beConstructedWith($manager, $validator, $provider, $orderItemQuantityModifier);
     }
 
     function it_is_initializable()
@@ -37,11 +40,55 @@ class CartSubscriberSpec extends ObjectBehavior
         $this->shouldHaveType('Sylius\Bundle\CartBundle\EventListener\CartSubscriber');
     }
 
-    function it_should_add_a_item_to_a_cart_from_event(CartItemEvent $event, CartInterface $cart, CartItemInterface $cartItem)
-    {
+    function it_adds_a_item_to_a_cart_from_event_if_not_already_exist(
+        CartItemEvent $event,
+        CartInterface $cart,
+        CartItemInterface $cartItem,
+        Collection $items,
+        OrderItemInterface $existingItem,
+        \Iterator $iterator
+    ) {
         $event->getCart()->willReturn($cart);
         $event->getItem()->willReturn($cartItem);
+
+        $cart->getItems()->willReturn($items);
+        $items->getIterator()->willReturn($iterator);
+        $iterator->rewind()->shouldBeCalled();
+        $iterator->valid()->willReturn(true, false);
+        $iterator->current()->willReturn($existingItem);
+        $iterator->next()->shouldBeCalled();
+
+        $cartItem->equals($existingItem)->willReturn(false);
+
         $cart->addItem($cartItem)->shouldBeCalled();
+
+        $this->addItem($event);
+    }
+
+    function it_merges_cart_items_if_equal(
+        $orderItemQuantityModifier,
+        CartItemEvent $event,
+        CartInterface $cart,
+        CartItemInterface $cartItem,
+        Collection $items,
+        OrderItemInterface $existingItem,
+        \Iterator $iterator
+    ) {
+        $event->getCart()->willReturn($cart);
+        $event->getItem()->willReturn($cartItem);
+
+        $cart->getItems()->willReturn($items);
+        $items->getIterator()->willReturn($iterator);
+        $iterator->rewind()->shouldBeCalled();
+        $iterator->valid()->willReturn(true, false);
+        $iterator->current()->willReturn($existingItem);
+
+        $cartItem->equals($existingItem)->willReturn(true);
+
+        $cartItem->getQuantity()->willReturn(3);
+        $existingItem->getQuantity()->willReturn(1);
+
+        $orderItemQuantityModifier->modify($existingItem, 4)->shouldBeCalled();
 
         $this->addItem($event);
     }

--- a/src/Sylius/Bundle/CartBundle/spec/Form/Type/CartItemTypeSpec.php
+++ b/src/Sylius/Bundle/CartBundle/spec/Form/Type/CartItemTypeSpec.php
@@ -43,11 +43,13 @@ class CartItemTypeSpec extends ObjectBehavior
         $builder
             ->add('quantity', 'integer', Argument::any())
             ->willReturn($builder)
+            ->shouldBeCalled()
         ;
 
         $builder
             ->setDataMapper($orderItemQuantityDataMapper)
             ->willReturn($builder)
+            ->shouldBeCalled()
         ;
 
         $this->buildForm($builder, array());

--- a/src/Sylius/Bundle/CartBundle/spec/Form/Type/CartItemTypeSpec.php
+++ b/src/Sylius/Bundle/CartBundle/spec/Form/Type/CartItemTypeSpec.php
@@ -13,6 +13,7 @@ namespace spec\Sylius\Bundle\CartBundle\Form\Type;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\Form\DataMapperInterface;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -22,9 +23,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class CartItemTypeSpec extends ObjectBehavior
 {
-    function let()
+    function let(DataMapperInterface $orderItemQuantityDataMapper)
     {
-        $this->beConstructedWith('CartItem', array('sylius'));
+        $this->beConstructedWith('CartItem', array('sylius'), $orderItemQuantityDataMapper);
     }
 
     function it_is_initializable()
@@ -37,11 +38,15 @@ class CartItemTypeSpec extends ObjectBehavior
         $this->shouldImplement(FormTypeInterface::class);
     }
 
-    function it_builds_form_with_quantity_field(FormBuilder $builder)
+    function it_builds_form_with_quantity_field($orderItemQuantityDataMapper, FormBuilder $builder)
     {
         $builder
             ->add('quantity', 'integer', Argument::any())
-            ->shouldBeCalled()
+            ->willReturn($builder)
+        ;
+
+        $builder
+            ->setDataMapper($orderItemQuantityDataMapper)
             ->willReturn($builder)
         ;
 

--- a/src/Sylius/Bundle/CartBundle/spec/Templating/Helper/CartHelperSpec.php
+++ b/src/Sylius/Bundle/CartBundle/spec/Templating/Helper/CartHelperSpec.php
@@ -12,6 +12,7 @@
 namespace spec\Sylius\Bundle\CartBundle\Templating\Helper;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\OrderBundle\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Component\Cart\Model\CartInterface;
 use Sylius\Component\Cart\Model\CartItemInterface;
 use Sylius\Component\Cart\Provider\CartProviderInterface;
@@ -26,9 +27,10 @@ class CartHelperSpec extends ObjectBehavior
     function let(
         CartProviderInterface $cartProvider,
         FactoryInterface $itemFactory,
-        FormFactoryInterface $formFactory
+        FormFactoryInterface $formFactory,
+        OrderItemQuantityModifierInterface $orderItemQuantityModifier
     ) {
-        $this->beConstructedWith($cartProvider, $itemFactory, $formFactory);
+        $this->beConstructedWith($cartProvider, $itemFactory, $formFactory, $orderItemQuantityModifier);
     }
 
     function it_is_initializable()
@@ -49,13 +51,16 @@ class CartHelperSpec extends ObjectBehavior
     }
 
     function its_getItemFormView_returns_a_form_view_of_cart_item_form(
-        $itemFactory,
         $formFactory,
+        $itemFactory,
+        $orderItemQuantityModifier,
+        CartItemInterface $item,
         FormInterface $form,
-        FormView $formView,
-        CartItemInterface $item
+        FormView $formView
     ) {
         $itemFactory->createNew()->shouldBeCalled()->willReturn($item);
+        $orderItemQuantityModifier->modify($item, 1)->shouldBeCalled();
+
         $formFactory->create('sylius_cart_item', $item, array())->shouldBeCalled()->willReturn($form);
         $form->createView()->willReturn($formView);
 
@@ -65,11 +70,14 @@ class CartHelperSpec extends ObjectBehavior
     function its_getItemFormView_uses_given_options_when_creating_form(
         $itemFactory,
         $formFactory,
+        $orderItemQuantityModifier,
         FormInterface $form,
         FormView $formView,
         CartItemInterface $item
     ) {
         $itemFactory->createNew()->shouldBeCalled()->willReturn($item);
+        $orderItemQuantityModifier->modify($item, 1)->shouldBeCalled();
+
         $formFactory->create('sylius_cart_item', $item, array('foo' => 'bar'))->shouldBeCalled()->willReturn($form);
         $form->createView()->willReturn($formView);
 

--- a/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
@@ -172,7 +172,7 @@ class CoreContext extends DefaultContext
     {
         $manager = $this->getEntityManager();
         $orderItemFactory = $this->getFactory('order_item');
-        $orderItemQuantityModifier = $this->getService('sylius.modifier.order_item_quantity');
+        $orderItemQuantityModifier = $this->getService('sylius.order_item_quantity_modifier');
 
         $order = $this->orders[$number];
 

--- a/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
@@ -172,6 +172,7 @@ class CoreContext extends DefaultContext
     {
         $manager = $this->getEntityManager();
         $orderItemFactory = $this->getFactory('order_item');
+        $orderItemQuantityModifier = $this->getService('sylius.modifier.order_item_quantity');
 
         $order = $this->orders[$number];
 
@@ -182,7 +183,8 @@ class CoreContext extends DefaultContext
             $item = $orderItemFactory->createNew();
             $item->setVariant($product->getMasterVariant());
             $item->setUnitPrice($product->getMasterVariant()->getPrice());
-            $item->setQuantity($data['quantity']);
+
+            $orderItemQuantityModifier->modify($item, $data['quantity']);
 
             $order->addItem($item);
         }

--- a/src/Sylius/Bundle/CoreBundle/Modifier/OrderItemQuantityModifier.php
+++ b/src/Sylius/Bundle/CoreBundle/Modifier/OrderItemQuantityModifier.php
@@ -11,8 +11,8 @@
 
 namespace Sylius\Bundle\CoreBundle\Modifier;
 
+use Sylius\Bundle\OrderBundle\Factory\OrderItemUnitFactoryInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
-use Sylius\Component\Resource\Factory\FactoryInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -20,14 +20,14 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
 class OrderItemQuantityModifier implements OrderItemQuantityModifierInterface
 {
     /**
-     * @var FactoryInterface
+     * @var OrderItemUnitFactoryInterface
      */
     private $orderItemUnitFactory;
 
     /**
-     * @param FactoryInterface $orderItemUnitFactory
+     * @param OrderItemUnitFactoryInterface $orderItemUnitFactory
      */
-    public function __construct(FactoryInterface $orderItemUnitFactory)
+    public function __construct(OrderItemUnitFactoryInterface $orderItemUnitFactory)
     {
         $this->orderItemUnitFactory = $orderItemUnitFactory;
     }
@@ -54,7 +54,7 @@ class OrderItemQuantityModifier implements OrderItemQuantityModifierInterface
     private function increaseUnitsNumber(OrderItemInterface $orderItem, $increaseBy)
     {
         for ($i = 0; $i < $increaseBy; $i++) {
-            $unit = $this->orderItemUnitFactory->createNew();
+            $unit = $this->orderItemUnitFactory->createForItem($orderItem);
             $orderItem->addUnit($unit);
         }
     }

--- a/src/Sylius/Bundle/CoreBundle/Modifier/OrderItemQuantityModifier.php
+++ b/src/Sylius/Bundle/CoreBundle/Modifier/OrderItemQuantityModifier.php
@@ -37,26 +37,23 @@ class OrderItemQuantityModifier implements OrderItemQuantityModifierInterface
      */
     public function modify(OrderItemInterface $orderItem, $targetQuantity)
     {
-        if ($targetQuantity === $itemQuantity = $orderItem->getQuantity()) {
-            return;
-        }
+        $itemQuantity = $orderItem->getQuantity();
 
         if ($targetQuantity > $itemQuantity) {
             $this->increaseUnitsNumber($orderItem, $targetQuantity - $itemQuantity);
-
-            return;
+        } else if ($targetQuantity < $itemQuantity) {
+            $this->decreaseUnitsNumber($orderItem, $itemQuantity - $targetQuantity);
         }
 
-        $this->decreaseUnitsNumber($orderItem, $itemQuantity, $targetQuantity);
     }
 
     /**
      * @param OrderItemInterface $orderItem
-     * @param int $targetUnitsNumber
+     * @param int $increaseBy
      */
-    private function increaseUnitsNumber(OrderItemInterface $orderItem, $targetUnitsNumber)
+    private function increaseUnitsNumber(OrderItemInterface $orderItem, $increaseBy)
     {
-        for ($i = 0; $i < $targetUnitsNumber; $i++) {
+        for ($i = 0; $i < $increaseBy; $i++) {
             $unit = $this->orderItemUnitFactory->createNew();
             $orderItem->addUnit($unit);
         }
@@ -64,13 +61,16 @@ class OrderItemQuantityModifier implements OrderItemQuantityModifierInterface
 
     /**
      * @param OrderItemInterface $orderItem
-     * @param int $itemQuantity
-     * @param int $targetQuantity
+     * @param int $decreaseBy
      */
-    private function decreaseUnitsNumber(OrderItemInterface $orderItem, $itemQuantity, $targetQuantity)
+    private function decreaseUnitsNumber(OrderItemInterface $orderItem, $decreaseBy)
     {
-        for ($i = $itemQuantity-1; $i >= $targetQuantity; $i--) {
-            $orderItem->removeUnitByIndex($i);
+        foreach ($orderItem->getUnits() as $unit) {
+            if (0 >= $decreaseBy--) {
+                break;
+            }
+
+            $orderItem->removeUnit($unit);
         }
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Modifier/OrderItemQuantityModifier.php
+++ b/src/Sylius/Bundle/CoreBundle/Modifier/OrderItemQuantityModifier.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Modifier;
+
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class OrderItemQuantityModifier implements OrderItemQuantityModifierInterface
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $orderItemUnitFactory;
+
+    /**
+     * @param FactoryInterface $orderItemUnitFactory
+     */
+    public function __construct(FactoryInterface $orderItemUnitFactory)
+    {
+        $this->orderItemUnitFactory = $orderItemUnitFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function modify(OrderItemInterface $orderItem, $targetQuantity)
+    {
+        if ($targetQuantity === $itemQuantity = $orderItem->getQuantity()) {
+            return;
+        }
+
+        if ($targetQuantity > $itemQuantity) {
+            $this->increaseUnitsNumber($orderItem, $targetQuantity - $itemQuantity);
+
+            return;
+        }
+
+        $this->decreaseUnitsNumber($orderItem, $itemQuantity, $targetQuantity);
+    }
+
+    /**
+     * @param OrderItemInterface $orderItem
+     * @param int $targetUnitsNumber
+     */
+    private function increaseUnitsNumber(OrderItemInterface $orderItem, $targetUnitsNumber)
+    {
+        for ($i = 0; $i < $targetUnitsNumber; $i++) {
+            $unit = $this->orderItemUnitFactory->createNew();
+            $orderItem->addUnit($unit);
+        }
+    }
+
+    /**
+     * @param OrderItemInterface $orderItem
+     * @param int $itemQuantity
+     * @param int $targetQuantity
+     */
+    private function decreaseUnitsNumber(OrderItemInterface $orderItem, $itemQuantity, $targetQuantity)
+    {
+        for ($i = $itemQuantity-1; $i >= $targetQuantity; $i--) {
+            $orderItem->removeUnitByIndex($i);
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Modifier/OrderItemQuantityModifierInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Modifier/OrderItemQuantityModifierInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Modifier;
+
+use Sylius\Component\Core\Model\OrderItemInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+interface OrderItemQuantityModifierInterface
+{
+    /**
+     * @param OrderItemInterface $orderItem
+     * @param int $quantity
+     */
+    public function modify(OrderItemInterface $orderItem, $quantity);
+}

--- a/src/Sylius/Bundle/CoreBundle/OrderProcessing/TaxationProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderProcessing/TaxationProcessor.php
@@ -119,8 +119,6 @@ class TaxationProcessor implements TaxationProcessorInterface
                 continue;
             }
 
-            $item->calculateTotal();
-
             $amount = $this->calculator->calculate($item->getTotal(), $rate);
             $taxAmount = $rate->getAmountAsPercentage();
             $description = sprintf('%s (%s%%)', $rate->getName(), (float) $taxAmount);

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -105,6 +105,8 @@
 
         <parameter key="sylius.authorization_checker.toggleable.class">Sylius\Bundle\CoreBundle\Authorization\ToggleableAuthorizationChecker</parameter>
         <parameter key="sylius.translation.locale_provider.contextual.class">Sylius\Bundle\CoreBundle\Locale\TranslationLocaleProvider</parameter>
+
+        <parameter key="sylius.modifier.order_item_quantity.class">Sylius\Bundle\CoreBundle\Modifier\OrderItemQuantityModifier</parameter>
     </parameters>
 
     <services>
@@ -553,6 +555,10 @@
         <service id="sylius.validator.has_enabled_entity" class="%sylius.validator.has_enabled_entity.class%">
             <argument type="service" id="doctrine" />
             <tag name="validator.constraint_validator" alias="sylius_has_enabled_entity" />
+        </service>
+
+        <service id="sylius.modifier.order_item_quantity" class="%sylius.modifier.order_item_quantity.class%">
+            <argument type="service" id="sylius.factory.order_item_unit" />
         </service>
     </services>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -410,7 +410,7 @@
         <service id="sylius.promotion_action.add_product" class="%sylius.promotion_action.add_product.class%">
             <argument type="service" id="sylius.factory.order_item" />
             <argument type="service" id="sylius.repository.product_variant" />
-            <argument type="service" id="sylius.modifier.order_item_quantity" />
+            <argument type="service" id="sylius.order_item_quantity_modifier" />
             <tag name="sylius.promotion_action" type="add_product" label="Add product" />
         </service>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -412,6 +412,7 @@
         <service id="sylius.promotion_action.add_product" class="%sylius.promotion_action.add_product.class%">
             <argument type="service" id="sylius.factory.order_item" />
             <argument type="service" id="sylius.repository.product_variant" />
+            <argument type="service" id="sylius.modifier.order_item_quantity" />
             <tag name="sylius.promotion_action" type="add_product" label="Add product" />
         </service>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -105,8 +105,6 @@
 
         <parameter key="sylius.authorization_checker.toggleable.class">Sylius\Bundle\CoreBundle\Authorization\ToggleableAuthorizationChecker</parameter>
         <parameter key="sylius.translation.locale_provider.contextual.class">Sylius\Bundle\CoreBundle\Locale\TranslationLocaleProvider</parameter>
-
-        <parameter key="sylius.modifier.order_item_quantity.class">Sylius\Bundle\CoreBundle\Modifier\OrderItemQuantityModifier</parameter>
     </parameters>
 
     <services>
@@ -556,10 +554,6 @@
         <service id="sylius.validator.has_enabled_entity" class="%sylius.validator.has_enabled_entity.class%">
             <argument type="service" id="doctrine" />
             <tag name="validator.constraint_validator" alias="sylius_has_enabled_entity" />
-        </service>
-
-        <service id="sylius.modifier.order_item_quantity" class="%sylius.modifier.order_item_quantity.class%">
-            <argument type="service" id="sylius.factory.order_item_unit" />
         </service>
     </services>
 

--- a/src/Sylius/Bundle/CoreBundle/spec/Modifier/OrderItemQuantityModifierSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Modifier/OrderItemQuantityModifierSpec.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\CoreBundle\Modifier;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\CoreBundle\Modifier\OrderItemQuantityModifierInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\OrderItemUnitInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class OrderItemQuantityModifierSpec extends ObjectBehavior
+{
+    function let(FactoryInterface $orderItemUnitFactory)
+    {
+        $this->beConstructedWith($orderItemUnitFactory);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\CoreBundle\Modifier\OrderItemQuantityModifier');
+    }
+
+    function it_implements_order_item_quantity_modifier_interface()
+    {
+        $this->shouldImplement(OrderItemQuantityModifierInterface::class);
+    }
+
+    function it_adds_proper_number_of_order_item_units_to_order_item(
+        $orderItemUnitFactory,
+        OrderItemInterface $orderItem,
+        OrderItemUnitInterface $unit1,
+        OrderItemUnitInterface $unit2
+    ) {
+        $orderItem->getQuantity()->willReturn(1);
+
+        $orderItemUnitFactory->createNew()->willReturn($unit1, $unit2);
+
+        $orderItem->addUnit($unit1)->shouldBeCalled();
+        $orderItem->addUnit($unit2)->shouldBeCalled();
+
+        $this->modify($orderItem, 3);
+    }
+
+    function it_removes_units_if_target_quantity_is_greater_than_current($orderItemUnitFactory, OrderItemInterface $orderItem)
+    {
+        $orderItem->getQuantity()->willReturn(5);
+
+        $orderItemUnitFactory->createNew()->shouldNotBeCalled();
+
+        $orderItem->removeUnitByIndex(4)->shouldBeCalled();
+        $orderItem->removeUnitByIndex(3)->shouldBeCalled();
+
+        $this->modify($orderItem, 3);
+    }
+
+    function it_does_nothing_if_target_quantity_is_equal_to_current($orderItemUnitFactory, OrderItemInterface $orderItem)
+    {
+        $orderItem->getQuantity()->willReturn(3);
+
+        $orderItemUnitFactory->createNew()->shouldNotBeCalled();
+        $orderItem->addUnit(Argument::any())->shouldNotBeCalled();
+        $orderItem->removeUnitByIndex(Argument::any())->shouldNotBeCalled();
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/spec/Modifier/OrderItemQuantityModifierSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Modifier/OrderItemQuantityModifierSpec.php
@@ -11,6 +11,7 @@
 
 namespace spec\Sylius\Bundle\CoreBundle\Modifier;
 
+use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\CoreBundle\Modifier\OrderItemQuantityModifierInterface;
@@ -54,14 +55,27 @@ class OrderItemQuantityModifierSpec extends ObjectBehavior
         $this->modify($orderItem, 3);
     }
 
-    function it_removes_units_if_target_quantity_is_greater_than_current($orderItemUnitFactory, OrderItemInterface $orderItem)
-    {
+    function it_removes_units_if_target_quantity_is_greater_than_current(
+        Collection $orderItemUnits,
+        \Iterator $iterator,
+        OrderItemInterface $orderItem,
+        OrderItemUnitInterface $unit1,
+        OrderItemUnitInterface $unit2,
+        OrderItemUnitInterface $unit3,
+        OrderItemUnitInterface $unit4
+    ) {
         $orderItem->getQuantity()->willReturn(5);
+        $orderItem->getUnits()->willReturn($orderItemUnits);
 
-        $orderItemUnitFactory->createNew()->shouldNotBeCalled();
+        $orderItemUnits->count()->willReturn(4);
+        $orderItemUnits->getIterator()->willReturn($iterator);
+        $iterator->rewind()->shouldBeCalled();
+        $iterator->valid()->willReturn(true, true, true, true, false);
+        $iterator->current()->willReturn($unit1, $unit2, $unit3, $unit4);
+        $iterator->next()->shouldBeCalled();
 
-        $orderItem->removeUnitByIndex(4)->shouldBeCalled();
-        $orderItem->removeUnitByIndex(3)->shouldBeCalled();
+        $orderItem->removeUnit($unit1)->shouldBeCalled();
+        $orderItem->removeUnit($unit2)->shouldBeCalled();
 
         $this->modify($orderItem, 3);
     }
@@ -72,6 +86,6 @@ class OrderItemQuantityModifierSpec extends ObjectBehavior
 
         $orderItemUnitFactory->createNew()->shouldNotBeCalled();
         $orderItem->addUnit(Argument::any())->shouldNotBeCalled();
-        $orderItem->removeUnitByIndex(Argument::any())->shouldNotBeCalled();
+        $orderItem->removeUnit(Argument::any())->shouldNotBeCalled();
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/Modifier/OrderItemQuantityModifierSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Modifier/OrderItemQuantityModifierSpec.php
@@ -15,16 +15,16 @@ use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\CoreBundle\Modifier\OrderItemQuantityModifierInterface;
+use Sylius\Bundle\OrderBundle\Factory\OrderItemUnitFactoryInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
-use Sylius\Component\Resource\Factory\FactoryInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
 class OrderItemQuantityModifierSpec extends ObjectBehavior
 {
-    function let(FactoryInterface $orderItemUnitFactory)
+    function let(OrderItemUnitFactoryInterface $orderItemUnitFactory)
     {
         $this->beConstructedWith($orderItemUnitFactory);
     }
@@ -47,7 +47,7 @@ class OrderItemQuantityModifierSpec extends ObjectBehavior
     ) {
         $orderItem->getQuantity()->willReturn(1);
 
-        $orderItemUnitFactory->createNew()->willReturn($unit1, $unit2);
+        $orderItemUnitFactory->createForItem($orderItem)->willReturn($unit1, $unit2);
 
         $orderItem->addUnit($unit1)->shouldBeCalled();
         $orderItem->addUnit($unit2)->shouldBeCalled();
@@ -84,7 +84,7 @@ class OrderItemQuantityModifierSpec extends ObjectBehavior
     {
         $orderItem->getQuantity()->willReturn(3);
 
-        $orderItemUnitFactory->createNew()->shouldNotBeCalled();
+        $orderItemUnitFactory->createForItem(Argument::any())->shouldNotBeCalled();
         $orderItem->addUnit(Argument::any())->shouldNotBeCalled();
         $orderItem->removeUnit(Argument::any())->shouldNotBeCalled();
     }

--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadOrdersData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadOrdersData.php
@@ -31,7 +31,7 @@ class LoadOrdersData extends DataFixture
     {
         $orderFactory = $this->getOrderFactory();
         $orderItemFactory = $this->getOrderItemFactory();
-        $orderItemQuantityModifier = $this->get('sylius.modifier.order_item_quantity');
+        $orderItemQuantityModifier = $this->get('sylius.order_item_quantity_modifier');
 
         $channels = array(
             'WEB-UK',

--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadOrdersData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadOrdersData.php
@@ -31,6 +31,7 @@ class LoadOrdersData extends DataFixture
     {
         $orderFactory = $this->getOrderFactory();
         $orderItemFactory = $this->getOrderItemFactory();
+        $orderItemQuantityModifier = $this->get('sylius.modifier.order_item_quantity');
 
         $channels = array(
             'WEB-UK',
@@ -53,7 +54,8 @@ class LoadOrdersData extends DataFixture
                 $item = $orderItemFactory->createNew();
                 $item->setVariant($variant);
                 $item->setUnitPrice($variant->getPrice());
-                $item->setQuantity(rand(1, 5));
+
+                $orderItemQuantityModifier->modify($item, rand(1, 5));
 
                 $order->addItem($item);
             }

--- a/src/Sylius/Bundle/OrderBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/OrderBundle/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\OrderBundle\DependencyInjection;
 
+use Sylius\Bundle\OrderBundle\Factory\OrderItemUnitFactory;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Sylius\Component\Order\Model\OrderItemUnit;
 use Sylius\Component\Order\Model\OrderItemUnitInterface;
@@ -155,7 +156,7 @@ class Configuration implements ConfigurationInterface
                                         ->scalarNode('model')->defaultValue(OrderItemUnit::class)->cannotBeEmpty()->end()
                                         ->scalarNode('interface')->defaultValue(OrderItemUnitInterface::class)->cannotBeEmpty()->end()
                                         ->scalarNode('repository')->cannotBeEmpty()->end()
-                                        ->scalarNode('factory')->defaultValue(Factory::class)->end()
+                                        ->scalarNode('factory')->defaultValue(OrderItemUnitFactory::class)->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/src/Sylius/Bundle/OrderBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/OrderBundle/DependencyInjection/Configuration.php
@@ -157,6 +157,7 @@ class Configuration implements ConfigurationInterface
                                         ->scalarNode('interface')->defaultValue(OrderItemUnitInterface::class)->cannotBeEmpty()->end()
                                         ->scalarNode('repository')->cannotBeEmpty()->end()
                                         ->scalarNode('factory')->defaultValue(OrderItemUnitFactory::class)->end()
+                                        ->scalarNode('repository')->cannotBeEmpty()->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
+++ b/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
@@ -40,7 +40,7 @@ class SyliusOrderExtension extends AbstractResourceExtension
             $loader->load($configFile);
         }
 
-        $orderItemQuantityDataMapper = $container->getDefinition('sylius.data_mapper.order_item_quantity');
+        $orderItemQuantityDataMapper = $container->getDefinition('sylius.form.data_mapper.order_item_quantity');
         $orderItemType = $container->getDefinition('sylius.form.type.order_item');
 
         $orderItemType->addArgument($orderItemQuantityDataMapper);

--- a/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
+++ b/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
@@ -17,8 +17,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 /**
- * Sylius orders system extension.
- *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
 class SyliusOrderExtension extends AbstractResourceExtension
@@ -41,5 +39,10 @@ class SyliusOrderExtension extends AbstractResourceExtension
         foreach ($configFiles as $configFile) {
             $loader->load($configFile);
         }
+
+        $orderItemQuantityDataMapper = $container->getDefinition('sylius.data_mapper.order_item_quantity');
+        $orderItemType = $container->getDefinition('sylius.form.type.order_item');
+
+        $orderItemType->addArgument($orderItemQuantityDataMapper);
     }
 }

--- a/src/Sylius/Bundle/OrderBundle/Factory/OrderItemUnitFactory.php
+++ b/src/Sylius/Bundle/OrderBundle/Factory/OrderItemUnitFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\OrderBundle\Factory;
+
+use Sylius\Component\Order\Model\OrderItemInterface;
+use Sylius\Component\Order\Model\OrderItemUnit;
+use Sylius\Component\Resource\Exception\UnsupportedMethodException;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class OrderItemUnitFactory implements OrderItemUnitFactoryInterface
+{
+    /**
+     * @var string
+     */
+    private $className;
+
+    /**
+     * @param string $className
+     */
+    public function __construct($className)
+    {
+        $this->className = $className;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createNew()
+    {
+        throw new UnsupportedMethodException('createNew');
+    }
+
+    /**
+     * @param OrderItemInterface $orderItem
+     *
+     * @return OrderItemUnit
+     */
+    public function createForItem(OrderItemInterface $orderItem)
+    {
+        return new $this->className($orderItem);
+    }
+}

--- a/src/Sylius/Bundle/OrderBundle/Factory/OrderItemUnitFactoryInterface.php
+++ b/src/Sylius/Bundle/OrderBundle/Factory/OrderItemUnitFactoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Sylius\Bundle\OrderBundle\Factory;
+
+use Sylius\Component\Order\Model\OrderItemInterface;
+use Sylius\Component\Order\Model\OrderItemUnit;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+interface OrderItemUnitFactoryInterface extends FactoryInterface
+{
+    /**
+     * @param OrderItemInterface $orderItem
+     *
+     * @return OrderItemUnit
+     */
+    public function createForItem(OrderItemInterface $orderItem);
+}

--- a/src/Sylius/Bundle/OrderBundle/Form/DataMapper/OrderItemQuantityDataMapper.php
+++ b/src/Sylius/Bundle/OrderBundle/Form/DataMapper/OrderItemQuantityDataMapper.php
@@ -57,7 +57,6 @@ class OrderItemQuantityDataMapper implements DataMapperInterface
         foreach ($forms as $key => $form) {
             if ('quantity' === $form->getName()) {
                 $targetQuantity = $form->getData();
-
                 $this->orderItemQuantityModifier->modify($data, $targetQuantity);
 
                 continue;

--- a/src/Sylius/Bundle/OrderBundle/Form/DataMapper/OrderItemQuantityDataMapper.php
+++ b/src/Sylius/Bundle/OrderBundle/Form/DataMapper/OrderItemQuantityDataMapper.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\OrderBundle\Form\DataMapper;
+
+use Sylius\Bundle\OrderBundle\Modifier\OrderItemQuantityModifierInterface;
+use Symfony\Component\Form\DataMapperInterface;
+use Symfony\Component\Form\Exception;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class OrderItemQuantityDataMapper implements DataMapperInterface
+{
+    /**
+     * @var OrderItemQuantityModifierInterface
+     */
+    private $orderItemQuantityModifier;
+
+    /**
+     * @var DataMapperInterface
+     */
+    private $propertyPathDataMapper;
+
+    /**
+     * @param OrderItemQuantityModifierInterface $orderItemQuantityModifier
+     * @param DataMapperInterface $propertyPathDataMapper
+     */
+    public function __construct(OrderItemQuantityModifierInterface $orderItemQuantityModifier, DataMapperInterface $propertyPathDataMapper)
+    {
+        $this->orderItemQuantityModifier = $orderItemQuantityModifier;
+        $this->propertyPathDataMapper = $propertyPathDataMapper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mapDataToForms($data, $forms)
+    {
+        $this->propertyPathDataMapper->mapDataToForms($data, $forms);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mapFormsToData($forms, &$data)
+    {
+        $nonQuantityForms = array();
+        foreach ($forms as $key => $form) {
+            if ('quantity' === $form->getName()) {
+                $targetQuantity = $form->getData();
+
+                $this->orderItemQuantityModifier->modify($data, $targetQuantity);
+
+                continue;
+            }
+
+            $nonQuantityForms[] = $form;
+        }
+
+        if (!empty($nonQuantityForms)) {
+            $this->propertyPathDataMapper->mapFormsToData($nonQuantityForms, $data);
+        }
+    }
+}

--- a/src/Sylius/Bundle/OrderBundle/Form/DataMapper/OrderItemQuantityDataMapper.php
+++ b/src/Sylius/Bundle/OrderBundle/Form/DataMapper/OrderItemQuantityDataMapper.php
@@ -53,7 +53,7 @@ class OrderItemQuantityDataMapper implements DataMapperInterface
      */
     public function mapFormsToData($forms, &$data)
     {
-        $nonQuantityForms = array();
+        $formsOtherThanQuantity = array();
         foreach ($forms as $key => $form) {
             if ('quantity' === $form->getName()) {
                 $targetQuantity = $form->getData();
@@ -62,11 +62,11 @@ class OrderItemQuantityDataMapper implements DataMapperInterface
                 continue;
             }
 
-            $nonQuantityForms[] = $form;
+            $formsOtherThanQuantity[] = $form;
         }
 
-        if (!empty($nonQuantityForms)) {
-            $this->propertyPathDataMapper->mapFormsToData($nonQuantityForms, $data);
+        if (!empty($formsOtherThanQuantity)) {
+            $this->propertyPathDataMapper->mapFormsToData($formsOtherThanQuantity, $data);
         }
     }
 }

--- a/src/Sylius/Bundle/OrderBundle/Form/Type/OrderItemType.php
+++ b/src/Sylius/Bundle/OrderBundle/Form/Type/OrderItemType.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\OrderBundle\Form\Type;
 
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
+use Symfony\Component\Form\DataMapperInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -19,6 +20,23 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class OrderItemType extends AbstractResourceType
 {
+    /**
+     * @var DataMapperInterface
+     */
+    protected $orderItemQuantityDataMapper;
+
+    /**
+     * @param string $dataClass
+     * @param array $validationGroups
+     * @param DataMapperInterface $orderItemQuantityDataMapper
+     */
+    public function __construct($dataClass, array $validationGroups = array(), DataMapperInterface $orderItemQuantityDataMapper)
+    {
+        parent::__construct($dataClass, $validationGroups);
+
+        $this->orderItemQuantityDataMapper = $orderItemQuantityDataMapper;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -32,6 +50,7 @@ class OrderItemType extends AbstractResourceType
             ->add('unitPrice', 'sylius_money', array(
                 'label'   => 'sylius.form.order_item.unit_price'
             ))
+            ->setDataMapper($this->orderItemQuantityDataMapper)
         ;
     }
 

--- a/src/Sylius/Bundle/OrderBundle/Form/Type/OrderItemType.php
+++ b/src/Sylius/Bundle/OrderBundle/Form/Type/OrderItemType.php
@@ -45,7 +45,6 @@ class OrderItemType extends AbstractResourceType
         $builder
             ->add('quantity', 'integer', array(
                 'label' => 'sylius.form.order_item.quantity',
-                'data' => 1,
             ))
             ->add('unitPrice', 'sylius_money', array(
                 'label'   => 'sylius.form.order_item.unit_price'

--- a/src/Sylius/Bundle/OrderBundle/Form/Type/OrderItemType.php
+++ b/src/Sylius/Bundle/OrderBundle/Form/Type/OrderItemType.php
@@ -15,8 +15,6 @@ use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
- * Order item type.
- *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
 class OrderItemType extends AbstractResourceType
@@ -28,7 +26,8 @@ class OrderItemType extends AbstractResourceType
     {
         $builder
             ->add('quantity', 'integer', array(
-                'label' => 'sylius.form.order_item.quantity'
+                'label' => 'sylius.form.order_item.quantity',
+                'data' => 1,
             ))
             ->add('unitPrice', 'sylius_money', array(
                 'label'   => 'sylius.form.order_item.unit_price'

--- a/src/Sylius/Bundle/OrderBundle/Modifier/OrderItemQuantityModifier.php
+++ b/src/Sylius/Bundle/OrderBundle/Modifier/OrderItemQuantityModifier.php
@@ -37,15 +37,15 @@ class OrderItemQuantityModifier implements OrderItemQuantityModifierInterface
      */
     public function modify(OrderItemInterface $orderItem, $targetQuantity)
     {
-        $itemQuantity = $orderItem->getQuantity();
-        if (0 >= $targetQuantity || $itemQuantity === $targetQuantity) {
+        $currentQuantity = $orderItem->getQuantity();
+        if (0 >= $targetQuantity || $currentQuantity === $targetQuantity) {
             return;
         }
 
-        if ($targetQuantity < $itemQuantity) {
-            $this->decreaseUnitsNumber($orderItem, $itemQuantity - $targetQuantity);
-        } else if ($targetQuantity > $itemQuantity) {
-            $this->increaseUnitsNumber($orderItem, $targetQuantity - $itemQuantity);
+        if ($targetQuantity < $currentQuantity) {
+            $this->decreaseUnitsNumber($orderItem, $currentQuantity - $targetQuantity);
+        } else if ($targetQuantity > $currentQuantity) {
+            $this->increaseUnitsNumber($orderItem, $targetQuantity - $currentQuantity);
         }
     }
 

--- a/src/Sylius/Bundle/OrderBundle/Modifier/OrderItemQuantityModifier.php
+++ b/src/Sylius/Bundle/OrderBundle/Modifier/OrderItemQuantityModifier.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Modifier;
+namespace Sylius\Bundle\OrderBundle\Modifier;
 
 use Sylius\Bundle\OrderBundle\Factory\OrderItemUnitFactoryInterface;
-use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Order\Model\OrderItemInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>

--- a/src/Sylius/Bundle/OrderBundle/Modifier/OrderItemQuantityModifier.php
+++ b/src/Sylius/Bundle/OrderBundle/Modifier/OrderItemQuantityModifier.php
@@ -38,13 +38,15 @@ class OrderItemQuantityModifier implements OrderItemQuantityModifierInterface
     public function modify(OrderItemInterface $orderItem, $targetQuantity)
     {
         $itemQuantity = $orderItem->getQuantity();
-
-        if ($targetQuantity > $itemQuantity) {
-            $this->increaseUnitsNumber($orderItem, $targetQuantity - $itemQuantity);
-        } else if ($targetQuantity < $itemQuantity) {
-            $this->decreaseUnitsNumber($orderItem, $itemQuantity - $targetQuantity);
+        if (0 >= $targetQuantity || $itemQuantity === $targetQuantity) {
+            return;
         }
 
+        if ($targetQuantity < $itemQuantity) {
+            $this->decreaseUnitsNumber($orderItem, $itemQuantity - $targetQuantity);
+        } else if ($targetQuantity > $itemQuantity) {
+            $this->increaseUnitsNumber($orderItem, $targetQuantity - $itemQuantity);
+        }
     }
 
     /**
@@ -54,8 +56,7 @@ class OrderItemQuantityModifier implements OrderItemQuantityModifierInterface
     private function increaseUnitsNumber(OrderItemInterface $orderItem, $increaseBy)
     {
         for ($i = 0; $i < $increaseBy; $i++) {
-            $unit = $this->orderItemUnitFactory->createForItem($orderItem);
-            $orderItem->addUnit($unit);
+            $this->orderItemUnitFactory->createForItem($orderItem);
         }
     }
 

--- a/src/Sylius/Bundle/OrderBundle/Modifier/OrderItemQuantityModifierInterface.php
+++ b/src/Sylius/Bundle/OrderBundle/Modifier/OrderItemQuantityModifierInterface.php
@@ -20,7 +20,7 @@ interface OrderItemQuantityModifierInterface
 {
     /**
      * @param OrderItemInterface $orderItem
-     * @param int $quantity
+     * @param int $targetQuantity
      */
-    public function modify(OrderItemInterface $orderItem, $quantity);
+    public function modify(OrderItemInterface $orderItem, $targetQuantity);
 }

--- a/src/Sylius/Bundle/OrderBundle/Modifier/OrderItemQuantityModifierInterface.php
+++ b/src/Sylius/Bundle/OrderBundle/Modifier/OrderItemQuantityModifierInterface.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Modifier;
+namespace Sylius\Bundle\OrderBundle\Modifier;
 
-use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Order\Model\OrderItemInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItem.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItem.orm.xml
@@ -28,6 +28,7 @@
         <field name="unitPrice" column="unit_price" type="integer">
             <gedmo:versioned />
         </field>
+        <field name="unitsTotal" column="units_total" type="integer" />
         <field name="adjustmentsTotal" column="adjustments_total" type="integer" />
         <field name="total" column="total" type="integer" />
         <field name="immutable" column="is_immutable" type="boolean" />

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItemUnit.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/OrderItemUnit.orm.xml
@@ -21,7 +21,6 @@
             <generator strategy="AUTO" />
         </id>
 
-        <field name="total" column="total" type="integer" />
         <field name="adjustmentsTotal" column="adjustments_total" type="integer" />
 
         <many-to-one field="orderItem" target-entity="Sylius\Component\Order\Model\OrderItemInterface" inversed-by="units">

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
@@ -23,6 +23,10 @@
         <parameter key="sylius.callback.complete_order.class">Sylius\Bundle\OrderBundle\StateMachineCallback\CompleteOrderCallback</parameter>
 
         <parameter key="sylius.originator.class">Sylius\Component\Originator\Originator\Originator</parameter>
+
+        <parameter key="sylius.modifier.order_item_quantity.class">Sylius\Bundle\OrderBundle\Modifier\OrderItemQuantityModifier</parameter>
+        <parameter key="sylius.data_mapper.property_path.class">Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper</parameter>
+        <parameter key="sylius.data_mapper.order_item_quantity.class">Sylius\Bundle\OrderBundle\Form\DataMapper\OrderItemQuantityDataMapper</parameter>
     </parameters>
 
     <services>
@@ -38,6 +42,17 @@
 
         <service id="sylius.listener.order_update" class="%sylius.listener.order_update.class%">
             <tag name="kernel.event_listener" event="sylius.order.pre_update" method="recalculateOrderTotal" />
+        </service>
+
+        <service id="sylius.modifier.order_item_quantity" class="%sylius.modifier.order_item_quantity.class%">
+            <argument type="service" id="sylius.factory.order_item_unit" />
+        </service>
+        <service id="sylius.data_mapper.property_path" class="%sylius.data_mapper.property_path.class%">
+            <argument type="service" id="property_accessor" />
+        </service>
+        <service id="sylius.data_mapper.order_item_quantity" class="%sylius.data_mapper.order_item_quantity.class%">
+            <argument type="service" id="sylius.modifier.order_item_quantity" />
+            <argument type="service" id="sylius.data_mapper.property_path" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
@@ -24,9 +24,9 @@
 
         <parameter key="sylius.originator.class">Sylius\Component\Originator\Originator\Originator</parameter>
 
-        <parameter key="sylius.modifier.order_item_quantity.class">Sylius\Bundle\OrderBundle\Modifier\OrderItemQuantityModifier</parameter>
-        <parameter key="sylius.data_mapper.property_path.class">Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper</parameter>
-        <parameter key="sylius.data_mapper.order_item_quantity.class">Sylius\Bundle\OrderBundle\Form\DataMapper\OrderItemQuantityDataMapper</parameter>
+        <parameter key="sylius.order_item_quantity_modifier.class">Sylius\Bundle\OrderBundle\Modifier\OrderItemQuantityModifier</parameter>
+        <parameter key="sylius.form.data_mapper.property_path.class">Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper</parameter>
+        <parameter key="sylius.form.data_mapper.order_item_quantity.class">Sylius\Bundle\OrderBundle\Form\DataMapper\OrderItemQuantityDataMapper</parameter>
     </parameters>
 
     <services>
@@ -44,15 +44,15 @@
             <tag name="kernel.event_listener" event="sylius.order.pre_update" method="recalculateOrderTotal" />
         </service>
 
-        <service id="sylius.modifier.order_item_quantity" class="%sylius.modifier.order_item_quantity.class%">
+        <service id="sylius.order_item_quantity_modifier" class="%sylius.order_item_quantity_modifier.class%">
             <argument type="service" id="sylius.factory.order_item_unit" />
         </service>
-        <service id="sylius.data_mapper.property_path" class="%sylius.data_mapper.property_path.class%">
+        <service id="sylius.form.data_mapper.property_path" class="%sylius.form.data_mapper.property_path.class%">
             <argument type="service" id="property_accessor" />
         </service>
-        <service id="sylius.data_mapper.order_item_quantity" class="%sylius.data_mapper.order_item_quantity.class%">
-            <argument type="service" id="sylius.modifier.order_item_quantity" />
-            <argument type="service" id="sylius.data_mapper.property_path" />
+        <service id="sylius.form.data_mapper.order_item_quantity" class="%sylius.form.data_mapper.order_item_quantity.class%">
+            <argument type="service" id="sylius.order_item_quantity_modifier" />
+            <argument type="service" id="sylius.form.data_mapper.property_path" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/OrderBundle/spec/Factory/OrderItemUnitFactorySpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Factory/OrderItemUnitFactorySpec.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\OrderBundle\Factory;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\OrderBundle\Factory\OrderItemUnitFactoryInterface;
+use Sylius\Component\Order\Model\OrderItemInterface;
+use Sylius\Component\Order\Model\OrderItemUnit;
+use Sylius\Component\Order\Model\OrderItemUnitInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class OrderItemUnitFactorySpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(OrderItemUnit::class);
+    }
+    
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\OrderBundle\Factory\OrderItemUnitFactory');
+    }
+
+    function it_implements_factory_interface()
+    {
+        $this->shouldImplement(OrderItemUnitFactoryInterface::class);
+    }
+
+    function it_throws_exception_while_trying_create_order_item_unit_without_order_item()
+    {
+        $this->shouldThrow('Sylius\Component\Resource\Exception\UnsupportedMethodException')->during('createNew');
+    }
+
+    function it_creates_new_order_item_unit_with_given_order_item(OrderItemInterface $orderItem, OrderItemUnitInterface $orderItemUnit)
+    {
+        $orderItemUnit->getOrderItem()->willReturn($orderItem);
+
+        $this->createForItem($orderItem)->shouldBeSameAs($orderItemUnit);
+    }
+
+    public function getMatchers()
+    {
+        return [
+            'beSameAs' => function ($subject, $key) {
+                if (!$subject instanceof OrderItemUnitInterface || !$key instanceof OrderItemUnitInterface) {
+                    return false;
+                }
+
+                return $subject->getOrderItem() === $key->getOrderItem();
+            },
+        ];
+    }
+}

--- a/src/Sylius/Bundle/OrderBundle/spec/Factory/OrderItemUnitFactorySpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Factory/OrderItemUnitFactorySpec.php
@@ -16,6 +16,7 @@ use Sylius\Bundle\OrderBundle\Factory\OrderItemUnitFactoryInterface;
 use Sylius\Component\Order\Model\OrderItemInterface;
 use Sylius\Component\Order\Model\OrderItemUnit;
 use Sylius\Component\Order\Model\OrderItemUnitInterface;
+use Sylius\Component\Resource\Exception\UnsupportedMethodException;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -39,7 +40,7 @@ class OrderItemUnitFactorySpec extends ObjectBehavior
 
     function it_throws_exception_while_trying_create_order_item_unit_without_order_item()
     {
-        $this->shouldThrow('Sylius\Component\Resource\Exception\UnsupportedMethodException')->during('createNew');
+        $this->shouldThrow(UnsupportedMethodException::class)->during('createNew');
     }
 
     function it_creates_new_order_item_unit_with_given_order_item(OrderItemInterface $orderItem, OrderItemUnitInterface $orderItemUnit)

--- a/src/Sylius/Bundle/OrderBundle/spec/Form/DataMapper/OrderItemQuantityDataMapperSpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Form/DataMapper/OrderItemQuantityDataMapperSpec.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\OrderBundle\Form\DataMapper;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\OrderBundle\Modifier\OrderItemQuantityModifierInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Symfony\Component\Form\DataMapperInterface;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class OrderItemQuantityDataMapperSpec extends ObjectBehavior
+{
+    function let(OrderItemQuantityModifierInterface $orderItemQuantityModifier, DataMapperInterface $propertyPathDataMapper)
+    {
+        $this->beConstructedWith($orderItemQuantityModifier, $propertyPathDataMapper);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\OrderBundle\Form\DataMapper\OrderItemQuantityDataMapper');
+    }
+
+    function it_implements_data_mapper_interface()
+    {
+        $this->shouldImplement(DataMapperInterface::class);
+    }
+
+    function it_uses_property_path_data_mapper_while_mapping_data_to_forms($propertyPathDataMapper, FormInterface $form, OrderItemInterface $orderItem)
+    {
+        $propertyPathDataMapper->mapDataToForms($orderItem, array($form))->shouldBeCalled();
+
+        $this->mapDataToForms($orderItem, array($form));
+    }
+}

--- a/src/Sylius/Bundle/OrderBundle/spec/Form/Type/OrderItemTypeSpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Form/Type/OrderItemTypeSpec.php
@@ -43,16 +43,19 @@ class OrderItemTypeSpec extends ObjectBehavior
         $builder
             ->add('quantity', 'integer', Argument::any())
             ->willReturn($builder)
+            ->shouldBeCalled()
         ;
 
         $builder
             ->add('unitPrice', 'sylius_money', Argument::any())
             ->willReturn($builder)
+            ->shouldBeCalled()
         ;
 
         $builder
             ->setDataMapper($orderItemQuantityDataMapper)
             ->willReturn($builder)
+            ->shouldBeCalled()
         ;
 
         $this->buildForm($builder, array());

--- a/src/Sylius/Bundle/OrderBundle/spec/Form/Type/OrderItemTypeSpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Form/Type/OrderItemTypeSpec.php
@@ -14,6 +14,7 @@ namespace spec\Sylius\Bundle\OrderBundle\Form\Type;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataMapperInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -22,9 +23,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class OrderItemTypeSpec extends ObjectBehavior
 {
-    function let()
+    function let(DataMapperInterface $orderItemQuantityDataMapper)
     {
-        $this->beConstructedWith('OrderItem', array('sylius'));
+        $this->beConstructedWith('OrderItem', array('sylius'), $orderItemQuantityDataMapper);
     }
 
     function it_is_initializable()
@@ -37,7 +38,7 @@ class OrderItemTypeSpec extends ObjectBehavior
         $this->shouldHaveType(AbstractType::class);
     }
 
-    function it_builds_form_with_quantity_and_unit_price_fields(FormBuilderInterface $builder)
+    function it_builds_form_with_quantity_and_unit_price_fields($orderItemQuantityDataMapper, FormBuilderInterface $builder)
     {
         $builder
             ->add('quantity', 'integer', Argument::any())
@@ -46,6 +47,11 @@ class OrderItemTypeSpec extends ObjectBehavior
 
         $builder
             ->add('unitPrice', 'sylius_money', Argument::any())
+            ->willReturn($builder)
+        ;
+
+        $builder
+            ->setDataMapper($orderItemQuantityDataMapper)
             ->willReturn($builder)
         ;
 

--- a/src/Sylius/Bundle/OrderBundle/spec/Modifier/OrderItemQuantityModifierSpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Modifier/OrderItemQuantityModifierSpec.php
@@ -41,16 +41,11 @@ class OrderItemQuantityModifierSpec extends ObjectBehavior
 
     function it_adds_proper_number_of_order_item_units_to_order_item(
         $orderItemUnitFactory,
-        OrderItemInterface $orderItem,
-        OrderItemUnitInterface $unit1,
-        OrderItemUnitInterface $unit2
+        OrderItemInterface $orderItem
     ) {
         $orderItem->getQuantity()->willReturn(1);
 
-        $orderItemUnitFactory->createForItem($orderItem)->willReturn($unit1, $unit2);
-
-        $orderItem->addUnit($unit1)->shouldBeCalled();
-        $orderItem->addUnit($unit2)->shouldBeCalled();
+        $orderItemUnitFactory->createForItem($orderItem)->shouldBeCalledTimes(2);
 
         $this->modify($orderItem, 3);
     }
@@ -64,7 +59,7 @@ class OrderItemQuantityModifierSpec extends ObjectBehavior
         OrderItemUnitInterface $unit3,
         OrderItemUnitInterface $unit4
     ) {
-        $orderItem->getQuantity()->willReturn(5);
+        $orderItem->getQuantity()->willReturn(4);
         $orderItem->getUnits()->willReturn($orderItemUnits);
 
         $orderItemUnits->count()->willReturn(4);
@@ -75,7 +70,6 @@ class OrderItemQuantityModifierSpec extends ObjectBehavior
         $iterator->next()->shouldBeCalled();
 
         $orderItem->removeUnit($unit1)->shouldBeCalled();
-        $orderItem->removeUnit($unit2)->shouldBeCalled();
 
         $this->modify($orderItem, 3);
     }
@@ -87,5 +81,29 @@ class OrderItemQuantityModifierSpec extends ObjectBehavior
         $orderItemUnitFactory->createForItem(Argument::any())->shouldNotBeCalled();
         $orderItem->addUnit(Argument::any())->shouldNotBeCalled();
         $orderItem->removeUnit(Argument::any())->shouldNotBeCalled();
+
+        $this->modify($orderItem, 3);
+    }
+
+    function it_does_nothing_if_target_quantity_is_0($orderItemUnitFactory, OrderItemInterface $orderItem)
+    {
+        $orderItem->getQuantity()->willReturn(3);
+
+        $orderItemUnitFactory->createForItem(Argument::any())->shouldNotBeCalled();
+        $orderItem->addUnit(Argument::any())->shouldNotBeCalled();
+        $orderItem->removeUnit(Argument::any())->shouldNotBeCalled();
+
+        $this->modify($orderItem, 0);
+    }
+
+    function it_does_nothing_if_target_quantity_is_below_0($orderItemUnitFactory, OrderItemInterface $orderItem)
+    {
+        $orderItem->getQuantity()->willReturn(3);
+
+        $orderItemUnitFactory->createForItem(Argument::any())->shouldNotBeCalled();
+        $orderItem->addUnit(Argument::any())->shouldNotBeCalled();
+        $orderItem->removeUnit(Argument::any())->shouldNotBeCalled();
+
+        $this->modify($orderItem, -10);
     }
 }

--- a/src/Sylius/Bundle/OrderBundle/spec/Modifier/OrderItemQuantityModifierSpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Modifier/OrderItemQuantityModifierSpec.php
@@ -9,13 +9,13 @@
  * file that was distributed with this source code.
  */
 
-namespace spec\Sylius\Bundle\CoreBundle\Modifier;
+namespace spec\Sylius\Bundle\OrderBundle\Modifier;
 
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Sylius\Bundle\CoreBundle\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Bundle\OrderBundle\Factory\OrderItemUnitFactoryInterface;
+use Sylius\Bundle\OrderBundle\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
 
@@ -31,7 +31,7 @@ class OrderItemQuantityModifierSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Bundle\CoreBundle\Modifier\OrderItemQuantityModifier');
+        $this->shouldHaveType('Sylius\Bundle\OrderBundle\Modifier\OrderItemQuantityModifier');
     }
 
     function it_implements_order_item_quantity_modifier_interface()

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -366,14 +366,12 @@ class Order extends Cart implements OrderInterface
     public function addPromotionCoupon(BaseCouponInterface $coupon = null)
     {
         if (null === $coupon) {
-            return $this;
+            return;
         }
 
         if (!$this->hasPromotionCoupon($coupon)) {
             $this->promotionCoupons->add($coupon);
         }
-
-        return $this;
     }
 
     /**
@@ -382,14 +380,12 @@ class Order extends Cart implements OrderInterface
     public function removePromotionCoupon(BaseCouponInterface $coupon = null)
     {
         if (null === $coupon) {
-            return $this;
+            return;
         }
 
         if ($this->hasPromotionCoupon($coupon)) {
             $this->promotionCoupons->removeElement($coupon);
         }
-
-        return $this;
     }
 
     /**

--- a/src/Sylius/Component/Core/Model/OrderItemUnit.php
+++ b/src/Sylius/Component/Core/Model/OrderItemUnit.php
@@ -47,9 +47,9 @@ class OrderItemUnit extends BaseOrderItemUnit implements OrderItemUnitInterface
      */
     protected $updatedAt;
 
-    public function __construct()
+    public function __construct(OrderItemInterface $orderItem)
     {
-        parent::__construct();
+        parent::__construct($orderItem);
 
         $this->createdAt = new \DateTime();
     }

--- a/src/Sylius/Component/Core/OrderProcessing/InventoryHandler.php
+++ b/src/Sylius/Component/Core/OrderProcessing/InventoryHandler.php
@@ -72,12 +72,6 @@ class InventoryHandler implements InventoryHandlerInterface
                 $item->removeUnit($unit);
             }
         }
-
-        foreach ($item->getUnits() as $unit) {
-            if ($unit->getStockable() !== $item->getVariant()) {
-                $unit->setStockable($item->getVariant());
-            }
-        }
     }
 
     /**
@@ -142,8 +136,6 @@ class InventoryHandler implements InventoryHandlerInterface
         for ($i = 0; $i < $quantity; $i++) {
             $unit = $this->orderItemUnitFactory->createForItem($item);
             $unit->setInventoryState($state);
-
-            $item->addUnit($unit);
         }
     }
 

--- a/src/Sylius/Component/Core/OrderProcessing/InventoryHandler.php
+++ b/src/Sylius/Component/Core/OrderProcessing/InventoryHandler.php
@@ -13,6 +13,7 @@ namespace Sylius\Component\Core\OrderProcessing;
 
 use Doctrine\Common\Collections\Collection;
 use SM\Factory\FactoryInterface as StateMachineFactoryInteraface;
+use Sylius\Bundle\OrderBundle\Factory\OrderItemUnitFactoryInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
@@ -33,7 +34,7 @@ class InventoryHandler implements InventoryHandlerInterface
     protected $inventoryOperator;
 
     /**
-     * @var FactoryInterface
+     * @var OrderItemUnitFactoryInterface
      */
     protected $orderItemUnitFactory;
 
@@ -44,12 +45,12 @@ class InventoryHandler implements InventoryHandlerInterface
 
     /**
      * @param InventoryOperatorInterface $inventoryOperator
-     * @param FactoryInterface $orderItemUnitFactory
+     * @param OrderItemUnitFactoryInterface $orderItemUnitFactory
      * @param StateMachineFactoryInteraface $stateMachineFactory
      */
     public function __construct(
         InventoryOperatorInterface $inventoryOperator,
-        FactoryInterface $orderItemUnitFactory,
+        OrderItemUnitFactoryInterface $orderItemUnitFactory,
         StateMachineFactoryInteraface $stateMachineFactory
     ) {
         $this->inventoryOperator    = $inventoryOperator;
@@ -139,7 +140,7 @@ class InventoryHandler implements InventoryHandlerInterface
         }
 
         for ($i = 0; $i < $quantity; $i++) {
-            $unit = $this->orderItemUnitFactory->createNew();
+            $unit = $this->orderItemUnitFactory->createForItem($item);
             $unit->setInventoryState($state);
 
             $item->addUnit($unit);

--- a/src/Sylius/Component/Core/Promotion/Action/AddProductAction.php
+++ b/src/Sylius/Component/Core/Promotion/Action/AddProductAction.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Component\Core\Promotion\Action;
 
-use Sylius\Bundle\CoreBundle\Modifier\OrderItemQuantityModifierInterface;
+use Sylius\Bundle\OrderBundle\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Order\Model\OrderItemInterface;
 use Sylius\Component\Promotion\Action\PromotionActionInterface;

--- a/src/Sylius/Component/Core/Promotion/Action/AddProductAction.php
+++ b/src/Sylius/Component/Core/Promotion/Action/AddProductAction.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Core\Promotion\Action;
 
+use Sylius\Bundle\CoreBundle\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Order\Model\OrderItemInterface;
 use Sylius\Component\Promotion\Action\PromotionActionInterface;
@@ -33,20 +34,25 @@ class AddProductAction implements PromotionActionInterface
     protected $itemFactory;
 
     /**
-     * Variant repository.
-     *
      * @var RepositoryInterface
      */
     protected $variantRepository;
 
     /**
+     * @var OrderItemQuantityModifierInterface
+     */
+    protected $orderItemQuantityModifier;
+
+    /**
      * @param FactoryInterface $itemFactory
      * @param RepositoryInterface $variantRepository
+     * @param OrderItemQuantityModifierInterface $orderItemQuantityModifier
      */
-    public function __construct(FactoryInterface $itemFactory, RepositoryInterface $variantRepository)
+    public function __construct(FactoryInterface $itemFactory, RepositoryInterface $variantRepository, OrderItemQuantityModifierInterface $orderItemQuantityModifier)
     {
         $this->itemFactory = $itemFactory;
         $this->variantRepository = $variantRepository;
+        $this->orderItemQuantityModifier = $orderItemQuantityModifier;
     }
 
     /**
@@ -107,8 +113,6 @@ class AddProductAction implements PromotionActionInterface
     }
 
     /**
-     * Create promotion item
-     *
      * @param array $configuration
      *
      * @return OrderItemInterface
@@ -119,8 +123,9 @@ class AddProductAction implements PromotionActionInterface
 
         $promotionItem = $this->itemFactory->createNew();
         $promotionItem->setVariant($variant);
-        $promotionItem->setQuantity((int) $configuration['quantity']);
         $promotionItem->setUnitPrice((int) $configuration['price']);
+
+        $this->orderItemQuantityModifier->modify($promotionItem, (int) $configuration['quantity']);
 
         return $promotionItem;
     }

--- a/src/Sylius/Component/Core/spec/Model/OrderItemUnitSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderItemUnitSpec.php
@@ -12,20 +12,27 @@
 namespace spec\Sylius\Component\Core\Model;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Inventory\Model\InventoryUnitInterface;
-use Sylius\Component\Inventory\Model\StockableInterface;
 use Sylius\Component\Order\Model\OrderItemUnit;
 use Sylius\Component\Shipping\Model\ShipmentInterface;
-use Sylius\Component\Shipping\Model\ShippableInterface;
+use Sylius\Component\Shipping\Model\ShipmentItemInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
 class OrderItemUnitSpec extends ObjectBehavior
 {
+    function let(OrderItemInterface $orderItem)
+    {
+        $orderItem->getUnitPrice()->willReturn(1000);
+        $orderItem->addUnit(Argument::type(OrderItemUnitInterface::class))->shouldBeCalled();
+        $this->beConstructedWith($orderItem);
+    }
+
     function it_is_initializable()
     {
         $this->shouldHaveType('Sylius\Component\Core\Model\OrderItemUnit');
@@ -34,6 +41,16 @@ class OrderItemUnitSpec extends ObjectBehavior
     function it_implements_order_item_unit_interface()
     {
         $this->shouldImplement(OrderItemUnitInterface::class);
+    }
+
+    function it_implements_inventory_unit_interface()
+    {
+        $this->shouldImplement(InventoryUnitInterface::class);
+    }
+
+    function it_implements_shipment_item_interface()
+    {
+        $this->shouldImplement(ShipmentItemInterface::class);
     }
 
     function it_is_order_item_unit()
@@ -53,12 +70,6 @@ class OrderItemUnitSpec extends ObjectBehavior
         $this->getShipment()->shouldReturn($shipment);
     }
 
-    function its_order_item_is_mutable(OrderItemInterface $orderItem)
-    {
-        $this->setOrderItem($orderItem);
-        $this->getOrderItem()->shouldReturn($orderItem);
-    }
-
     function its_created_at_is_mutable(\DateTime $createdAt)
     {
         $this->setCreatedAt($createdAt);
@@ -74,7 +85,6 @@ class OrderItemUnitSpec extends ObjectBehavior
     function it_stockable_is_order_item_variant(OrderItemInterface $orderItem, ProductVariantInterface $variant)
     {
         $orderItem->getVariant()->willReturn($variant);
-        $this->setOrderItem($orderItem);
 
         $this->getStockable()->shouldReturn($variant);
     }
@@ -83,7 +93,6 @@ class OrderItemUnitSpec extends ObjectBehavior
     {
         $variant->getSku()->willReturn('test_sku');
         $orderItem->getVariant()->willReturn($variant);
-        $this->setOrderItem($orderItem);
 
         $this->getSku()->shouldReturn('test_sku');
     }
@@ -101,7 +110,6 @@ class OrderItemUnitSpec extends ObjectBehavior
     function its_shippable_is_order_item_variant(OrderItemInterface $orderItem, ProductVariantInterface $variant)
     {
         $orderItem->getVariant()->willReturn($variant);
-        $this->setOrderItem($orderItem);
 
         $this->getShippable()->shouldReturn($variant);
     }
@@ -111,5 +119,4 @@ class OrderItemUnitSpec extends ObjectBehavior
         $this->setShippingState(ShipmentInterface::STATE_SHIPPED);
         $this->getShippingState()->shouldReturn(ShipmentInterface::STATE_SHIPPED);
     }
-
 }

--- a/src/Sylius/Component/Core/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderSpec.php
@@ -137,9 +137,11 @@ class OrderSpec extends ObjectBehavior
     ) {
         $shippingAdjustment->getType()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
         $shippingAdjustment->setAdjustable($this)->shouldBeCalled();
+        $shippingAdjustment->isNeutral()->willReturn(true);
 
         $taxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
         $taxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $taxAdjustment->isNeutral()->willReturn(true);
 
         $this->addAdjustment($shippingAdjustment);
         $this->addAdjustment($taxAdjustment);
@@ -157,9 +159,11 @@ class OrderSpec extends ObjectBehavior
     ) {
         $shippingAdjustment->getType()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
         $shippingAdjustment->setAdjustable($this)->shouldBeCalled();
+        $shippingAdjustment->isNeutral()->willReturn(true);
 
         $taxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
         $taxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $taxAdjustment->isNeutral()->willReturn(true);
 
         $this->addAdjustment($shippingAdjustment);
         $this->addAdjustment($taxAdjustment);
@@ -180,9 +184,11 @@ class OrderSpec extends ObjectBehavior
     ) {
         $shippingAdjustment->getType()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
         $shippingAdjustment->setAdjustable($this)->shouldBeCalled();
+        $shippingAdjustment->isNeutral()->willReturn(true);
 
         $taxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
         $taxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $taxAdjustment->isNeutral()->willReturn(true);
 
         $this->addAdjustment($shippingAdjustment);
         $this->addAdjustment($taxAdjustment);
@@ -200,9 +206,11 @@ class OrderSpec extends ObjectBehavior
     ) {
         $shippingAdjustment->getType()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
         $shippingAdjustment->setAdjustable($this)->shouldBeCalled();
+        $shippingAdjustment->isNeutral()->willReturn(true);
 
         $taxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
         $taxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $taxAdjustment->isNeutral()->willReturn(true);
 
         $this->addAdjustment($shippingAdjustment);
         $this->addAdjustment($taxAdjustment);
@@ -259,6 +267,7 @@ class OrderSpec extends ObjectBehavior
         $unit2->getInventoryState()->willReturn(InventoryUnitInterface::STATE_SOLD);
 
         $item->getUnits()->willReturn(array($unit1, $unit2));
+        $item->getTotal()->willReturn(4000);
 
         $item->setOrder($this)->shouldBeCalled();
         $this->addItem($item);
@@ -275,6 +284,7 @@ class OrderSpec extends ObjectBehavior
         $unit2->getInventoryState()->willReturn(InventoryUnitInterface::STATE_SOLD);
 
         $item->getUnits()->willReturn(array($unit1, $unit2));
+        $item->getTotal()->willReturn(4000);
 
         $item->setOrder($this)->shouldBeCalled();
         $this->addItem($item);

--- a/src/Sylius/Component/Core/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderSpec.php
@@ -296,10 +296,11 @@ class OrderSpec extends ObjectBehavior
     {
         $payment->getState()->willReturn(PaymentInterface::STATE_PENDING);
         $payment->setOrder($this)->shouldBeCalled();
-        $payment->setOrder(null)->shouldBeCalled();
 
         $this->addPayment($payment);
         $this->shouldHavePayment($payment);
+
+        $payment->setOrder(null)->shouldBeCalled();
 
         $this->removePayment($payment);
         $this->shouldNotHavePayment($payment);
@@ -321,10 +322,11 @@ class OrderSpec extends ObjectBehavior
     function it_adds_and_removes_shipments(ShipmentInterface $shipment)
     {
         $shipment->setOrder($this)->shouldBeCalled();
-        $shipment->setOrder(null)->shouldBeCalled();
 
         $this->addShipment($shipment);
         $this->shouldHaveShipment($shipment);
+
+        $shipment->setOrder(null)->shouldBeCalled();
 
         $this->removeShipment($shipment);
         $this->shouldNotHaveShipment($shipment);

--- a/src/Sylius/Component/Core/spec/OrderProcessing/InventoryHandlerSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/InventoryHandlerSpec.php
@@ -14,6 +14,7 @@ namespace spec\Sylius\Component\Core\OrderProcessing;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
+use Sylius\Bundle\OrderBundle\Factory\OrderItemUnitFactoryInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
@@ -22,7 +23,6 @@ use Sylius\Component\Core\OrderProcessing\InventoryHandlerInterface;
 use Sylius\Component\Inventory\InventoryUnitTransitions;
 use Sylius\Component\Inventory\Model\InventoryUnitInterface;
 use Sylius\Component\Inventory\Operator\InventoryOperatorInterface;
-use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Resource\StateMachine\StateMachineInterface;
 
 /**
@@ -34,7 +34,7 @@ class InventoryHandlerSpec extends ObjectBehavior
 {
     function let(
         InventoryOperatorInterface $inventoryOperator,
-        FactoryInterface $orderItemUnitFactory,
+        OrderItemUnitFactoryInterface $orderItemUnitFactory,
         StateMachineFactoryInterface $stateMachineFactory
     ) {
         $this->beConstructedWith($inventoryOperator, $orderItemUnitFactory, $stateMachineFactory);
@@ -61,7 +61,7 @@ class InventoryHandlerSpec extends ObjectBehavior
         $item->getQuantity()->willReturn(2);
 
         $item->getUnits()->willReturn(new ArrayCollection());
-        $orderItemUnitFactory->createNew()->willReturn($unit1, $unit2);
+        $orderItemUnitFactory->createForItem($item)->willReturn($unit1, $unit2);
 
         $unit1->setInventoryState(InventoryUnitInterface::STATE_CHECKOUT)->shouldBeCalled();
         $unit2->setInventoryState(InventoryUnitInterface::STATE_CHECKOUT)->shouldBeCalled();
@@ -87,7 +87,7 @@ class InventoryHandlerSpec extends ObjectBehavior
         $item->getQuantity()->willReturn(2);
 
         $item->getUnits()->willReturn(new ArrayCollection());
-        $orderItemUnitFactory->createNew()->willReturn($unit2);
+        $orderItemUnitFactory->createForItem($item)->willReturn($unit2);
 
         $unit1->setInventoryState(InventoryUnitInterface::STATE_CHECKOUT)->shouldNotBeCalled();
         $unit2->setInventoryState(InventoryUnitInterface::STATE_CHECKOUT)->shouldBeCalled();

--- a/src/Sylius/Component/Core/spec/OrderProcessing/InventoryHandlerSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/InventoryHandlerSpec.php
@@ -66,9 +66,6 @@ class InventoryHandlerSpec extends ObjectBehavior
         $unit1->setInventoryState(InventoryUnitInterface::STATE_CHECKOUT)->shouldBeCalled();
         $unit2->setInventoryState(InventoryUnitInterface::STATE_CHECKOUT)->shouldBeCalled();
 
-        $item->addUnit($unit1)->shouldBeCalled();
-        $item->addUnit($unit2)->shouldBeCalled();
-
         $this->processInventoryUnits($item);
     }
 
@@ -91,9 +88,6 @@ class InventoryHandlerSpec extends ObjectBehavior
 
         $unit1->setInventoryState(InventoryUnitInterface::STATE_CHECKOUT)->shouldNotBeCalled();
         $unit2->setInventoryState(InventoryUnitInterface::STATE_CHECKOUT)->shouldBeCalled();
-
-        $item->addUnit($unit1)->shouldNotBeCalled();
-        $item->addUnit($unit2)->shouldBeCalled();
 
         $this->processInventoryUnits($item);
     }

--- a/src/Sylius/Component/Core/spec/Promotion/Action/AddProductActionSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/AddProductActionSpec.php
@@ -12,7 +12,7 @@
 namespace spec\Sylius\Component\Core\Promotion\Action;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Bundle\CoreBundle\Modifier\OrderItemQuantityModifierInterface;
+use Sylius\Bundle\OrderBundle\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;

--- a/src/Sylius/Component/Core/spec/Promotion/Action/AddProductActionSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/AddProductActionSpec.php
@@ -12,6 +12,7 @@
 namespace spec\Sylius\Component\Core\Promotion\Action;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\CoreBundle\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -22,12 +23,13 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 /**
  * @author Alexandre Bacco <alexandre.bacco@gmail.com>
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
 class AddProductActionSpec extends ObjectBehavior
 {
-    function let(FactoryInterface $itemFactory, RepositoryInterface $variantRepository)
+    function let(FactoryInterface $itemFactory, RepositoryInterface $variantRepository, OrderItemQuantityModifierInterface $orderItemQuantityModifier)
     {
-        $this->beConstructedWith($itemFactory, $variantRepository);
+        $this->beConstructedWith($itemFactory, $variantRepository, $orderItemQuantityModifier);
     }
 
     function it_is_initializable()
@@ -41,31 +43,32 @@ class AddProductActionSpec extends ObjectBehavior
     }
 
     function it_adds_product_as_promotion(
-        FactoryInterface $itemFactory,
+        $orderItemQuantityModifier,
         $variantRepository,
+        FactoryInterface $itemFactory,
         OrderInterface $order,
         OrderItemInterface $item,
         ProductVariantInterface $variant,
         PromotionInterface $promotion
     ) {
-        $configuration = array('variant' => 500, 'quantity' => 2, 'price' => 0);
-
-        $variantRepository->find($configuration['variant'])->willReturn($variant);
+        $variantRepository->find(500)->willReturn($variant);
 
         $itemFactory->createNew()->willReturn($item);
-        $item->setUnitPrice($configuration['price'])->willReturn($item);
+        $item->setUnitPrice(0)->willReturn($item);
         $item->setVariant($variant)->willReturn($item);
-        $item->setQuantity($configuration['quantity'])->willReturn($item);
+        $orderItemQuantityModifier->modify($item, 2)->shouldBeCalled();
+
         $item->setImmutable(true)->shouldBeCalled();
 
         $order->getItems()->willReturn(array());
 
         $order->addItem($item)->shouldBeCalled();
 
-        $this->execute($order, $configuration, $promotion);
+        $this->execute($order, array('variant' => 500, 'quantity' => 2, 'price' => 0), $promotion);
     }
 
     function it_does_not_add_product_if_exists(
+        $orderItemQuantityModifier,
         $variantRepository,
         FactoryInterface $itemFactory,
         OrderInterface $order,
@@ -73,24 +76,23 @@ class AddProductActionSpec extends ObjectBehavior
         ProductVariantInterface $variant,
         PromotionInterface $promotion
     ) {
-        $configuration = array('variant' => 500, 'quantity' => 2, 'price' => 1);
-
-        $variantRepository->find($configuration['variant'])->willReturn($variant);
+        $variantRepository->find(500)->willReturn($variant);
 
         $itemFactory->createNew()->willReturn($item);
-        $item->setUnitPrice($configuration['price'])->willReturn($item);
+        $item->setUnitPrice(1)->willReturn($item);
         $item->setVariant($variant)->willReturn($item);
-        $item->setQuantity($configuration['quantity'])->willReturn($item);
+        $orderItemQuantityModifier->modify($item, 2)->shouldBeCalled();
         $item->equals($item)->willReturn(true);
 
         $order->getItems()->willReturn(array($item));
 
         $order->addItem($item)->shouldNotBeCalled();
 
-        $this->execute($order, $configuration, $promotion);
+        $this->execute($order, array('variant' => 500, 'quantity' => 2, 'price' => 1), $promotion);
     }
 
     function it_reverts_product(
+        $orderItemQuantityModifier,
         $variantRepository,
         FactoryInterface $itemFactory,
         OrderInterface $order,
@@ -98,14 +100,12 @@ class AddProductActionSpec extends ObjectBehavior
         ProductVariantInterface $variant,
         PromotionInterface $promotion
     ) {
-        $configuration = array('variant' => 500, 'quantity' => 3, 'price' => 2);
-
-        $variantRepository->find($configuration['variant'])->willReturn($variant);
+        $variantRepository->find(500)->willReturn($variant);
 
         $itemFactory->createNew()->willReturn($item);
-        $item->setUnitPrice($configuration['price'])->willReturn($item);
+        $item->setUnitPrice(2)->willReturn($item);
         $item->setVariant($variant)->willReturn($item);
-        $item->setQuantity($configuration['quantity'])->willReturn($item);
+        $orderItemQuantityModifier->modify($item, 3)->shouldBeCalled();
         $item->equals($item)->willReturn(true);
         $item->setImmutable(true)->shouldBeCalled();
 
@@ -113,6 +113,6 @@ class AddProductActionSpec extends ObjectBehavior
 
         $order->removeItem($item)->shouldBeCalled();
 
-        $this->revert($order, $configuration, $promotion);
+        $this->revert($order, array('variant' => 500, 'quantity' => 3, 'price' => 2), $promotion);
     }
 }

--- a/src/Sylius/Component/Order/Model/AdjustableInterface.php
+++ b/src/Sylius/Component/Order/Model/AdjustableInterface.php
@@ -38,7 +38,7 @@ interface AdjustableInterface
     /**
      * @param null|string $type
      *
-     * @return integer
+     * @return int
      */
     public function getAdjustmentsTotal($type = null);
 
@@ -49,5 +49,8 @@ interface AdjustableInterface
 
     public function clearAdjustments();
 
-    public function calculateAdjustmentsTotal();
+    /**
+     * Recalculates adjustments total. Should be used after adjustment change.
+     */
+    public function recalculateAdjustmentsTotal();
 }

--- a/src/Sylius/Component/Order/Model/Adjustment.php
+++ b/src/Sylius/Component/Order/Model/Adjustment.php
@@ -187,6 +187,18 @@ class Adjustment implements AdjustmentInterface
         }
 
         $this->amount = $amount;
+        $this->recalculateAdjustable();
+    }
+
+    protected function recalculateAdjustable()
+    {
+        if (null !== $this->order) {
+            $this->order->recalculateAdjustmentsTotal();
+        } elseif (null !== $this->orderItem) {
+            $this->orderItem->recalculateAdjustmentsTotal();
+        } elseif (null !== $this->orderItemUnit) {
+            $this->orderItemUnit->recalculateAdjustmentsTotal();
+        }
     }
 
     /**

--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -269,8 +269,6 @@ class Order implements OrderInterface
         $itemsTotal = 0;
 
         foreach ($this->items as $item) {
-            $item->calculateTotal();
-
             $itemsTotal += $item->getTotal();
         }
 
@@ -332,7 +330,7 @@ class Order implements OrderInterface
     public function calculateTotal()
     {
         $this->calculateItemsTotal();
-        $this->calculateAdjustmentsTotal();
+        $this->recalculateAdjustmentsTotal();
 
         $this->total = $this->itemsTotal + $this->adjustmentsTotal;
 
@@ -569,7 +567,7 @@ class Order implements OrderInterface
     /**
      * {@inheritdoc}
      */
-    public function calculateAdjustmentsTotal()
+    public function recalculateAdjustmentsTotal()
     {
         $this->adjustmentsTotal = 0;
 

--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -211,16 +211,9 @@ class Order implements OrderInterface
             return;
         }
 
-        foreach ($this->items as $existingItem) {
-            if ($item->equals($existingItem)) {
-                $existingItem->merge($item, false);
-
-                return;
-            }
-        }
-
         $item->setOrder($this);
-        $this->itemsTotal += $item->getTotal();
+        $itemTotal = $item->getTotal();
+        $this->itemsTotal = $this->itemsTotal + $itemTotal;
         $this->items->add($item);
 
         $this->calculateTotal();
@@ -261,13 +254,12 @@ class Order implements OrderInterface
      */
     public function calculateItemsTotal()
     {
-        $itemsTotal = 0;
-
+        $this->itemsTotal = 0;
         foreach ($this->items as $item) {
-            $itemsTotal += $item->getTotal();
+            $this->itemsTotal += $item->getTotal();
         }
 
-        $this->itemsTotal = $itemsTotal;
+        $this->calculateTotal();
     }
 
     /**

--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -181,17 +181,11 @@ class Order implements OrderInterface
     /**
      * {@inheritdoc}
      */
-    public function setItems(Collection $items)
-    {
-        $this->items = $items;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function clearItems()
     {
         $this->items->clear();
+
+        $this->calculateItemsTotal();
     }
 
     /**
@@ -211,10 +205,10 @@ class Order implements OrderInterface
             return;
         }
 
-        $item->setOrder($this);
         $itemTotal = $item->getTotal();
         $this->itemsTotal = $this->itemsTotal + $itemTotal;
         $this->items->add($item);
+        $item->setOrder($this);
 
         $this->calculateTotal();
     }

--- a/src/Sylius/Component/Order/Model/OrderInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderInterface.php
@@ -99,11 +99,6 @@ interface OrderInterface extends
     public function getTotal();
 
     /**
-     * @param int $total
-     */
-    public function setTotal($total);
-
-    /**
      * Calculate total.
      * Items total + Adjustments total.
      */

--- a/src/Sylius/Component/Order/Model/OrderInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderInterface.php
@@ -60,11 +60,6 @@ interface OrderInterface extends
     public function getItems();
 
     /**
-     * @param Collection|OrderItemInterface[] $items
-     */
-    public function setItems(Collection $items);
-
-    /**
      * @return int
      */
     public function countItems();

--- a/src/Sylius/Component/Order/Model/OrderItem.php
+++ b/src/Sylius/Component/Order/Model/OrderItem.php
@@ -138,7 +138,7 @@ class OrderItem implements OrderItemInterface
         }
 
         $this->unitPrice = $unitPrice;
-        $this->recalculateUnits();
+        $this->recalculateUnitsTotal();
     }
 
     /**
@@ -185,21 +185,6 @@ class OrderItem implements OrderItemInterface
         $this->unitsTotal = 0;
 
         foreach ($this->units as $unit) {
-            $this->unitsTotal += $unit->getTotal();
-        }
-
-        $this->recalculateTotal();
-    }
-
-    /**
-     *  Recalculates all units' total together with units total update.
-     */
-    protected function recalculateUnits()
-    {
-        $this->unitsTotal = 0;
-
-        foreach ($this->units as $unit) {
-            $unit->recalculateTotal();
             $this->unitsTotal += $unit->getTotal();
         }
 

--- a/src/Sylius/Component/Order/Model/OrderItem.php
+++ b/src/Sylius/Component/Order/Model/OrderItem.php
@@ -127,6 +127,10 @@ class OrderItem implements OrderItemInterface
 
         $this->unitPrice = $unitPrice;
         $this->recalculateUnitsTotal();
+
+        if (null !== $this->order) {
+            $this->order->calculateItemsTotal();
+        }
     }
 
     /**
@@ -190,20 +194,6 @@ class OrderItem implements OrderItemInterface
     /**
      * {@inheritdoc}
      */
-    public function merge(OrderItemInterface $orderItem, $throwOnInvalid = true)
-    {
-        if ($throwOnInvalid && !$orderItem->equals($this)) {
-            throw new \LogicException('Given item cannot be merged.');
-        }
-
-        if ($this !== $orderItem) {
-            $this->quantity += $orderItem->getQuantity();
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function isImmutable()
     {
         return $this->immutable;
@@ -240,6 +230,10 @@ class OrderItem implements OrderItemInterface
             $this->quantity++;
             $this->unitsTotal += $unit->getTotal();
             $this->recalculateTotal();
+
+            if (null !== $this->order) {
+                $this->order->calculateItemsTotal();
+            }
         }
     }
 
@@ -254,6 +248,10 @@ class OrderItem implements OrderItemInterface
             $this->quantity--;
             $this->unitsTotal -= $unit->getTotal();
             $this->recalculateTotal();
+
+            if (null !== $this->order) {
+                $this->order->calculateItemsTotal();
+            }
         }
     }
 

--- a/src/Sylius/Component/Order/Model/OrderItem.php
+++ b/src/Sylius/Component/Order/Model/OrderItem.php
@@ -237,6 +237,19 @@ class OrderItem implements OrderItemInterface
     /**
      * {@inheritdoc}
      */
+    public function removeUnitByIndex($index)
+    {
+        if (null === $unit = $this->units->get($index)) {
+            return;
+        }
+
+        $unit->setOrderItem(null);
+        $this->units->remove($index);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function hasUnit(OrderItemUnitInterface $unit)
     {
         return $this->units->contains($unit);

--- a/src/Sylius/Component/Order/Model/OrderItem.php
+++ b/src/Sylius/Component/Order/Model/OrderItem.php
@@ -220,6 +220,8 @@ class OrderItem implements OrderItemInterface
         if (!$this->hasUnit($unit)) {
             $unit->setOrderItem($this);
             $this->units->add($unit);
+
+            $this->quantity++;
         }
     }
 
@@ -231,20 +233,9 @@ class OrderItem implements OrderItemInterface
         if ($this->hasUnit($unit)) {
             $unit->setOrderItem(null);
             $this->units->removeElement($unit);
-        }
-    }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function removeUnitByIndex($index)
-    {
-        if (null === $unit = $this->units->get($index)) {
-            return;
+            $this->quantity--;
         }
-
-        $unit->setOrderItem(null);
-        $this->units->remove($index);
     }
 
     /**
@@ -254,6 +245,7 @@ class OrderItem implements OrderItemInterface
     {
         return $this->units->contains($unit);
     }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Sylius/Component/Order/Model/OrderItem.php
+++ b/src/Sylius/Component/Order/Model/OrderItem.php
@@ -33,7 +33,7 @@ class OrderItem implements OrderItemInterface
     /**
      * @var int
      */
-    protected $quantity = 1;
+    protected $quantity = 0;
 
     /**
      * @var int

--- a/src/Sylius/Component/Order/Model/OrderItem.php
+++ b/src/Sylius/Component/Order/Model/OrderItem.php
@@ -105,7 +105,26 @@ class OrderItem implements OrderItemInterface
      */
     public function setOrder(OrderInterface $order = null)
     {
+        $currentOrder = $this->getOrder();
+        if ($currentOrder === $order) {
+            return;
+        }
+
+        $this->order = null;
+
+        if (null !== $currentOrder) {
+            $currentOrder->removeItem($this);
+        }
+
+        if (null === $order) {
+            return;
+        }
+
         $this->order = $order;
+
+        if (!$order->hasItem($this)) {
+            $order->addItem($this);
+        }
     }
 
     /**

--- a/src/Sylius/Component/Order/Model/OrderItem.php
+++ b/src/Sylius/Component/Order/Model/OrderItem.php
@@ -95,18 +95,6 @@ class OrderItem implements OrderItemInterface
     /**
      * {@inheritdoc}
      */
-    public function setQuantity($quantity)
-    {
-        if (1 > $quantity) {
-            throw new \OutOfRangeException('Quantity must be greater than 0.');
-        }
-
-        $this->quantity = $quantity;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getOrder()
     {
         return $this->order;
@@ -152,7 +140,7 @@ class OrderItem implements OrderItemInterface
     /**
      *  Recalculates total after units total or adjustments total change.
      */
-    protected function recalculateTotal()
+    public function recalculateTotal()
     {
         $this->total = $this->unitsTotal + $this->adjustmentsTotal;
 

--- a/src/Sylius/Component/Order/Model/OrderItemInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderItemInterface.php
@@ -109,11 +109,4 @@ interface OrderItemInterface extends AdjustableInterface, OrderAwareInterface, R
      * @param OrderItemUnitInterface $itemUnit
      */
     public function removeUnit(OrderItemUnitInterface $itemUnit);
-
-    /**
-     * @param int $index
-     *
-     * @return mixed
-     */
-    public function removeUnitByIndex($index);
 }

--- a/src/Sylius/Component/Order/Model/OrderItemInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderItemInterface.php
@@ -59,15 +59,6 @@ interface OrderItemInterface extends AdjustableInterface, OrderAwareInterface, R
     public function equals(OrderItemInterface $orderItem);
 
     /**
-     * Merge the item given as argument corresponding to
-     * the same cart item.
-     *
-     * @param OrderItemInterface $orderItem
-     * @param bool               $throwOnInvalid
-     */
-    public function merge(OrderItemInterface $orderItem, $throwOnInvalid = true);
-
-    /**
      * @return bool
      */
     public function isImmutable();

--- a/src/Sylius/Component/Order/Model/OrderItemInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderItemInterface.php
@@ -27,11 +27,6 @@ interface OrderItemInterface extends AdjustableInterface, OrderAwareInterface, R
     public function getQuantity();
 
     /**
-     * @param int $quantity
-     */
-    public function setQuantity($quantity);
-
-    /**
      * @return int
      */
     public function getUnitPrice();

--- a/src/Sylius/Component/Order/Model/OrderItemInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderItemInterface.php
@@ -49,15 +49,9 @@ interface OrderItemInterface extends AdjustableInterface, OrderAwareInterface, R
     public function getTotal();
 
     /**
-     * @param int $total
+     * Recalculate totals. Should be used after every unit change.
      */
-    public function setTotal($total);
-
-    /**
-     * Calculate total based on quantity and unit price.
-     * Take adjustments into account.
-     */
-    public function calculateTotal();
+    public function recalculateUnitsTotal();
 
     /**
      * Checks whether the item given as argument corresponds to

--- a/src/Sylius/Component/Order/Model/OrderItemInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderItemInterface.php
@@ -109,4 +109,11 @@ interface OrderItemInterface extends AdjustableInterface, OrderAwareInterface, R
      * @param OrderItemUnitInterface $itemUnit
      */
     public function removeUnit(OrderItemUnitInterface $itemUnit);
+
+    /**
+     * @param int $index
+     *
+     * @return mixed
+     */
+    public function removeUnitByIndex($index);
 }

--- a/src/Sylius/Component/Order/Model/OrderItemUnit.php
+++ b/src/Sylius/Component/Order/Model/OrderItemUnit.php
@@ -26,11 +26,6 @@ class OrderItemUnit implements OrderItemUnitInterface
     protected $id;
 
     /**
-     * @var int
-     */
-    protected $total = 0;
-
-    /**
      * @var OrderItemInterface
      */
     protected $orderItem;
@@ -49,7 +44,6 @@ class OrderItemUnit implements OrderItemUnitInterface
     {
         $this->adjustments = new ArrayCollection();
         $this->orderItem = $orderItem;
-        $this->recalculateTotal();
         $this->orderItem->addUnit($this);
     }
 
@@ -66,19 +60,13 @@ class OrderItemUnit implements OrderItemUnitInterface
      */
     public function getTotal()
     {
-        return $this->total;
-    }
+        $total = $this->orderItem->getUnitPrice() + $this->adjustmentsTotal;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function recalculateTotal()
-    {
-        $this->total = $this->orderItem->getUnitPrice() + $this->adjustmentsTotal;
-
-        if ($this->total < 0) {
-            $this->total = 0;
+        if ($total < 0) {
+            return 0;
         }
+
+        return $total;
     }
 
     /**
@@ -184,7 +172,6 @@ class OrderItemUnit implements OrderItemUnitInterface
     {
         if (!$adjustment->isNeutral()) {
             $this->adjustmentsTotal += $adjustment->getAmount();
-            $this->recalculateTotal();
         }
     }
 
@@ -192,7 +179,6 @@ class OrderItemUnit implements OrderItemUnitInterface
     {
         if (!$adjustment->isNeutral()) {
             $this->adjustmentsTotal -= $adjustment->getAmount();
-            $this->recalculateTotal();
         }
     }
 
@@ -208,7 +194,5 @@ class OrderItemUnit implements OrderItemUnitInterface
                 $this->adjustmentsTotal += $adjustment->getAmount();
             }
         }
-
-        $this->recalculateTotal();
     }
 }

--- a/src/Sylius/Component/Order/Model/OrderItemUnit.php
+++ b/src/Sylius/Component/Order/Model/OrderItemUnit.php
@@ -99,12 +99,14 @@ class OrderItemUnit implements OrderItemUnitInterface
      */
     public function addAdjustment(AdjustmentInterface $adjustment)
     {
-        if (!$this->hasAdjustment($adjustment)) {
-            $adjustment->setAdjustable($this);
-            $this->adjustments->add($adjustment);
-            $this->addToAdjustmentsTotal($adjustment);
-            $this->orderItem->recalculateUnitsTotal();
+        if ($this->hasAdjustment($adjustment)) {
+            return;
         }
+
+        $adjustment->setAdjustable($this);
+        $this->adjustments->add($adjustment);
+        $this->addToAdjustmentsTotal($adjustment);
+        $this->orderItem->recalculateUnitsTotal();
     }
 
     /**
@@ -112,12 +114,14 @@ class OrderItemUnit implements OrderItemUnitInterface
      */
     public function removeAdjustment(AdjustmentInterface $adjustment)
     {
-        if (!$adjustment->isLocked() && $this->hasAdjustment($adjustment)) {
-            $adjustment->setAdjustable(null);
-            $this->adjustments->removeElement($adjustment);
-            $this->subtractFromAdjustmentsTotal($adjustment);
-            $this->orderItem->recalculateUnitsTotal();
+        if ($adjustment->isLocked() || !$this->hasAdjustment($adjustment)) {
+            return;
         }
+
+        $adjustment->setAdjustable(null);
+        $this->adjustments->removeElement($adjustment);
+        $this->subtractFromAdjustmentsTotal($adjustment);
+        $this->orderItem->recalculateUnitsTotal();
     }
 
     /**

--- a/src/Sylius/Component/Order/Model/OrderItemUnit.php
+++ b/src/Sylius/Component/Order/Model/OrderItemUnit.php
@@ -40,6 +40,9 @@ class OrderItemUnit implements OrderItemUnitInterface
      */
     protected $adjustmentsTotal = 0;
 
+    /**
+     * @param OrderItemInterface $orderItem
+     */
     public function __construct(OrderItemInterface $orderItem)
     {
         $this->adjustments = new ArrayCollection();
@@ -168,20 +171,6 @@ class OrderItemUnit implements OrderItemUnitInterface
         $this->orderItem->recalculateUnitsTotal();
     }
 
-    protected function addToAdjustmentsTotal(AdjustmentInterface $adjustment)
-    {
-        if (!$adjustment->isNeutral()) {
-            $this->adjustmentsTotal += $adjustment->getAmount();
-        }
-    }
-
-    protected function subtractFromAdjustmentsTotal(AdjustmentInterface $adjustment)
-    {
-        if (!$adjustment->isNeutral()) {
-            $this->adjustmentsTotal -= $adjustment->getAmount();
-        }
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -193,6 +182,26 @@ class OrderItemUnit implements OrderItemUnitInterface
             if (!$adjustment->isNeutral()) {
                 $this->adjustmentsTotal += $adjustment->getAmount();
             }
+        }
+    }
+
+    /**
+     * @param AdjustmentInterface $adjustment
+     */
+    protected function addToAdjustmentsTotal(AdjustmentInterface $adjustment)
+    {
+        if (!$adjustment->isNeutral()) {
+            $this->adjustmentsTotal += $adjustment->getAmount();
+        }
+    }
+
+    /**
+     * @param AdjustmentInterface $adjustment
+     */
+    protected function subtractFromAdjustmentsTotal(AdjustmentInterface $adjustment)
+    {
+        if (!$adjustment->isNeutral()) {
+            $this->adjustmentsTotal -= $adjustment->getAmount();
         }
     }
 }

--- a/src/Sylius/Component/Order/Model/OrderItemUnitInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderItemUnitInterface.php
@@ -27,11 +27,6 @@ interface OrderItemUnitInterface extends AdjustableInterface
     public function getTotal();
 
     /**
-     * Recalculates total. Should be used after every unit price change.
-     */
-    public function recalculateTotal();
-
-    /**
      * @return OrderItemInterface
      */
     public function getOrderItem();

--- a/src/Sylius/Component/Order/Model/OrderItemUnitInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderItemUnitInterface.php
@@ -26,15 +26,13 @@ interface OrderItemUnitInterface extends AdjustableInterface
      */
     public function getTotal();
 
-    public function calculateTotal();
+    /**
+     * Recalculates total. Should be used after every unit price change.
+     */
+    public function recalculateTotal();
 
     /**
      * @return OrderItemInterface
      */
     public function getOrderItem();
-
-    /**
-     * @param null|OrderItemInterface $orderItem
-     */
-    public function setOrderItem(OrderItemInterface $orderItem = null);
 }

--- a/src/Sylius/Component/Order/spec/Model/AdjustmentSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/AdjustmentSpec.php
@@ -106,6 +106,25 @@ class AdjustmentSpec extends ObjectBehavior
         $this->getAmount()->shouldReturn(399);
     }
 
+    function it_recalculates_adjustments_on_adjustable_entity_on_amount_change(
+        OrderInterface $order,
+        OrderItemInterface $orderItem,
+        OrderItemUnitInterface $orderItemUnit
+    ) {
+        $this->setAdjustable($order);
+        $this->setAmount(200);
+        $order->recalculateAdjustmentsTotal()->shouldBeCalled();
+
+        $this->setAdjustable($orderItem);
+        $this->setAmount(300);
+        $orderItem->recalculateAdjustmentsTotal()->shouldBeCalled();
+
+        $this->setAdjustable($orderItemUnit);
+        $this->setAmount(400);
+        $orderItemUnit->recalculateAdjustmentsTotal()->shouldBeCalled();
+
+    }
+
     function its_amount_should_accept_only_integer()
     {
         $this->setAmount(4498);

--- a/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
@@ -155,8 +155,6 @@ class OrderItemSpec extends ObjectBehavior
         $this->addUnit($orderItemUnit1);
         $this->addUnit($orderItemUnit2);
 
-        $orderItemUnit1->recalculateTotal()->shouldBeCalled();
-        $orderItemUnit2->recalculateTotal()->shouldBeCalled();
         $this->setUnitPrice(100);
     }
 
@@ -317,8 +315,6 @@ class OrderItemSpec extends ObjectBehavior
         $this->addUnit($orderItemUnit1);
         $this->addUnit($orderItemUnit2);
 
-        $orderItemUnit1->recalculateTotal()->shouldBeCalled();
-        $orderItemUnit2->recalculateTotal()->shouldBeCalled();
         $this->setUnitPrice(100);
         $this->getTotal()->shouldReturn(200);
     }

--- a/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
@@ -11,14 +11,17 @@
 
 namespace spec\Sylius\Component\Order\Model;
 
+use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Core\Model\OrderItemUnitInterface;
+use Sylius\Component\Order\Model\AdjustableInterface;
 use Sylius\Component\Order\Model\AdjustmentInterface;
 use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Order\Model\OrderItemInterface;
+use Sylius\Component\Order\Model\OrderItemUnitInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
  */
 class OrderItemSpec extends ObjectBehavior
 {
@@ -27,14 +30,14 @@ class OrderItemSpec extends ObjectBehavior
         $this->shouldHaveType('Sylius\Component\Order\Model\OrderItem');
     }
 
-    function it_implements_Sylius_order_item_interface()
+    function it_implements_sylius_order_item_interface()
     {
         $this->shouldImplement(OrderItemInterface::class);
     }
 
-    function it_implements_Sylius_adjustable_interface()
+    function it_implements_sylius_adjustable_interface()
     {
-        $this->shouldImplement('Sylius\Component\Order\Model\AdjustableInterface');
+        $this->shouldImplement(AdjustableInterface::class);
     }
 
     function it_has_no_id_by_default()
@@ -81,6 +84,7 @@ class OrderItemSpec extends ObjectBehavior
     function its_unit_price_should_accept_only_integer()
     {
         $this->setUnitPrice(4498);
+        $this->getUnitPrice()->shouldReturn(4498);
         $this->getUnitPrice()->shouldBeInteger();
         $this->shouldThrow('\InvalidArgumentException')->duringSetUnitPrice(44.98 * 100);
         $this->shouldThrow('\InvalidArgumentException')->duringSetUnitPrice('4498');
@@ -94,32 +98,71 @@ class OrderItemSpec extends ObjectBehavior
         $this->getTotal()->shouldReturn(0);
     }
 
-    function its_total_should_accept_only_integer()
-    {
-        $this->setTotal(4498);
-        $this->getTotal()->shouldBeInteger();
-        $this->shouldThrow('\InvalidArgumentException')->duringSetTotal(44.98 * 100);
-        $this->shouldThrow('\InvalidArgumentException')->duringSetTotal('4498');
-        $this->shouldThrow('\InvalidArgumentException')->duringSetTotal(round(44.98 * 100));
-        $this->shouldThrow('\InvalidArgumentException')->duringSetTotal(array(4498));
-        $this->shouldThrow('\InvalidArgumentException')->duringSetTotal(new \stdClass());
-    }
-
     function it_throws_exception_when_quantity_is_less_than_1()
     {
         $this
             ->shouldThrow(new \OutOfRangeException('Quantity must be greater than 0.'))
-            ->duringSetQuantity(-5)
+            ->duringSetQuantity(0)
         ;
     }
 
     function it_initializes_adjustments_collection_by_default()
     {
-        $this->getAdjustments()->shouldHaveType('Doctrine\Common\Collections\Collection');
+        $this->getAdjustments()->shouldHaveType(Collection::class);
+    }
+
+    function it_adds_and_removes_units(OrderItemUnitInterface $orderItemUnit1, OrderItemUnitInterface $orderItemUnit2)
+    {
+        $orderItemUnit1->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit1->getTotal()->willReturn(0);
+        $orderItemUnit2->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit2->getTotal()->willReturn(0);
+        $this->getUnits()->shouldHaveType(Collection::class);
+
+        $this->addUnit($orderItemUnit1);
+        $this->addUnit($orderItemUnit2);
+        $this->hasUnit($orderItemUnit1)->shouldReturn(true);
+        $this->hasUnit($orderItemUnit2)->shouldReturn(true);
+
+        $this->removeUnit($orderItemUnit1);
+        $this->hasUnit($orderItemUnit1)->shouldReturn(false);
+        $this->hasUnit($orderItemUnit2)->shouldReturn(true);
+    }
+
+    function it_adds_only_unit_that_is_assigned_to_it(OrderItemUnitInterface $orderItemUnit1, OrderItemInterface $orderItem)
+    {
+        $this
+            ->shouldThrow(new \LogicException('This order item unit is assigned to a different order item.'))
+            ->duringAddUnit($orderItemUnit1)
+        ;
+
+        $orderItemUnit1->getOrderItem()->willReturn($orderItem);
+        $this
+            ->shouldThrow(new \LogicException('This order item unit is assigned to a different order item.'))
+            ->duringAddUnit($orderItemUnit1)
+        ;
+    }
+
+    function it_recalculates_units_total_on_unit_price_change(
+        OrderItemUnitInterface $orderItemUnit1,
+        OrderItemUnitInterface $orderItemUnit2
+    ) {
+        $orderItemUnit1->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit1->getTotal()->willReturn(0, 100);
+        $orderItemUnit2->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit2->getTotal()->willReturn(0, 100);
+
+        $this->addUnit($orderItemUnit1);
+        $this->addUnit($orderItemUnit2);
+
+        $orderItemUnit1->recalculateTotal()->shouldBeCalled();
+        $orderItemUnit2->recalculateTotal()->shouldBeCalled();
+        $this->setUnitPrice(100);
     }
 
     function it_adds_adjustments_properly(AdjustmentInterface $adjustment)
     {
+        $adjustment->isNeutral()->willReturn(true);
         $adjustment->setAdjustable($this)->shouldBeCalled();
 
         $this->hasAdjustment($adjustment)->shouldReturn(false);
@@ -129,88 +172,286 @@ class OrderItemSpec extends ObjectBehavior
 
     function it_removes_adjustments_properly(AdjustmentInterface $adjustment)
     {
-        $this->hasAdjustment($adjustment)->shouldReturn(false);
-
+        $adjustment->isNeutral()->willReturn(true);
         $adjustment->setAdjustable($this)->shouldBeCalled();
-        $this->addAdjustment($adjustment);
 
+        $this->hasAdjustment($adjustment)->shouldReturn(false);
+        $this->addAdjustment($adjustment);
         $this->hasAdjustment($adjustment)->shouldReturn(true);
 
         $adjustment->setAdjustable(null)->shouldBeCalled();
         $adjustment->isLocked()->willReturn(false);
-        $this->removeAdjustment($adjustment);
 
+        $this->removeAdjustment($adjustment);
         $this->hasAdjustment($adjustment)->shouldReturn(false);
     }
 
-    function its_total_is_mutable()
-    {
-        $this->setTotal(5999);
-        $this->getTotal()->shouldReturn(5999);
-    }
-
-    function it_calculates_correct_total_based_on_quantity_and_unit_price()
-    {
-        $this->setQuantity(13);
-        $this->setUnitPrice(1499);
-
-        $this->calculateTotal();
-
-        $this->getTotal()->shouldReturn(19487);
-    }
-
-    function it_calculates_correct_total_based_on_adjustments(AdjustmentInterface $adjustment)
-    {
-        $this->setQuantity(13);
-        $this->setUnitPrice(1499);
-
-        $adjustment->isNeutral()->willReturn(false);
-        $adjustment->getAmount()->willReturn(-1000);
-        $adjustment->setAdjustable($this)->shouldBeCalled();
-
-        $this->addAdjustment($adjustment);
-
-        $this->calculateTotal();
-
-        $this->getTotal()->shouldReturn(18487);
-    }
-
-    function it_ignores_neutral_adjustments_when_calculating_total(
-        AdjustmentInterface $adjustment,
-        AdjustmentInterface $neutralAdjustment
+    function it_has_correct_total_based_on_unit_items(
+        OrderItemUnitInterface $orderItemUnit1,
+        OrderItemUnitInterface $orderItemUnit2
     ) {
-        $this->setQuantity(13);
-        $this->setUnitPrice(1499);
+        $orderItemUnit1->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit1->getTotal()->willReturn(1499);
+        $orderItemUnit2->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit2->getTotal()->willReturn(1499);
+
+        $this->addUnit($orderItemUnit1);
+        $this->addUnit($orderItemUnit2);
+        $this->getTotal()->shouldReturn(2998);
+    }
+
+    function it_has_correct_total_after_unit_item_remove(
+        OrderItemUnitInterface $orderItemUnit1,
+        OrderItemUnitInterface $orderItemUnit2
+    ) {
+        $orderItemUnit1->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit1->getTotal()->willReturn(2000);
+        $orderItemUnit2->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit2->getTotal()->willReturn(1000);
+
+        $this->addUnit($orderItemUnit1);
+        $this->addUnit($orderItemUnit2);
+        $this->getTotal()->shouldReturn(3000);
+
+        $this->removeUnit($orderItemUnit2);
+        $this->getTotal()->shouldReturn(2000);
+    }
+
+    function it_has_correct_total_after_negative_adjustment_add(
+        AdjustmentInterface $adjustment,
+        OrderItemUnitInterface $orderItemUnit1,
+        OrderItemUnitInterface $orderItemUnit2
+    ) {
+        $orderItemUnit1->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit1->getTotal()->willReturn(1499);
+        $orderItemUnit2->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit2->getTotal()->willReturn(1499);
 
         $adjustment->isNeutral()->willReturn(false);
         $adjustment->getAmount()->willReturn(-1000);
         $adjustment->setAdjustable($this)->shouldBeCalled();
+
+        $this->addUnit($orderItemUnit1);
+        $this->addUnit($orderItemUnit2);
         $this->addAdjustment($adjustment);
-
-        $neutralAdjustment->isNeutral()->willReturn(true);
-        $neutralAdjustment->getAmount()->willReturn(2499);
-        $neutralAdjustment->setAdjustable($this)->shouldBeCalled();
-        $this->addAdjustment($neutralAdjustment);
-
-        $this->calculateTotal();
-
-        $this->getTotal()->shouldReturn(18487);
+        $this->getTotal()->shouldReturn(1998);
     }
 
-    function it_calculates_correct_total_when_adjustment_is_bigger_than_cost(AdjustmentInterface $adjustment)
+    function it_has_correct_total_after_adjustment_add_and_remove(AdjustmentInterface $adjustment)
     {
-        $this->setQuantity(1);
-        $this->setUnitPrice(1500);
+        $adjustment->isNeutral()->willReturn(false);
+        $adjustment->getAmount()->willReturn(200);
+        $adjustment->setAdjustable($this)->shouldBeCalled();
+
+        $this->addAdjustment($adjustment);
+        $this->getTotal()->shouldReturn(200);
+
+        $adjustment->setAdjustable(null)->shouldBeCalled();
+        $adjustment->isLocked()->willReturn(false);
+
+        $this->removeAdjustment($adjustment);
+        $this->getTotal()->shouldReturn(0);
+    }
+
+    function it_has_correct_total_after_neutral_adjustment_add_and_remove(AdjustmentInterface $adjustment)
+    {
+        $adjustment->isNeutral()->willReturn(true);
+        $adjustment->getAmount()->willReturn(200);
+        $adjustment->setAdjustable($this)->shouldBeCalled();
+
+        $this->addAdjustment($adjustment);
+        $this->getTotal()->shouldReturn(0);
+
+        $adjustment->setAdjustable(null)->shouldBeCalled();
+        $adjustment->isLocked()->willReturn(false);
+
+        $this->removeAdjustment($adjustment);
+        $this->getTotal()->shouldReturn(0);
+    }
+
+    function it_has_correct_total_after_adjustments_clear(
+        AdjustmentInterface $adjustment1,
+        AdjustmentInterface $adjustment2
+    ) {
+        $adjustment1->isNeutral()->willReturn(false);
+        $adjustment1->getAmount()->willReturn(200);
+        $adjustment1->setAdjustable($this)->shouldBeCalled();
+
+        $adjustment2->isNeutral()->willReturn(false);
+        $adjustment2->getAmount()->willReturn(300);
+        $adjustment2->setAdjustable($this)->shouldBeCalled();
+
+        $this->addAdjustment($adjustment1);
+        $this->addAdjustment($adjustment2);
+        $this->getTotal()->shouldReturn(500);
+
+        $this->clearAdjustments();
+        $this->getTotal()->shouldReturn(0);
+    }
+
+    function it_has_0_total_when_adjustment_decreases_total_under_0(
+        AdjustmentInterface $adjustment,
+        OrderItemUnitInterface $orderItemUnit1
+    ) {
+        $orderItemUnit1->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit1->getTotal()->willReturn(1499);
 
         $adjustment->isNeutral()->willReturn(false);
         $adjustment->getAmount()->willReturn(-2000);
         $adjustment->setAdjustable($this)->shouldBeCalled();
 
+        $this->addUnit($orderItemUnit1);
         $this->addAdjustment($adjustment);
+        $this->getTotal()->shouldReturn(0);
+    }
 
-        $this->calculateTotal();
+    function it_has_correct_total_after_unit_price_change(
+        OrderItemUnitInterface $orderItemUnit1,
+        OrderItemUnitInterface $orderItemUnit2
+    ) {
+        $orderItemUnit1->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit1->getTotal()->willReturn(0, 100);
+        $orderItemUnit2->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit2->getTotal()->willReturn(0, 100);
+
+        $this->addUnit($orderItemUnit1);
+        $this->addUnit($orderItemUnit2);
+
+        $orderItemUnit1->recalculateTotal()->shouldBeCalled();
+        $orderItemUnit2->recalculateTotal()->shouldBeCalled();
+        $this->setUnitPrice(100);
+        $this->getTotal()->shouldReturn(200);
+    }
+
+    function it_has_correct_total_after_order_item_unit_total_change(
+        OrderItemUnitInterface $orderItemUnit1,
+        OrderItemUnitInterface $orderItemUnit2
+    ) {
+        $orderItemUnit1->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit1->getTotal()->willReturn(0);
+        $orderItemUnit2->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit2->getTotal()->willReturn(0, 100);
+
+        $this->addUnit($orderItemUnit1);
+        $this->addUnit($orderItemUnit2);
 
         $this->getTotal()->shouldReturn(0);
+        $this->recalculateUnitsTotal();
+        $this->getTotal()->shouldReturn(100);
+    }
+
+    function it_has_correct_total_after_adjustment_amount_change(
+        AdjustmentInterface $adjustment1,
+        AdjustmentInterface $adjustment2
+    ) {
+        $adjustment1->getAmount()->willReturn(100);
+        $adjustment1->isNeutral()->willReturn(false);
+        $adjustment1->setAdjustable($this)->shouldBeCalled();
+        $adjustment2->getAmount()->willReturn(500, 300);
+        $adjustment2->isNeutral()->willReturn(false);
+        $adjustment2->setAdjustable($this)->shouldBeCalled();
+
+        $this->addAdjustment($adjustment1);
+        $this->addAdjustment($adjustment2);
+
+        $this->getTotal()->shouldReturn(600);
+        $this->recalculateAdjustmentsTotal();
+        $this->getTotal()->shouldReturn(400);
+    }
+
+    function it_returns_correct_adjustments_total(
+        AdjustmentInterface $adjustment1,
+        AdjustmentInterface $adjustment2
+    ) {
+        $adjustment1->getAmount()->willReturn(100);
+        $adjustment1->isNeutral()->willReturn(false);
+        $adjustment1->setAdjustable($this)->shouldBeCalled();
+        $adjustment2->getAmount()->willReturn(500);
+        $adjustment2->isNeutral()->willReturn(false);
+        $adjustment2->setAdjustable($this)->shouldBeCalled();
+
+        $this->addAdjustment($adjustment1);
+        $this->addAdjustment($adjustment2);
+
+        $this->getAdjustmentsTotal()->shouldReturn(600);
+    }
+
+    function it_returns_correct_adjustments_total_by_type(
+        AdjustmentInterface $adjustment1,
+        AdjustmentInterface $adjustment2,
+        AdjustmentInterface $adjustment3
+    ) {
+        $adjustment1->getType()->willReturn('tax');
+        $adjustment1->getAmount()->willReturn(200);
+        $adjustment1->isNeutral()->willReturn(false);
+        $adjustment1->setAdjustable($this)->shouldBeCalled();
+        $adjustment2->getType()->willReturn('tax');
+        $adjustment2->getAmount()->willReturn(-50);
+        $adjustment2->isNeutral()->willReturn(false);
+        $adjustment2->setAdjustable($this)->shouldBeCalled();
+
+        $adjustment3->getType()->willReturn('promotion');
+        $adjustment3->getAmount()->willReturn(-1000);
+        $adjustment3->isNeutral()->willReturn(false);
+        $adjustment3->setAdjustable($this)->shouldBeCalled();
+
+        $this->addAdjustment($adjustment1);
+        $this->addAdjustment($adjustment2);
+        $this->addAdjustment($adjustment3);
+
+        $this->getAdjustmentsTotal('tax')->shouldReturn(150);
+        $this->getAdjustmentsTotal('promotion')->shouldReturn(-1000);
+        $this->getAdjustmentsTotal('any')->shouldReturn(0);
+    }
+
+    function it_returns_correct_adjustments_total_recursively(
+        AdjustmentInterface $adjustment1,
+        OrderItemUnitInterface $orderItemUnit1,
+        OrderItemUnitInterface $orderItemUnit2
+    ) {
+        $adjustment1->getAmount()->willReturn(200);
+        $adjustment1->isNeutral()->willReturn(false);
+        $adjustment1->setAdjustable($this)->shouldBeCalled();
+
+        $orderItemUnit1->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit1->getTotal()->willReturn(500);
+        $orderItemUnit1->getAdjustmentsTotal(null)->willReturn(150);
+        $orderItemUnit2->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit2->getTotal()->willReturn(300);
+        $orderItemUnit2->getAdjustmentsTotal(null)->willReturn(100);
+
+        $this->addAdjustment($adjustment1);
+        $this->addUnit($orderItemUnit1);
+        $this->addUnit($orderItemUnit2);
+
+        $this->getAdjustmentsTotalRecursively()->shouldReturn(450);
+    }
+
+    function it_returns_correct_adjustments_total_by_type_recursively(
+        AdjustmentInterface $adjustment1,
+        OrderItemUnitInterface $orderItemUnit1,
+        OrderItemUnitInterface $orderItemUnit2
+    ) {
+        $adjustment1->getType()->willReturn('tax');
+        $adjustment1->getAmount()->willReturn(200);
+        $adjustment1->isNeutral()->willReturn(false);
+        $adjustment1->setAdjustable($this)->shouldBeCalled();
+
+        $orderItemUnit1->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit1->getTotal()->willReturn(500);
+        $orderItemUnit1->getAdjustmentsTotal('tax')->willReturn(150);
+        $orderItemUnit1->getAdjustmentsTotal('promotion')->willReturn(30);
+        $orderItemUnit2->getOrderItem()->willReturn($this->getWrappedObject());
+        $orderItemUnit2->getTotal()->willReturn(300);
+        $orderItemUnit2->getAdjustmentsTotal('tax')->willReturn(100);
+        $orderItemUnit2->getAdjustmentsTotal('promotion')->willReturn(0);
+
+        $this->addAdjustment($adjustment1);
+        $this->addUnit($orderItemUnit1);
+        $this->addUnit($orderItemUnit2);
+
+        $this->getAdjustmentsTotalRecursively('tax')->shouldReturn(450);
+        $this->getAdjustmentsTotalRecursively('promotion')->shouldReturn(30);
     }
 
     function it_ignores_merging_same_items()
@@ -246,7 +487,7 @@ class OrderItemSpec extends ObjectBehavior
         $item->equals($this)->willReturn(false);
 
         $this
-            ->shouldThrow(new \RuntimeException('Given item cannot be merged.'))
+            ->shouldThrow(new \LogicException('Given item cannot be merged.'))
             ->duringMerge($item);
     }
 

--- a/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
@@ -492,20 +492,4 @@ class OrderItemSpec extends ObjectBehavior
         $this->setImmutable(true);
         $this->isImmutable()->shouldReturn(true);
     }
-
-    function it_adds_and_removes_units(OrderItemUnitInterface $unit1, OrderItemUnitInterface $unit2)
-    {
-        $this->getUnits()->shouldHaveType('Doctrine\Common\Collections\ArrayCollection');
-
-        $this->addUnit($unit1);
-        $this->addUnit($unit2);
-
-        $this->shouldHaveUnit($unit1);
-        $this->shouldHaveUnit($unit2);
-
-        $this->removeUnit($unit1);
-
-        $this->shouldNotHaveUnit($unit1);
-        $this->shouldHaveUnit($unit2);
-    }
 }

--- a/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
@@ -65,9 +65,9 @@ class OrderItemSpec extends ObjectBehavior
         $this->getOrder()->shouldReturn(null);
     }
 
-    function it_has_quantity_equal_to_1_by_default()
+    function it_has_quantity_equal_to_0_by_default()
     {
-        $this->getQuantity()->shouldReturn(1);
+        $this->getQuantity()->shouldReturn(0);
     }
 
     function its_quantity_is_mutable()
@@ -453,7 +453,7 @@ class OrderItemSpec extends ObjectBehavior
     function it_ignores_merging_same_items()
     {
         $this->merge($this);
-        $this->getQuantity()->shouldReturn(1);
+        $this->getQuantity()->shouldReturn(0);
     }
 
     function it_merges_an_equal_item_by_summing_quantities(OrderItemInterface $item)

--- a/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
@@ -30,7 +30,7 @@ class OrderItemSpec extends ObjectBehavior
         $this->shouldHaveType('Sylius\Component\Order\Model\OrderItem');
     }
 
-    function it_implements_sylius_order_item_interface()
+    function it_implements_Sylius_order_item_interface()
     {
         $this->shouldImplement(OrderItemInterface::class);
     }
@@ -434,67 +434,6 @@ class OrderItemSpec extends ObjectBehavior
 
         $this->getAdjustmentsTotalRecursively('tax')->shouldReturn(450);
         $this->getAdjustmentsTotalRecursively('promotion')->shouldReturn(30);
-    }
-
-    function it_ignores_merging_same_items()
-    {
-        $this->merge($this);
-        $this->getQuantity()->shouldReturn(0);
-    }
-
-    function it_merges_an_equal_item_by_summing_quantities(
-        OrderItemInterface $item,
-        OrderItemUnitInterface $unit1,
-        OrderItemUnitInterface $unit2,
-        OrderItemUnitInterface $unit3
-    ) {
-        $unit1->getTotal()->willReturn(100);
-        $unit2->getTotal()->willReturn(100);
-        $unit3->getTotal()->willReturn(100);
-        $unit1->getOrderItem()->willReturn($this);
-        $unit2->getOrderItem()->willReturn($this);
-        $unit3->getOrderItem()->willReturn($this);
-        $this->addUnit($unit1);
-        $this->addUnit($unit2);
-        $this->addUnit($unit3);
-
-        $item->getQuantity()->willReturn(7);
-        $item->equals($this)->willReturn(true);
-
-        $this->merge($item);
-        $this->getQuantity()->shouldReturn(10);
-    }
-
-    function it_merges_a_known_equal_item_without_calling_equals(
-        OrderItemInterface $item,
-        OrderItemUnitInterface $unit1,
-        OrderItemUnitInterface $unit2,
-        OrderItemUnitInterface $unit3
-    ) {
-        $unit1->getTotal()->willReturn(100);
-        $unit2->getTotal()->willReturn(100);
-        $unit3->getTotal()->willReturn(100);
-        $unit1->getOrderItem()->willReturn($this);
-        $unit2->getOrderItem()->willReturn($this);
-        $unit3->getOrderItem()->willReturn($this);
-        $this->addUnit($unit1);
-        $this->addUnit($unit2);
-        $this->addUnit($unit3);
-
-        $item->getQuantity()->willReturn(7);
-        $item->equals($this)->shouldNotBeCalled();
-
-        $this->merge($item, false);
-        $this->getQuantity()->shouldReturn(10);
-    }
-
-    function it_throws_exception_when_merging_unequal_item(OrderItemInterface $item)
-    {
-        $item->equals($this)->willReturn(false);
-
-        $this
-            ->shouldThrow(new \LogicException('Given item cannot be merged.'))
-            ->duringMerge($item);
     }
 
     function it_can_be_immutable()

--- a/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
@@ -271,26 +271,4 @@ class OrderItemSpec extends ObjectBehavior
         $this->shouldNotHaveUnit($unit1);
         $this->shouldHaveUnit($unit2);
     }
-
-    function it_can_removes_its_units_by_index(OrderItemUnitInterface $unit1, OrderItemUnitInterface $unit2)
-    {
-        $this->addUnit($unit1);
-        $this->addUnit($unit2);
-
-        $this->shouldHaveUnit($unit1);
-        $this->shouldHaveUnit($unit2);
-
-        $this->removeUnitByIndex(0);
-
-        $this->shouldNotHaveUnit($unit1);
-        $this->shouldHaveUnit($unit2);
-    }
-
-    function it_does_nothing_if_there_is_no_unit_to_remove_on_given_index(OrderItemUnitInterface $unit)
-    {
-        $this->addUnit($unit);
-        $this->removeUnitByIndex(2);
-
-        $this->shouldHaveUnit($unit);
-    }
 }

--- a/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
@@ -263,12 +263,34 @@ class OrderItemSpec extends ObjectBehavior
         $this->addUnit($unit1);
         $this->addUnit($unit2);
 
-        $this->hasUnit($unit1)->shouldReturn(true);
-        $this->hasUnit($unit2)->shouldReturn(true);
+        $this->shouldHaveUnit($unit1);
+        $this->shouldHaveUnit($unit2);
 
         $this->removeUnit($unit1);
 
-        $this->hasUnit($unit1)->shouldReturn(false);
-        $this->hasUnit($unit2)->shouldReturn(true);
+        $this->shouldNotHaveUnit($unit1);
+        $this->shouldHaveUnit($unit2);
+    }
+
+    function it_can_removes_its_units_by_index(OrderItemUnitInterface $unit1, OrderItemUnitInterface $unit2)
+    {
+        $this->addUnit($unit1);
+        $this->addUnit($unit2);
+
+        $this->shouldHaveUnit($unit1);
+        $this->shouldHaveUnit($unit2);
+
+        $this->removeUnitByIndex(0);
+
+        $this->shouldNotHaveUnit($unit1);
+        $this->shouldHaveUnit($unit2);
+    }
+
+    function it_does_nothing_if_there_is_no_unit_to_remove_on_given_index(OrderItemUnitInterface $unit)
+    {
+        $this->addUnit($unit);
+        $this->removeUnitByIndex(2);
+
+        $this->shouldHaveUnit($unit);
     }
 }

--- a/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
@@ -70,12 +70,6 @@ class OrderItemSpec extends ObjectBehavior
         $this->getQuantity()->shouldReturn(0);
     }
 
-    function its_quantity_is_mutable()
-    {
-        $this->setQuantity(8);
-        $this->getQuantity()->shouldReturn(8);
-    }
-
     function it_has_unit_price_equal_to_0_by_default()
     {
         $this->getUnitPrice()->shouldReturn(0);
@@ -96,14 +90,6 @@ class OrderItemSpec extends ObjectBehavior
     function it_has_total_equal_to_0_by_default()
     {
         $this->getTotal()->shouldReturn(0);
-    }
-
-    function it_throws_exception_when_quantity_is_less_than_1()
-    {
-        $this
-            ->shouldThrow(new \OutOfRangeException('Quantity must be greater than 0.'))
-            ->duringSetQuantity(0)
-        ;
     }
 
     function it_initializes_adjustments_collection_by_default()
@@ -456,9 +442,21 @@ class OrderItemSpec extends ObjectBehavior
         $this->getQuantity()->shouldReturn(0);
     }
 
-    function it_merges_an_equal_item_by_summing_quantities(OrderItemInterface $item)
-    {
-        $this->setQuantity(3);
+    function it_merges_an_equal_item_by_summing_quantities(
+        OrderItemInterface $item,
+        OrderItemUnitInterface $unit1,
+        OrderItemUnitInterface $unit2,
+        OrderItemUnitInterface $unit3
+    ) {
+        $unit1->getTotal()->willReturn(100);
+        $unit2->getTotal()->willReturn(100);
+        $unit3->getTotal()->willReturn(100);
+        $unit1->getOrderItem()->willReturn($this);
+        $unit2->getOrderItem()->willReturn($this);
+        $unit3->getOrderItem()->willReturn($this);
+        $this->addUnit($unit1);
+        $this->addUnit($unit2);
+        $this->addUnit($unit3);
 
         $item->getQuantity()->willReturn(7);
         $item->equals($this)->willReturn(true);
@@ -467,9 +465,21 @@ class OrderItemSpec extends ObjectBehavior
         $this->getQuantity()->shouldReturn(10);
     }
 
-    function it_merges_a_known_equal_item_without_calling_equals(OrderItemInterface $item)
-    {
-        $this->setQuantity(3);
+    function it_merges_a_known_equal_item_without_calling_equals(
+        OrderItemInterface $item,
+        OrderItemUnitInterface $unit1,
+        OrderItemUnitInterface $unit2,
+        OrderItemUnitInterface $unit3
+    ) {
+        $unit1->getTotal()->willReturn(100);
+        $unit2->getTotal()->willReturn(100);
+        $unit3->getTotal()->willReturn(100);
+        $unit1->getOrderItem()->willReturn($this);
+        $unit2->getOrderItem()->willReturn($this);
+        $unit3->getOrderItem()->willReturn($this);
+        $this->addUnit($unit1);
+        $this->addUnit($unit2);
+        $this->addUnit($unit3);
 
         $item->getQuantity()->willReturn(7);
         $item->equals($this)->shouldNotBeCalled();

--- a/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
@@ -65,6 +65,14 @@ class OrderItemSpec extends ObjectBehavior
         $this->getOrder()->shouldReturn(null);
     }
 
+    function it_does_not_set_order_if_it_is_already_set(OrderInterface $order)
+    {
+        $this->setOrder($order);
+        $this->setOrder($order);
+
+        $order->addItem($this)->shouldBeCalledTimes(1);
+    }
+
     function it_has_quantity_equal_to_0_by_default()
     {
         $this->getQuantity()->shouldReturn(0);

--- a/src/Sylius/Component/Order/spec/Model/OrderItemUnitSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemUnitSpec.php
@@ -157,7 +157,7 @@ class OrderItemUnitSpec extends ObjectBehavior
         $this->getTotal()->shouldReturn(1000);
     }
 
-    function it_recalculates_its_total_properly_after_order_item_unit_price_change(
+    function it_has_proper_total_after_order_item_unit_price_change(
         AdjustmentInterface $adjustment1,
         AdjustmentInterface $adjustment2,
         OrderItemInterface $orderItem
@@ -177,7 +177,6 @@ class OrderItemUnitSpec extends ObjectBehavior
 
         $orderItem->getUnitPrice()->willReturn(500);
 
-        $this->recalculateTotal();
         $this->getTotal()->shouldReturn(650);
     }
 

--- a/src/Sylius/Component/Order/spec/Model/OrderItemUnitSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemUnitSpec.php
@@ -12,15 +12,24 @@
 namespace spec\Sylius\Component\Order\Model;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Sylius\Component\Order\Model\AdjustmentInterface;
 use Sylius\Component\Order\Model\OrderItemInterface;
 use Sylius\Component\Order\Model\OrderItemUnitInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
  */
 class OrderItemUnitSpec extends ObjectBehavior
 {
+    function let(OrderItemInterface $orderItem)
+    {
+        $orderItem->getUnitPrice()->willReturn(1000);
+        $orderItem->addUnit(Argument::type(OrderItemUnitInterface::class))->shouldBeCalled();
+        $this->beConstructedWith($orderItem);
+    }
+
     function it_is_initializable()
     {
         $this->shouldHaveType('Sylius\Component\Order\Model\OrderItemUnit');
@@ -31,130 +40,168 @@ class OrderItemUnitSpec extends ObjectBehavior
         $this->shouldImplement(OrderItemUnitInterface::class);
     }
 
-    function it_has_0_total_as_default()
+    function it_has_correct_total_when_there_are_no_adjustments()
     {
-        $this->getTotal()->shouldReturn(0);
+        $this->getTotal()->shouldReturn(1000);
     }
 
-    function it_adds_and_removes_adjustments(AdjustmentInterface $adjustment)
+    function it_adds_and_removes_adjustments(AdjustmentInterface $adjustment, OrderItemInterface $orderItem)
     {
+        $orderItem->recalculateUnitsTotal()->shouldBeCalled();
+
+        $adjustment->isNeutral()->willReturn(true);
+        $adjustment->setAdjustable($this)->shouldBeCalled();
+
         $this->addAdjustment($adjustment);
         $this->hasAdjustment($adjustment)->shouldReturn(true);
+
+        $adjustment->setAdjustable(null)->shouldBeCalled();
+        $adjustment->isLocked()->willReturn(false);
 
         $this->removeAdjustment($adjustment);
         $this->hasAdjustment($adjustment)->shouldReturn(false);
     }
 
-    function it_calculates_its_total(AdjustmentInterface $adjustment1, AdjustmentInterface $adjustment2, OrderItemInterface $orderItem)
-    {
-        $adjustment1->isNeutral()->willReturn(false);
-        $adjustment1->setAdjustable($this)->shouldBeCalled();
+    function it_does_not_remove_adjustment_when_it_is_locked(
+        AdjustmentInterface $adjustment,
+        OrderItemInterface $orderItem
+    ) {
+        $orderItem->recalculateUnitsTotal()->shouldBeCalledTimes(1);
 
-        $adjustment2->isNeutral()->willReturn(false);
-        $adjustment2->setAdjustable($this)->shouldBeCalled();
+        $adjustment->isNeutral()->willReturn(true);
+        $adjustment->setAdjustable($this)->shouldBeCalled();
 
-        $adjustment1->getAmount()->willReturn(100);
-        $adjustment2->getAmount()->willReturn(50);
+        $this->addAdjustment($adjustment);
 
-        $this->addAdjustment($adjustment1);
-        $this->addAdjustment($adjustment2);
+        $adjustment->setAdjustable(null)->shouldNotBeCalled();
+        $adjustment->isLocked()->willReturn(true);
 
-        $this->setOrderItem($orderItem);
-        $orderItem->getUnitPrice()->willReturn(1000);
-
-        $this->calculateTotal();
-
-        $this->getTotal()->shouldReturn(1150);
+        $this->removeAdjustment($adjustment);
+        $this->hasAdjustment($adjustment)->shouldReturn(true);
     }
 
-    function it_calculates_its_total_properly_after_order_item_unit_price_change(AdjustmentInterface $adjustment1, AdjustmentInterface $adjustment2, OrderItemInterface $orderItem)
-    {
-        $adjustment1->isNeutral()->willReturn(false);
-        $adjustment1->setAdjustable($this)->shouldBeCalled();
-
-        $adjustment2->isNeutral()->willReturn(false);
-        $adjustment2->setAdjustable($this)->shouldBeCalled();
-
-        $adjustment1->getAmount()->willReturn(100);
-        $adjustment2->getAmount()->willReturn(50);
-
-        $this->addAdjustment($adjustment1);
-        $this->addAdjustment($adjustment2);
-
-        $this->setOrderItem($orderItem);
-        $orderItem->getUnitPrice()->willReturn(1000, 4000);
-
-        $this->calculateTotal();
-
-        $this->getTotal()->shouldReturn(1150);
-
-        $this->calculateTotal();
-
-        $this->getTotal()->shouldReturn(4150);
-    }
-
-    function it_calculates_its_total_properly_after_adjustments_modification(
+    function it_has_correct_total_after_adjustment_add_and_remove(
         AdjustmentInterface $adjustment1,
         AdjustmentInterface $adjustment2,
         AdjustmentInterface $adjustment3,
         OrderItemInterface $orderItem
     ) {
+        $orderItem->recalculateUnitsTotal()->shouldBeCalledTimes(4);
+
         $adjustment1->isNeutral()->willReturn(false);
         $adjustment1->setAdjustable($this)->shouldBeCalled();
         $adjustment1->isLocked()->willReturn(false);
         $adjustment1->setAdjustable(null)->shouldBeCalled();
+        $adjustment1->getAmount()->willReturn(100);
 
         $adjustment2->isNeutral()->willReturn(false);
         $adjustment2->setAdjustable($this)->shouldBeCalled();
+        $adjustment2->getAmount()->willReturn(50);
 
         $adjustment3->isNeutral()->willReturn(false);
         $adjustment3->setAdjustable($this)->shouldBeCalled();
-
-        $adjustment1->getAmount()->willReturn(100);
-        $adjustment2->getAmount()->willReturn(50);
         $adjustment3->getAmount()->willReturn(250);
 
         $this->addAdjustment($adjustment1);
         $this->addAdjustment($adjustment2);
 
-        $this->setOrderItem($orderItem);
-        $orderItem->getUnitPrice()->willReturn(1000);
-
-        $this->calculateTotal();
-
         $this->getTotal()->shouldReturn(1150);
 
-        $this->removeAdjustment($adjustment1);
         $this->addAdjustment($adjustment3);
-        $this->calculateTotal();
+        $this->removeAdjustment($adjustment1);
 
         $this->getTotal()->shouldReturn(1300);
     }
 
-    function it_calculates_its_total_properly_after_adjustments_clear(AdjustmentInterface $adjustment1, AdjustmentInterface $adjustment2, OrderItemInterface $orderItem)
-    {
+    function it_has_correct_total_after_adjustments_clear(
+        AdjustmentInterface $adjustment1,
+        AdjustmentInterface $adjustment2,
+        OrderItemInterface $orderItem
+    ) {
+        $orderItem->recalculateUnitsTotal()->shouldBeCalled(3);
+
         $adjustment1->isNeutral()->willReturn(false);
+        $adjustment1->getAmount()->willReturn(200);
         $adjustment1->setAdjustable($this)->shouldBeCalled();
 
         $adjustment2->isNeutral()->willReturn(false);
+        $adjustment2->getAmount()->willReturn(300);
         $adjustment2->setAdjustable($this)->shouldBeCalled();
 
+        $this->addAdjustment($adjustment1);
+        $this->addAdjustment($adjustment2);
+
+        $this->getTotal()->shouldReturn(1500);
+
+        $this->clearAdjustments();
+        $this->getTotal()->shouldReturn(1000);
+    }
+
+    function it_has_correct_total_after_neutral_adjustment_add_and_remove(
+        AdjustmentInterface $adjustment,
+        OrderItemInterface $orderItem
+    ) {
+        $orderItem->recalculateUnitsTotal()->shouldBeCalled();
+
+        $adjustment->isNeutral()->willReturn(true);
+        $adjustment->getAmount()->willReturn(200);
+        $adjustment->setAdjustable($this)->shouldBeCalled();
+
+        $this->addAdjustment($adjustment);
+        $this->getTotal()->shouldReturn(1000);
+
+        $adjustment->setAdjustable(null)->shouldBeCalled();
+        $adjustment->isLocked()->willReturn(false);
+
+        $this->removeAdjustment($adjustment);
+        $this->getTotal()->shouldReturn(1000);
+    }
+
+    function it_recalculates_its_total_properly_after_order_item_unit_price_change(
+        AdjustmentInterface $adjustment1,
+        AdjustmentInterface $adjustment2,
+        OrderItemInterface $orderItem
+    ) {
+        $orderItem->recalculateUnitsTotal()->shouldBeCalledTimes(2);
+
+        $adjustment1->isNeutral()->willReturn(false);
+        $adjustment1->setAdjustable($this)->shouldBeCalled();
         $adjustment1->getAmount()->willReturn(100);
+
+        $adjustment2->isNeutral()->willReturn(false);
+        $adjustment2->setAdjustable($this)->shouldBeCalled();
         $adjustment2->getAmount()->willReturn(50);
 
         $this->addAdjustment($adjustment1);
         $this->addAdjustment($adjustment2);
 
-        $this->setOrderItem($orderItem);
-        $orderItem->getUnitPrice()->willReturn(1000);
+        $orderItem->getUnitPrice()->willReturn(500);
 
-        $this->calculateTotal();
+        $this->recalculateTotal();
+        $this->getTotal()->shouldReturn(650);
+    }
 
-        $this->getTotal()->shouldReturn(1150);
+    function it_recalculates_its_total_properly_after_adjustment_amount_change(
+        AdjustmentInterface $adjustment1,
+        AdjustmentInterface $adjustment2,
+        OrderItemInterface $orderItem
+    ) {
+        $orderItem->recalculateUnitsTotal()->shouldBeCalledTimes(2);
 
-        $this->clearAdjustments();
-        $this->calculateTotal();
+        $adjustment1->isNeutral()->willReturn(false);
+        $adjustment1->setAdjustable($this)->shouldBeCalled();
+        $adjustment1->getAmount()->willReturn(100);
 
-        $this->getTotal()->shouldReturn(1000);
+        $adjustment2->isNeutral()->willReturn(false);
+        $adjustment2->setAdjustable($this)->shouldBeCalled();
+        $adjustment2->getAmount()->willReturn(50);
+
+        $this->addAdjustment($adjustment1);
+        $this->addAdjustment($adjustment2);
+
+        $adjustment2->getAmount()->willReturn(150);
+
+        $this->recalculateAdjustmentsTotal();
+        $this->getTotal()->shouldReturn(1250);
     }
 }

--- a/src/Sylius/Component/Order/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderSpec.php
@@ -387,23 +387,6 @@ class OrderSpec extends ObjectBehavior
         $this->shouldBeEmpty();
     }
 
-    function it_merges_equal_items(OrderItemInterface $item1, OrderItemInterface $item2)
-    {
-        $item1->setOrder($this)->shouldBeCalled();
-        $item1->merge($item2, false)->shouldBeCalled();
-        $item1->getTotal()->willReturn(1000);
-
-        $item2->getTotal()->willReturn(1000);
-
-        $item1->equals($item2)->willReturn(true);
-        $item2->equals($item1)->willReturn(true);
-
-        $this->addItem($item1);
-        $this->addItem($item2);
-
-        $this->countItems()->shouldReturn(1);
-    }
-
     function it_should_be_able_to_clear_items(OrderItemInterface $item)
     {
         $this->shouldBeEmpty();

--- a/src/Sylius/Component/Order/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderSpec.php
@@ -161,10 +161,6 @@ class OrderSpec extends ObjectBehavior
         OrderItemInterface $item2,
         OrderItemInterface $item3
     ) {
-        $item1->calculateTotal()->shouldBeCalled();
-        $item2->calculateTotal()->shouldBeCalled();
-        $item3->calculateTotal()->shouldBeCalled();
-
         $item1->getTotal()->willReturn(29999);
         $item2->getTotal()->willReturn(45000);
         $item3->getTotal()->willReturn(250);
@@ -239,7 +235,7 @@ class OrderSpec extends ObjectBehavior
         $this->addAdjustment($adjustment2);
         $this->addAdjustment($adjustment3);
 
-        $this->calculateAdjustmentsTotal();
+        $this->recalculateAdjustmentsTotal();
 
         $this->getAdjustmentsTotal()->shouldReturn(6930);
     }
@@ -277,9 +273,6 @@ class OrderSpec extends ObjectBehavior
 
     function it_calculates_correct_total(OrderItemInterface $item1, OrderItemInterface $item2, AdjustmentInterface $adjustment1, AdjustmentInterface $adjustment2)
     {
-        $item1->calculateTotal()->shouldBeCalled();
-        $item2->calculateTotal()->shouldBeCalled();
-
         $item1->getTotal()->willReturn(29999);
         $item2->getTotal()->willReturn(45000);
 
@@ -309,9 +302,6 @@ class OrderSpec extends ObjectBehavior
 
     function it_ignores_neutral_adjustments_when_calculating_total(OrderItemInterface $item1, OrderItemInterface $item2, AdjustmentInterface $adjustment1, AdjustmentInterface $adjustment2)
     {
-        $item1->calculateTotal()->shouldBeCalled();
-        $item2->calculateTotal()->shouldBeCalled();
-
         $item1->getTotal()->willReturn(29999);
         $item2->getTotal()->willReturn(45000);
 
@@ -341,8 +331,6 @@ class OrderSpec extends ObjectBehavior
 
     function it_calculates_correct_total_when_adjustment_is_bigger_than_cost(OrderItemInterface $item, AdjustmentInterface $adjustment)
     {
-        $item->calculateTotal()->shouldBeCalled();
-
         $item->getTotal()->willReturn(45000);
 
         $item->equals(Argument::any())->willReturn(false);

--- a/src/Sylius/Component/Order/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderSpec.php
@@ -145,17 +145,6 @@ class OrderSpec extends ObjectBehavior
         $this->getItemsTotal()->shouldReturn(0);
     }
 
-    function its_items_total_should_accept_only_integer()
-    {
-        $this->setItemsTotal(4498);
-        $this->getItemsTotal()->shouldBeInteger();
-        $this->shouldThrow(\InvalidArgumentException::class)->duringSetItemsTotal(44.98 * 100);
-        $this->shouldThrow(\InvalidArgumentException::class)->duringSetItemsTotal('4498');
-        $this->shouldThrow(\InvalidArgumentException::class)->duringSetItemsTotal(round(44.98 * 100));
-        $this->shouldThrow(\InvalidArgumentException::class)->duringSetItemsTotal(array(4498));
-        $this->shouldThrow(\InvalidArgumentException::class)->duringSetItemsTotal(new \stdClass());
-    }
-
     function it_calculates_correct_items_total(
         OrderItemInterface $item1,
         OrderItemInterface $item2,
@@ -177,8 +166,6 @@ class OrderSpec extends ObjectBehavior
         $this->addItem($item2);
         $this->addItem($item3);
 
-        $this->calculateItemsTotal();
-
         $this->getItemsTotal()->shouldReturn(75249);
     }
 
@@ -190,6 +177,7 @@ class OrderSpec extends ObjectBehavior
     function it_adds_adjustments_properly(AdjustmentInterface $adjustment)
     {
         $adjustment->setAdjustable($this)->shouldBeCalled();
+        $adjustment->isNeutral()->willReturn(true);
 
         $this->hasAdjustment($adjustment)->shouldReturn(false);
         $this->addAdjustment($adjustment);
@@ -201,8 +189,9 @@ class OrderSpec extends ObjectBehavior
         $this->hasAdjustment($adjustment)->shouldReturn(false);
 
         $adjustment->setAdjustable($this)->shouldBeCalled();
-        $this->addAdjustment($adjustment);
+        $adjustment->isNeutral()->willReturn(true);
 
+        $this->addAdjustment($adjustment);
         $this->hasAdjustment($adjustment)->shouldReturn(true);
 
         $adjustment->isLocked()->willReturn(false);
@@ -235,8 +224,6 @@ class OrderSpec extends ObjectBehavior
         $this->addAdjustment($adjustment2);
         $this->addAdjustment($adjustment3);
 
-        $this->recalculateAdjustmentsTotal();
-
         $this->getAdjustmentsTotal()->shouldReturn(6930);
     }
 
@@ -245,25 +232,16 @@ class OrderSpec extends ObjectBehavior
         $this->getTotal()->shouldReturn(0);
     }
 
-    function its_total_should_accept_only_integer()
-    {
-        $this->setTotal(4498);
-        $this->getTotal()->shouldBeInteger();
-        $this->shouldThrow(\InvalidArgumentException::class)->duringSetTotal(44.98 * 100);
-        $this->shouldThrow(\InvalidArgumentException::class)->duringSetTotal('4498');
-        $this->shouldThrow(\InvalidArgumentException::class)->duringSetTotal(round(44.98 * 100));
-        $this->shouldThrow(\InvalidArgumentException::class)->duringSetTotal(array(4498));
-        $this->shouldThrow(\InvalidArgumentException::class)->duringSetTotal(new \stdClass());
-    }
-
     function it_has_total_quantity(OrderItemInterface $orderItem1, OrderItemInterface $orderItem2)
     {
         $orderItem1->getQuantity()->willReturn(10);
         $orderItem1->setOrder($this)->shouldBeCalled();
+        $orderItem1->getTotal()->willReturn(500);
 
         $orderItem2->getQuantity()->willReturn(30);
         $orderItem2->setOrder($this)->shouldBeCalled();
         $orderItem2->equals($orderItem1)->willReturn(false);
+        $orderItem2->getTotal()->willReturn(1000);
 
         $this->addItem($orderItem1);
         $this->addItem($orderItem2);
@@ -295,7 +273,54 @@ class OrderSpec extends ObjectBehavior
         $this->addAdjustment($adjustment1);
         $this->addAdjustment($adjustment2);
 
-        $this->calculateTotal();
+        $this->getTotal()->shouldReturn(80000);
+    }
+
+    function it_calculates_correct_total_after_items_and_adjustments_changes(
+        AdjustmentInterface $adjustment1,
+        AdjustmentInterface $adjustment2,
+        OrderItemInterface $item1,
+        OrderItemInterface $item2,
+        OrderItemInterface $item3
+    ) {
+        $item1->getTotal()->willReturn(29999);
+        $item2->getTotal()->willReturn(45000);
+
+        $item1->equals(Argument::any())->willReturn(false);
+        $item2->equals(Argument::any())->willReturn(false);
+
+        $item1->setOrder($this)->shouldBeCalled();
+        $item2->setOrder($this)->shouldBeCalled();
+
+        $adjustment1->isNeutral()->willReturn(false);
+        $adjustment1->getAmount()->willReturn(10000);
+        $adjustment1->setAdjustable($this)->shouldBeCalled();
+
+        $this->addItem($item1);
+        $this->addItem($item2);
+        $this->addAdjustment($adjustment1);
+
+        $this->getTotal()->shouldReturn(84999);
+
+        $item2->setOrder(null)->shouldBeCalled();
+
+        $this->removeItem($item2);
+
+        $adjustment1->setAdjustable(null)->shouldBeCalled();
+        $adjustment1->isLocked()->willReturn(false);
+
+        $adjustment2->isNeutral()->willReturn(false);
+        $adjustment2->getAmount()->willReturn(-4999);
+        $adjustment2->setAdjustable($this)->shouldBeCalled();
+
+        $this->removeAdjustment($adjustment1);
+        $this->addAdjustment($adjustment2);
+
+        $item3->getTotal()->willReturn(55000);
+        $item3->equals(Argument::any())->willReturn(false);
+        $item3->setOrder($this)->shouldBeCalled();
+
+        $this->addItem($item3);
 
         $this->getTotal()->shouldReturn(80000);
     }
@@ -324,8 +349,6 @@ class OrderSpec extends ObjectBehavior
         $this->addAdjustment($adjustment1);
         $this->addAdjustment($adjustment2);
 
-        $this->calculateTotal();
-
         $this->getTotal()->shouldReturn(70000);
     }
 
@@ -344,8 +367,6 @@ class OrderSpec extends ObjectBehavior
 
         $this->addItem($item);
         $this->addAdjustment($adjustment);
-
-        $this->calculateTotal();
 
         $this->getTotal()->shouldReturn(0);
     }
@@ -370,6 +391,9 @@ class OrderSpec extends ObjectBehavior
     {
         $item1->setOrder($this)->shouldBeCalled();
         $item1->merge($item2, false)->shouldBeCalled();
+        $item1->getTotal()->willReturn(1000);
+
+        $item2->getTotal()->willReturn(1000);
 
         $item1->equals($item2)->willReturn(true);
         $item2->equals($item1)->willReturn(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #3524
| License       | MIT
| Doc PR        | https://github.com/Sylius/Sylius-Docs/pull/400

This PR is based on https://github.com/Sylius/Sylius/pull/3771 and correspond with @michalmarcinkowski work in https://github.com/Sylius/Sylius/pull/3786.

In this PR there is ``OrderItemQuantityModifier`` implemented, that handles item units management. The idea is, to change ``OrderItem`` quantity only by adding/removing units.

**Possible improvements/modifications**
- it will be better to remove *backordered* units first, then *sold* ones

**UPDATE**

I've applied commits from https://github.com/Sylius/Sylius/pull/3808, as they're necessary to make behat scenarios green.

**UPDATE vol.2**

Docs PR mentioned.