### PR TITLE
[Resource][Paginator] - setMaxPerPage is set before setCurrentPage to get proper results

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourcesCollectionProvider.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourcesCollectionProvider.php
@@ -43,8 +43,8 @@ class ResourcesCollectionProvider implements ResourcesCollectionProviderInterfac
 
         if ($resources instanceof Pagerfanta) {
             $request = $requestConfiguration->getRequest();
-            $resources->setCurrentPage($request->query->get('page', 1));
             $resources->setMaxPerPage($requestConfiguration->getPaginationMaxPerPage());
+            $resources->setCurrentPage($request->query->get('page', 1));
 
             if (!$requestConfiguration->isHtmlRequest()) {
                 $route = new Route($request->attributes->get('_route'), array_merge($request->attributes->get('_route_params'), $request->query->all()));

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourcesCollectionProviderSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourcesCollectionProviderSpec.php
@@ -126,8 +126,8 @@ class ResourcesCollectionProviderSpec extends ObjectBehavior
         $request->query = $queryParameters;
         $queryParameters->get('page', 1)->willReturn(6);
 
-        $paginator->setCurrentPage(6)->shouldBeCalled();
         $paginator->setMaxPerPage(5)->shouldBeCalled();
+        $paginator->setCurrentPage(6)->shouldBeCalled();
 
         $this->get($requestConfiguration, $repository)->shouldReturn($paginator);
     }
@@ -161,8 +161,8 @@ class ResourcesCollectionProviderSpec extends ObjectBehavior
         $requestAttributes->get('_route')->willReturn('sylius_product_index');
         $requestAttributes->get('_route_params')->willReturn(['slug' => 'foo-bar']);
 
-        $paginator->setCurrentPage(6)->shouldBeCalled();
         $paginator->setMaxPerPage(5)->shouldBeCalled();
+        $paginator->setCurrentPage(6)->shouldBeCalled();
 
         $pagerfantaRepresentationFactory->createRepresentation($paginator, Argument::type(Route::class))->willReturn($paginatedRepresentation);
 
@@ -191,13 +191,13 @@ class ResourcesCollectionProviderSpec extends ObjectBehavior
         $request->query = $queryParameters;
         $queryParameters->get('page', 1)->willReturn(8);
 
-        $paginator->setCurrentPage(8)->shouldBeCalled();
         $paginator->setMaxPerPage(5)->shouldBeCalled();
+        $paginator->setCurrentPage(8)->shouldBeCalled();
 
         $this->get($requestConfiguration, $repository)->shouldReturn($paginator);
     }
 
-    function it_creates_a_ppaginated_representation_for_pagerfanta_for_non_html_requests_with_a_custom_repository_method(
+    function it_creates_a_paginated_representation_for_pagerfanta_for_non_html_requests_with_a_custom_repository_method(
         RequestConfiguration $requestConfiguration,
         RepositoryInterface $repository,
         Pagerfanta $paginator,
@@ -227,8 +227,8 @@ class ResourcesCollectionProviderSpec extends ObjectBehavior
         $requestAttributes->get('_route')->willReturn('sylius_product_index');
         $requestAttributes->get('_route_params')->willReturn(['slug' => 'foo-bar']);
 
-        $paginator->setCurrentPage(6)->shouldBeCalled();
         $paginator->setMaxPerPage(5)->shouldBeCalled();
+        $paginator->setCurrentPage(6)->shouldBeCalled();
 
         $pagerfantaRepresentationFactory->createRepresentation($paginator, Argument::type(Route::class))->willReturn($paginatedRepresentation);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no|
| Deprecations? | no
| License       | MIT

Fixing yesterday fix, sorry -1:
MaxPerPage needs to be set before current page, so proper number of pages is calculated and current page would be set successfully.
