### PR TITLE
[Translation] Move TranslationLocaleProvider from the CoreBundle to Translation

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -110,7 +110,7 @@
         <parameter key="sylius.form.type.data_fetcher.user_registration.class">Sylius\Bundle\CoreBundle\Form\Type\DataFetcher\UserRegistrationType</parameter>
 
         <parameter key="sylius.authorization_checker.toggleable.class">Sylius\Bundle\CoreBundle\Authorization\ToggleableAuthorizationChecker</parameter>
-        <parameter key="sylius.translation.locale_provider.contextual.class">Sylius\Bundle\CoreBundle\Locale\TranslationLocaleProvider</parameter>
+        <parameter key="sylius.translation.locale_provider.contextual.class">Sylius\Component\Translation\Provider\TranslationLocaleProvider</parameter>
     </parameters>
 
     <services>

--- a/src/Sylius/Component/Translation/Provider/TranslationLocaleProvider.php
+++ b/src/Sylius/Component/Translation/Provider/TranslationLocaleProvider.php
@@ -9,10 +9,9 @@
 * file that was distributed with this source code.
 */
 
-namespace Sylius\Bundle\CoreBundle\Locale;
+namespace Sylius\Component\Translation\Provider;
 
 use Sylius\Component\Locale\Context\LocaleContextInterface;
-use Sylius\Component\Translation\Provider\LocaleProviderInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #2693, #4633
| License       | MIT
| Doc PR        | n/a

The class is not dependent on Symfony, but registering this class
as a service would be required in some projects using Sylius
translatable models.

Question: Should the service definition be moved from the CoreBundle to either the TranslationBundle or LocaleBundle, or stay in the CoreBundle?