### PR TITLE
[Promotions] Orphan removal on actions and rules

### DIFF
--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/doctrine/model/Promotion.orm.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/doctrine/model/Promotion.orm.xml
@@ -37,12 +37,12 @@
                 <cascade-all />
             </cascade>
         </one-to-many>
-        <one-to-many field="rules" target-entity="Sylius\Component\Promotion\Model\RuleInterface" mapped-by="promotion">
+        <one-to-many field="rules" target-entity="Sylius\Component\Promotion\Model\RuleInterface" mapped-by="promotion" orphan-removal="true">
             <cascade>
                 <cascade-all />
             </cascade>
         </one-to-many>
-        <one-to-many field="actions" target-entity="Sylius\Component\Promotion\Model\ActionInterface" mapped-by="promotion">
+        <one-to-many field="actions" target-entity="Sylius\Component\Promotion\Model\ActionInterface" mapped-by="promotion" orphan-removal="true">
             <cascade>
                 <cascade-all />
             </cascade>


### PR DESCRIPTION
When updating promotions through the API, it leaves orphans in the database. Right now it only disconnects the relationship, but when you leave out an action, you want it to be gone completely. With this PR they are correctly removed when they are disconnected from their promotion.