### PR TITLE
[WIP][ThemeBundle] Context aware themes

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Theme/ChannelBasedThemeContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Theme/ChannelBasedThemeContext.php
@@ -18,6 +18,7 @@ use Sylius\Component\Core\Model\ChannelInterface;
 
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
+ * @author Rafał Muszyński <rafal.muszynski@sourcefabric.org>
  */
 final class ChannelBasedThemeContext implements ThemeContextInterface
 {
@@ -41,7 +42,7 @@ final class ChannelBasedThemeContext implements ThemeContextInterface
     {
         try {
             /** @var ChannelInterface $channel */
-            $channel = $this->channelContext->getChannel();
+            $channel = $this->getChannel();
 
             return $channel->getTheme();
         } catch (ChannelNotFoundException $exception) {
@@ -49,5 +50,25 @@ final class ChannelBasedThemeContext implements ThemeContextInterface
         } catch (\Exception $exception) {
             return null;
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        try {
+            /** @var ChannelInterface $channel */
+            $channel = $this->getChannel();
+
+            return $channel->getCode();
+        } catch (ChannelNotFoundException $exception) {
+            return null;
+        }
+    }
+
+    private function getChannel()
+    {
+        return $this->channelContext->getChannel();
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Theme/ChannelBasedThemeContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Theme/ChannelBasedThemeContext.php
@@ -42,7 +42,7 @@ final class ChannelBasedThemeContext implements ThemeContextInterface
     {
         try {
             /** @var ChannelInterface $channel */
-            $channel = $this->getChannel();
+            $channel = $this->channelContext->getChannel();
 
             return $channel->getTheme();
         } catch (ChannelNotFoundException $exception) {
@@ -57,18 +57,6 @@ final class ChannelBasedThemeContext implements ThemeContextInterface
      */
     public function getName()
     {
-        try {
-            /** @var ChannelInterface $channel */
-            $channel = $this->getChannel();
-
-            return $channel->getCode();
-        } catch (ChannelNotFoundException $exception) {
-            return null;
-        }
-    }
-
-    private function getChannel()
-    {
-        return $this->channelContext->getChannel();
+        return;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/Theme/ChannelBasedThemeContextSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Theme/ChannelBasedThemeContextSpec.php
@@ -80,22 +80,7 @@ class ChannelBasedThemeContextSpec extends ObjectBehavior
         $this->getTheme()->shouldReturn(null);
     }
 
-    function it_returns_a_name(
-        ChannelContextInterface $channelContext,
-        ChannelInterface $channel,
-        ThemeInterface $theme
-    ) {
-        $channelContext->getChannel()->willReturn($channel);
-        $channel->getCode()->willReturn('default');
-
-        $this->getName()->shouldReturn('default');
-    }
-
-    function its_name_is_null_if_there_is_no_channel(
-        ChannelContextInterface $channelContext
-    ) {
-        $channelContext->getChannel()->willThrow(ChannelNotFoundException::class);
-
+    function its_name_is_null() {
         $this->getName()->shouldReturn(null);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/Theme/ChannelBasedThemeContextSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Theme/ChannelBasedThemeContextSpec.php
@@ -24,6 +24,7 @@ use Sylius\Component\Core\Model\ChannelInterface;
  * @mixin ChannelBasedThemeContext
  *
  * @author Kamil Kokot <kamil.kokot@lakion.com>
+ * @author Rafał Muszyński <rafal.muszynski@sourcefabric.org>
  */
 class ChannelBasedThemeContextSpec extends ObjectBehavior
 {
@@ -77,5 +78,24 @@ class ChannelBasedThemeContextSpec extends ObjectBehavior
         $channelContext->getChannel()->willThrow(\Exception::class);
 
         $this->getTheme()->shouldReturn(null);
+    }
+
+    function it_returns_a_name(
+        ChannelContextInterface $channelContext,
+        ChannelInterface $channel,
+        ThemeInterface $theme
+    ) {
+        $channelContext->getChannel()->willReturn($channel);
+        $channel->getCode()->willReturn('default');
+
+        $this->getName()->shouldReturn('default');
+    }
+
+    function its_name_is_null_if_there_is_no_channel(
+        ChannelContextInterface $channelContext
+    ) {
+        $channelContext->getChannel()->willThrow(ChannelNotFoundException::class);
+
+        $this->getName()->shouldReturn(null);
     }
 }

--- a/src/Sylius/Bundle/ThemeBundle/Context/EmptyThemeContext.php
+++ b/src/Sylius/Bundle/ThemeBundle/Context/EmptyThemeContext.php
@@ -18,11 +18,17 @@ final class EmptyThemeContext implements ThemeContextInterface
 {
     /**
      * {@inheritdoc}
-     *
-     * @return null
      */
     public function getTheme()
     {
-        return null;
+        return;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return;
     }
 }

--- a/src/Sylius/Bundle/ThemeBundle/Context/SettableThemeContext.php
+++ b/src/Sylius/Bundle/ThemeBundle/Context/SettableThemeContext.php
@@ -38,4 +38,12 @@ final class SettableThemeContext implements ThemeContextInterface
     {
         return $this->theme;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return;
+    }
 }

--- a/src/Sylius/Bundle/ThemeBundle/Context/ThemeContextInterface.php
+++ b/src/Sylius/Bundle/ThemeBundle/Context/ThemeContextInterface.php
@@ -24,4 +24,11 @@ interface ThemeContextInterface
      * @return ThemeInterface|null
      */
     public function getTheme();
+
+    /**
+     * Returns context name.
+     *
+     * @return string|null
+     */
+    public function getName();
 }

--- a/src/Sylius/Bundle/ThemeBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/ThemeBundle/DependencyInjection/Configuration.php
@@ -119,6 +119,24 @@ class Configuration implements ConfigurationInterface
      */
     private function addContextConfiguration(ArrayNodeDefinition $rootNode)
     {
-        $rootNode->children()->scalarNode('context')->defaultValue('sylius.theme.context.settable')->cannotBeEmpty();
+        $rootNode
+            ->children()
+                ->arrayNode('context')
+                    ->beforeNormalization()
+                    ->ifString()
+                        ->then(function($value) { return ['service_id' => $value]; })
+                    ->end()
+                    ->children()
+                        ->scalarNode('service_id')
+                            ->defaultValue('sylius.theme.context.settable')
+                            ->cannotBeEmpty()
+                        ->end()
+                        ->booleanNode('context_aware_paths')
+                            ->defaultFalse()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
     }
 }

--- a/src/Sylius/Bundle/ThemeBundle/DependencyInjection/SyliusThemeExtension.php
+++ b/src/Sylius/Bundle/ThemeBundle/DependencyInjection/SyliusThemeExtension.php
@@ -44,7 +44,7 @@ class SyliusThemeExtension extends AbstractResourceExtension
         $container->setAlias('sylius.theme.configuration.loader', 'sylius.theme.configuration.loader.json_file');
         $container->setAlias('sylius.theme.configuration.provider', 'sylius.theme.configuration.provider.filesystem');
         $container->setParameter('sylius.theme.configuration.filesystem.locations', $config['sources']['filesystem']['locations']);
-        $container->setParameter('sylius.theme.context.context_aware_paths', $config['context']['context_aware_paths']);
+        $container->setParameter('sylius.theme.configuration.context.context_aware_paths', $config['context']['context_aware_paths']);
 
         $loader->load(sprintf('driver/%s.xml', $config['driver']));
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/ThemeBundle/DependencyInjection/SyliusThemeExtension.php
+++ b/src/Sylius/Bundle/ThemeBundle/DependencyInjection/SyliusThemeExtension.php
@@ -35,14 +35,16 @@ class SyliusThemeExtension extends AbstractResourceExtension
         $loader->load('services.xml');
         $loader->load('templating.xml');
         $loader->load('translations.xml');
+        $loader->load('listeners.xml');
 
-        $container->setAlias('sylius.context.theme', $config['context']);
+        $container->setAlias('sylius.context.theme', $config['context']['service_id']);
 
         // TODO: Interfaces ready for filesystem decoupling, configuration not ready yet
         $loader->load('filesystem_configuration.xml');
         $container->setAlias('sylius.theme.configuration.loader', 'sylius.theme.configuration.loader.json_file');
         $container->setAlias('sylius.theme.configuration.provider', 'sylius.theme.configuration.provider.filesystem');
         $container->setParameter('sylius.theme.configuration.filesystem.locations', $config['sources']['filesystem']['locations']);
+        $container->setParameter('sylius.theme.context.context_aware_paths', $config['context']['context_aware_paths']);
 
         $loader->load(sprintf('driver/%s.xml', $config['driver']));
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/ThemeBundle/EventListener/ThemeSynchronizationListener.php
+++ b/src/Sylius/Bundle/ThemeBundle/EventListener/ThemeSynchronizationListener.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ThemeBundle\EventListener;
+
+use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
+use Sylius\Bundle\ThemeBundle\Synchronizer\ThemeSynchronizerInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * @author Rafał Muszyński <rafal.muszynski@sourcefabric.org>
+ */
+class ThemeSynchronizationListener
+{
+    /**
+     * @var ThemeSynchronizerInterface
+     */
+    private $themeSynchronizer;
+
+    /**
+     * @param ThemeSynchronizerInterface $themeSynchronizer
+     */
+    public function __construct(ThemeSynchronizerInterface $themeSynchronizer)
+    {
+        $this->themeSynchronizer = $themeSynchronizer;
+    }
+
+    /**
+     * @param GenericEvent $event
+     */
+    public function synchronizeTheme(GenericEvent $event)
+    {
+        $this->themeSynchronizer->synchronize($this->getTheme($event));
+    }
+
+    /**
+     * @param GenericEvent $event
+     */
+    public function synchronize(GenericEvent $event)
+    {
+        $this->themeSynchronizer->synchronize();
+    }
+
+    /**
+     * @param GenericEvent $event
+     *
+     * @return ThemeInterface
+     *
+     * @throws UnexpectedTypeException
+     */
+    protected function getTheme(GenericEvent $event)
+    {
+        $theme = $event->getSubject();
+
+        if (!$theme instanceof ThemeInterface) {
+            throw new UnexpectedTypeException($theme, ThemeInterface::class);
+        }
+
+        return $theme;
+    }
+}

--- a/src/Sylius/Bundle/ThemeBundle/Helper/PathHelper.php
+++ b/src/Sylius/Bundle/ThemeBundle/Helper/PathHelper.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ThemeBundle\Helper;
+
+use Sylius\Bundle\ThemeBundle\Context\ThemeContextInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+/**
+ * @author Rafał Muszyński <rafal.muszynski@sourcefabric.org>
+ */
+final class PathHelper implements PathHelperInterface
+{
+    /**
+     * @var ThemeContextInterface
+     */
+    private $themeContext;
+
+    /**
+     * @var bool
+     */
+    private $isContextAware;
+
+    /**
+     * @param ThemeContextInterface $themeContext
+     * @param bool                  $isContextAware
+     */
+    public function __construct(ThemeContextInterface $themeContext, $isContextAware)
+    {
+        $this->themeContext = $themeContext;
+        $this->isContextAware = $isContextAware;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function applySuffixFor(array $paths = [])
+    {
+        if (!$this->canBeContextAware()) {
+            return $paths;
+        }
+
+        $contextAwarePaths = [];
+        foreach ($paths as $path) {
+            $paths[] = rtrim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$this->themeContext->getName();
+        }
+
+        return $contextAwarePaths;
+    }
+
+    /**
+     * @return bool
+     *
+     * @throws InvalidConfigurationException
+     */
+    private function canBeContextAware()
+    {
+        $this->isContextAware = true;
+        if ($this->isContextAware &&
+            isset($this->themeContext) &&
+            null === $this->themeContext->getName()
+        ) {
+            throw new InvalidConfigurationException(
+                sprintf('You have enabled "context_aware_paths" setting but your "%s::getName()" method must return a name!', get_class($this->themeContext))
+            );
+        }
+
+        if (!$this->isContextAware ||
+            !isset($this->themeContext) ||
+            null === $this->themeContext->getName()
+        ) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Sylius/Bundle/ThemeBundle/Helper/PathHelper.php
+++ b/src/Sylius/Bundle/ThemeBundle/Helper/PathHelper.php
@@ -50,7 +50,7 @@ final class PathHelper implements PathHelperInterface
 
         $contextAwarePaths = [];
         foreach ($paths as $path) {
-            $paths[] = rtrim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$this->themeContext->getName();
+            $contextAwarePaths[] = rtrim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$this->themeContext->getName();
         }
 
         return $contextAwarePaths;
@@ -63,20 +63,13 @@ final class PathHelper implements PathHelperInterface
      */
     private function canBeContextAware()
     {
-        $this->isContextAware = true;
-        if ($this->isContextAware &&
-            isset($this->themeContext) &&
-            null === $this->themeContext->getName()
-        ) {
+        if ($this->isContextAware && null === $this->themeContext->getName()) {
             throw new InvalidConfigurationException(
                 sprintf('You have enabled "context_aware_paths" setting but your "%s::getName()" method must return a name!', get_class($this->themeContext))
             );
         }
 
-        if (!$this->isContextAware ||
-            !isset($this->themeContext) ||
-            null === $this->themeContext->getName()
-        ) {
+        if (!$this->isContextAware || null === $this->themeContext->getName()) {
             return false;
         }
 

--- a/src/Sylius/Bundle/ThemeBundle/Helper/PathHelperInterface.php
+++ b/src/Sylius/Bundle/ThemeBundle/Helper/PathHelperInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ThemeBundle\Helper;
+
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+/**
+ * @author Rafał Muszyński <rafal.muszynski@sourcefabric.org>
+ */
+interface PathHelperInterface
+{
+    /**
+     * @return array
+     *
+     * @throws InvalidConfigurationException If not allowed to make context aware paths.
+     */
+    public function applySuffixFor(array $paths = []);
+}

--- a/src/Sylius/Bundle/ThemeBundle/Locator/RecursiveFileLocator.php
+++ b/src/Sylius/Bundle/ThemeBundle/Locator/RecursiveFileLocator.php
@@ -31,7 +31,15 @@ final class RecursiveFileLocator implements FileLocatorInterface
      */
     private $paths;
 
+    /**
+     * @var ThemeContextInterface|null
+     */
     private $themeContext;
+
+    /**
+     * @var bool
+     */
+    private $isContextAware;
 
     /**
      * @param FinderFactoryInterface $finderFactory
@@ -67,6 +75,16 @@ final class RecursiveFileLocator implements FileLocatorInterface
     public function setThemeContext(ThemeContextInterface $themeContext = null)
     {
         $this->themeContext = $themeContext;
+    }
+
+    /**
+     * Is context aware path.
+     *
+     * @param bool Determines if the themes path should be context aware.
+     */
+    public function isContextAware($isContextAware = false)
+    {
+        $this->isContextAware = $isContextAware;
     }
 
     /**
@@ -107,20 +125,6 @@ final class RecursiveFileLocator implements FileLocatorInterface
         }
     }
 
-    private function applySuffixForPaths()
-    {
-        if (!isset($this->themeContext) || null === $this->themeContext->getName()) {
-            return;
-        }
-
-        $paths = [];
-        foreach ($this->paths as $path) {
-            $paths[] = rtrim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$this->themeContext->getName();
-        }
-
-        $this->paths = $paths;
-    }
-
     /**
      * @param string $name
      */
@@ -131,5 +135,22 @@ final class RecursiveFileLocator implements FileLocatorInterface
                 'An empty file name is not valid to be located.'
             );
         }
+    }
+
+    private function applySuffixForPaths()
+    {
+        if (!$this->isContextAware ||
+            !isset($this->themeContext) ||
+            null === $this->themeContext->getName()
+        ) {
+            return;
+        }
+
+        $paths = [];
+        foreach ($this->paths as $path) {
+            $paths[] = rtrim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$this->themeContext->getName();
+        }
+
+        $this->paths = $paths;
     }
 }

--- a/src/Sylius/Bundle/ThemeBundle/Locator/RecursiveFileLocator.php
+++ b/src/Sylius/Bundle/ThemeBundle/Locator/RecursiveFileLocator.php
@@ -12,11 +12,12 @@
 namespace Sylius\Bundle\ThemeBundle\Locator;
 
 use Sylius\Bundle\ThemeBundle\Factory\FinderFactoryInterface;
-use Symfony\Component\Finder\Finder;
+use Sylius\Bundle\ThemeBundle\Context\ThemeContextInterface;
 use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
+ * @author Rafał Muszyński <rafal.muszynski@sourcefabric.org>
  */
 final class RecursiveFileLocator implements FileLocatorInterface
 {
@@ -30,9 +31,11 @@ final class RecursiveFileLocator implements FileLocatorInterface
      */
     private $paths;
 
+    private $themeContext;
+
     /**
      * @param FinderFactoryInterface $finderFactory
-     * @param array $paths An array of paths where to look for resources
+     * @param array                  $paths         An array of paths where to look for resources
      */
     public function __construct(FinderFactoryInterface $finderFactory, array $paths)
     {
@@ -57,6 +60,16 @@ final class RecursiveFileLocator implements FileLocatorInterface
     }
 
     /**
+     * Sets the Theme Context.
+     *
+     * @param ThemeContextInterface|null $themeContext Theme context
+     */
+    public function setThemeContext(ThemeContextInterface $themeContext = null)
+    {
+        $this->themeContext = $themeContext;
+    }
+
+    /**
      * @param string $name
      *
      * @return \Generator
@@ -64,7 +77,7 @@ final class RecursiveFileLocator implements FileLocatorInterface
     private function doLocateFilesNamed($name)
     {
         $this->assertNameIsNotEmpty($name);
-
+        $this->applySuffixForPaths();
         $found = false;
         foreach ($this->paths as $path) {
             try {
@@ -92,6 +105,20 @@ final class RecursiveFileLocator implements FileLocatorInterface
                 implode(', ', $this->paths)
             ));
         }
+    }
+
+    private function applySuffixForPaths()
+    {
+        if (!isset($this->themeContext) || null === $this->themeContext->getName()) {
+            return;
+        }
+
+        $paths = [];
+        foreach ($this->paths as $path) {
+            $paths[] = rtrim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$this->themeContext->getName();
+        }
+
+        $this->paths = $paths;
     }
 
     /**

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/filesystem_configuration.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/filesystem_configuration.xml
@@ -29,7 +29,7 @@
                 <argument type="service" id="sylius.context.theme" />
             </call>
             <call method="isContextAware">
-                <argument>%sylius.theme.context.context_aware_paths%</argument>
+                <argument>%sylius.theme.configuration.context.context_aware_paths%</argument>
             </call>
         </service>
 

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/filesystem_configuration.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/filesystem_configuration.xml
@@ -25,12 +25,7 @@
         <service id="sylius.theme.recursive_file_locator" class="%sylius.theme.recursive_file_locator.class%" public="false">
             <argument type="service" id="sylius.theme.finder_factory" />
             <argument>%sylius.theme.configuration.filesystem.locations%</argument>
-            <call method="setThemeContext">
-                <argument type="service" id="sylius.context.theme" />
-            </call>
-            <call method="isContextAware">
-                <argument>%sylius.theme.configuration.context.context_aware_paths%</argument>
-            </call>
+            <argument type="service" id="sylius.theme.path_helper" />
         </service>
 
         <!-- TODO: json_file.processing as decorator (some bug :/) -->

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/filesystem_configuration.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/filesystem_configuration.xml
@@ -28,6 +28,9 @@
             <call method="setThemeContext">
                 <argument type="service" id="sylius.context.theme" />
             </call>
+            <call method="isContextAware">
+                <argument>%sylius.theme.context.context_aware_paths%</argument>
+            </call>
         </service>
 
         <!-- TODO: json_file.processing as decorator (some bug :/) -->

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/filesystem_configuration.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/filesystem_configuration.xml
@@ -25,6 +25,9 @@
         <service id="sylius.theme.recursive_file_locator" class="%sylius.theme.recursive_file_locator.class%" public="false">
             <argument type="service" id="sylius.theme.finder_factory" />
             <argument>%sylius.theme.configuration.filesystem.locations%</argument>
+            <call method="setThemeContext">
+                <argument type="service" id="sylius.context.theme" />
+            </call>
         </service>
 
         <!-- TODO: json_file.processing as decorator (some bug :/) -->

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/listeners.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="sylius.listener.theme_synchronization.class">Sylius\Bundle\ThemeBundle\EventListener\ThemeSynchronizationListener</parameter>
+    </parameters>
+
+    <services>
+        <service id="sylius.listener.theme_synchronization" class="%sylius.listener.theme_synchronization.class%">
+            <argument type="service" id="sylius.theme.synchronizer" />
+            <tag name="kernel.event_listener" event="sylius.theme.added" method="synchronize" />
+            <tag name="kernel.event_listener" event="sylius.theme.updated" method="synchronizeTheme" />
+            <tag name="kernel.event_listener" event="sylius.theme.removed" method="synchronizeTheme" />
+        </service>
+    </services>
+</container>

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/services.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/services.xml
@@ -13,6 +13,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
+        <parameter key="sylius.theme.path_helper.class">Sylius\Bundle\ThemeBundle\Helper\PathHelper</parameter>
         <parameter key="sylius.context.theme.class">Sylius\Bundle\ThemeBundle\Context\SettableThemeContext</parameter>
         <parameter key="sylius.factory.theme_author.class">Sylius\Bundle\ThemeBundle\Factory\ThemeAuthorFactory</parameter>
         <parameter key="sylius.theme.hydrator.class">Sylius\Bundle\ThemeBundle\Hydrator\ThemeHydrator</parameter>
@@ -30,6 +31,11 @@
     </parameters>
 
     <services>
+        <service id="sylius.theme.path_helper" class="%sylius.theme.path_helper.class%" public="false">
+            <argument type="service" id="sylius.context.theme" />
+            <argument>%sylius.theme.configuration.context.context_aware_paths%</argument>
+        </service>
+
         <service id="sylius.theme.context.settable" class="%sylius.theme.context.settable.class%" public="false">
             <argument type="service" id="sylius.theme.hierarchy_provider" />
         </service>

--- a/src/Sylius/Bundle/ThemeBundle/SyliusThemeEvents.php
+++ b/src/Sylius/Bundle/ThemeBundle/SyliusThemeEvents.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ThemeBundle;
+
+/**
+ * @author Rafał Muszyński <rafal.muszynski@sourcefabric.org>
+ */
+final class SyliusThemeEvents
+{
+    /**
+     * The THEME_ADDED event occurs when a new theme is added.
+     *
+     * @var string
+     */
+    const THEME_ADDED = 'sylius.theme.added';
+
+    /**
+     * The THEME_REMOVED event occurs when the existing theme is removed.
+     *
+     * @var string
+     */
+    const THEME_REMOVED = 'sylius.theme.removed';
+
+    /**
+     * The THEME_UPDATED event occurs when the existing theme is updated.
+     *
+     * @var string
+     */
+    const THEME_UPDATED = 'sylius.theme.updated';
+}

--- a/src/Sylius/Bundle/ThemeBundle/Synchronizer/ThemeSynchronizer.php
+++ b/src/Sylius/Bundle/ThemeBundle/Synchronizer/ThemeSynchronizer.php
@@ -17,6 +17,7 @@ use Sylius\Bundle\ThemeBundle\Repository\ThemeRepositoryInterface;
 
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
+ * @author Rafał Muszyński <rafal.muszynski@sourcefabric.org>
  */
 final class ThemeSynchronizer implements ThemeSynchronizerInterface
 {
@@ -53,10 +54,10 @@ final class ThemeSynchronizer implements ThemeSynchronizerInterface
     /**
      * {@inheritdoc}
      */
-    public function synchronize()
+    public function synchronize(ThemeInterface $theme = null)
     {
-        $persistedThemes = $this->themeRepository->findAll();
         $loadedThemes = $this->themeLoader->load();
+        $persistedThemes = $this->getPersisted($theme);
 
         $removedThemes = $this->removeAbandonedThemes($persistedThemes, $loadedThemes);
         $existingThemes = array_udiff(
@@ -68,6 +69,20 @@ final class ThemeSynchronizer implements ThemeSynchronizerInterface
         );
 
         $this->updateThemes($existingThemes, $loadedThemes);
+    }
+
+    /**
+     * @param  ThemeInterface|null $theme
+     *
+     * @return ThemeInterface[]
+     */
+    private function getPersisted(ThemeInterface $theme = null)
+    {
+        if (null !== $theme) {
+            return [$theme];
+        }
+
+        return $this->themeRepository->findAll();
     }
 
     /**

--- a/src/Sylius/Bundle/ThemeBundle/Synchronizer/ThemeSynchronizerInterface.php
+++ b/src/Sylius/Bundle/ThemeBundle/Synchronizer/ThemeSynchronizerInterface.php
@@ -11,13 +11,17 @@
 
 namespace Sylius\Bundle\ThemeBundle\Synchronizer;
 
+use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
+
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
 interface ThemeSynchronizerInterface
 {
     /**
+     * @param null|ThemeInterface $theme The theme
+     *
      * @throws SynchronizationFailedException If synchronization fails
      */
-    public function synchronize();
+    public function synchronize(ThemeInterface $theme = null);
 }

--- a/src/Sylius/Bundle/ThemeBundle/spec/Context/EmptyThemeContextSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/Context/EmptyThemeContextSpec.php
@@ -20,6 +20,7 @@ use Sylius\Bundle\ThemeBundle\Context\ThemeContextInterface;
  * @mixin EmptyThemeContext
  *
  * @author Kamil Kokot <kamil.kokot@lakion.com>
+ * @author Rafał Muszyński <rafal.muszynski@sourcefabric.org>
  */
 class EmptyThemeContextSpec extends ObjectBehavior
 {
@@ -36,5 +37,6 @@ class EmptyThemeContextSpec extends ObjectBehavior
     function it_always_returns_null()
     {
         $this->getTheme()->shouldReturn(null);
+        $this->getName()->shouldReturn(null);
     }
 }

--- a/src/Sylius/Bundle/ThemeBundle/spec/Context/SettableThemeContextSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/Context/SettableThemeContextSpec.php
@@ -22,6 +22,7 @@ use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
  * @mixin SettableThemeContext
  *
  * @author Kamil Kokot <kamil.kokot@lakion.com>
+ * @author Rafał Muszyński <rafal.muszynski@sourcefabric.org>
  */
 class SettableThemeContextSpec extends ObjectBehavior
 {
@@ -41,5 +42,10 @@ class SettableThemeContextSpec extends ObjectBehavior
 
         $this->setTheme($theme);
         $this->getTheme()->shouldReturn($theme);
+    }
+
+    function its_name_is_empty(ThemeInterface $theme)
+    {
+        $this->getName()->shouldReturn(null);
     }
 }

--- a/src/Sylius/Bundle/ThemeBundle/spec/EventListener/ThemeSynchronizationListenerSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/EventListener/ThemeSynchronizationListenerSpec.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ThemeBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ThemeBundle\EventListener\ThemeSynchronizationListener;
+use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
+use Sylius\Bundle\ThemeBundle\Synchronizer\ThemeSynchronizerInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * @mixin ThemeSynchronizationListener
+ *
+ * @author Rafał Muszyński <rafal.muszynski@sourcefabric.org>
+ */
+class ThemeSynchronizationListenerSpec extends ObjectBehavior
+{
+    function let(ThemeSynchronizerInterface $themeSynchronizer) {
+        $this->beConstructedWith($themeSynchronizer);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ThemeSynchronizationListener::class);
+    }
+
+    function it_throws_exception_if_subject_is_not_theme(GenericEvent $event, \stdClass $nonTheme)
+    {
+        $event->getSubject()->willReturn($nonTheme);
+
+        $this->shouldThrow(UnexpectedTypeException::class)
+            ->duringSynchronizeTheme($event);
+    }
+
+    function it_synchronizes_theme(GenericEvent $event, ThemeInterface $theme, $themeSynchronizer)
+    {
+        $event->getSubject()->willReturn($theme);
+        $themeSynchronizer->synchronize($theme)->shouldBeCalled();
+
+        $this->synchronizeTheme($event);
+    }
+
+    function it_synchronizes_themes(GenericEvent $event, $themeSynchronizer)
+    {
+        $themeSynchronizer->synchronize()->shouldBeCalled();
+
+        $this->synchronize($event);
+    }
+}

--- a/src/Sylius/Bundle/ThemeBundle/spec/Helper/PathHelperSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/Helper/PathHelperSpec.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ThemeBundle\Helper;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ThemeBundle\Context\ThemeContextInterface;
+use Sylius\Bundle\ThemeBundle\Helper\PathHelper;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+/**
+ * @mixin PathHelper
+ *
+ * @author Rafał Muszyński <rafal.muszynski@sourcefabric.org>
+ */
+class PathHelperSpec extends ObjectBehavior
+{
+	function let(ThemeContextInterface $themeContext)
+    {
+        $this->beConstructedWith($themeContext, false);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PathHelper::class);
+    }
+
+    function it_should_not_apply_suffix($themeContext)
+    {
+    	$paths = ['sylius/nested1', 'theme/nested2'];
+
+    	$this->applySuffixFor($paths)->shouldReturn($paths);
+    }
+
+    function it_should_apply_suffix_to_paths($themeContext)
+    {
+    	$this->beConstructedWith($themeContext, true);
+
+    	$themeContext->getName()->willReturn('suffix');
+    	$paths = ['sylius/nested1', 'theme/nested2'];
+
+    	$this->applySuffixFor($paths)->shouldReturn(['sylius/nested1/suffix', 'theme/nested2/suffix']);
+    }
+
+    function it_should_not_apply_suffix_to_paths_when_name_is_null_and_setting_not_enabled($themeContext)
+    {
+    	$themeContext->getName()->willReturn(null);
+    	$paths = ['sylius/nested1', 'theme/nested2'];
+
+    	$this->applySuffixFor($paths)->shouldReturn($paths);
+    }
+
+    function it_should_throw_an_exception($themeContext)
+    {
+    	$this->beConstructedWith($themeContext, true);
+    	$themeContext->getName()->willReturn(null);
+
+    	$this->shouldThrow(InvalidConfigurationException::class)
+    		->duringApplySuffixFor(['sylius/nested1', 'theme/nested2']);
+    }
+
+    function it_should_return_empty_array($themeContext)
+    {
+    	$themeContext->getName()->willReturn('suffix');
+
+    	$this->applySuffixFor([])->shouldReturn([]);
+    }
+}

--- a/src/Sylius/Bundle/ThemeBundle/spec/Locator/RecursiveFileLocatorSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/Locator/RecursiveFileLocatorSpec.php
@@ -80,6 +80,7 @@ class RecursiveFileLocatorSpec extends ObjectBehavior
 
         $splFileInfo->getPathname()->willReturn('/search/path/context_dir/nested/readme.md');
 
+        $this->isContextAware(true)->shouldBeNull();
         $this->setThemeContext($themeContext)->shouldBeNull();
         $this->locateFileNamed('readme.md')->shouldReturn('/search/path/context_dir/nested/readme.md');
     }
@@ -104,6 +105,32 @@ class RecursiveFileLocatorSpec extends ObjectBehavior
 
         $splFileInfo->getPathname()->willReturn('/search/path/nested/readme.md');
 
+        $this->isContextAware(true)->shouldBeNull();
+        $this->setThemeContext($themeContext)->shouldBeNull();
+        $this->locateFileNamed('readme.md')->shouldReturn('/search/path/nested/readme.md');
+    }
+
+    function it_should_not_make_context_aware_paths_when_setting_disabled(
+        FinderFactoryInterface $finderFactory,
+        Finder $finder,
+        SplFileInfo $splFileInfo,
+        ThemeContextInterface $themeContext
+    ) {
+        $finderFactory->create()->willReturn($finder);
+        $themeContext->getName()->shouldNotBeCalled();
+
+        $finder->name('readme.md')->shouldBeCalled()->willReturn($finder);
+        $finder->in('/search/path/')->shouldBeCalled()->willReturn($finder);
+        $finder->ignoreUnreadableDirs()->shouldBeCalled()->willReturn($finder);
+        $finder->files()->shouldBeCalled()->willReturn($finder);
+
+        $finder->getIterator()->willReturn(new \ArrayIterator([
+            $splFileInfo->getWrappedObject(),
+        ]));
+
+        $splFileInfo->getPathname()->willReturn('/search/path/nested/readme.md');
+
+        $this->isContextAware(false)->shouldBeNull();
         $this->setThemeContext($themeContext)->shouldBeNull();
         $this->locateFileNamed('readme.md')->shouldReturn('/search/path/nested/readme.md');
     }
@@ -158,6 +185,7 @@ class RecursiveFileLocatorSpec extends ObjectBehavior
         $firstSplFileInfo->getPathname()->willReturn('/search/path/context_dir/nested1/readme.md');
         $secondSplFileInfo->getPathname()->willReturn('/search/path/context_dir/nested2/readme.md');
 
+        $this->isContextAware(true)->shouldBeNull();
         $this->setThemeContext($themeContext)->shouldBeNull();
         $this->locateFilesNamed('readme.md')->shouldReturn([
             '/search/path/context_dir/nested1/readme.md',


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | fixes #4280 
| License         | MIT
| Doc PR          | -

New features:
- [x] - possibility to store themes under context aware directories

If a config setting `context_aware_paths` under `sylius_theme -> context` is set to `true` in config file and if a name of the current context is given (see `ChannelBasedThemeContext` class - `getName()` method), themes will be loaded from the directory: e.g. `/themes/<context_name>/<theme>`.

If a config setting `context_aware_paths` is set to `true` and theme context name is `null`, it will throw an exception:
```
You have enabled "context_aware_paths" setting but your "%s" method must return a name!
```
**Note**
The code will break if someone uses a custom theme context with current implementation (without these changes), because in this PR I introduced `getName` method in `ThemeContextInterface`, so it can allow to get the context name on which we can rely later on to keep themes per channel (channel name in Sylius case) under the different subdirectories.

- [x] - implemented theme events: update / remove / add

TODO
- [ ] - fix RecursiveFileLocator spec
- [ ] - add unit tests for configuration (phpunit)