### PR TITLE
Update backordered units after inventory onhand is updated

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderItemUnitRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderItemUnitRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Doctrine\ORM;
+
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+use Sylius\Component\Inventory\Repository\InventoryUnitRepositoryInterface;
+use Sylius\Component\Inventory\Model\StockableInterface;
+
+/**
+ * @author Robin Jansen <robinjansen51@gmail.com>
+ */
+class OrderItemUnitRepository extends EntityRepository implements InventoryUnitRepositoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function findByStockableAndInventoryState(StockableInterface $stockable, $state, $limit = null)
+    {
+        return $this->createQueryBuilder('o')
+            ->innerJoin('o.orderItem', 'item')
+            ->where('item.variant = :variant')
+            ->setParameter('variant', $stockable)
+            ->andWhere('o.inventoryState = :state')
+            ->setParameter('state', $state)
+            ->orderBy('o.createdAt', 'ASC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
@@ -177,10 +177,13 @@ sylius_promotion:
 sylius_inventory:
     backorders: %sylius.inventory.backorders_enabled%
     track_inventory: %sylius.inventory.tracking_enabled%
+    events:
+        - sylius.product_variant.pre_update
     resources:
         inventory_unit:
             classes:
                 model: %sylius.model.order_item_unit.class%
+                repository: Sylius\Bundle\CoreBundle\Doctrine\ORM\OrderItemUnitRepository
 
 sylius_payment:
     resources:
@@ -227,6 +230,7 @@ sylius_order:
         order_item_unit:
             classes:
                 model: Sylius\Component\Core\Model\OrderItemUnit
+                repository: Sylius\Bundle\CoreBundle\Doctrine\ORM\OrderItemUnitRepository
 
 sylius_sequence:
     generators:

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/state-machine.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/state-machine.yml
@@ -164,6 +164,11 @@ winzou_state_machine:
     sylius_inventory_unit:
         callbacks:
             after:
+                sylius_update_shipment_state:
+                    from: 'backordered'
+                    to: ['onhold', 'sold']
+                    do: [@sylius.callback.order_item_unit, 'updateShipmentStateOnInventoryRestock']
+                    args: ['object']
                 sylius_sync_shipping:
                     excluded_to: [sold]
                     do:   [@sm.callback.cascade_transition, 'apply']

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/state_machine.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/state_machine.xml
@@ -21,6 +21,7 @@
         <parameter key="sylius.callback.shipment_states.class">Sylius\Bundle\CoreBundle\StateMachineCallback\ShipmentStatesCallback</parameter>
         <parameter key="sylius.callback.order_payment.class">Sylius\Bundle\CoreBundle\StateMachineCallback\OrderPaymentCallback</parameter>
         <parameter key="sylius.callback.coupon_usage.class">Sylius\Bundle\CoreBundle\StateMachineCallback\CouponUsageCallback</parameter>
+        <parameter key="sylius.callback.order_item_unit.class">Sylius\Bundle\CoreBundle\StateMachineCallback\OrderItemUnitCallback</parameter>
         <parameter key="sylius.callback.promotion_usage.class">Sylius\Bundle\CoreBundle\StateMachineCallback\PromotionUsageCallback</parameter>
         <parameter key="sylius.callback.order_shipment.class">Sylius\Bundle\CoreBundle\StateMachineCallback\OrderShipmentCallback</parameter>
     </parameters>
@@ -36,6 +37,9 @@
         </service>
 
         <service id="sylius.callback.coupon_usage" class="%sylius.callback.coupon_usage.class%" />
+        <service id="sylius.callback.order_item_unit" class="%sylius.callback.order_item_unit.class%">
+            <argument type="service" id="sm.factory" />
+        </service>
         <service id="sylius.callback.promotion_usage" class="%sylius.callback.promotion_usage.class%" />
 
         <service id="sylius.callback.order_shipment" class="%sylius.callback.order_shipment.class%">

--- a/src/Sylius/Bundle/CoreBundle/StateMachineCallback/OrderItemUnitCallback.php
+++ b/src/Sylius/Bundle/CoreBundle/StateMachineCallback/OrderItemUnitCallback.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\StateMachineCallback;
+
+use SM\Factory\FactoryInterface;
+use Sylius\Component\Core\Model\OrderItemUnitInterface;
+use Sylius\Component\Shipping\ShipmentTransitions;
+
+/**
+ * @author Robin Jansen <robinjansen51@gmail.com>
+ */
+class OrderItemUnitCallback
+{
+    /**
+     * @var FactoryInterface
+     */
+    protected $factory;
+
+    /**
+     * @param FactoryInterface $factory
+     */
+    public function __construct(FactoryInterface $factory)
+    {
+        $this->factory = $factory;
+    }
+
+    /**
+     * @param OrderItemUnitInterface $unit
+     */
+    public function updateShipmentStateOnInventoryRestock(OrderItemUnitInterface $unit)
+    {
+        if (!$shipment = $unit->getShipment()) {
+            return;
+        }
+
+        $units = $shipment->getUnits();
+
+        foreach ($units as $unit) {
+            if (!in_array($unit->getInventoryState(), [
+                OrderItemUnitInterface::STATE_ONHOLD,
+                OrderItemUnitInterface::STATE_SOLD,
+            ])) {
+                return;
+            }
+        }
+
+        $this->factory->get($shipment, ShipmentTransitions::GRAPH)->apply(ShipmentTransitions::SYLIUS_PREPARE);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/spec/StateMachineCallback/OrderItemUnitCallbackSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/StateMachineCallback/OrderItemUnitCallbackSpec.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\CoreBundle\StateMachineCallback;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use SM\Factory\FactoryInterface;
+use SM\StateMachine\StateMachineInterface;
+use Sylius\Bundle\CoreBundle\StateMachineCallback\OrderItemUnitCallback;
+use Sylius\Component\Core\Model\OrderItemUnitInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+use Sylius\Component\Shipping\ShipmentTransitions;
+
+/**
+ * @author Robin Jansen <robinjansen51@gmail.com>
+ */
+class OrderItemUnitCallbackSpec extends ObjectBehavior
+{
+    function let(FactoryInterface $factory)
+    {
+        $this->beConstructedWith($factory);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(OrderItemUnitCallback::class);
+    }
+
+    function it_updates_shipment_state_when_no_unit_in_backorder(
+        $factory,
+        OrderItemUnitInterface $unit1,
+        OrderItemUnitInterface $unit2,
+        ShipmentInterface $shipment,
+        StateMachineInterface $stateMachine
+    ) {
+        $unit1->getShipment()->willReturn($shipment);
+
+        $shipment->getUnits()->willReturn([$unit2]);
+
+        $unit2->getInventoryState()
+            ->shouldBeCalled()
+            ->willReturn(OrderItemUnitInterface::STATE_ONHOLD)
+        ;
+
+        $factory->get($shipment, ShipmentTransitions::GRAPH)
+            ->shouldBeCalled()
+            ->willReturn($stateMachine)
+        ;
+
+        $stateMachine->apply(ShipmentTransitions::SYLIUS_PREPARE)->shouldBeCalled();
+
+        $this->updateShipmentStateOnInventoryRestock($unit1);
+    }
+
+    function it_does_not_update_shipment_state_when_units_in_backorder(
+        $factory,
+        OrderItemUnitInterface $unit1,
+        OrderItemUnitInterface $unit2,
+        OrderItemUnitInterface $unit3,
+        ShipmentInterface $shipment
+    ) {
+        $unit1->getShipment()->willReturn($shipment);
+
+        $shipment->getUnits()->willReturn([$unit2, $unit3]);
+
+        $unit2->getInventoryState()
+            ->shouldBeCalled()
+            ->willReturn(OrderItemUnitInterface::STATE_ONHOLD)
+        ;
+
+        $unit3->getInventoryState()
+            ->shouldBeCalled()
+            ->willReturn(OrderItemUnitInterface::STATE_BACKORDERED)
+        ;
+
+        $factory->get($shipment, ShipmentTransitions::GRAPH)
+            ->shouldNotBeCalled()
+        ;
+
+        $this->updateShipmentStateOnInventoryRestock($unit1);
+    }
+}

--- a/src/Sylius/Bundle/InventoryBundle/DependencyInjection/SyliusInventoryExtension.php
+++ b/src/Sylius/Bundle/InventoryBundle/DependencyInjection/SyliusInventoryExtension.php
@@ -32,6 +32,8 @@ class SyliusInventoryExtension extends AbstractResourceExtension
         $config = $this->processConfiguration(new Configuration(), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
+        $loader->load(sprintf('driver/%s.xml', $config['driver']));
+
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);
 
         $configFiles = [

--- a/src/Sylius/Bundle/InventoryBundle/Doctrine/ORM/InventoryUnitRepository.php
+++ b/src/Sylius/Bundle/InventoryBundle/Doctrine/ORM/InventoryUnitRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\InventoryBundle\Doctrine\ORM;
+
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+use Sylius\Component\Inventory\Repository\InventoryUnitRepositoryInterface;
+use Sylius\Component\Inventory\Model\StockableInterface;
+
+/**
+ * @author Robin Jansen <robinjansen51@gmail.com>
+ */
+class InventoryUnitRepository extends EntityRepository implements InventoryUnitRepositoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function findByStockableAndInventoryState(StockableInterface $stockable, $state, $limit = null)
+    {
+        return $this->findBy(
+            [
+                'stockable' => $stockable,
+                'inventoryState' => $state,
+            ],
+            [
+                'createdAt' => 'ASC',
+            ],
+            $limit
+        );
+    }
+}

--- a/src/Sylius/Bundle/InventoryBundle/Resources/config/driver/doctrine/orm.xml
+++ b/src/Sylius/Bundle/InventoryBundle/Resources/config/driver/doctrine/orm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+                               http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sylius.repository.inventory_unit.class">Sylius\Bundle\InventoryBundle\Doctrine\ORM\InventoryUnitRepository</parameter>
+    </parameters>
+
+</container>

--- a/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
@@ -41,6 +41,7 @@
 
         <service id="sylius.backorders_handler" class="%sylius.backorders_handler.class%">
             <argument type="service" id="sylius.repository.inventory_unit" />
+            <argument type="service" id="sm.factory" />
         </service>
 
         <service id="sylius.listener.inventory" class="%sylius.listener.inventory.class%">

--- a/src/Sylius/Bundle/InventoryBundle/Resources/config/state-machine.yml
+++ b/src/Sylius/Bundle/InventoryBundle/Resources/config/state-machine.yml
@@ -12,7 +12,7 @@ winzou_state_machine:
             returned:    ~
         transitions:
             hold:
-                from: [checkout]
+                from: [checkout, backordered]
                 to:   onhold
             release:
                 from: [onhold]

--- a/src/Sylius/Component/Inventory/Repository/InventoryUnitRepositoryInterface.php
+++ b/src/Sylius/Component/Inventory/Repository/InventoryUnitRepositoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Inventory\Repository;
+
+use Sylius\Component\Inventory\Model\InventoryUnitInterface;
+use Sylius\Component\Inventory\Model\StockableInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+/**
+ * @author Robin Jansen <robinjansen51@gmail.com>
+ */
+interface InventoryUnitRepositoryInterface extends RepositoryInterface
+{
+    /**
+     * @param StockableInterface $stockable
+     * @param string $state
+     * @param int|null $limit
+     *
+     * @return InventoryUnitInterface[]
+     */
+    public function findByStockableAndInventoryState(StockableInterface $stockable, $state, $limit = null);
+}


### PR DESCRIPTION
Q | A
--------------- | ---
Bug fix? | yes
New feature? | yes
BC breaks? | no
Deprecations? | no
Related tickets | fixes #3857 
License | MIT

- [x] Update backordered inventory units when `variants.onhand` is updated
- [x] Update `shipment.state` when unit inventory state is updated

This PR should fix #3857. When the `onhand` value of a `variant` is updated, the `fillBackorders` will be called from the `backordersHandler`. I also added a new transition option from `backordered` to `onhold`. 

~~Previously units where set to `sold` if it could be updated. But according to http://docs.sylius.org/en/latest/book/inventory.html#inventoryunit the units won't get get the state `sold` until they leave the warehouse. Also when an order is placed with a completed payment, the units are also getting the `sold` inventory state. So I think this is the right state to transition to.~~

~~The InventoryBundle will set the `inventoryUnit` to `sold` if it is not backordered anymore. But in combination with the PaymentBundle Sylius is using the state `sold` only if the `payment` is `completed`. Otherwise the backordered units will transition to the `onhold` state.~~

If an `inventoryUnit` is restocked and it has backordered `units`, than those units will been refilled automatically until there are no more `onhand` variants.

Ready!