### PR TITLE
Update LoadProductOptionData.php

### DIFF
--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadProductOptionData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadProductOptionData.php
@@ -109,6 +109,7 @@ class LoadProductOptionData extends DataFixture
         $option->setCode($optionCode);
 
         foreach ($nameTranslation as $locale => $name) {
+            $option->setFallbackLocale($locale);
             $option->setCurrentLocale($locale);
             $option->setName($name);
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT


If not fallback is set, the option translations will not be set.