### PR TITLE
[Metadata] Fix modifying metadata by serializing it early

### DIFF
--- a/features/legacy/backend/metadata/metadata_customization.feature
+++ b/features/legacy/backend/metadata/metadata_customization.feature
@@ -24,6 +24,16 @@ Feature: Metadata customization
             | Description | <empty>           |
             | Twitter     | <empty>           |
 
+    Scenario: Modifying existing page metadata
+        Given there is the following metadata "ZBIGNIEW-WODECKI":
+            | Title | Regular musician |
+        And I am customizing metadata with identifier "ZBIGNIEW-WODECKI"
+        When I fill in "Title" with "Expressive virtuoso"
+        And I press "Save changes"
+        Then I should be on the page of metadata container with id "ZBIGNIEW-WODECKI"
+        And I should see the following metadata:
+            | Title | Expressive virtuoso |
+
     @javascript
     Scenario: Managing dynamic Twitter form
         Given I am customizing metadata

--- a/src/Sylius/Bundle/CoreBundle/Behat/MetadataContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Behat/MetadataContext.php
@@ -181,14 +181,7 @@ class MetadataContext extends DefaultContext
      */
     public function thereIsTheFollowingMetadata($metadataName, TableNode $table)
     {
-        /** @var MetadataContainerInterface $metadata */
-        $metadata = $this->getFactory('metadata_container')->createNew();
-
         $pageMetadata = new PageMetadata();
-
-        $metadata->setId($metadataName);
-        $metadata->setMetadata($pageMetadata);
-
         foreach ($table->getRowsHash() as $key => $value) {
             if ($this->createNewMetadataObjectIfNeeded($pageMetadata, $key, $value)) {
                 continue;
@@ -200,6 +193,11 @@ class MetadataContext extends DefaultContext
 
             $this->propertyAccessor->setValue($pageMetadata, $key, $value);
         }
+
+        /** @var MetadataContainerInterface $metadata */
+        $metadata = $this->getFactory('metadata_container')->createNew();
+        $metadata->setId($metadataName);
+        $metadata->setMetadata($pageMetadata);
 
         $em = $this->getEntityManager();
         $em->persist($metadata);

--- a/src/Sylius/Bundle/MetadataBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/MetadataBundle/DependencyInjection/Configuration.php
@@ -12,8 +12,8 @@
 namespace Sylius\Bundle\MetadataBundle\DependencyInjection;
 
 use Sylius\Bundle\MetadataBundle\Controller\MetadataController;
-use Sylius\Bundle\MetadataBundle\Form\Type\MetadataContainerType;
 use Sylius\Bundle\MetadataBundle\Model\MetadataContainer;
+use Sylius\Bundle\MetadataBundle\Form\Type\MetadataContainerType;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Sylius\Component\Metadata\Factory\MetadataContainerFactory;
 use Sylius\Component\Metadata\Model\MetadataContainerInterface;

--- a/src/Sylius/Bundle/MetadataBundle/Model/MetadataContainer.php
+++ b/src/Sylius/Bundle/MetadataBundle/Model/MetadataContainer.php
@@ -12,13 +12,12 @@
 namespace Sylius\Bundle\MetadataBundle\Model;
 
 use Sylius\Component\Metadata\Model\MetadataContainer as BaseMetadataContainer;
-use Sylius\Component\Metadata\Model\MetadataContainerInterface;
 use Sylius\Component\Metadata\Model\MetadataInterface;
 
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-class MetadataContainer extends BaseMetadataContainer implements MetadataContainerInterface
+class MetadataContainer extends BaseMetadataContainer
 {
     /**
      * @var MetadataInterface
@@ -43,10 +42,6 @@ class MetadataContainer extends BaseMetadataContainer implements MetadataContain
     public function setMetadata(MetadataInterface $metadata)
     {
         $this->metadataAsObject = $metadata;
-    }
-
-    public function serializeMetadata()
-    {
-        $this->metadata = serialize($this->metadataAsObject);
+        $this->metadata = serialize($metadata);
     }
 }

--- a/src/Sylius/Bundle/MetadataBundle/Resources/config/doctrine/model/MetadataContainer.orm.xml
+++ b/src/Sylius/Bundle/MetadataBundle/Resources/config/doctrine/model/MetadataContainer.orm.xml
@@ -12,16 +12,9 @@
 -->
 
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping">
-
     <mapped-superclass name="Sylius\Bundle\MetadataBundle\Model\MetadataContainer" table="sylius_metadata">
         <id name="id" column="id" type="string" />
 
         <field name="metadata" column="metadata" type="text" />
-
-        <lifecycle-callbacks>
-            <lifecycle-callback type="prePersist" method="serializeMetadata" />
-            <lifecycle-callback type="preUpdate" method="serializeMetadata" />
-        </lifecycle-callbacks>
     </mapped-superclass>
-
 </doctrine-mapping>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #4472
| License         | MIT

Metadata cannot be stored as `object` ORM type, because objects are
compared (===) by reference, not by value, what means that changes
would not be persisted.

The only working way I have found is to store metadata as `text`
type and serialize it on MetadataContainer::setMetadata() method
call. However, after every metadata modification we have to use that
method once again, if not - changes won't be persisted.