### PR TITLE
reports correct sum with currencies and label

### DIFF
--- a/app/migrations/Version20160118140609.php
+++ b/app/migrations/Version20160118140609.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20160118140609 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_order ADD exchange_rate NUMERIC(10, 5) NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_order DROP exchange_rate');
+    }
+}

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -237,6 +237,7 @@ default:
                 - Behat\MinkExtension\Context\MinkContext
                 - Sylius\Bundle\CoreBundle\Behat\HookContext
                 - Sylius\Bundle\AddressingBundle\Behat\AddressingContext
+                - Sylius\Bundle\ShippingBundle\Behat\ShippingContext
                 - Sylius\Bundle\CoreBundle\Behat\CoreContext
                 - Sylius\Bundle\PaymentBundle\Behat\PaymentContext
                 - Sylius\Bundle\ProductBundle\Behat\ProductContext

--- a/features/reports/reports.feature
+++ b/features/reports/reports.feature
@@ -9,6 +9,7 @@ Feature: Reports
           And there are following reports configured:
             | code             | name           | description | renderer | renderer_configuration                                       | data_fetcher      | data_fetcher_configuration                   |
             | table_report     | TableReport    | Lorem ipsum | table    | Template:SyliusReportBundle:Table:default.html.twig          | user_registration | Period:day,Start:2010-01-01,End:2010-04-01   |
+            | sales_report     | SalesReport    | Lorem ipsum | table    | Template:SyliusReportBundle:Table:default.html.twig          | sales_total       | Period:day,Start:2010-01-01,End:2010-01-05   |
             | bar_chart_report | BarChartReport | Lorem ipsum | chart    | Type:bar,Template:SyliusReportBundle:Chart:default.html.twig | user_registration | Period:month,Start:2010-01-01,End:2010-04-01 |
           And there are following users:
             | email          | enabled  | created at          |
@@ -20,13 +21,13 @@ Feature: Reports
     Scenario: Seeing created reports it the list
         Given I am on the dashboard page
          When I follow "Reports"
-         Then I should see 2 reports in the list
+         Then I should see 3 reports in the list
 
     Scenario: Adding new report with default options
         Given I am on the report creation page
          When I fill in the following:
             | Code        | report1           |
-            | Name        | Report1           | 
+            | Name        | Report1           |
             | Description | Lorem ipsum dolor |
           And I press "Create"
          Then I should be on the page of report "Report1"
@@ -59,7 +60,7 @@ Feature: Reports
           And I select "1" from "sylius_report_dataFetcherConfiguration_start_day"
           And I select "3" from "sylius_report_dataFetcherConfiguration_end_day"
           And I select "month" from "Time period"
-          And I press "Create" 
+          And I press "Create"
          Then I should be on the page of report "Report3"
           And I should see "Report has been successfully created"
           And I should see 1 results in the list
@@ -88,7 +89,7 @@ Feature: Reports
         Given I am on the report index page
          When I press "Details" near "TableReport"
          Then I should be on the page of report "TableReport"
-  
+
     Scenario: Accessing report edit form from list
         Given I am on the report index page
          When I press "Edit" near "TableReport"
@@ -140,3 +141,44 @@ Feature: Reports
         And I press "Create"
         Then I should still be on the report creation page
         And I should see "Report code cannot be blank"
+
+    Scenario: Getting the correct sum with exchange rate
+        Given the following zones are defined:
+            | name        | type    | members                 |
+            | Scandinavia | country | Norway, Sweden, Finland |
+            | France      | country | France                  |
+        And there are following shipping categories:
+            | code | name    |
+            | SC1  | Regular |
+            | SC2  | Heavy   |
+        And the following shipping methods exist:
+            | code | category | zone        | name |
+            | SM1  | Regular  | Scandinavia | DHL  |
+            | SM2  | Heavy    | France      | UPS  |
+        And the following products exist:
+            | name | price | sku |
+            | Mug  | 10    | 456 |
+            | Book | 22    | 948 |
+        And the following orders exist:
+            | customer                | shipment                 | address                                                           | currency | exchange_rate |
+            | sylius@example.com      | UPS, shipped, DTBHH380HG | Théophile Morel, 17 avenue Jean Portalis, 33000, Bordeaux, France | EUR      | 1.00000       |
+            | linustorvalds@linux.com | DHL, shipped, DTBHH380HH | Linus Torvalds, Väätäjänniementie 59, 00440, Helsinki, Finland    | USD      | 0.5           |
+            | sylius@example.com      | UPS, shipped, DTBHH380HI | Théophile Morel, 17 avenue Jean Portalis, 33000, Bordeaux, France | GBP      | 1.25          |
+        And order #000000001 has following items:
+            | product | quantity |
+            | Mug     | 2        |
+            | Book    | 1        |
+        And order #000000002 has following items:
+            | product | quantity |
+            | Mug     | 2        |
+            | Book    | 1        |
+        And order #000000003 has following items:
+            | product | quantity |
+            | Mug     | 2        |
+            | Book    | 1        |
+        And order #000000001 will be completed on "2010-01-01"
+        And order #000000002 will be completed on "2010-01-02"
+        And order #000000003 will be completed on "2010-01-02"
+        When I am on the page of report "SalesReport"
+        Then date "2010-01-01" will have "42" as total amount
+        Then date "2010-01-02" will have "73.50" as total amount

--- a/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
@@ -148,7 +148,16 @@ class CoreContext extends DefaultContext
 
             $this->createPayment($order, $paymentMethod);
 
-            $order->setCurrency('EUR');
+            if (isset($data['currency']) && '' !== trim($data['currency'])) {
+                $order->setCurrency($data['currency']);
+            } else {
+                $order->setCurrency('EUR');
+            }
+
+            if (isset($data['exchange_rate']) && '' !== trim($data['exchange_rate'])) {
+                $order->setExchangeRate($data['exchange_rate']);
+            }
+
             $order->setPaymentState(PaymentInterface::STATE_COMPLETED);
 
             $order->complete();

--- a/src/Sylius/Bundle/CoreBundle/DataFetcher/SalesTotalDataFetcher.php
+++ b/src/Sylius/Bundle/CoreBundle/DataFetcher/SalesTotalDataFetcher.php
@@ -13,12 +13,14 @@ namespace Sylius\Bundle\CoreBundle\DataFetcher;
 
 use Sylius\Bundle\ReportBundle\DataFetcher\TimePeriod;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Currency\Provider\CurrencyProviderInterface;
 use Sylius\Component\Report\DataFetcher\DefaultDataFetchers;
 
 /**
  * Sales total data fetcher
  *
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ * @author Fernando Caraballo Ortiz <caraballo.ortiz@gmail.com>
  */
 class SalesTotalDataFetcher extends TimePeriod
 {
@@ -28,11 +30,18 @@ class SalesTotalDataFetcher extends TimePeriod
     private $orderRepository;
 
     /**
-     * @param OrderRepositoryInterface $orderRepository
+     * @var CurrencyProviderInterface
      */
-    public function __construct(OrderRepositoryInterface $orderRepository)
+    private $currencyProvider;
+
+    /**
+     * @param OrderRepositoryInterface  $orderRepository
+     * @param CurrencyProviderInterface $currencyProvider
+     */
+    public function __construct(OrderRepositoryInterface $orderRepository, CurrencyProviderInterface $currencyProvider)
     {
-        $this->orderRepository = $orderRepository;
+        $this->orderRepository  = $orderRepository;
+        $this->currencyProvider = $currencyProvider;
     }
 
     /**
@@ -40,7 +49,9 @@ class SalesTotalDataFetcher extends TimePeriod
      */
     protected function getData(array $configuration = array())
     {
-        return $this->orderRepository->revenueBetweenDatesGroupByDate($configuration);
+        return $this->orderRepository->revenueBetweenDatesGroupByDate(
+            $configuration, $this->currencyProvider->getBaseCurrency()
+        );
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -316,7 +316,7 @@ class OrderRepository extends CartRepository implements OrderRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function revenueBetweenDatesGroupByDate(array $configuration = array())
+    public function revenueBetweenDatesGroupByDate(array $configuration = array(), $baseCurrency)
     {
         $groupBy = '';
         foreach ($configuration['groupBy'] as $groupByArray) {
@@ -330,8 +330,9 @@ class OrderRepository extends CartRepository implements OrderRepositoryInterface
             $configuration['end'],
             $groupBy);
 
+        $baseCurrencyCode = $baseCurrency ? 'in ' . $baseCurrency->getCode() : '';
         $queryBuilder
-            ->select('DATE(o.completed_at) as date', 'TRUNCATE(SUM(o.total)/ 100,2) as "total sum"')
+            ->select('DATE(o.completed_at) as date', 'TRUNCATE(SUM(o.total * o.exchange_rate)/ 100,2) as "total sum ' . $baseCurrencyCode . '"')
         ;
 
         return $queryBuilder

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Order.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Order.orm.xml
@@ -11,6 +11,7 @@
             <gedmo:versioned />
         </field>
 
+        <field name="exchangeRate" column="exchange_rate" type="decimal" precision="10" scale="5" />
         <field type="string" name="checkoutState" column="checkout_state" />
         <field type="string" name="paymentState" column="payment_state" />
         <field type="string" name="shippingState" column="shipping_state" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/reports.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/reports.xml
@@ -30,6 +30,7 @@
 
         <service id="sylius.report.data_fetcher.sales_total" class="%sylius.report.data_fetcher.sales_total.class%">
             <argument type="service" id="sylius.repository.order" />
+            <argument type="service" id="sylius.currency_provider" />
             <tag name="sylius.report.data_fetcher" fetcher="sales_total" label="Sales Total" />
         </service>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -296,6 +296,7 @@
         </service>
         <service id="sylius.listener.order_currency" class="%sylius.listener.order_currency.class%">
             <argument type="service" id="sylius.context.currency" />
+            <argument type="service" id="sylius.repository.currency" />
             <tag name="kernel.event_listener" event="sylius.cart.initialize" method="processOrderCurrency" />
         </service>
         <service id="sylius.listener.customer_aware" class="%sylius.listener.customer_aware.class%">

--- a/src/Sylius/Bundle/CoreBundle/spec/DataFetcher/SalesTotalDataFetcherSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/DataFetcher/SalesTotalDataFetcherSpec.php
@@ -15,6 +15,7 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\ReportBundle\DataFetcher\TimePeriod;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Currency\Provider\CurrencyProviderInterface;
 use Sylius\Component\Report\DataFetcher\Data;
 use Sylius\Component\Report\DataFetcher\DataFetcherInterface;
 use Sylius\Component\Report\DataFetcher\DefaultDataFetchers;
@@ -39,9 +40,9 @@ class SalesTotalDataFetcherSpec extends ObjectBehavior
         $this->shouldImplement(DataFetcherInterface::class);
     }
 
-    public function let(OrderRepositoryInterface $orderRepository)
+    public function let(OrderRepositoryInterface $orderRepository, CurrencyProviderInterface $currencyProvider)
     {
-        $this->beConstructedWith($orderRepository);
+        $this->beConstructedWith($orderRepository, $currencyProvider);
     }
 
     public function it_has_type()
@@ -59,7 +60,7 @@ class SalesTotalDataFetcherSpec extends ObjectBehavior
             'period' => 'day',
             'empty_records' => false, );
 
-        $orderRepository->revenueBetweenDatesGroupByDate(Argument::type('array'))->willReturn($rawData);
+        $orderRepository->revenueBetweenDatesGroupByDate(Argument::type('array'), null)->willReturn($rawData);
 
         $data = new Data();
         $data->setLabels(array_keys($rawData[0]));
@@ -78,7 +79,7 @@ class SalesTotalDataFetcherSpec extends ObjectBehavior
             'period' => 'month',
             'empty_records' => false, );
 
-        $orderRepository->revenueBetweenDatesGroupByDate(Argument::type('array'))->willReturn($rawData);
+        $orderRepository->revenueBetweenDatesGroupByDate(Argument::type('array'), null)->willReturn($rawData);
 
         $data = new Data();
         $data->setLabels(array_keys($rawData[0]));
@@ -97,7 +98,7 @@ class SalesTotalDataFetcherSpec extends ObjectBehavior
             'period' => 'year',
             'empty_records' => false, );
 
-        $orderRepository->revenueBetweenDatesGroupByDate(Argument::type('array'))->willReturn($rawData);
+        $orderRepository->revenueBetweenDatesGroupByDate(Argument::type('array'), null)->willReturn($rawData);
 
         $data = new Data();
         $data->setLabels(array_keys($rawData[0]));
@@ -116,7 +117,7 @@ class SalesTotalDataFetcherSpec extends ObjectBehavior
             'period' => 'month',
             'empty_records' => true, );
 
-        $orderRepository->revenueBetweenDatesGroupByDate(Argument::type('array'))->willReturn($rawData);
+        $orderRepository->revenueBetweenDatesGroupByDate(Argument::type('array'), null)->willReturn($rawData);
 
         $data = new Data();
         $data->setLabels(array_keys($rawData[0]));
@@ -125,7 +126,7 @@ class SalesTotalDataFetcherSpec extends ObjectBehavior
         $this->fetch($configuration)->shouldBeLike($data);
     }
 
-    public function it_does_not_allowed_wrond_data_period($orderRepository, Data $data)
+    public function it_does_not_allowed_wrond_data_period()
     {
         $configuration = array(
             'start' => new \DateTime('2010-01-01 00:00:00.000000'),

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/OrderCurrencyListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/OrderCurrencyListenerSpec.php
@@ -12,15 +12,17 @@
 namespace spec\Sylius\Bundle\CoreBundle\EventListener;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Currency\Context\CurrencyContextInterface;
+use Sylius\Component\Currency\Model\Currency;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 class OrderCurrencyListenerSpec extends ObjectBehavior
 {
-    function let(CurrencyContextInterface $currencyContext)
+    function let(CurrencyContextInterface $currencyContext, EntityRepository $currencyRepository)
     {
-        $this->beConstructedWith($currencyContext);
+        $this->beConstructedWith($currencyContext, $currencyRepository);
     }
 
     function it_is_initializable()
@@ -44,11 +46,19 @@ class OrderCurrencyListenerSpec extends ObjectBehavior
     function it_sets_currency_on_order(
         $currencyContext,
         GenericEvent $event,
-        OrderInterface $order
+        OrderInterface $order,
+        EntityRepository $currencyRepository,
+        Currency $currency
     )
     {
         $event->getSubject()->willReturn($order);
         $currencyContext->getCurrency()->shouldBeCalled()->willReturn('PLN');
+
+        $currencyRepository->findOneBy(['code' => 'PLN'])->shouldBeCalled()->willReturn($currency);
+
+        $currency->getCode()->willReturn('EUR');
+
+        $currencyContext->getDefaultCurrency()->willReturn('EUR');
 
         $this->processOrderCurrency($event);
     }

--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadOrdersData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadOrdersData.php
@@ -40,6 +40,12 @@ class LoadOrdersData extends DataFixture
             'MOBILE',
         );
 
+        $currencyExchangeRates = array(
+            'GBP' => 0.8,
+            'USD' => 1.2,
+            'EUR' => 1.0
+        );
+
         for ($i = 1; $i <= 50; $i++) {
             /* @var $order OrderInterface */
             $order = $orderFactory->createNew();
@@ -62,7 +68,8 @@ class LoadOrdersData extends DataFixture
 
             $this->createShipment($order);
 
-            $order->setCurrency($this->faker->randomElement(array('EUR', 'USD', 'GBP')));
+            $order->setCurrency($this->faker->randomElement(array_keys($currencyExchangeRates)));
+            $order->setExchangeRate($currencyExchangeRates[$order->getCurrency()]);
             $order->setShippingAddress($this->createAddress());
             $order->setBillingAddress($this->createAddress());
             $order->setCreatedAt($this->faker->dateTimeBetween('1 year ago', 'now'));

--- a/src/Sylius/Bundle/ReportBundle/Behat/ReportContext.php
+++ b/src/Sylius/Bundle/ReportBundle/Behat/ReportContext.php
@@ -18,6 +18,7 @@ use Sylius\Bundle\ResourceBundle\Behat\DefaultContext;
  * ReportContext for ReportBundle scenarios.
  *
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ * @author Fernando Caraballo Ortiz <caraballo.ortiz@gmail.com>
  */
 class ReportContext extends DefaultContext
 {
@@ -95,5 +96,34 @@ class ReportContext extends DefaultContext
         }
 
         return $report;
+    }
+
+    /**
+     * @Then date :date will have :total as total amount
+     */
+    public function dateWillHaveAsTotalAmount($date, $total)
+    {
+        $page = $this->getSession()->getPage();
+        $rows = $page->findAll('css', 'table tbody tr');
+        foreach($rows as $row) {
+            $columns = $row->findAll('css', 'td');
+            if ($columns[1]->getText() === $date) {
+                \PHPUnit_Framework_Assert::assertEquals($columns[2]->getText(), $total);
+            }
+        }
+    }
+
+    /**
+     * @Given order #:orderNumber will be completed on :date
+     */
+    public function orderWillBeCompletedOn($orderNumber, $date)
+    {
+        $orderRepository = $this->getContainer()->get('sylius.repository.cart');
+        $orderManager    = $this->getContainer()->get('sylius.manager.cart');
+
+        $order = $orderRepository->findOneBy(['number' => $orderNumber]);
+        $order->setCompletedAt(new \DateTime($date));
+
+        $orderManager->flush();
     }
 }

--- a/src/Sylius/Component/Core/Currency/ChannelAwareCurrencyProvider.php
+++ b/src/Sylius/Component/Core/Currency/ChannelAwareCurrencyProvider.php
@@ -19,6 +19,7 @@ use Sylius\Component\Currency\Provider\CurrencyProviderInterface;
  * Currency provider, which returns currencies enabled for this channel.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Fernando Caraballo Ortiz <caraballo.ortiz@gmail.com.org>
  */
 class ChannelAwareCurrencyProvider implements CurrencyProviderInterface
 {
@@ -47,5 +48,19 @@ class ChannelAwareCurrencyProvider implements CurrencyProviderInterface
         return $currentChannel->getCurrencies()->filter(function (CurrencyInterface $currency) {
             return $currency->isEnabled();
         });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBaseCurrency()
+    {
+        $currentChannel =  $this->channelContext->getChannel();
+
+        foreach ($currentChannel->getCurrencies() as $currency) {
+            if ($currency->isBase()) return $currency;
+        }
+
+        return;
     }
 }

--- a/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
+++ b/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
@@ -54,11 +54,12 @@ interface OrderRepositoryInterface extends BaseOrderRepositoryInterface
      * Gets revenue group by date
      * between particular dates
      *
-     * @param array $configuration
+     * @param array  $configuration
+     * @param string $baseCurrency
      *
      * @return array
      */
-    public function revenueBetweenDatesGroupByDate(array $configuration = array());
+    public function revenueBetweenDatesGroupByDate(array $configuration = array(), $baseCurrency);
 
     /**
      * Gets number of orders group by date

--- a/src/Sylius/Component/Currency/Provider/CurrencyProvider.php
+++ b/src/Sylius/Component/Currency/Provider/CurrencyProvider.php
@@ -15,6 +15,7 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Fernando Caraballo Ortiz <caraballo.ortiz@gmail.com>
  */
 class CurrencyProvider implements CurrencyProviderInterface
 {
@@ -37,5 +38,13 @@ class CurrencyProvider implements CurrencyProviderInterface
     public function getAvailableCurrencies()
     {
         return $this->currencyRepository->findBy(array('enabled' => true));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBaseCurrency()
+    {
+        return $this->currencyRepository->findOneBy(['base' => true]);
     }
 }

--- a/src/Sylius/Component/Currency/Provider/CurrencyProviderInterface.php
+++ b/src/Sylius/Component/Currency/Provider/CurrencyProviderInterface.php
@@ -15,6 +15,7 @@ use Sylius\Component\Currency\Model\CurrencyInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Fernando Caraballo Ortiz <caraballo.ortiz@gmail.com>
  */
 interface CurrencyProviderInterface
 {
@@ -22,4 +23,9 @@ interface CurrencyProviderInterface
      * @return CurrencyInterface[]
      */
     public function getAvailableCurrencies();
+
+    /**
+     * @return CurrencyInterface
+     */
+    public function getBaseCurrency();
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #3715
| License       | MIT
| Doc PR        | no

- Added field exchange_rate to sylius_order in order to save the exchange rate in that specific date
- Updated query for reports in order to count check the exchange rate (o.total * o.exchange_rate)
- Behat for reports feature "Getting the correct sum with exchange rate"
- Table label: if there's a base currency it should be showed on it. For e.g. TOTAL SUM IN GBP
- Created method for getting the channel base currency (getBaseCurrency)
- Behats and PHPSpec updated