### PR TITLE
[product] - originalPrice allow null, fix error 500 on save

### DIFF
--- a/src/Sylius/Component/Core/Model/ProductVariant.php
+++ b/src/Sylius/Component/Core/Model/ProductVariant.php
@@ -185,7 +185,7 @@ class ProductVariant extends BaseVariant implements ProductVariantInterface
      */
     public function setOriginalPrice($originalPrice)
     {
-        if (!is_int($originalPrice)) {
+        if (null !== $originalPrice && !is_int($originalPrice)) {
             throw new \InvalidArgumentException('Original price must be an integer.');
         }
         $this->originalPrice = $originalPrice;

--- a/src/Sylius/Component/Core/Model/ProductVariantInterface.php
+++ b/src/Sylius/Component/Core/Model/ProductVariantInterface.php
@@ -119,7 +119,7 @@ interface ProductVariantInterface extends
     public function getOriginalPrice();
 
     /**
-     * @param int $originalPrice
+     * @param int|null $originalPrice
      */
     public function setOriginalPrice($originalPrice);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

Original price can be set to null with the setOriginalPrice() method.

Previously if you had original price set lets say to 100$, only way to reset/remove it was with filling in 0.
If you tried setting it with empty value, on saving the product an error 500 would be shown.
The error was thrown from the setter method.
