### PR TITLE
Remove ObjectToIdentifierTransformer from  ShippingMethodChoiceType f…

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Shipping/ShippingMethodChoiceType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Shipping/ShippingMethodChoiceType.php
@@ -50,7 +50,7 @@ class ShippingMethodChoiceType extends BaseShippingMethodType
                 $methods = $filteredMethods;
             }
 
-            return new ObjectChoiceList($methods, null, [], null, 'id');
+            return new ObjectChoiceList($methods, null, [], null, $options['identifier']);
         };
 
         $resolver
@@ -58,6 +58,7 @@ class ShippingMethodChoiceType extends BaseShippingMethodType
                 'choice_list' => $choiceList,
                 'criteria' => [],
                 'channel' => null,
+                'identifier' => 'id'
             ])
             ->setAllowedTypes('channel', [ChannelInterface::class, 'null'])
         ;

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
@@ -53,6 +53,15 @@ class ShippingMethodChoiceType extends AbstractType
     protected $repository;
 
     /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        if ($options['multiple']) {
+            $builder->addModelTransformer( new CollectionToArrayTransformer());
+        }
+    }
+    /**
      * @param MethodsResolverInterface    $resolver
      * @param ServiceRegistryInterface    $calculators
      * @param RepositoryInterface         $repository
@@ -70,14 +79,6 @@ class ShippingMethodChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
-    {
-        $builder->addModelTransformer($this->getProperTransformer($options));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $choiceList = function (Options $options) {
@@ -87,13 +88,14 @@ class ShippingMethodChoiceType extends AbstractType
                 $methods = $this->repository->findBy($options['criteria']);
             }
 
-            return new ObjectChoiceList($methods, null, [], null, 'id');
+            return new ObjectChoiceList($methods, null, [], null, $options['identifier']);
         };
 
         $resolver
             ->setDefaults([
                 'choice_list' => $choiceList,
                 'criteria' => [],
+                'identifier'=>'id'
             ])
             ->setDefined([
                 'subject',
@@ -145,17 +147,5 @@ class ShippingMethodChoiceType extends AbstractType
         return 'sylius_shipping_method_choice';
     }
 
-    /**
-     * @param array $options
-     *
-     * @return ObjectToIdentifierTransformer|CollectionToArrayTransformer
-     */
-    private function getProperTransformer(array $options)
-    {
-        if ($options['multiple']) {
-            return new CollectionToArrayTransformer();
-        }
 
-        return new ObjectToIdentifierTransformer($this->repository);
-    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |

Remove ObjectToIdentifierTransformer from  ShippingMethodChoiceType for ChoiceType handles it internally and add a indentifier option , so we can use shipment method code name instead id, the value of id changes every time, when we load fixtures, it is not good for API
