### PR TITLE
[Travis] Use strict Composer validation for the main composer.json / composer.lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_script:
     - php -i | grep -v 'SYMFONY__'
 
 script:
-    - composer validate
+    - composer validate --strict
     - etc/bin/validate-packages
 
     - if [[ $TRAVIS_PHP_VERSION = 7.* ]]; then bin/kawaii gherkin:check --align=left features/; fi;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

`--strict` ensures that package is ready for releasing.