### PR TITLE
[Behat][Promotions] Promotions with fixed discount scenarios

### DIFF
--- a/etc/behat/suites.yml
+++ b/etc/behat/suites.yml
@@ -32,3 +32,4 @@ imports:
     - suites/ui_cart.yml
     - suites/ui_channels.yml
     - suites/ui_checkout.yml
+    - suites/ui_promotion.yml

--- a/etc/behat/suites/ui_promotion.yml
+++ b/etc/behat/suites/ui_promotion.yml
@@ -1,0 +1,22 @@
+# This file is part of the Sylius package.
+# (c) Paweł Jędrzejewski
+
+default:
+    suites:
+        ui_promotion:
+            contexts_as_services:
+                - sylius.behat.context.hook.doctrine_orm
+
+                - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.currency
+                - sylius.behat.context.setup.security
+                - sylius.behat.context.setup.user
+                - sylius.behat.context.setup.product
+                - sylius.behat.context.setup.zone
+
+                - sylius.behat.context.ui.checkout
+                - sylius.behat.context.ui.cart
+                - sylius.behat.context.ui.user
+
+            filters:
+                tags: @promotion && @ui

--- a/features/shop/apply_fixed_discount_promotion_on_order.feature
+++ b/features/shop/apply_fixed_discount_promotion_on_order.feature
@@ -1,0 +1,37 @@
+@todo
+@ui-cart
+Feature: Apply fixed discount promotion on order
+    In order to pay proper amount while buying promoted goods
+    As a Customer
+    I want to have promotions applied
+
+    Background:
+        Given the store is operating on a single channel
+        And default currency is "EUR"
+        And the store has a product "PHP T-Shirt" priced at "€100.00"
+        And the store has a product "PHP Mug" priced at "€6.00"
+        And the store has a product "Symfony Mug" priced at "€10.00"
+        And there is user "john@example.com" identified by "password123"
+        And I am logged in as "john@example.com"
+
+    Scenario: Applying proper promotion discount
+        Given there is a promotion "Total based promotion"
+        And it gives "€10.00" fixed discount for customers with carts above "€80.00"
+        And I have product "PHP T-Shirt" in the cart
+        Then my cart total should be "€90.00"
+        And my cart promotions should be "-€10.00"
+
+    Scenario: Reset cart total if promotion discount is equal with items total
+        Given there is a promotion "Item based promotion"
+        And it gives "€16.00" fixed discount for customers with carts with more than 1 item
+        And I have product "PHP Mug" in the cart
+        And I have product "Symfony Mug" in the cart
+        Then my cart total should be "€0.00"
+        And my cart promotions should be "-€16.00"
+
+    Scenario: Set cart total to €0.00 if promotion discount is bigger than items total
+        Given there is a promotion "Silly promotion"
+        And it gives "€10.00" fixed discount for customers with carts above "€5.00"
+        And I have product "PHP Mug" in the cart
+        Then my cart total should be "€0.00"
+        And my cart promotions should be "-€5.00"

--- a/features/shop/apply_fixed_discount_promotion_on_order.feature
+++ b/features/shop/apply_fixed_discount_promotion_on_order.feature
@@ -1,37 +1,47 @@
-@todo
-@ui-cart
+@cart
 Feature: Apply fixed discount promotion on order
     In order to pay proper amount while buying promoted goods
     As a Customer
-    I want to have promotions applied
+    I want to have promotions applied to my cart
 
     Background:
-        Given the store is operating on a single channel
-        And default currency is "EUR"
+        Given the store is operating on a single channel in "France"
         And the store has a product "PHP T-Shirt" priced at "€100.00"
         And the store has a product "PHP Mug" priced at "€6.00"
-        And the store has a product "Symfony Mug" priced at "€10.00"
-        And there is user "john@example.com" identified by "password123"
-        And I am logged in as "john@example.com"
 
+    @todo
     Scenario: Applying proper promotion discount
-        Given there is a promotion "Total based promotion"
-        And it gives "€10.00" fixed discount for customers with carts above "€80.00"
-        And I have product "PHP T-Shirt" in the cart
+        Given there is a promotion "Holiday promotion"
+        And it gives "€10.00" fixed discount to every order
+        When I add product "PHP T-Shirt" to the cart
         Then my cart total should be "€90.00"
         And my cart promotions should be "-€10.00"
 
-    Scenario: Reset cart total if promotion discount is equal with items total
-        Given there is a promotion "Item based promotion"
-        And it gives "€16.00" fixed discount for customers with carts with more than 1 item
-        And I have product "PHP Mug" in the cart
-        And I have product "Symfony Mug" in the cart
+    @todo
+    Scenario: Apply proper discount when promotion discount is equal to items total
+        Given there is a promotion "Christmas Sale"
+        And it gives "€106.00" fixed discount to every order
+        When I add product "PHP T-Shirt" to the cart
+        And I add product "PHP Mug" to the cart
         Then my cart total should be "€0.00"
-        And my cart promotions should be "-€16.00"
+        And my cart promotions should be "-€106.00"
 
-    Scenario: Set cart total to €0.00 if promotion discount is bigger than items total
-        Given there is a promotion "Silly promotion"
-        And it gives "€10.00" fixed discount for customers with carts above "€5.00"
-        And I have product "PHP Mug" in the cart
+    @todo
+    Scenario: Apply discount equal to items total when promotion discount is bigger than items total
+        Given there is a promotion "Thanksgiving sale"
+        And it gives "200.00" fixed discount to every order
+        When I add product "PHP Mug" to the cart
         Then my cart total should be "€0.00"
-        And my cart promotions should be "-€5.00"
+        And my cart promotions should be "-€100.00"
+
+    @todo
+    Scenario: The fixed discount does not affect a shipping fee
+        Given the store has "DHL" shipping method with "€10.00" fee
+        And there is a promotion "Holiday promotion"
+        And it gives "€10.00" fixed discount to every order
+        And I am logged in customer
+        When I add product "PHP T-Shirt" to the cart
+        And I proceed selecting "DHL" shipping method
+        Then my cart total should be "€100.00"
+        And my cart shipping fee should be "€10.00"
+        And my cart promotions should be "-€10.00"

--- a/features/shop/promotion/apply_fixed_discount_promotion_on_order.feature
+++ b/features/shop/promotion/apply_fixed_discount_promotion_on_order.feature
@@ -1,16 +1,16 @@
-@cart
+@promotion
 Feature: Apply fixed discount promotion on order
     In order to pay proper amount while buying promoted goods
-    As a Customer
+    As a Visitor
     I want to have promotions applied to my cart
 
     Background:
-        Given the store is operating on a single channel in "France"
+        Given the store operates on a single channel in "France"
         And the store has a product "PHP T-Shirt" priced at "€100.00"
         And the store has a product "PHP Mug" priced at "€6.00"
 
     @todo
-    Scenario: Applying proper promotion discount
+    Scenario: Receiving fixed discount for my cart
         Given there is a promotion "Holiday promotion"
         And it gives "€10.00" fixed discount to every order
         When I add product "PHP T-Shirt" to the cart
@@ -18,7 +18,7 @@ Feature: Apply fixed discount promotion on order
         And my cart promotions should be "-€10.00"
 
     @todo
-    Scenario: Apply proper discount when promotion discount is equal to items total
+    Scenario: Receiving fixed discount equal to the items total of my cart
         Given there is a promotion "Christmas Sale"
         And it gives "€106.00" fixed discount to every order
         When I add product "PHP T-Shirt" to the cart
@@ -27,15 +27,15 @@ Feature: Apply fixed discount promotion on order
         And my cart promotions should be "-€106.00"
 
     @todo
-    Scenario: Apply discount equal to items total when promotion discount is bigger than items total
+    Scenario: Receiving fixed discount equal to the items total of my cart even if the discount is bigger than the items total
         Given there is a promotion "Thanksgiving sale"
-        And it gives "200.00" fixed discount to every order
+        And it gives "€200.00" fixed discount to every order
         When I add product "PHP Mug" to the cart
         Then my cart total should be "€0.00"
         And my cart promotions should be "-€100.00"
 
     @todo
-    Scenario: The fixed discount does not affect a shipping fee
+    Scenario: Receiving fixed discount does not affect the shipping fee
         Given the store has "DHL" shipping method with "€10.00" fee
         And there is a promotion "Holiday promotion"
         And it gives "€10.00" fixed discount to every order


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets |
| License       | MIT
| Doc PR        |

First portion of new scenarios for *Promotion*, describing simple fixed discount on customer's cart.
It uses "@todo" tag introduced by @pamil in https://github.com/Sylius/Sylius/pull/4169.