### PR TITLE
[Bug Fix] Make sure doctrine removes orphan tax rates

### DIFF
--- a/src/Sylius/Bundle/TaxationBundle/Resources/config/doctrine/model/TaxCategory.orm.xml
+++ b/src/Sylius/Bundle/TaxationBundle/Resources/config/doctrine/model/TaxCategory.orm.xml
@@ -23,7 +23,8 @@
         <field name="name" column="name" type="string" />
         <field name="description" column="description" type="text" nullable="true" />
 
-        <one-to-many field="rates" target-entity="Sylius\Component\Taxation\Model\TaxRateInterface" mapped-by="category">
+        <one-to-many field="rates" target-entity="Sylius\Component\Taxation\Model\TaxRateInterface" mapped-by="category"
+            orphan-removal="true">
             <cascade>
                 <cascade-all/>
             </cascade>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

There is a bug now where you cannot remove existing tax rates from a tax category instance. It will try to set the tax rates category to `null`. We want to remove the tax rate entirely when it's not connected to a tax category anymore. This PR fixes this.
