### PR TITLE
Mark some services as lazy to prevent db connection

### DIFF
--- a/src/Sylius/Bundle/CartBundle/Resources/config/templating.xml
+++ b/src/Sylius/Bundle/CartBundle/Resources/config/templating.xml
@@ -21,7 +21,7 @@
     </parameters>
 
     <services>
-        <service id="sylius.templating.helper.cart" class="%sylius.templating.helper.cart.class%">
+        <service id="sylius.templating.helper.cart" class="%sylius.templating.helper.cart.class%" lazy="true">
             <argument type="service" id="sylius.cart_provider" />
             <argument type="service" id="sylius.factory.cart_item" />
             <argument type="service" id="form.factory" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -418,7 +418,7 @@
             <argument type="service" id="event_dispatcher" />
         </service>
 
-        <service id="sylius.price_calculator.channel_based" class="%sylius.price_calculator.channel_based.class%">
+        <service id="sylius.price_calculator.channel_based" class="%sylius.price_calculator.channel_based.class%" lazy="true">
             <argument type="service" id="sylius.context.channel" />
             <tag name="sylius.price_calculator" type="channel_based" label="Channel based" />
         </service>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/templating.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/templating.xml
@@ -22,7 +22,7 @@
     </parameters>
 
     <services>
-        <service id="sylius.templating.helper.restricted_zone" class="%sylius.templating.helper.restricted_zone.class%">
+        <service id="sylius.templating.helper.restricted_zone" class="%sylius.templating.helper.restricted_zone.class%" lazy="true">
             <argument type="service" id="sylius.checker.restricted_zone" />
             <tag name="templating.helper" alias="sylius_restricted_zone" />
         </service>

--- a/src/Sylius/Bundle/RbacBundle/Resources/config/templating.xml
+++ b/src/Sylius/Bundle/RbacBundle/Resources/config/templating.xml
@@ -21,7 +21,7 @@
     </parameters>
 
     <services>
-        <service id="sylius.templating.helper.rbac" class="%sylius.templating.helper.rbac.class%">
+        <service id="sylius.templating.helper.rbac" class="%sylius.templating.helper.rbac.class%" lazy="true">
             <argument type="service" id="sylius.authorization_checker" />
             <tag name="templating.helper" alias="sylius_rbac" />
         </service>

--- a/src/Sylius/Bundle/SettingsBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/SettingsBundle/Resources/config/services.xml
@@ -37,7 +37,7 @@
 
         <service id="sylius.settings.cache" alias="doctrine_cache.providers.sylius_settings" />
 
-        <service id="sylius.settings.manager" class="%sylius.settings.manager.class%">
+        <service id="sylius.settings.manager" class="%sylius.settings.manager.class%" lazy="true">
             <argument type="service" id="sylius.settings.schema_registry" />
             <argument type="service" id="sylius.manager.parameter" />
             <argument type="service" id="sylius.repository.parameter" />

--- a/src/Sylius/Bundle/UserBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/services.xml
@@ -153,7 +153,7 @@
             <argument type="service" id="sylius.repository.user" />
             <argument type="service" id="sylius.user.canonicalizer" />
         </service>
-        <service id="sylius.user_provider.name_or_email" class="%sylius.user_provider.name_or_email.class%">
+        <service id="sylius.user_provider.name_or_email" class="%sylius.user_provider.name_or_email.class%" lazy="true">
             <argument type="service" id="sylius.repository.user" />
             <argument type="service" id="sylius.user.canonicalizer" />
         </service>
@@ -161,7 +161,7 @@
             <argument type="service" id="sylius.repository.user" />
             <argument type="service" id="sylius.user.canonicalizer" />
         </service>
-        <service id="sylius.oauth.user_provider" class="%sylius.oauth.user_provider.class%">
+        <service id="sylius.oauth.user_provider" class="%sylius.oauth.user_provider.class%" lazy="true">
             <argument type="service" id="sylius.factory.customer" />
             <argument type="service" id="sylius.repository.customer" />
             <argument type="service" id="sylius.factory.user" />


### PR DESCRIPTION
This is so bad and annoying. It is obviously a workaround for now, but I marked some services as lazy so that it does not connect to the db during cache warmup.