### PR TITLE
[RFC][Promotion] Change "item count" promotion to "cart quantity"

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,10 @@ UPGRADE
 
 ## From 0.16 to 0.17.x
 
+### Promotion and PromotionBundle
+
+* Changed "item_count" promotion type into "cart_quantity". It now checks cart quantity rather than different items number.
+
 ### Resource and SyliusResourceBundle
 
  * All resources must implement ``Sylius\Component\Resource\Model\ResourceInterface``;

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,7 +5,7 @@ UPGRADE
 
 ### Promotion and PromotionBundle
 
-* Changed "item_count" promotion type into "cart_quantity". It now checks cart quantity rather than different items number.
+* Changed "item_count" promotion type into "cart_quantity". It now checks cart quantity instead different items number.
 
 ### Resource and SyliusResourceBundle
 

--- a/features/legacy/backend/promotions.feature
+++ b/features/legacy/backend/promotions.feature
@@ -13,8 +13,8 @@ Feature: Promotions
             | P3   | Press Campaign | Coupon based promotion                 | 0           | 0    |            |            |
             | P4   | Free orders    | First 3 orders have 100% discount!     | 3           | 0    |            |            |
         And promotion "New Year" has following rules defined:
-            | type       | configuration |
-            | Item count | Count: 3      |
+            | type          | configuration |
+            | Cart quantity | Count: 3      |
         And promotion "New year" has following actions defined:
             | type           | configuration |
             | Fixed discount | Amount: 10    |
@@ -76,13 +76,13 @@ Feature: Promotions
         And I should see "Promotion has been successfully created"
 
     @javascript
-    Scenario: Creating new promotion with item count rule
+    Scenario: Creating new promotion with cart quantity rule
         Given I am on the promotion creation page
         When I fill in "Code" with "P5"
         And I fill in "Name" with "Behat Training"
         And I fill in "Description" with "Behat Training Sale for 10 and more people"
         And I click "Add rule"
-        And I select "Item count" from "Type"
+        And I select "Cart quantity" from "Type"
         And I fill in "Count" with "10"
         And I press "Create"
         Then I should see "Behat Training"

--- a/features/legacy/frontend/cart_promotions_complex.feature
+++ b/features/legacy/frontend/cart_promotions_complex.feature
@@ -45,7 +45,7 @@ Feature: Checkout promotions with multiple rules and actions
     Scenario: Promotion is not applied when one of the cart does not
             fulfills one of the rule
         Given I am on the store homepage
-        When I add product "Sarge" to cart, with quantity "7"
+        When I add product "Sarge" to cart, with quantity "2"
         Then I should be on the cart summary page
         And "Promotion total" should not appear on the page
-        And "Grand total: €175.00" should appear on the page
+        And "Grand total: €50.00" should appear on the page

--- a/features/legacy/frontend/cart_promotions_complex.feature
+++ b/features/legacy/frontend/cart_promotions_complex.feature
@@ -10,9 +10,9 @@ Feature: Checkout promotions with multiple rules and actions
             | code | name              | description                                            |
             | P1   | 150 EUR / 2 items | Discount for orders over 150 EUR with at least 2 items |
         And promotion "150 EUR / 2 items" has following rules defined:
-            | type       | configuration        |
-            | Item total | Amount: 150          |
-            | Item count | Count: 2,Equal: true |
+            | type          | configuration        |
+            | Item total    | Amount: 150          |
+            | Cart quantity | Count: 2,Equal: true |
         And promotion "150 EUR / 2 items" has following actions defined:
             | type                | configuration |
             | Fixed discount      | Amount: 20    |

--- a/features/legacy/frontend/cart_promotions_coupons.feature
+++ b/features/legacy/frontend/cart_promotions_coupons.feature
@@ -20,8 +20,8 @@ Feature: Checkout coupon promotions
             | type           | configuration |
             | Fixed discount | Amount: 5     |
         And promotion "New Year campaign" has following rules defined:
-            | type         | configuration |
-            | Cart quantity| Count: 2      |
+            | type          | configuration |
+            | Cart quantity | Count: 2      |
         And promotion "New Year campaign" has following actions defined:
             | type           | configuration |
             | Fixed discount | Amount: 10    |

--- a/features/legacy/frontend/cart_promotions_coupons.feature
+++ b/features/legacy/frontend/cart_promotions_coupons.feature
@@ -20,8 +20,8 @@ Feature: Checkout coupon promotions
             | type           | configuration |
             | Fixed discount | Amount: 5     |
         And promotion "New Year campaign" has following rules defined:
-            | type       | configuration |
-            | Item count | Count: 2      |
+            | type         | configuration |
+            | Cart quantity| Count: 2      |
         And promotion "New Year campaign" has following actions defined:
             | type           | configuration |
             | Fixed discount | Amount: 10    |

--- a/features/legacy/frontend/cart_promotions_fixed.feature
+++ b/features/legacy/frontend/cart_promotions_fixed.feature
@@ -36,7 +36,7 @@ Feature: Checkout fixed discount promotions
         And all promotions are assigned to the default channel
         And promotion "3 items" has following rules defined:
             | type          | configuration        |
-            | Cart quantity | Count: 3,Equal: true |
+            | Cart quantity | Count: 4,Equal: true |
         And promotion "3 items" has following actions defined:
             | type           | configuration |
             | Fixed discount | Amount: 15    |
@@ -77,50 +77,50 @@ Feature: Checkout fixed discount promotions
     Scenario: Fixed discount promotion is not applied when the cart
             has not the required amount
         Given I am on the store homepage
-        When I add product "Sarge" to cart, with quantity "8"
+        When I add product "Sarge" to cart, with quantity "3"
         Then I should be on the cart summary page
         And "Promotion total" should not appear on the page
-        And "Grand total: €200.00" should appear on the page
+        And "Grand total: €75.00" should appear on the page
 
     Scenario: Cart quantity promotion is applied when the cart has the
             number of items required
         Given I am on the store homepage
-        And I added product "Sarge" to cart, with quantity "3"
+        And I added product "Sarge" to cart, with quantity "1"
         And I added product "Etch" to cart, with quantity "1"
         When I add product "Lenny" to cart, with quantity "2"
         Then I should be on the cart summary page
         And "Promotion total: -€15.00" should appear on the page
-        And "Grand total: €110.00" should appear on the page
+        And "Grand total: €60.00" should appear on the page
 
     Scenario: Cart quantity promotion is not applied when the cart has
-            not the number of items required
+            not required quantity
         Given I am on the store homepage
-        When I add product "Etch" to cart, with quantity "8"
+        When I add product "Etch" to cart, with quantity "3"
         Then I should be on the cart summary page
         And "Promotion total" should not appear on the page
-        And "Grand total: €160.00" should appear on the page
+        And "Grand total: €60.00" should appear on the page
 
     Scenario: Shipping country promotion is applied when shipping country match
         Given I am on the store homepage
-        When I add product "Lenny" to cart, with quantity "5"
+        When I add product "Lenny" to cart, with quantity "3"
         And I go to the checkout start page
         And I fill in the shipping address to Germany
         And I press "Continue"
         And I go to the cart summary page
         Then "Promotion total: -€40.00" should appear on the page
-        And "Grand total: €35.00" should appear on the page
+        And "Grand total: €5.00" should appear on the page
 
     Scenario: Shipping country promotion is not applied when shipping country does not match
         Given I am on the store homepage
-        When I add product "Lenny" to cart, with quantity "5"
+        When I add product "Lenny" to cart, with quantity "3"
         And I go to the checkout start page
         And I fill in the shipping address to Poland
         And I press "Continue"
         And I go to the cart summary page
         And "Promotion total" should not appear on the page
-        And "Grand total: €75.00" should appear on the page
+        And "Grand total: €45.00" should appear on the page
 
-    Scenario: Ubuntu T-Shirts promotion is applied when the cart containes Ubuntu T-Shirts
+    Scenario: Ubuntu T-Shirts promotion is applied when the cart contains Ubuntu T-Shirts
         Given I am on the store homepage
         When I add product "Ubu" to cart, with quantity "1"
         Then I should be on the cart summary page

--- a/features/legacy/frontend/cart_promotions_fixed.feature
+++ b/features/legacy/frontend/cart_promotions_fixed.feature
@@ -35,8 +35,8 @@ Feature: Checkout fixed discount promotions
         And all products are assigned to the default channel
         And all promotions are assigned to the default channel
         And promotion "3 items" has following rules defined:
-            | type       | configuration        |
-            | Item count | Count: 3,Equal: true |
+            | type          | configuration        |
+            | Cart quantity | Count: 3,Equal: true |
         And promotion "3 items" has following actions defined:
             | type           | configuration |
             | Fixed discount | Amount: 15    |
@@ -82,7 +82,7 @@ Feature: Checkout fixed discount promotions
         And "Promotion total" should not appear on the page
         And "Grand total: €200.00" should appear on the page
 
-    Scenario: Item count promotion is applied when the cart has the
+    Scenario: Cart quantity promotion is applied when the cart has the
             number of items required
         Given I am on the store homepage
         And I added product "Sarge" to cart, with quantity "3"
@@ -92,7 +92,7 @@ Feature: Checkout fixed discount promotions
         And "Promotion total: -€15.00" should appear on the page
         And "Grand total: €110.00" should appear on the page
 
-    Scenario: Item count promotion is not applied when the cart has
+    Scenario: Cart quantity promotion is not applied when the cart has
             not the number of items required
         Given I am on the store homepage
         When I add product "Etch" to cart, with quantity "8"

--- a/features/legacy/frontend/cart_promotions_percentage.feature
+++ b/features/legacy/frontend/cart_promotions_percentage.feature
@@ -8,12 +8,12 @@ Feature: Checkout percentage discount promotions
         Given store has default configuration
         And the following promotions exist:
             | code | name    | description                                   |
-            | PR1  | 3 items | 25% Discount for orders with at least 3 items |
+            | PR1  | 5 items | 25% Discount for orders with at least 5 items |
             | PR2  | 300 EUR | 10% Discount for orders over 300 EUR          |
-        And promotion "3 items" has following rules defined:
+        And promotion "5 items" has following rules defined:
             | type          | configuration        |
-            | cart quantity | Count: 3,Equal: true |
-        And promotion "3 items" has following actions defined:
+            | cart quantity | Count: 5,Equal: true |
+        And promotion "5 items" has following actions defined:
             | type                | configuration  |
             | percentage discount | percentage: 25 |
         And promotion "300 EUR" has following rules defined:
@@ -43,18 +43,18 @@ Feature: Checkout percentage discount promotions
         Given I am on the store homepage
         When I add product "Etch" to cart, with quantity "4"
         Then I should be on the cart summary page
-#        Valid scenario that is not passing, should follow '3 items' promotion
+#        Valid scenario that is not passing, should follow '5 items' promotion
 #          And "Promotion total: -€20.00" should appear on the page
 #          And "Grand total: €60.00" should appear on the page
 
     Scenario: Percentage discount promotion is not applied when the cart
             has not the required amount
         Given I am on the store homepage
-        When I add product "Sarge" to cart, with quantity "8"
+        When I add product "Sarge" to cart, with quantity "3"
         Then I should be on the cart summary page
-#        8 items should follow '3 items' promotion
+#        8 items should follow '5 items' promotion
         And "Promotion total" should not appear on the page
-        And "Grand total: €200.00" should appear on the page
+        And "Grand total: €75.00" should appear on the page
 
     Scenario: Cart quantity promotion is applied when the cart has the
             number of items required
@@ -63,18 +63,17 @@ Feature: Checkout percentage discount promotions
         And I added product "Etch" to cart, with quantity "1"
         When I add product "Lenny" to cart, with quantity "2"
         Then I should be on the cart summary page
-#           125 - 25% * 125 = 93.75
         And "Promotion total: -€31.25" should appear on the page
         And "Grand total: €93.75" should appear on the page
 
     Scenario: Cart quantity promotion is not applied when the cart has
             not the number of items required
         Given I am on the store homepage
-        When I add product "Etch" to cart, with quantity "8"
+        When I add product "Etch" to cart, with quantity "4"
         Then I should be on the cart summary page
-#        8 items should follow '3 items' promotion
+#        8 items should follow '5 items' promotion
         And "Promotion total" should not appear on the page
-        And "Grand total: €160.00" should appear on the page
+        And "Grand total: €80.00" should appear on the page
 
     Scenario: Several promotions are applied when an cart fulfills
             the rules of several promotions

--- a/features/legacy/frontend/cart_promotions_percentage.feature
+++ b/features/legacy/frontend/cart_promotions_percentage.feature
@@ -38,21 +38,11 @@ Feature: Checkout percentage discount promotions
         And all products are assigned to the default channel
         And all promotions are assigned to the default channel
 
-    Scenario: Percentage discount promotion is applied when the cart
-            has the required amount
-        Given I am on the store homepage
-        When I add product "Etch" to cart, with quantity "4"
-        Then I should be on the cart summary page
-#        Valid scenario that is not passing, should follow '5 items' promotion
-#          And "Promotion total: -€20.00" should appear on the page
-#          And "Grand total: €60.00" should appear on the page
-
     Scenario: Percentage discount promotion is not applied when the cart
             has not the required amount
         Given I am on the store homepage
         When I add product "Sarge" to cart, with quantity "3"
         Then I should be on the cart summary page
-#        8 items should follow '5 items' promotion
         And "Promotion total" should not appear on the page
         And "Grand total: €75.00" should appear on the page
 
@@ -71,7 +61,6 @@ Feature: Checkout percentage discount promotions
         Given I am on the store homepage
         When I add product "Etch" to cart, with quantity "4"
         Then I should be on the cart summary page
-#        8 items should follow '5 items' promotion
         And "Promotion total" should not appear on the page
         And "Grand total: €80.00" should appear on the page
 
@@ -82,6 +71,5 @@ Feature: Checkout percentage discount promotions
         And I added product "Buzz" to cart, with quantity "1"
         When I add product "Woody" to cart, with quantity "3"
         Then I should still be on the cart summary page
-#        1675 - (10 + 25)% * 1675 = 586.25
         And "Promotion total: -€586.25" should appear on the page
         And "Grand total: €1,088.75" should appear on the page

--- a/features/legacy/frontend/cart_promotions_percentage.feature
+++ b/features/legacy/frontend/cart_promotions_percentage.feature
@@ -11,8 +11,8 @@ Feature: Checkout percentage discount promotions
             | PR1  | 3 items | 25% Discount for orders with at least 3 items |
             | PR2  | 300 EUR | 10% Discount for orders over 300 EUR          |
         And promotion "3 items" has following rules defined:
-            | type       | configuration        |
-            | item_count | Count: 3,Equal: true |
+            | type          | configuration        |
+            | cart quantity | Count: 3,Equal: true |
         And promotion "3 items" has following actions defined:
             | type                | configuration  |
             | percentage discount | percentage: 25 |
@@ -56,7 +56,7 @@ Feature: Checkout percentage discount promotions
         And "Promotion total" should not appear on the page
         And "Grand total: €200.00" should appear on the page
 
-    Scenario: Item count promotion is applied when the cart has the
+    Scenario: Cart quantity promotion is applied when the cart has the
             number of items required
         Given I am on the store homepage
         And I added product "Sarge" to cart, with quantity "3"
@@ -67,7 +67,7 @@ Feature: Checkout percentage discount promotions
         And "Promotion total: -€31.25" should appear on the page
         And "Grand total: €93.75" should appear on the page
 
-    Scenario: Item count promotion is not applied when the cart has
+    Scenario: Cart quantity promotion is not applied when the cart has
             not the number of items required
         Given I am on the store homepage
         When I add product "Etch" to cart, with quantity "8"

--- a/features/legacy/frontend/cart_promotions_usage_limit.feature
+++ b/features/legacy/frontend/cart_promotions_usage_limit.feature
@@ -17,8 +17,8 @@ Feature: Checkout usage limited promotions
             | type                | configuration  |
             | Percentage discount | Percentage: 25 |
         And promotion "Free order with at least 3 items" has following rules defined:
-            | type       | configuration        |
-            | Item count | Count: 3,Equal: true |
+            | type          | configuration        |
+            | Cart quantity | Count: 3,Equal: true |
         And promotion "Free order with at least 3 items" has following actions defined:
             | type                | configuration   |
             | Percentage discount | Percentage: 100 |

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Rule/ContainsProductConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Rule/ContainsProductConfigurationType.php
@@ -53,14 +53,14 @@ class ContainsProductConfigurationType extends AbstractType
                 ],
             ])
             ->add('count', 'integer', [
-                'label' => 'sylius.form.rule.item_count_configuration.count',
+                'label' => 'sylius.form.rule.cart_quantity_configuration.count',
                 'constraints' => [
                     new NotBlank(),
                     new Type(['type' => 'numeric']),
                 ],
             ])
             ->add('equal', 'checkbox', [
-                'label' => 'sylius.form.rule.item_count_configuration.equal',
+                'label' => 'sylius.form.rule.cart_quantity_configuration.equal',
                 'constraints' => [
                     new Type(['type' => 'bool']),
                 ],

--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadPromotionsData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadPromotionsData.php
@@ -37,7 +37,7 @@ class LoadPromotionsData extends DataFixture
             'New Year Sale for 3 and more items.',
             3,
             $channel,
-            [$this->createRule(PromotionRuleInterface::TYPE_ITEM_COUNT, ['count' => 3, 'equal' => true])],
+            [$this->createRule(PromotionRuleInterface::TYPE_CART_QUANTITY, ['count' => 3, 'equal' => true])],
             [$this->createAction(ActionInterface::TYPE_FIXED_DISCOUNT, ['amount' => 500])]
         );
 

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Rule/CartQuantityConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Rule/CartQuantityConfigurationType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class ItemCountConfigurationType extends AbstractType
+class CartQuantityConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}
@@ -28,14 +28,14 @@ class ItemCountConfigurationType extends AbstractType
     {
         $builder
             ->add('count', 'integer', [
-                'label' => 'sylius.form.rule.item_count_configuration.count',
+                'label' => 'sylius.form.rule.cart_quantity_configuration.count',
                 'constraints' => [
                     new NotBlank(),
                     new Type(['type' => 'numeric']),
                 ],
             ])
             ->add('equal', 'checkbox', [
-                'label' => 'sylius.form.rule.item_count_configuration.equal',
+                'label' => 'sylius.form.rule.cart_quantity_configuration.equal',
                 'constraints' => [
                     new Type(['type' => 'bool']),
                 ],
@@ -48,6 +48,6 @@ class ItemCountConfigurationType extends AbstractType
      */
     public function getName()
     {
-        return 'sylius_promotion_rule_item_count_configuration';
+        return 'sylius_promotion_rule_cart_quantity_configuration';
     }
 }

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
@@ -20,7 +20,7 @@
         <parameter key="sylius.promotion_processor.class">Sylius\Component\Promotion\Processor\PromotionProcessor</parameter>
         <parameter key="sylius.promotion_eligibility_checker.class">Sylius\Component\Promotion\Checker\PromotionEligibilityChecker</parameter>
         <parameter key="sylius.promotion_rule_checker.item_total.class">Sylius\Component\Promotion\Checker\ItemTotalRuleChecker</parameter>
-        <parameter key="sylius.promotion_rule_checker.item_count.class">Sylius\Component\Promotion\Checker\ItemCountRuleChecker</parameter>
+        <parameter key="sylius.promotion_rule_checker.cart_quantity.class">Sylius\Component\Promotion\Checker\CartQuantityRuleChecker</parameter>
         <parameter key="sylius.promotion_applicator.class">Sylius\Component\Promotion\Action\PromotionApplicator</parameter>
 
         <parameter key="sylius.active_promotions_provider.class">Sylius\Component\Promotion\Provider\ActivePromotionsProvider</parameter>
@@ -35,7 +35,7 @@
         <parameter key="sylius.form.type.promotion_action.collection.class">Sylius\Bundle\PromotionBundle\Form\Type\ActionCollectionType</parameter>
         <parameter key="sylius.form.type.promotion_rule_choice.class">Sylius\Bundle\PromotionBundle\Form\Type\RuleChoiceType</parameter>
         <parameter key="sylius.form.type.promotion_rule.item_total_configuration.class">Sylius\Bundle\PromotionBundle\Form\Type\Rule\ItemTotalConfigurationType</parameter>
-        <parameter key="sylius.form.type.promotion_rule.item_count_configuration.class">Sylius\Bundle\PromotionBundle\Form\Type\Rule\ItemCountConfigurationType</parameter>
+        <parameter key="sylius.form.type.promotion_rule.cart_quantity_configuration.class">Sylius\Bundle\PromotionBundle\Form\Type\Rule\CartQuantityConfigurationType</parameter>
         <parameter key="sylius.form.type.promotion_action_choice.class">Sylius\Bundle\PromotionBundle\Form\Type\ActionChoiceType</parameter>
         <parameter key="sylius.form.type.promotion_action.fixed_discount_configuration.class">Sylius\Bundle\PromotionBundle\Form\Type\Action\FixedDiscountConfigurationType</parameter>
         <parameter key="sylius.form.type.promotion_action.percentage_discount_configuration.class">Sylius\Bundle\PromotionBundle\Form\Type\Action\PercentageDiscountConfigurationType</parameter>
@@ -58,8 +58,8 @@
         <service id="sylius.promotion_rule_checker.item_total" class="%sylius.promotion_rule_checker.item_total.class%">
             <tag name="sylius.promotion_rule_checker" type="item_total" label="Item total" />
         </service>
-        <service id="sylius.promotion_rule_checker.item_count" class="%sylius.promotion_rule_checker.item_count.class%">
-            <tag name="sylius.promotion_rule_checker" type="item_count" label="Item count" />
+        <service id="sylius.promotion_rule_checker.cart_quantity" class="%sylius.promotion_rule_checker.cart_quantity.class%">
+            <tag name="sylius.promotion_rule_checker" type="cart_quantity" label="Cart quantity" />
         </service>
 
         <service id="sylius.promotion_applicator" class="%sylius.promotion_applicator.class%">
@@ -93,8 +93,8 @@
         <service id="sylius.form.type.promotion_rule.item_total_configuration" class="%sylius.form.type.promotion_rule.item_total_configuration.class%">
             <tag name="form.type" alias="sylius_promotion_rule_item_total_configuration" />
         </service>
-        <service id="sylius.form.type.promotion_rule.item_count_configuration" class="%sylius.form.type.promotion_rule.item_count_configuration.class%">
-            <tag name="form.type" alias="sylius_promotion_rule_item_count_configuration" />
+        <service id="sylius.form.type.promotion_rule.cart_quantity_configuration" class="%sylius.form.type.promotion_rule.cart_quantity_configuration.class%">
+            <tag name="form.type" alias="sylius_promotion_rule_cart_quantity_configuration" />
         </service>
         <service id="sylius.form.type.promotion_action_choice" class="%sylius.form.type.promotion_action_choice.class%">
             <argument>%sylius.promotion_actions%</argument>

--- a/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.en.yml
@@ -17,7 +17,7 @@ sylius:
             contains_product_configuration:
                 variants: Products
                 exclude: Exclude
-            item_count_configuration:
+            cart_quantity_configuration:
                 count: Count
                 equal: Equal
             item_total_configuration:

--- a/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Rule/CartQuantityConfigurationTypeSpec.php
+++ b/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Rule/CartQuantityConfigurationTypeSpec.php
@@ -19,11 +19,11 @@ use Symfony\Component\Form\FormBuilder;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class ItemCountConfigurationTypeSpec extends ObjectBehavior
+class CartQuantityConfigurationTypeSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Bundle\PromotionBundle\Form\Type\Rule\ItemCountConfigurationType');
+        $this->shouldHaveType('Sylius\Bundle\PromotionBundle\Form\Type\Rule\CartQuantityConfigurationType');
     }
 
     function it_should_be_a_form_type()

--- a/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/RuleChoiceTypeSpec.php
+++ b/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/RuleChoiceTypeSpec.php
@@ -23,7 +23,7 @@ class RuleChoiceTypeSpec extends ObjectBehavior
 {
     private $choices = [
         RuleInterface::TYPE_ITEM_TOTAL => 'Order total',
-        RuleInterface::TYPE_CART_QUANTITY => 'Order items count',
+        RuleInterface::TYPE_CART_QUANTITY => 'Order quantity',
     ];
 
     function let()

--- a/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/RuleChoiceTypeSpec.php
+++ b/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/RuleChoiceTypeSpec.php
@@ -23,7 +23,7 @@ class RuleChoiceTypeSpec extends ObjectBehavior
 {
     private $choices = [
         RuleInterface::TYPE_ITEM_TOTAL => 'Order total',
-        RuleInterface::TYPE_ITEM_COUNT => 'Order items count',
+        RuleInterface::TYPE_CART_QUANTITY => 'Order items count',
     ];
 
     function let()

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -380,7 +380,7 @@ class Order extends Cart implements OrderInterface
      */
     public function getPromotionSubjectCount()
     {
-        return $this->items->count();
+        return $this->getTotalQuantity();
     }
 
     /**

--- a/src/Sylius/Component/Core/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderSpec.php
@@ -342,9 +342,11 @@ class OrderSpec extends ObjectBehavior
     function it_count_promotions_subjects(OrderItemInterface $item1, OrderItemInterface $item2)
     {
         $this->addItem($item1);
+        $item1->getQuantity()->willReturn(4);
         $this->addItem($item2);
+        $item2->getQuantity()->willReturn(3);
 
-        $this->getPromotionSubjectCount()->shouldReturn(2);
+        $this->getPromotionSubjectCount()->shouldReturn(7);
     }
 
     function it_adds_and_removes_promotions(PromotionInterface $promotion)

--- a/src/Sylius/Component/Promotion/Checker/CartQuantityRuleChecker.php
+++ b/src/Sylius/Component/Promotion/Checker/CartQuantityRuleChecker.php
@@ -15,11 +15,9 @@ use Sylius\Component\Promotion\Model\PromotionCountableSubjectInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
 
 /**
- * Checks if subject item count exceeds (or at least equal) to the configured count.
- *
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class ItemCountRuleChecker implements RuleCheckerInterface
+class CartQuantityRuleChecker implements RuleCheckerInterface
 {
     /**
      * {@inheritdoc}
@@ -42,6 +40,6 @@ class ItemCountRuleChecker implements RuleCheckerInterface
      */
     public function getConfigurationFormType()
     {
-        return 'sylius_promotion_rule_item_count_configuration';
+        return 'sylius_promotion_rule_cart_quantity_configuration';
     }
 }

--- a/src/Sylius/Component/Promotion/Model/RuleInterface.php
+++ b/src/Sylius/Component/Promotion/Model/RuleInterface.php
@@ -19,7 +19,7 @@ use Sylius\Component\Resource\Model\ResourceInterface;
 interface RuleInterface extends ResourceInterface
 {
     const TYPE_ITEM_TOTAL = 'item_total';
-    const TYPE_ITEM_COUNT = 'item_count';
+    const TYPE_CART_QUANTITY = 'cart_quantity';
 
     /**
      * @return string

--- a/src/Sylius/Component/Promotion/spec/Checker/CartQuantityRuleCheckerSpec.php
+++ b/src/Sylius/Component/Promotion/spec/Checker/CartQuantityRuleCheckerSpec.php
@@ -18,11 +18,11 @@ use Sylius\Component\Promotion\Model\PromotionCountableSubjectInterface;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class ItemCountRuleCheckerSpec extends ObjectBehavior
+class CartQuantityRuleCheckerSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Component\Promotion\Checker\ItemCountRuleChecker');
+        $this->shouldHaveType('Sylius\Component\Promotion\Checker\CartQuantityRuleChecker');
     }
 
     function it_should_be_Sylius_rule_checker()
@@ -37,7 +37,7 @@ class ItemCountRuleCheckerSpec extends ObjectBehavior
         $this->isEligible($subject, ['count' => 10, 'equal' => false])->shouldReturn(false);
     }
 
-    function it_should_recognize_subject_as_not_eligible_if_item_count_is_less_then_configured(
+    function it_should_recognize_subject_as_not_eligible_if_cart_quantity_is_less_then_configured(
         PromotionCountableSubjectInterface $subject
     ) {
         $subject->getPromotionSubjectCount()->shouldBeCalled()->willReturn(7);
@@ -45,7 +45,7 @@ class ItemCountRuleCheckerSpec extends ObjectBehavior
         $this->isEligible($subject, ['count' => 10, 'equal' => false])->shouldReturn(false);
     }
 
-    function it_should_recognize_subject_as_eligible_if_item_count_is_greater_then_configured(
+    function it_should_recognize_subject_as_eligible_if_cart_quantity_is_greater_then_configured(
         PromotionCountableSubjectInterface $subject
     ) {
         $subject->getPromotionSubjectCount()->shouldBeCalled()->willReturn(12);
@@ -53,7 +53,7 @@ class ItemCountRuleCheckerSpec extends ObjectBehavior
         $this->isEligible($subject, ['count' => 10, 'equal' => false])->shouldReturn(true);
     }
 
-    function it_should_recognize_subject_as_eligible_if_item_count_is_equal_with_configured_depending_on_equal_setting(
+    function it_should_recognize_subject_as_eligible_if_cart_quantity_is_equal_with_configured_depending_on_equal_setting(
         PromotionCountableSubjectInterface $subject
     ) {
         $subject->getPromotionSubjectCount()->shouldBeCalled()->willReturn(10);
@@ -62,8 +62,8 @@ class ItemCountRuleCheckerSpec extends ObjectBehavior
         $this->isEligible($subject, ['count' => 10, 'equal' => true])->shouldReturn(true);
     }
 
-    function it_should_return_item_count_configuration_form_type()
+    function it_should_return_cart_quantity_configuration_form_type()
     {
-        $this->getConfigurationFormType()->shouldReturn('sylius_promotion_rule_item_count_configuration');
+        $this->getConfigurationFormType()->shouldReturn('sylius_promotion_rule_cart_quantity_configuration');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets |
| License       | MIT
| Doc PR        |

It's quite misleading to have "item count" promotion which checks how many different items are inside cart. At the first it looks as it uses cart quantity, but it does not. Moreover, new behat scenarios will operate on quantity, not items count (see [here](https://github.com/Sylius/Sylius/blob/master/features/promotion/receiving_discount_based_on_cart_quantity.feature)). Furthermore, I think that using "cart quantity" to promotion rather than "items count" is more suitable for most of cases. However, I know it can be a big change and BC break, that's because I **request for comments** ;)