### PR TITLE
[Promotion] Don't lock Doctrine to version 2.4.x only

### DIFF
--- a/src/Sylius/Component/Promotion/composer.json
+++ b/src/Sylius/Component/Promotion/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^5.5.9|^7.0",
 
-        "doctrine/orm": "^2.4.8,<2.5",
+        "doctrine/orm": "^2.4.8",
         "sylius/registry": "^0.18",
         "sylius/resource": "^0.18"
     },


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Without this change I cannot use newest versions of this standalone component.
