### PR TITLE
[Core][ProductAccessor] Use option code instead of name

### DIFF
--- a/src/Sylius/Component/Core/Accessor/ProductAccessor.php
+++ b/src/Sylius/Component/Core/Accessor/ProductAccessor.php
@@ -42,7 +42,7 @@ class ProductAccessor extends PropertyAccessor
             $propertyPath = strtolower((string) $propertyPath);
             foreach ($product->getAvailableVariants() as $variant) {
                 foreach ($variant->getOptions() as $option) {
-                    if ($propertyPath === strtolower($option->getPresentation())) {
+                    if ($propertyPath === strtolower($option->getOptionCode())) {
                         $tags[] = $option->getValue();
                     }
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no|yes
| BC breaks?    | no|yes
| Deprecations? | no|yes
| License       | MIT

At this moment this class only used in SearchBundle and it is wrong to match option by presentation since it might contain non-latin characters that cannot be used in YAML. 

It is better to use code field in this case.

This PR is based on #4237