### PR TITLE
[Cart] remove deprecated isFresh() method from CartEvent

### DIFF
--- a/src/Sylius/Bundle/CartBundle/Controller/CartController.php
+++ b/src/Sylius/Bundle/CartBundle/Controller/CartController.php
@@ -69,7 +69,6 @@ class CartController extends Controller
 
         if ($form->handleRequest($request)->isValid()) {
             $event = new CartEvent($cart);
-            $event->isFresh(true);
 
             $eventDispatcher = $this->getEventDispatcher();
 

--- a/src/Sylius/Bundle/CartBundle/Controller/CartItemController.php
+++ b/src/Sylius/Bundle/CartBundle/Controller/CartItemController.php
@@ -65,7 +65,6 @@ class CartItemController extends Controller
         }
 
         $event = new CartItemEvent($cart, $item);
-        $event->isFresh(true);
 
         // Update models
         $eventDispatcher->dispatch(SyliusCartEvents::ITEM_ADD_INITIALIZE, $event);
@@ -120,7 +119,6 @@ class CartItemController extends Controller
         }
 
         $event = new CartItemEvent($cart, $item);
-        $event->isFresh(true);
 
         // Update models
         $eventDispatcher->dispatch(SyliusCartEvents::ITEM_REMOVE_INITIALIZE, $event);

--- a/src/Sylius/Component/Cart/Event/CartEvent.php
+++ b/src/Sylius/Component/Cart/Event/CartEvent.php
@@ -27,11 +27,6 @@ class CartEvent extends ResourceEvent
     protected $cart;
 
     /**
-     * @var Boolean
-     */
-    protected $isFresh = false;
-
-    /**
      * @param CartInterface $cart
      */
     public function __construct(CartInterface $cart)
@@ -45,22 +40,5 @@ class CartEvent extends ResourceEvent
     public function getCart()
     {
         return $this->cart;
-    }
-
-    /**
-     * Notice the event listeners to refresh/recalculate cart
-     * information's
-     *
-     * @param null|Boolean $fresh
-     *
-     * @return Boolean
-     */
-    public function isFresh($fresh = null)
-    {
-        if (null === $fresh) {
-            return $this->isFresh;
-        }
-
-        return $this->isFresh = (Boolean) $fresh;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | #3820
| License       | MIT

In older versions of Sylius the cart totals were recalculated (aka the cart was "refreshed") via setting the CartEvent to fresh and checking if it is fresh on the right places. If the event was fresh, the cart was recalculated. Now that is solved via triggering the SyliusCartEvents::CART_CHANGE event. The isFresh() method is removed (it was only set, resulting in a more convoluted code, but never checked for after the switch to event listeners).