### PR TITLE
[Product] VariantFactory naming changes

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/DependencyInjection/Compiler/ServicesPass.php
+++ b/src/Sylius/Bundle/ProductBundle/DependencyInjection/Compiler/ServicesPass.php
@@ -56,12 +56,12 @@ class ServicesPass implements CompilerPassInterface
         $variantFactoryClass = $variantFactoryDefinition->getClass();
         $variantFactoryDefinition->setClass(Factory::class);
 
-        $decoratedVariantFactoryDefinition = new Definition($variantFactoryClass);
-        $decoratedVariantFactoryDefinition
+        $decoratedProductVariantFactoryDefinition = new Definition($variantFactoryClass);
+        $decoratedProductVariantFactoryDefinition
             ->addArgument($variantFactoryDefinition)
             ->addArgument(new Reference('sylius.repository.product'))
         ;
 
-        $container->setDefinition('sylius.factory.product_variant', $decoratedVariantFactoryDefinition);
+        $container->setDefinition('sylius.factory.product_variant', $decoratedProductVariantFactoryDefinition);
     }
 }

--- a/src/Sylius/Bundle/ProductBundle/DependencyInjection/SyliusProductExtension.php
+++ b/src/Sylius/Bundle/ProductBundle/DependencyInjection/SyliusProductExtension.php
@@ -14,7 +14,7 @@ namespace Sylius\Bundle\ProductBundle\DependencyInjection;
 use Sylius\Bundle\ProductBundle\Controller\VariantController;
 use Sylius\Bundle\ProductBundle\Form\Type\VariantType;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractResourceExtension;
-use Sylius\Component\Product\Factory\VariantFactory;
+use Sylius\Component\Product\Factory\ProductVariantFactory;
 use Sylius\Component\Product\Model\Attribute;
 use Sylius\Component\Product\Model\AttributeInterface;
 use Sylius\Component\Product\Model\AttributeTranslation;
@@ -128,7 +128,7 @@ class SyliusProductExtension extends AbstractResourceExtension implements Prepen
                             'model' => Variant::class,
                             'interface' => VariantInterface::class,
                             'controller' => VariantController::class,
-                            'factory' => VariantFactory::class,
+                            'factory' => ProductVariantFactory::class,
                             'form' => [
                                 'default' => VariantType::class,
                             ],

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/product_variant.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/product_variant.yml
@@ -9,7 +9,7 @@ sylius_backend_product_variant_create:
         _sylius:
             template: SyliusWebBundle:Backend/ProductVariant:create.html.twig
             factory:
-                method: createForProduct
+                method: createBasedOnProductId
                 arguments: $productId
             redirect:
                 route: sylius_backend_product_show

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/product_variant.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/product_variant.yml
@@ -9,7 +9,7 @@ sylius_backend_product_variant_create:
         _sylius:
             template: SyliusWebBundle:Backend/ProductVariant:create.html.twig
             factory:
-                method: createBasedOnProductId
+                method: createForProductWithId
                 arguments: $productId
             redirect:
                 route: sylius_backend_product_show

--- a/src/Sylius/Component/Product/Factory/ProductVariantFactory.php
+++ b/src/Sylius/Component/Product/Factory/ProductVariantFactory.php
@@ -17,7 +17,7 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class VariantFactory implements VariantFactoryInterface
+class ProductVariantFactory implements ProductVariantFactoryInterface
 {
     /**
      * @var FactoryInterface
@@ -50,15 +50,15 @@ class VariantFactory implements VariantFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createForProduct($productId)
+    public function createBasedOnProductId($id)
     {
-        if (null === $product = $this->productRepository->find($productId)) {
-            throw new \InvalidArgumentException(sprintf('Product with id "%s" does not exist.', $productId));
+        if (null === $product = $this->productRepository->find($id)) {
+            throw new \InvalidArgumentException(sprintf('Product with id "%s" does not exist.', $id));
         }
 
-        $coupon = $this->factory->createNew();
-        $coupon->setProduct($product);
+        $variant = $this->createNew();
+        $variant->setProduct($product);
 
-        return $coupon;
+        return $variant;
     }
 }

--- a/src/Sylius/Component/Product/Factory/ProductVariantFactory.php
+++ b/src/Sylius/Component/Product/Factory/ProductVariantFactory.php
@@ -50,9 +50,10 @@ class ProductVariantFactory implements ProductVariantFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createBasedOnProductId($id)
+    public function createForProductWithId($id)
     {
-        if (null === $product = $this->productRepository->find($id)) {
+        $product = $this->productRepository->find($id);
+        if (null === $product) {
             throw new \InvalidArgumentException(sprintf('Product with id "%s" does not exist.', $id));
         }
 

--- a/src/Sylius/Component/Product/Factory/ProductVariantFactoryInterface.php
+++ b/src/Sylius/Component/Product/Factory/ProductVariantFactoryInterface.php
@@ -11,19 +11,20 @@
 
 namespace Sylius\Component\Product\Factory;
 
+use Sylius\Component\Product\Model\VariantInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface VariantFactoryInterface extends FactoryInterface
+interface ProductVariantFactoryInterface extends FactoryInterface
 {
     /**
-     * @param mixed $promotionId
+     * @param mixed $id
      *
      * @return VariantInterface
      *
      * @throws \InvalidArgumentException
      */
-    public function createForProduct($promotionId);
+    public function createBasedOnProductId($id);
 }

--- a/src/Sylius/Component/Product/Factory/ProductVariantFactoryInterface.php
+++ b/src/Sylius/Component/Product/Factory/ProductVariantFactoryInterface.php
@@ -23,8 +23,6 @@ interface ProductVariantFactoryInterface extends FactoryInterface
      * @param mixed $id
      *
      * @return VariantInterface
-     *
-     * @throws \InvalidArgumentException
      */
-    public function createBasedOnProductId($id);
+    public function createForProductWithId($id);
 }

--- a/src/Sylius/Component/Product/spec/Factory/ProductVariantFactorySpec.php
+++ b/src/Sylius/Component/Product/spec/Factory/ProductVariantFactorySpec.php
@@ -56,7 +56,7 @@ class ProductVariantFactorySpec extends ObjectBehavior
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)
-            ->during('createBasedOnProductId', [15])
+            ->during('createForProductWithId', [15])
         ;
     }
 
@@ -70,6 +70,6 @@ class ProductVariantFactorySpec extends ObjectBehavior
         $productRepository->find(13)->willReturn($product);
         $variant->setProduct($product)->shouldBeCalled();
 
-        $this->createBasedOnProductId(13)->shouldReturn($variant);
+        $this->createForProductWithId(13)->shouldReturn($variant);
     }
 }

--- a/src/Sylius/Component/Product/spec/Factory/ProductVariantFactorySpec.php
+++ b/src/Sylius/Component/Product/spec/Factory/ProductVariantFactorySpec.php
@@ -12,7 +12,7 @@
 namespace spec\Sylius\Component\Product\Factory;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Product\Factory\VariantFactoryInterface;
+use Sylius\Component\Product\Factory\ProductVariantFactoryInterface;
 use Sylius\Component\Product\Model\ProductInterface;
 use Sylius\Component\Product\Model\VariantInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
@@ -21,7 +21,7 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class VariantFactorySpec extends ObjectBehavior
+class ProductVariantFactorySpec extends ObjectBehavior
 {
     function let(FactoryInterface $factory, RepositoryInterface $productRepository)
     {
@@ -30,7 +30,7 @@ class VariantFactorySpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Component\Product\Factory\VariantFactory');
+        $this->shouldHaveType('Sylius\Component\Product\Factory\ProductVariantFactory');
     }
 
     function it_is_a_resource_factory()
@@ -40,7 +40,7 @@ class VariantFactorySpec extends ObjectBehavior
 
     function it_implements_variant_factory_interface()
     {
-        $this->shouldImplement(VariantFactoryInterface::class);
+        $this->shouldImplement(ProductVariantFactoryInterface::class);
     }
 
     function it_creates_new_variant(FactoryInterface $factory, VariantInterface $variant)
@@ -56,7 +56,7 @@ class VariantFactorySpec extends ObjectBehavior
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)
-            ->during('createForProduct', [15])
+            ->during('createBasedOnProductId', [15])
         ;
     }
 
@@ -70,6 +70,6 @@ class VariantFactorySpec extends ObjectBehavior
         $productRepository->find(13)->willReturn($product);
         $variant->setProduct($product)->shouldBeCalled();
 
-        $this->createForProduct(13)->shouldReturn($variant);
+        $this->createBasedOnProductId(13)->shouldReturn($variant);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |
| License       | MIT
| Doc PR        |

- changed ``VariantFactory`` into ``ProductVariantFactory``, as it's placed in *Product* component and creates only ``ProductVariant`` objects
- changed ``createForProduct`` method into ``createBasedOnProductId``
- change invalid parameter names in factory and factory interface