### PR TITLE
[AssociationBundle ] Added Association component dependecy in the AssociationBundle

### DIFF
--- a/src/Sylius/Bundle/AssociationBundle/composer.json
+++ b/src/Sylius/Bundle/AssociationBundle/composer.json
@@ -34,7 +34,8 @@
         "stof/doctrine-extensions-bundle": "~1.1",
         "symfony/form": "^2.7.7",
         "symfony/validator": "^2.7.7",
-        "sylius/resource-bundle": "0.17.*@dev"
+        "sylius/resource-bundle": "0.17.*@dev",
+        "sylius/association": "0.17.*@dev"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.4"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Shouldn't the AssociationBundle bundle depent on the component? Like with must of the Sylius bundles?


