### PR TITLE
[Resource] Remove static from ResourceBundleInterface::getSupportedDrivers

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/SyliusAddressingBundle.php
+++ b/src/Sylius/Bundle/AddressingBundle/SyliusAddressingBundle.php
@@ -32,7 +32,7 @@ class SyliusAddressingBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/ApiBundle/SyliusApiBundle.php
+++ b/src/Sylius/Bundle/ApiBundle/SyliusApiBundle.php
@@ -29,7 +29,7 @@ class SyliusApiBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/ArchetypeBundle/SyliusArchetypeBundle.php
+++ b/src/Sylius/Bundle/ArchetypeBundle/SyliusArchetypeBundle.php
@@ -22,7 +22,7 @@ class SyliusArchetypeBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/AssociationBundle/SyliusAssociationBundle.php
+++ b/src/Sylius/Bundle/AssociationBundle/SyliusAssociationBundle.php
@@ -22,7 +22,7 @@ class SyliusAssociationBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/AttributeBundle/SyliusAttributeBundle.php
+++ b/src/Sylius/Bundle/AttributeBundle/SyliusAttributeBundle.php
@@ -26,7 +26,7 @@ class SyliusAttributeBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/CartBundle/SyliusCartBundle.php
+++ b/src/Sylius/Bundle/CartBundle/SyliusCartBundle.php
@@ -26,7 +26,7 @@ class SyliusCartBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/ChannelBundle/SyliusChannelBundle.php
+++ b/src/Sylius/Bundle/ChannelBundle/SyliusChannelBundle.php
@@ -29,7 +29,7 @@ class SyliusChannelBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/ContactBundle/SyliusContactBundle.php
+++ b/src/Sylius/Bundle/ContactBundle/SyliusContactBundle.php
@@ -28,7 +28,7 @@ class SyliusContactBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/ContentBundle/SyliusContentBundle.php
+++ b/src/Sylius/Bundle/ContentBundle/SyliusContentBundle.php
@@ -24,7 +24,7 @@ class SyliusContentBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_PHPCR_ODM,

--- a/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
+++ b/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
@@ -31,7 +31,7 @@ class SyliusCoreBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/CurrencyBundle/SyliusCurrencyBundle.php
+++ b/src/Sylius/Bundle/CurrencyBundle/SyliusCurrencyBundle.php
@@ -25,7 +25,7 @@ class SyliusCurrencyBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/InventoryBundle/SyliusInventoryBundle.php
+++ b/src/Sylius/Bundle/InventoryBundle/SyliusInventoryBundle.php
@@ -25,7 +25,7 @@ class SyliusInventoryBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/LocaleBundle/SyliusLocaleBundle.php
+++ b/src/Sylius/Bundle/LocaleBundle/SyliusLocaleBundle.php
@@ -23,7 +23,7 @@ class SyliusLocaleBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/MailerBundle/SyliusMailerBundle.php
+++ b/src/Sylius/Bundle/MailerBundle/SyliusMailerBundle.php
@@ -25,7 +25,7 @@ class SyliusMailerBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/MetadataBundle/SyliusMetadataBundle.php
+++ b/src/Sylius/Bundle/MetadataBundle/SyliusMetadataBundle.php
@@ -39,7 +39,7 @@ class SyliusMetadataBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/OrderBundle/SyliusOrderBundle.php
+++ b/src/Sylius/Bundle/OrderBundle/SyliusOrderBundle.php
@@ -30,7 +30,7 @@ class SyliusOrderBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/PaymentBundle/SyliusPaymentBundle.php
+++ b/src/Sylius/Bundle/PaymentBundle/SyliusPaymentBundle.php
@@ -27,7 +27,7 @@ class SyliusPaymentBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/PayumBundle/SyliusPayumBundle.php
+++ b/src/Sylius/Bundle/PayumBundle/SyliusPayumBundle.php
@@ -20,7 +20,7 @@ class SyliusPayumBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/ProductBundle/SyliusProductBundle.php
+++ b/src/Sylius/Bundle/ProductBundle/SyliusProductBundle.php
@@ -37,7 +37,7 @@ class SyliusProductBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/PromotionBundle/SyliusPromotionBundle.php
+++ b/src/Sylius/Bundle/PromotionBundle/SyliusPromotionBundle.php
@@ -32,7 +32,7 @@ class SyliusPromotionBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/RbacBundle/SyliusRbacBundle.php
+++ b/src/Sylius/Bundle/RbacBundle/SyliusRbacBundle.php
@@ -26,7 +26,7 @@ class SyliusRbacBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/ReportBundle/SyliusReportBundle.php
+++ b/src/Sylius/Bundle/ReportBundle/SyliusReportBundle.php
@@ -31,7 +31,7 @@ class SyliusReportBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/ResourceBundle/AbstractResourceBundle.php
+++ b/src/Sylius/Bundle/ResourceBundle/AbstractResourceBundle.php
@@ -49,8 +49,7 @@ abstract class AbstractResourceBundle extends Bundle implements ResourceBundleIn
         }
 
         if (null !== $this->getModelNamespace()) {
-            $className = get_class($this);
-            foreach ($className::getSupportedDrivers() as $driver) {
+            foreach ($this->getSupportedDrivers() as $driver) {
                 list($compilerPassClassName, $compilerPassMethod) = $this->getMappingCompilerPassInfo($driver);
 
                 if (class_exists($compilerPassClassName)) {

--- a/src/Sylius/Bundle/ResourceBundle/ResourceBundleInterface.php
+++ b/src/Sylius/Bundle/ResourceBundle/ResourceBundleInterface.php
@@ -21,9 +21,13 @@ interface ResourceBundleInterface
     const MAPPING_ANNOTATION = 'annotation';
 
     /**
-     * Return an array which contains the supported drivers.
+     * Returns a vector of supported drivers.
+     *
+     * @see SyliusResourceBundle::DRIVER_DOCTRINE_ORM
+     * @see SyliusResourceBundle::DRIVER_DOCTRINE_MONGODB_ODM
+     * @see SyliusResourceBundle::DRIVER_DOCTRINE_PHPCR_ODM
      *
      * @return array
      */
-    public static function getSupportedDrivers();
+    public function getSupportedDrivers();
 }

--- a/src/Sylius/Bundle/ReviewBundle/SyliusReviewBundle.php
+++ b/src/Sylius/Bundle/ReviewBundle/SyliusReviewBundle.php
@@ -25,7 +25,7 @@ class SyliusReviewBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/SearchBundle/SyliusSearchBundle.php
+++ b/src/Sylius/Bundle/SearchBundle/SyliusSearchBundle.php
@@ -26,7 +26,7 @@ class SyliusSearchBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/SequenceBundle/SyliusSequenceBundle.php
+++ b/src/Sylius/Bundle/SequenceBundle/SyliusSequenceBundle.php
@@ -27,7 +27,7 @@ class SyliusSequenceBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/SettingsBundle/SyliusSettingsBundle.php
+++ b/src/Sylius/Bundle/SettingsBundle/SyliusSettingsBundle.php
@@ -28,7 +28,7 @@ class SyliusSettingsBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/ShippingBundle/SyliusShippingBundle.php
+++ b/src/Sylius/Bundle/ShippingBundle/SyliusShippingBundle.php
@@ -36,7 +36,7 @@ class SyliusShippingBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/TaxationBundle/SyliusTaxationBundle.php
+++ b/src/Sylius/Bundle/TaxationBundle/SyliusTaxationBundle.php
@@ -28,7 +28,7 @@ class SyliusTaxationBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/TaxonomyBundle/SyliusTaxonomyBundle.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/SyliusTaxonomyBundle.php
@@ -26,7 +26,7 @@ class SyliusTaxonomyBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/ThemeBundle/SyliusThemeBundle.php
+++ b/src/Sylius/Bundle/ThemeBundle/SyliusThemeBundle.php
@@ -28,7 +28,7 @@ class SyliusThemeBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/UserBundle/SyliusUserBundle.php
+++ b/src/Sylius/Bundle/UserBundle/SyliusUserBundle.php
@@ -28,7 +28,7 @@ class SyliusUserBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,

--- a/src/Sylius/Bundle/VariationBundle/SyliusVariationBundle.php
+++ b/src/Sylius/Bundle/VariationBundle/SyliusVariationBundle.php
@@ -25,7 +25,7 @@ class SyliusVariationBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public static function getSupportedDrivers()
+    public function getSupportedDrivers()
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

There's no need to keep it static.