### PR TITLE
[Behat] Set "twig.strict_variables" to true in test_cached

### DIFF
--- a/app/config/config_test_cached.yml
+++ b/app/config/config_test_cached.yml
@@ -19,3 +19,6 @@ doctrine_phpcr:
             type: memcached
             host: localhost
             port: 11211
+
+twig:
+    strict_variables: true


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #4410
| License         | MIT
| Doc PR          | -


As it defaults to `%kernel.debug%`, we don't get any error if referencing unexisting variable / attribute in Twig.