### PR TITLE
Set promotion coupon in cart to not required

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/CartType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/CartType.php
@@ -47,6 +47,7 @@ class CartType extends BaseCartType
             ->add('promotionCoupon', 'sylius_promotion_coupon_to_code', [
                 'by_reference' => false,
                 'label' => 'sylius.form.cart.coupon',
+                'required' => false,
             ])
             ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
                 $data = $event->getData();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

Shouldn't the promotion coupon be optional in cart?