### PR TITLE
use ROLE_API_ACCESS instead of ROLE_API

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -101,6 +101,6 @@ security:
         - { path: ^/admin/login-check, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: "/admin.*", role: ROLE_ADMINISTRATION_ACCESS }
 
-        - { path: ^/api, role: ROLE_API }
+        - { path: ^/api, role: ROLE_API_ACCESS }
 
         - { path: "/_partial.*", ip: 127.0.0.1 }

--- a/src/Sylius/Bundle/CoreBundle/Tests/DataFixtures/ORM/authentication/api_administrator.yml
+++ b/src/Sylius/Bundle/CoreBundle/Tests/DataFixtures/ORM/authentication/api_administrator.yml
@@ -13,7 +13,7 @@ Sylius\Bundle\ApiBundle\Model\AccessToken:
 Sylius\Component\Core\Model\User:
     admin:
         plainPassword: sylius
-        roles: [ROLE_API]
+        roles: [ROLE_API_ACCESS]
         enabled: true
         customer: @customerAdmin
 

--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadApiData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadApiData.php
@@ -35,7 +35,7 @@ class LoadApiData extends DataFixture
             'api@example.com',
             'api',
             true,
-            ['ROLE_API']
+            ['ROLE_API_ACCESS']
         );
         $user->addAuthorizationRole($this->get('sylius.repository.role')->findOneBy(['code' => 'administrator']));
 

--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadGroupsData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadGroupsData.php
@@ -27,12 +27,12 @@ class LoadGroupsData extends DataFixture
      */
     public function load(ObjectManager $manager)
     {
-        $manager->persist($this->createGroup('Administrators', ['ROLE_ADMINISTRATION_ACCESS']));
+        $manager->persist($this->createGroup('Administrators'));
         $manager->persist($this->createGroup('Wholesale Customers'));
         $manager->persist($this->createGroup('Retail Customers'));
         $manager->persist($this->createGroup('Sales'));
         $manager->persist($this->createGroup('Suppliers'));
-        $manager->persist($this->createGroup('API', ['ROLE_API']));
+        $manager->persist($this->createGroup('API'));
 
         $manager->flush();
     }
@@ -47,11 +47,10 @@ class LoadGroupsData extends DataFixture
 
     /**
      * @param string $name
-     * @param array  $roles
      *
      * @return GroupInterface
      */
-    protected function createGroup($name, array $roles = [])
+    protected function createGroup($name)
     {
         /* @var $group GroupInterface */
         $group = $this->getGroupFactory()->createNew();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

I guess we need to change the security role ROLE_API with ROLE_API_ACCESS in order to allow the manage of this permission from the Sylius backend
