### PR TITLE
[Twig] Sematic money widget

### DIFF
--- a/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/CurrencyHelper.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/CurrencyHelper.php
@@ -14,6 +14,7 @@ namespace Sylius\Bundle\CurrencyBundle\Templating\Helper;
 use Sylius\Bundle\MoneyBundle\Templating\Helper\MoneyHelperInterface;
 use Sylius\Component\Currency\Context\CurrencyContextInterface;
 use Sylius\Component\Currency\Converter\CurrencyConverterInterface;
+use Symfony\Component\Intl\Intl;
 use Symfony\Component\Templating\Helper\Helper;
 
 /**
@@ -70,6 +71,14 @@ class CurrencyHelper extends Helper implements CurrencyHelperInterface
         $amount = $this->converter->convertFromBase($amount, $currency);
 
         return $this->moneyHelper->formatAmount($amount, $currency, $decimal);
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentCurrencySymbol()
+    {
+        return Intl::getCurrencyBundle()->getCurrencySymbol($this->currencyContext->getCurrency());
     }
 
     /**

--- a/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/CurrencyHelperInterface.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/CurrencyHelperInterface.php
@@ -37,4 +37,9 @@ interface CurrencyHelperInterface
      * @return string
      */
     public function convertAndFormatAmount($amount, $currency = null, $decimal = false);
+
+    /**
+     * @return string
+     */
+    public function getCurrentCurrencySymbol();
 }

--- a/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
@@ -36,38 +36,22 @@ class CurrencyExtension extends \Twig_Extension
     /**
      * {@inheritdoc}
      */
-    public function getFilters()
+    public function getFunctions()
     {
         return [
-            new \Twig_SimpleFilter('sylius_currency', [$this, 'convertAmount']),
-            new \Twig_SimpleFilter('sylius_price', [$this, 'convertAndFormatAmount']),
+            new \Twig_SimpleFunction('sylius_currency_symbol', [$this->helper, 'getCurrentCurrencySymbol']),
         ];
     }
 
     /**
-     * Convert amount to target currency.
-     *
-     * @param int     $amount
-     * @param string|null $currency
-     *
-     * @return string
+     * {@inheritdoc}
      */
-    public function convertAmount($amount, $currency = null)
+    public function getFilters()
     {
-        return $this->helper->convertAmount($amount, $currency);
-    }
-
-    /**
-     * Convert and format amount.
-     *
-     * @param int     $amount
-     * @param string|null $currency
-     *
-     * @return string
-     */
-    public function convertAndFormatAmount($amount, $currency = null)
-    {
-        return $this->helper->convertAndFormatAmount($amount, $currency);
+        return [
+            new \Twig_SimpleFilter('sylius_currency', [$this->helper, 'convertAmount']),
+            new \Twig_SimpleFilter('sylius_price', [$this->helper, 'convertAndFormatAmount']),
+        ];
     }
 
     /**

--- a/src/Sylius/Bundle/CurrencyBundle/spec/Templating/Helper/CurrencyHelperSpec.php
+++ b/src/Sylius/Bundle/CurrencyBundle/spec/Templating/Helper/CurrencyHelperSpec.php
@@ -12,12 +12,15 @@
 namespace spec\Sylius\Bundle\CurrencyBundle\Templating\Helper;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelper;
 use Sylius\Bundle\MoneyBundle\Templating\Helper\MoneyHelperInterface;
 use Sylius\Component\Currency\Context\CurrencyContextInterface;
 use Sylius\Component\Currency\Converter\CurrencyConverterInterface;
 use Symfony\Component\Templating\Helper\Helper;
 
 /**
+ * @mixin CurrencyHelper
+ * 
  * @author Paweł Jędrzejewski <pjedrzejewski@diweb.pl>
  */
 class CurrencyHelperSpec extends ObjectBehavior
@@ -55,5 +58,12 @@ class CurrencyHelperSpec extends ObjectBehavior
         $this->convertAmount(2500, 'USD')->shouldReturn(1913);
         $this->convertAmount(312, 'PLN')->shouldReturn(407);
         $this->convertAmount(500)->shouldReturn(653);
+    }
+
+    function it_provides_current_currency(CurrencyContextInterface $currencyContext)
+    {
+        $currencyContext->getCurrency()->willReturn('PLN');
+
+        $this->getCurrentCurrencySymbol()->shouldReturn('PLN');
     }
 }

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -27,3 +27,10 @@
         </div>
     </div>
 {%- endblock checkbox_row %}
+
+{% block money_widget -%}
+    <div class="ui labeled input">
+        <div class="ui label">$</div>
+        {{- form_widget(form) -}}
+    </div>
+{%- endblock money_widget %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -30,7 +30,7 @@
 
 {% block money_widget -%}
     <div class="ui labeled input">
-        <div class="ui label">$</div>
+        <div class="ui label">{{ sylius_currency_symbol() }}</div>
         {{- form_widget(form) -}}
     </div>
 {%- endblock money_widget %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This widget rendering:
![zrzut ekranu 2016-04-04 o 13 48 55](https://cloud.githubusercontent.com/assets/6213903/14247128/43ee7906-fa6c-11e5-811b-1a8c826f5c6c.png)
will be changed to this one:
![zrzut ekranu 2016-04-04 o 13 49 15](https://cloud.githubusercontent.com/assets/6213903/14247136/51e0df9a-fa6c-11e5-8973-e3083fcf6c2a.png)

_Update_
Currency extension was extended to provide current currency instead of hardcoded _$_