### PR TITLE
[Resource] Lazy resource repositories

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineODMDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineODMDriver.php
@@ -65,6 +65,7 @@ class DoctrineODMDriver extends AbstractDoctrineDriver
             $unitOfWorkDefinition,
             $this->getClassMetadataDefinition($metadata),
         ]);
+        $definition->setLazy(true);
 
         $container->setDefinition($metadata->getServiceId('repository'), $definition);
     }

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineODMDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineODMDriver.php
@@ -53,6 +53,8 @@ class DoctrineODMDriver extends AbstractDoctrineDriver
             $repositoryClass = $metadata->getClass('repository');
         }
 
+        $repositoryReflection = new \ReflectionClass($repositoryClass);
+
         $unitOfWorkDefinition = new Definition('Doctrine\\ODM\\MongoDB\\UnitOfWork');
         $unitOfWorkDefinition
             ->setFactory([new Reference($this->getManagerServiceId($metadata)), 'getUnitOfWork'])
@@ -65,7 +67,7 @@ class DoctrineODMDriver extends AbstractDoctrineDriver
             $unitOfWorkDefinition,
             $this->getClassMetadataDefinition($metadata),
         ]);
-        $definition->setLazy(true);
+        $definition->setLazy(!$repositoryReflection->isFinal());
 
         $container->setDefinition($metadata->getServiceId('repository'), $definition);
     }

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineORMDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineORMDriver.php
@@ -67,6 +67,7 @@ class DoctrineORMDriver extends AbstractDoctrineDriver
             new Reference($metadata->getServiceId('manager')),
             $this->getClassMetadataDefinition($metadata),
         ]);
+        $definition->setLazy(true);
 
         if ($metadata->hasParameter('translation')) {
             $repositoryReflection = new \ReflectionClass($repositoryClass);

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineORMDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineORMDriver.php
@@ -62,15 +62,16 @@ class DoctrineORMDriver extends AbstractDoctrineDriver
             $repositoryClass = $metadata->getClass('repository');
         }
 
+        $repositoryReflection = new \ReflectionClass($repositoryClass);
+
         $definition = new Definition($repositoryClass);
         $definition->setArguments([
             new Reference($metadata->getServiceId('manager')),
             $this->getClassMetadataDefinition($metadata),
         ]);
-        $definition->setLazy(true);
+        $definition->setLazy(!$repositoryReflection->isFinal());
 
         if ($metadata->hasParameter('translation')) {
-            $repositoryReflection = new \ReflectionClass($repositoryClass);
             $translatableRepositoryInterface = TranslatableResourceRepositoryInterface::class;
             $translationConfig = $metadata->getParameter('translation');
 

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrinePHPCRDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrinePHPCRDriver.php
@@ -44,15 +44,16 @@ class DoctrinePHPCRDriver extends AbstractDoctrineDriver
             $repositoryClass = $metadata->getClass('repository');
         }
 
+        $repositoryReflection = new \ReflectionClass($repositoryClass);
+
         $definition = new Definition($repositoryClass);
         $definition->setArguments([
             new Reference($metadata->getServiceId('manager')),
             $this->getClassMetadataDefinition($metadata),
         ]);
-        $definition->setLazy(true);
+        $definition->setLazy(!$repositoryReflection->isFinal());
 
         if ($metadata->hasParameter('translation')) {
-            $repositoryReflection = new \ReflectionClass($repositoryClass);
             $translatableRepositoryInterface = TranslatableResourceRepositoryInterface::class;
             $translationConfig = $metadata->getParameter('translation');
 

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrinePHPCRDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrinePHPCRDriver.php
@@ -49,6 +49,7 @@ class DoctrinePHPCRDriver extends AbstractDoctrineDriver
             new Reference($metadata->getServiceId('manager')),
             $this->getClassMetadataDefinition($metadata),
         ]);
+        $definition->setLazy(true);
 
         if ($metadata->hasParameter('translation')) {
             $repositoryReflection = new \ReflectionClass($repositoryClass);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

It will save a lot of our time when we inject a repository to a service that does not use it, but is used while there is no database, eg. repositories injected to Twig extensions or cache warmers.
