### PR TITLE
[RFC][Taxation] Skip 0 value tax adjustment on shipping.

### DIFF
--- a/src/Sylius/Component/Core/Taxation/OrderShipmentTaxesByZoneApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/OrderShipmentTaxesByZoneApplicator.php
@@ -20,6 +20,7 @@ use Sylius\Component\Taxation\Resolver\TaxRateResolverInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ * @author Mark McKelvie <mark.mckelvie@reiss.com>
  */
 class OrderShipmentTaxesByZoneApplicator implements OrderShipmentTaxesByZoneApplicatorInterface
 {
@@ -72,6 +73,9 @@ class OrderShipmentTaxesByZoneApplicator implements OrderShipmentTaxesByZoneAppl
 
         $lastShippingAdjustment = $shippingAdjustments->last();
         $taxAmount = $this->calculator->calculate($lastShippingAdjustment->getAmount(), $taxRate);
+        if (0 === $taxAmount) {
+            return;
+        }
 
         $this->addAdjustment($order, $taxAmount, $taxRate->getLabel(), $taxRate->isIncludedInPrice());
     }

--- a/src/Sylius/Component/Core/spec/Taxation/OrderShipmentTaxesByZoneApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Taxation/OrderShipmentTaxesByZoneApplicatorSpec.php
@@ -105,7 +105,7 @@ class OrderShipmentTaxesByZoneApplicatorSpec extends ObjectBehavior
 
         $calculator->calculate(1000, $taxRate)->willReturn(0);
 
-        $adjustmentsFactory->createWithData(AdjustmentInterface::TAX_ADJUSTMENT, 'Simple tax (0%)', 0, false)->shouldNotBeCalled();
+        $adjustmentsFactory->createWithData(Argument::any())->shouldNotBeCalled();
 
         $this->apply($order, $zone);
     }

--- a/src/Sylius/Component/Core/spec/Taxation/OrderShipmentTaxesByZoneApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Taxation/OrderShipmentTaxesByZoneApplicatorSpec.php
@@ -106,6 +106,7 @@ class OrderShipmentTaxesByZoneApplicatorSpec extends ObjectBehavior
         $calculator->calculate(1000, $taxRate)->willReturn(0);
 
         $adjustmentsFactory->createWithData(Argument::any())->shouldNotBeCalled();
+        $order->addAdjustment(Argument::any())->shouldNotBeCalled();
 
         $this->apply($order, $zone);
     }

--- a/src/Sylius/Component/Core/spec/Taxation/OrderShipmentTaxesByZoneApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Taxation/OrderShipmentTaxesByZoneApplicatorSpec.php
@@ -105,7 +105,7 @@ class OrderShipmentTaxesByZoneApplicatorSpec extends ObjectBehavior
 
         $calculator->calculate(1000, $taxRate)->willReturn(0);
 
-        $adjustmentsFactory->createWithData(Argument::any())->shouldNotBeCalled();
+        $adjustmentsFactory->createWithData(Argument::cetera())->shouldNotBeCalled();
         $order->addAdjustment(Argument::any())->shouldNotBeCalled();
 
         $this->apply($order, $zone);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #4452
| License         | MIT
| Doc PR          | 

The shipment tax adjustment will not be added if the resulting tax amount calculated for it is 0.
