### PR TITLE
Always declare HTML encoding immediately after the opening head tag.

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/views/layout.html.twig
@@ -2,8 +2,8 @@
 
 <html>
     <head>
-        <title>{% block sylius_title %}Sylius bundles example layout{% endblock %}</title>
         <meta charset="UTF-8">
+        <title>{% block sylius_title %}Sylius bundles example layout{% endblock %}</title>
 
         <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
         <!--[if lt IE 9]>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Security/login.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Security/login.html.twig
@@ -2,12 +2,12 @@
 
 <html xmlns="http://www.w3.org/1999/html">
     <head>
+        <meta charset="UTF-8">
         <title>
             {% block title %}
                 {{ 'sylius.meta.backend_title'|trans }}
             {% endblock %}
         </title>
-        <meta charset="UTF-8">
 
         <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
         <!--[if lt IE 9]>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/layout.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/layout.html.twig
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="UTF-8">
         <title>
             {% block title %}
                 {{ 'sylius.meta.backend_title'|trans }}
             {% endblock %}
         </title>
-        <meta charset="UTF-8">
 
         <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:400,700|Open+Sans:300italic,400,300,700&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
 

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/layout.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/layout.html.twig
@@ -3,12 +3,12 @@
 <html>
     <head>
         {% block head %}
+            <meta charset="UTF-8">
             <title>
                 {% block title %}
                     {{ settings.title|default('sylius.meta.frontend_title'|trans) }}
                 {% endblock %}
             </title>
-            <meta charset="UTF-8">
             <meta name="description" content="{{ settings.meta_description|default('sylius.meta.frontend_description'|trans) }}">
             <meta name="keywords" content="{{ settings.meta_keywords|default('sylius.meta.frontend_keywords'|trans) }}">
         {% endblock %}


### PR DESCRIPTION
From the [W3C documentation][1] :

> The declaration should fit completely within the first 1024 bytes at
> the start of the file, so it's best to put it immediately after the
> opening head tag.

If the Twig title blocks exceed this (which would be rare), it's possible
for pages using those templates to not be encoded as UTF-8 when sent.

[1]: https://www.w3.org/International/questions/qa-html-encoding-declarations.en#quickanswer