### PR TITLE
Changing viewport of backend invoice PDF generation.

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/OrderController.php
+++ b/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/OrderController.php
@@ -110,7 +110,7 @@ class OrderController extends FOSRestController
             'margin-bottom' => 10,
             'margin-left' => 5,
         ]);
-        
+
         return new Response(
             $generator->getOutputFromHtml($html),
             200,

--- a/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/OrderController.php
+++ b/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/OrderController.php
@@ -104,8 +104,13 @@ class OrderController extends FOSRestController
             'footer-line' => true,
             'footer-font-name' => '"Helvetica Neue",​Helvetica,​Arial,​sans-serif',
             'footer-font-size' => 10,
+            'viewport-size' => '1200x1024',
+            'margin-top' => 10,
+            'margin-right' => 5,
+            'margin-bottom' => 10,
+            'margin-left' => 5,
         ]);
-
+        
         return new Response(
             $generator->getOutputFromHtml($html),
             200,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no|yes
| Deprecations?   | no
| Related tickets | -
| License         | MIT
| Doc PR          | -


Desktop view for bootstrap needs viewport width > 1200px (`A4 print`) so for better PDF format I added some options to the controller