### PR TITLE
[Twig] Percentage twig widget

### DIFF
--- a/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
@@ -54,12 +54,12 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
      */
     public function checkValidationMessageFor($element, $message)
     {
-        $foundedElement = $this->getElement($element)->getParent()->find('css', '.pointing');
+        $foundedElement = $this->getFieldElement($element);
         if (null === $foundedElement) {
             throw new ElementNotFoundException(sprintf('Element %s with message %s cannot be found on page', $element, $message));
         }
 
-        return $message === $foundedElement->getText();
+        return $message === $foundedElement->find('css', '.pointing')->getText();
     }
 
     /**
@@ -76,5 +76,22 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
     protected function getResourceName()
     {
         return $this->resourceName;
+    }
+
+    /**
+     * @param string $element
+     *
+     * @return \Behat\Mink\Element\NodeElement|null
+     *
+     * @throws ElementNotFoundException
+     */
+    private function getFieldElement($element)
+    {
+        $element = $this->getElement($element);
+        while (null !== $element && !($element->hasClass('field'))) {
+            $element = $element->getParent();
+        }
+
+        return $element;
     }
 }

--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
@@ -54,12 +54,12 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
      */
     public function checkValidationMessageFor($element, $message)
     {
-        $foundedElement = $this->getElement($element)->getParent()->find('css', '.pointing');
+        $foundedElement = $this->getFieldElement($element);
         if (null === $foundedElement) {
             throw new ElementNotFoundException($this->getSession(), 'Tag', 'css', '.pointing');
         }
 
-        return $message === $foundedElement->getText();
+        return $message === $foundedElement->find('css', '.pointing')->getText();
     }
 
     /**
@@ -76,5 +76,22 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
     protected function getResourceName()
     {
         return $this->resourceName;
+    }
+
+    /**
+     * @param string $element
+     *
+     * @return \Behat\Mink\Element\NodeElement|null
+     *
+     * @throws ElementNotFoundException
+     */
+    private function getFieldElement($element)
+    {
+        $element = $this->getElement($element);
+        while (null !== $element && !($element->hasClass('field'))) {
+            $element = $element->getParent();
+        }
+
+        return $element;
     }
 }

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -42,3 +42,10 @@
         {{- form_errors(form) -}}
     </div>
 {%- endblock choice_row %}
+
+{% block percent_widget -%}
+    <div class="ui right labeled input">
+        {{- form_widget(form) -}}
+        <div class="ui basic label">%</div>
+    </div>
+{%- endblock percent_widget %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -36,7 +36,9 @@
 {%- endblock money_widget %}
 
 {% block choice_row -%}
-    {{- form_label(form) -}}
-    {{- form_widget(form, {'attr': {'class': 'ui dropdown'}}) -}}
-    {{- form_errors(form) -}}
+    <div class="{% if required %}required {% endif %}field{% if (not compound or force_error|default(false)) and not valid %} error{% endif %}">
+        {{- form_label(form) -}}
+        {{- form_widget(form, {'attr': {'class': 'ui dropdown'}}) -}}
+        {{- form_errors(form) -}}
+    </div>
 {%- endblock choice_row %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Deprecations?   | no|yes
| Related tickets | 
| License         | MIT

Just UI change. Instead of something like this:
![zrzut ekranu 2016-04-04 o 13 35 00](https://cloud.githubusercontent.com/assets/6213903/14246871/52456a98-fa6a-11e5-9953-ddf1b812f08d.png)
we will receive something like this:
![zrzut ekranu 2016-04-04 o 13 34 18](https://cloud.githubusercontent.com/assets/6213903/14246918/906c9878-fa6a-11e5-8f89-221316d714f0.png)

Based on #4683 and #4729 