### PR TITLE
[ResourceBundle] Pass form options in route configuration

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfiguration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfiguration.php
@@ -122,7 +122,27 @@ class RequestConfiguration
      */
     public function getFormType()
     {
-        return $this->parameters->get('form', sprintf('%s_%s', $this->metadata->getApplicationName(), $this->metadata->getName()));
+        $form = $this->parameters->get('form', sprintf('%s_%s', $this->metadata->getApplicationName(), $this->metadata->getName()));
+
+        if (is_array($form) && array_key_exists('type', $form)) {
+            return $form['type'];
+        }
+
+        return $form;
+    }
+
+    /**
+     * @return mixed|null
+     */
+    public function getFormOptions()
+    {
+        $form = $this->parameters->get('form', sprintf('%s_%s', $this->metadata->getApplicationName(), $this->metadata->getName()));
+
+        if (is_array($form) && array_key_exists('options', $form)) {
+            return $form['options'];
+        }
+
+        return [];
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceFormFactory.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceFormFactory.php
@@ -43,10 +43,12 @@ class ResourceFormFactory implements ResourceFormFactoryInterface
             $formType = new $formType();
         }
 
+        $formOptions = $requestConfiguration->getFormOptions();
+
         if ($requestConfiguration->isHtmlRequest()) {
-            return $this->formFactory->create($formType, $resource);
+            return $this->formFactory->create($formType, $resource, $formOptions);
         }
 
-        return $this->formFactory->createNamed('', $formType, $resource, ['csrf_protection' => false]);
+        return $this->formFactory->createNamed('', $formType, $resource, array_merge($formOptions, ['csrf_protection' => false]));
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationSpec.php
@@ -87,9 +87,25 @@ class RequestConfigurationSpec extends ObjectBehavior
 
         $parameters->get('form', 'sylius_product')->willReturn('sylius_product');
         $this->getFormType()->shouldReturn('sylius_product');
+        $this->getFormOptions()->shouldReturn([]);
 
         $parameters->get('form', 'sylius_product')->willReturn('sylius_product_pricing');
         $this->getFormType()->shouldReturn('sylius_product_pricing');
+        $this->getFormOptions()->shouldReturn([]);
+    }
+
+    function it_generates_form_type_with_array_configuration(MetadataInterface $metadata, Parameters $parameters)
+    {
+        $metadata->getApplicationName()->willReturn('sylius');
+        $metadata->getName()->willReturn('product');
+
+        $parameters->get('form', 'sylius_product')->willReturn(['type'=> 'sylius_product', 'options' => ['validation_groups' => ['sylius']]]);
+        $this->getFormType()->shouldReturn('sylius_product');
+        $this->getFormOptions()->shouldReturn(['validation_groups' => ['sylius']]);
+
+        $parameters->get('form', 'sylius_product')->willReturn(['type'=> 'sylius_product_pricing', 'options' => ['validation_groups' => ['sylius', 'custom_group']]]);
+        $this->getFormType()->shouldReturn('sylius_product_pricing');
+        $this->getFormOptions()->shouldReturn(['validation_groups' => ['sylius', 'custom_group']]);
     }
 
     function it_generates_route_names(MetadataInterface $metadata, Parameters $parameters)

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceFormFactorySpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceFormFactorySpec.php
@@ -48,7 +48,8 @@ class ResourceFormFactorySpec extends ObjectBehavior
     ) {
         $requestConfiguration->isHtmlRequest()->willReturn(true);
         $requestConfiguration->getFormType()->willReturn('sylius_product_pricing');
-        $formFactory->create('sylius_product_pricing', $resource)->willReturn($form);
+        $requestConfiguration->getFormOptions()->willReturn([]);
+        $formFactory->create('sylius_product_pricing', $resource, Argument::type('array'))->willReturn($form);
 
         $this->create($requestConfiguration, $resource)->shouldReturn($form);
     }
@@ -61,6 +62,7 @@ class ResourceFormFactorySpec extends ObjectBehavior
     ) {
         $requestConfiguration->isHtmlRequest()->willReturn(false);
         $requestConfiguration->getFormType()->willReturn('sylius_product_api');
+        $requestConfiguration->getFormOptions()->willReturn([]);
         $formFactory->createNamed('', 'sylius_product_api', $resource, ['csrf_protection' => false])->willReturn($form);
 
         $this->create($requestConfiguration, $resource)->shouldReturn($form);
@@ -74,7 +76,8 @@ class ResourceFormFactorySpec extends ObjectBehavior
     ) {
         $requestConfiguration->isHtmlRequest()->willReturn(true);
         $requestConfiguration->getFormType()->willReturn(TextType::class);
-        $formFactory->create(Argument::type(TextType::class), $resource)->willReturn($form);
+        $requestConfiguration->getFormOptions()->willReturn([]);
+        $formFactory->create(Argument::type(TextType::class), $resource, Argument::type('array'))->willReturn($form);
 
         $this->create($requestConfiguration, $resource)->shouldReturn($form);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | [#412](https://github.com/Sylius/Sylius-Docs/pull/412)

This PR handle the form options from routing configuration.

Now we can pass options using this syntax:
<pre><code>some_route:
    path: /new
    methods: [GET, POST]
    defaults:
        _controller: ...
        _sylius:
            template: ...
            form:
                type: some_sylius_form
                options:
                    validation_groups: some_validation_groups
                    another_option: ...
                    ...
            redirect: ...
</pre></code>

The previous syntas is allow too:
<pre><code>some_route:
    path: /new
    methods: [GET, POST]
    defaults:
        _controller: ...
        _sylius:
            template: ...
            form: some_sylius_form
            redirect: ...
</pre></code>