### PR TITLE
[CoreBundle] Decode url when finding entity based on request URI

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Routing/RouteProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Routing/RouteProvider.php
@@ -73,7 +73,9 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
         }
 
         foreach ($this->getRepositories() as $className => $repository) {
-            $entity = $repository->findOneBy([$this->routeConfigs[$className]['field'] => $name]);
+            $entity = $repository->findOneBy([
+                $this->routeConfigs[$className]['field'] => urldecode($name)
+            ]);
             if ($entity) {
                 return $this->createRouteFromEntity($entity);
             }
@@ -139,6 +141,7 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
                     continue;
                 }
 
+                $value = urldecode($value);
                 $entity = $repository->findOneBy([$this->routeConfigs[$className]['field'] => $value]);
 
                 if (null === $entity) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | maybe!?
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

We've created a custom slug `Transliterator` to have Persian characters in URL but when visit a Taxon URI needs to be decoded.

Do you think this a right place to decode it?


