### PR TITLE
[CoreBundle] Sitemap - Fix priority setter

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Sitemap/Model/SitemapUrl.php
+++ b/src/Sylius/Bundle/CoreBundle/Sitemap/Model/SitemapUrl.php
@@ -97,7 +97,7 @@ class SitemapUrl implements SitemapUrlInterface
      */
     public function setPriority($priority)
     {
-        if (!is_numeric($priority) || 0 >= $priority || 1 <= $priority) {
+        if (!is_numeric($priority) || 0 > $priority || 1 < $priority) {
             throw new \InvalidArgumentException(sprintf(
                 'The value %s is not supported by the option priority, it must be a numeric between 0.0 and 1.0.', $priority
             ));


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Fixed the setter so that it maches the exception. Previously a priority of 1.0 would not be allowed.

