### PR TITLE
[Fixture] Quick fixes for channel not found bug

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderChannelListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderChannelListener.php
@@ -50,6 +50,8 @@ class OrderChannelListener
             );
         }
 
-        $order->setChannel($this->channelContext->getChannel());
+        if (null === $order->getChannel()) {
+            $order->setChannel($this->channelContext->getChannel());
+        }
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/OrderProcessing/PromotionProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/OrderProcessing/PromotionProcessor.php
@@ -11,31 +11,29 @@
 
 namespace Sylius\Bundle\CoreBundle\OrderProcessing;
 
-use Sylius\Component\Channel\Context\ChannelContextInterface;
-use Sylius\Component\Promotion\Action\PromotionApplicatorInterface;
-use Sylius\Component\Promotion\Checker\PromotionEligibilityCheckerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
 use Sylius\Component\Promotion\Processor\PromotionProcessor as BasePromotionProcessor;
-use Sylius\Component\Promotion\Repository\PromotionRepositoryInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 
 /**
- * Process all active promotions.
- *
  * @author Kristian Loevstroem <kristian@loevstroem.dk>
  */
 class PromotionProcessor extends BasePromotionProcessor
 {
-    protected $channelContext;
-
-    public function __construct(PromotionRepositoryInterface $repository, PromotionEligibilityCheckerInterface $checker, PromotionApplicatorInterface $applicator, ChannelContextInterface $channelContext)
+    /**
+     * @param PromotionSubjectInterface $subject
+     *
+     * @return array
+     */
+    protected function getActivePromotions(PromotionSubjectInterface $subject)
     {
-        parent::__construct($repository, $checker, $applicator);
-        $this->channelContext = $channelContext;
-    }
+        if (!$subject instanceof OrderInterface) {
+            throw new UnexpectedTypeException($subject, OrderInterface::class);
+        }
 
-    protected function getActivePromotions()
-    {
         if (null === $this->promotions) {
-            $channel = $this->channelContext->getChannel();
+            $channel = $subject->getChannel();
             $this->promotions = $this->repository->findActiveByChannel($channel);
         }
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -384,13 +384,6 @@
             </argument>
         </service>
 
-        <service id="sylius.promotion_processor" class="%sylius.promotion_processor.class%">
-            <argument type="service" id="sylius.repository.promotion" />
-            <argument type="service" id="sylius.promotion_eligibility_checker" />
-            <argument type="service" id="sylius.promotion_applicator" />
-            <argument type="service" id="sylius.context.channel" />
-        </service>
-
         <service id="sylius.promotion_rule_checker.nth_order" class="%sylius.promotion_rule_checker.nth_order.class%">
             <argument type="service" id="sylius.repository.order" />
             <tag name="sylius.promotion_rule_checker" type="nth_order" label="Nth order" />

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/OrderChannelListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/OrderChannelListenerSpec.php
@@ -52,11 +52,25 @@ class OrderChannelListenerSpec extends ObjectBehavior
         ChannelContextInterface $channelContext,
         ChannelInterface $channel
     ) {
-        $event->getSubject()->shouldBeCalled()->willReturn($order);
+        $event->getSubject()->willReturn($order);
+        $order->getChannel()->willReturn(null);
 
         $channelContext->getChannel()->shouldBeCalled()->willReturn($channel);
 
         $order->setChannel($channel)->shouldBeCalled();
+
+        $this->processOrderChannel($event);
+    }
+
+    function it_does_not_proceed_order_channel_if_it_is_already_set(
+        GenericEvent $event,
+        OrderInterface $order,
+        ChannelInterface $channel
+    ) {
+        $event->getSubject()->willReturn($order);
+        $order->getChannel()->willReturn($channel);
+
+        $order->setChannel($channel)->shouldNotBeCalled();
 
         $this->processOrderChannel($event);
     }

--- a/src/Sylius/Component/Promotion/Processor/PromotionProcessor.php
+++ b/src/Sylius/Component/Promotion/Processor/PromotionProcessor.php
@@ -45,7 +45,7 @@ class PromotionProcessor implements PromotionProcessorInterface
 
         $eligiblePromotions = [];
 
-        foreach ($this->getActivePromotions() as $promotion) {
+        foreach ($this->getActivePromotions($subject) as $promotion) {
             if (!$this->checker->isEligible($subject, $promotion)) {
                 continue;
             }
@@ -62,7 +62,7 @@ class PromotionProcessor implements PromotionProcessorInterface
         }
     }
 
-    protected function getActivePromotions()
+    protected function getActivePromotions(PromotionSubjectInterface $subject)
     {
         if (null === $this->promotions) {
             $this->promotions = $this->repository->findActive();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | https://github.com/Sylius/Sylius/issues/4094
| License       | MIT
| Doc PR        |

After last updates, problem with fixtures occurred, with ``ChannelNotFoundException``. There were two sources of this evil:
- ``OrderChannelListener`` which got channel from ``ChannelContext`` (which led to exception) and set it on order
- ``PromotionProcessor`` which found active promotions by channel (the same case as above)

Quick fixes for these problems are:
- set channel on ``Order`` in ``OrderChannelListener`` only if it is not set yet (we're setting channel on each order in ``LoadOrdersData``
- pass order's channel to ``findActiveByChannel`` repository method, rather than this from ``ChannelContext``

Of course, these are a little bit workarounds, but fortunately there is huge checkout and promotion's refactoring upcoming, which should kill these nasty bugs forever ;)