### PR TITLE
[Promotion rule] added items quantity

### DIFF
--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
@@ -21,6 +21,8 @@
         <parameter key="sylius.promotion_eligibility_checker.class">Sylius\Component\Promotion\Checker\PromotionEligibilityChecker</parameter>
         <parameter key="sylius.promotion_rule_checker.item_total.class">Sylius\Component\Promotion\Checker\ItemTotalRuleChecker</parameter>
         <parameter key="sylius.promotion_rule_checker.item_count.class">Sylius\Component\Promotion\Checker\ItemCountRuleChecker</parameter>
+        <parameter key="sylius.promotion_rule_checker.items_quantity.class">Sylius\Component\Promotion\Checker\ItemsQuantityRuleChecker</parameter>
+
         <parameter key="sylius.promotion_applicator.class">Sylius\Component\Promotion\Action\PromotionApplicator</parameter>
 
         <parameter key="sylius.generator.instructions.class">Sylius\Component\Promotion\Generator\Instruction</parameter>
@@ -58,6 +60,9 @@
         </service>
         <service id="sylius.promotion_rule_checker.item_count" class="%sylius.promotion_rule_checker.item_count.class%">
             <tag name="sylius.promotion_rule_checker" type="item_count" label="Item count" />
+        </service>
+        <service id="sylius.promotion_rule_checker.items_quantity" class="%sylius.promotion_rule_checker.items_quantity.class%">
+            <tag name="sylius.promotion_rule_checker" type="items_quantity" label="Items quantity" />
         </service>
 
         <service id="sylius.promotion_applicator" class="%sylius.promotion_applicator.class%">

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -471,6 +471,18 @@ class Order extends Cart implements OrderInterface
     /**
      * {@inheritdoc}
      */
+    public function getPromotionSubjectQuantity()
+    {
+        $sum = 0;
+        foreach($this->items as $item){
+            $sum += $item->getQuantity();
+        }
+        return $sum;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getCurrency()
     {
         return $this->currency;

--- a/src/Sylius/Component/Core/Model/OrderItem.php
+++ b/src/Sylius/Component/Core/Model/OrderItem.php
@@ -134,6 +134,14 @@ class OrderItem extends CartItem implements OrderItemInterface
     /**
      * {@inheritdoc}
      */
+    public function getPromotionSubjectQuantity()
+    {
+        return $this->quantity;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function hasPromotion(BasePromotionInterface $promotion)
     {
         return $this->promotions->contains($promotion);

--- a/src/Sylius/Component/Promotion/Checker/ItemsQuantityRuleChecker.php
+++ b/src/Sylius/Component/Promotion/Checker/ItemsQuantityRuleChecker.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Promotion\Checker;
+
+use Sylius\Component\Promotion\Model\PromotionCountableSubjectInterface;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+
+/**
+ * Checks if subject items quantity exceeds (or at least equal) to the configured count.
+ *
+ * @author Krzysztof Wędrowicz <krzysztof@wedrowicz.me>
+ */
+class ItemsQuantityRuleChecker implements RuleCheckerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isEligible(PromotionSubjectInterface $subject, array $configuration)
+    {
+        if (!$subject instanceof PromotionCountableSubjectInterface) {
+            return false;
+        }
+
+        if (isset($configuration['equal']) && $configuration['equal']) {
+            return $subject->getPromotionSubjectQuantity() >= $configuration['count'];
+        }
+
+        return $subject->getPromotionSubjectQuantity() > $configuration['count'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigurationFormType()
+    {
+        return 'sylius_promotion_rule_item_count_configuration';
+    }
+}

--- a/src/Sylius/Component/Promotion/Model/PromotionCountableSubjectInterface.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionCountableSubjectInterface.php
@@ -20,4 +20,9 @@ interface PromotionCountableSubjectInterface extends PromotionSubjectInterface
      * @return int
      */
     public function getPromotionSubjectCount();
+
+    /**
+     * @return int
+     */
+    public function getPromotionSubjectQuantity();
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT
| Doc PR        | 

Sometimes you want to give promotions when items in cart exceeds some quantity, doesn't matter if they are different or not (Item count rule counts only different items). This PR does actually this - add rule which calculate total items quantity.