### PR TITLE
[DX] Moved custom scripts from bin/ to etc/bin/, fixed relative paths issues, removed bin/install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,7 @@
 /web/css
 /web/js
 
-/bin/*
-!/bin/install
-!/bin/sylius-cs-fixer
-
+/bin
 /vendor
 /node_modules
 

--- a/bin/install
+++ b/bin/install
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-composer install
-app/console sylius:install

--- a/bin/sylius-cs-fixer
+++ b/bin/sylius-cs-fixer
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-bin/php-cs-fixer fix . --config-file etc/phpcs/.php_cs
-bin/php-cs-fixer fix . --config-file etc/phpcs/.phpspec_cs

--- a/etc/bash/common.lib.sh
+++ b/etc/bash/common.lib.sh
@@ -39,3 +39,8 @@ get_number_of_jobs_for_parallel()
 
     echo "${jobs}"
 }
+
+get_sylius_path()
+{
+    echo "$(cd "$(dirname "${BASH_SOURCE[0]}")/../../" && pwd)"
+}

--- a/etc/bin/fix-coding-standards
+++ b/etc/bin/fix-coding-standards
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../bash/common.lib.sh"
+
+run_command "$(get_sylius_path)/bin/php-cs-fixer --ansi fix \"$(get_sylius_path)\" --config-file \"$(get_sylius_path)/etc/phpcs/.php_cs\""
+run_command "$(get_sylius_path)/bin/php-cs-fixer --ansi fix \"$(get_sylius_path)\" --config-file \"$(get_sylius_path)/etc/phpcs/.phpspec_cs\""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes (can call `etc/bin/fix-coding-standards` from any directory)
| New feature?    | no
| BC breaks?      | yes (removed `bin/install`, moved `bin/sylius-cs-fixer` to `etc/bin/fix-coding-standards`)
| Deprecations?   | no
| Related tickets | -
| License         | MIT
| Doc PR          | -

 - [x] `bin/install` removed; it is not referenced in any docs and quite useless
 - [x] moved `bin/sylius-cs-fixer` to `etc/bin/fix-coding-standards`, allowing to call that script from any directory