### PR TITLE
[Travis] [Core] Improved showing exceptions in test environment

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -7,9 +7,6 @@ imports:
     - { resource: migrations.yml }    
     - { resource: @SyliusCoreBundle/Resources/config/app/main.yml }
 
-parameters:
-    sylius.twig.show_exceptions: %kernel.debug%
-
 framework:
     translator:      { fallback: %sylius.locale% }
     secret:          %sylius.secret%

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -5,7 +5,6 @@ imports:
     - { resource: config.yml }
 
 parameters:
-    sylius.twig.show_exceptions: true
     sylius.order.allow_guest_order: true
 
 framework:
@@ -47,3 +46,6 @@ monolog:
             type:  stream
             path:  %kernel.logs_dir%/%kernel.environment%.log
             level: error
+
+twig:
+    exception_controller: 'Sylius\Bundle\CoreBundle\Controller\VerboseExceptionController::showAction'

--- a/src/Sylius/Bundle/CoreBundle/Controller/VerboseExceptionController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/VerboseExceptionController.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Controller;
+
+use FOS\RestBundle\Controller\ExceptionController as BaseExceptionController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
+
+/**
+ * {@inheritdoc}
+ *
+ * BEWARE: This exception controller always shows the exception messages,
+ * stacktraces, etc., no matter how %kernel.debug% is set
+ *
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+class VerboseExceptionController extends BaseExceptionController
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function showAction(Request $request, $exception, DebugLoggerInterface $logger = null)
+    {
+        $request->attributes->set('showException', true);
+
+        return parent::showAction($request, $exception, $logger);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/twig.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/twig.xml
@@ -25,11 +25,6 @@
             <argument type="service" id="sylius.templating.helper.restricted_zone" />
             <tag name="twig.extension" />
         </service>
-
-        <service id="twig.controller.exception" class="%twig.controller.exception.class%">
-            <argument type="service" id="twig" />
-            <argument>%sylius.twig.show_exceptions%</argument>
-        </service>
     </services>
 
 </container>


### PR DESCRIPTION
Reverted #3827, as we don't use default Twig's exception handler but the FOSRestBundle one.