### PR TITLE
Fix typo in PaymentMethodRepository method getQueryBuilderForChoiceType

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/PaymentMethodRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/PaymentMethodRepository.php
@@ -18,9 +18,9 @@ class PaymentMethodRepository extends BasePaymentMethodRepository
     /**
      * {@inheritdoc}
      */
-    public function getQueryBuidlerForChoiceType(array $options)
+    public function getQueryBuilderForChoiceType(array $options)
     {
-        $queryBuilder = parent::getQueryBuidlerForChoiceType($options);
+        $queryBuilder = parent::getQueryBuilderForChoiceType($options);
 
         if ($options['channel']) {
             $queryBuilder->andWhere('method IN (:methods)')

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Payment/PaymentMethodChoiceType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Payment/PaymentMethodChoiceType.php
@@ -38,7 +38,7 @@ class PaymentMethodChoiceType extends BasePaymentMethodChoiceType
             ];
 
             return function (PaymentMethodRepositoryInterface $repository) use ($repositoryOptions) {
-                return $repository->getQueryBuidlerForChoiceType($repositoryOptions);
+                return $repository->getQueryBuilderForChoiceType($repositoryOptions);
             };
         };
 

--- a/src/Sylius/Bundle/CoreBundle/spec/Doctrine/ORM/PaymentMethodRepositorySpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Doctrine/ORM/PaymentMethodRepositorySpec.php
@@ -58,7 +58,7 @@ class PaymentMethodRepositorySpec extends ObjectBehavior
         $paymentMethods->toArray()->shouldBeCalled()->willReturn([$paymentMethod]);
         $builder->setParameter('methods', [$paymentMethod])->shouldBeCalled()->willReturn($builder);
 
-        $this->getQueryBuidlerForChoiceType([
+        $this->getQueryBuilderForChoiceType([
             'channel' => $channel,
             'disabled' => true,
         ])->shouldReturn($builder);

--- a/src/Sylius/Bundle/PaymentBundle/Doctrine/ORM/PaymentMethodRepository.php
+++ b/src/Sylius/Bundle/PaymentBundle/Doctrine/ORM/PaymentMethodRepository.php
@@ -22,7 +22,7 @@ class PaymentMethodRepository extends TranslatableResourceRepository implements 
     /**
      * {@inheritdoc}
      */
-    public function getQueryBuidlerForChoiceType(array $options)
+    public function getQueryBuilderForChoiceType(array $options)
     {
         $queryBuilder = $this->getCollectionQueryBuilder();
 

--- a/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentMethodChoiceType.php
+++ b/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentMethodChoiceType.php
@@ -38,7 +38,7 @@ class PaymentMethodChoiceType extends ResourceChoiceType
             ];
 
             return function (PaymentMethodRepositoryInterface $repository) use ($repositoryOptions) {
-                return $repository->getQueryBuidlerForChoiceType($repositoryOptions);
+                return $repository->getQueryBuilderForChoiceType($repositoryOptions);
             };
         };
 

--- a/src/Sylius/Bundle/PaymentBundle/spec/Doctrine/ORM/PaymentMethodRepositorySpec.php
+++ b/src/Sylius/Bundle/PaymentBundle/spec/Doctrine/ORM/PaymentMethodRepositorySpec.php
@@ -44,7 +44,7 @@ class PaymentMethodRepositorySpec extends ObjectBehavior
         $builder->from(Argument::any(), 'method', Argument::cetera())->shouldBeCalled()->willReturn($builder);
         $builder->where('method.enabled = true')->shouldBeCalled()->willReturn($builder);
 
-        $this->getQueryBuidlerForChoiceType([
+        $this->getQueryBuilderForChoiceType([
             'disabled' => false,
         ])->shouldReturn($builder);
     }
@@ -57,7 +57,7 @@ class PaymentMethodRepositorySpec extends ObjectBehavior
         $builder->leftJoin('method.translations', 'translation')->shouldBeCalled()->willReturn($builder);
         $builder->from(Argument::any(), 'method', Argument::cetera())->shouldBeCalled()->willReturn($builder);
 
-        $this->getQueryBuidlerForChoiceType([
+        $this->getQueryBuilderForChoiceType([
             'disabled' => true,
         ])->shouldReturn($builder);
     }

--- a/src/Sylius/Component/Payment/Repository/PaymentMethodRepositoryInterface.php
+++ b/src/Sylius/Component/Payment/Repository/PaymentMethodRepositoryInterface.php
@@ -21,5 +21,5 @@ interface PaymentMethodRepositoryInterface
      *
      * @return mixed
      */
-    public function getQueryBuidlerForChoiceType(array $options);
+    public function getQueryBuilderForChoiceType(array $options);
 }


### PR DESCRIPTION
Obvious typo in the word 'builder', all methods specifications for the PaymentMethodRepository were typed 'buidler'.