### PR TITLE
[User][Cart][Dependency] Extract Cart dependencies from UserBundle

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/CustomerAwareListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/CustomerAwareListener.php
@@ -9,34 +9,26 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\UserBundle\EventListener;
+namespace Sylius\Bundle\CoreBundle\EventListener;
 
+use Sylius\Bundle\UserBundle\EventListener\CustomerAwareListener as BaseCustomerAwareListener;
+use Sylius\Component\Cart\Event\CartEvent;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
-use Sylius\Component\User\Context\CustomerContextInterface;
 use Sylius\Component\User\Model\CustomerAwareInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
-class CustomerAwareListener
+class CustomerAwareListener extends BaseCustomerAwareListener
 {
-    /**
-     * @var CustomerContextInterface
-     */
-    protected $customerContext;
-
-    /**
-     * @param CustomerContextInterface $securityContext
-     */
-    public function __construct(CustomerContextInterface $securityContext)
-    {
-        $this->customerContext = $securityContext;
-    }
-
     /**
      * @param GenericEvent $event
      */
     public function setCustomer(GenericEvent $event)
     {
-        $resource = $event->getSubject();
+        if ($event instanceof CartEvent) {
+            $resource = $event->getCart();
+        } else {
+            $resource = $event->getSubject();
+        }
 
         if (!$resource instanceof CustomerAwareInterface) {
             throw new UnexpectedTypeException($resource, CustomerAwareInterface::class);

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -56,6 +56,7 @@
         <parameter key="sylius.listener.insufficient_stock_exception.class">Sylius\Bundle\CoreBundle\EventListener\InsufficientStockExceptionListener</parameter>
         <parameter key="sylius.listener.image_upload.class">Sylius\Bundle\CoreBundle\EventListener\ImageUploadListener</parameter>
         <parameter key="sylius.listener.channel.class">Sylius\Bundle\CoreBundle\EventListener\ChannelDeletionListener</parameter>
+        <parameter key="sylius.listener.customer_aware.class">Sylius\Bundle\CoreBundle\EventListener\CustomerAwareListener</parameter>
 
         <parameter key="sylius.promotion_processor.class">Sylius\Bundle\CoreBundle\OrderProcessing\PromotionProcessor</parameter>
         <parameter key="sylius.promotion_rule_checker.nth_order.class">Sylius\Component\Core\Promotion\Checker\NthOrderRuleChecker</parameter>

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/CustomerAwareListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/CustomerAwareListenerSpec.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\CoreBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\CoreBundle\EventListener\CustomerAwareListener;
+use Sylius\Bundle\UserBundle\EventListener\CustomerAwareListener as BaseCustomerAwareListener;
+use Sylius\Component\Cart\Event\CartEvent;
+use Sylius\Component\User\Context\CustomerContextInterface;
+use Sylius\Component\User\Model\CustomerAwareInterface;
+use Sylius\Component\User\Model\CustomerInterface;
+
+/**
+ * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
+ */
+class CustomerAwareListenerSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(CustomerAwareListener::class);
+    }
+
+    function it_extends_user_customer_aware_interface()
+    {
+        $this->shouldHaveType(BaseCustomerAwareListener::class);
+    }
+
+    function let(CustomerContextInterface $customerContext)
+    {
+        $this->beConstructedWith($customerContext);
+    }
+
+    function it_sets_customer_on_a_cart(
+        $customerContext,
+        CartEvent $event,
+        CustomerAwareInterface $cart,
+        CustomerInterface $customer
+    ) {
+        $event->getCart()->willReturn($cart);
+        $customerContext->getCustomer()->willReturn($customer);
+
+        $cart->setCustomer($customer)->shouldBeCalled();
+
+        $this->setCustomer($event);
+    }
+}

--- a/src/Sylius/Bundle/UserBundle/composer.json
+++ b/src/Sylius/Bundle/UserBundle/composer.json
@@ -35,7 +35,6 @@
         "php": "^5.5.9|^7.0",
 
         "sylius/user": "0.17.*",
-        "sylius/cart": "0.17.*",
         "sylius/resource-bundle": "0.17.*",
         "sylius/mailer-bundle": "0.17.*",
         "symfony/framework-bundle": "^2.7.5",

--- a/src/Sylius/Bundle/UserBundle/spec/EventListener/CustomerAwareListenerSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/EventListener/CustomerAwareListenerSpec.php
@@ -13,7 +13,7 @@ namespace spec\Sylius\Bundle\UserBundle\EventListener;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Sylius\Component\Cart\Event\CartEvent;
+use Sylius\Bundle\UserBundle\EventListener\CustomerAwareListener;
 use Sylius\Component\User\Context\CustomerContextInterface;
 use Sylius\Component\User\Model\CustomerAwareInterface;
 use Sylius\Component\User\Model\CustomerInterface;
@@ -26,7 +26,7 @@ class CustomerAwareListenerSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Bundle\UserBundle\EventListener\CustomerAwareListener');
+        $this->shouldHaveType(CustomerAwareListener::class);
     }
 
     function let(CustomerContextInterface $customerContext)
@@ -67,20 +67,6 @@ class CustomerAwareListenerSpec extends ObjectBehavior
         $customerContext->getCustomer()->willReturn($customer);
 
         $resource->setCustomer($customer)->shouldBeCalled();
-
-        $this->setCustomer($event);
-    }
-
-    function it_sets_customer_on_a_cart(
-        $customerContext,
-        CartEvent $event,
-        CustomerAwareInterface $cart,
-        CustomerInterface $customer
-    ) {
-        $event->getCart()->willReturn($cart);
-        $customerContext->getCustomer()->willReturn($customer);
-
-        $cart->setCustomer($customer)->shouldBeCalled();
 
         $this->setCustomer($event);
     }


### PR DESCRIPTION
<code>UserBundle</code> requires <code>Cart</code>, <code>Cart</code> requires <code>Order</code>, so <code>UserBundle</code> is not usable in standalone mode... This PR move the <code>Cart</code> related code to <code>Core</code> to fix that.