### PR TITLE
[Core] Get last payment's method also from failed payments

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checkout/CheckoutProcessScenario.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/CheckoutProcessScenario.php
@@ -74,7 +74,7 @@ class CheckoutProcessScenario implements ProcessScenarioInterface
     {
         $lastNewPayment = $this->getCurrentCart()->getLastPayment();
 
-        if (false !== $lastNewPayment) {
+        if (null !== $lastNewPayment) {
             return $lastNewPayment->getId();
         }
 

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -297,12 +297,14 @@ class Order extends Cart implements OrderInterface
     public function getLastPayment($state = BasePaymentInterface::STATE_NEW)
     {
         if ($this->payments->isEmpty()) {
-            return false;
+            return null;
         }
 
-        return $this->payments->filter(function (BasePaymentInterface $payment) use ($state) {
+        $payment = $this->payments->filter(function (BasePaymentInterface $payment) use ($state) {
             return $payment->getState() === $state;
         })->last();
+
+        return $payment !== false ? $payment : null;
     }
 
     /**

--- a/src/Sylius/Component/Core/Model/OrderInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderInterface.php
@@ -170,7 +170,7 @@ interface OrderInterface extends
     /**
      * @param $state
      *
-     * @return PaymentInterface|false
+     * @return null|PaymentInterface
      */
     public function getLastPayment($state = PaymentInterface::STATE_NEW);
 

--- a/src/Sylius/Component/Core/spec/OrderProcessing/PaymentProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/PaymentProcessorSpec.php
@@ -45,8 +45,9 @@ class PaymentProcessorSpec extends ObjectBehavior
     ) {
         $order->getTotal()->willReturn(1234);
         $order->getCurrency()->willReturn('EUR');
-        $order->getLastPayment(PaymentInterface::STATE_CANCELLED)->willReturn(false);
-        $order->getLastPayment(PaymentInterface::STATE_NEW)->willReturn(false);
+        $order->getLastPayment(PaymentInterface::STATE_CANCELLED)->willReturn(null);
+        $order->getLastPayment(PaymentInterface::STATE_FAILED)->willReturn(null);
+        $order->getLastPayment(PaymentInterface::STATE_NEW)->willReturn(null);
 
         $paymentFactory->createWithAmountAndCurrency(1234, 'EUR')->willReturn($payment);
 
@@ -65,7 +66,7 @@ class PaymentProcessorSpec extends ObjectBehavior
         $order->getTotal()->willReturn(1234);
         $order->getCurrency()->willReturn('EUR');
         $order->getLastPayment(PaymentInterface::STATE_CANCELLED)->willReturn($cancelledPayment);
-        $order->getLastPayment(PaymentInterface::STATE_NEW)->willReturn(false);
+        $order->getLastPayment(PaymentInterface::STATE_NEW)->willReturn(null);
         $cancelledPayment->getMethod()->willReturn($paymentMethodFromLastCancelledPayment);
 
         $paymentFactory->createWithAmountAndCurrency(1234, 'EUR')->willReturn($payment);
@@ -84,15 +85,55 @@ class PaymentProcessorSpec extends ObjectBehavior
         $order->getTotal()->willReturn(1234);
         $order->getCurrency()->willReturn('EUR');
         $paymentFactory->createWithAmountAndCurrency(1234, 'EUR')->willReturn($payment);
-        $order->getLastPayment(PaymentInterface::STATE_CANCELLED)->willReturn(false);
-        $order->getLastPayment(PaymentInterface::STATE_NEW)->willReturn(false);
+        $order->getLastPayment(PaymentInterface::STATE_CANCELLED)->willReturn(null);
+        $order->getLastPayment(PaymentInterface::STATE_FAILED)->willReturn(null);
+        $order->getLastPayment(PaymentInterface::STATE_NEW)->willReturn(null);
         $payment->setMethod()->shouldNotBeCalled();
         $order->addPayment($payment)->shouldBeCalled();
 
         $this->processOrderPayments($order);
     }
 
-    function it_does_not_set_payment_method_from_last_cancelled_payment_during_processing_if_new_payment_exists(
+    function it_sets_payment_method_from_last_failed_payment_during_processing(
+        $paymentFactory,
+        PaymentInterface $payment,
+        PaymentInterface $failedPayment,
+        OrderInterface $order,
+        PaymentMethodInterface $paymentMethodFromLastFailedPayment
+    ) {
+        $order->getTotal()->willReturn(1234);
+        $order->getCurrency()->willReturn('EUR');
+        $order->getLastPayment(PaymentInterface::STATE_CANCELLED)->willReturn(null);
+        $order->getLastPayment(PaymentInterface::STATE_FAILED)->willReturn($failedPayment);
+        $order->getLastPayment(PaymentInterface::STATE_NEW)->willReturn(null);
+        $failedPayment->getMethod()->willReturn($paymentMethodFromLastFailedPayment);
+
+        $paymentFactory->createWithAmountAndCurrency(1234, 'EUR')->willReturn($payment);
+        $payment->setMethod($paymentMethodFromLastFailedPayment)->shouldBeCalled();
+
+        $order->addPayment($payment)->shouldBeCalled();
+
+        $this->processOrderPayments($order);
+    }
+
+    function it_does_not_set_payment_method_from_last_failed_payment_during_processing(
+        $paymentFactory,
+        PaymentInterface $payment,
+        OrderInterface $order
+    ) {
+        $order->getTotal()->willReturn(1234);
+        $order->getCurrency()->willReturn('EUR');
+        $paymentFactory->createWithAmountAndCurrency(1234, 'EUR')->willReturn($payment);
+        $order->getLastPayment(PaymentInterface::STATE_CANCELLED)->willReturn(null);
+        $order->getLastPayment(PaymentInterface::STATE_FAILED)->willReturn(null);
+        $order->getLastPayment(PaymentInterface::STATE_NEW)->willReturn(null);
+        $payment->setMethod()->shouldNotBeCalled();
+        $order->addPayment($payment)->shouldBeCalled();
+
+        $this->processOrderPayments($order);
+    }
+
+    function it_does_not_add_payment_during_processing_if_new_payment_already_exists(
         PaymentFactoryInterface $paymentFactory,
         PaymentInterface $newPaymentReadyToPay,
         PaymentInterface $cancelledPayment,
@@ -102,11 +143,12 @@ class PaymentProcessorSpec extends ObjectBehavior
         $order->getTotal()->willReturn(1234);
         $order->getCurrency()->willReturn('EUR');
         $order->getLastPayment(PaymentInterface::STATE_CANCELLED)->willReturn($cancelledPayment);
+        $order->getLastPayment(PaymentInterface::STATE_FAILED)->willReturn(null);
         $order->getLastPayment(PaymentInterface::STATE_NEW)->willReturn($newPaymentReadyToPay);
 
         $paymentFactory->createWithAmountAndCurrency(1234, 'EUR')->willReturn($payment);
         $payment->setMethod($cancelledPayment)->shouldNotBeCalled();
-        $order->addPayment($payment)->shouldBeCalled();
+        $order->addPayment($payment)->shouldNotBeCalled();
 
         $this->processOrderPayments($order);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Because of this bug customers would see an exception due to `lastPayment->method` was not set (`null`) correctly.
