### PR TITLE
[Behat] Renamed ui-* suites to ui_*

### DIFF
--- a/etc/behat/suites.yml
+++ b/etc/behat/suites.yml
@@ -29,6 +29,6 @@ imports:
     - suites/shipping.yml
     - suites/taxation.yml
     - suites/taxonomies.yml
-    - suites/ui-cart.yml
-    - suites/ui-checkout.yml
+    - suites/ui_cart.yml
+    - suites/ui_checkout.yml
     - suites/users.yml

--- a/etc/behat/suites/ui_cart.yml
+++ b/etc/behat/suites/ui_cart.yml
@@ -3,7 +3,7 @@
 
 default:
     suites:
-        ui-cart:
+        ui_cart:
             contexts:
                 - Sylius\Behat\Context\Hook\DoctrineORMContext:
                     entityManager: "@doctrine.orm.entity_manager"
@@ -72,5 +72,6 @@ default:
                     zoneRepository: "@sylius.repository.zone"
 
                 - Sylius\Behat\Context\Ui\UserContext: ~
+
             filters:
                 tags: "@ui-cart"

--- a/etc/behat/suites/ui_checkout.yml
+++ b/etc/behat/suites/ui_checkout.yml
@@ -3,7 +3,7 @@
 
 default:
     suites:
-        ui-checkout:
+        ui_checkout:
             contexts:
                 - Sylius\Behat\Context\Setup\ChannelContext:
                     sharedStorage: "@sylius.behat.shared_storage"


### PR DESCRIPTION
Running `bin/behat -s ui-cart` returns:

![screen shot 2016-02-12 at 12 01 44](https://cloud.githubusercontent.com/assets/1897953/13005182/6edf0b90-d180-11e5-854a-2b4f51292b18.png)
