### PR TITLE
[API] [User] Customers CRUD tests

### DIFF
--- a/features/user/users.feature
+++ b/features/user/users.feature
@@ -81,12 +81,25 @@ Feature: Customers management
         Then I should still be on the customer creation page
         And I should see "Please enter your first name"
 
+    @javascript
+    Scenario: Creating customer with user
+        Given I am on the customer creation page
+        When I check "Create account?"
+        And I fill in the following:
+            | First name | Saša               |
+            | Last name  | Stamenković        |
+            | Password   | Password           |
+            | Email      | umpirsky@gmail.com |
+        And I press "Create"
+        Then I should be on the page of customer with email "umpirsky@gmail.com"
+        And I should see "Customer has been successfully created"
+
+    @javascript
     Scenario: Creating customer
         Given I am on the customer creation page
         When I fill in the following:
             | First name | Saša               |
             | Last name  | Stamenković        |
-            | Password   | Password           |
             | Email      | umpirsky@gmail.com |
         And I press "Create"
         Then I should be on the page of customer with email "umpirsky@gmail.com"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/customer.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/customer.yml
@@ -1,8 +1,41 @@
 # This file is part of the Sylius package.
 # (c) Paweł Jędrzejewski
 
+sylius_api_customer_index:
+    path: /
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.customer:indexAction
+        _sylius:
+            serialization_groups: [Default]
+            paginate: $limit
+            sorting:
+                id: desc
+
 sylius_api_customer_show:
     path: /{id}
     methods: [GET]
     defaults:
         _controller: sylius.controller.customer:showAction
+        _sylius:
+            serialization_groups: [Detailed]
+
+sylius_api_customer_create:
+    path: /
+    methods: [POST]
+    defaults:
+        _controller: sylius.controller.customer:createAction
+        _sylius:
+            serialization_groups: [Detailed]
+
+sylius_api_customer_update:
+    path: /{id}
+    methods: [PUT, PATCH]
+    defaults:
+        _controller: sylius.controller.customer:updateAction
+
+sylius_api_customer_delete:
+    path: /{id}
+    methods: [DELETE]
+    defaults:
+        _controller: sylius.controller.customer:deleteAction

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.Customer.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.Customer.yml
@@ -1,0 +1,3 @@
+Sylius\Component\Core\Model\Customer:
+    exclusion_policy: ALL
+    xml_root_name: sylius_customer

--- a/src/Sylius/Bundle/CoreBundle/Tests/Controller/CustomerApiTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Controller/CustomerApiTest.php
@@ -1,0 +1,359 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Tests\Controller;
+
+use Lakion\ApiTestCase\JsonApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ */
+class CustomerApiTest extends JsonApiTestCase
+{
+    /**
+     * @var array
+     */
+    private static $authorizedHeaderWithContentType = [
+        'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+        'CONTENT_TYPE' => 'application/json',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $authorizedHeaderWithAccept = [
+        'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+        'ACCEPT' => 'application/json',
+    ];
+
+    /**
+     * @test
+     */
+    public function it_denies_customer_creation_for_not_authenticated_users()
+    {
+        $this->client->request('POST', '/api/customers/');
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_create_customer_without_specifying_required_data()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('POST', '/api/customers/', [], [], static::$authorizedHeaderWithContentType);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'customer/create_validation_fail_response', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_create_customer_with_user_without_specifying_required_data()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $data =
+<<<EOT
+        {
+            "user": {
+                "enabled": "true"
+            }
+        }
+EOT;
+
+        $this->client->request('POST', '/api/customers/', [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'customer/create_with_user_validation_fail_response', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_create_customer_without_user_account()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $data =
+<<<EOT
+        {
+            "firstName": "John",
+            "lastName": "Diggle",
+            "email": "john.diggle@yahoo.com",
+            "gender": "m"
+        }
+EOT;
+
+        $this->client->request('POST', '/api/customers/', [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'customer/create_response', Response::HTTP_CREATED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_create_customer_with_user_account()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $data =
+<<<EOT
+        {
+            "firstName": "John",
+            "lastName": "Diggle",
+            "email": "john.diggle@yahoo.com",
+            "gender": "m",
+            "user": {
+                "plainPassword" : "testPassword"
+            }
+        }
+EOT;
+
+        $this->client->request('POST', '/api/customers/', [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'customer/create_with_user_response', Response::HTTP_CREATED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_denies_access_to_customers_list_for_not_authenticated_users()
+    {
+        $this->client->request('GET', '/api/customers/');
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_get_customers_list()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/customers.yml');
+
+        $this->client->request('GET', '/api/customers/', [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'customer/index_response', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_denies_access_to_customer_details_for_not_authenticated_users()
+    {
+        $this->client->request('GET', '/api/customers/1');
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_not_found_response_when_requesting_details_of_a_customer_which_does_not_exist()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('GET', '/api/customers/-1', [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_only_customer_details_if_no_user_account_is_connected()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $customers = $this->loadFixturesFromFile('resources/customers.yml');
+
+        $this->client->request('GET', '/api/customers/'.$customers['customer_Barry']->getId(), [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'customer/show_response', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_shows_customer_and_user_details()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $customers = $this->loadFixturesFromFile('resources/customers.yml');
+
+        $this->client->request('GET', '/api/customers/'.$customers['customer_Roy']->getId(), [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'customer/show_with_user_response', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_denies_full_customer_update_for_not_authenticated_users()
+    {
+        $this->client->request('PUT', '/api/customers/1');
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_not_found_response_when_requesting_full_update_of_a_customer_which_does_not_exist()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('PUT', '/api/customers/-1', [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_update_customer_fully_without_specifying_required_data()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $customers = $this->loadFixturesFromFile('resources/customers.yml');
+
+        $this->client->request('PUT', '/api/customers/'.$customers['customer_Oliver']->getId(), [], [], static::$authorizedHeaderWithContentType);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'customer/update_validation_fail_response', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_update_customer_fully()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $customers = $this->loadFixturesFromFile('resources/customers.yml');
+
+        $data =
+<<<EOT
+        {
+            "firstName": "John",
+            "lastName": "Diggle",
+            "email": "john.diggle@example.com",
+            "gender": "m"
+        }
+EOT;
+
+        $this->client->request('PUT', '/api/customers/'.$customers['customer_Oliver']->getId(), [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+
+        $this->client->request('GET', '/api/customers/'.$customers['customer_Oliver']->getId(), [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'customer/update_response', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_not_found_response_when_requesting_partial_update_of_a_customer_which_does_not_exist()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('PATCH', '/api/customers/-1', [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_update_customer_partially()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $customers = $this->loadFixturesFromFile('resources/customers.yml');
+
+        $data =
+<<<EOT
+        {
+            "firstName": "John",
+            "lastName": "Doe"
+        }
+EOT;
+
+        $this->client->request('PATCH', '/api/customers/'.$customers['customer_Oliver']->getId(), [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+
+        $this->client->request('GET', '/api/customers/'.$customers['customer_Oliver']->getId(), [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'customer/partial_update_response', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_denies_customer_deletion_for_not_authenticated_users()
+    {
+        $this->client->request('DELETE', '/api/customers/1');
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_not_found_response_when_requesting_deletion_of_a_customer_which_does_not_exist()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('DELETE', '/api/customers/-1', [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_delete_customer()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $customers = $this->loadFixturesFromFile('resources/customers.yml');
+
+        $this->client->request('DELETE', '/api/customers/'.$customers['customer_Oliver']->getId(), [], [], static::$authorizedHeaderWithContentType);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+
+        $this->client->request('GET', '/api/customers/'.$customers['customer_Oliver']->getId(), [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/DataFixtures/ORM/resources/customers.yml
+++ b/src/Sylius/Bundle/CoreBundle/Tests/DataFixtures/ORM/resources/customers.yml
@@ -1,0 +1,16 @@
+Sylius\Component\Core\Model\User:
+    user_{Oliver, Roy, Thea}:
+        plainPassword: <password()>
+        roles: [ROLE_USER]
+        enabled: true
+        customer: @customer_<current()>
+        username: <current()>@doe.com
+        usernameCanonical: <current()>@doe.com
+
+Sylius\Component\Core\Model\Customer:
+    customer_{Oliver, Roy, Thea, Barry, Joe}:
+        firstName: <current()>
+        lastName: Doe
+        email (unique): <current()>@doe.com
+        emailCanonical: <current()>@doe.com
+        birthday: <date()>

--- a/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/create_response.json
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/create_response.json
@@ -1,0 +1,9 @@
+{
+    "id": @integer@,
+    "email": "john.diggle@yahoo.com",
+    "email_canonical": "john.diggle@yahoo.com",
+    "first_name": "John",
+    "last_name": "Diggle",
+    "gender": "m",
+    "groups": []
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/create_validation_fail_response.json
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/create_validation_fail_response.json
@@ -1,0 +1,30 @@
+{
+    "code": 400,
+    "message": "Validation Failed",
+    "errors": {
+        "children": {
+            "firstName": {
+                "errors": [
+                    "Please enter your first name."
+                ]
+            },
+            "lastName": {
+                "errors": [
+                    "Please enter your last name."
+                ]
+            },
+            "email": {
+                "errors": [
+                    "Please enter your email."
+                ]
+            },
+            "birthday": {},
+            "gender":{
+                "errors": [
+                    "Please choose your gender."
+                ]
+            },
+            "groups": {}
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/create_with_user_response.json
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/create_with_user_response.json
@@ -1,0 +1,17 @@
+{
+    "id": @integer@,
+    "user": {
+        "id": @integer@,
+        "username": "john.diggle@yahoo.com",
+        "roles": [
+            "ROLE_USER"
+        ],
+        "enabled": false
+    },
+    "email": "john.diggle@yahoo.com",
+    "email_canonical": "john.diggle@yahoo.com",
+    "first_name": "John",
+    "last_name": "Diggle",
+    "gender": "m",
+    "groups": []
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/create_with_user_validation_fail_response.json
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/create_with_user_validation_fail_response.json
@@ -1,0 +1,41 @@
+{
+    "code": 400,
+    "message": "Validation Failed",
+    "errors": {
+        "children": {
+            "firstName": {
+                "errors": [
+                    "Please enter your first name."
+                ]
+            },
+            "lastName": {
+                "errors": [
+                    "Please enter your last name."
+                ]
+            },
+            "email": {
+                "errors": [
+                    "Please enter your email."
+                ]
+            },
+            "birthday": {},
+            "gender":{
+                "errors": [
+                    "Please choose your gender."
+                ]
+            },
+            "groups": {},
+            "user": {
+                "children": {
+                    "plainPassword": {
+                        "errors": [
+                            "This value should not be blank."
+                        ]
+                    },
+                    "enabled": {},
+                    "authorizationRoles": {}
+                }
+            }
+        }
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/index_response.json
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/index_response.json
@@ -1,0 +1,75 @@
+{
+    "page": 1,
+    "limit": 10,
+    "pages": 1,
+    "total": 6,
+    "_links": {
+        "self": {
+            "href": "\/api\/customers\/?page=1&limit=10"
+        },
+        "first": {
+            "href": "\/api\/customers\/?page=1&limit=10"
+        },
+        "last": {
+            "href": "\/api\/customers\/?page=1&limit=10"
+        }
+    },
+    "_embedded": {
+        "items": [
+            {
+                "id": @integer@,
+                "email": "Joe@doe.com",
+                "first_name": "Joe",
+                "last_name": "Doe"
+            },
+            {
+                "id": @integer@,
+                "email": "Barry@doe.com",
+                "first_name": "Barry",
+                "last_name": "Doe"
+            },
+            {
+                "id": @integer@,
+                "user": {
+                    "id": @integer@,
+                    "username": "Thea@doe.com",
+                    "enabled": true
+                },
+                "email": "Thea@doe.com",
+                "first_name": "Thea",
+                "last_name": "Doe"
+            },
+            {
+                "id": @integer@,
+                "user": {
+                    "id": @integer@,
+                    "username": "Roy@doe.com",
+                    "enabled": true
+                },
+                "email": "Roy@doe.com",
+                "first_name": "Roy",
+                "last_name": "Doe"
+            },
+            {
+                "id": @integer@,
+                "user": {
+                    "id": @integer@,
+                    "username": "Oliver@doe.com",
+                    "enabled": true
+                },
+                "email": "Oliver@doe.com",
+                "first_name": "Oliver",
+                "last_name": "Doe"
+            },
+            {
+                "id": @integer@,
+                "user": {
+                    "id": @integer@,
+                    "username": "api@sylius.com",
+                    "enabled": true
+                },
+                "email": "api@sylius.com"
+            }
+        ]
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/partial_update_response.json
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/partial_update_response.json
@@ -1,0 +1,19 @@
+{
+    "id": @integer@,
+    "user": {
+        "id": @integer@,
+        "username": "Oliver@doe.com",
+        "username_canonical": "oliver@doe.com",
+        "roles": [
+            "ROLE_USER"
+        ],
+        "enabled": true
+    },
+    "email": "Oliver@doe.com",
+    "email_canonical": "oliver@doe.com",
+    "first_name": "John",
+    "last_name": "Doe",
+    "gender": "u",
+    "birthday": "@string@.isDateTime()",
+    "groups": []
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/show_response.json
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/show_response.json
@@ -1,0 +1,10 @@
+{
+    "id": @integer@,
+    "email": "Barry@doe.com",
+    "email_canonical": "barry@doe.com",
+    "first_name": "Barry",
+    "last_name": "Doe",
+    "birthday": "@string@.isDateTime()",
+    "gender": "u",
+    "groups": []
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/show_with_user_response.json
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/show_with_user_response.json
@@ -1,0 +1,19 @@
+{
+    "id": @integer@,
+    "user": {
+        "id": @integer@,
+        "username": "Roy@doe.com",
+        "username_canonical": "roy@doe.com",
+        "roles": [
+            "ROLE_USER"
+        ],
+        "enabled": true
+    },
+    "email": "Roy@doe.com",
+    "email_canonical": "roy@doe.com",
+    "first_name": "Roy",
+    "last_name": "Doe",
+    "birthday": "@string@.isDateTime()",
+    "gender": "u",
+    "groups": []
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/update_response.json
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/update_response.json
@@ -1,0 +1,18 @@
+{
+    "id": @integer@,
+    "user": {
+        "id": @integer@,
+        "username": "john.diggle@example.com",
+        "username_canonical": "john.diggle@example.com",
+        "roles": [
+            "ROLE_USER"
+        ],
+        "enabled": true
+    },
+    "email": "john.diggle@example.com",
+    "email_canonical": "john.diggle@example.com",
+    "first_name": "John",
+    "last_name": "Diggle",
+    "gender": "m",
+    "groups": []
+}

--- a/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/update_validation_fail_response.json
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Responses/Expected/customer/update_validation_fail_response.json
@@ -1,0 +1,30 @@
+{
+    "code": 400,
+    "message": "Validation Failed",
+    "errors": {
+        "children": {
+            "firstName": {
+                "errors": [
+                    "Please enter your first name."
+                ]
+            },
+            "lastName": {
+                "errors": [
+                    "Please enter your last name."
+                ]
+            },
+            "email": {
+                "errors": [
+                    "Please enter your email."
+                ]
+            },
+            "birthday": {},
+            "gender": {
+                "errors": [
+                    "Please choose your gender."
+                ]
+            },
+            "groups": {}
+        }
+    }
+}

--- a/src/Sylius/Bundle/UserBundle/DependencyInjection/SyliusUserExtension.php
+++ b/src/Sylius/Bundle/UserBundle/DependencyInjection/SyliusUserExtension.php
@@ -58,5 +58,9 @@ class SyliusUserExtension extends AbstractResourceExtension
             ->getDefinition('sylius.form.type.customer_guest')
             ->addArgument(new Reference('sylius.repository.customer'))
         ;
+        $container
+            ->getDefinition('sylius.form.type.customer')
+            ->addArgument(new Reference('sylius.form.event_subscriber.add_user_type'))
+        ;
     }
 }

--- a/src/Sylius/Bundle/UserBundle/Form/EventSubscriber/AddUserFormSubscriber.php
+++ b/src/Sylius/Bundle/UserBundle/Form/EventSubscriber/AddUserFormSubscriber.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\UserBundle\Form\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ */
+class AddUserFormSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            FormEvents::PRE_SET_DATA => 'preSetData',
+            FormEvents::PRE_SUBMIT => 'preSubmit',
+        ];
+    }
+
+    /**
+     * @param FormEvent $event
+     */
+    public function preSetData(FormEvent $event)
+    {
+        $form = $event->getForm();
+        $form->add('user', 'sylius_user');
+    }
+
+    /**
+     * @param FormEvent $event
+     */
+    public function preSubmit(FormEvent $event)
+    {
+        $data = $event->getData();
+
+        if (!isset($data['user'])) {
+            $this->removeUserField($event);
+
+            return;
+        }
+
+        if ($this->isUserDataEmpty($data)) {
+            unset($data['user']);
+            $event->setData($data);
+            $this->removeUserField($event);
+        }
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return bool
+     */
+    private function isUserDataEmpty(array $data)
+    {
+        foreach ($data['user'] as $field) {
+            if (!empty($field)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param FormEvent $event
+     */
+    private function removeUserField(FormEvent $event)
+    {
+        $form = $event->getForm();
+        $form->remove('user');
+    }
+}

--- a/src/Sylius/Bundle/UserBundle/Form/Type/CustomerType.php
+++ b/src/Sylius/Bundle/UserBundle/Form/Type/CustomerType.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\UserBundle\Form\Type;
 
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -19,6 +20,22 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class CustomerType extends CustomerProfileType
 {
+    /**
+     * @var EventSubscriberInterface
+     */
+    private $addUserFormSubscriber;
+
+    /**
+     * @param string $dataClass
+     * @param string[] $validationGroups
+     * @param EventSubscriberInterface $addUserFormSubscriber
+     */
+    public function __construct($dataClass, array $validationGroups = [], EventSubscriberInterface $addUserFormSubscriber)
+    {
+        parent::__construct($dataClass, $validationGroups);
+        $this->addUserFormSubscriber = $addUserFormSubscriber;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -31,7 +48,7 @@ class CustomerType extends CustomerProfileType
                 'multiple' => true,
                 'required' => false,
             ])
-            ->add('user', 'sylius_user')
+            ->addEventSubscriber($this->addUserFormSubscriber)
         ;
     }
 

--- a/src/Sylius/Bundle/UserBundle/Resources/config/serializer/Model.Customer.yml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/serializer/Model.Customer.yml
@@ -5,35 +5,35 @@ Sylius\Component\User\Model\Customer:
         id:
             expose: true
             type: integer
+            groups: [Default, Detailed]
         email:
             expose: true
             type: string
+            groups: [Default, Detailed]
         emailCanonical:
             expose: true
             type: string
+            groups: [Detailed]
         firstName:
             expose: true
             type: string
+            groups: [Default, Detailed]
         lastName:
             expose: true
             type: string
+            groups: [Default, Detailed]
+        user:
+            expose: true
+            groups: [Default, Detailed]
         gender:
             expose: true
             type: string
+            groups: [Detailed]
         birthday:
             expose: true
             type: DateTime
+            groups: [Detailed]
         groups:
             expose: true
             type: array
-    relations:
-        - rel: user
-          href:
-              route: sylius_api_user_show
-              parameters:
-                  id: expr(object.getUser().getId())
-          embedded:
-              content: expr(object.getUser())
-              xmlElementName: sylius_user
-          exclusion:
-              exclude_if: expr(object.getUser() === null)
+            groups: [Detailed]

--- a/src/Sylius/Bundle/UserBundle/Resources/config/serializer/Model.User.yml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/serializer/Model.User.yml
@@ -5,24 +5,20 @@ Sylius\Component\User\Model\User:
         id:
             expose: true
             type: integer
+            groups: [Default, Detailed]
         username:
             expose: true
             type: string
+            groups: [Default, Detailed]
         usernameCanonical:
             expose: true
             type: string
+            groups: [Detailed]
         enabled:
             expose: true
             type: boolean
+            groups: [Default, Detailed]
         roles:
             expose: true
             type: array
-    relations:
-        - rel: user
-          href:
-              route: sylius_api_customer_show
-              parameters:
-                  id: expr(object.getCustomer().getId())
-          embedded:
-              content: expr(object.getCustomer())
-              xmlElementName: sylius_customer
+            groups: [Detailed]

--- a/src/Sylius/Bundle/UserBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/services.xml
@@ -52,6 +52,8 @@
         <parameter key="sylius.listener.user_reloader.class">Sylius\Bundle\UserBundle\EventListener\UserReloaderListener</parameter>
         <parameter key="sylius.listener.user_mailer_listener.class">Sylius\Bundle\UserBundle\EventListener\MailerListener</parameter>
 
+        <parameter key="sylius.form.event_subscriber.add_user_type.class">Sylius\Bundle\UserBundle\Form\EventSubscriber\AddUserFormSubscriber</parameter>
+
         <parameter key="sylius.controller.user_security.class">Sylius\Bundle\UserBundle\Controller\SecurityController</parameter>
 
         <parameter key="sylius.user.validator.unique_registered_user.class">Sylius\Bundle\UserBundle\Validator\Constraints\RegisteredUserValidator</parameter>
@@ -188,6 +190,9 @@
         <service id="sylius.form.type.gender" class="%sylius.form.type.gender.class%">
             <tag name="form.type" alias="sylius_gender" />
         </service>
+
+        <!-- Form event subscribers-->
+        <service id="sylius.form.event_subscriber.add_user_type" class="%sylius.form.event_subscriber.add_user_type.class%" />
 
         <!-- Validators -->
         <service id="validator.unique.registered_user" class="%sylius.user.validator.unique_registered_user.class%">

--- a/src/Sylius/Bundle/UserBundle/Resources/config/validation.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/validation.xml
@@ -52,6 +52,12 @@
                 <option name="groups">sylius_customer_profile</option>
             </constraint>
         </property>
+        <property name="gender">
+            <constraint name="NotBlank">
+                <option name="message">sylius.customer.gender.not_blank</option>
+                <option name="groups">sylius</option>
+            </constraint>
+        </property>
         <property name="email">
             <constraint name="NotBlank">
                 <option name="message">sylius.customer.email.not_blank</option>

--- a/src/Sylius/Bundle/UserBundle/Resources/public/js/sylius-user.js
+++ b/src/Sylius/Bundle/UserBundle/Resources/public/js/sylius-user.js
@@ -1,0 +1,16 @@
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+(function ($) {
+    'use strict';
+
+    $('#sylius_customer_create_user').change(function(){
+        $('#user-form').toggle();
+    });
+})( jQuery );

--- a/src/Sylius/Bundle/UserBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/UserBundle/Resources/translations/messages.en.yml
@@ -20,6 +20,7 @@ sylius:
             birthday: Birthday
             billing_address: Billing address
             different_billing_address: Use different address for billing?
+            only_customer_registration: Create account?
         user_filter:
             query: Search
         user_change_password:

--- a/src/Sylius/Bundle/UserBundle/Resources/translations/validators.en.yml
+++ b/src/Sylius/Bundle/UserBundle/Resources/translations/validators.en.yml
@@ -24,6 +24,8 @@ sylius:
             max: Last name must not be longer than {{ limit }} characters.
             min: Last name must be at least {{ limit }} characters long.
             not_blank: Please enter your last name.
+        gender:
+            not_blank: Please choose your gender.
         email:
             already_used: This email is already used, please login or use forgotten password.
             max: Email must not be longer than {{ limit }} characters.

--- a/src/Sylius/Bundle/UserBundle/spec/Form/EventSubscriber/AddUserFormSubscriberSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/Form/EventSubscriber/AddUserFormSubscriberSpec.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\UserBundle\Form\EventSubscriber;
+
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormEvent;
+
+/**
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ */
+class AddUserFormSubscriberSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\UserBundle\Form\EventSubscriber\AddUserFormSubscriber');
+    }
+
+    function it_is_event_subscriber_instance()
+    {
+        $this->shouldImplement(EventSubscriberInterface::class);
+    }
+
+    function it_adds_user_form_type_and_create_user_check(
+        FormEvent $event,
+        Form $form
+    ) {
+        $event->getForm()->willReturn($form);
+
+        $form->add('user', 'sylius_user')->shouldBeCalled();
+
+        $this->preSetData($event);
+    }
+
+    function it_removes_user_form_type_by_default(
+        FormEvent $event,
+        Form $form
+    ) {
+        $event->getData()->willReturn([], ['user' => ['plainPassword' => '']]);
+        $event->getForm()->willReturn($form);
+
+        $event->setData([])->shouldBeCalledTimes(1);
+        $form->remove('user')->shouldBeCalledTimes(2);
+
+        $this->preSubmit($event);
+        $this->preSubmit($event);
+    }
+
+    function it_does_not_remove_user_form_type_if_users_data_is_submitted(
+        FormEvent $event,
+        Form $form
+    ) {
+        $event->getData()->willReturn(['user' => ['plainPassword' => 'test']]);
+
+        $event->getForm()->shouldNotBeCalled();
+        $form->remove('user')->shouldNotBeCalled();
+
+        $this->preSubmit($event);
+    }
+}

--- a/src/Sylius/Bundle/UserBundle/spec/Form/Type/CustomerTypeSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/Form/Type/CustomerTypeSpec.php
@@ -15,6 +15,7 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Component\User\Model\Customer;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -22,9 +23,9 @@ use Symfony\Component\Form\FormBuilderInterface;
  */
 class CustomerTypeSpec extends ObjectBehavior
 {
-    function let()
+    function let(EventSubscriberInterface $addUserTypeSubscriber)
     {
-        $this->beConstructedWith(Customer::class, ['sylius']);
+        $this->beConstructedWith(Customer::class, ['sylius'], $addUserTypeSubscriber);
     }
 
     function it_is_initializable()
@@ -42,7 +43,7 @@ class CustomerTypeSpec extends ObjectBehavior
         $this->getName()->shouldReturn('sylius_customer');
     }
 
-    function it_builds_form(FormBuilderInterface $builder)
+    function it_builds_form(FormBuilderInterface $builder, EventSubscriberInterface $addUserTypeSubscriber)
     {
         $builder->add('firstName', 'text', Argument::any())->shouldBeCalled()->willReturn($builder);
         $builder->add('lastName', 'text', Argument::any())->shouldBeCalled()->willReturn($builder);
@@ -50,7 +51,7 @@ class CustomerTypeSpec extends ObjectBehavior
         $builder->add('birthday', 'birthday', Argument::any())->shouldBeCalled()->willReturn($builder);
         $builder->add('gender', 'sylius_gender', Argument::any())->shouldBeCalled()->willReturn($builder);
         $builder->add('groups', 'sylius_group_choice', Argument::any())->shouldBeCalled()->willReturn($builder);
-        $builder->add('user', 'sylius_user', Argument::any())->shouldBeCalled()->willReturn($builder);
+        $builder->addEventSubscriber($addUserTypeSubscriber)->shouldBeCalled()->willReturn($builder);
 
         $this->buildForm($builder, []);
     }

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/_form.html.twig
@@ -8,30 +8,44 @@
             {{ form_row(form.lastName) }}
             {{ form_row(form.birthday) }}
             {{ form_row(form.gender) }}
-            {{ form_row(form.user.plainPassword) }}
-            {{ form_row(form.user.enabled) }}
             {{ form_row(form.groups) }}
+            {% if form.user is defined %}
+                {% if form.user.vars.data.id is not defined %}
+                    <div class="form-group">
+                        <label class="col-lg-2 control-label" for="sylius_customer_create_user">
+                            {{ 'sylius.form.customer.only_customer_registration'|trans }}
+                        </label>
+                        <div class="col-lg-10">
+                            <input type="checkbox" id="sylius_customer_create_user">
+                        </div>
+                    </div>
+                {% endif %}
+                <div id="user-form" {% if form.user.vars.data.id is not defined %} style="display: none" {% endif %}>
+                    {{ form_row(form.user.plainPassword) }}
+                    {{ form_row(form.user.enabled) }}
 
-            <div class="form-group">
-                {{ form_label(form.user.authorizationRoles) }}
-                <div class="col-lg-2">
-                    {% set level = 1 %}
-                    <ul class="list-unstyled" id="hierarchy-root">
-                        {% for roleForm in form.user.authorizationRoles %}
-                            {% set currentLevel = form.user.authorizationRoles.vars.choices[roleForm.vars.value].data.level %}
-                            <li>
-                                {% if currentLevel != level %}
-                                    </ul>
-                                    <ul class="hierarchy-node list-unstyled level-{{ currentLevel }}" data-level="{{ currentLevel }}" style="width: 100%; margin-left: {{ currentLevel * 20 }}px">
-                                    {% set level = currentLevel %}
+                    <div class="form-group">
+                        {{ form_label(form.user.authorizationRoles) }}
+                        <div class="col-lg-2">
+                            {% set level = 1 %}
+                            <ul class="list-unstyled" id="hierarchy-root">
+                                {% for roleForm in form.user.authorizationRoles %}
+                                {% set currentLevel = form.user.authorizationRoles.vars.choices[roleForm.vars.value].data.level %}
+                                <li>
+                                    {% if currentLevel != level %}
+                            </ul>
+                            <ul class="hierarchy-node list-unstyled level-{{ currentLevel }}" data-level="{{ currentLevel }}" style="width: 100%; margin-left: {{ currentLevel * 20 }}px">
+                                {% set level = currentLevel %}
                                 {% endif %}
                                 {{ form_widget(roleForm) }}
                                 {{ form.user.authorizationRoles.vars.choices[roleForm.vars.value].data.name }}
-                            </li>
-                        {% endfor %}
-                    </ul>
+                                </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    </div>
                 </div>
-            </div>
+            {% endif %}
             {{ form_row(form._token) }}
         </fieldset>
     </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/create.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/create.html.twig
@@ -2,6 +2,15 @@
 
 {% from 'SyliusResourceBundle:Macros:actions.html.twig' import create %}
 
+{% block javascripts %}
+    {{ parent() }}
+    {% javascripts output='assets/compiled/backend_customer.js'
+        'bundles/syliususer/js/sylius-user.js'
+    %}
+    <script type="text/javascript" src="{{ asset_url }}"></script>
+    {% endjavascripts %}
+{% endblock %}
+
 {% block topbar %}
 <ol class="breadcrumb">
     <li>{{ 'sylius.breadcrumb.section.customer'|trans }}</li>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/update.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/update.html.twig
@@ -2,6 +2,15 @@
 
 {% from 'SyliusResourceBundle:Macros:actions.html.twig' import update %}
 
+{% block javascripts %}
+    {{ parent() }}
+    {% javascripts output='assets/compiled/backend_customer.js'
+        'bundles/syliususer/js/sylius-user.js'
+    %}
+    <script type="text/javascript" src="{{ asset_url }}"></script>
+    {% endjavascripts %}
+{% endblock %}
+
 {% block topbar %}
 <ol class="breadcrumb">
     <li>{{ 'sylius.breadcrumb.section.customer'|trans }}</li>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | partially #3549 
| License       | MIT
| Doc PR        | [#409](https://github.com/Sylius/Sylius-Docs/pull/409)
This PR contains tested Customer CRUD. During tests I've had to update User/Customer serialization, add Customer serialization to CoreBundle. I wasn't able to force HatoasBundle to serialize User and Customer bidirectional, because of [#136 issue](https://github.com/willdurand/Hateoas/issues/136). If you have any thoughts for some workaround or even better for some solution, please share or contribute. Current solution is to embed User into Customer, but Customer cannot be embedded into User. 

I had to update CustomerType, what results in introducing AddUserTypeSubscriber. This subscriber partially fix #3549 , because UserType is no longer coupled with CustomerType.

**Update**
I have resigned with maxDepth strategy and HATEOAS relations in favor of good serialization approach after considering @nakashu [advices](https://github.com/Sylius/Sylius/pull/4037#issuecomment-178563508)

**Update 2**
Added documentation reference