### PR TITLE
[Promotion] do not check for eligibility if no coupon is specified

### DIFF
--- a/src/Sylius/Component/Promotion/Checker/CouponsEligibilityChecker.php
+++ b/src/Sylius/Component/Promotion/Checker/CouponsEligibilityChecker.php
@@ -41,7 +41,7 @@ class CouponsEligibilityChecker implements PromotionSubjectEligibilityCheckerInt
      */
     public function isEligible(PromotionSubjectInterface $subject, PromotionInterface $promotion)
     {
-        if (!$subject instanceof PromotionCouponAwareSubjectInterface) {
+        if (!$subject instanceof PromotionCouponAwareSubjectInterface || null === $subject->getPromotionCoupon()) {
             return false;
         }
 
@@ -64,8 +64,6 @@ class CouponsEligibilityChecker implements PromotionSubjectEligibilityCheckerInt
      */
     protected function isCouponEligible(PromotionInterface $promotion, PromotionCouponAwareSubjectInterface $subject)
     {
-        $coupon = $subject->getPromotionCoupon();
-
-        return null !== $coupon && $promotion === $coupon->getPromotion();
+        return $promotion === $subject->getPromotionCoupon()->getPromotion();
     }
 }

--- a/src/Sylius/Component/Promotion/spec/Checker/CouponsEligibilityCheckerSpec.php
+++ b/src/Sylius/Component/Promotion/spec/Checker/CouponsEligibilityCheckerSpec.php
@@ -86,7 +86,7 @@ class CouponsEligibilityCheckerSpec extends ObjectBehavior
 
         $eventDispatcher
             ->dispatch(SyliusPromotionEvents::COUPON_NOT_ELIGIBLE, Argument::type(GenericEvent::class))
-            ->shouldBeCalled()
+            ->shouldNotBeCalled()
         ;
 
         $this->isEligible($subject, $promotion)->shouldReturn(false);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially https://github.com/Sylius/Sylius/issues/4544
| License         | MIT

There was a bug introduced in https://github.com/Sylius/Sylius/pull/4645 that basically threw flash messages when a user added an item to the cart because it was checking for coupon eligibility even when there was none specified.

@Zales0123: Hope this is an appropriate solution.