### PR TITLE
[Currency] Base currency's enabled status and exchange rate should not be editable

### DIFF
--- a/src/Sylius/Component/Currency/Model/Currency.php
+++ b/src/Sylius/Component/Currency/Model/Currency.php
@@ -111,6 +111,10 @@ class Currency implements CurrencyInterface
      */
     public function setExchangeRate($rate)
     {
+        if ($this->isBase()) {
+            throw new \LogicException('You cannot change the exchange rate of the base currency!');
+        }
+
         $this->exchangeRate = $rate;
     }
 
@@ -127,6 +131,10 @@ class Currency implements CurrencyInterface
      */
     public function setEnabled($enabled)
     {
+        if ($this->isBase()) {
+            throw new \LogicException('You cannot change the enabled status of the base currency!');
+        }
+
         $this->enabled = (bool) $enabled;
     }
 
@@ -175,6 +183,10 @@ class Currency implements CurrencyInterface
      */
     public function disable()
     {
+        if ($this->isBase()) {
+            throw new \LogicException('You cannot change the enabled status of the base currency!');
+        }
+
         $this->enabled = false;
     }
 

--- a/src/Sylius/Component/Currency/spec/Model/CurrencySpec.php
+++ b/src/Sylius/Component/Currency/spec/Model/CurrencySpec.php
@@ -127,4 +127,20 @@ class CurrencySpec extends ObjectBehavior
         $this->setUpdatedAt($date);
         $this->getUpdatedAt()->shouldReturn($date);
     }
+    
+    function its_exchange_rate_cannot_be_changed_if_it_is_base()
+    {
+        $this->setExchangeRate(1);
+        $this->setBase(true);
+
+        $this->shouldThrow(\LogicException::class)->duringSetExchangeRate(2.61);
+    }
+
+    function its_enabled_state_cannot_be_changed_if_it_is_base()
+    {
+        $this->setBase(true);
+
+        $this->shouldThrow(\LogicException::class)->duringDisable();
+        $this->shouldThrow(\LogicException::class)->duringSetEnabled(false);
+    }
 }


### PR DESCRIPTION
| Q                    | A
| -------------       | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| related PRs | #3814 #3887 
| License       | MIT