### PR TITLE
[WebBundle] Improve shipment transitions and tracking form

### DIFF
--- a/src/Sylius/Bundle/ShippingBundle/Controller/ShipmentController.php
+++ b/src/Sylius/Bundle/ShippingBundle/Controller/ShipmentController.php
@@ -44,7 +44,7 @@ class ShipmentController extends ResourceController
 
             $this->flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $shipment);
 
-            return $this->redirectHandler->redirectToResource($configuration, $shipment);
+            return $this->redirectHandler->redirectToReferer($configuration);
         }
 
         $view = View::create()

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Macros/misc.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Macros/misc.html.twig
@@ -85,13 +85,23 @@
     {%- endfor %}
 {% endmacro %}
 
-{% macro shipment_form(shipment) %}
+{% macro shipment_form(shipment, tracking_form = null) %}
     {% for transition in ['hold', 'release', 'backorder', 'prepare', 'ship', 'cancel', 'return'] if sm_can(shipment, transition, 'sylius_shipment') -%}
-        <form action="{{ path('sylius_backend_shipment_update_state', {'id': shipment.id, 'transition': transition}) }}" method="post" style="display: inline">
-            <input type="hidden" name="_method" value="PUT">
-            <button class="btn btn-{{ transition == 'cancel' ? 'warning' : 'primary' }}" type="submit">
-                <i class="glyphicon glyphicon-{{ transition == 'cancel' ? 'remove' : 'share' }}"></i> <span>{{ ('sylius.shipment.transition.'~transition)|trans }}</span>
-            </button>
-        </form>
+        {% if transition == 'ship' %}
+            <form action="{{ path('sylius_backend_shipment_ship', {'id': shipment.id}) }}" method="post">
+                {% if tracking_form is defined and tracking_form is not null %}
+                    {% include 'SyliusWebBundle:Backend/Shipment:trackingForm.html.twig' with {'form': tracking_form} %}
+                {% else %}
+                    {% render(controller('sylius.controller.backend.form:showAction', {'type': 'sylius_shipment_tracking', 'template': 'SyliusWebBundle:Backend/Shipment:trackingForm.html.twig'})) %}
+                {% endif %}
+            </form>
+        {% else %}
+            <form action="{{ path('sylius_backend_shipment_update_state', {'id': shipment.id, 'transition': transition}) }}" method="post" style="display: inline">
+                <input type="hidden" name="_method" value="PUT">
+                <button class="btn btn-{{ transition == 'cancel' ? 'warning' : 'primary' }}" type="submit">
+                    <i class="glyphicon glyphicon-{{ transition == 'cancel' ? 'remove' : 'share' }}"></i> <span>{{ ('sylius.shipment.transition.'~transition)|trans }}</span>
+                </button>
+            </form>
+        {% endif %}
     {%- endfor %}
 {% endmacro %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
@@ -293,10 +293,6 @@
                 <i class="glyphicon glyphicon-repeat"></i> <span>{{ 'sylius.ui.release_inventory'|trans }}</span>
             </button>
         </form>
-    {% elseif 1 == order.shipments|length and constant('Sylius\\Component\\Order\\Model\\OrderInterface::STATE_CONFIRMED') == order.state and constant('Sylius\\Component\\Payment\\Model\\PaymentInterface::STATE_COMPLETED') == order.paymentState %}
-        <form action="{{ path('sylius_backend_shipment_ship', {'id': order.shipments.current.id}) }}" method="post">
-            {% render(controller('sylius.controller.backend.form:showAction', {'type': 'sylius_shipment_tracking', 'template': 'SyliusWebBundle:Backend/Shipment:trackingForm.html.twig'})) %}
-        </form>
     {% endif %}
     </div>
 </div>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/show.html.twig
@@ -88,17 +88,9 @@
         <h4>{{ 'sylius.ui.shipping_address'|trans }}</h4>
         {% include 'SyliusWebBundle:Backend/Address:_show.html.twig' with {'address': shipment.order.shippingAddress } %}
     </div>
-    {% if sm_can(shipment, constant('Sylius\\Component\\Shipping\\ShipmentTransitions::SYLIUS_SHIP'), constant('Sylius\\Component\\Shipping\\ShipmentTransitions::GRAPH')) %}
-        <div class="col-md-6">
-            <form action="{{ path('sylius_backend_shipment_ship', {'id': shipment.id}) }}" method="post">
-                {% if shipment_tracking_form is defined %}
-                    {% include 'SyliusWebBundle:Backend/Shipment:trackingForm.html.twig' with {'form': shipment_tracking_form} %}
-                {% else %}
-                    {% render(controller('sylius.controller.backend.form:showAction', {'type': 'sylius_shipment_tracking', 'template': 'SyliusWebBundle:Backend/Shipment:trackingForm.html.twig'})) %}
-                {% endif %}
-            </form>
-        </div>
-    {% endif %}
+    <div class="col-md-12">
+        {{ misc.shipment_form(shipment, shipment_tracking_form is defined ? shipment_tracking_form : null) }}
+    </div>
 </div>
 
 {% if shipment.units|length > 0 %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Now when shipments are in one of `hold`, `release`, `backorder`, `prepare`, `cancel` or `return` transition states, it will show the transition buttons, and if in **ship** transition state it will show a tracking form.