### PR TITLE
[Review] - average rating recalculation on change, decouple model

### DIFF
--- a/src/Sylius/Bundle/ReviewBundle/EventListener/ReviewChangeListener.php
+++ b/src/Sylius/Bundle/ReviewBundle/EventListener/ReviewChangeListener.php
@@ -19,7 +19,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 /**
  * @author Mateusz Zalewski <mateusz.p.zalewski@gmail.com>
  */
-class ReviewDeleteListener
+class ReviewChangeListener
 {
     /**
      * @var ReviewableRatingUpdaterInterface

--- a/src/Sylius/Bundle/ReviewBundle/Remover/ReviewerReviewsRemover.php
+++ b/src/Sylius/Bundle/ReviewBundle/Remover/ReviewerReviewsRemover.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\ReviewBundle\Remover;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+use Sylius\Bundle\ReviewBundle\Updater\ReviewableRatingUpdaterInterface;
 use Sylius\Component\Review\Calculator\ReviewableRatingCalculatorInterface;
 use Sylius\Component\Review\Model\ReviewableInterface;
 use Sylius\Component\Review\Model\ReviewerInterface;
@@ -34,23 +35,23 @@ class ReviewerReviewsRemover implements ReviewerReviewsRemoverInterface
     private $reviewManager;
 
     /**
-     * @var ReviewableRatingCalculatorInterface
+     * @var ReviewableRatingUpdaterInterface
      */
-    private $averageRatingCalculator;
+    private $averageRatingUpdater;
 
     /**
      * @param EntityRepository $reviewRepository
      * @param ObjectManager $reviewManager
-     * @param ReviewableRatingCalculatorInterface $averageRatingCalculator
+     * @param ReviewableRatingUpdaterInterface $averageRatingUpdater
      */
     public function __construct(
         EntityRepository $reviewRepository,
         ObjectManager $reviewManager,
-        ReviewableRatingCalculatorInterface $averageRatingCalculator
+        ReviewableRatingUpdaterInterface $averageRatingUpdater
     ) {
         $this->reviewRepository = $reviewRepository;
         $this->reviewManager = $reviewManager;
-        $this->averageRatingCalculator = $averageRatingCalculator;
+        $this->averageRatingUpdater = $averageRatingUpdater;
     }
 
     /**
@@ -66,7 +67,7 @@ class ReviewerReviewsRemover implements ReviewerReviewsRemoverInterface
         $this->reviewManager->flush();
 
         foreach ($reviewSubjectsToRecalculate as $reviewSubject) {
-            $reviewSubject->setAverageRating($this->averageRatingCalculator->calculate($reviewSubject));
+            $this->averageRatingUpdater->update($reviewSubject);
         }
     }
 

--- a/src/Sylius/Bundle/ReviewBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ReviewBundle/Resources/config/services.xml
@@ -19,7 +19,7 @@
         <parameter key="sylius.event_subscriber.review.load_metadata.class">Sylius\Bundle\ReviewBundle\EventListener\LoadMetadataSubscriber</parameter>
         <parameter key="sylius.review.validator.unique_reviewer_email.class">Sylius\Bundle\ReviewBundle\Validator\Constraints\UniqueReviewerEmailValidator</parameter>
         <parameter key="sylius.listener.review_create.class">Sylius\Bundle\ReviewBundle\EventListener\ReviewCreateListener</parameter>
-        <parameter key="sylius.listener.review_delete.class">Sylius\Bundle\ReviewBundle\EventListener\ReviewDeleteListener</parameter>
+        <parameter key="sylius.listener.review_change.class">Sylius\Bundle\ReviewBundle\EventListener\ReviewChangeListener</parameter>
         <parameter key="sylius.review.calculator.average_rating.class">Sylius\Component\Review\Calculator\AverageRatingCalculator</parameter>
         <parameter key="sylius.review.updater.average_rating.class">Sylius\Bundle\ReviewBundle\Updater\AverageRatingUpdater</parameter>
         <parameter key="sylius.review.remover.reviewer_reviews.class">Sylius\Bundle\ReviewBundle\Remover\ReviewerReviewsRemover</parameter>
@@ -45,8 +45,10 @@
             <argument type="service" id="sylius.context.customer" />
             <tag name="kernel.event_listener" event="sylius.product_review.pre_create" method="ensureReviewHasAuthor" />
         </service>
-        <service id="sylius.listener.review_delete" class="%sylius.listener.review_delete.class%">
+        <service id="sylius.listener.review_change" class="%sylius.listener.review_change.class%">
             <argument type="service" id="sylius.review.updater.average_rating" />
+            <tag name="kernel.event_listener" event="sylius.product_review.post_update" method="recalculateSubjectRating" />
+            <tag name="kernel.event_listener" event="sylius.product_review.post_delete" method="recalculateSubjectRating" />
         </service>
 
         <service id="sylius.review.calculator.average_rating" class="%sylius.review.calculator.average_rating.class%" />
@@ -57,7 +59,7 @@
         <service id="sylius.review.remover.reviewer_reviews" class="%sylius.review.remover.reviewer_reviews.class%">
             <argument type="service" id="sylius.repository.product_review" />
             <argument type="service" id="sylius.manager.product_review" />
-            <argument type="service" id="sylius.review.calculator.average_rating" />
+            <argument type="service" id="sylius.review.updater.average_rating" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ReviewBundle/spec/EventListener/ReviewChangeListenerSpec.php
+++ b/src/Sylius/Bundle/ReviewBundle/spec/EventListener/ReviewChangeListenerSpec.php
@@ -22,7 +22,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class ReviewDeleteListenerSpec extends ObjectBehavior
+class ReviewChangeListenerSpec extends ObjectBehavior
 {
     function let(ReviewableRatingUpdaterInterface $averageRatingUpdater)
     {
@@ -31,7 +31,7 @@ class ReviewDeleteListenerSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Bundle\ReviewBundle\EventListener\ReviewDeleteListener');
+        $this->shouldHaveType('Sylius\Bundle\ReviewBundle\EventListener\ReviewChangeListener');
     }
 
     function it_recalculates_subject_rating_on_accepted_review_deletion(

--- a/src/Sylius/Bundle/ReviewBundle/spec/Remover/ReviewerReviewsRemoverSpec.php
+++ b/src/Sylius/Bundle/ReviewBundle/spec/Remover/ReviewerReviewsRemoverSpec.php
@@ -15,7 +15,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 use Sylius\Bundle\ReviewBundle\Remover\ReviewerReviewsRemoverInterface;
-use Sylius\Component\Review\Calculator\ReviewableRatingCalculatorInterface;
+use Sylius\Bundle\ReviewBundle\Updater\ReviewableRatingUpdaterInterface;
 use Sylius\Component\Review\Model\ReviewableInterface;
 use Sylius\Component\Review\Model\ReviewerInterface;
 use Sylius\Component\Review\Model\ReviewInterface;
@@ -28,9 +28,9 @@ class ReviewerReviewsRemoverSpec extends ObjectBehavior
     function let(
         EntityRepository $reviewRepository,
         ObjectManager $reviewManager,
-        ReviewableRatingCalculatorInterface $averageRatingCalculator
+        ReviewableRatingUpdaterInterface $averageRatingUpdater
     ) {
-        $this->beConstructedWith($reviewRepository, $reviewManager, $averageRatingCalculator);
+        $this->beConstructedWith($reviewRepository, $reviewManager, $averageRatingUpdater);
     }
 
     function it_is_initializable()
@@ -44,7 +44,7 @@ class ReviewerReviewsRemoverSpec extends ObjectBehavior
     }
 
     function it_removes_soft_deleted_customer_reviews_and_recalculates_their_product_ratings(
-        $averageRatingCalculator,
+        $averageRatingUpdater,
         $reviewRepository,
         $reviewManager,
         ReviewerInterface $author,
@@ -57,9 +57,7 @@ class ReviewerReviewsRemoverSpec extends ObjectBehavior
         $reviewManager->remove($review)->shouldBeCalled();
         $reviewManager->flush()->shouldBeCalled();
 
-        $averageRatingCalculator->calculate($reviewSubject)->willReturn(0);
-
-        $reviewSubject->setAverageRating(0)->shouldBeCalled();
+        $averageRatingUpdater->update($reviewSubject)->shouldBeCalled();
 
         $this->removeReviewerReviews($author);
     }

--- a/src/Sylius/Component/Review/Model/ReviewInterface.php
+++ b/src/Sylius/Component/Review/Model/ReviewInterface.php
@@ -11,7 +11,6 @@
 
 namespace Sylius\Component\Review\Model;
 
-use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
@@ -76,7 +75,7 @@ interface ReviewInterface extends TimestampableInterface, ResourceInterface
     public function getStatus();
 
     /**
-     * @return ProductInterface
+     * @return ReviewableInterface
      */
     public function getReviewSubject();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Average rating on `review subject` (Product) was only recalculated when approved (state machine).
This PR adds events and fixes remover code to recalculate also when:

* `review` is deleted
* `review` rating was changed - its possible in administration
* `customer` was removed and associated `reviews` where deleted.

There is still one problem with recalculation when updating `review` in administration and `review subject `is changed. In that situation, average rating on previous `review subject` is not modified.
Possibility to change the subject is in my opinion pretty weird one so there are two solutions:

* disable change of subject on review once it is set.
* add onFlush doctrine listener to handle updating both old and new subject average rating.

