### PR TITLE
Prevent from twig InvalidParameterException

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_list.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_list.html.twig
@@ -17,29 +17,31 @@
             </thead>
             <tbody>
             {% for order in orders %}
-                <tr class="order" id="order-{{ order.number }}">
-                    <td>{{ order.createdAt|date }}</td>
-                    <td>{{ order.number }}</td>
-                    <td>{{ order.total|sylius_money(order.currency) }}</td>
-                    <td>
-                        {% include "SyliusWebBundle:Frontend/Account:Order/_state.html.twig" %}
-                    </td>
-                    <td>
-                        {% if order.isInvoiceAvailable %}
-                            {{ buttons.btn(
-                            path('sylius_account_order_invoice', {'number': order.number}),
-                            '',
-                            'order-' ~ order.number ~ '-invoice',
-                            'file'
-                            ) }}
-                        {% else %}
-                            -
-                        {% endif %}
-                    </td>
-                    <td>
-                        {{ buttons.show(path('sylius_account_order_show', {'number': order.number}), '', 'order-' ~ order.number ~ '-details') }}
-                    </td>
-                </tr>
+                {% if not order.number is empty %}
+                    <tr class="order" id="order-{{ order.number }}">
+                        <td>{{ order.createdAt|date }}</td>
+                        <td>{{ order.number }}</td>
+                        <td>{{ order.total|sylius_money(order.currency) }}</td>
+                        <td>
+                            {% include "SyliusWebBundle:Frontend/Account:Order/_state.html.twig" %}
+                        </td>
+                        <td>
+                            {% if order.isInvoiceAvailable %}
+                                {{ buttons.btn(
+                                path('sylius_account_order_invoice', {'number': order.number}),
+                                '',
+                                'order-' ~ order.number ~ '-invoice',
+                                'file'
+                                ) }}
+                            {% else %}
+                                -
+                            {% endif %}
+                        </td>
+                        <td>
+                            {{ buttons.show(path('sylius_account_order_show', {'number': order.number}), '', 'order-' ~ order.number ~ '-details') }}
+                        </td>
+                    </tr>
+                {% endif %}
             {% endfor %}
             </tbody>
         </table>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT
| Doc PR          | -

If someone is in checkout process and the order is not finalized yet (order number is null) it rise an `InvalidParameterException: Parameter "number" for route "sylius_account_order_show" must match "[^/]++" ("" given) to generate a corresponding URL.`
