### PR TITLE
[ResourceBundle] fixed #4524 resource.settings not taken in account

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfigurationFactory.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfigurationFactory.php
@@ -57,7 +57,7 @@ class RequestConfigurationFactory implements RequestConfigurationFactoryInterfac
      */
     public function create(MetadataInterface $metadata, Request $request)
     {
-        $parameters = $this->parseApiParameters($request);
+        $parameters = array_merge($this->defaultParameters, $this->parseApiParameters($request));
         $parameters = $this->parametersParser->parseRequestValues($parameters, $request);
 
         return new $this->configurationClass($metadata, $request, new Parameters($parameters));
@@ -67,6 +67,8 @@ class RequestConfigurationFactory implements RequestConfigurationFactoryInterfac
      * @param Request $request
      *
      * @return array
+     *
+     * @throws \InvalidArgumentException
      */
     private function parseApiParameters(Request $request)
     {
@@ -86,4 +88,5 @@ class RequestConfigurationFactory implements RequestConfigurationFactoryInterfac
 
         return array_merge($request->attributes->get('_sylius', []), $parameters);
     }
+
 }

--- a/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfigurationFactoryInterface.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfigurationFactoryInterface.php
@@ -26,6 +26,8 @@ interface RequestConfigurationFactoryInterface
      * @param Request $request
      *
      * @return RequestConfiguration
+     *
+     * @throws \InvalidArgumentException
      */
     public function create(MetadataInterface $metadata, Request $request);
 }

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/controller.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/controller.xml
@@ -42,6 +42,7 @@
         <service id="sylius.resource_controller.request_configuration_factory" class="%sylius.resource_controller.request_configuration_factory.class%">
             <argument type="service" id="sylius.resource_controller.parameters_parser" />
             <argument>%sylius.resource_controller.request_configuration.class%</argument>
+            <argument>%sylius.resource.settings%</argument>
         </service>
         <service id="sylius.resource_controller.new_resource_factory" class="%sylius.resource_controller.new_resource_factory.class%" />
         <service id="sylius.resource_controller.single_resource_provider" class="%sylius.resource_controller.single_resource_provider.class%" />

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationFactorySpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationFactorySpec.php
@@ -54,13 +54,53 @@ class RequestConfigurationFactorySpec extends ObjectBehavior
         $request->attributes = $attributesBag;
 
         $headersBag->has('Accept')->willReturn(false);
-        $headersBag->has('Accept')->willReturn(false);
 
         $configuration = ['template' => ':Product:show.html.twig'];
 
-        $attributesBag->get('_sylius', [])->shouldBeCalled()->willReturn($configuration);
+        $attributesBag->get('_sylius', [])->willReturn($configuration);
         $parametersParser->parseRequestValues($configuration, $request)->willReturn($configuration);
 
         $this->create($metadata, $request)->shouldHaveType(RequestConfiguration::class);
+    }
+
+    function it_creates_configuration_without_default_settings(
+        MetadataInterface $metadata,
+        Request $request,
+        ParametersParser $parametersParser,
+        ParameterBag $headersBag,
+        ParameterBag $attributesBag
+    ) {
+        $request->headers = $headersBag;
+        $request->attributes = $attributesBag;
+
+        $configuration = ['template' => ':Product:list.html.twig'];
+
+        $attributesBag->get('_sylius', [])->willReturn($configuration);
+        $parametersParser->parseRequestValues($configuration, $request)->willReturn($configuration);
+
+        $this->create($metadata, $request)->isSortable()->shouldReturn(false);
+    }
+
+    function it_creates_configuration_with_default_settings(
+        MetadataInterface $metadata,
+        Request $request,
+        ParametersParser $parametersParser,
+        ParameterBag $headersBag,
+        ParameterBag $attributesBag
+    ) {
+        $defaultParameters = ['sortable' => true];
+
+        $this->beConstructedWith($parametersParser, RequestConfiguration::class, $defaultParameters);
+
+        $request->headers = $headersBag;
+        $request->attributes = $attributesBag;
+
+        $configuration = ['template' => ':Product:list.html.twig'];
+        $attributesBag->get('_sylius', [])->willReturn($configuration);
+
+        $configuration = ['template' => ':Product:list.html.twig', 'sortable' => true];
+        $parametersParser->parseRequestValues($configuration, $request)->willReturn($configuration);
+
+        $this->create($metadata, $request)->isSortable()->shouldReturn(true);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #4524
| License         | MIT
| Doc PR          | no  need

Since v0.17.0 the settings in sylius_resource in `sylius.yml` are not taken in account anymore.
This PR 

- fills the `defaultParameters `of `RequestConfigurationFactory` in `controller.xml` by adding an argument `%sylius.resource.settings%`

- then merge the `defaultParameters` in `create` method 

- two news tests are added to `RequestConfigurationFactorySpec`

- it indicates as deprecated the `KernelControllerSubscriber` methods since it doesn't seems to be call anymore
