### PR TITLE
[Migration] Auto-generate code in db field while running migration

### DIFF
--- a/app/migrations/Version20151203134947.php
+++ b/app/migrations/Version20151203134947.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;

--- a/app/migrations/Version20151203134947.php
+++ b/app/migrations/Version20151203134947.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Sylius package.
- *
- * (c) Paweł Jędrzejewski
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
@@ -28,8 +19,16 @@ class Version20151203134947 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_shipping_category ADD code VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE sylius_shipping_category s,
+                           (SELECT @n := 0) m
+                           SET s.`code` = CONCAT("SC", @n := @n + 1)         
+                      ');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_B1D6465277153098 ON sylius_shipping_category (code)');
         $this->addSql('ALTER TABLE sylius_shipping_method ADD code VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE sylius_shipping_method s,
+                           (SELECT @n := 0) m
+                           SET s.`code` = CONCAT("SM", @n := @n + 1)         
+                      ');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_5FB0EE1177153098 ON sylius_shipping_method (code)');
     }
 

--- a/app/migrations/Version20151209104639.php
+++ b/app/migrations/Version20151209104639.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;

--- a/app/migrations/Version20151209104639.php
+++ b/app/migrations/Version20151209104639.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Sylius package.
- *
- * (c) Paweł Jędrzejewski
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
@@ -28,6 +19,10 @@ class Version20151209104639 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_payment_method ADD code VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE sylius_payment_method s,
+                           (SELECT @n := 0) m
+                           SET s.`code` = CONCAT("PM", @n := @n + 1)         
+                      ');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_A75B0B0D77153098 ON sylius_payment_method (code)');
     }
 

--- a/app/migrations/Version20151209104827.php
+++ b/app/migrations/Version20151209104827.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;

--- a/app/migrations/Version20151209104827.php
+++ b/app/migrations/Version20151209104827.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Sylius package.
- *
- * (c) Paweł Jędrzejewski
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
@@ -28,8 +19,16 @@ class Version20151209104827 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_tax_category ADD code VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE sylius_tax_category s,
+                           (SELECT @n := 0) m
+                           SET s.`code` = CONCAT("TC", @n := @n + 1)         
+                      ');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_221EB0BE77153098 ON sylius_tax_category (code)');
         $this->addSql('ALTER TABLE sylius_tax_rate ADD code VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE sylius_tax_rate s,
+                           (SELECT @n := 0) m
+                           SET s.`code` = CONCAT("TR", @n := @n + 1)         
+                      ');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_3CD86B2E77153098 ON sylius_tax_rate (code)');
     }
 

--- a/app/migrations/Version20151210134607.php
+++ b/app/migrations/Version20151210134607.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;

--- a/app/migrations/Version20151210134607.php
+++ b/app/migrations/Version20151210134607.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Sylius package.
- *
- * (c) Paweł Jędrzejewski
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
@@ -29,6 +20,10 @@ class Version20151210134607 extends AbstractMigration
 
         $this->addSql('CREATE UNIQUE INDEX UNIQ_B04EBA8577153098 ON sylius_promotion_coupon (code)');
         $this->addSql('ALTER TABLE sylius_promotion ADD code VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE sylius_promotion s,
+                           (SELECT @n := 0) m
+                           SET s.`code` = CONCAT("P", @n := @n + 1)         
+                      ');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_F157396377153098 ON sylius_promotion (code)');
     }
 

--- a/app/migrations/Version20151216125201.php
+++ b/app/migrations/Version20151216125201.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;

--- a/app/migrations/Version20151216125201.php
+++ b/app/migrations/Version20151216125201.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Sylius package.
- *
- * (c) Paweł Jędrzejewski
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
@@ -28,6 +19,10 @@ class Version20151216125201 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_taxon ADD code VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE sylius_taxon s,
+                           (SELECT @n := 0) m
+                           SET s.`code` = CONCAT("T", @n := @n + 1)         
+                      ');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_CFD811CA77153098 ON sylius_taxon (code)');
     }
 

--- a/app/migrations/Version20151221121710.php
+++ b/app/migrations/Version20151221121710.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;

--- a/app/migrations/Version20151221121710.php
+++ b/app/migrations/Version20151221121710.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Sylius package.
- *
- * (c) Paweł Jędrzejewski
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
@@ -28,8 +19,16 @@ class Version20151221121710 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_product_option ADD code VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE sylius_product_option s,
+                           (SELECT @n := 0) m
+                           SET s.`code` = CONCAT("PO", @n := @n + 1)         
+                      ');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_E4C0EBEF77153098 ON sylius_product_option (code)');
         $this->addSql('ALTER TABLE sylius_product_option_value ADD code VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE sylius_product_option_value s,
+                           (SELECT @n := 0) m
+                           SET s.`code` = CONCAT("POV", @n := @n + 1)         
+                      ');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_F7FF7D4B77153098 ON sylius_product_option_value (code)');
     }
 

--- a/app/migrations/Version20151228162916.php
+++ b/app/migrations/Version20151228162916.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;

--- a/app/migrations/Version20151228162916.php
+++ b/app/migrations/Version20151228162916.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Sylius package.
- *
- * (c) Paweł Jędrzejewski
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
@@ -28,6 +19,10 @@ class Version20151228162916 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_product_attribute ADD storage_type VARCHAR(255) NOT NULL, CHANGE name code VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE sylius_product_attribute s,
+                           (SELECT @n := 0) m
+                           SET s.`code` = CONCAT("PA", @n := @n + 1)         
+                      ');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_BFAF484A77153098 ON sylius_product_attribute (code)');
         $this->addSql('ALTER TABLE sylius_product_attribute_translation CHANGE presentation name VARCHAR(255) NOT NULL');
         $this->addSql('ALTER TABLE sylius_product_attribute_value ADD boolean_value TINYINT(1) DEFAULT NULL, ADD integer_value INT DEFAULT NULL, ADD float_value DOUBLE PRECISION DEFAULT NULL, ADD datetime_value DATETIME DEFAULT NULL, ADD date_value DATE DEFAULT NULL, CHANGE value text_value LONGTEXT DEFAULT NULL');

--- a/app/migrations/Version20160112154949.php
+++ b/app/migrations/Version20160112154949.php
@@ -29,13 +29,17 @@ class Version20160112154949 extends AbstractMigration
 
         $this->addSql('DROP INDEX UNIQ_E74256BF4B80EAC0 ON sylius_country');
         $this->addSql('DROP INDEX IDX_E74256BF4B80EAC0 ON sylius_country');
-        $this->addSql('ALTER TABLE sylius_country ADD code VARCHAR(2) NOT NULL, DROP iso_name');
+        $this->addSql('ALTER TABLE `sylius_country` CHANGE `iso_name` `code` VARCHAR(2) NOT NULL');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_E74256BF77153098 ON sylius_country (code)');
         $this->addSql('CREATE INDEX IDX_E74256BF77153098 ON sylius_country (code)');
-        $this->addSql('ALTER TABLE sylius_province ADD code VARCHAR(255) NOT NULL, DROP iso_name');
+        $this->addSql('ALTER TABLE `sylius_province` CHANGE `iso_name` `code` VARCHAR(255) NOT NULL');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_B5618FE477153098 ON sylius_province (code)');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_B5618FE4F92F3E705E237E06 ON sylius_province (country_id, name)');
         $this->addSql('ALTER TABLE sylius_zone ADD code VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE sylius_zone s,
+                           (SELECT @n := 0) m
+                           SET s.`code` = CONCAT("Z", @n := @n + 1)         
+                      ');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_7BE2258E77153098 ON sylius_zone (code)');
         $this->addSql('ALTER TABLE sylius_zone_member DROP FOREIGN KEY FK_E8B5ABF39F2C3FAB');
         $this->addSql('ALTER TABLE sylius_zone_member DROP FOREIGN KEY FK_E8B5ABF3E946114A');
@@ -44,6 +48,10 @@ class Version20160112154949 extends AbstractMigration
         $this->addSql('DROP INDEX IDX_E8B5ABF3E946114A ON sylius_zone_member');
         $this->addSql('DROP INDEX IDX_E8B5ABF39F2C3FAB ON sylius_zone_member');
         $this->addSql('ALTER TABLE sylius_zone_member ADD code VARCHAR(255) NOT NULL, DROP zone_id, DROP province_id, DROP country_id, DROP type');
+        $this->addSql('UPDATE sylius_zone_member s,
+                           (SELECT @n := 0) m
+                           SET s.`code` = CONCAT("ZM", @n := @n + 1)         
+                      ');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_E8B5ABF34B0E929B77153098 ON sylius_zone_member (belongs_to, code)');
         $this->addSql('ALTER TABLE sylius_address DROP FOREIGN KEY FK_B97FF058E946114A');
         $this->addSql('ALTER TABLE sylius_address DROP FOREIGN KEY FK_B97FF058F92F3E70');


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

Automatically add incremental code based on the db name.
eg: for sylius_shipping_category, generate SC1, SC2, SC3 .....

This is to prevent migration fails due to the UNIQUE INDEX statement.
When the migration fails you have to manually add code to db for each line, comment SQL query already ran and run migration script again... :(

Tested and fully working

Enjoy