### PR TITLE
Fixed wrong namespace in Bundle registration for ReportBundle

### DIFF
--- a/docs/bundles/SyliusReportBundle/installation.rst
+++ b/docs/bundles/SyliusReportBundle/installation.rst
@@ -38,7 +38,7 @@ Don't worry, everything was automatically installed via Composer.
             new JMS\SerializerBundle\JMSSerializerBundle($this),
             new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
-            new Sylius\Bundle\ProductBundle\SyliusReportBundle(),
+            new Sylius\Bundle\ReportBundle\SyliusReportBundle(),
             new Sylius\Bundle\ResourceBundle\SyliusResourceBundle(),
 
             // Other bundles...


### PR DESCRIPTION
I just fixed wrong namespace usage in bundle registration (@ AppKernel) for ReportBundle.


| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT
| Doc PR        | http://docs.sylius.org/en/latest/bundles/SyliusReportBundle/installation.html 1.1
