### PR TITLE
[RFC] [POC] [Resource] Resource configuration builder

### DIFF
--- a/src/Sylius/Bundle/LocaleBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/LocaleBundle/DependencyInjection/Configuration.php
@@ -14,10 +14,11 @@ namespace Sylius\Bundle\LocaleBundle\DependencyInjection;
 use Sylius\Bundle\LocaleBundle\Controller\LocaleController;
 use Sylius\Bundle\LocaleBundle\Form\Type\LocaleChoiceType;
 use Sylius\Bundle\LocaleBundle\Form\Type\LocaleType;
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration\ResourceConfigurationBuilder;
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration\SyliusResource;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Sylius\Component\Locale\Model\Locale;
 use Sylius\Component\Locale\Model\LocaleInterface;
-use Sylius\Component\Resource\Factory\Factory;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -53,50 +54,21 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * @param ArrayNodeDefinition $node
+     * @param ArrayNodeDefinition $rootDefinition
      */
-    private function addResourcesSection(ArrayNodeDefinition $node)
+    private function addResourcesSection(ArrayNodeDefinition $rootDefinition)
     {
-        $node
-            ->children()
-                ->arrayNode('resources')
-                    ->addDefaultsIfNotSet()
-                    ->children()
-                        ->arrayNode('locale')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->variableNode('options')->end()
-                                ->arrayNode('classes')
-                                    ->addDefaultsIfNotSet()
-                                    ->children()
-                                        ->scalarNode('model')->defaultValue(Locale::class)->cannotBeEmpty()->end()
-                                        ->scalarNode('interface')->defaultValue(LocaleInterface::class)->cannotBeEmpty()->end()
-                                        ->scalarNode('controller')->defaultValue(LocaleController::class)->cannotBeEmpty()->end()
-                                        ->scalarNode('repository')->cannotBeEmpty()->end()
-                                        ->scalarNode('factory')->defaultValue(Factory::class)->end()
-                                        ->arrayNode('form')
-                                            ->addDefaultsIfNotSet()
-                                            ->children()
-                                                ->scalarNode('default')->defaultValue(LocaleType::class)->cannotBeEmpty()->end()
-                                                ->scalarNode('choice')->defaultValue(LocaleChoiceType::class)->cannotBeEmpty()->end()
-                                            ->end()
-                                        ->end()
-                                    ->end()
-                                ->end()
-                                ->arrayNode('validation_groups')
-                                    ->addDefaultsIfNotSet()
-                                    ->children()
-                                        ->arrayNode('default')
-                                            ->prototype('scalar')->end()
-                                            ->defaultValue(array('sylius'))
-                                        ->end()
-                                    ->end()
-                                ->end()
-                            ->end()
-                        ->end()
-                    ->end()
-                ->end()
-            ->end()
-        ;
+        $resourceConfigurationGenerator = new ResourceConfigurationBuilder();
+
+        $resourcesDefinition = $resourceConfigurationGenerator->initResourcesConfiguration($rootDefinition);
+
+        $localeResource = new SyliusResource('locale', Locale::class, LocaleInterface::class);
+        $localeResource->useController(LocaleController::class);
+        $localeResource->useDefaultRepository();
+        $localeResource->useDefaultFactory();
+        $localeResource->addForm('default', LocaleType::class, ['sylius']);
+        $localeResource->addForm('choice', LocaleChoiceType::class);
+
+        $resourceConfigurationGenerator->addSyliusResource($resourcesDefinition, $localeResource);
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration/AbstractSyliusResource.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration/AbstractSyliusResource.php
@@ -1,0 +1,236 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration;
+
+use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
+use Sylius\Component\Resource\Factory\Factory;
+
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+abstract class AbstractSyliusResource
+{
+    /**
+     * @var string
+     */
+    private $modelClass;
+
+    /**
+     * @var string|null
+     */
+    private $interfaceClass;
+
+    /**
+     * @var string|null
+     */
+    private $factoryClass;
+
+    /**
+     * @var string|null
+     */
+    private $controllerClass;
+
+    /**
+     * @var string|null
+     */
+    private $repositoryClass;
+
+    /**
+     * @var array
+     */
+    private $formsClasses = [];
+
+    /**
+     * @var array
+     */
+    private $validationGroups = [];
+
+    /**
+     * @var array
+     */
+    private $options = [];
+
+    /**
+     * @param string|null $modelClass
+     * @param string|null $interfaceClass
+     *
+     * @throws \InvalidArgumentException If given model class does not implement given interface
+     */
+    public function __construct($modelClass = null, $interfaceClass = null)
+    {
+        $this->modelClass = $modelClass;
+        $this->interfaceClass = $interfaceClass;
+    }
+
+    /**
+     * @return string
+     */
+    public function getModelClass()
+    {
+        return $this->modelClass;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getInterfaceClass()
+    {
+        return $this->interfaceClass;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getFactoryClass()
+    {
+        return $this->factoryClass;
+    }
+
+    /**
+     * @param string $factoryClass
+     *
+     * @return $this
+     */
+    public function useFactory($factoryClass)
+    {
+        $this->factoryClass = $factoryClass;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function useDefaultFactory()
+    {
+        $this->factoryClass = Factory::class;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getControllerClass()
+    {
+        return $this->controllerClass;
+    }
+
+    /**
+     * @param string $controllerClass
+     *
+     * @return $this
+     */
+    public function useController($controllerClass)
+    {
+        $this->controllerClass = $controllerClass;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function useDefaultController()
+    {
+        $this->controllerClass = ResourceController::class;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getRepositoryClass()
+    {
+        return $this->repositoryClass;
+    }
+
+    /**
+     * @param string $repositoryClass
+     *
+     * @return $this
+     */
+    public function useRepository($repositoryClass)
+    {
+        $this->repositoryClass = $repositoryClass;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function useDefaultRepository()
+    {
+        // Should work out of the box, based on selected driver.
+        // This method exists in case of further changes.
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getFormsClasses()
+    {
+        return $this->formsClasses;
+    }
+
+    /**
+     * @return array
+     */
+    public function getValidationGroups()
+    {
+        return $this->validationGroups;
+    }
+
+    /**
+     * @param string $name
+     * @param string $formClass
+     * @param array $validationGroups
+     *
+     * @return $this
+     */
+    public function addForm($name, $formClass, array $validationGroups = [])
+    {
+        $name = $name ?: 'default';
+
+        $this->formsClasses[$name] = $formClass;
+
+        if (0 !== count($validationGroups)) {
+            $this->validationGroups[$name] = $validationGroups;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return $this
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration/ResourceConfigurationBuilder.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration/ResourceConfigurationBuilder.php
@@ -1,0 +1,250 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+class ResourceConfigurationBuilder implements ResourceConfigurationBuilderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function initResourcesConfiguration(ArrayNodeDefinition $bundleRootDefinition)
+    {
+        $resourcesDefinition = $bundleRootDefinition
+            ->children()
+            ->arrayNode('resources')
+            ->fixXmlConfig('resource')
+        ;
+
+        return $resourcesDefinition;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addSyliusResource(ArrayNodeDefinition $resourcesDefinition, SyliusResource $syliusResource)
+    {
+        $resourceDefinition = $resourcesDefinition->children()->arrayNode($syliusResource->getName())->addDefaultsIfNotSet();
+
+        $this->addOptionsDefinition($resourceDefinition, $syliusResource);
+        $this->addClassesDefinition($resourceDefinition, $syliusResource);
+        $this->addValidationGroupsDefinition($resourceDefinition, $syliusResource);
+        $this->addTranslationResourceDefinition($resourceDefinition, $syliusResource);
+
+        return $resourceDefinition;
+    }
+
+    /**
+     * @param ArrayNodeDefinition $resourceDefinition
+     * @param AbstractSyliusResource $syliusResource
+     */
+    private function addOptionsDefinition(ArrayNodeDefinition $resourceDefinition, AbstractSyliusResource $syliusResource)
+    {
+        $optionsDefinition = $resourceDefinition->children()->variableNode('options');
+
+        $options = $syliusResource->getOptions();
+        if (0 === count($options)) {
+            return;
+        }
+
+        $optionsDefinition->defaultValue($options);
+    }
+
+    /**
+     * @param ArrayNodeDefinition $resourceDefinition
+     * @param AbstractSyliusResource $syliusResource
+     */
+    private function addClassesDefinition(ArrayNodeDefinition $resourceDefinition, AbstractSyliusResource $syliusResource)
+    {
+        $classesDefinition = $resourceDefinition->children()->arrayNode('classes')->addDefaultsIfNotSet();
+
+        $this->addModelDefinition($classesDefinition, $syliusResource);
+        $this->addInterfaceDefinition($classesDefinition, $syliusResource);
+        $this->addControllerDefinition($classesDefinition, $syliusResource);
+        $this->addRepositoryDefinition($classesDefinition, $syliusResource);
+        $this->addFactoryDefinition($classesDefinition, $syliusResource);
+        $this->addFormsDefinitions($classesDefinition, $syliusResource);
+    }
+
+    /**
+     * @param ArrayNodeDefinition $resourceDefinition
+     * @param AbstractSyliusResource $syliusResource
+     */
+    private function addValidationGroupsDefinition(ArrayNodeDefinition $resourceDefinition, AbstractSyliusResource $syliusResource)
+    {
+        if (0 === count($syliusResource->getValidationGroups())) {
+            return;
+        }
+
+        $validationGroupsNodeBuilder = $resourceDefinition
+            ->children()
+            ->arrayNode('validation_groups')
+            ->addDefaultsIfNotSet()
+            ->children()
+        ;
+
+        foreach ($syliusResource->getValidationGroups() as $name => $validationGroups) {
+            $validationGroupsDefinition = $validationGroupsNodeBuilder->arrayNode($name);
+            $validationGroupsDefinition->defaultValue($validationGroups);
+            $validationGroupsDefinition->prototype('scalar');
+        }
+    }
+
+    /**
+     * @param ArrayNodeDefinition $resourceDefinition
+     * @param SyliusResource $syliusResource
+     */
+    private function addTranslationResourceDefinition(ArrayNodeDefinition $resourceDefinition, SyliusResource $syliusResource)
+    {
+        if (null === $syliusResource->getTranslationResource()) {
+            return;
+        }
+
+        $syliusTranslationResource = $syliusResource->getTranslationResource();
+        $translationDefinition = $resourceDefinition->children()->arrayNode('translation')->addDefaultsIfNotSet();
+
+        $this->addOptionsDefinition($translationDefinition, $syliusTranslationResource);
+        $this->addClassesDefinition($translationDefinition, $syliusTranslationResource);
+        $this->addValidationGroupsDefinition($translationDefinition, $syliusTranslationResource);
+        $this->addTranslatableFieldsDefinition($translationDefinition, $syliusTranslationResource);
+    }
+
+    /**
+     * @param ArrayNodeDefinition $translationResourceDefinition
+     * @param SyliusTranslationResource $syliusTranslationResource
+     */
+    private function addTranslatableFieldsDefinition(ArrayNodeDefinition $translationResourceDefinition, SyliusTranslationResource $syliusTranslationResource)
+    {
+        if (0 === count($syliusTranslationResource->getTranslatableFields())) {
+            return;
+        }
+
+        $translatableFieldsDefinition = $translationResourceDefinition->children()->arrayNode('fields');
+        $translatableFieldsDefinition->defaultValue($syliusTranslationResource->getTranslatableFields());
+        $translatableFieldsDefinition->prototype('scalar');
+    }
+
+    /**
+     * @param ArrayNodeDefinition $classesDefinition
+     * @param AbstractSyliusResource $syliusResource
+     */
+    private function addModelDefinition(ArrayNodeDefinition $classesDefinition, AbstractSyliusResource $syliusResource)
+    {
+        $modelDefinition = $classesDefinition->children()->scalarNode('model')->cannotBeEmpty();
+
+        if (null === $syliusResource->getModelClass()) {
+            $modelDefinition->isRequired();
+            return;
+        }
+
+        $modelDefinition->defaultValue($syliusResource->getModelClass());
+    }
+
+    /**
+     * @param ArrayNodeDefinition $classesDefinition
+     * @param AbstractSyliusResource $syliusResource
+     */
+    private function addInterfaceDefinition(ArrayNodeDefinition $classesDefinition, AbstractSyliusResource $syliusResource)
+    {
+        $interfaceDefinition = $classesDefinition->children()->scalarNode('interface')->cannotBeEmpty();
+
+        if (null === $syliusResource->getInterfaceClass()) {
+            return;
+        }
+
+        $interfaceDefinition->defaultValue($syliusResource->getInterfaceClass());
+    }
+
+    /**
+     * @param ArrayNodeDefinition $classesDefinition
+     * @param AbstractSyliusResource $syliusResource
+     */
+    private function addControllerDefinition(ArrayNodeDefinition $classesDefinition, AbstractSyliusResource $syliusResource)
+    {
+        if (null === $syliusResource->getControllerClass()) {
+            return;
+        }
+
+        $classesDefinition
+            ->children()
+            ->scalarNode('controller')
+            ->defaultValue($syliusResource->getControllerClass())
+            ->cannotBeEmpty()
+        ;
+    }
+
+    /**
+     * @param ArrayNodeDefinition $classesDefinition
+     * @param AbstractSyliusResource $syliusResource
+     */
+    private function addRepositoryDefinition(ArrayNodeDefinition $classesDefinition, AbstractSyliusResource $syliusResource)
+    {
+        if (null === $syliusResource->getRepositoryClass()) {
+            return;
+        }
+
+        $classesDefinition
+            ->children()
+            ->scalarNode('repository')
+            ->defaultValue($syliusResource->getRepositoryClass())
+            ->cannotBeEmpty()
+        ;
+    }
+
+    /**
+     * @param ArrayNodeDefinition $classesDefinition
+     * @param AbstractSyliusResource $syliusResource
+     */
+    private function addFactoryDefinition(ArrayNodeDefinition $classesDefinition, AbstractSyliusResource $syliusResource)
+    {
+        if (null === $syliusResource->getFactoryClass()) {
+            return;
+        }
+
+        $classesDefinition
+            ->children()
+            ->scalarNode('factory')
+            ->defaultValue($syliusResource->getFactoryClass())
+            ->cannotBeEmpty()
+        ;
+    }
+
+    /**
+     * @param ArrayNodeDefinition $classesDefinition
+     * @param AbstractSyliusResource $syliusResource
+     */
+    private function addFormsDefinitions(ArrayNodeDefinition $classesDefinition, AbstractSyliusResource $syliusResource)
+    {
+        if (0 === count($syliusResource->getFormsClasses())) {
+            return;
+        }
+
+        $formsNodeBuilder = $classesDefinition
+            ->children()
+            ->arrayNode('form') // TODO: Rename to forms?
+            ->addDefaultsIfNotSet()
+            ->children()
+        ;
+
+        foreach ($syliusResource->getFormsClasses() as $name => $formClass) {
+            $formsNodeBuilder
+                ->scalarNode($name)
+                ->defaultValue($formClass)
+                ->cannotBeEmpty()
+            ;
+        }
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration/ResourceConfigurationBuilderInterface.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration/ResourceConfigurationBuilderInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration;
+
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+interface ResourceConfigurationBuilderInterface
+{
+    /**
+     * @param ArrayNodeDefinition $bundleRootDefinition
+     *
+     * @return ArrayNodeDefinition Resources node definition
+     */
+    public function initResourcesConfiguration(ArrayNodeDefinition $bundleRootDefinition);
+
+    /**
+     * @param ArrayNodeDefinition $resourcesDefinition Resources node builder of the bundle
+     * @param SyliusResource $syliusResource
+     *
+     * @return ArrayNodeDefinition Resource node definition
+     */
+    public function addSyliusResource(ArrayNodeDefinition $resourcesDefinition, SyliusResource $syliusResource);
+}

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration/SyliusResource.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration/SyliusResource.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration;
+
+use Sylius\Component\Translation\Factory\TranslatableFactory;
+
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+final class SyliusResource extends AbstractSyliusResource
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var SyliusTranslationResource
+     */
+    private $translationResource;
+
+    /**
+     * @param string $name
+     * @param string|null $modelClass
+     * @param string|null $interfaceClass
+     */
+    public function __construct($name, $modelClass = null, $interfaceClass = null)
+    {
+        parent::__construct($modelClass, $interfaceClass);
+
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return $this
+     */
+    public function useDefaultTranslatableFactory()
+    {
+        $this->useFactory(TranslatableFactory::class);
+
+        return $this;
+    }
+
+    /**
+     * @return SyliusTranslationResource|null
+     */
+    public function getTranslationResource()
+    {
+        return $this->translationResource;
+    }
+
+    /**
+     * @param SyliusTranslationResource $translationResource
+     *
+     * @return $this
+     */
+    public function useTranslationResource(SyliusTranslationResource $translationResource)
+    {
+        $this->translationResource = $translationResource;
+
+        return $this;
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration/SyliusTranslationResource.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration/SyliusTranslationResource.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration;
+
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+final class SyliusTranslationResource extends AbstractSyliusResource
+{
+    /**
+     * @var array
+     */
+    private $fields = [];
+
+    /**
+     * @return array
+     */
+    public function getTranslatableFields()
+    {
+        return $this->fields;
+    }
+
+    /**
+     * @param array $fields
+     *
+     * @return $this
+     */
+    public function setTranslatableFields(array $fields)
+    {
+        $this->fields = $fields;
+
+        return $this;
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
@@ -155,11 +155,12 @@ abstract class AbstractDriver implements DriverInterface
 
                 default:
                     $validationGroupsParameterName = sprintf('%s.validation_groups.%s%s', $metadata->getApplicationName(), $metadata->getName(), $suffix);
-                    $validationGroups = new Parameter($validationGroupsParameterName);
 
                     if (!$container->hasParameter($validationGroupsParameterName)) {
-                        $validationGroups = array('Default');
+                        $container->setParameter($validationGroupsParameterName, array('Default'));
                     }
+
+                    $validationGroups = new Parameter($validationGroupsParameterName);
 
                     $definition->setArguments(array(
                         $metadata->getClass('model'),

--- a/src/Sylius/Bundle/ResourceBundle/spec/DependencyInjection/Configuration/ResourceConfigurationBuilderSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/DependencyInjection/Configuration/ResourceConfigurationBuilderSpec.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration\ResourceConfigurationBuilder;
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration\ResourceConfigurationBuilderInterface;
+
+/**
+ * @mixin ResourceConfigurationBuilder
+ *
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+class ResourceConfigurationBuilderSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration\ResourceConfigurationBuilder');
+    }
+
+    function it_implements_resource_configuration_builder_interface()
+    {
+        $this->shouldImplement(ResourceConfigurationBuilderInterface::class);
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/spec/DependencyInjection/Configuration/SyliusResourceSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/DependencyInjection/Configuration/SyliusResourceSpec.php
@@ -1,0 +1,186 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration\SyliusResource;
+use spec\Sylius\Bundle\ResourceBundle\Fixture\Model\Foo;
+use spec\Sylius\Bundle\ResourceBundle\Fixture\Model\FooInterface;
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration\SyliusTranslationResource;
+use Sylius\Component\Resource\Factory\Factory;
+use Sylius\Component\Translation\Factory\TranslatableFactory;
+
+require_once __DIR__ . '/../../Fixture/Model/FooInterface.php';
+require_once __DIR__ . '/../../Fixture/Model/Foo.php';
+
+/**
+ * @mixin SyliusResource
+ *
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+class SyliusResourceSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('foo', Foo::class, FooInterface::class);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration\SyliusResource');
+    }
+
+    function it_correctly_assigns_name_passed_to_the_constructor()
+    {
+        $this->beConstructedWith('foo', Foo::class);
+
+        $this->getName()->shouldReturn('foo');
+    }
+
+    function it_correctly_assigns_model_passed_to_the_constructor()
+    {
+        $this->beConstructedWith('foo', Foo::class);
+
+        $this->getModelClass()->shouldReturn(Foo::class);
+    }
+
+    function it_correctly_assigns_interface_passed_to_the_constructor()
+    {
+        $this->beConstructedWith('foo', Foo::class, FooInterface::class);
+
+        $this->getInterfaceClass()->shouldReturn(FooInterface::class);
+    }
+
+    function it_has_no_factory_by_default()
+    {
+        $this->getFactoryClass()->shouldReturn(null);
+    }
+    
+    function it_sets_resource_factory_as_used_if_using_default()
+    {
+        $this->useDefaultFactory();
+        
+        $this->getFactoryClass()->shouldReturn(Factory::class);
+    }
+
+    function it_uses_given_factory()
+    {
+        $this->useFactory(\stdClass::class);
+
+        $this->getFactoryClass()->shouldReturn(\stdClass::class);
+    }
+
+    function it_has_no_controller_by_default()
+    {
+        $this->getControllerClass()->shouldReturn(null);
+    }
+
+    function it_sets_resource_controller_as_used_if_using_default()
+    {
+        $this->useDefaultController();
+
+        $this->getControllerClass()->shouldReturn(ResourceController::class);
+    }
+
+    function it_uses_given_controller()
+    {
+        $this->useController(\stdClass::class);
+
+        $this->getControllerClass()->shouldReturn(\stdClass::class);
+    }
+
+    function it_has_no_repository_by_default()
+    {
+        $this->getRepositoryClass()->shouldReturn(null);
+    }
+
+    function it_does_not_set_anything_as_used_if_using_default()
+    {
+        $this->useDefaultRepository();
+
+        $this->getRepositoryClass()->shouldReturn(null);
+    }
+
+    function it_uses_given_repository()
+    {
+        $this->useRepository(\stdClass::class);
+
+        $this->getRepositoryClass()->shouldReturn(\stdClass::class);
+    }
+
+    function it_adds_form_without_validation_groups()
+    {
+        $this->addForm('name', \stdClass::class);
+
+        $this->getFormsClasses()->shouldReturn(['name' => \stdClass::class]);
+        $this->getValidationGroups()->shouldReturn([]);
+    }
+
+    function it_adds_form_with_validation_groups()
+    {
+        $this->addForm('name', \stdClass::class, ['validation group']);
+
+        $this->getFormsClasses()->shouldReturn(['name' => \stdClass::class]);
+        $this->getValidationGroups()->shouldReturn(['name' => ['validation group']]);
+    }
+
+    function it_adds_default_form_if_null_name_is_provided()
+    {
+        $this->addForm(null, \stdClass::class);
+
+        $this->getFormsClasses()->shouldReturn(['default' => \stdClass::class]);
+        $this->getValidationGroups()->shouldReturn([]);
+    }
+
+    function it_adds_default_form_if_empty_name_is_provided()
+    {
+        $this->addForm('', \stdClass::class);
+
+        $this->getFormsClasses()->shouldReturn(['default' => \stdClass::class]);
+        $this->getValidationGroups()->shouldReturn([]);
+    }
+
+    function it_has_no_translation_resource_by_default()
+    {
+        $this->getTranslationResource()->shouldReturn(null);
+    }
+
+    function it_has_no_options_by_default()
+    {
+        $this->getOptions()->shouldReturn([]);
+    }
+
+    function its_options_are_mutable()
+    {
+        $this->setOptions(['option' => 'value']);
+
+        $this->getOptions()->shouldReturn(['option' => 'value']);
+    }
+
+    function it_sets_resource_translatable_factory_as_the_default_translatable_factory()
+    {
+        $this->useDefaultTranslatableFactory();
+
+        $this->getFactoryClass()->shouldReturn(TranslatableFactory::class);
+    }
+
+    function its_translation_resource_can_be_set()
+    {
+        $translationResource = new SyliusTranslationResource(Foo::class);
+
+        $this->useTranslationResource($translationResource);
+
+        $this->getTranslationResource()->shouldReturn($translationResource);
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/spec/DependencyInjection/Configuration/SyliusTranslationResourceSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/DependencyInjection/Configuration/SyliusTranslationResourceSpec.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use spec\Sylius\Bundle\ResourceBundle\Fixture\Model\Foo;
+use spec\Sylius\Bundle\ResourceBundle\Fixture\Model\FooInterface;
+use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration\SyliusTranslationResource;
+use Sylius\Component\Resource\Factory\Factory;
+
+require_once __DIR__ . '/../../Fixture/Model/FooInterface.php';
+require_once __DIR__ . '/../../Fixture/Model/Foo.php';
+
+/**
+ * @mixin SyliusTranslationResource
+ *
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+class SyliusTranslationResourceSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(Foo::class, FooInterface::class);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\DependencyInjection\Configuration\SyliusTranslationResource');
+    }
+
+    function it_correctly_assigns_model_passed_to_the_constructor()
+    {
+        $this->beConstructedWith(Foo::class);
+
+        $this->getModelClass()->shouldReturn(Foo::class);
+    }
+
+    function it_correctly_assigns_interface_passed_to_the_constructor()
+    {
+        $this->beConstructedWith(Foo::class, FooInterface::class);
+
+        $this->getInterfaceClass()->shouldReturn(FooInterface::class);
+    }
+
+    function it_has_no_factory_by_default()
+    {
+        $this->getFactoryClass()->shouldReturn(null);
+    }
+
+    function it_sets_resource_factory_as_used_if_using_default()
+    {
+        $this->useDefaultFactory();
+
+        $this->getFactoryClass()->shouldReturn(Factory::class);
+    }
+
+    function it_uses_given_factory()
+    {
+        $this->useFactory(\stdClass::class);
+
+        $this->getFactoryClass()->shouldReturn(\stdClass::class);
+    }
+
+    function it_has_no_controller_by_default()
+    {
+        $this->getControllerClass()->shouldReturn(null);
+    }
+
+    function it_sets_resource_controller_as_used_if_using_default()
+    {
+        $this->useDefaultController();
+
+        $this->getControllerClass()->shouldReturn(ResourceController::class);
+    }
+
+    function it_uses_given_controller()
+    {
+        $this->useController(\stdClass::class);
+
+        $this->getControllerClass()->shouldReturn(\stdClass::class);
+    }
+
+    function it_has_no_repository_by_default()
+    {
+        $this->getRepositoryClass()->shouldReturn(null);
+    }
+
+    function it_does_not_set_anything_as_used_if_using_default()
+    {
+        $this->useDefaultRepository();
+
+        $this->getRepositoryClass()->shouldReturn(null);
+    }
+
+    function it_uses_given_repository()
+    {
+        $this->useRepository(\stdClass::class);
+
+        $this->getRepositoryClass()->shouldReturn(\stdClass::class);
+    }
+
+    function it_adds_form_without_validation_groups()
+    {
+        $this->addForm('name', \stdClass::class);
+
+        $this->getFormsClasses()->shouldReturn(['name' => \stdClass::class]);
+        $this->getValidationGroups()->shouldReturn([]);
+    }
+
+    function it_adds_form_with_validation_groups()
+    {
+        $this->addForm('name', \stdClass::class, ['validation group']);
+
+        $this->getFormsClasses()->shouldReturn(['name' => \stdClass::class]);
+        $this->getValidationGroups()->shouldReturn(['name' => ['validation group']]);
+    }
+
+    function it_adds_default_form_if_null_name_is_provided()
+    {
+        $this->addForm(null, \stdClass::class);
+
+        $this->getFormsClasses()->shouldReturn(['default' => \stdClass::class]);
+        $this->getValidationGroups()->shouldReturn([]);
+    }
+
+    function it_adds_default_form_if_empty_name_is_provided()
+    {
+        $this->addForm('', \stdClass::class);
+
+        $this->getFormsClasses()->shouldReturn(['default' => \stdClass::class]);
+        $this->getValidationGroups()->shouldReturn([]);
+    }
+
+    function it_has_no_options_by_default()
+    {
+        $this->getOptions()->shouldReturn([]);
+    }
+
+    function its_options_are_mutable()
+    {
+        $this->setOptions(['option' => 'value']);
+
+        $this->getOptions()->shouldReturn(['option' => 'value']);
+    }
+
+    function it_has_no_translatable_fields_by_default()
+    {
+        $this->getTranslatableFields()->shouldReturn([]);
+    }
+
+    function its_translatable_fields_can_be_set()
+    {
+        $this->setTranslatableFields(['field1', 'field2']);
+
+        $this->getTranslatableFields()->shouldReturn(['field1', 'field2']);
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/spec/Fixture/Model/Foo.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Fixture/Model/Foo.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\Fixture\Model;
+
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+class Foo implements FooInterface
+{
+
+}

--- a/src/Sylius/Bundle/ResourceBundle/spec/Fixture/Model/FooInterface.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Fixture/Model/FooInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\Fixture\Model;
+
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+interface FooInterface
+{
+
+}


### PR DESCRIPTION
Resource configuration builder allows us to define bundle's resources configuration without messing with endless `->end()`, tabs, method chains having hundreds of lines and no autocompletion after first `->end()` call :)

It also ensures that the most of future changes can be done seamlessly and without any trouble by modifying only a single class.

This PR is still in progress, I'm open for any thoughts about the architecture and the whole idea. There are two example configurations rewritten to use the resource configuration builder: 
  - [AttributeBundle](https://github.com/Sylius/Sylius/commit/da7e3e52415527aa4a854940ad031ae8c0f3a8b4) (which is a bit unusual configuration, because `sylius_attribute.resources` holds an array prototype)
  - [LocaleBundle](https://github.com/Sylius/Sylius/commit/fedc704065f0c355e8da5f4d0fd67fba0451ad40) (simple configuration made simplier :))