### PR TITLE
[Taxation] - reset pointer for orderUnits collection before each call

### DIFF
--- a/src/Sylius/Component/Core/Taxation/OrderItemsTaxesByZoneApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/OrderItemsTaxesByZoneApplicator.php
@@ -81,6 +81,7 @@ class OrderItemsTaxesByZoneApplicator implements OrderItemsTaxesByZoneApplicator
             $splitTaxes = $this->distributor->distribute($totalTaxAmount, $quantity);
 
             $units = $item->getUnits();
+            $units->first();
             foreach ($splitTaxes as $key => $tax) {
                 if (0 === $tax) {
                     continue;
@@ -112,7 +113,7 @@ class OrderItemsTaxesByZoneApplicator implements OrderItemsTaxesByZoneApplicator
     private function getNextUnit(Collection $units)
     {
         $unit = $units->current();
-        if (null === $unit) {
+        if (false === $unit) {
             throw new \InvalidArgumentException('The number of tax items is greater than number of units.');
         }
         $units->next();

--- a/src/Sylius/Component/Core/spec/Taxation/OrderItemsTaxesByZoneApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Taxation/OrderItemsTaxesByZoneApplicatorSpec.php
@@ -91,6 +91,7 @@ class OrderItemsTaxesByZoneApplicatorSpec extends ObjectBehavior
 
         $orderItem->getUnits()->willReturn($units);
 
+        $units->first()->shouldBeCalled();
         $units->current()->willReturn($unit1, $unit2);
         $units->next()->shouldBeCalledTimes(2);
 
@@ -192,6 +193,7 @@ class OrderItemsTaxesByZoneApplicatorSpec extends ObjectBehavior
         $taxRate->isIncludedInPrice()->willReturn(false);
 
         $orderItem->getUnits()->willReturn($units);
+        $units->first()->shouldBeCalled();
         $units->current()->shouldNotBeCalled();
         $units->next()->shouldNotBeCalled();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #4202
| License       | MIT