### PR TITLE
[Core] [Theme] raise required php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^5.5.9|^7.0",
+        "php": "^5.5.11|^7.0",
         "ext-exif": "*",
         "ext-fileinfo": "*",
         "ext-gd": "*",

--- a/src/Sylius/Bundle/ThemeBundle/composer.json
+++ b/src/Sylius/Bundle/ThemeBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^5.5.9|^7.0",
+        "php": "^5.5.11|^7.0",
 
         "sylius/resource-bundle": "^0.17",
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Deprecations?   | no|yes
| Related tickets | no
| License         | MIT
| Doc PR          | no

SplFileObject::fread used in "sylius/theme-bundle" is available from 5.5.11