### PR TITLE
Fix TaxonsToCodesTransformer

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/DataTransformer/TaxonsToCodesTransformer.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/DataTransformer/TaxonsToCodesTransformer.php
@@ -61,20 +61,23 @@ class TaxonsToCodesTransformer implements DataTransformerInterface
             throw new UnexpectedTypeException($value, Collection::class);
         }
 
-        if ($value->isEmpty() || null === $value->get('taxons')) {
+        $taxons = $value->get('taxons');
+
+        if (null === $taxons) {
             return [];
         }
 
-        if (!is_array($value->get('taxons'))) {
-            throw new \InvalidArgumentException('"taxons" element of collection should be an array.');
+        if (!(is_array($taxons) || $taxons instanceof \Traversable)) {
+            throw new \InvalidArgumentException('"taxons" element of collection should be Traversable');
         }
 
-        $taxons = [];
+        $taxonCodes = [];
+
         /** @var TaxonInterface $taxon */
-        foreach ($value->get('taxons') as $taxon) {
-            $taxons[] = $taxon->getCode();
+        foreach ($taxons as $taxon) {
+            $taxonCodes[] = $taxon->getCode();
         }
 
-        return ['taxons' => $taxons];
+        return ['taxons' => $taxonCodes];
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/Form/DataTransformer/TaxonsToCodesTransformerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Form/DataTransformer/TaxonsToCodesTransformerSpec.php
@@ -110,7 +110,7 @@ class TaxonsToCodesTransformerSpec extends ObjectBehavior
     function it_throws_exception_while_reverse_transform_if_taxons_element_is_not_an_array(TaxonInterface $axes)
     {
         $this
-            ->shouldThrow(new \InvalidArgumentException('"taxons" element of collection should be an array.'))
+            ->shouldThrow(new \InvalidArgumentException('"taxons" element of collection should be Traversable'))
             ->during('reverseTransform', [new ArrayCollection(['taxons' => $axes->getWrappedObject()])])
         ;
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/Sylius/issues/4544
| License         | MIT

Fixed the TaxonsToCodesTransformer by adjusting the array check to allow for ArrayCollection.

This is the same change as https://github.com/Sylius/Sylius/pull/4651 - except that I screwed up the rebase pretty bad in the previous branch.