### PR TITLE
[Core][Promotion] Fix taxon based promotions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,6 +9,10 @@ UPGRADE
 * Merged ``TranslationBundle`` with ``ResourceBundle``
 * Renamed ``TranslatableResourceRepository`` to ``TranslatableRepository``
 
+### Core and CoreBundle
+
+* Removed "exclude" option from ``taxon`` rule
+
 
 ## From 0.16 to 0.17.x
 

--- a/features/legacy/frontend/cart_promotions_fixed.feature
+++ b/features/legacy/frontend/cart_promotions_fixed.feature
@@ -53,8 +53,8 @@ Feature: Checkout fixed discount promotions
             | type                 | configuration |
             | Order fixed discount | Amount: 40    |
         And promotion "Ubuntu T-Shirts" has following rules defined:
-            | type  | configuration                      |
-            | Taxon | Taxons: Ubuntu T-Shirts,Exclude: 0 |
+            | type  | configuration           |
+            | Taxon | Taxons: Ubuntu T-Shirts |
         And promotion "Ubuntu T-Shirts" has following actions defined:
             | type                 | configuration |
             | Order fixed discount | Amount: 40    |

--- a/src/Sylius/Bundle/CoreBundle/Form/DataTransformer/TaxonsToCodesTransformer.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/DataTransformer/TaxonsToCodesTransformer.php
@@ -65,6 +65,10 @@ class TaxonsToCodesTransformer implements DataTransformerInterface
             return [];
         }
 
+        if (!is_array($value->get('taxons'))) {
+            throw new \InvalidArgumentException('"taxons" element of collection should be an array.');
+        }
+
         $taxons = [];
         /** @var TaxonInterface $taxon */
         foreach ($value->get('taxons') as $taxon) {

--- a/src/Sylius/Bundle/CoreBundle/Form/DataTransformer/TaxonsToCodesTransformer.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/DataTransformer/TaxonsToCodesTransformer.php
@@ -49,12 +49,7 @@ class TaxonsToCodesTransformer implements DataTransformerInterface
             return new ArrayCollection();
         }
 
-        $taxons = new ArrayCollection();
-        foreach ($value['taxons'] as $code) {
-            $taxons->add($this->taxonRepository->findOneBy(['code' => $code]));
-        }
-
-        return $taxons;
+        return new ArrayCollection($this->taxonRepository->findBy(['code' => $value['taxons']]));
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Form/DataTransformer/TaxonsToCodesTransformer.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/DataTransformer/TaxonsToCodesTransformer.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Form\DataTransformer;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Core\Model\TaxonInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
+use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class TaxonsToCodesTransformer implements DataTransformerInterface
+{
+    /**
+     * @var TaxonRepositoryInterface
+     */
+    private $taxonRepository;
+
+    /**
+     * @param TaxonRepositoryInterface $taxonRepository
+     */
+    public function __construct(TaxonRepositoryInterface $taxonRepository)
+    {
+        $this->taxonRepository = $taxonRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($value)
+    {
+        if (!is_array($value)) {
+            throw new UnexpectedTypeException($value, 'array');
+        }
+
+        if (empty($value)) {
+            return new ArrayCollection();
+        }
+
+        $taxons = new ArrayCollection();
+        foreach ($value['taxons'] as $code) {
+            $taxons->add($this->taxonRepository->findOneBy(['code' => $code]));
+        }
+
+        return $taxons;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reverseTransform($value)
+    {
+        if (!$value instanceof Collection) {
+            throw new UnexpectedTypeException($value, Collection::class);
+        }
+
+        if ($value->isEmpty() || null === $value->get('taxons')) {
+            return [];
+        }
+
+        $taxons = [];
+        /** @var TaxonInterface $taxon */
+        foreach ($value->get('taxons') as $taxon) {
+            $taxons[] = $taxon->getCode();
+        }
+
+        return ['taxons' => $taxons];
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Rule/TaxonConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Rule/TaxonConfigurationType.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\CoreBundle\Form\Type\Rule;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -20,6 +21,19 @@ use Symfony\Component\Form\FormBuilderInterface;
 class TaxonConfigurationType extends AbstractType
 {
     /**
+     * @var DataTransformerInterface
+     */
+    private $taxonsToCodesTransformer;
+
+    /**
+     * @param DataTransformerInterface $taxonsToCodesTransformer
+     */
+    public function __construct(DataTransformerInterface $taxonsToCodesTransformer)
+    {
+        $this->taxonsToCodesTransformer = $taxonsToCodesTransformer;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -27,10 +41,9 @@ class TaxonConfigurationType extends AbstractType
         $builder
             ->add('taxons', 'sylius_taxon_choice', [
                 'label' => 'sylius.form.rule.taxon_configuration.taxons',
+                'multiple' => true,
             ])
-            ->add('exclude', 'checkbox', [
-                'label' => 'sylius.form.rule.taxonomy_configuration.exclude',
-            ])
+            ->addModelTransformer($this->taxonsToCodesTransformer)
         ;
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/form.xml
@@ -48,6 +48,8 @@
         <parameter key="sylius.form.type.promotion_rule.customer_group_configuration.class">Sylius\Bundle\CoreBundle\Form\Type\Rule\CustomerGroupType</parameter>
         <parameter key="sylius.form.type.promotion_action.shipping_discount_configuration.class">Sylius\Bundle\CoreBundle\Form\Type\Action\ShippingDiscountConfigurationType</parameter>
         <parameter key="sylius.form.type.promotion_action.add_product_configuration.class">Sylius\Bundle\CoreBundle\Form\Type\Action\AddProductConfigurationType</parameter>
+
+        <parameter key="sylius.form.type.data_transformer.taxons_to_codes.class">Sylius\Bundle\CoreBundle\Form\DataTransformer\TaxonsToCodesTransformer</parameter>
     </parameters>
 
     <services>
@@ -140,6 +142,7 @@
             <tag name="form.type" alias="sylius_promotion_rule_shipping_country_configuration" />
         </service>
         <service id="sylius.form.type.promotion_rule.taxon_configuration" class="%sylius.form.type.promotion_rule.taxon_configuration.class%">
+            <argument type="service" id="sylius.form.type.data_transformer.taxons_to_codes" />
             <tag name="form.type" alias="sylius_promotion_rule_taxon_configuration" />
         </service>
         <service id="sylius.form.type.promotion_rule.contains_product_configuration" class="%sylius.form.type.promotion_rule.contains_product_configuration.class%">
@@ -169,6 +172,10 @@
         <service id="sylius.form.type.price_calculator.zone_based" class="%sylius.form.type.price_calculator.zone_based.class%">
             <argument type="service" id="sylius.repository.zone" />
             <tag name="form.type" alias="sylius_price_calculator_zone_based" />
+        </service>
+
+        <service id="sylius.form.type.data_transformer.taxons_to_codes" class="%sylius.form.type.data_transformer.taxons_to_codes.class%">
+            <argument type="service" id="sylius.repository.taxon" />
         </service>
     </services>
 

--- a/src/Sylius/Bundle/CoreBundle/spec/Form/DataTransformer/TaxonsToCodesTransformerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Form/DataTransformer/TaxonsToCodesTransformerSpec.php
@@ -30,14 +30,14 @@ class TaxonsToCodesTransformerSpec extends ObjectBehavior
         $this->beConstructedWith($taxonRepository);
     }
 
-    function it_implements_data_transformer_interface()
-    {
-        $this->shouldImplement(DataTransformerInterface::class);
-    }
-
     function it_is_initializable()
     {
         $this->shouldHaveType('Sylius\Bundle\CoreBundle\Form\DataTransformer\TaxonsToCodesTransformer');
+    }
+
+    function it_implements_data_transformer_interface()
+    {
+        $this->shouldImplement(DataTransformerInterface::class);
     }
 
     function it_transforms_array_of_taxons_codes_to_taxons_collection(
@@ -45,10 +45,20 @@ class TaxonsToCodesTransformerSpec extends ObjectBehavior
         TaxonInterface $bows,
         TaxonInterface $swords
     ) {
-        $taxonRepository->findOneBy(['code' => 'bows'])->willReturn($bows);
-        $taxonRepository->findOneBy(['code' => 'swords'])->willReturn($swords);
+        $taxonRepository->findBy(['code' => ['bows', 'swords']])->willReturn([$bows, $swords]);
 
         $taxons = new ArrayCollection([$bows->getWrappedObject(), $swords->getWrappedObject()]);
+
+        $this->transform(['taxons' => ['bows', 'swords']])->shouldBeCollection($taxons);
+    }
+
+    function it_transforms_only_existing_taxons(
+        TaxonRepositoryInterface $taxonRepository,
+        TaxonInterface $bows
+    ) {
+        $taxonRepository->findBy(['code' => ['bows', 'swords']])->willReturn([$bows]);
+
+        $taxons = new ArrayCollection([$bows->getWrappedObject()]);
 
         $this->transform(['taxons' => ['bows', 'swords']])->shouldBeCollection($taxons);
     }

--- a/src/Sylius/Bundle/CoreBundle/spec/Form/DataTransformer/TaxonsToCodesTransformerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Form/DataTransformer/TaxonsToCodesTransformerSpec.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\CoreBundle\Form\DataTransformer;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Core\Model\TaxonInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
+use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class TaxonsToCodesTransformerSpec extends ObjectBehavior
+{
+    function let(TaxonRepositoryInterface $taxonRepository)
+    {
+        $this->beConstructedWith($taxonRepository);
+    }
+
+    function it_implements_data_transformer_interface()
+    {
+        $this->shouldImplement(DataTransformerInterface::class);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\CoreBundle\Form\DataTransformer\TaxonsToCodesTransformer');
+    }
+
+    function it_transforms_array_of_taxons_codes_to_taxons_collection(
+        TaxonRepositoryInterface $taxonRepository,
+        TaxonInterface $bows,
+        TaxonInterface $swords
+    ) {
+        $taxonRepository->findOneBy(['code' => 'bows'])->willReturn($bows);
+        $taxonRepository->findOneBy(['code' => 'swords'])->willReturn($swords);
+
+        $taxons = new ArrayCollection([$bows->getWrappedObject(), $swords->getWrappedObject()]);
+
+        $this->transform(['taxons' => ['bows', 'swords']])->shouldBeCollection($taxons);
+    }
+    
+    function it_transforms_empty_array_into_empty_collection()
+    {
+        $this->transform([])->shouldBeCollection(new ArrayCollection([]));
+    }
+
+    function it_throws_exception_if_value_to_transform_is_not_array()
+    {
+        $this
+            ->shouldThrow(new UnexpectedTypeException('badObject', 'array'))
+            ->during('transform', ['badObject'])
+        ;
+    }
+
+    function it_reverse_transforms_taxons_collection_into_taxons_ids_and_names_array(
+        TaxonInterface $axes,
+        TaxonInterface $shields
+    ) {
+        $axes->getCode()->willReturn('axes');
+        $shields->getCode()->willReturn('shields');
+
+        $this
+            ->reverseTransform(new ArrayCollection(['taxons' => [$axes->getWrappedObject(), $shields->getWrappedObject()]]))
+            ->shouldReturn(['taxons' => ['axes', 'shields']])
+        ;
+    }
+
+    function it_throws_exception_if_reverse_transformed_object_is_not_collection()
+    {
+        $this
+            ->shouldThrow(new UnexpectedTypeException('badObject', Collection::class))
+            ->during('reverseTransform', ['badObject'])
+        ;
+    }
+
+    function it_returns_empty_array_if_passed_collection_is_empty()
+    {
+        $this->reverseTransform(new ArrayCollection())->shouldReturn([]);
+    }
+
+    function it_returns_empty_array_if_passed_collection_has_no_taxon_element()
+    {
+        $this->reverseTransform(new ArrayCollection(['test' => ['test']]))->shouldReturn([]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMatchers()
+    {
+        return [
+            'beCollection' => function ($subject, $key) {
+                if (!$subject instanceof Collection || !$key instanceof Collection) {
+                    return false;
+                }
+
+                if ($subject->count() !== $key->count()) {
+                    return false;
+                }
+
+                foreach ($subject as $subjectElement) {
+                    if (!$key->contains($subjectElement)) {
+                        return false;
+                    }
+                }
+
+                return true;
+            },
+        ];
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/spec/Form/DataTransformer/TaxonsToCodesTransformerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Form/DataTransformer/TaxonsToCodesTransformerSpec.php
@@ -76,7 +76,7 @@ class TaxonsToCodesTransformerSpec extends ObjectBehavior
         ;
     }
 
-    function it_reverse_transforms_taxons_collection_into_taxons_ids_and_names_array(
+    function it_reverse_transforms_into_array_of_taxons_codes(
         TaxonInterface $axes,
         TaxonInterface $shields
     ) {
@@ -105,6 +105,14 @@ class TaxonsToCodesTransformerSpec extends ObjectBehavior
     function it_returns_empty_array_if_passed_collection_has_no_taxon_element()
     {
         $this->reverseTransform(new ArrayCollection(['test' => ['test']]))->shouldReturn([]);
+    }
+
+    function it_throws_exception_while_reverse_transform_if_taxons_element_is_not_an_array(TaxonInterface $axes)
+    {
+        $this
+            ->shouldThrow(new \InvalidArgumentException('"taxons" element of collection should be an array.'))
+            ->during('reverseTransform', [new ArrayCollection(['taxons' => $axes->getWrappedObject()])])
+        ;
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/Behat/DefaultContext.php
+++ b/src/Sylius/Bundle/ResourceBundle/Behat/DefaultContext.php
@@ -200,7 +200,7 @@ abstract class DefaultContext extends RawMinkContext implements Context, KernelA
                     break;
 
                 case 'taxons':
-                    $configuration[$key] = new ArrayCollection([$this->getRepository('taxon')->findOneByName(trim($value))->getId()]);
+                    $configuration[$key] = [$this->getRepository('taxon')->findOneByName(trim($value))->getCode()];
                     break;
 
                 case 'variant':

--- a/src/Sylius/Component/Core/Promotion/Checker/TaxonRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/TaxonRuleChecker.php
@@ -18,8 +18,6 @@ use Sylius\Component\Promotion\Exception\UnsupportedTypeException;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
 
 /**
- * Checks if order contains products with given taxon.
- *
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
 class TaxonRuleChecker implements RuleCheckerInterface
@@ -29,6 +27,10 @@ class TaxonRuleChecker implements RuleCheckerInterface
      */
     public function isEligible(PromotionSubjectInterface $subject, array $configuration)
     {
+        if (!isset($configuration['taxons'])) {
+            return;
+        }
+
         if (!$subject instanceof OrderInterface) {
             throw new UnsupportedTypeException($subject, OrderInterface::class);
         }
@@ -36,13 +38,13 @@ class TaxonRuleChecker implements RuleCheckerInterface
         /* @var $item OrderItemInterface */
         foreach ($subject->getItems() as $item) {
             foreach ($item->getProduct()->getTaxons() as $taxon) {
-                if ($configuration['taxons']->contains($taxon->getId())) {
-                    return !$configuration['exclude'];
+                if (in_array($taxon->getCode(), $configuration['taxons'])) {
+                    return true;
                 }
             }
         }
 
-        return (Boolean) $configuration['exclude'];
+        return false;
     }
 
     /**

--- a/src/Sylius/Component/Core/Promotion/Checker/TaxonRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/TaxonRuleChecker.php
@@ -38,7 +38,7 @@ class TaxonRuleChecker implements RuleCheckerInterface
         /* @var $item OrderItemInterface */
         foreach ($subject->getItems() as $item) {
             foreach ($item->getProduct()->getTaxons() as $taxon) {
-                if (in_array($taxon->getCode(), $configuration['taxons'])) {
+                if (in_array($taxon->getCode(), $configuration['taxons'], true)) {
                     return true;
                 }
             }

--- a/src/Sylius/Component/Core/spec/Promotion/Checker/TaxonRuleCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Checker/TaxonRuleCheckerSpec.php
@@ -11,16 +11,19 @@
 
 namespace spec\Sylius\Component\Core\Promotion\Checker;
 
-use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\Product;
 use Sylius\Component\Core\Model\Taxon;
 use Sylius\Component\Promotion\Checker\RuleCheckerInterface;
+use Sylius\Component\Promotion\Exception\UnsupportedTypeException;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
 
 /**
  * @author Joseph Bielawski <stloyd@gmail.com>
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
 class TaxonRuleCheckerSpec extends ObjectBehavior
 {
@@ -29,84 +32,73 @@ class TaxonRuleCheckerSpec extends ObjectBehavior
         $this->shouldHaveType('Sylius\Component\Core\Promotion\Checker\TaxonRuleChecker');
     }
 
-    function it_should_be_sylius_rule_checker()
+    function it_is_rule_checker()
     {
         $this->shouldImplement(RuleCheckerInterface::class);
     }
 
-    function it_should_recognize_subject_as_eligible_if_product_taxon_is_matched(
+    function it_recognizes_subject_as_eligible_if_product_taxon_is_matched(
         OrderInterface $subject,
         OrderItemInterface $item,
-        Taxon $taxon,
-        Product $product,
-        ArrayCollection $collection
+        Product $bastardSword,
+        Taxon $swords
     ) {
-        $configuration = ['taxons' => $collection, 'exclude' => false];
+        $configuration = ['taxons' => ['swords']];
 
-        $collection->contains(1)->willReturn(true);
-
-        $taxon->getId()->willReturn(1);
-        $product->getTaxons()->willReturn([$taxon]);
-        $item->getProduct()->willReturn($product);
+        $swords->getCode()->willReturn('swords');
+        $bastardSword->getTaxons()->willReturn([$swords]);
+        $item->getProduct()->willReturn($bastardSword);
         $subject->getItems()->willReturn([$item]);
 
         $this->isEligible($subject, $configuration)->shouldReturn(true);
     }
 
-    function it_should_recognize_subject_as_not_eligible_if_product_taxon_is_not_matched(
+    function it_recognizes_subject_as_eligible_if_product_taxon_is_matched_to_one_of_required_taxons(
         OrderInterface $subject,
         OrderItemInterface $item,
-        Taxon $taxon,
-        Product $product,
-        ArrayCollection $collection
+        Product $bastardSword,
+        Taxon $swords
     ) {
-        $configuration = ['taxons' => $collection, 'exclude' => false];
+        $configuration = ['taxons' => ['swords', 'axes']];
 
-        $collection->contains(1)->willReturn(false);
-
-        $taxon->getId()->willReturn(1);
-        $product->getTaxons()->willReturn([$taxon]);
-        $item->getProduct()->willReturn($product);
-        $subject->getItems()->willReturn([$item]);
-
-        $this->isEligible($subject, $configuration)->shouldReturn(false);
-    }
-
-    function it_should_recognize_subject_as_eligible_if_product_taxon_is_not_matched_and_exclude_is_set(
-        OrderInterface $subject,
-        OrderItemInterface $item,
-        Taxon $taxon,
-        Product $product,
-        ArrayCollection $collection
-    ) {
-        $configuration = ['taxons' => $collection, 'exclude' => true];
-
-        $collection->contains(1)->willReturn(false);
-
-        $taxon->getId()->willReturn(1);
-        $product->getTaxons()->willReturn([$taxon]);
-        $item->getProduct()->willReturn($product);
+        $swords->getCode()->willReturn('swords');
+        $bastardSword->getTaxons()->willReturn([$swords]);
+        $item->getProduct()->willReturn($bastardSword);
         $subject->getItems()->willReturn([$item]);
 
         $this->isEligible($subject, $configuration)->shouldReturn(true);
     }
 
-    function it_should_recognize_subject_as_not_eligible_if_product_taxon_is_matched_and_exclude_is_set(
+    function it_recognizes_subject_as_not_eligible_if_product_taxon_is_not_matched(
         OrderInterface $subject,
         OrderItemInterface $item,
-        Taxon $taxon,
-        Product $product,
-        ArrayCollection $collection
+        Product $reflexBow,
+        Taxon $bows
     ) {
-        $configuration = ['taxons' => $collection, 'exclude' => true];
+        $configuration = ['taxons' => ['swords', 'axes']];
 
-        $collection->contains(2)->willReturn(true);
-
-        $taxon->getId()->willReturn(2);
-        $product->getTaxons()->willReturn([$taxon]);
-        $item->getProduct()->willReturn($product);
+        $bows->getCode()->willReturn('bows');
+        $reflexBow->getTaxons()->willReturn([$bows]);
+        $item->getProduct()->willReturn($reflexBow);
         $subject->getItems()->willReturn([$item]);
 
         $this->isEligible($subject, $configuration)->shouldReturn(false);
+    }
+
+    function it_does_nothing_if_configuration_is_invalid(OrderInterface $subject)
+    {
+        $subject->getItems()->shouldNotBeCalled();
+
+        $this->isEligible($subject, []);
+    }
+
+    function it_throws_exception_if_promotion_subject_is_not_order(
+        Collection $taxonsCollection,
+        PromotionSubjectInterface $subject
+    ) {
+        $this
+            ->shouldThrow(new UnsupportedTypeException($subject->getWrappedObject(), OrderInterface::class))
+            ->during('isEligible', [$subject, ['taxons' => $taxonsCollection]])
+        ;
     }
 }

--- a/src/Sylius/Component/Core/spec/Promotion/Checker/TaxonRuleCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Checker/TaxonRuleCheckerSpec.php
@@ -15,8 +15,8 @@ use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
-use Sylius\Component\Core\Model\Product;
-use Sylius\Component\Core\Model\Taxon;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Promotion\Checker\RuleCheckerInterface;
 use Sylius\Component\Promotion\Exception\UnsupportedTypeException;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
@@ -40,8 +40,8 @@ class TaxonRuleCheckerSpec extends ObjectBehavior
     function it_recognizes_subject_as_eligible_if_product_taxon_is_matched(
         OrderInterface $subject,
         OrderItemInterface $item,
-        Product $bastardSword,
-        Taxon $swords
+        ProductInterface $bastardSword,
+        TaxonInterface $swords
     ) {
         $configuration = ['taxons' => ['swords']];
 
@@ -56,8 +56,8 @@ class TaxonRuleCheckerSpec extends ObjectBehavior
     function it_recognizes_subject_as_eligible_if_product_taxon_is_matched_to_one_of_required_taxons(
         OrderInterface $subject,
         OrderItemInterface $item,
-        Product $bastardSword,
-        Taxon $swords
+        ProductInterface $bastardSword,
+        TaxonInterface $swords
     ) {
         $configuration = ['taxons' => ['swords', 'axes']];
 
@@ -72,8 +72,8 @@ class TaxonRuleCheckerSpec extends ObjectBehavior
     function it_recognizes_subject_as_not_eligible_if_product_taxon_is_not_matched(
         OrderInterface $subject,
         OrderItemInterface $item,
-        Product $reflexBow,
-        Taxon $bows
+        ProductInterface $reflexBow,
+        TaxonInterface $bows
     ) {
         $configuration = ['taxons' => ['swords', 'axes']];
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially https://github.com/Sylius/Sylius/issues/4544
| License         | MIT
| Doc PR          |

* fix ``taxon`` promotion rule (change taxons collection to taxons' codes array)
* removed "exclude" option for ``taxon`` rule
* modify ``taxon`` rule configuration type to handle multiple taxons

Known issues:
* while editing promotion with existing ``taxon`` rule, picked taxons are not checked - I suppose it can be skipped for now, as in the nearest future it will be rewrite into new backend layout