### PR TITLE
[Shipping] Rename ShipmentItem to ShipmentUnit

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -242,6 +242,34 @@ class BookController extends ResourceController
 * Introduced ``OrderItemQuantityDataMapper``, which attached to ``OrderItemType`` uses proper service to modify ``OrderItem`` quantity;
 * Changed ``Adjustment`` ``description`` field to ``label``;
 
+### Shipping and ShippingBundle
+
+* Renamed ``ShipmentItem`` to ``ShipmentUnit`` to align with full-stack ``OrderItemUnit`` that it represents and avoid confusion
+against the similarly named ``OrderItem``.
+* Also renamed all associated 'item' wording to 'unit' in forms and form configuration (e.g. ``DefaultCalculators::PER_UNIT_RATE`` and ``RuleInterface::TYPE_UNIT_TOTAL``).
+* Shipping resources config must be updated:
+
+Before:
+
+```yml
+ sylius_shipping:
+     resources:
+         shipment_item:
+              classes:
+                  model: %sylius.model.order_item_unit.class%
+```
+
+After:
+
+```yml
+ sylius_shipping:
+     resources:
+         shipment_unit:
+              classes:
+                  model: %sylius.model.order_item_unit.class%
+```
+
+
 ## From 0.15.0 to 0.16.x
 
 ### General

--- a/features/backend/shipping_methods.feature
+++ b/features/backend/shipping_methods.feature
@@ -57,7 +57,7 @@ Feature: Shipping methods
         When I fill in "Name" with "FedEx World Shipping"
         And I fill in "Code" with "SM5"
         And I select "USA" from "Zone"
-        And I select "Flat rate per item" from "Calculator"
+        And I select "Flat rate per unit" from "Calculator"
         And I fill in "Amount" with "10"
         And I press "Create"
         Then I should be on the page of shipping method "FedEx World Shipping"
@@ -65,12 +65,12 @@ Feature: Shipping methods
         And I should see "USA"
 
     @javascript
-    Scenario: Creating new shipping method with flat rate per item
+    Scenario: Creating new shipping method with flat rate per unit
         Given I am on the shipping method creation page
         When I fill in "Name" with "FedEx World Shipping"
         And I fill in "Code" with "SM6"
         And I select "USA" from "Zone"
-        And I select "Flat rate per item" from "Calculator"
+        And I select "Flat rate per unit" from "Calculator"
         And I fill in "Amount" with "10"
         And I press "Create"
         Then I should be on the page of shipping method "FedEx World Shipping"
@@ -93,9 +93,9 @@ Feature: Shipping methods
         When I fill in "Name" with "FedEx World Shipping"
         And I fill in "Code" with "SM7"
         And I select "Flexible rate" from "Calculator"
-        And I fill in "First item cost" with "100"
-        And I fill in "Additional item cost" with "10"
-        And I fill in "Limit additional items" with "5"
+        And I fill in "First unit cost" with "100"
+        And I fill in "Additional unit cost" with "10"
+        And I fill in "Limit additional units" with "5"
         And I press "Create"
         Then I should be on the page of shipping method "FedEx World Shipping"
         And I should see "Shipping method has been successfully created"

--- a/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Behat/CoreContext.php
@@ -427,7 +427,7 @@ class CoreContext extends DefaultContext
     public function thereAreShippingMethods(TableNode $table)
     {
         foreach ($table->getHash() as $data) {
-            $calculator = array_key_exists('calculator', $data) ? str_replace(' ', '_', strtolower($data['calculator'])) : DefaultCalculators::PER_ITEM_RATE;
+            $calculator = array_key_exists('calculator', $data) ? str_replace(' ', '_', strtolower($data['calculator'])) : DefaultCalculators::PER_UNIT_RATE;
             $configuration = array_key_exists('configuration', $data) ? $this->getConfiguration($data['configuration']) : null;
             $taxCategory = (isset($data['tax category'])) ? $this->findOneByName('tax_category', trim($data['tax category'])) : null;
 
@@ -446,7 +446,7 @@ class CoreContext extends DefaultContext
      * @Given /^There is shipping method "([^""]*)" with code "([^""]*)" and zone "([^""]*)"$/
      * @Given /^there is an enabled shipping method "([^""]*)" with code "([^""]*)" and zone "([^""]*)"$/
      */
-    public function thereIsShippingMethod($name, $code, $zoneName, $calculator = DefaultCalculators::PER_ITEM_RATE, TaxCategoryInterface $taxCategory = null, array $configuration = null, $enabled = true, $flush = true)
+    public function thereIsShippingMethod($name, $code, $zoneName, $calculator = DefaultCalculators::PER_UNIT_RATE, TaxCategoryInterface $taxCategory = null, array $configuration = null, $enabled = true, $flush = true)
     {
         $repository = $this->getRepository('shipping_method');
         $factory = $this->getFactory('shipping_method');
@@ -478,7 +478,7 @@ class CoreContext extends DefaultContext
      */
     public function thereIsDisabledShippingMethod($name, $code, $zoneName)
     {
-        $this->thereIsShippingMethod($name, $code, $zoneName, DefaultCalculators::PER_ITEM_RATE, null, null, false);
+        $this->thereIsShippingMethod($name, $code, $zoneName, DefaultCalculators::PER_UNIT_RATE, null, null, false);
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
@@ -148,7 +148,7 @@ sylius_shipping:
             classes:
                 model: Sylius\Component\Core\Model\Shipment
                 repository: Sylius\Bundle\CoreBundle\Doctrine\ORM\ShipmentRepository
-        shipment_item:
+        shipment_unit:
             classes:
                 model: %sylius.model.order_item_unit.class%
         shipping_method:

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/OrderItemUnit.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/OrderItemUnit.orm.xml
@@ -28,7 +28,7 @@
             <gedmo:timestampable on="update"/>
         </field>
 
-        <many-to-one field="shipment" target-entity="Sylius\Component\Shipping\Model\ShipmentInterface" inversed-by="items">
+        <many-to-one field="shipment" target-entity="Sylius\Component\Shipping\Model\ShipmentInterface" inversed-by="units">
             <join-column name="shipment_id" referenced-column-name="id" nullable="true" on-delete="SET NULL" />
         </many-to-one>
     </mapped-superclass>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/state-machine.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/state-machine.yml
@@ -167,7 +167,7 @@ winzou_state_machine:
                 sylius_sync_shipping:
                     excluded_to: [sold]
                     do:   [@sm.callback.cascade_transition, 'apply']
-                    args: ['object', 'event', 'null', '"sylius_shipment_item"']
+                    args: ['object', 'event', 'null', '"sylius_shipment_unit"']
 
     sylius_shipment:
         callbacks:

--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadOrdersData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadOrdersData.php
@@ -130,7 +130,7 @@ class LoadOrdersData extends DataFixture
         $shipment->setState($this->getShipmentState());
 
         foreach ($order->getItemUnits() as $item) {
-            $shipment->addItem($item);
+            $shipment->addUnit($item);
         }
 
         $order->addShipment($shipment);

--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadShippingData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadShippingData.php
@@ -37,7 +37,7 @@ class LoadShippingData extends DataFixture
         $manager->persist($regular);
         $manager->persist($heavy);
 
-        $config = ['first_item_cost' => 1000, 'additional_item_cost' => 500, 'additional_item_limit' => 0];
+        $config = ['first_unit_cost' => 1000, 'additional_unit_cost' => 500, 'additional_unit_limit' => 0];
         $manager->persist($this->createShippingMethod([$this->defaultLocale => 'FedEx'], 'SM1', 'USA', DefaultCalculators::FLEXIBLE_RATE, $config));
 
         $config = ['amount' => 2500];
@@ -46,7 +46,7 @@ class LoadShippingData extends DataFixture
         $config = ['amount' => 2350];
         $manager->persist($this->createShippingMethod([$this->defaultLocale => 'DHL'], 'SM3', 'EU', DefaultCalculators::FLAT_RATE, $config));
 
-        $config = ['first_item_cost' => 4000, 'additional_item_cost' => 500, 'additional_item_limit' => 10];
+        $config = ['first_unit_cost' => 4000, 'additional_unit_cost' => 500, 'additional_unit_limit' => 10];
         $manager->persist($this->createShippingMethod([$this->defaultLocale => 'FedEx World Shipping', 'es_ES' => 'FedEx internacional'], 'SM4', 'RoW', DefaultCalculators::FLEXIBLE_RATE, $config));
 
         $manager->flush();
@@ -94,7 +94,7 @@ class LoadShippingData extends DataFixture
      *
      * @return ShippingMethodInterface
      */
-    protected function createShippingMethod(array $translatedNames, $code, $zoneCode, $calculator = DefaultCalculators::PER_ITEM_RATE, array $configuration = [], ShippingCategoryInterface $category = null)
+    protected function createShippingMethod(array $translatedNames, $code, $zoneCode, $calculator = DefaultCalculators::PER_UNIT_RATE, array $configuration = [], ShippingCategoryInterface $category = null)
     {
         /* @var $method ShippingMethodInterface */
         $method = $this->getShippingMethodFactory()->createNew();

--- a/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Configuration.php
@@ -25,8 +25,8 @@ use Sylius\Component\Shipping\Model\Rule;
 use Sylius\Component\Shipping\Model\RuleInterface;
 use Sylius\Component\Shipping\Model\Shipment;
 use Sylius\Component\Shipping\Model\ShipmentInterface;
-use Sylius\Component\Shipping\Model\ShipmentItem;
-use Sylius\Component\Shipping\Model\ShipmentItemInterface;
+use Sylius\Component\Shipping\Model\ShipmentUnit;
+use Sylius\Component\Shipping\Model\ShipmentUnitInterface;
 use Sylius\Component\Shipping\Model\ShippingCategory;
 use Sylius\Component\Shipping\Model\ShippingCategoryInterface;
 use Sylius\Component\Shipping\Model\ShippingMethod;
@@ -104,15 +104,15 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
-                        ->arrayNode('shipment_item')
+                        ->arrayNode('shipment_unit')
                             ->addDefaultsIfNotSet()
                             ->children()
                                 ->variableNode('options')->end()
                                 ->arrayNode('classes')
                                     ->addDefaultsIfNotSet()
                                     ->children()
-                                        ->scalarNode('model')->defaultValue(ShipmentItem::class)->cannotBeEmpty()->end()
-                                        ->scalarNode('interface')->defaultValue(ShipmentItemInterface::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('model')->defaultValue(ShipmentUnit::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('interface')->defaultValue(ShipmentUnitInterface::class)->cannotBeEmpty()->end()
                                         ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
                                         ->scalarNode('repository')->cannotBeEmpty()->end()
                                         ->scalarNode('factory')->defaultValue(Factory::class)->end()

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/Calculator/FlexibleRateConfigurationType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/Calculator/FlexibleRateConfigurationType.php
@@ -28,23 +28,23 @@ class FlexibleRateConfigurationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('first_item_cost', 'sylius_money', [
-                'label' => 'sylius.form.shipping_calculator.flexible_rate_configuration.first_item_cost',
+            ->add('first_unit_cost', 'sylius_money', [
+                'label' => 'sylius.form.shipping_calculator.flexible_rate_configuration.first_unit_cost',
                 'constraints' => [
                     new NotBlank(),
                     new Type(['type' => 'integer']),
                 ],
             ])
-            ->add('additional_item_cost', 'sylius_money', [
-                'label' => 'sylius.form.shipping_calculator.flexible_rate_configuration.additional_item_cost',
+            ->add('additional_unit_cost', 'sylius_money', [
+                'label' => 'sylius.form.shipping_calculator.flexible_rate_configuration.additional_unit_cost',
                 'constraints' => [
                     new NotBlank(),
                     new Type(['type' => 'integer']),
                 ],
             ])
-            ->add('additional_item_limit', 'integer', [
+            ->add('additional_unit_limit', 'integer', [
                 'required' => false,
-                'label' => 'sylius.form.shipping_calculator.flexible_rate_configuration.additional_item_limit',
+                'label' => 'sylius.form.shipping_calculator.flexible_rate_configuration.additional_unit_limit',
                 'constraints' => [
                     new Type(['type' => 'integer']),
                 ],

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/Calculator/PerUnitRateConfigurationType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/Calculator/PerUnitRateConfigurationType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class PerItemRateConfigurationType extends AbstractType
+class PerUnitRateConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}
@@ -29,7 +29,7 @@ class PerItemRateConfigurationType extends AbstractType
     {
         $builder
             ->add('amount', 'sylius_money', [
-                'label' => 'sylius.form.shipping_calculator.per_item_rate_configuration.amount',
+                'label' => 'sylius.form.shipping_calculator.per_unit_rate_configuration.amount',
                 'constraints' => [
                     new NotBlank(),
                     new Type(['type' => 'integer']),
@@ -55,6 +55,6 @@ class PerItemRateConfigurationType extends AbstractType
      */
     public function getName()
     {
-        return 'sylius_shipping_calculator_per_item_rate';
+        return 'sylius_shipping_calculator_per_unit_rate';
     }
 }

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/Rule/UnitCountConfigurationType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/Rule/UnitCountConfigurationType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class ItemCountConfigurationType extends AbstractType
+class UnitCountConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}
@@ -28,14 +28,14 @@ class ItemCountConfigurationType extends AbstractType
     {
         $builder
             ->add('count', 'integer', [
-                'label' => 'sylius.form.rule.item_count_configuration.count',
+                'label' => 'sylius.form.rule.unit_count_configuration.count',
                 'constraints' => [
                     new NotBlank(),
                     new Type(['type' => 'numeric']),
                 ],
             ])
             ->add('equal', 'checkbox', [
-                'label' => 'sylius.form.rule.item_count_configuration.equal',
+                'label' => 'sylius.form.rule.unit_count_configuration.equal',
                 'constraints' => [
                     new Type(['type' => 'bool']),
                 ],
@@ -45,6 +45,6 @@ class ItemCountConfigurationType extends AbstractType
 
     public function getName()
     {
-        return 'sylius_shipping_rule_item_count_configuration';
+        return 'sylius_shipping_rule_unit_count_configuration';
     }
 }

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/doctrine/model/Shipment.orm.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/doctrine/model/Shipment.orm.xml
@@ -26,7 +26,7 @@
         <field name="state" column="state" type="string" nullable="false" />
         <field name="tracking" column="tracking" type="string" nullable="true" />
 
-        <one-to-many field="items" target-entity="Sylius\Component\Shipping\Model\ShipmentItemInterface" mapped-by="shipment" orphan-removal="false">
+        <one-to-many field="units" target-entity="Sylius\Component\Shipping\Model\ShipmentUnitInterface" mapped-by="shipment" orphan-removal="false">
             <cascade>
                 <cascade-persist/>
             </cascade>

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/doctrine/model/ShipmentUnit.orm.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/doctrine/model/ShipmentUnit.orm.xml
@@ -14,14 +14,14 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
                   xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
 
-    <mapped-superclass name="Sylius\Component\Shipping\Model\ShipmentItem" table="sylius_shipment_item">
+    <mapped-superclass name="Sylius\Component\Shipping\Model\ShipmentUnit" table="sylius_shipment_unit">
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>
 
         <field name="shippingState" column="shipping_state" type="string" nullable="false" />
 
-        <many-to-one field="shipment" target-entity="Sylius\Component\Shipping\Model\ShipmentInterface" inversed-by="items">
+        <many-to-one field="shipment" target-entity="Sylius\Component\Shipping\Model\ShipmentInterface" inversed-by="units">
             <join-column name="shipment_id" referenced-column-name="id" nullable="false" />
         </many-to-one>
 

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/serializer/Model.ShipmentUnit.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/serializer/Model.ShipmentUnit.yml
@@ -1,6 +1,6 @@
-Sylius\Component\Shipping\Model\ShipmentItem:
+Sylius\Component\Shipping\Model\ShipmentUnit:
     exclusion_policy: ALL
-    xml_root_name: shipment-item
+    xml_root_name: shipment-unit
     properties:
         id:
             expose: true
@@ -18,7 +18,7 @@ Sylius\Component\Shipping\Model\ShipmentItem:
     relations:
         - rel: self
           href:
-                route: sylius_api_shipment_item_show
+                route: sylius_api_shipment_unit_show
                 parameters:
                     shipmentId: expr(object.getShipment().getId())
                     id: expr(object.getId())

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
@@ -19,7 +19,7 @@
     <parameters>
         <parameter key="sylius.form.type.shipping_calculator_choice.class">Sylius\Bundle\ShippingBundle\Form\Type\CalculatorChoiceType</parameter>
 
-        <parameter key="sylius.form.type.shipping_rule_item_count_configuration.class">Sylius\Bundle\ShippingBundle\Form\Type\Rule\ItemCountConfigurationType</parameter>
+        <parameter key="sylius.form.type.shipping_rule_unit_count_configuration.class">Sylius\Bundle\ShippingBundle\Form\Type\Rule\UnitCountConfigurationType</parameter>
 
         <parameter key="sylius.shipping_methods_resolver.class">Sylius\Component\Shipping\Resolver\MethodsResolver</parameter>
 
@@ -29,13 +29,13 @@
         <parameter key="sylius.registry.shipping_rule_checker.class">Sylius\Component\Registry\ServiceRegistry</parameter>
 
         <parameter key="sylius.shipping_eligibility_checker.class">Sylius\Component\Shipping\Checker\ShippingMethodEligibilityChecker</parameter>
-        <parameter key="sylius.shipping_rule_checker.item_count.class">Sylius\Component\Shipping\Checker\ItemCountRuleChecker</parameter>
+        <parameter key="sylius.shipping_rule_checker.unit_count.class">Sylius\Component\Shipping\Checker\UnitCountRuleChecker</parameter>
 
         <parameter key="sylius.shipping_calculator.flat_rate.class">Sylius\Component\Shipping\Calculator\FlatRateCalculator</parameter>
         <parameter key="sylius.form.type.shipping_calculator.flat_rate.class">Sylius\Bundle\ShippingBundle\Form\Type\Calculator\FlatRateConfigurationType</parameter>
 
-        <parameter key="sylius.shipping_calculator.per_item_rate.class">Sylius\Component\Shipping\Calculator\PerItemRateCalculator</parameter>
-        <parameter key="sylius.form.type.shipping_calculator.per_item_rate.class">Sylius\Bundle\ShippingBundle\Form\Type\Calculator\PerItemRateConfigurationType</parameter>
+        <parameter key="sylius.shipping_calculator.per_unit_rate.class">Sylius\Component\Shipping\Calculator\PerUnitRateCalculator</parameter>
+        <parameter key="sylius.form.type.shipping_calculator.per_unit_rate.class">Sylius\Bundle\ShippingBundle\Form\Type\Calculator\PerUnitRateConfigurationType</parameter>
 
         <parameter key="sylius.shipping_calculator.flexible_rate.class">Sylius\Component\Shipping\Calculator\FlexibleRateCalculator</parameter>
         <parameter key="sylius.form.type.shipping_calculator.flexible_rate.class">Sylius\Bundle\ShippingBundle\Form\Type\Calculator\FlexibleRateConfigurationType</parameter>
@@ -52,14 +52,14 @@
     </parameters>
 
     <services>
-        <service id="sylius.form.type.shipping_rule_item_count_configuration" class="%sylius.form.type.shipping_rule_item_count_configuration.class%">
-            <tag name="form.type" alias="sylius_shipping_rule_item_count_configuration" />
+        <service id="sylius.form.type.shipping_rule_unit_count_configuration" class="%sylius.form.type.shipping_rule_unit_count_configuration.class%">
+            <tag name="form.type" alias="sylius_shipping_rule_unit_count_configuration" />
         </service>
         <service id="sylius.shipping_eligibility_checker" class="%sylius.shipping_eligibility_checker.class%">
             <argument type="service" id="sylius.registry.shipping_rule_checker" />
         </service>
-        <service id="sylius.shipping_rule_checker.item_count" class="%sylius.shipping_rule_checker.item_count.class%">
-            <tag name="sylius.shipping_rule_checker" type="item_count" label="Item count" />
+        <service id="sylius.shipping_rule_checker.unit_count" class="%sylius.shipping_rule_checker.unit_count.class%">
+            <tag name="sylius.shipping_rule_checker" type="unit_count" label="Unit count" />
         </service>
 
         <service id="sylius.registry.shipping_rule_checker" class="%sylius.registry.shipping_rule_checker.class%" >
@@ -96,11 +96,11 @@
             <tag name="form.type" alias="sylius_shipping_calculator_flat_rate" />
         </service>
 
-        <service id="sylius.shipping_calculator.per_item_rate" class="%sylius.shipping_calculator.per_item_rate.class%">
-            <tag name="sylius.shipping_calculator" calculator="per_item_rate" label="sylius.form.shipping_calculator.per_item_rate_configuration.label" />
+        <service id="sylius.shipping_calculator.per_unit_rate" class="%sylius.shipping_calculator.per_unit_rate.class%">
+            <tag name="sylius.shipping_calculator" calculator="per_unit_rate" label="sylius.form.shipping_calculator.per_unit_rate_configuration.label" />
         </service>
-        <service id="sylius.form.type.shipping_calculator.per_item_rate" class="%sylius.form.type.shipping_calculator.per_item_rate.class%">
-            <tag name="form.type" alias="sylius_shipping_calculator_per_item_rate" />
+        <service id="sylius.form.type.shipping_calculator.per_unit_rate" class="%sylius.form.type.shipping_calculator.per_unit_rate.class%">
+            <tag name="form.type" alias="sylius_shipping_calculator_per_unit_rate" />
         </service>
 
         <service id="sylius.shipping_calculator.flexible_rate" class="%sylius.shipping_calculator.flexible_rate.class%">

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/state-machine.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/state-machine.yml
@@ -37,14 +37,14 @@ winzou_state_machine:
                 to:   returned
         callbacks:
             after:
-                sylius_sync_items:
+                sylius_sync_units:
                     do:   [@sm.callback.cascade_transition, 'apply']
-                    args: ['object.getItems()', 'event', 'null', '"sylius_shipment_item"']
+                    args: ['object.getUnits()', 'event', 'null', '"sylius_shipment_unit"']
 
-    sylius_shipment_item:
-        class:         %sylius.model.shipment_item.class%
+    sylius_shipment_unit:
+        class:         %sylius.model.shipment_unit.class%
         property_path: shippingState
-        graph:         sylius_shipment_item
+        graph:         sylius_shipment_unit
         state_machine_class: %sylius.state_machine.class%
         states:
             checkout: ~

--- a/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
@@ -4,7 +4,7 @@
 sylius:
     form:
         rule:
-            item_count_configuration:
+            unit_count_configuration:
                 count: Count
                 equal: Equal to
 
@@ -28,12 +28,12 @@ sylius:
 
             flexible_rate_configuration:
                 label: Flexible rate
-                additional_item_cost: Additional item cost
-                additional_item_limit: Limit additional items
-                first_item_cost: First item cost
+                additional_unit_cost: Additional unit cost
+                additional_unit_limit: Limit additional units
+                first_unit_cost: First unit cost
 
-            per_item_rate_configuration:
-                label: Flat rate per item
+            per_unit_rate_configuration:
+                label: Flat rate per unit
                 amount: Amount
 
             weight_rate_configuration:

--- a/src/Sylius/Bundle/ShippingBundle/SyliusShippingBundle.php
+++ b/src/Sylius/Bundle/ShippingBundle/SyliusShippingBundle.php
@@ -17,7 +17,7 @@ use Sylius\Bundle\ShippingBundle\DependencyInjection\Compiler\RegisterCalculator
 use Sylius\Bundle\ShippingBundle\DependencyInjection\Compiler\RegisterRuleCheckersPass;
 use Sylius\Component\Shipping\Model\RuleInterface;
 use Sylius\Component\Shipping\Model\ShipmentInterface;
-use Sylius\Component\Shipping\Model\ShipmentItemInterface;
+use Sylius\Component\Shipping\Model\ShipmentUnitInterface;
 use Sylius\Component\Shipping\Model\ShippingCategoryInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -61,7 +61,7 @@ class SyliusShippingBundle extends AbstractResourceBundle
     {
         return [
             ShipmentInterface::class => 'sylius.model.shipment.class',
-            ShipmentItemInterface::class => 'sylius.model.shipment_item.class',
+            ShipmentUnitInterface::class => 'sylius.model.shipment_unit.class',
             ShippingCategoryInterface::class => 'sylius.model.shipping_category.class',
             ShippingMethodInterface::class => 'sylius.model.shipping_method.class',
             RuleInterface::class => 'sylius.model.shipping_method_rule.class',

--- a/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/Calculator/FlexibleRateConfigurationTypeSpec.php
+++ b/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/Calculator/FlexibleRateConfigurationTypeSpec.php
@@ -34,9 +34,9 @@ class FlexibleRateConfigurationTypeSpec extends ObjectBehavior
 
     function it_builds_a_form(FormBuilderInterface $builder)
     {
-        $builder->add('first_item_cost', 'sylius_money', Argument::withKey('constraints'))->shouldBeCalled()->willReturn($builder);
-        $builder->add('additional_item_cost', 'sylius_money', Argument::withKey('constraints'))->shouldBeCalled()->willReturn($builder);
-        $builder->add('additional_item_limit', 'integer', Argument::withKey('constraints'))->shouldBeCalled()->willReturn($builder);
+        $builder->add('first_unit_cost', 'sylius_money', Argument::withKey('constraints'))->shouldBeCalled()->willReturn($builder);
+        $builder->add('additional_unit_cost', 'sylius_money', Argument::withKey('constraints'))->shouldBeCalled()->willReturn($builder);
+        $builder->add('additional_unit_limit', 'integer', Argument::withKey('constraints'))->shouldBeCalled()->willReturn($builder);
 
         $this->buildForm($builder, []);
     }

--- a/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/Calculator/PerUnitRateConfigurationTypeSpec.php
+++ b/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/Calculator/PerUnitRateConfigurationTypeSpec.php
@@ -20,11 +20,11 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Arnaud Langlade <arn0d.dev@gamil.com>
  */
-class PerItemRateConfigurationTypeSpec extends ObjectBehavior
+class PerUnitRateConfigurationTypeSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Bundle\ShippingBundle\Form\Type\Calculator\PerItemRateConfigurationType');
+        $this->shouldHaveType('Sylius\Bundle\ShippingBundle\Form\Type\Calculator\PerUnitRateConfigurationType');
     }
 
     function it_is_a_form()
@@ -50,6 +50,6 @@ class PerItemRateConfigurationTypeSpec extends ObjectBehavior
 
     function it_has_a_name()
     {
-        $this->getName()->shouldReturn('sylius_shipping_calculator_per_item_rate');
+        $this->getName()->shouldReturn('sylius_shipping_calculator_per_unit_rate');
     }
 }

--- a/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/CalculatorChoiceTypeSpec.php
+++ b/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/CalculatorChoiceTypeSpec.php
@@ -24,7 +24,7 @@ class CalculatorChoiceTypeSpec extends ObjectBehavior
     {
         $choices = [
             'flat_rate' => 'Flat rate per shipment',
-            'per_item_rate' => 'Per item rate',
+            'per_unit_rate' => 'Per unit rate',
         ];
 
         $this->beConstructedWith($choices);
@@ -44,7 +44,7 @@ class CalculatorChoiceTypeSpec extends ObjectBehavior
     {
         $choices = [
             'flat_rate' => 'Flat rate per shipment',
-            'per_item_rate' => 'Per item rate',
+            'per_unit_rate' => 'Per unit rate',
         ];
 
         $resolver->setDefaults(['choices' => $choices])->shouldBeCalled();

--- a/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/Rule/UnitCountConfigurationTypeSpec.php
+++ b/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/Rule/UnitCountConfigurationTypeSpec.php
@@ -19,11 +19,11 @@ use Symfony\Component\Form\Test\FormBuilderInterface;
 /**
  * @author Arnaud Langlade <arn0d.dev@gamil.com>
  */
-class ItemCountConfigurationTypeSpec extends ObjectBehavior
+class UnitCountConfigurationTypeSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Bundle\ShippingBundle\Form\Type\Rule\ItemCountConfigurationType');
+        $this->shouldHaveType('Sylius\Bundle\ShippingBundle\Form\Type\Rule\UnitCountConfigurationType');
     }
 
     function it_is_a_form()
@@ -41,6 +41,6 @@ class ItemCountConfigurationTypeSpec extends ObjectBehavior
 
     function it_has_a_name()
     {
-        $this->getName()->shouldReturn('sylius_shipping_rule_item_count_configuration');
+        $this->getName()->shouldReturn('sylius_shipping_rule_unit_count_configuration');
     }
 }

--- a/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/RuleChoiceTypeSpec.php
+++ b/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/RuleChoiceTypeSpec.php
@@ -22,8 +22,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class RuleChoiceTypeSpec extends ObjectBehavior
 {
     private $choices = [
-        RuleInterface::TYPE_ITEM_TOTAL => 'Order total',
-        RuleInterface::TYPE_ITEM_COUNT => 'Order items count',
+        RuleInterface::TYPE_UNIT_TOTAL => 'Order total',
+        RuleInterface::TYPE_UNIT_COUNT => 'Order units count',
     ];
 
     function let()

--- a/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/ShippingMethodTypeSpec.php
+++ b/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/ShippingMethodTypeSpec.php
@@ -17,7 +17,7 @@ use Sylius\Bundle\ResourceBundle\Form\EventSubscriber\AddCodeFormSubscriber;
 use Sylius\Bundle\ShippingBundle\Form\EventListener\BuildShippingMethodFormSubscriber;
 use Sylius\Component\Registry\ServiceRegistryInterface;
 use Sylius\Component\Shipping\Calculator\FlatRateCalculator;
-use Sylius\Component\Shipping\Calculator\PerItemRateCalculator;
+use Sylius\Component\Shipping\Calculator\PerUnitRateCalculator;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -117,9 +117,9 @@ class ShippingMethodTypeSpec extends ObjectBehavior
         FormBuilder $flatRateFormBuilder,
         Form $flatRateForm,
         FlatRateCalculator $flatRateCalculator,
-        FormBuilder $perItemFormBuilder,
-        Form $perItemForm,
-        PerItemRateCalculator $perItemRateCalculator,
+        FormBuilder $perUnitFormBuilder,
+        Form $perUnitForm,
+        PerUnitRateCalculator $perUnitRateCalculator,
         $formRegistry
     ) {
         $builder
@@ -137,9 +137,9 @@ class ShippingMethodTypeSpec extends ObjectBehavior
             ->willReturn('flat_rate')
         ;
 
-        $perItemRateCalculator
+        $perUnitRateCalculator
             ->getType()
-            ->willReturn('per_item_rate')
+            ->willReturn('per_unit_rate')
         ;
 
         $calculatorRegistry
@@ -147,7 +147,7 @@ class ShippingMethodTypeSpec extends ObjectBehavior
             ->willReturn(
                 [
                     'flat_rate' => $flatRateCalculator,
-                    'per_item_rate' => $perItemRateCalculator,
+                    'per_unit_rate' => $perUnitRateCalculator,
                 ]
             )
         ;
@@ -162,17 +162,17 @@ class ShippingMethodTypeSpec extends ObjectBehavior
             ->willReturn($flatRateFormBuilder)
         ;
 
-        $perItemFormBuilder
+        $perUnitFormBuilder
             ->getForm()
-            ->willReturn($perItemForm)
+            ->willReturn($perUnitForm)
         ;
 
         $builder
-            ->create('configuration', 'sylius_shipping_calculator_per_item_rate')
-            ->willReturn($perItemFormBuilder)
+            ->create('configuration', 'sylius_shipping_calculator_per_unit_rate')
+            ->willReturn($perUnitFormBuilder)
         ;
 
-        $formRegistry->hasType('sylius_shipping_calculator_per_item_rate')->shouldBeCalled()->willReturn(true);
+        $formRegistry->hasType('sylius_shipping_calculator_per_unit_rate')->shouldBeCalled()->willReturn(true);
         $formRegistry->hasType('sylius_shipping_calculator_flat_rate')->shouldBeCalled()->willReturn(true);
 
         $builder
@@ -181,7 +181,7 @@ class ShippingMethodTypeSpec extends ObjectBehavior
                 [
                     'calculators' => [
                         'flat_rate' => $flatRateForm,
-                        'per_item_rate' => $perItemForm,
+                        'per_unit_rate' => $perUnitForm,
                     ],
                     'rules' => [],
                 ]

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/macros.html.twig
@@ -31,7 +31,7 @@
             <td>{{ shipment.method.name }}</td>
             <td>{{ misc.shipment_state(shipment.state) }}</td>
             <td>{{ address.firstname }} {{ address.lastname }} ({{ address.city }}, {{ address.countryCode|sylius_country_name }})</td>
-            <td class="text-center">{{ shipment.items|length }}</td>
+            <td class="text-center">{{ shipment.units|length }}</td>
             <td>{{ shipment.createdAt|date }}</td>
             <td>
                 <div class="pull-right">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/show.html.twig
@@ -101,7 +101,7 @@
     {% endif %}
 </div>
 
-{% if shipment.items|length > 0 %}
+{% if shipment.units|length > 0 %}
     <table class="table table-bordered table-condensed">
         <thead>
             <tr>
@@ -115,7 +115,7 @@
             </tr>
         </thead>
         <tbody>
-        {% for item in shipment.items %}
+        {% for item in shipment.units %}
             <tr>
                 <td>{{ loop.index }}</td>
                 <td>{{ item.stockable.sku }}</td>

--- a/src/Sylius/Component/Core/Model/OrderItemUnitInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderItemUnitInterface.php
@@ -13,11 +13,11 @@ namespace Sylius\Component\Core\Model;
 
 use Sylius\Component\Inventory\Model\InventoryUnitInterface;
 use Sylius\Component\Order\Model\OrderItemUnitInterface as BaseOrderItemUnitInterface;
-use Sylius\Component\Shipping\Model\ShipmentItemInterface;
+use Sylius\Component\Shipping\Model\ShipmentUnitInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-interface OrderItemUnitInterface extends BaseOrderItemUnitInterface, InventoryUnitInterface, ShipmentItemInterface
+interface OrderItemUnitInterface extends BaseOrderItemUnitInterface, InventoryUnitInterface, ShipmentUnitInterface
 {
 }

--- a/src/Sylius/Component/Core/OrderProcessing/OrderShipmentFactory.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderShipmentFactory.php
@@ -52,7 +52,7 @@ class OrderShipmentFactory implements OrderShipmentFactoryInterface
 
         foreach ($order->getItemUnits() as $itemUnit) {
             if (null === $itemUnit->getShipment()) {
-                $shipment->addItem($itemUnit);
+                $shipment->addUnit($itemUnit);
             }
         }
     }

--- a/src/Sylius/Component/Core/spec/Model/OrderItemUnitSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderItemUnitSpec.php
@@ -19,7 +19,7 @@ use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Inventory\Model\InventoryUnitInterface;
 use Sylius\Component\Order\Model\OrderItemUnit;
 use Sylius\Component\Shipping\Model\ShipmentInterface;
-use Sylius\Component\Shipping\Model\ShipmentItemInterface;
+use Sylius\Component\Shipping\Model\ShipmentUnitInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -48,9 +48,9 @@ class OrderItemUnitSpec extends ObjectBehavior
         $this->shouldImplement(InventoryUnitInterface::class);
     }
 
-    function it_implements_shipment_item_interface()
+    function it_implements_shipment_unit_interface()
     {
-        $this->shouldImplement(ShipmentItemInterface::class);
+        $this->shouldImplement(ShipmentUnitInterface::class);
     }
 
     function it_is_order_item_unit()

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentFactorySpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentFactorySpec.php
@@ -41,7 +41,7 @@ class OrderShipmentFactorySpec extends ObjectBehavior
         $this->shouldImplement(OrderShipmentFactoryInterface::class);
     }
 
-    function it_creates_a_single_shipment_and_assigns_all_item_units_to_it(
+    function it_creates_a_single_shipment_and_assigns_all_unit_units_to_it(
         FactoryInterface $shipmentFactory,
         OrderInterface $order,
         ShipmentInterface $shipment,
@@ -64,7 +64,7 @@ class OrderShipmentFactorySpec extends ObjectBehavior
         ;
 
         $shipment
-            ->addItem($itemUnit)
+            ->addUnit($itemUnit)
             ->shouldBeCalled()
         ;
 
@@ -115,12 +115,12 @@ class OrderShipmentFactorySpec extends ObjectBehavior
         ;
 
         $shipment
-            ->addItem($itemUnitWithoutShipment)
+            ->addUnit($itemUnitWithoutShipment)
             ->shouldBeCalled()
         ;
 
         $shipment
-            ->addItem($itemUnit)
+            ->addUnit($itemUnit)
             ->shouldNotBeCalled()
         ;
 

--- a/src/Sylius/Component/Shipping/CHANGELOG.md
+++ b/src/Sylius/Component/Shipping/CHANGELOG.md
@@ -19,6 +19,10 @@ CHANGELOG
   `ShippingMethodEligibilityCheckerSpec`, `DelegatingCalculatorSpec`
 
 * Rework CalculatorInterface, now it has only two methods : getType and calculate.
-* All calculators have new type, which is accordant with calculator rate type, for example : "per_item_rate".
+* All calculators have new type, which is accordant with calculator rate type, for example : "per_unit_rate".
 * Remove getConfiguration and isConfigurable form all calculators.
 * Rework specs according to above changes.
+
+### v0.17.0
+
+* Rename all shipping references of 'Item' to 'Unit' to align with `OrderItemUnit` which represents a `ShippingUnit` in full-stack Sylius

--- a/src/Sylius/Component/Shipping/Calculator/DefaultCalculators.php
+++ b/src/Sylius/Component/Shipping/Calculator/DefaultCalculators.php
@@ -22,14 +22,14 @@ final class DefaultCalculators
     const FLAT_RATE = 'flat_rate';
 
     /**
-     * Fixed price per item calculator.
+     * Fixed price per unit calculator.
      */
-    const PER_ITEM_RATE = 'per_item_rate';
+    const PER_UNIT_RATE = 'per_unit_rate';
 
     /**
      * Flexible rate calculator.
-     * Fixed price for first item and constant rate
-     * for each additional item with a limit.
+     * Fixed price for first unit and constant rate
+     * for each additional unit with a limit.
      */
     const FLEXIBLE_RATE = 'flexible_rate';
 

--- a/src/Sylius/Component/Shipping/Calculator/FlexibleRateCalculator.php
+++ b/src/Sylius/Component/Shipping/Calculator/FlexibleRateCalculator.php
@@ -23,18 +23,18 @@ class FlexibleRateCalculator implements CalculatorInterface
      */
     public function calculate(ShippingSubjectInterface $subject, array $configuration)
     {
-        $firstItemCost = $configuration['first_item_cost'];
-        $additionalItemCost = $configuration['additional_item_cost'];
-        $additionalItemLimit = $configuration['additional_item_limit'];
+        $firstUnitCost = $configuration['first_unit_cost'];
+        $additionalUnitCost = $configuration['additional_unit_cost'];
+        $additionalUnitLimit = $configuration['additional_unit_limit'];
 
-        $totalItems = $subject->getShippingItemCount();
-        $additionalItems = $totalItems - 1;
+        $totalUnits = $subject->getShippingUnitCount();
+        $additionalUnits = $totalUnits - 1;
 
-        if (0 !== $additionalItemLimit) {
-            $additionalItems = $additionalItemLimit >= $additionalItems ? $additionalItems : $additionalItemLimit;
+        if (0 !== $additionalUnitLimit) {
+            $additionalUnits = $additionalUnitLimit >= $additionalUnits ? $additionalUnits : $additionalUnitLimit;
         }
 
-        return (int) ($firstItemCost + ($additionalItems * $additionalItemCost));
+        return (int) ($firstUnitCost + ($additionalUnits * $additionalUnitCost));
     }
 
     /**

--- a/src/Sylius/Component/Shipping/Calculator/PerUnitRateCalculator.php
+++ b/src/Sylius/Component/Shipping/Calculator/PerUnitRateCalculator.php
@@ -16,14 +16,14 @@ use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class PerItemRateCalculator implements CalculatorInterface
+class PerUnitRateCalculator implements CalculatorInterface
 {
     /**
      * {@inheritdoc}
      */
     public function calculate(ShippingSubjectInterface $subject, array $configuration)
     {
-        return (int) ($configuration['amount'] * $subject->getShippingItemCount());
+        return (int) ($configuration['amount'] * $subject->getShippingUnitCount());
     }
 
     /**
@@ -31,6 +31,6 @@ class PerItemRateCalculator implements CalculatorInterface
      */
     public function getType()
     {
-        return 'per_item_rate';
+        return 'per_unit_rate';
     }
 }

--- a/src/Sylius/Component/Shipping/Checker/UnitCountRuleChecker.php
+++ b/src/Sylius/Component/Shipping/Checker/UnitCountRuleChecker.php
@@ -16,14 +16,14 @@ use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class ItemCountRuleChecker implements RuleCheckerInterface
+class UnitCountRuleChecker implements RuleCheckerInterface
 {
     /**
      * {@inheritdoc}
      */
     public function isEligible(ShippingSubjectInterface $subject, array $configuration)
     {
-        $count = $subject->getShippingItemCount();
+        $count = $subject->getShippingUnitCount();
 
         if ($configuration['equal']) {
             return $count >= $configuration['count'];
@@ -37,6 +37,6 @@ class ItemCountRuleChecker implements RuleCheckerInterface
      */
     public function getConfigurationFormType()
     {
-        return 'sylius_shipping_rule_item_count_configuration';
+        return 'sylius_shipping_rule_unit_count_configuration';
     }
 }

--- a/src/Sylius/Component/Shipping/Model/RuleInterface.php
+++ b/src/Sylius/Component/Shipping/Model/RuleInterface.php
@@ -18,8 +18,8 @@ use Sylius\Component\Resource\Model\ResourceInterface;
  */
 interface RuleInterface extends ResourceInterface
 {
-    const TYPE_ITEM_TOTAL = 'item_total';
-    const TYPE_ITEM_COUNT = 'item_count';
+    const TYPE_UNIT_TOTAL = 'unit_total';
+    const TYPE_UNIT_COUNT = 'unit_count';
     const TYPE_WEIGHT = 'weight';
 
     /**

--- a/src/Sylius/Component/Shipping/Model/Shipment.php
+++ b/src/Sylius/Component/Shipping/Model/Shipment.php
@@ -38,9 +38,9 @@ class Shipment implements ShipmentInterface
     protected $method;
 
     /**
-     * @var Collection|ShipmentItemInterface[]
+     * @var Collection|ShipmentUnitInterface[]
      */
-    protected $items;
+    protected $units;
 
     /**
      * @var string
@@ -49,7 +49,7 @@ class Shipment implements ShipmentInterface
 
     public function __construct()
     {
-        $this->items = new ArrayCollection();
+        $this->units = new ArrayCollection();
         $this->createdAt = new \DateTime();
     }
 
@@ -58,7 +58,7 @@ class Shipment implements ShipmentInterface
      */
     public function __toString()
     {
-        return $this->id;
+        return (string) $this->id;
     }
 
     /**
@@ -104,38 +104,38 @@ class Shipment implements ShipmentInterface
     /**
      * {@inheritdoc}
      */
-    public function getItems()
+    public function getUnits()
     {
-        return $this->items;
+        return $this->units;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function hasItem(ShipmentItemInterface $item)
+    public function hasUnit(ShipmentUnitInterface $unit)
     {
-        return $this->items->contains($item);
+        return $this->units->contains($unit);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function addItem(ShipmentItemInterface $item)
+    public function addUnit(ShipmentUnitInterface $unit)
     {
-        if (!$this->hasItem($item)) {
-            $item->setShipment($this);
-            $this->items->add($item);
+        if (!$this->hasUnit($unit)) {
+            $unit->setShipment($this);
+            $this->units->add($unit);
         }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function removeItem(ShipmentItemInterface $item)
+    public function removeUnit(ShipmentUnitInterface $unit)
     {
-        if ($this->hasItem($item)) {
-            $item->setShipment(null);
-            $this->items->removeElement($item);
+        if ($this->hasUnit($unit)) {
+            $unit->setShipment(null);
+            $this->units->removeElement($unit);
         }
     }
 
@@ -146,8 +146,8 @@ class Shipment implements ShipmentInterface
     {
         $shippables = new ArrayCollection();
 
-        foreach ($this->items as $item) {
-            $shippable = $item->getShippable();
+        foreach ($this->units as $unit) {
+            $shippable = $unit->getShippable();
             if (!$shippables->contains($shippable)) {
                 $shippables->add($shippable);
             }
@@ -187,8 +187,8 @@ class Shipment implements ShipmentInterface
     {
         $weight = 0;
 
-        foreach ($this->items as $item) {
-            $weight += $item->getShippable()->getShippingWeight();
+        foreach ($this->units as $unit) {
+            $weight += $unit->getShippable()->getShippingWeight();
         }
 
         return $weight;
@@ -201,8 +201,8 @@ class Shipment implements ShipmentInterface
     {
         $volume = 0;
 
-        foreach ($this->items as $item) {
-            $volume += $item->getShippable()->getShippingVolume();
+        foreach ($this->units as $unit) {
+            $volume += $unit->getShippable()->getShippingVolume();
         }
 
         return $volume;
@@ -211,15 +211,15 @@ class Shipment implements ShipmentInterface
     /**
      * {@inheritdoc}
      */
-    public function getShippingItemCount()
+    public function getShippingUnitCount()
     {
-        return $this->items->count();
+        return $this->units->count();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getShippingItemTotal()
+    public function getShippingUnitTotal()
     {
         return 0;
     }

--- a/src/Sylius/Component/Shipping/Model/ShipmentInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShipmentInterface.php
@@ -51,26 +51,26 @@ interface ShipmentInterface extends ResourceInterface, ShippingSubjectInterface,
     public function setMethod(ShippingMethodInterface $method);
 
     /**
-     * @return Collection|ShipmentItemInterface[]
+     * @return Collection|ShipmentUnitInterface[]
      */
-    public function getItems();
+    public function getUnits();
 
     /**
-     * @param ShipmentItemInterface $item
+     * @param ShipmentUnitInterface $unit
      */
-    public function addItem(ShipmentItemInterface $item);
+    public function addUnit(ShipmentUnitInterface $unit);
 
     /**
-     * @param ShipmentItemInterface $item
+     * @param ShipmentUnitInterface $unit
      */
-    public function removeItem(ShipmentItemInterface $item);
+    public function removeUnit(ShipmentUnitInterface $unit);
 
     /**
-     * @param ShipmentItemInterface $item
+     * @param ShipmentUnitInterface $unit
      *
      * @return bool
      */
-    public function hasItem(ShipmentItemInterface $item);
+    public function hasUnit(ShipmentUnitInterface $unit);
 
     /**
      * @return string

--- a/src/Sylius/Component/Shipping/Model/ShipmentUnit.php
+++ b/src/Sylius/Component/Shipping/Model/ShipmentUnit.php
@@ -16,7 +16,7 @@ use Sylius\Component\Resource\Model\TimestampableTrait;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ShipmentItem implements ShipmentItemInterface
+class ShipmentUnit implements ShipmentUnitInterface
 {
     use TimestampableTrait;
 
@@ -50,7 +50,7 @@ class ShipmentItem implements ShipmentItemInterface
      */
     public function __toString()
     {
-        return $this->id;
+        return (string) $this->id;
     }
 
     /**

--- a/src/Sylius/Component/Shipping/Model/ShipmentUnitInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShipmentUnitInterface.php
@@ -17,7 +17,7 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface ShipmentItemInterface extends TimestampableInterface, ResourceInterface
+interface ShipmentUnitInterface extends TimestampableInterface, ResourceInterface
 {
     /**
      * @return ShipmentInterface

--- a/src/Sylius/Component/Shipping/Model/ShippingMethod.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethod.php
@@ -232,9 +232,9 @@ class ShippingMethod extends AbstractTranslatable implements ShippingMethodInter
     public static function getCategoryRequirementLabels()
     {
         return [
-            ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_NONE => 'None of items have to match method category',
-            ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_ANY => 'At least 1 item have to match method category',
-            ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_ALL => 'All items have to match method category',
+            ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_NONE => 'None of the units have to match the method category',
+            ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_ANY => 'At least 1 unit has to match the method category',
+            ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_ALL => 'All units has to match the method category',
         ];
     }
 

--- a/src/Sylius/Component/Shipping/Model/ShippingSubjectInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingSubjectInterface.php
@@ -34,12 +34,12 @@ interface ShippingSubjectInterface
     /**
      * @return int
      */
-    public function getShippingItemCount();
+    public function getShippingUnitCount();
 
     /**
      * @return int
      */
-    public function getShippingItemTotal();
+    public function getShippingUnitTotal();
 
     /**
      * Get collection of unique shippables.

--- a/src/Sylius/Component/Shipping/Processor/ShipmentProcessor.php
+++ b/src/Sylius/Component/Shipping/Processor/ShipmentProcessor.php
@@ -15,9 +15,9 @@ use Doctrine\Common\Collections\Collection;
 use SM\Factory\FactoryInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Sylius\Component\Shipping\Model\ShipmentInterface;
-use Sylius\Component\Shipping\Model\ShipmentItemInterface;
-use Sylius\Component\Shipping\ShipmentItemTransitions;
+use Sylius\Component\Shipping\Model\ShipmentUnitInterface;
 use Sylius\Component\Shipping\ShipmentTransitions;
+use Sylius\Component\Shipping\ShipmentUnitTransitions;
 
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
@@ -55,18 +55,18 @@ class ShipmentProcessor implements ShipmentProcessorInterface
     /**
      * {@inheritdoc}
      */
-    public function updateItemStates($items, $transition)
+    public function updateUnitStates($units, $transition)
     {
-        if (!is_array($items) && !$items instanceof Collection) {
-            throw new \InvalidArgumentException('Inventory items value must be array or instance of "Doctrine\Common\Collections\Collection".');
+        if (!is_array($units) && !$units instanceof Collection) {
+            throw new \InvalidArgumentException('Shipping units value must be array or instance of "Doctrine\Common\Collections\Collection".');
         }
 
-        foreach ($items as $item) {
-            if (!$item instanceof ShipmentItemInterface) {
-                throw new UnexpectedTypeException($item, 'Sylius\Component\Shipping\Model\ShipmentItemInterface');
+        foreach ($units as $unit) {
+            if (!$unit instanceof ShipmentUnitInterface) {
+                throw new UnexpectedTypeException($unit, 'Sylius\Component\Shipping\Model\ShipmentUnitInterface');
             }
 
-            $this->factory->get($item, ShipmentItemTransitions::GRAPH)->apply($transition, true);
+            $this->factory->get($unit, ShipmentUnitTransitions::GRAPH)->apply($transition, true);
         }
     }
 }

--- a/src/Sylius/Component/Shipping/Processor/ShipmentProcessorInterface.php
+++ b/src/Sylius/Component/Shipping/Processor/ShipmentProcessorInterface.php
@@ -12,7 +12,7 @@
 namespace Sylius\Component\Shipping\Processor;
 
 use Sylius\Component\Shipping\Model\ShipmentInterface;
-use Sylius\Component\Shipping\Model\ShipmentItemInterface;
+use Sylius\Component\Shipping\Model\ShipmentUnitInterface;
 
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
@@ -26,8 +26,8 @@ interface ShipmentProcessorInterface
     public function updateShipmentStates($shipments, $transition);
 
     /**
-     * @param ShipmentItemInterface[] $items
-     * @param string                  $transition ShipmentItemTransitions::*
+     * @param ShipmentUnitInterface[] $units
+     * @param string                  $transition ShipmentUnitTransitions::*
      */
-    public function updateItemStates($items, $transition);
+    public function updateUnitStates($units, $transition);
 }

--- a/src/Sylius/Component/Shipping/README.md
+++ b/src/Sylius/Component/Shipping/README.md
@@ -5,7 +5,7 @@ Sylius e-commerce Shipping component is a complete solution to manage
 shipments & shipping methods and shipping cost calculation for modern PHP
 applications.
 
-The component provides models for Shipment, ShipmentItem, ShippingMethod and
+The component provides models for Shipment, ShipmentUnit, ShippingMethod and
 many more. It supports complex ShippingRules system to cover most
 sophisticated logic for selecting available methods for particular shipment.
 

--- a/src/Sylius/Component/Shipping/ShipmentUnitTransitions.php
+++ b/src/Sylius/Component/Shipping/ShipmentUnitTransitions.php
@@ -11,9 +11,9 @@
 
 namespace Sylius\Component\Shipping;
 
-class ShipmentItemTransitions
+class ShipmentUnitTransitions
 {
-    const GRAPH = 'sylius_shipment_item';
+    const GRAPH = 'sylius_shipment_unit';
 
     const SYLIUS_HOLD = 'hold';
     const SYLIUS_RELEASE = 'release';

--- a/src/Sylius/Component/Shipping/spec/Calculator/FlexibleRateCalculatorSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Calculator/FlexibleRateCalculatorSpec.php
@@ -35,55 +35,55 @@ class FlexibleRateCalculatorSpec extends ObjectBehavior
         $this->getType()->shouldReturn('flexible_rate');
     }
 
-    function it_should_calculate_the_first_item_cost_if_shipment_has_only_one_item(ShipmentInterface $shipment)
+    function it_should_calculate_the_first_unit_cost_if_shipment_has_only_one_unit(ShipmentInterface $shipment)
     {
         $configuration = [
-            'first_item_cost' => 1000,
-            'additional_item_cost' => 200,
-            'additional_item_limit' => 0,
+            'first_unit_cost' => 1000,
+            'additional_unit_cost' => 200,
+            'additional_unit_limit' => 0,
         ];
 
-        $shipment->getShippingItemCount()->willReturn(1);
+        $shipment->getShippingUnitCount()->willReturn(1);
 
         $this->calculate($shipment, $configuration)->shouldReturn(1000);
     }
 
-    function it_should_calculate_the_first_and_every_additional_item_cost_when_shipment_has_more_items(
+    function it_should_calculate_the_first_and_every_additional_unit_cost_when_shipment_has_more_units(
         ShipmentInterface $shipment
     ) {
         $configuration = [
-            'first_item_cost' => 1500,
-            'additional_item_cost' => 300,
-            'additional_item_limit' => 0,
+            'first_unit_cost' => 1500,
+            'additional_unit_cost' => 300,
+            'additional_unit_limit' => 0,
         ];
 
-        $shipment->getShippingItemCount()->willReturn(5);
+        $shipment->getShippingUnitCount()->willReturn(5);
 
         $this->calculate($shipment, $configuration)->shouldReturn(2700);
     }
 
-    function it_should_calculate_the_first_and_every_additional_item_cost_taking_limit_into_account(ShipmentInterface $shipment)
+    function it_should_calculate_the_first_and_every_additional_unit_cost_taking_limit_into_account(ShipmentInterface $shipment)
     {
         $configuration = [
-            'first_item_cost' => 1500,
-            'additional_item_cost' => 300,
-            'additional_item_limit' => 3,
+            'first_unit_cost' => 1500,
+            'additional_unit_cost' => 300,
+            'additional_unit_limit' => 3,
         ];
 
-        $shipment->getShippingItemCount()->willReturn(8);
+        $shipment->getShippingUnitCount()->willReturn(8);
 
         $this->calculate($shipment, $configuration)->shouldReturn(2400);
     }
 
-    function it_should_calculate_the_first_and_every_additional_item_cost_when_the_limit_is_equal_to_additional_items_number(ShipmentInterface $shipment)
+    function it_should_calculate_the_first_and_every_additional_unit_cost_when_the_limit_is_equal_to_additional_units_number(ShipmentInterface $shipment)
     {
         $configuration = [
-            'first_item_cost' => 1000,
-            'additional_item_cost' => 200,
-            'additional_item_limit' => 3,
+            'first_unit_cost' => 1000,
+            'additional_unit_cost' => 200,
+            'additional_unit_limit' => 3,
         ];
 
-        $shipment->getShippingItemCount()->willReturn(4);
+        $shipment->getShippingUnitCount()->willReturn(4);
 
         $this->calculate($shipment, $configuration)->shouldReturn(1600);
     }
@@ -91,12 +91,12 @@ class FlexibleRateCalculatorSpec extends ObjectBehavior
     function its_calculated_value_should_be_an_integer(ShipmentInterface $shipment)
     {
         $configuration = [
-            'first_item_cost' => 1090,
-            'additional_item_cost' => 200,
-            'additional_item_limit' => 3,
+            'first_unit_cost' => 1090,
+            'additional_unit_cost' => 200,
+            'additional_unit_limit' => 3,
         ];
 
-        $shipment->getShippingItemCount()->willReturn(6);
+        $shipment->getShippingUnitCount()->willReturn(6);
 
         $this->calculate($shipment, $configuration)->shouldBeInteger();
     }

--- a/src/Sylius/Component/Shipping/spec/Calculator/PerUnitRateCalculatorSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Calculator/PerUnitRateCalculatorSpec.php
@@ -18,11 +18,11 @@ use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class PerItemRateCalculatorSpec extends ObjectBehavior
+class PerUnitRateCalculatorSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Component\Shipping\Calculator\PerItemRateCalculator');
+        $this->shouldHaveType('Sylius\Component\Shipping\Calculator\PerUnitRateCalculator');
     }
 
     function it_should_implement_Sylius_shipping_calculator_interface()
@@ -30,22 +30,22 @@ class PerItemRateCalculatorSpec extends ObjectBehavior
         $this->shouldImplement(CalculatorInterface::class);
     }
 
-    function it_returns_per_item_type()
+    function it_returns_per_unit_type()
     {
-        $this->getType()->shouldReturn('per_item_rate');
+        $this->getType()->shouldReturn('per_unit_rate');
     }
 
-    function it_should_calculate_the_total_with_the_per_item_amount_configured_on_the_method(
+    function it_should_calculate_the_total_with_the_per_unit_amount_configured_on_the_method(
         ShippingSubjectInterface $subject
     ) {
-        $subject->getShippingItemCount()->willReturn(11);
+        $subject->getShippingUnitCount()->willReturn(11);
 
         $this->calculate($subject, ['amount' => 200])->shouldReturn(2200);
     }
 
     function its_calculated_value_should_be_an_integer(ShippingSubjectInterface $subject)
     {
-        $subject->getShippingItemCount()->willReturn(6);
+        $subject->getShippingUnitCount()->willReturn(6);
 
         $this->calculate($subject, ['amount' => 200])->shouldBeInteger();
     }

--- a/src/Sylius/Component/Shipping/spec/Checker/ShippingMethodEligibilityCheckerSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Checker/ShippingMethodEligibilityCheckerSpec.php
@@ -50,12 +50,12 @@ class ShippingMethodEligibilityCheckerSpec extends ObjectBehavior
     ) {
         $configuration = [];
 
-        $rule->getType()->shouldBeCalled()->willReturn(RuleInterface::TYPE_ITEM_TOTAL);
+        $rule->getType()->shouldBeCalled()->willReturn(RuleInterface::TYPE_UNIT_TOTAL);
         $rule->getConfiguration()->shouldBeCalled()->willReturn($configuration);
 
         $shippingMethod->getCategory()->shouldBeCalled();
         $shippingMethod->getRules()->shouldBeCalled()->willReturn([$rule]);
-        $registry->get(RuleInterface::TYPE_ITEM_TOTAL)->shouldBeCalled()->willReturn($checker);
+        $registry->get(RuleInterface::TYPE_UNIT_TOTAL)->shouldBeCalled()->willReturn($checker);
 
         $checker->isEligible($subject, $configuration)->shouldBeCalled()->willReturn(true);
 
@@ -71,12 +71,12 @@ class ShippingMethodEligibilityCheckerSpec extends ObjectBehavior
     ) {
         $configuration = [];
 
-        $rule->getType()->shouldBeCalled()->willReturn(RuleInterface::TYPE_ITEM_TOTAL);
+        $rule->getType()->shouldBeCalled()->willReturn(RuleInterface::TYPE_UNIT_TOTAL);
         $rule->getConfiguration()->shouldBeCalled()->willReturn($configuration);
 
         $shippingMethod->getCategory()->shouldBeCalled();
         $shippingMethod->getRules()->shouldBeCalled()->willReturn([$rule]);
-        $registry->get(RuleInterface::TYPE_ITEM_TOTAL)->shouldBeCalled()->willReturn($checker);
+        $registry->get(RuleInterface::TYPE_UNIT_TOTAL)->shouldBeCalled()->willReturn($checker);
 
         $checker->isEligible($subject, $configuration)->shouldBeCalled()->willReturn(false);
 

--- a/src/Sylius/Component/Shipping/spec/Checker/UnitCountRuleCheckerSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Checker/UnitCountRuleCheckerSpec.php
@@ -18,11 +18,11 @@ use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class ItemCountRuleCheckerSpec extends ObjectBehavior
+class UnitCountRuleCheckerSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Component\Shipping\Checker\ItemCountRuleChecker');
+        $this->shouldHaveType('Sylius\Component\Shipping\Checker\UnitCountRuleChecker');
     }
 
     function it_is_Sylius_rule_checker()
@@ -32,38 +32,38 @@ class ItemCountRuleCheckerSpec extends ObjectBehavior
 
     function it_should_recognize_empty_subject_as_not_eligible(ShippingSubjectInterface $subject)
     {
-        $subject->getShippingItemCount()->shouldBeCalled()->willReturn(0);
+        $subject->getShippingUnitCount()->shouldBeCalled()->willReturn(0);
 
         $this->isEligible($subject, ['count' => 10, 'equal' => false])->shouldReturn(false);
     }
 
-    function it_should_recognize_subject_as_not_eligible_if_item_count_is_less_then_configured(
+    function it_should_recognize_subject_as_not_eligible_if_unit_count_is_less_then_configured(
         ShippingSubjectInterface $subject
     ) {
-        $subject->getShippingItemCount()->shouldBeCalled()->willReturn(7);
+        $subject->getShippingUnitCount()->shouldBeCalled()->willReturn(7);
 
         $this->isEligible($subject, ['count' => 10, 'equal' => false])->shouldReturn(false);
     }
 
-    function it_should_recognize_subject_as_eligible_if_item_count_is_greater_then_configured(
+    function it_should_recognize_subject_as_eligible_if_unit_count_is_greater_then_configured(
         ShippingSubjectInterface $subject
     ) {
-        $subject->getShippingItemCount()->shouldBeCalled()->willReturn(12);
+        $subject->getShippingUnitCount()->shouldBeCalled()->willReturn(12);
 
         $this->isEligible($subject, ['count' => 10, 'equal' => false])->shouldReturn(true);
     }
 
-    function it_should_recognize_subject_as_eligible_if_item_count_is_equal_with_configured_depending_on_equal_setting(
+    function it_should_recognize_subject_as_eligible_if_unit_count_is_equal_with_configured_depending_on_equal_setting(
         ShippingSubjectInterface $subject
     ) {
-        $subject->getShippingItemCount()->shouldBeCalled()->willReturn(10);
+        $subject->getShippingUnitCount()->shouldBeCalled()->willReturn(10);
 
         $this->isEligible($subject, ['count' => 10, 'equal' => false])->shouldReturn(false);
         $this->isEligible($subject, ['count' => 10, 'equal' => true])->shouldReturn(true);
     }
 
-    function it_returns_item_count_configuration_form_type()
+    function it_returns_unit_count_configuration_form_type()
     {
-        $this->getConfigurationFormType()->shouldReturn('sylius_shipping_rule_item_count_configuration');
+        $this->getConfigurationFormType()->shouldReturn('sylius_shipping_rule_unit_count_configuration');
     }
 }

--- a/src/Sylius/Component/Shipping/spec/Model/RuleSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Model/RuleSpec.php
@@ -42,8 +42,8 @@ class RuleSpec extends ObjectBehavior
 
     function its_type_is_mutable()
     {
-        $this->setType(RuleInterface::TYPE_ITEM_COUNT);
-        $this->getType()->shouldReturn(RuleInterface::TYPE_ITEM_COUNT);
+        $this->setType(RuleInterface::TYPE_UNIT_COUNT);
+        $this->getType()->shouldReturn(RuleInterface::TYPE_UNIT_COUNT);
     }
 
     function it_initializes_empty_array_for_configuration_by_default()

--- a/src/Sylius/Component/Shipping/spec/Model/ShipmentSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Model/ShipmentSpec.php
@@ -13,7 +13,7 @@ namespace spec\Sylius\Component\Shipping\Model;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Shipping\Model\ShipmentInterface;
-use Sylius\Component\Shipping\Model\ShipmentItemInterface;
+use Sylius\Component\Shipping\Model\ShipmentUnitInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 
 /**
@@ -58,32 +58,32 @@ class ShipmentSpec extends ObjectBehavior
         $this->getMethod()->shouldReturn($shippingMethod);
     }
 
-    function it_initializes_items_collection_by_default()
+    function it_initializes_units_collection_by_default()
     {
-        $this->getItems()->shouldHaveType('Doctrine\Common\Collections\Collection');
+        $this->getUnits()->shouldHaveType('Doctrine\Common\Collections\Collection');
     }
 
-    function it_adds_items(ShipmentItemInterface $shipmentItem)
+    function it_adds_units(ShipmentUnitInterface $shipmentUnit)
     {
-        $this->hasItem($shipmentItem)->shouldReturn(false);
+        $this->hasUnit($shipmentUnit)->shouldReturn(false);
 
-        $shipmentItem->setShipment($this)->shouldBeCalled();
-        $this->addItem($shipmentItem);
+        $shipmentUnit->setShipment($this)->shouldBeCalled();
+        $this->addUnit($shipmentUnit);
 
-        $this->hasItem($shipmentItem)->shouldReturn(true);
+        $this->hasUnit($shipmentUnit)->shouldReturn(true);
     }
 
-    function it_removes_item(ShipmentItemInterface $shipmentItem)
+    function it_removes_unit(ShipmentUnitInterface $shipmentUnit)
     {
-        $this->hasItem($shipmentItem)->shouldReturn(false);
+        $this->hasUnit($shipmentUnit)->shouldReturn(false);
 
-        $shipmentItem->setShipment($this)->shouldBeCalled();
-        $this->addItem($shipmentItem);
+        $shipmentUnit->setShipment($this)->shouldBeCalled();
+        $this->addUnit($shipmentUnit);
 
-        $shipmentItem->setShipment(null)->shouldBeCalled();
-        $this->removeItem($shipmentItem);
+        $shipmentUnit->setShipment(null)->shouldBeCalled();
+        $this->removeUnit($shipmentUnit);
 
-        $this->hasItem($shipmentItem)->shouldReturn(false);
+        $this->hasUnit($shipmentUnit)->shouldReturn(false);
     }
 
     function it_has_no_tracking_code_by_default()

--- a/src/Sylius/Component/Shipping/spec/Model/ShipmentUnitSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Model/ShipmentUnitSpec.php
@@ -13,22 +13,22 @@ namespace spec\Sylius\Component\Shipping\Model;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Shipping\Model\ShipmentInterface;
-use Sylius\Component\Shipping\Model\ShipmentItemInterface;
+use Sylius\Component\Shipping\Model\ShipmentUnitInterface;
 use Sylius\Component\Shipping\Model\ShippableInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ShipmentItemSpec extends ObjectBehavior
+class ShipmentUnitSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Component\Shipping\Model\ShipmentItem');
+        $this->shouldHaveType('Sylius\Component\Shipping\Model\ShipmentUnit');
     }
 
-    function it_implements_Sylius_shipment_item_interface()
+    function it_implements_Sylius_shipment_unit_interface()
     {
-        $this->shouldImplement(ShipmentItemInterface::class);
+        $this->shouldImplement(ShipmentUnitInterface::class);
     }
 
     function it_has_no_id_by_default()

--- a/src/Sylius/Component/Shipping/spec/Processor/ShipmentProcessorSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Processor/ShipmentProcessorSpec.php
@@ -15,10 +15,10 @@ use PhpSpec\ObjectBehavior;
 use SM\Factory\FactoryInterface;
 use Sylius\Component\Resource\StateMachine\StateMachineInterface;
 use Sylius\Component\Shipping\Model\ShipmentInterface;
-use Sylius\Component\Shipping\Model\ShipmentItemInterface;
+use Sylius\Component\Shipping\Model\ShipmentUnitInterface;
 use Sylius\Component\Shipping\Processor\ShipmentProcessorInterface;
-use Sylius\Component\Shipping\ShipmentItemTransitions;
 use Sylius\Component\Shipping\ShipmentTransitions;
+use Sylius\Component\Shipping\ShipmentUnitTransitions;
 
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
@@ -52,15 +52,15 @@ class ShipmentProcessorSpec extends ObjectBehavior
         $this->updateShipmentStates([$shipment], 'transition');
     }
 
-    function it_updates_item_states(
+    function it_updates_unit_states(
         $factory,
-        ShipmentItemInterface $item,
+        ShipmentUnitInterface $unit,
         StateMachineInterface $sm
     ) {
-        $factory->get($item, ShipmentItemTransitions::GRAPH)->shouldBeCalled()->willReturn($sm);
+        $factory->get($unit, ShipmentUnitTransitions::GRAPH)->shouldBeCalled()->willReturn($sm);
 
         $sm->apply('transition', true)->shouldBeCalled();
 
-        $this->updateItemStates([$item], 'transition');
+        $this->updateUnitStates([$unit], 'transition');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets | #4083
| License       | MIT

Due to the introduction of `OrderItemUnit`, it is confusing to have `ShippingItem` referring to `OrderItemUnit` when there is also `OrderItem`.

This updates the naming for consistency.