### PR TITLE
[Travis] Removed CS checker from Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ before_script:
 
 script:
     - composer validate
-    - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then etc/travis/check-sylius-cs; fi;
+    
     - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then bin/kawaii gherkin:check --align=left features/; fi;
 
     - bin/phpspec run --no-interaction -f dot


### PR DESCRIPTION
It's quite annoying when you need to push once again because empty line has 4 spaces instead of none, some original licensing header needs to be changed or coding standard is enforced even on copied files. It causes a lot of false-negatives.