### PR TITLE
[ResourceBundle] Fix ObjectToIdentifierTransformer to check for an empty value

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Form/DataTransformer/ObjectToIdentifierTransformer.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/DataTransformer/ObjectToIdentifierTransformer.php
@@ -48,7 +48,7 @@ class ObjectToIdentifierTransformer implements DataTransformerInterface
      */
     public function transform($value)
     {
-        if (null === $value) {
+        if (empty($value)) {
             return '';
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #4468, #4373 
| License         | MIT
| Doc PR          | -

When rendering checkout **shipping** step if Product does not have a shipping category an `Internal Server Error` happens; because `sylius_shipping_method_choice` cannot be rendered, I don't exactly know why.

What happens is inside the transformer passed `$value` in not `null` (it is `""` empty string) so the transformer enters into an exception point.

It can also be a mis-configuration in shipping method choice, but I'm not sure.