### PR TITLE
[Currency] Fix wrong twig helper call

### DIFF
--- a/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
@@ -39,7 +39,7 @@ class CurrencyExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sylius_currency_symbol', [$this->helper, 'getCurrentCurrencySymbol']),
+            new \Twig_SimpleFunction('sylius_currency_symbol', [$this->helper, 'getBaseCurrencySymbol']),
         ];
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I have forgotten to change method name in extension to in #4740 PR