### PR TITLE
[Behat] Decouple checkout steps in context

### DIFF
--- a/features/shop/apply_correct_shipping_fee_on_order.feature
+++ b/features/shop/apply_correct_shipping_fee_on_order.feature
@@ -7,11 +7,10 @@ Feature: Apply correct shipping fee on order
     Background:
         Given the store is operating on a single channel
         And default currency is "EUR"
-        And the store ships to "Australia", "France" and "United States"
+        And the store ships to "France"
         And the store has a product "PHP T-Shirt" priced at "€100.00"
         And the store has "DHL" shipping method with "€10.00" fee
         And the store has "FedEx" shipping method with "€30.00" fee
-        And the store allows paying offline
         And there is user "john@example.com" identified by "password123"
         And I am logged in as "john@example.com"
 

--- a/features/shop/apply_correct_shipping_fee_with_product_taxes_on_order.feature
+++ b/features/shop/apply_correct_shipping_fee_with_product_taxes_on_order.feature
@@ -19,22 +19,24 @@ Feature: Apply correct shipping fee with product taxes on order
         And the store has a product "PHP T-Shirt" priced at "€100.00"
         And product "PHP T-Shirt" belongs to "Clothes" tax category
         And the store has "DHL" shipping method with "€10.00" fee within "EU" zone
-        And the store has "DHL-World" shipping method with "€10.00" fee for the rest of the world
+        And the store has "FedEx" shipping method with "€20.00" fee for the rest of the world
         And shipping method "DHL" belongs to "Shipping Services" tax category
-        And shipping method "DHL-World" belongs to "Shipping Services" tax category
+        And shipping method "FedEx" belongs to "Shipping Services" tax category
         And the store allows paying offline
         And I am logged in as "john@example.com"
 
     Scenario: Proper shipping fee, tax and product tax
         Given I have product "PHP T-Shirt" in the cart
         When I proceed selecting "DHL" shipping method
+        And I choose "Offline" payment method
         Then my cart total should be "€135.30"
         And my cart taxes should be "€25.30"
         And my cart shipping fee should be "€12.30"
 
     Scenario: Proper shipping fee, tax and products' taxes after addressing
         Given I have 3 products "PHP T-Shirt" in the cart
-        When I proceed selecting "Australia" as shipping country with "DHL" method
-        Then my cart total should be "€341.00"
-        And my cart taxes should be "€31.00"
-        And my cart shipping fee should be "€11.00"
+        When I proceed selecting "Australia" as shipping country with "FedEx" method
+        And I choose "Offline" payment method
+        Then my cart total should be "€352.00"
+        And my cart taxes should be "€32.00"
+        And my cart shipping fee should be "€22.00"

--- a/features/shop/apply_correct_shipping_fee_with_taxes_on_order.feature
+++ b/features/shop/apply_correct_shipping_fee_with_taxes_on_order.feature
@@ -27,6 +27,7 @@ Feature: Apply correct shipping fee with taxes on order
     Scenario: Proper shipping fee and tax
         Given I have product "PHP T-Shirt" in the cart
         When I proceed selecting "DHL" shipping method
+        And I choose "Offline" payment method
         Then my cart total should be "€112.30"
         And my cart taxes should be "€2.30"
         And my cart shipping fee should be "€12.30"
@@ -34,6 +35,7 @@ Feature: Apply correct shipping fee with taxes on order
     Scenario: Proper shipping fee and tax after addressing
         Given I have product "PHP T-Shirt" in the cart
         When I proceed selecting "Australia" as shipping country with "DHL-World" method
+        And I choose "Offline" payment method
         Then my cart total should be "€122.00"
         And my cart taxes should be "€2.00"
         And my cart shipping fee should be "€22.00"

--- a/features/shop/apply_correct_taxes_for_products_with_different_tax_rates_for_different_zones.feature
+++ b/features/shop/apply_correct_taxes_for_products_with_different_tax_rates_for_different_zones.feature
@@ -18,9 +18,6 @@ Feature: Apply correct taxes for products with different tax rates for different
         And product "PHP T-Shirt" belongs to "Clothes" tax category
         And the store has a product "Symfony Mug" priced at "€50.00"
         And product "Symfony Mug" belongs to "Mugs" tax category
-        And the store ships everything for free within "EU" zone
-        And the store ships everything for free for the rest of the world
-        And the store allows paying offline
         And there is user "john@example.com" identified by "password123"
         And I am logged in as "john@example.com"
 
@@ -30,14 +27,14 @@ Feature: Apply correct taxes for products with different tax rates for different
         And my cart taxes should be "€23.00"
 
     Scenario: Displaying correct tax after specifying shipping address
-        When I add product "PHP T-Shirt" to the cart
-        And I proceed selecting "Australia" as shipping country with "Offline" payment method
+        Given I have product "PHP T-Shirt" in the cart
+        When I proceed selecting "Australia" as shipping country
         Then my cart total should be "€100.00"
         And my cart taxes should be "€0.00"
 
     Scenario: Displaying correct taxes for multiple products after specifying shipping address
-        When I add 3 products "PHP T-Shirt" to the cart
-        And I proceed selecting "Australia" as shipping country with "Offline" payment method
+        Given I have 3 products "PHP T-Shirt" in the cart
+        When I proceed selecting "Australia" as shipping country
         Then my cart total should be "€300.00"
         And my cart taxes should be "€0.00"
 
@@ -48,8 +45,8 @@ Feature: Apply correct taxes for products with different tax rates for different
         And my cart taxes should be "€23.00"
 
     Scenario: Displaying correct taxes for multiple products from different zones after specifying shipping address
-        When I add product "PHP T-Shirt" to the cart
-        And I add 2 products "Symfony Mug" to the cart
-        And I proceed selecting "Australia" as shipping country with "Offline" payment method
+        Given I have product "PHP T-Shirt" in the cart
+        And I have 2 products "Symfony Mug" in the cart
+        When I proceed selecting "Australia" as shipping country
         Then my cart total should be "€205.00"
         And my cart taxes should be "€5.00"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |
| License       | MIT
| Doc PR        |

* Do not enforce to always select payment method when proceeding with checkout since in most scenarios we do not need to
* Explicitly choose payment method when proceeding with checkout (right now the taxes to shipping fee are only applied after choosing payment method, but it should be applied at the moment the shipping method is chosen, so let's be explicitly aware of that)