### PR TITLE
[WebBundle] Fix finalize page

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
@@ -97,7 +97,7 @@
                 {% endfor %}
                 </ul>
                 </td>
-                {% set promotionTotal = cart.getPromotionsTotalRecursively() %}
+                {% set promotionTotal = order.getPromotionsTotalRecursively() %}
                 <td colspan="2">
                     <span class="pull-right">
                     <strong>{{ 'sylius.ui.promotion_total'|trans }}</strong>: -{{ (-1 * promotionTotal)|sylius_price }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

```getPromotionsTotalRecursively``` exists on the Order model, not the Cart model.

