### PR TITLE
[Addressing] Province fixes

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceCodeChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceCodeChoiceType.php
@@ -54,7 +54,7 @@ class ProvinceCodeChoiceType extends ProvinceChoiceType
      *
      * @return array
      */
-    private function getProvinceCodes(array $provinces)
+    private function getProvinceCodes($provinces)
     {
         $provincesCodes = array();
 

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/services.xml
@@ -65,6 +65,7 @@
         </service>
         <service id="sylius.validator.valid_province_address" class="%sylius.validator.valid_province_address.class%">
             <argument type="service" id="sylius.repository.country" />
+            <argument type="service" id="sylius.repository.province" />
             <tag name="validator.constraint_validator" alias="sylius_province_address_validator" />
         </service>
     </services>

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraintValidator.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraintValidator.php
@@ -27,11 +27,18 @@ class ProvinceAddressConstraintValidator extends ConstraintValidator
     private $countryRepository;
 
     /**
-     * @param RepositoryInterface $countryRepository
+     * @var RepositoryInterface
      */
-    public function __construct(RepositoryInterface $countryRepository)
+    private $provinceRepository;
+
+    /**
+     * @param RepositoryInterface $countryRepository
+     * @param RepositoryInterface $provinceRepository
+     */
+    public function __construct(RepositoryInterface $countryRepository, RepositoryInterface $provinceRepository)
     {
         $this->countryRepository = $countryRepository;
+        $this->provinceRepository = $provinceRepository;
     }
 
     /**
@@ -78,7 +85,11 @@ class ProvinceAddressConstraintValidator extends ConstraintValidator
             return false;
         }
 
-        if ($country->hasProvince($address->getProvinceCode())) {
+        if (null === $province = $this->provinceRepository->findOneBy(array('code' => $address->getProvinceCode()))) {
+            return false;
+        }
+
+        if ($country->hasProvince($province)) {
             return true;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT


- ProvinceAddressConstraintValidator passing object correctly to country->hasProvince instead of string
- ProvinceCodeChoiceType no longer typehints array as this doesn't handle PersistentCollection