### PR TITLE
[DX] Imporve SharedStorage transformator

### DIFF
--- a/src/Sylius/Behat/Context/Transform/SharedStorageContext.php
+++ b/src/Sylius/Behat/Context/Transform/SharedStorageContext.php
@@ -53,6 +53,6 @@ final class SharedStorageContext implements Context
      */
     public function getResource($resource)
     {
-        return $this->sharedStorage->get($resource);
+        return $this->sharedStorage->get(str_replace(' ', '_', $resource));
     }
 }

--- a/src/Sylius/Behat/spec/Context/Transform/SharedStorageContextSpec.php
+++ b/src/Sylius/Behat/spec/Context/Transform/SharedStorageContextSpec.php
@@ -48,11 +48,14 @@ class SharedStorageContextSpec extends ObjectBehavior
 
     function it_transforms_this_that_and_the_with_resource_name_to_current_resource_of_this_type(
         $sharedStorage,
-        CustomerInterface $customer
+        CustomerInterface $customer,
+        \stdClass $taxCategory
     ) {
         $sharedStorage->get('customer')->willReturn($customer);
+        $sharedStorage->get('tax_category')->willReturn($taxCategory);
 
         $this->getResource('customer')->shouldReturn($customer);
+        $this->getResource('tax category')->shouldReturn($taxCategory);
     }
 
     function it_transforms_this_that_and_the_should_no_longer_with_resource_name_to_current_id_set_for_that_resource(


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT
| Doc PR          | 

It is more natural to use snake_cased words as a key in shared storage. With this fix `this tax category` will be translated to last `tax_category` resource. 