### PR TITLE
[Admin] Don't render whole form by default on create/update page

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Country/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Country/_form.html.twig
@@ -3,4 +3,3 @@
     {{ form_row(form.code) }}
     {{ form_row(form.enabled) }}
 </div>
-{{ form_rest(form) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/create.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/create.html.twig
@@ -20,5 +20,6 @@
         {% endif %}
         {% include 'SyliusUiBundle:Form:_create.html.twig' %}
     </div>
-{{ form_end(form) }}
+{{ form_row(form._token) }}
+{{ form_end(form, {'render_rest': false}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/update.html.twig
@@ -21,5 +21,6 @@
         {% endif %}
         {% include 'SyliusUiBundle:Form:_saveChanges.html.twig' %}
     </div>
-{{ form_end(form) }}
+{{ form_row(form._token) }}
+{{ form_end(form, {'render_rest': false}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Locale/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Locale/_form.html.twig
@@ -3,4 +3,3 @@
     {{ form_row(form.code) }}
     {{ form_row(form.enabled) }}
 </div>
-{{ form_rest(form) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/TaxCategory/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/TaxCategory/_form.html.twig
@@ -4,4 +4,3 @@
     {{ form_row(form.name) }}
 </div>
 {{ form_row(form.description) }}
-{{ form_rest(form) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/TaxRate/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/TaxRate/_form.html.twig
@@ -1,4 +1,3 @@
-
 {{ form_errors(form) }}
 <div class="three fields">
     {{ form_row(form.code) }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

As ``{{ form_end(form) }}`` has been added at the end of every form, it was impossible to render only part of form's fields. I've changed it into ``{{ form_end(form, {'render_rest': false}) }}`` and added {{ form_row(form._token) }} (as token is always needed) to prevent such a inconvenience. 