### PR TITLE
[Storage] Get the request from the request stack in CookieStorage.

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/storage.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/storage.xml
@@ -24,9 +24,7 @@
 
     <services>
         <service id="sylius.storage.cookie" class="%sylius.storage.cookie.class%" public="false">
-            <call method="setRequest">
-                <argument type="service" id="request" on-invalid="null" strict="false" />
-            </call>
+            <argument type="service" id="request_stack" />
         </service>
 
         <service id="sylius.storage.session" class="%sylius.storage.session.class%" public="false">

--- a/src/Sylius/Component/Storage/CookieStorage.php
+++ b/src/Sylius/Component/Storage/CookieStorage.php
@@ -11,24 +11,25 @@
 
 namespace Sylius\Component\Storage;
 
-use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * @author Joseph Bielawski <stloyd@gmail.com>
+ * @author Adam Elsodaney <adam.elso@gmail.com>
  */
 class CookieStorage implements StorageInterface
 {
     /**
-     * @var Request
+     * @var RequestStack
      */
-    protected $request;
+    protected $requestStack;
 
     /**
-     * @param Request $request
+     * @param RequestStack $requestStack
      */
-    public function setRequest($request)
+    public function __construct(RequestStack $requestStack)
     {
-        $this->request = $request;
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -36,7 +37,7 @@ class CookieStorage implements StorageInterface
      */
     public function hasData($key)
     {
-        return $this->request->cookies->has($key);
+        return $this->requestStack->getMasterRequest()->cookies->has($key);
     }
 
     /**
@@ -44,7 +45,7 @@ class CookieStorage implements StorageInterface
      */
     public function getData($key, $default = null)
     {
-        return $this->request->cookies->get($key, $default);
+        return $this->requestStack->getMasterRequest()->cookies->get($key, $default);
     }
 
     /**
@@ -52,7 +53,7 @@ class CookieStorage implements StorageInterface
      */
     public function setData($key, $value)
     {
-        $this->request->cookies->set($key, $value);
+        $this->requestStack->getMasterRequest()->cookies->set($key, $value);
     }
 
     /**
@@ -60,6 +61,6 @@ class CookieStorage implements StorageInterface
      */
     public function removeData($key)
     {
-        $this->request->cookies->remove($key);
+        $this->requestStack->getMasterRequest()->cookies->remove($key);
     }
 }

--- a/src/Sylius/Component/Storage/spec/CookieStorageSpec.php
+++ b/src/Sylius/Component/Storage/spec/CookieStorageSpec.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Storage;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Storage\StorageInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @author Adam Elsodaney <adam.elso@gmail.com>
+ */
+class CookieStorageSpec extends ObjectBehavior
+{
+    function let(RequestStack $requestStack, Request $request, ParameterBag $cookies)
+    {
+        $requestStack->getMasterRequest()->willReturn($request);
+        $request->cookies = $cookies;
+
+        $this->beConstructedWith($requestStack);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Storage\CookieStorage');
+    }
+
+    function it_is_a_Sylius_storage()
+    {
+        $this->shouldHaveType(StorageInterface::class);
+    }
+
+    function it_checks_if_it_has_stored_data_in_a_cookie(ParameterBag $cookies)
+    {
+        $cookies->has('filling')->willReturn(true);
+
+        $this->hasData('filling')->shouldBe(true);
+    }
+
+    function it_gets_data_stored_in_a_cookie(ParameterBag $cookies)
+    {
+        $cookies->get('filling', null)->willReturn('cream');
+
+        $this->getData('filling')->shouldReturn('cream');
+    }
+
+    function it_returns_a_default_if_no_data_was_found_in_a_cookie(ParameterBag $cookies)
+    {
+        $cookies->get('filling', 'chocolate')->willReturn('chocolate');
+
+        $this->getData('filling', 'chocolate')->shouldReturn('chocolate');
+    }
+
+    function it_stores_data_in_a_cookie(ParameterBag $cookies)
+    {
+        $cookies->set('filling', 'jam')->shouldBeCalled();
+
+        $this->setData('filling', 'jam');
+    }
+
+    function it_removes_data_from_a_cookie(ParameterBag $cookies)
+    {
+        $cookies->remove('filling')->shouldBeCalled();
+
+        $this->removeData('filling');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no for application, yes for component
| Deprecations? | no
| Fixed tickets |
| License       | MIT
| Doc PR        | https://github.com/Sylius/Sylius-Docs/pull/402


In order to read and write from cookies, the Request object needs to be
accessible from the Storage implementation, but instead of using the
deprecated Symfony `request` service in a setter injection, the
CookieStorage is constructed with a RequestStack and the cookie data
accessed from the master request of the RequestStack.

I take it this service was created when Sylius was still using the
Symfony 2.3 LTS which didn't have the request stack.
