### PR TITLE
[SearchBundle] Make orm_indexes node properly overridable

### DIFF
--- a/src/Sylius/Bundle/SearchBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/SearchBundle/DependencyInjection/Configuration.php
@@ -180,6 +180,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('class')
                             ->end()
                             ->arrayNode('mappings')
+                            ->performNoDeepMerging()
                                 ->prototype('array')
                                 ->end()
                             ->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no|yes
| BC breaks?    | no|yes
| Deprecations? | no|yes
| License       | MIT

Just got stuck with inability to add any new mapping w/o this fix.