### PR TITLE
[SearchBundle] Hide empty filters for elasticsearch engine

### DIFF
--- a/src/Sylius/Bundle/SearchBundle/Finder/ElasticsearchFinder.php
+++ b/src/Sylius/Bundle/SearchBundle/Finder/ElasticsearchFinder.php
@@ -297,6 +297,12 @@ class ElasticsearchFinder extends AbstractFinder
                 $facets[$name] = $facetData['buckets'];
             }
         }
+        
+        foreach ($facets as &$facet) {
+            $facet = array_filter($facet, function($v){
+                return $v["doc_count"] != 0;
+            });
+        }
 
         return array_reverse($facets);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Deprecations?   | no|yes
| License         | MIT

I noticed that even though some filters are hidden if empty some are still being shown(like price ranges, for example) even if there are no matches found.
