### PR TITLE
[WebBundle] Hide option values on product show page in backend

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/show.html.twig
@@ -97,7 +97,7 @@
                         {% if product.options|length > 0 %}
                         <ul>
                         {% for option in product.options %}
-                            <li><strong>{{ option.name }}</strong>: {{ option.values|join(', ') }}.</li>
+                            <li><strong>{{ option.name }}</strong>.</li>
                         {% endfor %}
                         </ul>
                         {% else %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no|yes
| BC breaks?    | no|yes
| Deprecations? | no|yes
| License       | MIT

IMO this is not only redundant but also could(and will) explode if you have too many values attached to an option.


