### PR TITLE
[RFC] Show only available option values on product page

### DIFF
--- a/src/Sylius/Bundle/VariationBundle/Form/Type/VariantMatchType.php
+++ b/src/Sylius/Bundle/VariationBundle/Form/Type/VariantMatchType.php
@@ -41,7 +41,7 @@ class VariantMatchType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        foreach ($options['variable']->getOptions() as $i => $option) {
+        foreach ($options['variable']->getAvailableOptions() as $i => $option) {
             $builder->add(Urlizer::urlize($option->getName()), sprintf('sylius_%s_option_value_choice', $this->variableName), [
                 'label' => $option->getPresentation(),
                 'option' => $option,

--- a/src/Sylius/Component/Core/Model/Product.php
+++ b/src/Sylius/Component/Core/Model/Product.php
@@ -354,4 +354,22 @@ class Product extends BaseProduct implements ProductInterface
     {
         $this->mainTaxon = $mainTaxon;
     }
+
+    public function getAvailableOptions()
+    {
+        $options = clone $this->getOptions();
+
+        foreach ($options as $option) {
+            $option->getValues()->clear();
+            foreach ($this->getVariants() as $variant) {
+                foreach ($variant->getOptions() as $optionValue) {
+                    if($option->getName() == $optionValue->getOption()->getName()){
+                        $option->addValue($optionValue);
+                    }
+                }
+            }
+        }
+
+        return $options;
+    }
 }


### PR DESCRIPTION
Hey folks!

**(do not review the code it's quick&dirty POC and not intended to be merged)**

As you know, we have 2 choice types: `VARIANT_SELECTION_MATCH` and `VARIANT_SELECTION_CHOICE`. 

Nothing wrong with `VARIANT_SELECTION_CHOICE` but it gets quite messy when your product has more than 2 options. In such case you want to use ol' good `<select>` provided by `VARIANT_SELECTION_MATCH`. 

This is where things get interesting. As of now, every select representing an option is populated with every optionValue that is attached to it(which in turn attached to a product), completely ignoring the fact that there may be no variant with such option or that you may have tons of optionValues attached to a single option. This is terribad from UX standpoint. 

So my idea is to filter those option values based on available variants and show only those actually available. This PR illustrates one of possible solutions but i beileve can be refactored to something decent(listener, maybe?) and mergeable. This is where i need your help guys.

WDYT?
