### PR TITLE
[FixtureBundle] Throw exception when method does not exists

### DIFF
--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/DataFixture.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/DataFixture.php
@@ -85,6 +85,10 @@ abstract class DataFixture extends AbstractFixture implements ContainerAwareInte
         if (preg_match('/^get(.*)Factory$/', $method, $matches)) {
             return $this->get('sylius.factory.'.$matches[1]);
         }
+        
+        if (!method_exists($this, $method)) {
+            throw new \Exception(sprintf('Method %s does not exist', $method));
+        }
 
         return call_user_func_array([$this, $method], $arguments);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Throw an exception when a method in Datafixture class does not exists.
Currently I get segmentation faults when calling a "wrong" function.

