### PR TITLE
[OptionValue][Core] - various fixes after option value model changes

### DIFF
--- a/src/Sylius/Bundle/VariationBundle/Form/Type/OptionValueType.php
+++ b/src/Sylius/Bundle/VariationBundle/Form/Type/OptionValueType.php
@@ -45,7 +45,7 @@ class OptionValueType extends AbstractResourceType
         $builder
             ->add('translations', 'a2lix_translationsForms', [
                 'form_type' => sprintf('sylius_%s_option_value_translation', $this->variableName),
-                'label' => 'sylius.form.option.presentation',
+                'label' => 'sylius.form.option.name',
             ])
             ->addEventSubscriber(new AddCodeFormSubscriber())
         ;

--- a/src/Sylius/Bundle/VariationBundle/Form/Type/VariantMatchType.php
+++ b/src/Sylius/Bundle/VariationBundle/Form/Type/VariantMatchType.php
@@ -42,7 +42,7 @@ class VariantMatchType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         foreach ($options['variable']->getOptions() as $i => $option) {
-            $builder->add(Urlizer::urlize($option->getName()), sprintf('sylius_%s_option_value_choice', $this->variableName), [
+            $builder->add($option->getCode(), sprintf('sylius_%s_option_value_choice', $this->variableName), [
                 'label' => $option->getName(),
                 'option' => $option,
                 'property_path' => '['.$i.']',

--- a/src/Sylius/Bundle/VariationBundle/Resources/config/validation.xml
+++ b/src/Sylius/Bundle/VariationBundle/Resources/config/validation.xml
@@ -55,9 +55,9 @@
             </constraint>
             <constraint name="Length">
                 <option name="min">2</option>
-                <option name="minMessage">sylius.option.presentation.min_length</option>
+                <option name="minMessage">sylius.option.name.min_length</option>
                 <option name="max">255</option>
-                <option name="maxMessage">sylius.option.presentation.max_length</option>
+                <option name="maxMessage">sylius.option.name.max_length</option>
                 <option name="groups">sylius</option>
             </constraint>
         </property>
@@ -83,7 +83,7 @@
     <class name="Sylius\Component\Variation\Model\OptionValueTranslation">
         <property name="value">
             <constraint name="NotBlank">
-                <option name="message">sylius.option.presentation.not_blank</option>
+                <option name="message">sylius.option_value.value.not_blank</option>
                 <option name="groups">sylius</option>
             </constraint>
         </property>

--- a/src/Sylius/Bundle/VariationBundle/spec/Form/Type/VariantMatchTypeSpec.php
+++ b/src/Sylius/Bundle/VariationBundle/spec/Form/Type/VariantMatchTypeSpec.php
@@ -41,8 +41,9 @@ class VariantMatchTypeSpec extends ObjectBehavior
     {
         $variable->getOptions()->shouldBeCalled()->willReturn([$option]);
         $option->getName()->shouldBeCalled()->willReturn('option_name');
+        $option->getCode()->shouldBeCalled()->willReturn('option-name-code');
 
-        $builder->add('option-name', 'sylius_varibale_name_option_value_choice', [
+        $builder->add('option-name-code', 'sylius_varibale_name_option_value_choice', [
             'label' => 'option_name',
             'option' => $option,
             'property_path' => '[0]',

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Inventory/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Inventory/macros.html.twig
@@ -72,7 +72,7 @@
                                     <td>
                                         <ul>
                                         {% for option in variant.options %}
-                                            <li><strong>{{ option.name }}</strong>: {{ option.value }}</li>
+                                            <li><strong>{{ option.presentation }}</strong>: {{ option.value }}</li>
                                         {% endfor %}
                                         </ul>
                                     </td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductOption/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductOption/macros.html.twig
@@ -9,8 +9,6 @@
             <tr>
                 <th>{{ sylius_resource_sort('id', '#id') }}</th>
                 <th>{{ sylius_resource_sort('code', 'sylius.ui.code'|trans) }}</th>
-                {#TODO allow sort by translation field#}
-                {#<th>{{ sylius_resource_sort('presentation', 'sylius.product_option.presentation'|trans) }}</th>#}
                 <th>{{ 'sylius.product_option.name'|trans }}</th>
                 <th>{{ 'sylius.product_option.values'|trans }}</th>
                 <th>{{ sylius_resource_sort('updatedAt', 'sylius.product_option.updated_at'|trans) }}</th>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #4449
| License         | MIT

Fixed:
* in inventory, where the script will throw an exception,
* cyrilc translations referenced in #4449 
* translation and validation strings and keys

Maybe for consistency all mentions of `presentation` should be changed to `name` in OptionValue and probably in productVariant. As it is proxied to the name anyway.

```php
    // OptionValue.php
    /**
     * {@inheritdoc}
     */
    public function getPresentation()
    {
        if (null === $this->option) {
            throw new \BadMethodCallException('The option have not been created yet so you cannot access proxy methods.');
        }

        return $this->option->getName();
    }
```

