### PR TITLE
[Cart] - itemresolver return correct CartItem from resolve() for items already present in cart.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Cart/ItemResolver.php
+++ b/src/Sylius/Bundle/CoreBundle/Cart/ItemResolver.php
@@ -159,6 +159,7 @@ class ItemResolver implements ItemResolverInterface
         foreach ($cart->getItems() as $cartItem) {
             if ($cartItem->equals($item)) {
                 $quantity += $cartItem->getQuantity();
+                $item = $cartItem;
                 break;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

When you tried to resolve item that is already in the Cart, ItemResolver returned the back the empty CartItem supplied to the resolve() method instead of the correct CartItem from Cart with updated quantity.