### PR TITLE
[Bug Fix] Fix orphan removal of channels and taxons on product model

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Product.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Product.orm.xml
@@ -35,7 +35,7 @@
             <join-column name="restricted_zone" referenced-column-name="id" nullable="true" on-delete="SET NULL" />
         </many-to-one>
 
-        <many-to-many field="taxons" inversed-by="products" target-entity="Sylius\Component\Taxonomy\Model\TaxonInterface">
+        <many-to-many field="taxons" inversed-by="products" target-entity="Sylius\Component\Taxonomy\Model\TaxonInterface" orphan-removal="true">
             <join-table name="sylius_product_taxon">
                 <join-columns>
                     <join-column name="product_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
@@ -46,7 +46,7 @@
             </join-table>
         </many-to-many>
 
-        <many-to-many field="channels" target-entity="Sylius\Component\Channel\Model\ChannelInterface">
+        <many-to-many field="channels" target-entity="Sylius\Component\Channel\Model\ChannelInterface" orphan-removal="true">
             <join-table name="sylius_product_channels">
                 <join-columns>
                     <join-column name="product_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


Channels and taxons relationships of a product should be removed when they are unset (orphaned). Right now they will stay in the join table, this is not the right behaviour.

It is late and I did not test this code, but it didn't make sense when I saw it. I have had that issue before with `many-to-many` relationships and it is important to properly define if it's orphans should live or not.