### PR TITLE
[CoreBundle] Change enabled = 1 in ProductRepository to true

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -159,7 +159,7 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
         return $this->createQueryBuilder('o')
             ->innerJoin('o.channels', 'channel')
             ->addOrderBy('o.createdAt', 'desc')
-            ->andWhere('o.enabled = 1')
+            ->andWhere('o.enabled = true')
             ->andWhere('channel = :channel')
             ->setParameter('channel', $channel)
             ->setMaxResults($limit)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT
| Doc PR          | -

I changed condition from value "1" (integer) to boolean (true).

Indeed, in mysql, there is no problem, but with more strict sgbd (as postgresql), that need to be casted.




