### PR TITLE
replace ThemeInterface with Theme entity in doctrine mapping

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/doctrine/model/Theme.orm.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/doctrine/model/Theme.orm.xml
@@ -29,7 +29,7 @@
         <field name="description" type="string" nullable="true" />
         <field name="authors" type="object" nullable="true" />
 
-        <many-to-many field="parents" target-entity="Sylius\Bundle\ThemeBundle\Model\ThemeInterface">
+        <many-to-many field="parents" target-entity="Sylius\Bundle\ThemeBundle\Model\Theme">
             <cascade>
                 <cascade-all/>
             </cascade>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT
| Doc PR          | no

With ThemeInterface used in mapping we can't generate update sql - error: 

```
$ php app/console doctrine:schema:update --dump-sql


  [Doctrine\Common\Persistence\Mapping\MappingException]
  Class 'Sylius\Bundle\ThemeBundle\Model\ThemeInterface' does not exist
```

In profiler there is also error with mapping:
```
The target entity 'Sylius\Bundle\ThemeBundle\Model\ThemeInterface' specified on Sylius\Bundle\ThemeBundle\Model\Theme#parents is unknown or not an entity.
```


