### PR TITLE
[Rbac] Remove softdelete interface and trait from Permission entity

### DIFF
--- a/src/Sylius/Component/Rbac/Model/Permission.php
+++ b/src/Sylius/Component/Rbac/Model/Permission.php
@@ -13,7 +13,6 @@ namespace Sylius\Component\Rbac\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Sylius\Component\Resource\Model\SoftDeletableTrait;
 use Sylius\Component\Resource\Model\TimestampableTrait;
 
 /**
@@ -23,7 +22,7 @@ use Sylius\Component\Resource\Model\TimestampableTrait;
  */
 class Permission implements PermissionInterface
 {
-    use SoftDeletableTrait, TimestampableTrait;
+    use TimestampableTrait;
 
     /**
      * @var mixed

--- a/src/Sylius/Component/Rbac/Model/PermissionInterface.php
+++ b/src/Sylius/Component/Rbac/Model/PermissionInterface.php
@@ -14,7 +14,6 @@ namespace Sylius\Component\Rbac\Model;
 use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Resource\Model\CodeAwareInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
-use Sylius\Component\Resource\Model\SoftDeletableInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
 /**
@@ -22,7 +21,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface PermissionInterface extends CodeAwareInterface, SoftDeletableInterface, TimestampableInterface, ResourceInterface
+interface PermissionInterface extends CodeAwareInterface, TimestampableInterface, ResourceInterface
 {
     /**
      * @return string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |
| License       | MIT
| Doc PR        |

Softdelete is not necessary here, what is more it can introduce unwanted behavior (after removing the permission you can't create permission with the same code). In addition the `deletedAt` field was not even included in the doctrine mapping.