### PR TITLE
[Grid] do not use output walkers in orm driver

### DIFF
--- a/src/Sylius/Bundle/GridBundle/Doctrine/ORM/DataSource.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/ORM/DataSource.php
@@ -70,7 +70,8 @@ class DataSource implements DataSourceInterface
      */
     public function getData(Parameters $parameters)
     {
-        $paginator = new Pagerfanta(new DoctrineORMAdapter($this->queryBuilder));
+        // Use output walkers option in DoctrineORMAdapter should be false as it affects performance greatly (see #3775)
+        $paginator = new Pagerfanta(new DoctrineORMAdapter($this->queryBuilder, true, false));
         $paginator->setCurrentPage($parameters->get('page', 1));
 
         return $paginator;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #3775
| License         | MIT

This matches the behaviour in the [EntityRepository](https://github.com/Sylius/Sylius/blob/710b8b4f2c0fecae03d71b19d977527602118c55/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/EntityRepository.php#L60-L69)

