### PR TITLE
[Currency] Add isBase flag on CurrencyInterface

### DIFF
--- a/app/migrations/Version20160112145643.php
+++ b/app/migrations/Version20160112145643.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20160112145643 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_currency ADD base TINYINT(1) NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_currency DROP base');
+    }
+}

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/doctrine/model/Currency.mongodb.xml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/doctrine/model/Currency.mongodb.xml
@@ -23,6 +23,7 @@
         <field fieldName="code" name="code" type="string" length="3" />
         <field fieldName="exchangeRate" name="exchangeRate" type="float" />
         <field fieldName="enabled" name="enabled" type="boolean" />
+        <field name="base" column="base" type="boolean" />
 
         <field fieldName="createdAt" name="createdAt" type="date">
             <gedmo:timestampable on="create"/>

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/doctrine/model/Currency.orm.xml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/doctrine/model/Currency.orm.xml
@@ -25,6 +25,7 @@
         <field name="code" column="code" type="string" length="3" unique="true"/>
         <field name="exchangeRate" column="exchange_rate" type="decimal" precision="10" scale="5" />
         <field name="enabled" column="enabled" type="boolean" />
+        <field name="base" column="base" type="boolean" />
 
         <field name="createdAt" column="created_at" type="datetime">
             <gedmo:timestampable on="create"/>

--- a/src/Sylius/Component/Currency/Model/Currency.php
+++ b/src/Sylius/Component/Currency/Model/Currency.php
@@ -39,6 +39,11 @@ class Currency implements CurrencyInterface
     protected $enabled = true;
 
     /**
+     * @var bool
+     */
+    protected $base = false;
+
+    /**
      * @var \DateTime
      */
     protected $createdAt;
@@ -171,5 +176,21 @@ class Currency implements CurrencyInterface
     public function disable()
     {
         $this->enabled = false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isBase()
+    {
+        return $this->base;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setBase($base)
+    {
+        $this->base = $base;
     }
 }

--- a/src/Sylius/Component/Currency/Model/CurrencyInterface.php
+++ b/src/Sylius/Component/Currency/Model/CurrencyInterface.php
@@ -41,4 +41,14 @@ interface CurrencyInterface extends
      * @param float $rate
      */
     public function setExchangeRate($rate);
+
+    /**
+     * @return bool
+     */
+    public function isBase();
+
+    /**
+     * @param bool $base
+     */
+    public function setBase($base);
 }

--- a/src/Sylius/Component/Currency/spec/Model/CurrencySpec.php
+++ b/src/Sylius/Component/Currency/spec/Model/CurrencySpec.php
@@ -91,6 +91,17 @@ class CurrencySpec extends ObjectBehavior
         $this->shouldNotBeEnabled();
     }
 
+    function it_is_not_base_currency_by_default()
+    {
+        $this->shouldNotBeBase();
+    }
+
+    function it_can_can_be_base_currency()
+    {
+        $this->setBase(true);
+        $this->shouldBeBase();
+    }
+
     function it_initializes_creation_date_by_default()
     {
         $this->getCreatedAt()->shouldHaveType(\DateTime::class);


### PR DESCRIPTION
| Q                    | A
| -------------       | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

Added all methods required to set a Currency as a base one. This PR is connected with #3814, because now during the installation we get only one currency from the user, and we want to set it as the base one.