### PR TITLE
[cart] - added missing translation for quantity on cart item form type

### DIFF
--- a/src/Sylius/Bundle/CartBundle/Form/Type/CartItemType.php
+++ b/src/Sylius/Bundle/CartBundle/Form/Type/CartItemType.php
@@ -45,6 +45,7 @@ class CartItemType extends AbstractResourceType
         $builder
             ->add('quantity', 'integer', [
                 'attr' => ['min' => 1],
+                'label' => 'sylius.form.cart_item.quantity',
             ])
             ->setDataMapper($this->orderItemQuantityDataMapper);
     }

--- a/src/Sylius/Bundle/CartBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/CartBundle/Resources/translations/messages.en.yml
@@ -1,0 +1,5 @@
+sylius:
+    form:
+        cart_item:
+            quantity: Quantity
+            


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no|
| Deprecations? | no
| License       | MIT

added missing translation for quantity on cart item form type