### PR TITLE
[RFC][Association] Introduce AssociableTrait with ability to get associated objects by association type

### DIFF
--- a/src/Sylius/Component/Association/Model/AssociationInterface.php
+++ b/src/Sylius/Component/Association/Model/AssociationInterface.php
@@ -36,7 +36,7 @@ interface AssociationInterface extends TimestampableInterface, ResourceInterface
     public function getOwner();
 
     /**
-     * @param AssociatableInterface
+     * @param AssociableInterface
      */
     public function setOwner(AssociableInterface $owner = null);
 
@@ -46,17 +46,17 @@ interface AssociationInterface extends TimestampableInterface, ResourceInterface
     public function getAssociatedObjects();
 
     /**
-     * @param AssociatableInterface
+     * @param AssociableInterface
      */
     public function addAssociatedObject(AssociableInterface $associatedObject);
 
     /**
-     * @param AssociatableInterface
+     * @param AssociableInterface
      */
     public function removeAssociatedObject(AssociableInterface $associatedObject);
 
     /**
-     * @param AssociatableInterface
+     * @param AssociableInterface
      *
      * @return bool
      */

--- a/src/Sylius/Component/Association/Traits/AssociableTrait.php
+++ b/src/Sylius/Component/Association/Traits/AssociableTrait.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Sylius\Component\Association\Traits;
+
+use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Association\Model\AssociationInterface;
+use Sylius\Component\Association\Model\AssociationTypeInterface;
+
+trait AssociableTrait
+{
+    /**
+     * @var Collection|AssociationInterface[]
+     */
+    protected $associations;
+
+    /**
+     * @return Collection|AssociationInterface[]
+     */
+    public function getAssociations()
+    {
+        return $this->associations;
+    }
+
+    /**
+     * @param null|string|AssociationTypeInterface $type
+     *
+     * @return array|AssociationInterface[]
+     */
+    public function getAssociatedObjects($type = null)
+    {
+        if (null === $type) {
+            return $this->associations;
+        }
+
+        if ($type instanceof AssociationTypeInterface) {
+            $type = $type->getCode();
+        }
+
+        $associatedObjects = [];
+
+        $this->associations->forAll(function (AssociationInterface $association) use (&$associatedObjects, $type) {
+            if ($association->getType()->getCode() === $type) {
+                return;
+            }
+
+            $associatedObjects = array_merge($associatedObjects, $association->getAssociatedObjects());
+        });
+
+        return $associatedObjects;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAssociation(AssociationInterface $association)
+    {
+        if (!$this->hasAssociation($association)) {
+            $this->associations->add($association);
+            $association->setOwner($this);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeAssociation(AssociationInterface $association)
+    {
+        if ($this->hasAssociation($association)) {
+            $association->setOwner(null);
+            $this->associations->removeElement($association);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasAssociation(AssociationInterface $association)
+    {
+        return $this->associations->contains($association);
+    }
+}

--- a/src/Sylius/Component/Product/Model/Product.php
+++ b/src/Sylius/Component/Product/Model/Product.php
@@ -14,6 +14,7 @@ namespace Sylius\Component\Product\Model;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Archetype\Model\ArchetypeInterface as BaseArchetypeInterface;
+use Sylius\Component\Association\Traits\AssociableTrait;
 use Sylius\Component\Attribute\Model\AttributeValueInterface as BaseAttributeValueInterface;
 use Sylius\Component\Resource\Model\SoftDeletableTrait;
 use Sylius\Component\Resource\Model\TimestampableTrait;
@@ -28,7 +29,7 @@ use Sylius\Component\Variation\Model\VariantInterface as BaseVariantInterface;
  */
 class Product extends AbstractTranslatable implements ProductInterface
 {
-    use SoftDeletableTrait, TimestampableTrait, ToggleableTrait;
+    use SoftDeletableTrait, TimestampableTrait, ToggleableTrait, AssociableTrait;
 
     /**
      * @var mixed
@@ -64,11 +65,6 @@ class Product extends AbstractTranslatable implements ProductInterface
      * @var Collection|BaseOptionInterface[]
      */
     protected $options;
-
-    /**
-     * @var Collection|ProductAssociationInterface[]
-     */
-    protected $associations;
 
     public function __construct()
     {
@@ -471,43 +467,5 @@ class Product extends AbstractTranslatable implements ProductInterface
         }
 
         $this->deletedAt = $deletedAt;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getAssociations()
-    {
-        return $this->associations;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function addAssociation(ProductAssociationInterface $association)
-    {
-        if (!$this->hasAssociation($association)) {
-            $this->associations->add($association);
-            $association->setOwner($this);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function removeAssociation(ProductAssociationInterface $association)
-    {
-        if ($this->hasAssociation($association)) {
-            $association->setOwner(null);
-            $this->associations->removeElement($association);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasAssociation(ProductAssociationInterface $association)
-    {
-        return $this->associations->contains($association);
     }
 }

--- a/src/Sylius/Component/Product/Model/ProductInterface.php
+++ b/src/Sylius/Component/Product/Model/ProductInterface.php
@@ -55,19 +55,4 @@ interface ProductInterface extends
      * @param null|\DateTime $availableUntil
      */
     public function setAvailableUntil(\DateTime $availableUntil = null);
-
-    /**
-     * @param ProductAssociationInterface $association
-     */
-    public function addAssociation(ProductAssociationInterface $association);
-
-    /**
-     * @param ProductAssociationInterface[] $association
-     */
-    public function getAssociations();
-
-    /**
-     * @param ProductAssociationInterface $association
-     */
-    public function removeAssociation(ProductAssociationInterface $association);
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | no |
| License | MIT |
| Doc PR | - |

I've extracted some code related to association from Product, Idk why it wasn't done and I couldn't figure out why so do you think this is good? And why `AssociableInterface` does not have method signatures such as `addAssociation`, `removeAssociation`, etc? Any specific reason? 

Also having `getAssociatedObjects($type = null)` method is useful in twig.

``` twig
{% for relatedProduct in product.associatedObjects('RELATED_PRODUCTS') %}
```

/cc @lchrusciel 
