### PR TITLE
[Core] Refactor order checkout state machine

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
@@ -31,6 +31,9 @@ class AddressingStep extends CheckoutStep
     public function displayAction(ProcessContextInterface $context)
     {
         $order = $this->getCurrentCart();
+
+        $this->applyTransition('readdress', $order, true);
+
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::ADDRESSING_INITIALIZE, $order);
         $form = $this->createCheckoutAddressingForm($order, $this->getCustomer());
 
@@ -51,6 +54,8 @@ class AddressingStep extends CheckoutStep
         if ($form->handleRequest($request)->isValid()) {
             $this->dispatchCheckoutEvent(SyliusCheckoutEvents::ADDRESSING_PRE_COMPLETE, $order);
 
+            $this->applyTransition('address', $order);
+
             $this->getManager()->persist($order);
             $this->getManager()->flush();
 
@@ -62,6 +67,13 @@ class AddressingStep extends CheckoutStep
         return $this->renderStep($context, $order, $form);
     }
 
+    /**
+     * @param ProcessContextInterface $context
+     * @param OrderInterface $order
+     * @param FormInterface $form
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
     protected function renderStep(ProcessContextInterface $context, OrderInterface $order, FormInterface $form)
     {
         return $this->render($this->container->getParameter(sprintf('sylius.checkout.step.%s.template', $this->getName())), [

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
@@ -16,6 +16,7 @@ use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * The addressing step of checkout.
@@ -72,7 +73,7 @@ class AddressingStep extends CheckoutStep
      * @param OrderInterface $order
      * @param FormInterface $form
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     protected function renderStep(ProcessContextInterface $context, OrderInterface $order, FormInterface $form)
     {

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
@@ -14,6 +14,7 @@ namespace Sylius\Bundle\CoreBundle\Checkout\Step;
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -33,7 +34,7 @@ class AddressingStep extends CheckoutStep
     {
         $order = $this->getCurrentCart();
 
-        $this->applyTransition('readdress', $order, true);
+        $this->applyTransition(OrderCheckoutTransitions::TRANSITION_READDRESS, $order, true);
 
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::ADDRESSING_INITIALIZE, $order);
         $form = $this->createCheckoutAddressingForm($order, $this->getCustomer());
@@ -55,7 +56,7 @@ class AddressingStep extends CheckoutStep
         if ($form->handleRequest($request)->isValid()) {
             $this->dispatchCheckoutEvent(SyliusCheckoutEvents::ADDRESSING_PRE_COMPLETE, $order);
 
-            $this->applyTransition('address', $order);
+            $this->applyTransition(OrderCheckoutTransitions::TRANSITION_ADDRESS, $order);
 
             $this->getManager()->persist($order);
             $this->getManager()->flush();

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/CheckoutStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/CheckoutStep.php
@@ -28,8 +28,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundE
 abstract class CheckoutStep extends AbstractControllerStep
 {
     /**
-     * Get cart provider.
-     *
      * @return CartProviderInterface
      */
     protected function getCartProvider()
@@ -38,8 +36,6 @@ abstract class CheckoutStep extends AbstractControllerStep
     }
 
     /**
-     * Get current cart instance.
-     *
      * @return OrderInterface
      */
     protected function getCurrentCart()
@@ -48,8 +44,6 @@ abstract class CheckoutStep extends AbstractControllerStep
     }
 
     /**
-     * Get object manager.
-     *
      * @return ObjectManager
      */
     protected function getManager()
@@ -58,8 +52,6 @@ abstract class CheckoutStep extends AbstractControllerStep
     }
 
     /**
-     * Get zone matcher.
-     *
      * @return ZoneMatcherInterface
      */
     protected function getZoneMatcher()
@@ -68,8 +60,6 @@ abstract class CheckoutStep extends AbstractControllerStep
     }
 
     /**
-     * Is user logged in?
-     *
      * @return bool
      */
     protected function isUserLoggedIn()
@@ -82,8 +72,6 @@ abstract class CheckoutStep extends AbstractControllerStep
     }
 
     /**
-     * Dispatch event.
-     *
      * @param string $name
      * @param Event  $event
      */
@@ -93,13 +81,32 @@ abstract class CheckoutStep extends AbstractControllerStep
     }
 
     /**
-     * Dispatch checkout event.
-     *
      * @param string         $name
      * @param OrderInterface $order
      */
     protected function dispatchCheckoutEvent($name, OrderInterface $order)
     {
         $this->dispatchEvent($name, new GenericEvent($order));
+    }
+
+    /**
+     * @param string $transition
+     * @param OrderInterface $order
+     * @param bool $flush
+     */
+    protected function applyTransition($transition, OrderInterface $order, $flush = false)
+    {
+        $stateMachineFactory = $this->get('sm.factory');
+        $cartStateMachine = $stateMachineFactory->get($order, 'sylius_order_checkout');
+
+        if (!$cartStateMachine->can($transition)) {
+            return;
+        }
+
+        $cartStateMachine->apply($transition);
+
+        if ($flush) {
+            $this->getManager()->flush($order);
+        }
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/FinalizeStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/FinalizeStep.php
@@ -18,8 +18,6 @@ use Sylius\Component\Core\SyliusOrderEvents;
 use Sylius\Component\Order\OrderTransitions;
 
 /**
- * Final checkout step.
- *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Fernando Caraballo Ortiz <caraballo.ortiz@gmail.com>
  */
@@ -49,6 +47,12 @@ class FinalizeStep extends CheckoutStep
         return $this->complete();
     }
 
+    /**
+     * @param ProcessContextInterface $context
+     * @param OrderInterface $order
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
     protected function renderStep(ProcessContextInterface $context, OrderInterface $order)
     {
         return $this->render($this->container->getParameter(sprintf('sylius.checkout.step.%s.template', $this->getName())), [
@@ -58,8 +62,6 @@ class FinalizeStep extends CheckoutStep
     }
 
     /**
-     * Mark the order as completed.
-     *
      * @param OrderInterface $order
      */
     protected function completeOrder(OrderInterface $order)
@@ -71,6 +73,7 @@ class FinalizeStep extends CheckoutStep
         $this->dispatchCheckoutEvent(SyliusOrderEvents::PRE_CREATE, $order);
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::FINALIZE_PRE_COMPLETE, $order);
 
+        $this->applyTransition('complete', $order);
         $this->get('sm.factory')->get($order, OrderTransitions::GRAPH)->apply(OrderTransitions::SYLIUS_CREATE, true);
         if ($order->getCurrency() !== $currencyProvider->getBaseCurrency()) {
             $currencyRepository = $this->get('sylius.repository.currency');

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/FinalizeStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/FinalizeStep.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\CoreBundle\Checkout\Step;
 
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Sylius\Component\Core\SyliusOrderEvents;
 use Sylius\Component\Order\OrderTransitions;
@@ -74,7 +75,7 @@ class FinalizeStep extends CheckoutStep
         $this->dispatchCheckoutEvent(SyliusOrderEvents::PRE_CREATE, $order);
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::FINALIZE_PRE_COMPLETE, $order);
 
-        $this->applyTransition('complete', $order);
+        $this->applyTransition(OrderCheckoutTransitions::TRANSITION_COMPLETE, $order);
         $this->get('sm.factory')->get($order, OrderTransitions::GRAPH)->apply(OrderTransitions::SYLIUS_CREATE, true);
         if ($order->getCurrency() !== $currencyProvider->getBaseCurrency()) {
             $currencyRepository = $this->get('sylius.repository.currency');

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/FinalizeStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/FinalizeStep.php
@@ -16,6 +16,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Sylius\Component\Core\SyliusOrderEvents;
 use Sylius\Component\Order\OrderTransitions;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -51,7 +52,7 @@ class FinalizeStep extends CheckoutStep
      * @param ProcessContextInterface $context
      * @param OrderInterface $order
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     protected function renderStep(ProcessContextInterface $context, OrderInterface $order)
     {

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\CoreBundle\Checkout\Step;
 
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -33,7 +34,7 @@ class PaymentStep extends CheckoutStep
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::PAYMENT_INITIALIZE, $order);
 
-        $this->applyTransition('reselect_payment', $order, true);
+        $this->applyTransition(OrderCheckoutTransitions::TRANSITION_RESELECT_PAYMENT, $order, true);
 
         $form = $this->createCheckoutPaymentForm($order);
 
@@ -55,7 +56,7 @@ class PaymentStep extends CheckoutStep
         if ($form->handleRequest($request)->isValid()) {
             $this->dispatchCheckoutEvent(SyliusCheckoutEvents::PAYMENT_PRE_COMPLETE, $order);
 
-            $this->applyTransition('select_payment', $order);
+            $this->applyTransition(OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT, $order);
 
             $this->getManager()->persist($order);
             $this->getManager()->flush();

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
@@ -15,6 +15,7 @@ use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * The payment step of checkout.
@@ -72,7 +73,7 @@ class PaymentStep extends CheckoutStep
      * @param OrderInterface $order
      * @param FormInterface $form
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     protected function renderStep(ProcessContextInterface $context, OrderInterface $order, FormInterface $form)
     {
@@ -86,7 +87,7 @@ class PaymentStep extends CheckoutStep
     /**
      * @param OrderInterface $order
      *
-     * @return \Symfony\Component\Form\Form
+     * @return FormInterface
      */
     protected function createCheckoutPaymentForm(OrderInterface $order)
     {

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
@@ -36,6 +36,8 @@ class SecurityStep extends CheckoutStep
     public function displayAction(ProcessContextInterface $context)
     {
         $order = $this->getCurrentCart();
+        $this->applyTransition('start', $order);
+
         // If user is already logged in, transparently jump to next step.
         if ($this->isUserLoggedIn()) {
             return $this->processUserLoggedIn($order);

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
@@ -16,6 +16,7 @@ use Sylius\Bundle\FlowBundle\Process\Step\ActionResult;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\UserInterface;
+use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Sylius\Component\Resource\Event\ResourceEvent;
 use Symfony\Component\Form\FormInterface;
@@ -36,7 +37,7 @@ class SecurityStep extends CheckoutStep
     public function displayAction(ProcessContextInterface $context)
     {
         $order = $this->getCurrentCart();
-        $this->applyTransition('start', $order);
+        $this->applyTransition(OrderCheckoutTransitions::TRANSITION_START, $order);
 
         // If user is already logged in, transparently jump to next step.
         if ($this->isUserLoggedIn()) {

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
@@ -14,6 +14,7 @@ namespace Sylius\Bundle\CoreBundle\Checkout\Step;
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -39,7 +40,7 @@ class ShippingStep extends CheckoutStep
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::SHIPPING_INITIALIZE, $order);
 
-        $this->applyTransition('reselect_shipping', $order, true);
+        $this->applyTransition(OrderCheckoutTransitions::TRANSITION_RESELECT_SHIPPING, $order, true);
 
         $form = $this->createCheckoutShippingForm($order);
 
@@ -65,7 +66,7 @@ class ShippingStep extends CheckoutStep
         if ($form->handleRequest($request)->isValid()) {
             $this->dispatchCheckoutEvent(SyliusCheckoutEvents::SHIPPING_PRE_COMPLETE, $order);
 
-            $this->applyTransition('select_shipping', $order);
+            $this->applyTransition(OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING, $order);
 
             $this->getManager()->persist($order);
             $this->getManager()->flush();

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
@@ -16,6 +16,7 @@ use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Based on the user address, we present the available shipping methods,
@@ -61,7 +62,7 @@ class ShippingStep extends CheckoutStep
 
         $form = $this->createCheckoutShippingForm($order);
 
-         if ($form->handleRequest($request)->isValid()) {
+        if ($form->handleRequest($request)->isValid()) {
             $this->dispatchCheckoutEvent(SyliusCheckoutEvents::SHIPPING_PRE_COMPLETE, $order);
 
             $this->applyTransition('select_shipping', $order);
@@ -82,7 +83,7 @@ class ShippingStep extends CheckoutStep
      * @param OrderInterface $order
      * @param FormInterface $form
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     protected function renderStep(ProcessContextInterface $context, OrderInterface $order, FormInterface $form)
     {
@@ -96,7 +97,7 @@ class ShippingStep extends CheckoutStep
     /**
      * @param OrderInterface $order
      *
-     * @return \Symfony\Component\Form\Form
+     * @return FormInterface
      */
     protected function createCheckoutShippingForm(OrderInterface $order)
     {

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/state-machine.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/state-machine.yml
@@ -6,27 +6,36 @@ winzou_state_machine:
         state_machine_class: %sylius.state_machine.class%
         states:
             cart: ~
-            addressing: ~
-            shipping: ~
-            payment: ~
-            finalize: ~
+            started: ~
+            addressed: ~
+            shipping_selected: ~
+            payment_selected: ~
             completed: ~
         transitions:
-            addressing:
+            start:
                 from: [cart]
-                to:   addressing
-            shipping:
-                from: [addressing]
-                to:   shipping
-            payment:
-                from: [shipping]
-                to:   payment
-            finalize:
-                from: [payment]
-                to:   finalize
+                to: started
+            address:
+                from: [started]
+                to: addressed
+            readdress:
+                from: [payment_selected, shipping_selected, addressed]
+                to: started
+            select_shipping:
+                from: [addressed]
+                to: shipping_selected
+            reselect_shipping:
+                from: [payment_selected, shipping_selected]
+                to: addressed
+            select_payment:
+                from: [shipping_selected]
+                to: payment_selected
+            reselect_payment:
+                from: [payment_selected]
+                to: shipping_selected
             complete:
-                from: [finalize]
-                to:   completed
+                from: [payment_selected]
+                to: completed
 
     sylius_order_shipping:
         class:         %sylius.model.order.class%

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Cart\Model\Cart;
 use Sylius\Component\Channel\Model\ChannelInterface as BaseChannelInterface;
+use Sylius\Component\Core\OrderCheckoutStates;
 use Sylius\Component\Inventory\Model\InventoryUnitInterface;
 use Sylius\Component\Payment\Model\PaymentInterface as BasePaymentInterface;
 use Sylius\Component\Promotion\Model\CouponInterface as BaseCouponInterface;
@@ -75,7 +76,7 @@ class Order extends Cart implements OrderInterface
     /**
      * @var string
      */
-    protected $checkoutState = OrderInterface::CHECKOUT_STATE_CART;
+    protected $checkoutState = OrderCheckoutStates::STATE_CART;
 
     /**
      * @var string

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -75,7 +75,7 @@ class Order extends Cart implements OrderInterface
     /**
      * @var string
      */
-    protected $checkoutState = OrderInterface::STATE_CART;
+    protected $checkoutState = OrderInterface::CHECKOUT_STATE_CART;
 
     /**
      * @var string

--- a/src/Sylius/Component/Core/Model/OrderInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderInterface.php
@@ -31,13 +31,6 @@ interface OrderInterface extends
     CustomerAwareInterface,
     ChannelAwareInterface
 {
-    const CHECKOUT_STATE_ADDRESSED = 'addressed';
-    const CHECKOUT_STATE_CART = 'cart';
-    const CHECKOUT_STATE_COMPLETED  = 'completed';
-    const CHECKOUT_STATE_PAYMENT_SELECTED = 'payment_selected';
-    const CHECKOUT_STATE_SHIPPING_SELECTED = 'shipping_selected';
-    const CHECKOUT_STATE_STARTED = 'started';
-
     /**
      * @return null|UserInterface
      */

--- a/src/Sylius/Component/Core/Model/OrderInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderInterface.php
@@ -31,12 +31,12 @@ interface OrderInterface extends
     CustomerAwareInterface,
     ChannelAwareInterface
 {
+    const CHECKOUT_STATE_ADDRESSED = 'addressed';
     const CHECKOUT_STATE_CART = 'cart';
-    const CHECKOUT_STATE_ADDRESSING = 'addressing';
-    const CHECKOUT_STATE_SHIPPING = 'shipping';
-    const CHECKOUT_STATE_PAYMENT = 'payment';
-    const CHECKOUT_STATE_FINALIZE = 'finalize';
-    const CHECKOUT_STATE_COMPLETED = 'completed';
+    const CHECKOUT_STATE_COMPLETED  = 'completed';
+    const CHECKOUT_STATE_PAYMENT_SELECTED = 'payment_selected';
+    const CHECKOUT_STATE_SHIPPING_SELECTED = 'shipping_selected';
+    const CHECKOUT_STATE_STARTED = 'started';
 
     /**
      * @return null|UserInterface

--- a/src/Sylius/Component/Core/OrderCheckoutStates.php
+++ b/src/Sylius/Component/Core/OrderCheckoutStates.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class OrderCheckoutStates
+{
+    const STATE_ADDRESSED = 'addressed';
+    const STATE_CART = 'cart';
+    const STATE_COMPLETED = 'completed';
+    const STATE_PAYMENT_SELECTED = 'payment_selected';
+    const STATE_SHIPPING_SELECTED = 'shipping_selected';
+    const STATE_STARTED = 'started';
+}

--- a/src/Sylius/Component/Core/OrderCheckoutTransitions.php
+++ b/src/Sylius/Component/Core/OrderCheckoutTransitions.php
@@ -11,13 +11,19 @@
 
 namespace Sylius\Component\Core;
 
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
 class OrderCheckoutTransitions
 {
     const GRAPH = 'sylius_order_checkout';
 
-    const SYLIUS_ADDRESSING = 'addressing';
-    const SYLIUS_PAYMENT = 'payment';
-    const SYLIUS_SHIPPING = 'shipping';
-    const SYLIUS_FINALIZE = 'finalize';
-    const SYLIUS_COMPLETE = 'complete';
+    const TRANSITION_ADDRESS = 'address';
+    const TRANSITION_COMPLETE = 'complete';
+    const TRANSITION_READDRESS = 'readdress';
+    const TRANSITION_RESELECT_PAYMENT = 'reselect_payment';
+    const TRANSITION_RESELECT_SHIPPING = 'reselect_shipping';
+    const TRANSITION_SELECT_PAYMENT = 'select_payment';
+    const TRANSITION_SELECT_SHIPPING = 'select_shipping';
+    const TRANSITION_START = 'start';
 }

--- a/src/Sylius/Component/Core/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderSpec.php
@@ -21,6 +21,7 @@ use Sylius\Component\Core\Model\OrderShippingStates;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Model\PromotionInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
+use Sylius\Component\Core\OrderCheckoutStates;
 use Sylius\Component\Inventory\Model\InventoryUnitInterface;
 use Sylius\Component\Order\Model\Order;
 use Sylius\Component\Order\Model\OrderInterface;
@@ -88,8 +89,8 @@ class OrderSpec extends ObjectBehavior
 
     function its_checkout_state_is_mutable()
     {
-        $this->setCheckoutState(OrderInterface::STATE_CART);
-        $this->getCheckoutState()->shouldReturn(OrderInterface::STATE_CART);
+        $this->setCheckoutState(OrderCheckoutStates::STATE_CART);
+        $this->getCheckoutState()->shouldReturn(OrderCheckoutStates::STATE_CART);
     }
 
     function its_payment_state_is_mutable()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |
| License       | MIT
| Doc PR        |

Hello everybody! This PR is the result of recent brainstorm with @pjedrzejewski and @michalmarcinkowski about cart checkout flow. We've decided to refactor *Cart* state machine and, finally, use it to handle whole checkout logic to get rid of these nasty cart/checkout events and listeners.

And this is the first step. ``sylius_order_checkout`` state machine has ben reworked to have better named states and transitions. Whole checkout workflow now looks like this:
![checkout](https://cloud.githubusercontent.com/assets/6212718/12419933/7783f1ae-beb9-11e5-8cb1-27289f569c53.png)

Besides, there are proper transitions applied on ``Cart`` object in checkout steps. In the nearest future, *cart* and *checkout* events and listeners will be removed and replaced with proper state machine callbacks.