### PR TITLE
[ResourceBundle] Toggle the resource with property accessor.

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -390,9 +390,11 @@ class ResourceController extends Controller
         $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);
 
         $this->isGrantedOr403($configuration, ResourceActions::UPDATE);
-
         $resource = $this->findOr404($configuration);
-        $resource->setEnabled($enabled);
+        $defaultAttribute = 'enabled';
+        $attribute = $this->metadata->hasParameter('attribute') ? $this->metadata->getParameter('attribute') : $defaultAttribute;
+        $accessor = PropertyAccess::createPropertyAccessor();
+        $accessor->setValue($resource, $attribute, $enabled);
 
         $this->eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource);
         $this->manager->flush();
@@ -402,7 +404,13 @@ class ResourceController extends Controller
             return $this->viewHandler->handle($configuration, View::create($resource, 204));
         }
 
-        $this->flashHelper->addSuccessFlash($configuration, $enabled ? 'enable' : 'disable', $resource);
+        $flashKey = $enabled ? 'enable' : 'disable';
+
+        if ($attribute !== $defaultAttribute) {
+            $flashKey .= '_' . $attribute;
+        }
+
+        $this->flashHelper->addSuccessFlash($configuration, $flashKey, $resource);
 
         return $this->redirectHandler->redirectToIndex($configuration, $resource);
     }

--- a/src/Sylius/Bundle/ResourceBundle/composer.json
+++ b/src/Sylius/Bundle/ResourceBundle/composer.json
@@ -31,6 +31,7 @@
         "symfony/expression-language": "^2.7",
         "symfony/form": "^2.7",
         "symfony/validator": "^2.7",
+        "symfony/property-access": "^2.7",
         "symfony/framework-bundle": "^2.7.7",
         "symfony/twig-bundle": "^2.7",
         "white-october/pagerfanta-bundle": "^1.0",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug Fix? | n |
| New Feature? | Y |
| BC Breaks? | n |
| Deprecations? | n |
| Tests Pass? | n |
| Fixed Tickets |  |
| License | MIT |
| Doc PR |  |

Doc:
Allow to configuration resource's attribute for toggle.

``` yaml

sylius_backend_locale_enable:
    path: /{id}/enable
    methods: [PATCH]
    defaults:
        _controller: sylius.controller.locale:enableAction
        _sylius:
            redirect: sylius_backend_locale_index
            attribute: enabled

sylius_backend_locale_disable:
    path: /{id}/disable
    methods: [PATCH]
    defaults:
        _controller: sylius.controller.locale:disableAction
        _sylius:
            redirect: sylius_backend_locale_index
            attribute: enabled
```

Note: About toggle resource we have some common use-case `batch-toggle`, Who has some idea?
