### PR TITLE
[Travis] Ability to add Github OAuth token to Composer configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ before_install:
 
     - composer self-update
 
+    # Add Github OAuth token to Composer config if that variable exists
+    - if [[ ! -z "$GITHUB_OAUTH_TOKEN" ]]; then composer config -g github-oauth.github.com "$GITHUB_OAUTH_TOKEN" >/dev/null 2>&1; fi
+
     - etc/travis/prepare-composer-doctrine-mongodb-odm
     - composer install --no-interaction --prefer-dist --no-scripts
 
@@ -58,8 +61,10 @@ before_script:
     - app/console assets:install --env=test_cached --no-debug
     - app/console assetic:dump --env=test_cached --no-debug
 
+    # Debug informations, PHP version & PHP configuration
+    # Its needed to remove the line with secret ariable, as it is listed in _SERVER variables
     - php -v
-    - php -i
+    - php -i | grep -v GITHUB_OAUTH_TOKEN
 
 script:
     - bin/phpspec run -f dot


### PR DESCRIPTION
It allows us to define `GITHUB_OAUTH_TOKEN` secret variable in Travis CI so we shouldn't get as many "Could not authenticate against github.com" error messages as before.

To use this feature:
 - merge this changes to your all branches on Sylius fork (unpatched `php -i` can cause the leak)
 - go to `https://travis-ci.org/<your user name>/Sylius/settings`
 - create environment variable with name `GITHUB_OAUTH_TOKEN` and your OAuth token as value
 - be sure to have "Display value in build log" option **disabled**

It only works for branches builds, does not run on PRs for security reasons, but it should be enough, as PRs cache uses `master` branch cache first, with all the dependencies already downloaded.