### PR TITLE
[Report] Quick fix after month change

### DIFF
--- a/features/reports/reports.feature
+++ b/features/reports/reports.feature
@@ -42,6 +42,8 @@ Feature: Reports
             | Description  | Lorem ipsum dolor |
           And I select "2010" from "sylius_report_dataFetcherConfiguration_start_year"
           And I select "2010" from "sylius_report_dataFetcherConfiguration_end_year"
+          And I select "Jan" from "sylius_report_dataFetcherConfiguration_start_month"
+          And I select "Jan" from "sylius_report_dataFetcherConfiguration_end_month"
           And I select "1" from "sylius_report_dataFetcherConfiguration_start_day"
           And I select "3" from "sylius_report_dataFetcherConfiguration_end_day"
           And I press "Create"
@@ -57,6 +59,8 @@ Feature: Reports
             | Description  | Lorem ipsum dolor |
           And I select "2010" from "sylius_report_dataFetcherConfiguration_start_year"
           And I select "2010" from "sylius_report_dataFetcherConfiguration_end_year"
+          And I select "Jan" from "sylius_report_dataFetcherConfiguration_start_month"
+          And I select "Jan" from "sylius_report_dataFetcherConfiguration_end_month"
           And I select "1" from "sylius_report_dataFetcherConfiguration_start_day"
           And I select "3" from "sylius_report_dataFetcherConfiguration_end_day"
           And I select "month" from "Time period"


### PR DESCRIPTION
In https://github.com/Sylius/Sylius/pull/3802 it has been fixed issue with reports scenarios after year change. Sadly, setting default date as current date occurred in different bug, after *month* change :)
Now each day, month and year are set manually in scenario to prevent such issues in the future.