### PR TITLE
[Resource] Fixed proviously spoiled transformer

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Form/DataTransformer/ObjectToIdentifierTransformer.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/DataTransformer/ObjectToIdentifierTransformer.php
@@ -48,26 +48,6 @@ class ObjectToIdentifierTransformer implements DataTransformerInterface
      */
     public function transform($value)
     {
-        if (empty($value)) {
-            return '';
-        }
-
-        $class = $this->repository->getClassName();
-
-        if (!$value instanceof $class) {
-            throw new UnexpectedTypeException($value, $class);
-        }
-
-        $accessor = PropertyAccess::createPropertyAccessor();
-
-        return $accessor->getValue($value, $this->identifier);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function reverseTransform($value)
-    {
         if (!$value) {
             return null;
         }
@@ -82,5 +62,25 @@ class ObjectToIdentifierTransformer implements DataTransformerInterface
         }
 
         return $entity;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reverseTransform($value)
+    {
+        if (empty($value)) {
+            return '';
+        }
+
+        $class = $this->repository->getClassName();
+
+        if (!$value instanceof $class) {
+            throw new UnexpectedTypeException($value, $class);
+        }
+
+        $accessor = PropertyAccess::createPropertyAccessor();
+
+        return $accessor->getValue($value, $this->identifier);
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Form/DataTransformer/ObjectToIdentifierTransformerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Form/DataTransformer/ObjectToIdentifierTransformerSpec.php
@@ -32,36 +32,36 @@ class ObjectToIdentifierTransformerSpec extends ObjectBehavior
         $this->shouldHaveType('Sylius\Bundle\ResourceBundle\Form\DataTransformer\ObjectToIdentifierTransformer');
     }
 
-    function it_does_not_reverse_null_value(ObjectRepository $repository)
+    function it_does_not_transform_null_value(ObjectRepository $repository)
     {
         $repository->findOneBy(Argument::any())->shouldNotBeCalled();
 
-        $this->reverseTransform(null)->shouldReturn(null);
+        $this->transform(null)->shouldReturn(null);
     }
 
     function it_throws_an_exception_on_non_existing_entity(ObjectRepository $repository)
     {
         $repository->findOneBy(['id' => 6])->shouldBeCalled()->willReturn(null);
 
-        $this->shouldThrow(TransformationFailedException::class)->during('reverseTransform', [6]);
+        $this->shouldThrow(TransformationFailedException::class)->during('transform', [6]);
     }
 
-    function it_reverses_identifier_in_entity(ObjectRepository $repository, FakeEntity $entity)
+    function it_transforms_identifier_to_entity(ObjectRepository $repository, FakeEntity $entity)
     {
         $repository->findOneBy(['id' => 5])->shouldBeCalled()->willReturn($entity);
 
-        $this->reverseTransform(5)->shouldReturn($entity);
+        $this->transform(5)->shouldReturn($entity);
     }
 
-    function it_does_not_transform_null_value()
+    function it_does_not_reverse_transforms_null_value()
     {
-        $this->transform(null)->shouldReturn('');
+        $this->reverseTransform(null)->shouldReturn('');
     }
 
-    function it_transforms_entity_in_identifier(FakeEntity $value)
+    function it_reverse_transforms_entity_in_identifier(FakeEntity $value)
     {
         $value->getId()->shouldBeCalled()->willReturn(6);
 
-        $this->transform($value)->shouldReturn(6);
+        $this->reverseTransform($value)->shouldReturn(6);
     }
 }

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
@@ -14,6 +14,7 @@ namespace Sylius\Bundle\ShippingBundle\Form\Type;
 use Sylius\Bundle\ResourceBundle\Form\DataTransformer\ObjectToIdentifierTransformer;
 use Sylius\Component\Registry\ServiceRegistryInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\Component\Shipping\Model\ShippingMethod;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 use Sylius\Component\Shipping\Resolver\MethodsResolverInterface;
@@ -72,7 +73,9 @@ class ShippingMethodChoiceType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addModelTransformer($this->getProperTransformer($options));
+        if ($options['multiple']) {
+            $builder->addModelTransformer(new CollectionToArrayTransformer());
+        }
     }
 
     /**
@@ -90,10 +93,19 @@ class ShippingMethodChoiceType extends AbstractType
             return new ObjectChoiceList($methods, null, [], null, 'id');
         };
 
+        $dataClass = function (Options $options) {
+            if ($options['multiple']) {
+                return null;
+            }
+
+            return ShippingMethodInterface::class;
+        };
+
         $resolver
             ->setDefaults([
                 'choice_list' => $choiceList,
                 'criteria' => [],
+                'data_class' => $dataClass,
             ])
             ->setDefined([
                 'subject',

--- a/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/ShippingMethodChoiceTypeSpec.php
+++ b/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/ShippingMethodChoiceTypeSpec.php
@@ -45,15 +45,11 @@ class ShippingMethodChoiceTypeSpec extends ObjectBehavior
         $this->shouldHaveType(AbstractType::class);
     }
 
-    function it_builds_a_form(FormBuilderInterface $builder)
+    function it_adds_transformer_if_options_multiple_is_set(FormBuilderInterface $builder)
     {
-        $builder->addModelTransformer(
-            Argument::type(CollectionToArrayTransformer::class)
-        )->shouldBeCalled();
+        $builder->addModelTransformer(Argument::type(CollectionToArrayTransformer::class))->shouldBeCalled();
 
-        $this->buildForm($builder, [
-            'multiple' => true,
-        ]);
+        $this->buildForm($builder, ['multiple' => true]);
     }
 
     function it_has_options(OptionsResolver $resolver)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Ok, 7th and 8th of October were bad days for the Republic :smile: These days I've fixed ``ObjectToIdentifierTransformer`` in https://github.com/Sylius/Sylius/pull/3406... but *de facto* I ruined it :( It has been written good, as in ``reverseTransform`` method value is object from form and in ``transform`` it's identifier - not otherwise. The reason why it was working is that if we pass object to ``findOneBy`` method instead of id, doctrine would return object based on passed object id :boom: Now it should be good, I really hope :)