### PR TITLE
[Core] FOSRest format rules can not be overwritten

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -4,7 +4,7 @@
 imports:
     - { resource: parameters.yml }
     - { resource: security.yml }
-    - { resource: migrations.yml }    
+    - { resource: migrations.yml }
     - { resource: @SyliusCoreBundle/Resources/config/app/main.yml }
 
 framework:
@@ -86,3 +86,9 @@ swiftmailer:
     port:      %sylius.mailer.port%
     username:  %sylius.mailer.user%
     password:  %sylius.mailer.password%
+
+fos_rest:
+    format_listener:
+        rules:
+            - { path: '^/api', priorities: ['json', 'xml'], fallback_format: json, prefer_extension: true }
+            - { path: '^/', stop: true }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/main.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/main.yml
@@ -74,10 +74,6 @@ fos_rest:
             json: true
             xml:  true
         empty_content: 204
-    format_listener:
-        rules:
-            - { path: '^/api', priorities: ['json', 'xml'], fallback_format: json, prefer_extension: true }
-            - { path: '^/', stop: true }
 
 hwi_oauth:
     firewall_name: main


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | 
| License       | MIT

FOSRestBundle's `format_listener.rules` configuration can not be overwritten, ref. [configuration](https://github.com/FriendsOfSymfony/FOSRestBundle/blob/master/DependencyInjection/Configuration.php#L290).
