### PR TITLE
[ResourceBundle] Allow applying transition when updating resources

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfiguration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfiguration.php
@@ -557,4 +557,28 @@ class RequestConfiguration
 
         return $this->parameters->get('grid');
     }
+
+    /**
+     * @return bool
+     */
+    public function hasStateMachine()
+    {
+        return $this->parameters->has('state_machine');
+    }
+
+    /**
+     * @return string
+     */
+    public function getStateMachineGraph()
+    {
+        return $this->parameters->get('state_machine[graph]', null, true);
+    }
+
+    /**
+     * @return string
+     */
+    public function getStateMachineTransition()
+    {
+        return $this->parameters->get('state_machine[transition]', null, true);
+    }
 }

--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -404,7 +404,7 @@ class ResourceController extends Controller
         $this->eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource);
 
         if (!$configuration->isHtmlRequest()) {
-            return $this->viewHandler->handle($configuration, View::create(null, 204));
+            return $this->viewHandler->handle($configuration, View::create($resource, 200));
         }
 
         $this->flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource);

--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -103,6 +103,11 @@ class ResourceController extends Controller
     protected $eventDispatcher;
 
     /**
+     * @var StateMachineInterface
+     */
+    protected $stateMachine;
+
+    /**
      * @param MetadataInterface $metadata
      * @param RequestConfigurationFactoryInterface $requestConfigurationFactory
      * @param ViewHandlerInterface $viewHandler
@@ -117,6 +122,7 @@ class ResourceController extends Controller
      * @param FlashHelperInterface $flashHelper
      * @param AuthorizationCheckerInterface $authorizationChecker
      * @param EventDispatcherInterface $eventDispatcher
+     * @param StateMachineInterface $stateMachine
      */
     public function __construct(
         MetadataInterface $metadata,
@@ -132,7 +138,8 @@ class ResourceController extends Controller
         RedirectHandlerInterface $redirectHandler,
         FlashHelperInterface $flashHelper,
         AuthorizationCheckerInterface $authorizationChecker,
-        EventDispatcherInterface $eventDispatcher
+        EventDispatcherInterface $eventDispatcher,
+        StateMachineInterface $stateMachine
     ) {
         $this->metadata = $metadata;
         $this->requestConfigurationFactory = $requestConfigurationFactory;
@@ -148,6 +155,7 @@ class ResourceController extends Controller
         $this->flashHelper = $flashHelper;
         $this->authorizationChecker = $authorizationChecker;
         $this->eventDispatcher = $eventDispatcher;
+        $this->stateMachine = $stateMachine;
     }
 
     /**
@@ -298,6 +306,10 @@ class ResourceController extends Controller
                 return $this->redirectHandler->redirectToResource($configuration, $resource);
             }
 
+            if ($configuration->hasStateMachine()) {
+                $this->stateMachine->apply($configuration, $resource);
+            }
+
             $this->manager->flush();
             $this->eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource);
 
@@ -361,6 +373,43 @@ class ResourceController extends Controller
         $this->flashHelper->addSuccessFlash($configuration, ResourceActions::DELETE, $resource);
 
         return $this->redirectHandler->redirectToIndex($configuration, $resource);
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    public function applyStateMachineTransitionAction(Request $request)
+    {
+        $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);
+
+        $this->isGrantedOr403($configuration, ResourceActions::UPDATE);
+        $resource = $this->findOr404($configuration);
+
+        $event = $this->eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource);
+
+        if ($event->isStopped() && !$configuration->isHtmlRequest()) {
+            throw new HttpException($event->getErrorCode(), $event->getMessage());
+        }
+        if ($event->isStopped()) {
+            $this->flashHelper->addFlashFromEvent($configuration, $event);
+
+            return $this->redirectHandler->redirectToResource($configuration, $resource);
+        }
+
+        $this->stateMachine->apply($configuration, $resource);
+        $this->manager->flush();
+
+        $this->eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource);
+
+        if (!$configuration->isHtmlRequest()) {
+            return $this->viewHandler->handle($configuration, View::create(null, 204));
+        }
+
+        $this->flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource);
+
+        return $this->redirectHandler->redirectToResource($configuration, $resource);
     }
 
     /**
@@ -460,41 +509,6 @@ class ResourceController extends Controller
         $this->flashHelper->addSuccessFlash($configuration, 'move', $resource);
 
         return $this->redirectHandler->redirectToIndex($configuration, $resource);
-    }
-
-    /**
-     * @param Request $request
-     * @param string $transition
-     * @param string $graph
-     *
-     * @return RedirectResponse
-     */
-    public function updateStateAction(Request $request, $transition, $graph)
-    {
-        $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);
-        $resource = $this->findOr404($configuration);
-
-        $stateMachine = $this->get('sm.factory')->get($resource, $graph);
-        if (!$stateMachine->can($transition)) {
-            throw new NotFoundHttpException(sprintf(
-                'The requested transition %s cannot be applied on the given %s with graph %s.',
-                $transition,
-                $this->metadata->getName(),
-                $graph
-            ));
-        }
-
-        $stateMachine->apply($transition);
-
-        $this->manager->flush();
-
-        if (!$configuration->isHtmlRequest()) {
-            return $this->viewHandler->handle($configuration, View::create($resource, 204));
-        }
-
-        $this->flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource);
-
-        return $this->redirectHandler->redirectToReferer($configuration);
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/Controller/StateMachine.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/StateMachine.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\Controller;
+
+use Sylius\Component\Resource\Model\ResourceInterface;
+use SM\Factory\FactoryInterface;
+
+/**
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+class StateMachine implements StateMachineInterface
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $stateMachineFactory;
+
+    /**
+     * @param FactoryInterface $stateMachineFactory
+     */
+    public function __construct(FactoryInterface $stateMachineFactory)
+    {
+        $this->stateMachineFactory = $stateMachineFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(RequestConfiguration $configuration, ResourceInterface $resource)
+    {
+        if (!$configuration->hasStateMachine()) {
+            throw new \InvalidArgumentException('State machine must be configured to apply transition, check your routing.');
+        }
+
+        $this->stateMachineFactory->get($resource, $configuration->getStateMachineGraph())->apply($configuration->getStateMachineTransition());
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/Controller/StateMachineInterface.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/StateMachineInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\Controller;
+
+use Sylius\Component\Resource\Model\ResourceInterface;
+
+/**
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+interface StateMachineInterface
+{
+    /**
+     * @param RequestConfiguration $configuration
+     * @param ResourceInterface $resource
+     */
+    public function apply(RequestConfiguration $configuration, ResourceInterface $resource);
+}

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
@@ -103,6 +103,7 @@ abstract class AbstractDriver implements DriverInterface
                 new Reference('sylius.resource_controller.flash_helper'),
                 new Reference('sylius.resource_controller.authorization_checker'),
                 new Reference('sylius.resource_controller.event_dispatcher'),
+                new Reference('sylius.resource_controller.state_machine'),
             ])
             ->addMethodCall('setContainer', [new Reference('service_container')])
         ;

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/controller.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/controller.xml
@@ -31,6 +31,7 @@
         <parameter key="sylius.resource_controller.event_dispatcher.class">Sylius\Bundle\ResourceBundle\Controller\EventDispatcher</parameter>
         <parameter key="sylius.resource_controller.pagerfanta_representation_factory.class">Hateoas\Representation\Factory\PagerfantaFactory</parameter>
         <parameter key="sylius.resource_controller.view_handler.class">Sylius\Bundle\ResourceBundle\Controller\ViewHandler</parameter>
+        <parameter key="sylius.resource_controller.state_machine.class">Sylius\Bundle\ResourceBundle\Controller\StateMachine</parameter>
     </parameters>
 
     <services>
@@ -68,6 +69,9 @@
         </service>
         <service id="sylius.resource_controller.view_handler" class="%sylius.resource_controller.view_handler.class%">
             <argument type="service" id="fos_rest.view_handler" />
+        </service>
+        <service id="sylius.resource_controller.state_machine" class="%sylius.resource_controller.state_machine.class%">
+            <argument type="service" id="sm.factory" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ResourceBundle/composer.json
+++ b/src/Sylius/Bundle/ResourceBundle/composer.json
@@ -35,7 +35,8 @@
         "symfony/framework-bundle": "^2.7.7",
         "symfony/twig-bundle": "^2.7",
         "white-october/pagerfanta-bundle": "^1.0",
-        "willdurand/hateoas-bundle": "^0.4|^1.0"
+        "willdurand/hateoas-bundle": "^0.4|^1.0",
+        "winzou/state-machine-bundle": "^0.2"
     },
     "require-dev": {
         "akeneo/phpspec-skip-example-extension": "~1.2",

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationSpec.php
@@ -503,4 +503,18 @@ class RequestConfigurationSpec extends ObjectBehavior
             ->during('getGrid')
         ;
     }
+    
+    function it_can_have_state_machine_transition(Parameters $parameters)
+    {
+        $parameters->has('state_machine')->willReturn(false);
+        $this->hasStateMachine()->shouldReturn(false);
+       
+        $parameters->has('state_machine')->willReturn(true);
+        $parameters->get('state_machine[graph]', null, true)->willReturn('sylius_product_review_state');
+        $parameters->get('state_machine[transition]', null, true)->willReturn('approve');
+
+        $this->hasStateMachine()->shouldReturn(true);
+        $this->getStateMachineGraph()->shouldReturn('sylius_product_review_state');
+        $this->getStateMachineTransition()->shouldReturn('approve');
+    }
 }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
@@ -1346,7 +1346,7 @@ class ResourceControllerSpec extends ObjectBehavior
         ;
     }
 
-    function it_applies_state_machine_transition_to_resource_and_redirects_by_for_html_request(
+    function it_applies_state_machine_transition_to_resource_and_redirects_for_html_request(
         MetadataInterface $metadata,
         RequestConfigurationFactoryInterface $requestConfigurationFactory,
         RequestConfiguration $configuration,
@@ -1433,7 +1433,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $this->applyStateMachineTransitionAction($request)->shouldReturn($redirectResponse);
     }
 
-    function it_applies_state_machine_transition_on_resource_and_returns_204_for_non_html_requests(
+    function it_applies_state_machine_transition_on_resource_and_returns_200_for_non_html_requests(
         MetadataInterface $metadata,
         RequestConfigurationFactoryInterface $requestConfigurationFactory,
         RequestConfiguration $configuration,
@@ -1469,7 +1469,7 @@ class ResourceControllerSpec extends ObjectBehavior
 
         $eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource)->shouldBeCalled();
 
-        $expectedView = View::create(null, 204);
+        $expectedView = View::create($resource, 200);
 
         $viewHandler->handle($configuration, Argument::that($this->getViewComparingCallback($expectedView)))->willReturn($response);
 

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
@@ -27,6 +27,7 @@ use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceFormFactoryInterface;
 use Sylius\Bundle\ResourceBundle\Controller\ResourcesCollectionProviderInterface;
 use Sylius\Bundle\ResourceBundle\Controller\SingleResourceProviderInterface;
+use Sylius\Bundle\ResourceBundle\Controller\StateMachineInterface;
 use Sylius\Bundle\ResourceBundle\Controller\ViewHandlerInterface;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 use Sylius\Component\Resource\Factory\FactoryInterface;
@@ -65,7 +66,8 @@ class ResourceControllerSpec extends ObjectBehavior
         RedirectHandlerInterface $redirectHandler,
         FlashHelperInterface $flashHelper,
         AuthorizationCheckerInterface $authorizationChecker,
-        EventDispatcherInterface $eventDispatcher
+        EventDispatcherInterface $eventDispatcher,
+        StateMachineInterface $stateMachine
     ) {
         $this->beConstructedWith(
             $metadata,
@@ -81,7 +83,8 @@ class ResourceControllerSpec extends ObjectBehavior
             $redirectHandler,
             $flashHelper,
             $authorizationChecker,
-            $eventDispatcher
+            $eventDispatcher,
+            $stateMachine
         );
     }
 
@@ -710,6 +713,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
         $configuration->hasPermission()->willReturn(true);
         $configuration->getPermission(ResourceActions::UPDATE)->willReturn('sylius.product.update');
+        $configuration->hasStateMachine()->willReturn(false);
 
         $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
 
@@ -912,6 +916,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
         $configuration->hasPermission()->willReturn(true);
         $configuration->getPermission(ResourceActions::UPDATE)->willReturn('sylius.product.update');
+        $configuration->hasStateMachine()->willReturn(false);
 
         $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
 
@@ -966,6 +971,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $configuration->hasPermission()->willReturn(true);
         $configuration->getPermission(ResourceActions::UPDATE)->willReturn('sylius.product.update');
         $configuration->isHtmlRequest()->willReturn(false);
+        $configuration->hasStateMachine()->willReturn(false);
 
         $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
 
@@ -1039,6 +1045,63 @@ class ResourceControllerSpec extends ObjectBehavior
             ->shouldThrow(new HttpException(500, 'Cannot update this channel.'))
             ->during('updateAction', [$request])
         ;
+    }
+
+    function it_applies_state_machine_transition_to_updated_resource_if_configured(
+        MetadataInterface $metadata,
+        RequestConfigurationFactoryInterface $requestConfigurationFactory,
+        RequestConfiguration $configuration,
+        AuthorizationCheckerInterface $authorizationChecker,
+        ObjectManager $manager,
+        RepositoryInterface $repository,
+        SingleResourceProviderInterface $singleResourceProvider,
+        StateMachineInterface $stateMachine,
+        ResourceInterface $resource,
+        ResourceFormFactoryInterface $resourceFormFactory,
+        Form $form,
+        EventDispatcherInterface $eventDispatcher,
+        RedirectHandlerInterface $redirectHandler,
+        FlashHelperInterface $flashHelper,
+        ResourceControllerEvent $event,
+        Request $request,
+        Response $redirectResponse
+    ) {
+        $metadata->getApplicationName()->willReturn('sylius');
+        $metadata->getName()->willReturn('product');
+
+        $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
+        $configuration->hasPermission()->willReturn(true);
+        $configuration->getPermission(ResourceActions::UPDATE)->willReturn('sylius.product.update');
+        $configuration->hasStateMachine()->willReturn(true);
+
+        $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
+
+        $configuration->isHtmlRequest()->willReturn(true);
+        $configuration->getTemplate(ResourceActions::UPDATE)->willReturn('SyliusShopBundle:Product:update.html.twig');
+
+        $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
+        $resourceFormFactory->create($configuration, $resource)->willReturn($form);
+
+        $request->isMethod('PATCH')->willReturn(false);
+        $request->getMethod()->willReturn('PUT');
+
+        $form->submit($request, true)->willReturn($form);
+
+        $form->isSubmitted()->willReturn(true);
+        $form->isValid()->willReturn(true);
+        $form->getData()->willReturn($resource);
+
+        $eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource)->willReturn($event);
+        $event->isStopped()->willReturn(false);
+
+        $manager->flush()->shouldBeCalled();
+        $stateMachine->apply($configuration, $resource)->shouldBeCalled();
+        $eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource)->shouldBeCalled();
+
+        $flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource)->shouldBeCalled();
+        $redirectHandler->redirectToResource($configuration, $resource)->willReturn($redirectResponse);
+
+        $this->updateAction($request)->shouldReturn($redirectResponse);
     }
 
     function it_throws_a_403_exception_if_user_is_unauthorized_to_delete_a_single_resource(
@@ -1239,6 +1302,222 @@ class ResourceControllerSpec extends ObjectBehavior
         $this
             ->shouldThrow(new HttpException(500, 'Cannot delete this product.'))
             ->during('deleteAction', [$request])
+        ;
+    }
+
+    function it_throws_a_403_exception_if_user_is_unauthorized_to_apply_state_machine_transition_on_resource(
+        MetadataInterface $metadata,
+        RequestConfigurationFactoryInterface $requestConfigurationFactory,
+        RequestConfiguration $configuration,
+        Request $request,
+        AuthorizationCheckerInterface $authorizationChecker
+    ) {
+        $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
+        $configuration->hasPermission()->willReturn(true);
+        $configuration->getPermission(ResourceActions::UPDATE)->willReturn('sylius.product.update');
+
+        $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(false);
+
+        $this
+            ->shouldThrow(new AccessDeniedException())
+            ->during('applyStateMachineTransitionAction', [$request])
+        ;
+    }
+
+    function it_throws_a_404_exception_if_resource_is_not_found_when_trying_to_apply_state_machine_transition(
+        MetadataInterface $metadata,
+        RequestConfigurationFactoryInterface $requestConfigurationFactory,
+        RequestConfiguration $configuration,
+        Request $request,
+        AuthorizationCheckerInterface $authorizationChecker,
+        RepositoryInterface $repository,
+        SingleResourceProviderInterface $singleResourceProvider
+    ) {
+        $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
+        $configuration->hasPermission()->willReturn(true);
+        $configuration->getPermission(ResourceActions::UPDATE)->willReturn('sylius.product.update');
+
+        $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
+        $singleResourceProvider->get($configuration, $repository)->willReturn(null);
+
+        $this
+            ->shouldThrow(new NotFoundHttpException())
+            ->during('applyStateMachineTransitionAction', [$request])
+        ;
+    }
+
+    function it_applies_state_machine_transition_to_resource_and_redirects_by_for_html_request(
+        MetadataInterface $metadata,
+        RequestConfigurationFactoryInterface $requestConfigurationFactory,
+        RequestConfiguration $configuration,
+        AuthorizationCheckerInterface $authorizationChecker,
+        StateMachineInterface $stateMachine,
+        RepositoryInterface $repository,
+        ObjectManager $manager,
+        SingleResourceProviderInterface $singleResourceProvider,
+        ResourceInterface $resource,
+        RedirectHandlerInterface $redirectHandler,
+        FlashHelperInterface $flashHelper,
+        EventDispatcherInterface $eventDispatcher,
+        ResourceControllerEvent $event,
+        Request $request,
+        Response $redirectResponse
+    ) {
+        $metadata->getApplicationName()->willReturn('sylius');
+        $metadata->getName()->willReturn('product');
+
+        $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
+        $configuration->hasPermission()->willReturn(true);
+        $configuration->getPermission(ResourceActions::UPDATE)->willReturn('sylius.product.update');
+
+        $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
+        $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
+
+        $configuration->isHtmlRequest()->willReturn(true);
+
+        $eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource)->willReturn($event);
+        $event->isStopped()->willReturn(false);
+
+        $stateMachine->apply($configuration, $resource)->shouldBeCalled();
+        $manager->flush()->shouldBeCalled();
+
+        $eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource)->shouldBeCalled();
+
+        $flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource)->shouldBeCalled();
+        $redirectHandler->redirectToResource($configuration, $resource)->willReturn($redirectResponse);
+
+        $this->applyStateMachineTransitionAction($request)->shouldReturn($redirectResponse);
+    }
+
+    function it_does_not_apply_state_machine_transition_on_resource_and_redirects_for_html_requests_stopped_via_event(
+        MetadataInterface $metadata,
+        RequestConfigurationFactoryInterface $requestConfigurationFactory,
+        RequestConfiguration $configuration,
+        AuthorizationCheckerInterface $authorizationChecker,
+        StateMachineInterface $stateMachine,
+        ObjectManager $manager,
+        RepositoryInterface $repository,
+        SingleResourceProviderInterface $singleResourceProvider,
+        ResourceInterface $resource,
+        RedirectHandlerInterface $redirectHandler,
+        FlashHelperInterface $flashHelper,
+        EventDispatcherInterface $eventDispatcher,
+        ResourceControllerEvent $event,
+        Request $request,
+        Response $redirectResponse
+    ) {
+        $metadata->getApplicationName()->willReturn('sylius');
+        $metadata->getName()->willReturn('product');
+
+        $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
+        $configuration->hasPermission()->willReturn(true);
+        $configuration->getPermission(ResourceActions::UPDATE)->willReturn('sylius.product.update');
+
+        $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
+        $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
+
+        $configuration->isHtmlRequest()->willReturn(true);
+
+        $eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource)->willReturn($event);
+        $event->isStopped()->willReturn(true);
+
+        $manager->flush()->shouldNotBeCalled();
+        $stateMachine->apply($resource)->shouldNotBeCalled();
+
+        $eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource)->shouldNotBeCalled();
+        $flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource)->shouldNotBeCalled();
+
+        $flashHelper->addFlashFromEvent($configuration, $event)->shouldBeCalled();
+        $redirectHandler->redirectToResource($configuration, $resource)->willReturn($redirectResponse);
+
+        $this->applyStateMachineTransitionAction($request)->shouldReturn($redirectResponse);
+    }
+
+    function it_applies_state_machine_transition_on_resource_and_returns_204_for_non_html_requests(
+        MetadataInterface $metadata,
+        RequestConfigurationFactoryInterface $requestConfigurationFactory,
+        RequestConfiguration $configuration,
+        AuthorizationCheckerInterface $authorizationChecker,
+        ViewHandlerInterface $viewHandler,
+        StateMachineInterface $stateMachine,
+        ObjectManager $manager,
+        RepositoryInterface $repository,
+        SingleResourceProviderInterface $singleResourceProvider,
+        ResourceInterface $resource,
+        EventDispatcherInterface $eventDispatcher,
+        ResourceControllerEvent $event,
+        Request $request,
+        Response $response
+    ) {
+        $metadata->getApplicationName()->willReturn('sylius');
+        $metadata->getName()->willReturn('product');
+
+        $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
+        $configuration->hasPermission()->willReturn(true);
+        $configuration->getPermission(ResourceActions::UPDATE)->willReturn('sylius.product.update');
+
+        $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
+        $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
+
+        $configuration->isHtmlRequest()->willReturn(false);
+
+        $eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource)->willReturn($event);
+        $event->isStopped()->willReturn(false);
+
+        $stateMachine->apply($configuration, $resource)->shouldBeCalled();
+        $manager->flush()->shouldBeCalled();
+
+        $eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource)->shouldBeCalled();
+
+        $expectedView = View::create(null, 204);
+
+        $viewHandler->handle($configuration, Argument::that($this->getViewComparingCallback($expectedView)))->willReturn($response);
+
+        $this->applyStateMachineTransitionAction($request)->shouldReturn($response);
+    }
+
+    function it_does_not_apply_state_machine_transition_resource_and_throws_http_exception_for_non_html_requests_stopped_via_event(
+        MetadataInterface $metadata,
+        RequestConfigurationFactoryInterface $requestConfigurationFactory,
+        RequestConfiguration $configuration,
+        AuthorizationCheckerInterface $authorizationChecker,
+        RepositoryInterface $repository,
+        ObjectManager $objectManager,
+        StateMachineInterface $stateMachine,
+        SingleResourceProviderInterface $singleResourceProvider,
+        ResourceInterface $resource,
+        FlashHelperInterface $flashHelper,
+        EventDispatcherInterface $eventDispatcher,
+        ResourceControllerEvent $event,
+        Request $request
+    ) {
+        $metadata->getApplicationName()->willReturn('sylius');
+        $metadata->getName()->willReturn('product');
+
+        $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
+        $configuration->hasPermission()->willReturn(true);
+        $configuration->getPermission(ResourceActions::UPDATE)->willReturn('sylius.product.update');
+
+        $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
+        $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
+
+        $configuration->isHtmlRequest()->willReturn(false);
+
+        $eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource)->willReturn($event);
+        $event->isStopped()->willReturn(true);
+        $event->getMessage()->willReturn('Cannot approve this product.');
+        $event->getErrorCode()->willReturn(500);
+
+        $stateMachine->apply($configuration, $resource)->shouldNotBeCalled();
+        $objectManager->flush()->shouldNotBeCalled();
+
+        $eventDispatcher->dispatchPostEvent(Argument::any())->shouldNotBeCalled();
+        $flashHelper->addSuccessFlash(Argument::any())->shouldNotBeCalled();
+        $flashHelper->addFlashFromEvent(Argument::any())->shouldNotBeCalled();
+
+        $this
+            ->shouldThrow(new HttpException(500, 'Cannot approve this product.'))
+            ->during('applyStateMachineTransitionAction', [$request])
         ;
     }
 

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/StateMachineSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/StateMachineSpec.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\Controller;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use SM\Factory\FactoryInterface;
+use SM\StateMachine\StateMachineInterface;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Bundle\ResourceBundle\Controller\StateMachine;
+use Sylius\Bundle\ResourceBundle\Controller\StateMachineInterface as ResourceStateMachineInterface;
+use Sylius\Component\Resource\Model\ResourceInterface;
+
+/**
+ * @mixin StateMachine
+ *
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+class StateMachineSpec extends ObjectBehavior
+{
+    function let(FactoryInterface $stateMachineFactory)
+    {
+        $this->beConstructedWith($stateMachineFactory);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\Controller\StateMachine');
+    }
+
+    function it_implements_state_machine_interface()
+    {
+        $this->shouldImplement(ResourceStateMachineInterface::class);
+    }
+
+    function it_throws_an_exception_if_transition_is_not_defined(RequestConfiguration $requestConfiguration, ResourceInterface $resource)
+    {
+        $requestConfiguration->hasStateMachine()->willReturn(false);
+
+        $this
+            ->shouldThrow(new \InvalidArgumentException('State machine must be configured to apply transition, check your routing.'))
+            ->during('apply', [$requestConfiguration, $resource])
+        ;
+    }
+
+    function it_applies_configured_state_machine_transition(
+        RequestConfiguration $requestConfiguration,
+        ResourceInterface $resource,
+        FactoryInterface $stateMachineFactory,
+        StateMachineInterface $stateMachine
+    ) {
+        $requestConfiguration->hasStateMachine()->willReturn(true);
+        $requestConfiguration->getStateMachineGraph()->willReturn('sylius_product_review_state');
+        $requestConfiguration->getStateMachineTransition()->willReturn('reject');
+
+        $stateMachineFactory->get($resource, 'sylius_product_review_state')->willReturn($stateMachine);
+        $stateMachine->apply('reject')->shouldBeCalled();
+
+        $this->apply($requestConfiguration, $resource);
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/app/AppKernel.php
@@ -32,6 +32,7 @@ class AppKernel extends Kernel
             new Bazinga\Bundle\HateoasBundle\BazingaHateoasBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
+            new \winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle(),
             new AppBundle\AppBundle(),
 

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/DefaultTestCase/bundles.php
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/DefaultTestCase/bundles.php
@@ -14,6 +14,7 @@ return [
 
     new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
     new Symfony\Bundle\TwigBundle\TwigBundle(),
+    new \winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
 
     new Sylius\Bundle\ThemeBundle\SyliusThemeBundle(),
 ];

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/inventory.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/inventory.yml
@@ -19,5 +19,9 @@ sylius_backend_inventory_unit_update_state:
     path: /update-state/{id}/{transition}
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.inventory_unit:updateStateAction
-        graph: sylius_inventory_unit
+        _controller: sylius.controller.inventory_unit:applyStateMachineTransitionAction
+        _sylius:
+            state_machine:
+                graph: sylius_inventory_unit
+                transition: $transition
+            redirect: referer

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/payment.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/payment.yml
@@ -54,5 +54,9 @@ sylius_backend_payment_update_state:
     path: /update-state/{id}/{transition}
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.payment:updateStateAction
-        graph: sylius_payment
+        _controller: sylius.controller.payment:applyStateMachineTransitionAction
+        _sylius:
+            state_machine:
+                graph: sylius_payment
+                transition: $transition
+            redirect: referer

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/product_review.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/product_review.yml
@@ -46,6 +46,10 @@ sylius_backend_product_review_update_state:
     pattern: /update-state/{id}/{transition}
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.product_review:updateStateAction
-        graph: sylius_product_review
+        _controller: sylius.controller.product_review:applyStateMachineTransitionAction
+        _sylius:
+            state_machine:
+                graph: sylius_product_review
+                transition: $transition
+            redirect: referer
 

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/shipment.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/shipment.yml
@@ -55,5 +55,9 @@ sylius_backend_shipment_update_state:
     path: /update-state/{id}/{transition}
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.shipment:updateStateAction
-        graph: sylius_shipment
+        _controller: sylius.controller.shipment:applyStateMachineTransitionAction
+        _sylius:
+            state_machine:
+                graph: sylius_shipment
+                transition: $transition
+            redirect: referer


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | -
| License         | MIT
| Doc PR          | -

Summary:

* Renamed ``updateStateAction`` to ``applyStateMachineTransitionAction`` in ResourceController;
* Extracted logic to separate service;
* Reimplemented the action from scratch BDD wayyy;
* Added ability to execute transition during updateAction :tada: 

The most important is the last point. Use cases:

Any action that needs to edit something on the resource and apply transition. Simplest example: shipping a shipment. We want to specify tracking code and apply "ship" transition - doable with routing configuration alone now.

More crazy use-case: simplified checkout process. Our checkout right now is:

* edit order via form (change address, select shipping method, select payment method)
* apply transition
* save
* redirect

Using FlowBundle for all that is quite an overkill and does not work via API nicely. With this action we can do it with HTML/XML/JSON. :D I recall pasing some examples in another issue, but can't find it.


