### PR TITLE
[Payment] Replace dummy payment gateway with offline

### DIFF
--- a/features/frontend/checkout_finalize.feature
+++ b/features/frontend/checkout_finalize.feature
@@ -25,11 +25,11 @@ Feature: Checkout finalization
             | SM1  | UK   | DHL Express |
           And the following payment methods exist:
             | code | name  | gateway | enabled |
-            | PM1  | Dummy | dummy   | yes     |
+            | PM1  | Offline | offline   | yes     |
           And all products are assigned to the default channel
           And the default channel has following configuration:
             | taxonomy | payment | shipping    |
-            | Category | Dummy   | DHL Express |
+            | Category | Offline   | DHL Express |
 
     Scenario: Placing the order
         Given I am logged in user
@@ -39,7 +39,7 @@ Feature: Checkout finalization
           And I press "Continue"
           And I select the "DHL Express" radio button
           And I press "Continue"
-          And I select the "Dummy" radio button
+          And I select the "Offline" radio button
           And I press "Continue"
          When I click "Place order"
          Then I should see "Thank you"
@@ -81,7 +81,7 @@ Feature: Checkout finalization
           And I press "Continue"
           And I select the "DHL Express" radio button
           And I press "Continue"
-          And I select the "Dummy" radio button
+          And I select the "Offline" radio button
           And I press "Continue"
          When I click "Place order"
          Then I should see "Thank you"

--- a/features/frontend/checkout_inventory.feature
+++ b/features/frontend/checkout_inventory.feature
@@ -23,7 +23,7 @@ Feature: Checkout inventory
             | SM1  | UK   | DHL Express |
           And the following payment methods exist:
             | code | name        | gateway | enabled |
-            | PM1  | Credit Card | dummy   | yes     |
+            | PM1  | Credit Card | offline   | yes     |
           And all products are assigned to the default channel
           And the default channel has following configuration:
             | taxonomy | payment       | shipping    |

--- a/features/frontend/checkout_security.feature
+++ b/features/frontend/checkout_security.feature
@@ -26,11 +26,11 @@ Feature: Checkout security
             | SM1  | UK   | DHL Express |
           And the following payment methods exist:
             | code | name  | gateway | enabled |
-            | PM1  | Dummy | dummy   | yes     |
+            | PM1  | Offline | offline   | yes     |
           And all products are assigned to the default channel
           And the default channel has following configuration:
             | taxonomy | payment | shipping    |
-            | Category | Dummy   | DHL Express |
+            | Category | Offline   | DHL Express |
           And I added product "PHP Top" to cart
           And I go to the checkout start page
 
@@ -71,7 +71,7 @@ Feature: Checkout security
           And I press "Continue"
           And I select the "DHL Express" radio button
           And I press "Continue"
-          And I select the "Dummy" radio button
+          And I select the "Offline" radio button
           And I press "Continue"
           And I click "Place order"
          Then I should be on the checkout thank you page

--- a/features/frontend/checkout_shipping.feature
+++ b/features/frontend/checkout_shipping.feature
@@ -32,11 +32,11 @@ Feature: Checkout shipping
             | SM4  | UK + Germany | UPS Ground    | Flat rate  | Amount: 20000 | no      |
           And the following payment methods exist:
             | code | name  | gateway | enabled |
-            | PM1  | Dummy | dummy   | yes     |
+            | PM1  | Offline | offline   | yes     |
           And all products are assigned to the default channel
           And the default channel has following configuration:
             | taxonomy | payment | shipping                                      |
-            | Category | Dummy   | DHL Express, FedEx, FedEx Premium, UPS Ground |
+            | Category | Offline   | DHL Express, FedEx, FedEx Premium, UPS Ground |
           And I am logged in user
           And I added product "PHP Top" to cart
 
@@ -88,7 +88,7 @@ Feature: Checkout shipping
           And I press "Continue"
           And I select the "FedEx" radio button
           And I press "Continue"
-          And I select the "Dummy" radio button
+          And I select the "Offline" radio button
          When I press "Continue"
          Then I should be on the checkout finalize step
           And "Shipping total: €65.00" should appear on the page

--- a/features/frontend/checkout_taxation.feature
+++ b/features/frontend/checkout_taxation.feature
@@ -28,11 +28,11 @@ Feature: Checkout taxation
             | SM1  | UK   | DHL Express | Taxable Goods | Flat rate  | Amount: 5000  |
           And the following payment methods exist:
             | code | name  | gateway | enabled |
-            | PM1  | Dummy | dummy   | yes     |
+            | PM1  | Offline | offline   | yes     |
           And all products are assigned to the default channel
           And the default channel has following configuration:
             | taxonomy | payment | shipping    |
-            | Category | Dummy   | DHL Express |
+            | Category | Offline   | DHL Express |
           And I am logged in user
           And I added product "PHP Top" to cart
           And I go to the checkout start page
@@ -42,7 +42,7 @@ Feature: Checkout taxation
           And I press "Continue"
           And I select the "DHL Express" radio button
           And I press "Continue"
-          And I select the "Dummy" radio button
+          And I select the "Offline" radio button
          When I press "Continue"
          Then I should be on the checkout finalize step
           And I should see "Shipping total: €57.50"

--- a/src/Sylius/Behat/Context/Setup/PaymentContext.php
+++ b/src/Sylius/Behat/Context/Setup/PaymentContext.php
@@ -55,7 +55,7 @@ class PaymentContext implements Context
     {
         $paymentMethod = $this->paymentMethodFactory->createNew();
         $paymentMethod->setCode('PM1');
-        $paymentMethod->setGateway('dummy');
+        $paymentMethod->setGateway('offline');
         $paymentMethod->setName('Offline');
         $paymentMethod->setDescription('Offline payment method');
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/payum.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/payum.yml
@@ -35,6 +35,5 @@ payum:
             stripe_checkout:
                 publishable_key: %stripe.publishable_key%
                 secret_key: %stripe.secret_key%
-
-        dummy:
+        offline:
             offline: ~

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
@@ -188,7 +188,6 @@ sylius_payment:
                 form:
                     choice: Sylius\Bundle\CoreBundle\Form\Type\Payment\PaymentMethodChoiceType
     gateways:
-        dummy: Test
         offline: Offline
         stripe: Stripe
         be2bill: Be2Bill

--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadPaymentMethodsData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadPaymentMethodsData.php
@@ -27,12 +27,11 @@ class LoadPaymentMethodsData extends DataFixture
      */
     public function load(ObjectManager $manager)
     {
-        $manager->persist($this->createPaymentMethod('PM1', 'Dummy', 'dummy'));
+        $manager->persist($this->createPaymentMethod('PM1', 'Offline', 'offline'));
         $manager->persist($this->createPaymentMethod('PM2', 'PaypalExpressCheckout', 'paypal_express_checkout'));
         $manager->persist($this->createPaymentMethod('PM3', 'Be2bill', 'be2bill_direct'));
         $manager->persist($this->createPaymentMethod('PM4', 'Be2billOffsite', 'be2bill_offsite'));
         $manager->persist($this->createPaymentMethod('PM5', 'StripeCheckout', 'stripe_checkout'));
-        $manager->persist($this->createPaymentMethod('PM6', 'Offline', 'offline', 'fixed'));
 
         $manager->flush();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #3685
| License       | MIT
| Doc PR        | 

Replaced `dummy` gateway with `offline` as it always succeed. Probably later we can think of introducing requirement to approve the offline payment manually by admin and then we can introduce some `dummy` gateway just for tests.