### PR TITLE
[Theme] Context interface cleanup

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Collector/ThemeDataCollector.php
+++ b/src/Sylius/Bundle/ThemeBundle/Collector/ThemeDataCollector.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\ThemeBundle\Collector;
 
 use Sylius\Bundle\ThemeBundle\Context\ThemeContextInterface;
+use Sylius\Bundle\ThemeBundle\HierarchyProvider\ThemeHierarchyProviderInterface;
 use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
 use Sylius\Bundle\ThemeBundle\Repository\ThemeRepositoryInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -23,6 +24,21 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
  */
 class ThemeDataCollector implements DataCollectorInterface, \Serializable
 {
+    /**
+     * @var ThemeRepositoryInterface
+     */
+    private $themeRepository;
+
+    /**
+     * @var ThemeContextInterface
+     */
+    private $themeContext;
+
+    /**
+     * @var ThemeHierarchyProviderInterface
+     */
+    private $themeHierarchyProvider;
+
     /**
      * @var ThemeInterface
      */
@@ -39,25 +55,18 @@ class ThemeDataCollector implements DataCollectorInterface, \Serializable
     private $allThemes;
 
     /**
-     * @var ThemeRepositoryInterface
-     */
-    private $themeRepository;
-
-    /**
-     * @var ThemeContextInterface
-     */
-    private $themeContext;
-
-    /**
      * @param ThemeRepositoryInterface $themeRepository
      * @param ThemeContextInterface $themeContext
+     * @param ThemeHierarchyProviderInterface $themeHierarchyProvider
      */
     public function __construct(
         ThemeRepositoryInterface $themeRepository,
-        ThemeContextInterface $themeContext
+        ThemeContextInterface $themeContext,
+        ThemeHierarchyProviderInterface $themeHierarchyProvider
     ) {
         $this->themeRepository = $themeRepository;
         $this->themeContext = $themeContext;
+        $this->themeHierarchyProvider = $themeHierarchyProvider;
     }
 
     /**
@@ -90,7 +99,7 @@ class ThemeDataCollector implements DataCollectorInterface, \Serializable
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
         $this->usedTheme = $this->themeContext->getTheme();
-        $this->themeHierarchy = $this->themeContext->getThemeHierarchy();
+        $this->themeHierarchy = $this->themeHierarchyProvider->getThemeHierarchy($this->themeContext->getTheme());
         $this->allThemes = $this->themeRepository->findAll();
     }
 

--- a/src/Sylius/Bundle/ThemeBundle/Context/SettableThemeContext.php
+++ b/src/Sylius/Bundle/ThemeBundle/Context/SettableThemeContext.php
@@ -11,31 +11,17 @@
 
 namespace Sylius\Bundle\ThemeBundle\Context;
 
-use Sylius\Bundle\ThemeBundle\HierarchyProvider\ThemeHierarchyProviderInterface;
 use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
 
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-final class ThemeContext implements ThemeContextInterface
+final class SettableThemeContext implements ThemeContextInterface
 {
-    /**
-     * @var ThemeHierarchyProviderInterface
-     */
-    private $themeHierarchyProvider;
-
     /**
      * @var ThemeInterface
      */
     private $theme;
-
-    /**
-     * @param ThemeHierarchyProviderInterface $themeHierarchyProvider
-     */
-    public function __construct(ThemeHierarchyProviderInterface $themeHierarchyProvider)
-    {
-        $this->themeHierarchyProvider = $themeHierarchyProvider;
-    }
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ThemeBundle/Context/ThemeContext.php
+++ b/src/Sylius/Bundle/ThemeBundle/Context/ThemeContext.php
@@ -52,12 +52,4 @@ final class ThemeContext implements ThemeContextInterface
     {
         return $this->theme;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getThemeHierarchy()
-    {
-        return null !== $this->theme ? $this->themeHierarchyProvider->getThemeHierarchy($this->theme) : [];
-    }
 }

--- a/src/Sylius/Bundle/ThemeBundle/Context/ThemeContextInterface.php
+++ b/src/Sylius/Bundle/ThemeBundle/Context/ThemeContextInterface.php
@@ -27,9 +27,4 @@ interface ThemeContextInterface
      * @return ThemeInterface|null
      */
     public function getTheme();
-
-    /**
-     * @return ThemeInterface[]
-     */
-    public function getThemeHierarchy();
 }

--- a/src/Sylius/Bundle/ThemeBundle/Context/ThemeContextInterface.php
+++ b/src/Sylius/Bundle/ThemeBundle/Context/ThemeContextInterface.php
@@ -19,11 +19,6 @@ use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
 interface ThemeContextInterface
 {
     /**
-     * @param ThemeInterface $theme
-     */
-    public function setTheme(ThemeInterface $theme);
-
-    /**
      * @return ThemeInterface|null
      */
     public function getTheme();

--- a/src/Sylius/Bundle/ThemeBundle/HierarchyProvider/ThemeHierarchyProvider.php
+++ b/src/Sylius/Bundle/ThemeBundle/HierarchyProvider/ThemeHierarchyProvider.php
@@ -35,8 +35,12 @@ final class ThemeHierarchyProvider implements ThemeHierarchyProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getThemeHierarchy(ThemeInterface $theme)
+    public function getThemeHierarchy(ThemeInterface $theme = null)
     {
+        if (null === $theme) {
+            return [];
+        }
+
         $parents = [];
         $parentsNames = $theme->getParentsNames();
         foreach ($parentsNames as $parentName) {

--- a/src/Sylius/Bundle/ThemeBundle/HierarchyProvider/ThemeHierarchyProviderInterface.php
+++ b/src/Sylius/Bundle/ThemeBundle/HierarchyProvider/ThemeHierarchyProviderInterface.php
@@ -19,11 +19,11 @@ use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
 interface ThemeHierarchyProviderInterface
 {
     /**
-     * @param ThemeInterface $theme
+     * @param ThemeInterface|null $theme
      *
      * @return ThemeInterface[]
      *
      * @throws \InvalidArgumentException If dependencies could not be resolved.
      */
-    public function getThemeHierarchy(ThemeInterface $theme);
+    public function getThemeHierarchy(ThemeInterface $theme = null);
 }

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/services.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/services.xml
@@ -42,6 +42,7 @@
         <service id="sylius.theme.data_collector" class="%sylius.theme.data_collector.class%" public="false">
             <argument type="service" id="sylius.theme.repository" />
             <argument type="service" id="sylius.theme.context" />
+            <argument type="service" id="sylius.theme.hierarchy_provider" />
             <tag name="data_collector" template="SyliusThemeBundle:Profiler:theme" id="sylius_theme" />
         </service>
 

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/services.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/services.xml
@@ -14,7 +14,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
         <parameter key="sylius.theme.model.class">Sylius\Bundle\ThemeBundle\Model\Theme</parameter>
-        <parameter key="sylius.theme.context.class">Sylius\Bundle\ThemeBundle\Context\ThemeContext</parameter>
+        <parameter key="sylius.theme.context.class">Sylius\Bundle\ThemeBundle\Context\SettableThemeContext</parameter>
         <parameter key="sylius.theme.factory.basic.class">Sylius\Component\Resource\Factory\Factory</parameter>
         <parameter key="sylius.theme.factory.class">Sylius\Bundle\ThemeBundle\Factory\ThemeFactory</parameter>
         <parameter key="sylius.theme.repository.class">Sylius\Bundle\ThemeBundle\Repository\ThemeRepository</parameter>

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/templating.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/templating.xml
@@ -36,6 +36,7 @@
         <service id="sylius.theme.templating.file_locator" class="%sylius.theme.templating.file_locator.class%" decorates="templating.locator" public="false">
             <argument type="service" id="sylius.theme.templating.file_locator.inner" />
             <argument type="service" id="sylius.theme.context" />
+            <argument type="service" id="sylius.theme.hierarchy_provider" />
             <argument type="service" id="sylius.theme.templating.locator" />
             <argument>%kernel.cache_dir%</argument>
         </service>

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/translations.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/translations.xml
@@ -21,6 +21,7 @@
         <service id="sylius.theme.translation.translator" class="%sylius.theme.translation.translator.class%" decorates="translator">
             <argument type="service" id="sylius.theme.translation.translator.inner" />
             <argument type="service" id="sylius.theme.context" />
+            <argument type="service" id="sylius.theme.hierarchy_provider" />
         </service>
 
         <service id="sylius.theme.translation.files_finder" class="%sylius.theme.translation.files_finder.class%" public="false">

--- a/src/Sylius/Bundle/ThemeBundle/Templating/Locator/TemplateFileLocator.php
+++ b/src/Sylius/Bundle/ThemeBundle/Templating/Locator/TemplateFileLocator.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\ThemeBundle\Templating\Locator;
 
 use Sylius\Bundle\ThemeBundle\Context\ThemeContextInterface;
+use Sylius\Bundle\ThemeBundle\HierarchyProvider\ThemeHierarchyProviderInterface;
 use Sylius\Bundle\ThemeBundle\Locator\ResourceNotFoundException;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Templating\TemplateReferenceInterface;
@@ -34,6 +35,11 @@ final class TemplateFileLocator implements FileLocatorInterface
     private $themeContext;
 
     /**
+     * @var ThemeHierarchyProviderInterface
+     */
+    private $themeHierarchyProvider;
+
+    /**
      * @var TemplateLocatorInterface
      */
     private $templateLocator;
@@ -41,15 +47,18 @@ final class TemplateFileLocator implements FileLocatorInterface
     /**
      * @param FileLocatorInterface $decoratedFileLocator
      * @param ThemeContextInterface $themeContext
+     * @param ThemeHierarchyProviderInterface $themeHierarchyProvider
      * @param TemplateLocatorInterface $templateLocator
      */
     public function __construct(
         FileLocatorInterface $decoratedFileLocator,
         ThemeContextInterface $themeContext,
+        ThemeHierarchyProviderInterface $themeHierarchyProvider,
         TemplateLocatorInterface $templateLocator
     ) {
         $this->decoratedFileLocator = $decoratedFileLocator;
         $this->themeContext = $themeContext;
+        $this->themeHierarchyProvider = $themeHierarchyProvider;
         $this->templateLocator = $templateLocator;
     }
 
@@ -62,7 +71,7 @@ final class TemplateFileLocator implements FileLocatorInterface
             throw new \InvalidArgumentException('The template must be an instance of TemplateReferenceInterface.');
         }
 
-        $themes = $this->themeContext->getThemeHierarchy();
+        $themes = $this->themeHierarchyProvider->getThemeHierarchy($this->themeContext->getTheme());
         foreach ($themes as $theme) {
             try {
                 return $this->templateLocator->locateTemplate($template, $theme);

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/DefaultTestCase/RequestListener.php
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/DefaultTestCase/RequestListener.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\ThemeBundle\Tests\Functional\app\DefaultTestCase;
 
+use Sylius\Bundle\ThemeBundle\Context\SettableThemeContext;
 use Sylius\Bundle\ThemeBundle\Context\ThemeContextInterface;
 use Sylius\Bundle\ThemeBundle\Repository\ThemeRepositoryInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -33,9 +34,9 @@ final class RequestListener
 
     /**
      * @param ThemeRepositoryInterface $themeRepository
-     * @param ThemeContextInterface $themeContext
+     * @param SettableThemeContext $themeContext
      */
-    public function __construct(ThemeRepositoryInterface $themeRepository, ThemeContextInterface $themeContext)
+    public function __construct(ThemeRepositoryInterface $themeRepository, SettableThemeContext $themeContext)
     {
         $this->themeRepository = $themeRepository;
         $this->themeContext = $themeContext;

--- a/src/Sylius/Bundle/ThemeBundle/Translation/Translator.php
+++ b/src/Sylius/Bundle/ThemeBundle/Translation/Translator.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\ThemeBundle\Translation;
 
 use Sylius\Bundle\ThemeBundle\Context\ThemeContextInterface;
+use Sylius\Bundle\ThemeBundle\HierarchyProvider\ThemeHierarchyProviderInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -32,11 +33,17 @@ final class Translator implements TranslatorInterface, TranslatorBagInterface, W
     private $themeContext;
 
     /**
+     * @var ThemeHierarchyProviderInterface
+     */
+    private $themeHierarchyProvider;
+
+    /**
      * {@inheritdoc}
      */
     public function __construct(
         TranslatorInterface $translator,
-        ThemeContextInterface $themeContext
+        ThemeContextInterface $themeContext,
+        ThemeHierarchyProviderInterface $themeHierarchyProvider
     ) {
         if (!$translator instanceof TranslatorBagInterface) {
             throw new \InvalidArgumentException(sprintf(
@@ -47,6 +54,7 @@ final class Translator implements TranslatorInterface, TranslatorBagInterface, W
 
         $this->translator = $translator;
         $this->themeContext = $themeContext;
+        $this->themeHierarchyProvider = $themeHierarchyProvider;
     }
 
     /**
@@ -137,7 +145,7 @@ final class Translator implements TranslatorInterface, TranslatorBagInterface, W
      */
     private function getPossibleIds($id)
     {
-        $themes = $this->themeContext->getThemeHierarchy();
+        $themes = $this->themeHierarchyProvider->getThemeHierarchy($this->themeContext->getTheme());
 
         foreach ($themes as $theme) {
             yield $id.'|'.$theme->getName();

--- a/src/Sylius/Bundle/ThemeBundle/spec/Context/SettableThemeContextSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/Context/SettableThemeContextSpec.php
@@ -13,26 +13,21 @@ namespace spec\Sylius\Bundle\ThemeBundle\Context;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Sylius\Bundle\ThemeBundle\Context\ThemeContext;
+use Sylius\Bundle\ThemeBundle\Context\SettableThemeContext;
 use Sylius\Bundle\ThemeBundle\Context\ThemeContextInterface;
 use Sylius\Bundle\ThemeBundle\HierarchyProvider\ThemeHierarchyProviderInterface;
 use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
 
 /**
- * @mixin ThemeContext
+ * @mixin SettableThemeContext
  *
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-class ThemeContextSpec extends ObjectBehavior
+class SettableThemeContextSpec extends ObjectBehavior
 {
-    function let(ThemeHierarchyProviderInterface $themeHierarchyProvider)
-    {
-        $this->beConstructedWith($themeHierarchyProvider);
-    }
-
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Bundle\ThemeBundle\Context\ThemeContext');
+        $this->shouldHaveType('Sylius\Bundle\ThemeBundle\Context\SettableThemeContext');
     }
 
     function it_implements_theme_context_interface()

--- a/src/Sylius/Bundle/ThemeBundle/spec/Context/ThemeContextSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/Context/ThemeContextSpec.php
@@ -47,22 +47,4 @@ class ThemeContextSpec extends ObjectBehavior
         $this->setTheme($theme);
         $this->getTheme()->shouldReturn($theme);
     }
-
-    function it_proxies_getting_theme_hierarchy_if_there_is_current_theme(
-        ThemeHierarchyProviderInterface $themeHierarchyProvider,
-        ThemeInterface $theme
-    ) {
-        $this->setTheme($theme);
-        $themeHierarchyProvider->getThemeHierarchy($theme)->willReturn([$theme]);
-
-        $this->getThemeHierarchy()->shouldReturn([$theme]);
-    }
-
-    function it_returns_an_empty_array_as_theme_hierarchy_if_there_is_no_current_theme(
-        ThemeHierarchyProviderInterface $themeHierarchyProvider
-    ) {
-        $themeHierarchyProvider->getThemeHierarchy(Argument::any())->shouldNotBeCalled();
-
-        $this->getThemeHierarchy()->shouldReturn([]);
-    }
 }

--- a/src/Sylius/Bundle/ThemeBundle/spec/Translation/TranslatorSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/Translation/TranslatorSpec.php
@@ -14,6 +14,7 @@ namespace spec\Sylius\Bundle\ThemeBundle\Translation;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\ThemeBundle\Context\ThemeContextInterface;
+use Sylius\Bundle\ThemeBundle\HierarchyProvider\ThemeHierarchyProviderInterface;
 use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
 use Sylius\Bundle\ThemeBundle\Translation\Translator;
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
@@ -30,11 +31,12 @@ class TranslatorSpec extends ObjectBehavior
 {
     function let(
         TranslatorInterface $translator,
-        ThemeContextInterface $themeContext
+        ThemeContextInterface $themeContext,
+        ThemeHierarchyProviderInterface $themeHierarchyProvider
     ) {
         $translator->implement(TranslatorBagInterface::class);
 
-        $this->beConstructedWith($translator, $themeContext);
+        $this->beConstructedWith($translator, $themeContext, $themeHierarchyProvider);
     }
 
     function it_is_initializable()
@@ -74,10 +76,12 @@ class TranslatorSpec extends ObjectBehavior
     function it_translates_id_using_theme_translations(
         TranslatorInterface $translator,
         ThemeContextInterface $themeContext,
+        ThemeHierarchyProviderInterface $themeHierarchyProvider,
         ThemeInterface $theme
     ) {
         $theme->getName()->willReturn('theme/name');
-        $themeContext->getThemeHierarchy()->willReturn([$theme]);
+        $themeContext->getTheme()->willReturn($theme);
+        $themeHierarchyProvider->getThemeHierarchy($theme)->willReturn([$theme]);
 
         $translator->trans('id|theme/name', Argument::cetera())->willReturn('Theme translation');
         $translator->trans('id', Argument::cetera())->shouldNotBeCalled();
@@ -88,10 +92,12 @@ class TranslatorSpec extends ObjectBehavior
     function it_translates_id_using_default_translations(
         TranslatorInterface $translator,
         ThemeContextInterface $themeContext,
+        ThemeHierarchyProviderInterface $themeHierarchyProvider,
         ThemeInterface $theme
     ) {
         $theme->getName()->willReturn('theme/name');
-        $themeContext->getThemeHierarchy()->willReturn([$theme]);
+        $themeContext->getTheme()->willReturn($theme);
+        $themeHierarchyProvider->getThemeHierarchy($theme)->willReturn([$theme]);
 
         $translator->trans('id|theme/name', Argument::cetera())->willReturn('id|theme/name');
         $translator->trans('id', Argument::cetera())->willReturn('Default translation');
@@ -102,10 +108,12 @@ class TranslatorSpec extends ObjectBehavior
     function it_returns_id_if_there_is_no_given_translation(
         TranslatorInterface $translator,
         ThemeContextInterface $themeContext,
+        ThemeHierarchyProviderInterface $themeHierarchyProvider,
         ThemeInterface $theme
     ) {
         $theme->getName()->willReturn('theme/name');
-        $themeContext->getThemeHierarchy()->willReturn([$theme]);
+        $themeContext->getTheme()->willReturn($theme);
+        $themeHierarchyProvider->getThemeHierarchy($theme)->willReturn([$theme]);
 
         $translator->trans('id|theme/name', Argument::cetera())->willReturn('id|theme/name');
         $translator->trans('id', Argument::cetera())->willReturn('id');
@@ -116,10 +124,12 @@ class TranslatorSpec extends ObjectBehavior
     function it_choice_translates_id_using_theme_translations(
         TranslatorInterface $translator,
         ThemeContextInterface $themeContext,
+        ThemeHierarchyProviderInterface $themeHierarchyProvider,
         ThemeInterface $theme
     ) {
         $theme->getName()->willReturn('theme/name');
-        $themeContext->getThemeHierarchy()->willReturn([$theme]);
+        $themeContext->getTheme()->willReturn($theme);
+        $themeHierarchyProvider->getThemeHierarchy($theme)->willReturn([$theme]);
 
         $translator->transChoice('id|theme/name', 42, Argument::cetera())->willReturn('Theme translation');
         $translator->transChoice('id', 42, Argument::cetera())->shouldNotBeCalled();
@@ -130,10 +140,12 @@ class TranslatorSpec extends ObjectBehavior
     function it_choice_translates_id_using_default_translations(
         TranslatorInterface $translator,
         ThemeContextInterface $themeContext,
+        ThemeHierarchyProviderInterface $themeHierarchyProvider,
         ThemeInterface $theme
     ) {
         $theme->getName()->willReturn('theme/name');
-        $themeContext->getThemeHierarchy()->willReturn([$theme]);
+        $themeContext->getTheme()->willReturn($theme);
+        $themeHierarchyProvider->getThemeHierarchy($theme)->willReturn([$theme]);
 
         $translator->transChoice('id|theme/name', 42, Argument::cetera())->willReturn('id|theme/name');
         $translator->transChoice('id', 42, Argument::cetera())->willReturn('Default translation');
@@ -144,10 +156,12 @@ class TranslatorSpec extends ObjectBehavior
     function it_returns_id_if_there_is_no_given_choice_translation(
         TranslatorInterface $translator,
         ThemeContextInterface $themeContext,
+        ThemeHierarchyProviderInterface $themeHierarchyProvider,
         ThemeInterface $theme
     ) {
         $theme->getName()->willReturn('theme/name');
-        $themeContext->getThemeHierarchy()->willReturn([$theme]);
+        $themeContext->getTheme()->willReturn($theme);
+        $themeHierarchyProvider->getThemeHierarchy($theme)->willReturn([$theme]);
 
         $translator->transChoice('id|theme/name', 42, Argument::cetera())->willReturn('id|theme/name');
         $translator->transChoice('id', 42, Argument::cetera())->willReturn('id');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes (within master)
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

 - [x] Removed `ThemeContextInterface::getThemeHierarchy()` proxy/helper method
 - [x] Removed `ThemeContextInterface::setTheme(ThemeInterface $theme)` method as it does not apply to all theme contexts out there

`ThemeContextInterface` has only a `getTheme()` method now, which will be a lot easier to implement and maintain.