### PR TITLE
[Archetype] Fix ParentArchetypeListener

### DIFF
--- a/src/Sylius/Bundle/ArchetypeBundle/Form/EventListener/ParentArchetypeListener.php
+++ b/src/Sylius/Bundle/ArchetypeBundle/Form/EventListener/ParentArchetypeListener.php
@@ -62,15 +62,13 @@ class ParentArchetypeListener implements EventSubscriberInterface
         );
 
         if (null != $currentArchetype->getId()) {
-            $parentOptions = array(
-                'query_builder' => function (RepositoryInterface $repository) use ($currentArchetype) {
-                    return $repository
-                        ->createQueryBuilder('o')
-                        ->where('o.id != :id')
-                        ->setParameter('id', $currentArchetype->getId())
-                    ;
-                }
-            );
+            $parentOptions['query_builder'] = function (RepositoryInterface $repository) use ($currentArchetype) {
+                return $repository
+                    ->createQueryBuilder('o')
+                    ->where('o.id != :id')
+                    ->setParameter('id', $currentArchetype->getId())
+                ;
+            };
         }
 
         $form->add('parent', sprintf('sylius_%s_archetype_choice', $this->subject), $parentOptions);


### PR DESCRIPTION
The previous implementations overrode `$parentOptions` defined above with *query_builder* option. 