### PR TITLE
[Promotion] Removed "equal" flag from rules

### DIFF
--- a/features/legacy/frontend/cart_promotions_complex.feature
+++ b/features/legacy/frontend/cart_promotions_complex.feature
@@ -10,9 +10,9 @@ Feature: Checkout promotions with multiple rules and actions
             | code | name              | description                                            |
             | P1   | 150 EUR / 2 items | Discount for orders over 150 EUR with at least 2 items |
         And promotion "150 EUR / 2 items" has following rules defined:
-            | type          | configuration        |
-            | Item total    | Amount: 150          |
-            | Cart quantity | Count: 2,Equal: true |
+            | type          | configuration |
+            | Item total    | Amount: 150   |
+            | Cart quantity | Count: 2      |
         And promotion "150 EUR / 2 items" has following actions defined:
             | type                | configuration |
             | Fixed discount      | Amount: 20    |

--- a/features/legacy/frontend/cart_promotions_fixed.feature
+++ b/features/legacy/frontend/cart_promotions_fixed.feature
@@ -35,8 +35,8 @@ Feature: Checkout fixed discount promotions
         And all products are assigned to the default channel
         And all promotions are assigned to the default channel
         And promotion "3 items" has following rules defined:
-            | type          | configuration        |
-            | Cart quantity | Count: 4,Equal: true |
+            | type          | configuration |
+            | Cart quantity | Count: 4      |
         And promotion "3 items" has following actions defined:
             | type           | configuration |
             | Fixed discount | Amount: 15    |

--- a/features/legacy/frontend/cart_promotions_percentage.feature
+++ b/features/legacy/frontend/cart_promotions_percentage.feature
@@ -11,8 +11,8 @@ Feature: Checkout percentage discount promotions
             | PR1  | 5 items | 25% Discount for orders with at least 5 items |
             | PR2  | 300 EUR | 10% Discount for orders over 300 EUR          |
         And promotion "5 items" has following rules defined:
-            | type          | configuration        |
-            | cart quantity | Count: 5,Equal: true |
+            | type          | configuration |
+            | cart quantity | Count: 5      |
         And promotion "5 items" has following actions defined:
             | type                | configuration  |
             | percentage discount | percentage: 25 |

--- a/features/legacy/frontend/cart_promotions_usage_limit.feature
+++ b/features/legacy/frontend/cart_promotions_usage_limit.feature
@@ -17,8 +17,8 @@ Feature: Checkout usage limited promotions
             | type                | configuration  |
             | Percentage discount | Percentage: 25 |
         And promotion "Free order with at least 3 items" has following rules defined:
-            | type          | configuration        |
-            | Cart quantity | Count: 3,Equal: true |
+            | type          | configuration |
+            | Cart quantity | Count: 3      |
         And promotion "Free order with at least 3 items" has following actions defined:
             | type                | configuration   |
             | Percentage discount | Percentage: 100 |

--- a/src/Sylius/Bundle/PromotionBundle/Behat/PromotionContext.php
+++ b/src/Sylius/Bundle/PromotionBundle/Behat/PromotionContext.php
@@ -187,9 +187,6 @@ class PromotionContext extends DefaultContext
                 case 'percentage':
                     $configuration[$key] = (int) $value / 100;
                     break;
-                case 'equal':
-                    $configuration[$key] = (Boolean) $value;
-                    break;
                 default:
                     break;
             }

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Rule/CartQuantityConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Rule/CartQuantityConfigurationType.php
@@ -34,12 +34,6 @@ class CartQuantityConfigurationType extends AbstractType
                     new Type(['type' => 'numeric']),
                 ],
             ])
-            ->add('equal', 'checkbox', [
-                'label' => 'sylius.form.rule.cart_quantity_configuration.equal',
-                'constraints' => [
-                    new Type(['type' => 'bool']),
-                ],
-            ])
         ;
     }
 

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Rule/ItemTotalConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Rule/ItemTotalConfigurationType.php
@@ -34,12 +34,6 @@ class ItemTotalConfigurationType extends AbstractType
                     new Type(['type' => 'numeric']),
                 ],
             ])
-            ->add('equal', 'checkbox', [
-                'label' => 'sylius.form.rule.item_total_configuration.equal',
-                'constraints' => [
-                    new Type(['type' => 'bool']),
-                ],
-            ])
         ;
     }
 

--- a/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/translations/messages.en.yml
@@ -19,10 +19,8 @@ sylius:
                 exclude: Exclude
             cart_quantity_configuration:
                 count: Count
-                equal: Equal
             item_total_configuration:
                 amount: Amount
-                equal: Equal
             nth_order_configuration:
                 nth: Nth
             customer_loyalty_configuration:

--- a/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Rule/CartQuantityConfigurationTypeSpec.php
+++ b/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Rule/CartQuantityConfigurationTypeSpec.php
@@ -38,11 +38,6 @@ class CartQuantityConfigurationTypeSpec extends ObjectBehavior
             ->willReturn($builder)
         ;
 
-        $builder
-            ->add('equal', 'checkbox', Argument::any())
-            ->willReturn($builder)
-        ;
-
         $this->buildForm($builder, []);
     }
 }

--- a/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Rule/ItemTotalConfigurationTypeSpec.php
+++ b/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Rule/ItemTotalConfigurationTypeSpec.php
@@ -38,11 +38,6 @@ class ItemTotalConfigurationTypeSpec extends ObjectBehavior
             ->willReturn($builder)
         ;
 
-        $builder
-            ->add('equal', 'checkbox', Argument::any())
-            ->willReturn($builder)
-        ;
-
         $this->buildForm($builder, []);
     }
 }

--- a/src/Sylius/Component/Core/Promotion/Checker/ContainsProductRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/ContainsProductRuleChecker.php
@@ -79,10 +79,6 @@ class ContainsProductRuleChecker implements RuleCheckerInterface
      */
     private function isItemQuantityEligible($quantity, array $configuration)
     {
-        if (isset($configuration['equal']) && $configuration['equal']) {
-            return $quantity >= $configuration['count'];
-        }
-
-        return $quantity > $configuration['count'];
+        return $quantity >= $configuration['count'];
     }
 }

--- a/src/Sylius/Component/Promotion/Checker/CartQuantityRuleChecker.php
+++ b/src/Sylius/Component/Promotion/Checker/CartQuantityRuleChecker.php
@@ -28,11 +28,7 @@ class CartQuantityRuleChecker implements RuleCheckerInterface
             return false;
         }
 
-        if (isset($configuration['equal']) && $configuration['equal']) {
-            return $subject->getPromotionSubjectCount() >= $configuration['count'];
-        }
-
-        return $subject->getPromotionSubjectCount() > $configuration['count'];
+        return $subject->getPromotionSubjectCount() >= $configuration['count'];
     }
 
     /**

--- a/src/Sylius/Component/Promotion/Checker/ItemTotalRuleChecker.php
+++ b/src/Sylius/Component/Promotion/Checker/ItemTotalRuleChecker.php
@@ -14,8 +14,6 @@ namespace Sylius\Component\Promotion\Checker;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
 
 /**
- * Checks if subject’s total exceeds (or at least equal) to the configured amount.
- *
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
 class ItemTotalRuleChecker implements RuleCheckerInterface
@@ -25,11 +23,7 @@ class ItemTotalRuleChecker implements RuleCheckerInterface
      */
     public function isEligible(PromotionSubjectInterface $subject, array $configuration)
     {
-        if (isset($configuration['equal']) && $configuration['equal']) {
-            return $subject->getPromotionSubjectTotal() >= $configuration['amount'];
-        }
-
-        return $subject->getPromotionSubjectTotal() > $configuration['amount'];
+        return $subject->getPromotionSubjectTotal() >= $configuration['amount'];
     }
 
     /**

--- a/src/Sylius/Component/Promotion/spec/Checker/CartQuantityRuleCheckerSpec.php
+++ b/src/Sylius/Component/Promotion/spec/Checker/CartQuantityRuleCheckerSpec.php
@@ -34,7 +34,7 @@ class CartQuantityRuleCheckerSpec extends ObjectBehavior
     {
         $subject->getPromotionSubjectCount()->shouldBeCalled()->willReturn(0);
 
-        $this->isEligible($subject, ['count' => 10, 'equal' => false])->shouldReturn(false);
+        $this->isEligible($subject, ['count' => 10])->shouldReturn(false);
     }
 
     function it_should_recognize_subject_as_not_eligible_if_cart_quantity_is_less_then_configured(
@@ -42,7 +42,7 @@ class CartQuantityRuleCheckerSpec extends ObjectBehavior
     ) {
         $subject->getPromotionSubjectCount()->shouldBeCalled()->willReturn(7);
 
-        $this->isEligible($subject, ['count' => 10, 'equal' => false])->shouldReturn(false);
+        $this->isEligible($subject, ['count' => 10])->shouldReturn(false);
     }
 
     function it_should_recognize_subject_as_eligible_if_cart_quantity_is_greater_then_configured(
@@ -50,16 +50,15 @@ class CartQuantityRuleCheckerSpec extends ObjectBehavior
     ) {
         $subject->getPromotionSubjectCount()->shouldBeCalled()->willReturn(12);
 
-        $this->isEligible($subject, ['count' => 10, 'equal' => false])->shouldReturn(true);
+        $this->isEligible($subject, ['count' => 10])->shouldReturn(true);
     }
 
-    function it_should_recognize_subject_as_eligible_if_cart_quantity_is_equal_with_configured_depending_on_equal_setting(
+    function it_should_recognize_subject_as_eligible_if_cart_quantity_is_equal_with_configured(
         PromotionCountableSubjectInterface $subject
     ) {
         $subject->getPromotionSubjectCount()->shouldBeCalled()->willReturn(10);
 
-        $this->isEligible($subject, ['count' => 10, 'equal' => false])->shouldReturn(false);
-        $this->isEligible($subject, ['count' => 10, 'equal' => true])->shouldReturn(true);
+        $this->isEligible($subject, ['count' => 10])->shouldReturn(true);
     }
 
     function it_should_return_cart_quantity_configuration_form_type()

--- a/src/Sylius/Component/Promotion/spec/Checker/ItemTotalRuleCheckerSpec.php
+++ b/src/Sylius/Component/Promotion/spec/Checker/ItemTotalRuleCheckerSpec.php
@@ -34,7 +34,7 @@ class ItemTotalRuleCheckerSpec extends ObjectBehavior
     {
         $subject->getPromotionSubjectTotal()->shouldBeCalled()->willReturn(0);
 
-        $this->isEligible($subject, ['amount' => 500, 'equal' => false])->shouldReturn(false);
+        $this->isEligible($subject, ['amount' => 500])->shouldReturn(false);
     }
 
     function it_should_recognize_subject_as_not_eligible_if_subject_total_is_less_then_configured(
@@ -42,7 +42,7 @@ class ItemTotalRuleCheckerSpec extends ObjectBehavior
     ) {
         $subject->getPromotionSubjectTotal()->shouldBeCalled()->willReturn(400);
 
-        $this->isEligible($subject, ['amount' => 500, 'equal' => false])->shouldReturn(false);
+        $this->isEligible($subject, ['amount' => 500])->shouldReturn(false);
     }
 
     function it_should_recognize_subject_as_eligible_if_subject_total_is_greater_then_configured(
@@ -50,16 +50,15 @@ class ItemTotalRuleCheckerSpec extends ObjectBehavior
     ) {
         $subject->getPromotionSubjectTotal()->shouldBeCalled()->willReturn(600);
 
-        $this->isEligible($subject, ['amount' => 500, 'equal' => false])->shouldReturn(true);
+        $this->isEligible($subject, ['amount' => 500])->shouldReturn(true);
     }
 
-    function it_should_recognize_subject_as_eligible_if_subject_total_is_equal_with_configured_depending_on_equal_setting(
+    function it_should_recognize_subject_as_eligible_if_subject_total_is_equal_with_configured(
         PromotionSubjectInterface $subject
     ) {
         $subject->getPromotionSubjectTotal()->shouldBeCalled()->willReturn(500);
 
-        $this->isEligible($subject, ['amount' => 500, 'equal' => false])->shouldReturn(false);
-        $this->isEligible($subject, ['amount' => 500, 'equal' => true])->shouldReturn(true);
+        $this->isEligible($subject, ['amount' => 500])->shouldReturn(true);
     }
 
     function it_should_return_subject_total_configuration_form_type()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Fixed tickets |
| License       | MIT
| Doc PR        | https://github.com/Sylius/Sylius-Docs/pull/418

Flag "equal" on promotions rules is redundant. For example, ``count: 5`` with ``equal: true`` is equivalent to ``count: 4`` without this flag. Moreover, in my opinion it's more natural to set promotion for "sth or more" rather than "for more than sth".