### PR TITLE
[Travis] Reset all composer.lock caches on composer.json update

### DIFF
--- a/etc/bash/packages.lib.sh
+++ b/etc/bash/packages.lib.sh
@@ -32,3 +32,25 @@ cast_package_argument_to_package_path() {
 
     echo "${package_path}"
 }
+
+# Argument 1: Cache key
+is_package_cache_fresh() {
+    local current_hash cached_hash
+
+    if [[ -f "${SYLIUS_CACHE_DIR}/composer-$1.lock" && -f "${SYLIUS_CACHE_DIR}/composer-$1.json.md5sum" ]]; then
+        current_hash="$(file_md5sum "composer.json")"
+        cached_hash="$(cat "${SYLIUS_CACHE_DIR}/composer-$1.json.md5sum")"
+
+        if [ "${current_hash}" = "${cached_hash}" ]; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+# Argument 1: Package path or name
+get_package_cache_key()
+{
+    text_md5sum "$(package_path_to_package_name "$1")"
+}

--- a/etc/bin/install-package
+++ b/etc/bin/install-package
@@ -8,11 +8,12 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../bash/travis.lib.sh"
 # Argument 1: Package directory
 install_package() {
     [[ "$(echo "$2" | grep -c "no-cache")" = "1" ]] && local cache_support=false
+    [[ "$(echo "$2" | grep -c "reset-cache")" = "1" ]] || local reset_cache=false
     local cache_key="$(text_md5sum "$(package_path_to_package_name "$1")")" exit_code=0
 
     print_header "Installing" "$(package_path_to_package_name "$1")"
 
-    if ${cache_support}; then
+    if ! ${reset_cache} && ${cache_support}; then
         inform_about_sylius_cache
     fi
 
@@ -22,6 +23,11 @@ install_package() {
 
     # In case some local composer.lock exists
     rm composer.lock 2>/dev/null
+
+    if ${reset_cache} && ${cache_support}; then
+        rm -fr "${SYLIUS_CACHE_DIR}/composer-${cache_key}.lock" 2>/dev/null
+        rm -fr "${SYLIUS_CACHE_DIR}/composer-${cache_key}.json.md5sum" 2>/dev/null
+    fi
 
     if ${cache_support} && has_sylius_cache && is_cache_fresh "${cache_key}"; then
         print_info "Restoring composer.lock from cache (cache key: ${cache_key})"
@@ -77,7 +83,7 @@ composer_install() {
 }
 
 display_help_message() {
-    print_error "Usage: $0 [--no-cache] <package paths or names>"
+    print_error "Usage: $0 [--no-cache] [--reset-cache] <package paths or names>"
 }
 
 main() {
@@ -87,6 +93,9 @@ main() {
         case "$1" in
             --no-cache)
                 options+=("no-cache")
+            ;;
+            --reset-cache)
+                options+=("reset-cache")
             ;;
             --help)
                 display_help_message

--- a/etc/bin/install-package
+++ b/etc/bin/install-package
@@ -9,7 +9,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../bash/travis.lib.sh"
 install_package() {
     [[ "$(echo "$2" | grep -c "no-cache")" = "1" ]] && local cache_support=false
     [[ "$(echo "$2" | grep -c "reset-cache")" = "1" ]] || local reset_cache=false
-    local cache_key="$(text_md5sum "$(package_path_to_package_name "$1")")" exit_code=0
+    local cache_key="$(get_package_cache_key "$1)")" exit_code=0
 
     print_header "Installing" "$(package_path_to_package_name "$1")"
 
@@ -29,14 +29,14 @@ install_package() {
         rm -fr "${SYLIUS_CACHE_DIR}/composer-${cache_key}.json.md5sum" 2>/dev/null
     fi
 
-    if ${cache_support} && has_sylius_cache && is_cache_fresh "${cache_key}"; then
+    if ${cache_support} && has_sylius_cache && is_package_cache_fresh "${cache_key}"; then
         print_info "Restoring composer.lock from cache (cache key: ${cache_key})"
         restore_composer_lock_from_cache "${cache_key}"
     fi
 
     composer_install "$1" || exit_code=$?
 
-    if ${cache_support} && has_sylius_cache && ! is_cache_fresh "${cache_key}" && [[ ${exit_code} -eq 0 ]]; then
+    if ${cache_support} && has_sylius_cache && ! is_package_cache_fresh "${cache_key}" && [[ ${exit_code} -eq 0 ]]; then
         print_info "Storing composer.lock in cache (cache key: ${cache_key})"
         store_composer_lock_in_cache "${cache_key}"
     fi
@@ -55,21 +55,6 @@ restore_composer_lock_from_cache() {
     cp "${SYLIUS_CACHE_DIR}/composer-$1.lock" composer.lock
 }
 
-# Argument 1: Cache key
-is_cache_fresh() {
-    local current_hash cached_hash
-
-    if [[ -f "${SYLIUS_CACHE_DIR}/composer-$1.lock" && -f "${SYLIUS_CACHE_DIR}/composer-$1.json.md5sum" ]]; then
-        current_hash="$(file_md5sum "composer.json")"
-        cached_hash="$(cat "${SYLIUS_CACHE_DIR}/composer-$1.json.md5sum")"
-
-        if [ "${current_hash}" = "${cached_hash}" ]; then
-            return 0
-        fi
-    fi
-
-    return 1
-}
 
 # Argument 1: Package path
 composer_install() {

--- a/etc/bin/install-packages
+++ b/etc/bin/install-packages
@@ -3,6 +3,17 @@
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../bash/common.lib.sh"
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../bash/packages.lib.sh"
 
+reset_cache() {
+    local packages="$(locate_packages)"
+
+    for package in "${packages[@]}"; do
+        if ! is_package_cache_fresh "$(get_package_cache_key "$package")"; then
+            echo "--reset-cache"
+            break
+        fi
+    done
+}
+
 install_package="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/install-package"
 
-locate_packages | parallel -j "$(get_number_of_jobs_for_parallel)" --gnu "${install_package} {} $*"
+locate_packages | parallel -j "$(get_number_of_jobs_for_parallel)" --gnu "${install_package} {} $* $(reset_cache)"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT
| Doc PR          | -

Eg. if ResourceBundle adds a new dependency, and ThemeBundle depends on ResourceBundle, ThemeBundle cache should be invalidated just as ResourceBundle one