### PR TITLE
[CoreBundle] Add enabled is true when retrieve latest products

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -181,7 +181,7 @@ class ProductRepository extends BaseProductRepository
      */
     public function findLatest($limit = 10, ChannelInterface $channel)
     {
-        return $this->findBy(['channels' => [$channel]], ['createdAt' => 'desc'], $limit);
+        return $this->findBy(['channels' => [$channel], 'enabled' => true], ['createdAt' => 'desc'], $limit);
     }
 
     protected function applyCriteria(QueryBuilder $queryBuilder, array $criteria = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Add enabled is true on findLatest productRepository function.

I think we have to hide "disabled" products in frontend.

This PR will only "filter" results, so, we have to control access in ProductController:detailsAction.

The simplier would be to throw an exception "NotEnabled" or something like this. What do you think ?
