### PR TITLE
[CoreBundle] Decode escaped characters of url in repository-based route provider

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Routing/RouteProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Routing/RouteProvider.php
@@ -135,6 +135,7 @@ class RouteProvider extends DoctrineProvider implements RouteProviderInterface
             ) {
                 $value = substr($path, strlen($this->routeConfigs[$className]['prefix']));
                 $value = trim($value, '/');
+                $value = urldecode($value);
 
                 if (empty($value)) {
                     continue;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT
| Doc PR          | -

This is a fix for regression of #4242 caused by #3854 
