### PR TITLE
[Bug Fix] Added customer validator initializer to set canonical email

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/services.xml
@@ -59,6 +59,7 @@
         <parameter key="sylius.controller.user_security.class">Sylius\Bundle\UserBundle\Controller\SecurityController</parameter>
 
         <parameter key="sylius.user.validator.unique_registered_user.class">Sylius\Bundle\UserBundle\Validator\Constraints\RegisteredUserValidator</parameter>
+        <parameter key="sylius.user.validator.customer_initializer.class">Sylius\Bundle\UserBundle\Validator\Initializer\CustomerInitializer</parameter>
     </parameters>
 
     <services>
@@ -207,6 +208,11 @@
         <service id="validator.unique.registered_user" class="%sylius.user.validator.unique_registered_user.class%">
             <argument type="service" id="sylius.repository.customer" />
             <tag name="validator.constraint_validator" alias="registered_user_validator" />
+        </service>
+
+        <service id="sylius.user.validator.customer_initializer" class="%sylius.user.validator.customer_initializer.class%">
+            <argument type="service" id="sylius.user.canonicalizer" />
+            <tag name="validator.initializer" />
         </service>
     </services>
 

--- a/src/Sylius/Bundle/UserBundle/Resources/config/validation.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/validation.xml
@@ -19,7 +19,8 @@
     <class name="Sylius\Component\User\Model\Customer">
         <constraint name="Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity">
             <option name="message">sylius.customer.email.unique</option>
-            <option name="fields">email</option>
+            <option name="fields">emailCanonical</option>
+            <option name="errorPath">email</option>
             <option name="groups">sylius</option>
         </constraint>
         <constraint name="Sylius\Bundle\UserBundle\Validator\Constraints\RegisteredUser">

--- a/src/Sylius/Bundle/UserBundle/Validator/Initializer/CustomerInitializer.php
+++ b/src/Sylius/Bundle/UserBundle/Validator/Initializer/CustomerInitializer.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\UserBundle\Validator\Initializer;
+
+use Sylius\Component\User\Canonicalizer\CanonicalizerInterface;
+use Sylius\Component\User\Model\CustomerInterface;
+use Symfony\Component\Validator\ObjectInitializerInterface;
+
+/**
+ * @author Steffen Brem <steffenbrem@gmail.com>
+ */
+final class CustomerInitializer implements ObjectInitializerInterface
+{
+    /**
+     * @var CanonicalizerInterface
+     */
+    private $canonicalizer;
+
+    /**
+     * @param CanonicalizerInterface $canonicalizer
+     */
+    public function __construct(CanonicalizerInterface $canonicalizer)
+    {
+        $this->canonicalizer = $canonicalizer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize($object)
+    {
+        if ($object instanceof CustomerInterface) {
+            $emailCanonical = $this->canonicalizer->canonicalize($object->getEmail());
+            $object->setEmailCanonical($emailCanonical);
+        }
+    }
+}

--- a/src/Sylius/Bundle/UserBundle/spec/Validator/Initializer/CustomerInitializerSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/Validator/Initializer/CustomerInitializerSpec.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\UserBundle\Validator\Initializer;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\User\Canonicalizer\CanonicalizerInterface;
+use Sylius\Component\User\Model\CustomerInterface;
+use Symfony\Component\Validator\ObjectInitializerInterface;
+
+/**
+ * @author Steffen Brem <steffenbrem@gmail.com>
+ */
+class CustomerInitializerSpec extends ObjectBehavior
+{
+    function let(CanonicalizerInterface $canonicalizer)
+    {
+        $this->beConstructedWith($canonicalizer);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\UserBundle\Validator\Initializer\CustomerInitializer');
+    }
+
+    function it_implements_symfony_validator_initializer_interface()
+    {
+        $this->shouldImplement(ObjectInitializerInterface::class);
+    }
+
+    function it_sets_canonical_email_when_initializing_customer($canonicalizer, CustomerInterface $customer)
+    {
+        $customer->getEmail()->willReturn('sTeFfEn@gMaiL.CoM');
+        $canonicalizer->canonicalize('sTeFfEn@gMaiL.CoM')->willReturn('steffen@gmail.com');
+        $customer->setEmailCanonical('steffen@gmail.com')->shouldBeCalled();
+
+        $this->initialize($customer);
+    }
+
+    function it_does_not_set_canonical_email_when_initializing_non_customer_object(\stdClass $object)
+    {
+        $this->initialize($object);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #4733 
| License         | MIT


Added customer validator initializer that sets email canonical on initialisation. Customer object is now also validating against `emailCanonical` and uses `email` as it's error path.