### PR TITLE
[Product] Fix invalid migration classname

### DIFF
--- a/app/migrations/Version20151228175507.php
+++ b/app/migrations/Version20151228175507.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Schema\Schema;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-class Version20150922153417 extends AbstractMigration
+class Version20151228175507 extends AbstractMigration
 {
     /**
      * @param Schema $schema


### PR DESCRIPTION
It seems that doctrine migration classname was generated incorrectly in #3783