### PR TITLE
[POC] Integration tests for bundles

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- http://phpunit.de/manual/4.1/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
          backupGlobals="false"

--- a/src/Sylius/Bundle/TaxationBundle/.gitignore
+++ b/src/Sylius/Bundle/TaxationBundle/.gitignore
@@ -3,3 +3,6 @@ bin/
 
 composer.phar
 composer.lock
+
+tests/app/cache
+tests/app/logs

--- a/src/Sylius/Bundle/TaxationBundle/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/composer.json
@@ -30,6 +30,7 @@
     },
     "require-dev": {
         "phpspec/phpspec": "^2.4",
+        "phpunit/phpunit": "^4.8",
         "doctrine/orm": "^2.4.8,<2.5",
         "symfony/form": "^2.7"
     },

--- a/src/Sylius/Bundle/TaxationBundle/phpunit.xml.dist
+++ b/src/Sylius/Bundle/TaxationBundle/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="tests/app/autoload.php"
+>
+    <testsuites>
+        <testsuite name="SyliusTaxationBundle Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Sylius/Bundle/TaxationBundle/tests/app/AppKernel.php
+++ b/src/Sylius/Bundle/TaxationBundle/tests/app/AppKernel.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+/**
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+class AppKernel extends Kernel
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function registerBundles()
+    {
+        return array(
+            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new Sylius\Bundle\TaxationBundle\SyliusTaxationBundle(),
+            new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            new \Sylius\Bundle\ResourceBundle\SyliusResourceBundle(),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(__DIR__.'/config.yml');
+    }
+}

--- a/src/Sylius/Bundle/TaxationBundle/tests/app/autoload.php
+++ b/src/Sylius/Bundle/TaxationBundle/tests/app/autoload.php
@@ -1,0 +1,5 @@
+<?php
+
+$loader = require __DIR__.'/../../vendor/autoload.php';
+
+require __DIR__.'/AppKernel.php';

--- a/src/Sylius/Bundle/TaxationBundle/tests/app/config.yml
+++ b/src/Sylius/Bundle/TaxationBundle/tests/app/config.yml
@@ -1,0 +1,17 @@
+framework:
+    secret: "Three can keep a secret, if two of them are dead."
+    router:
+        resource: %kernel.root_dir%/routing.yml
+    session: ~
+
+doctrine:
+    dbal:
+        driver: pdo_sqlite
+        dbname: sylius
+        path: db.sql
+        charset: UTF8
+    orm:
+        auto_generate_proxy_classes: %kernel.debug%
+        entity_managers:
+            default:
+                auto_mapping: true

--- a/src/Sylius/Bundle/TaxationBundle/tests/app/routing.yml
+++ b/src/Sylius/Bundle/TaxationBundle/tests/app/routing.yml
@@ -1,0 +1,4 @@
+sylius_tax_category:
+    resource: |
+        alias: sylius.tax_category
+    type: sylius.resource

--- a/src/Sylius/Bundle/TaxationBundle/tests/src/Tests/ContainerTest.php
+++ b/src/Sylius/Bundle/TaxationBundle/tests/src/Tests/ContainerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\TaxationBundle\Tests;
+
+use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+use Sylius\Bundle\ResourceBundle\Form\Type\ResourceChoiceType;
+use Sylius\Bundle\TaxationBundle\Form\Type\TaxCategoryType;
+use Sylius\Component\Resource\Factory\Factory;
+use Sylius\Component\Taxation\Model\TaxCategory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+class ContainerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    protected function setUp()
+    {
+        $kernel = new \AppKernel('test', true);
+        $kernel->boot();
+
+        $this->container = $kernel->getContainer();
+    }
+
+    /**
+     * @test
+     */
+    public function it_registers_tax_category_services()
+    {
+        $this->assertEquals(TaxCategory::class, $this->container->getParameter('sylius.model.tax_category.class'));
+
+        $factoryService = $this->container->get('sylius.factory.tax_category');
+        $this->assertInstanceOf(Factory::class, $factoryService);
+
+        $repositoryService = $this->container->get('sylius.repository.tax_category');
+        $this->assertInstanceOf(EntityRepository::class, $repositoryService);
+
+        $controllerService = $this->container->get('sylius.controller.tax_category');
+        $this->assertInstanceOf(ResourceController::class, $controllerService);
+
+        $formType = $this->container->get('sylius.form.type.tax_category');
+        $this->assertInstanceOf(TaxCategoryType::class, $formType);
+
+        $choiceFormType = $this->container->get('sylius.form.type.tax_category_choice');
+        $this->assertInstanceOf(ResourceChoiceType::class, $choiceFormType);
+    }
+}


### PR DESCRIPTION
Hi,

For v0.16.0 I spent way too much time over several days in order to fix bundle's composer.json files and generally various coupling issues. I'd to like to avoid doing that for future releases and release more often with bundles/components working standalone. I have enabled tests on all subtree splits, so now when subtree split is updated we can see the result of test case. For components that works fine, we have them covered with specs, so we are sure that composer.json works well and has all required deps.

With bundles however, specs are not enough because we need to actually verify that they work inside Symfony.

This is a very PoC of how we could test bundles individually and I already see it works wonders for discovering what are real deps of a bundle, what is minimal configuration to setup etc. This is based on - http://gnugat.github.io/2014/10/29/sf2-bundle-standalone.html - very cool article.

I am 100% convinced that going the way of standalone eCommerce bundles and components was a good decision, but we need to fulfill the promise of shipping decoupled, standalone bundles that work without Sylius. Without these tests it is difficult, we can easily overlook some coupling and bugs occurding outside of Sylius, without the core. Especially that development happens inside the core.

Overview of benefits:

* Ensuring that composer.json's are valid and have all deps;
* Ensuring that there is no coupling to the core;
* Clear view on what is needed to get it working;
* Features can be implemented in bundles first, then integrated into the core, so we can make smaller PRs;

Overview of possible problems and stuff that we need to figure out:

This ``ContainerTest`` is super simple example, I just wanted to show you what I imagine and we can grow the idea together. This test is already helpful and +12423 improvement over no test - we verify that bundle is installed like in documentation etc. but there is plenty of other ways to test these:

* Test container services;
* Test API with ApiTestCase;
* Test HTML interface with SyliusUiBundle and Grids (we would not need to have any templates in the bundle, yay)
* Test console commands;

So yeah, we need to decide what we really want to test, of course, best would be everything but of course it comes at a cost, so we should definitely consider that and stick to good practices about economy of tests.

One thing I see with the ContainerTest example is that this will be duplicated for pretty much every single Sylius resource but not always consistent - some resources have custom repositories etc.

What do you think? :>

Also, would be best if we can figure out a good practices on a single bundle (let's stick with Taxation), I will finish it and then hopefully community will pick up this and add it for other bundles. :)