### PR TITLE
[Promotion] make Toggleable

### DIFF
--- a/src/Sylius/Component/Addressing/Model/Country.php
+++ b/src/Sylius/Component/Addressing/Model/Country.php
@@ -13,6 +13,7 @@ namespace Sylius\Component\Addressing\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Resource\Model\ToggleableTrait;
 use Symfony\Component\Intl\Intl;
 
 /**
@@ -22,6 +23,8 @@ use Symfony\Component\Intl\Intl;
  */
 class Country implements CountryInterface
 {
+    use ToggleableTrait;
+
     /**
      * @var mixed
      */
@@ -38,11 +41,6 @@ class Country implements CountryInterface
      * @var Collection|ProvinceInterface[]
      */
     protected $provinces;
-
-    /**
-     * @var bool
-     */
-    protected $enabled = true;
 
     public function __construct()
     {
@@ -143,35 +141,4 @@ class Country implements CountryInterface
         return $this->provinces->contains($province);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isEnabled()
-    {
-        return $this->enabled;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setEnabled($enabled)
-    {
-        $this->enabled = (bool) $enabled;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function enable()
-    {
-        $this->enabled = true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function disable()
-    {
-        $this->enabled = false;
-    }
 }

--- a/src/Sylius/Component/Promotion/Checker/PromotionEligibilityChecker.php
+++ b/src/Sylius/Component/Promotion/Checker/PromotionEligibilityChecker.php
@@ -55,6 +55,10 @@ class PromotionEligibilityChecker implements PromotionEligibilityCheckerInterfac
      */
     public function isEligible(PromotionSubjectInterface $subject, PromotionInterface $promotion)
     {
+        if (!$promotion->isEnabled()) {
+            return false;
+        }
+
         if (!$this->isEligibleToDates($promotion)) {
             return false;
         }

--- a/src/Sylius/Component/Promotion/Model/Coupon.php
+++ b/src/Sylius/Component/Promotion/Model/Coupon.php
@@ -226,6 +226,10 @@ class Coupon implements CouponInterface
             return false;
         }
 
+        if (!$this->promotion->isEnabled()) {
+            return false;
+        }
+
         return true;
     }
 }

--- a/src/Sylius/Component/Promotion/Model/Promotion.php
+++ b/src/Sylius/Component/Promotion/Model/Promotion.php
@@ -13,12 +13,15 @@ namespace Sylius\Component\Promotion\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Resource\Model\ToggleableTrait;
 
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
 class Promotion implements PromotionInterface
 {
+    use ToggleableTrait;
+
     /**
      * @var mixed
      */

--- a/src/Sylius/Component/Promotion/Model/PromotionInterface.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionInterface.php
@@ -16,11 +16,12 @@ use Sylius\Component\Resource\Model\CodeAwareInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Model\SoftDeletableInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
+use Sylius\Component\Resource\Model\ToggleableInterface;
 
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-interface PromotionInterface extends CodeAwareInterface, SoftDeletableInterface, TimestampableInterface, ResourceInterface
+interface PromotionInterface extends CodeAwareInterface, SoftDeletableInterface, TimestampableInterface, ResourceInterface, ToggleableInterface
 {
     /**
      * @return string

--- a/src/Sylius/Component/Resource/Model/ToggleableTrait.php
+++ b/src/Sylius/Component/Resource/Model/ToggleableTrait.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Sylius\Component\Resource\Model;
+
+/**
+ * @author Richard van Laak <rvanlaak@gmail.com>
+ */
+trait ToggleableTrait
+{
+
+    /**
+     * @var bool
+     */
+    protected $enabled = true;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setEnabled($enabled = true)
+    {
+        $this->enabled = (bool) $enabled;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function enable()
+    {
+        $this->enabled = true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function disable()
+    {
+        $this->enabled = false;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | #2739 , #3098 |
| License | MIT |
| Doc PR |  |
#3098 did implement the `ToggleableInterface`, which also should be applied to `Promotion` because others can use their own custom implementation and don't have `Rules` when a promotion is added.

Because `0.17` bumped php to `>5.4` the actual implementation that already was there at the `Country` model has been refactored to a trait.

This PR probably isn't ready to merge, because we don't use all the Sylius components. Do we need to make changes to the web bundle?
