### PR TITLE
Allow gedmo 3.0.x-dev to be installed 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
             "homepage": "http://github.com/Sylius/Sylius/contributors"
         }
     ],
+    "prefer-stable": true,
     "require": {
         "php": "^5.5.9|^7.0",
         "ext-exif": "*",
@@ -54,7 +55,7 @@
         "payum/payum-bundle": "~1.0",
         "sensio/distribution-bundle": "~3.0",
         "stof/doctrine-extensions-bundle": "~1.1",
-        "gedmo/doctrine-extensions": "^2.4.12",
+        "gedmo/doctrine-extensions": "^2.4.12|^3.0@dev",
         "swiftmailer/swiftmailer": "~5.0",
         "symfony-cmf/block-bundle": "~1.2",
         "symfony-cmf/content-bundle": "~1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ad226aefe9335182f5ea02cd222697bf",
-    "content-hash": "3c8ea86d828ddefea603976d90a0a4d0",
+    "hash": "9932dd01512d6cb380c5d05e0929dbb0",
+    "content-hash": "2da4bc590bf31c6250bb036dc5e16bd0",
     "packages": [
         {
             "name": "a2lix/translation-form-bundle",
@@ -10495,11 +10495,12 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "gedmo/doctrine-extensions": 20,
         "symfony-cmf/routing-bundle": 5,
         "coduo/php-matcher": 20,
         "lakion/api-test-case": 20
     },
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^5.5.9|^7.0",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

I made this change since you want to use the `NestedSetTraits` etc. to easily move up nodes etc. Normally you would extend the `NestedSetRepository` but since Sylius uses a base repository class for all resources this is impossible with gedmo `2.4.x`. 

This way you can use the un-released `3.0.x` of gedmo extensions. So you could optionally use that when requiring Sylius in your project and use those traits!