### PR TITLE
[Core] Checkout flow and errors improvements

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/AddressingStep.php
@@ -14,6 +14,7 @@ namespace Sylius\Bundle\CoreBundle\Checkout\Step;
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderCheckoutStates;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Symfony\Component\Form\FormInterface;
@@ -34,7 +35,9 @@ class AddressingStep extends CheckoutStep
     {
         $order = $this->getCurrentCart();
 
-        $this->applyTransition(OrderCheckoutTransitions::TRANSITION_READDRESS, $order, true);
+        if (OrderCheckoutStates::STATE_STARTED !== $order->getCheckoutState()) {
+            $this->applyTransition(OrderCheckoutTransitions::TRANSITION_READDRESS, $order);
+        }
 
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::ADDRESSING_INITIALIZE, $order);
         $form = $this->createCheckoutAddressingForm($order, $this->getCustomer());

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/CheckoutStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/CheckoutStep.php
@@ -95,13 +95,13 @@ abstract class CheckoutStep extends AbstractControllerStep
      *
      * @throws InvalidTransitionException
      */
-    protected function applyTransition($transition, OrderInterface $order, $flush = false)
+    protected function applyTransition($transition, OrderInterface $order, $flush = true)
     {
         $stateMachineFactory = $this->get('sm.factory');
         $cartStateMachine = $stateMachineFactory->get($order, 'sylius_order_checkout');
 
         if (!$cartStateMachine->can($transition)) {
-            throw new InvalidTransitionException($transition);
+            throw new InvalidTransitionException($transition, $cartStateMachine);
         }
 
         $cartStateMachine->apply($transition);

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/CheckoutStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/CheckoutStep.php
@@ -15,14 +15,13 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Bundle\FlowBundle\Process\Step\AbstractControllerStep;
 use Sylius\Component\Addressing\Matcher\ZoneMatcherInterface;
 use Sylius\Component\Cart\Provider\CartProviderInterface;
+use Sylius\Component\Core\Exception\InvalidTransitionException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
 /**
- * Base class for checkout steps.
- *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
 abstract class CheckoutStep extends AbstractControllerStep
@@ -93,6 +92,8 @@ abstract class CheckoutStep extends AbstractControllerStep
      * @param string $transition
      * @param OrderInterface $order
      * @param bool $flush
+     *
+     * @throws InvalidTransitionException
      */
     protected function applyTransition($transition, OrderInterface $order, $flush = false)
     {
@@ -100,7 +101,7 @@ abstract class CheckoutStep extends AbstractControllerStep
         $cartStateMachine = $stateMachineFactory->get($order, 'sylius_order_checkout');
 
         if (!$cartStateMachine->can($transition)) {
-            return;
+            throw new InvalidTransitionException($transition);
         }
 
         $cartStateMachine->apply($transition);

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/PaymentStep.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\CoreBundle\Checkout\Step;
 
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderCheckoutStates;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Symfony\Component\Form\FormInterface;
@@ -34,7 +35,9 @@ class PaymentStep extends CheckoutStep
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::PAYMENT_INITIALIZE, $order);
 
-        $this->applyTransition(OrderCheckoutTransitions::TRANSITION_RESELECT_PAYMENT, $order, true);
+        if (OrderCheckoutStates::STATE_SHIPPING_SELECTED !== $order->getCheckoutState()) {
+            $this->applyTransition(OrderCheckoutTransitions::TRANSITION_RESELECT_PAYMENT, $order);
+        }
 
         $form = $this->createCheckoutPaymentForm($order);
 

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/SecurityStep.php
@@ -16,6 +16,7 @@ use Sylius\Bundle\FlowBundle\Process\Step\ActionResult;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\UserInterface;
+use Sylius\Component\Core\OrderCheckoutStates;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Sylius\Component\Resource\Event\ResourceEvent;
@@ -37,7 +38,10 @@ class SecurityStep extends CheckoutStep
     public function displayAction(ProcessContextInterface $context)
     {
         $order = $this->getCurrentCart();
-        $this->applyTransition(OrderCheckoutTransitions::TRANSITION_START, $order);
+
+        if (OrderCheckoutStates::STATE_CART === $order->getCheckoutState()) {
+            $this->applyTransition(OrderCheckoutTransitions::TRANSITION_START, $order);
+        }
 
         // If user is already logged in, transparently jump to next step.
         if ($this->isUserLoggedIn()) {

--- a/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/Step/ShippingStep.php
@@ -14,6 +14,7 @@ namespace Sylius\Bundle\CoreBundle\Checkout\Step;
 use Sylius\Bundle\FlowBundle\Process\Context\ProcessContextInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderCheckoutStates;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\SyliusCheckoutEvents;
 use Symfony\Component\Form\FormInterface;
@@ -40,7 +41,9 @@ class ShippingStep extends CheckoutStep
         $order = $this->getCurrentCart();
         $this->dispatchCheckoutEvent(SyliusCheckoutEvents::SHIPPING_INITIALIZE, $order);
 
-        $this->applyTransition(OrderCheckoutTransitions::TRANSITION_RESELECT_SHIPPING, $order, true);
+        if (OrderCheckoutStates::STATE_ADDRESSED !== $order->getCheckoutState()) {
+            $this->applyTransition(OrderCheckoutTransitions::TRANSITION_RESELECT_SHIPPING, $order);
+        }
 
         $form = $this->createCheckoutShippingForm($order);
 

--- a/src/Sylius/Component/Core/Exception/InvalidTransitionException.php
+++ b/src/Sylius/Component/Core/Exception/InvalidTransitionException.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Core\Exception;
 
 use SM\SMException;
+use SM\StateMachine\StateMachineInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -20,9 +21,17 @@ class InvalidTransitionException extends SMException
 {
     /**
      * @param string $transition
+     * @param StateMachineInterface $stateMachine
      */
-    public function __construct($transition)
+    public function __construct($transition, StateMachineInterface $stateMachine)
     {
-        parent::__construct(sprintf('Transition "%s" is invalid for this state machine.', $transition));
+        parent::__construct(
+            sprintf(
+                'Transition "%s" is invalid for "%s" state machine. Possible transitions are: %s.',
+                $transition,
+                $stateMachine->getGraph(),
+                implode($stateMachine->getPossibleTransitions(), ' and ')
+            )
+        );
     }
 }

--- a/src/Sylius/Component/Core/Exception/InvalidTransitionException.php
+++ b/src/Sylius/Component/Core/Exception/InvalidTransitionException.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Exception;
+
+use SM\SMException;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class InvalidTransitionException extends SMException
+{
+    /**
+     * @param string $transition
+     */
+    public function __construct($transition)
+    {
+        parent::__construct(sprintf('Transition "%s" is invalid for this state machine.', $transition));
+    }
+}

--- a/src/Sylius/Component/Core/spec/Exception/InvalidTransitionExceptionSpec.php
+++ b/src/Sylius/Component/Core/spec/Exception/InvalidTransitionExceptionSpec.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Core\Exception;
+
+use PhpSpec\ObjectBehavior;
+use SM\SMException;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class InvalidTransitionExceptionSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith('start_checkout');
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Core\Exception\InvalidTransitionException');
+    }
+
+    function it_is_sm_exception()
+    {
+        $this->shouldHaveType(SMException::class);
+    }
+
+    function it_has_message()
+    {
+        $this->getMessage()->shouldReturn('Transition "start_checkout" is invalid for this state machine.');
+    }
+}

--- a/src/Sylius/Component/Core/spec/Exception/InvalidTransitionExceptionSpec.php
+++ b/src/Sylius/Component/Core/spec/Exception/InvalidTransitionExceptionSpec.php
@@ -13,15 +13,19 @@ namespace spec\Sylius\Component\Core\Exception;
 
 use PhpSpec\ObjectBehavior;
 use SM\SMException;
+use SM\StateMachine\StateMachineInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
 class InvalidTransitionExceptionSpec extends ObjectBehavior
 {
-    function let()
+    function let(StateMachineInterface $stateMachine)
     {
-        $this->beConstructedWith('start_checkout');
+        $stateMachine->getGraph()->willReturn('checkout_state_machine');
+        $stateMachine->getPossibleTransitions()->willReturn(['start', 'abandon']);
+        
+        $this->beConstructedWith('start_checkout', $stateMachine);
     }
 
     function it_is_initializable()
@@ -36,6 +40,9 @@ class InvalidTransitionExceptionSpec extends ObjectBehavior
 
     function it_has_message()
     {
-        $this->getMessage()->shouldReturn('Transition "start_checkout" is invalid for this state machine.');
+        $this
+            ->getMessage()
+            ->shouldReturn('Transition "start_checkout" is invalid for "checkout_state_machine" state machine. Possible transitions are: start and abandon.')
+        ;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT
| Doc PR          |

- previous implementation led to confusion; if transition is invalid, then state machine is wrongly configured or wrongly used and it should be shown
- added checking order state before applying some transitions