### PR TITLE
[ResourceBundle] fix return from MongoDB Document Repository

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Doctrine/ODM/MongoDB/DocumentRepository.php
+++ b/src/Sylius/Bundle/ResourceBundle/Doctrine/ODM/MongoDB/DocumentRepository.php
@@ -48,7 +48,7 @@ class DocumentRepository extends BaseDocumentRepository implements RepositoryInt
         return $this
             ->getCollectionQueryBuilder()
             ->getQuery()
-            ->execute()
+            ->getIterator()
         ;
     }
 
@@ -94,7 +94,7 @@ class DocumentRepository extends BaseDocumentRepository implements RepositoryInt
 
         return $queryBuilder
             ->getQuery()
-            ->execute()
+            ->getIterator()
         ;
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #3533 #4072
| License         | MIT
| Doc PR          | -

when paginate is disabled for MongoODM it breaks return of indexAction because `findAll` or `findBy` methods returns a Cursor object instead array or iterator