### PR TITLE
[RFC] [Ui] Cancel button

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
@@ -9,6 +9,7 @@ sylius:
         administration_panel_login: Administration panel login
         an_error_occurred: An error occurred
         are_your_sure_you_want_to_perform_this_action: Are you sure you want to perform this action?
+        cancel: Cancel
         clear_filters: Clear filters
         confirm_your_action: Confirm your action
         contains: Contains
@@ -42,6 +43,7 @@ sylius:
         not_contains: Not contains
         not_empty: Not empty
         not_in: Not in
+        or: or
         powered_by: Powered by
         save_changes: Save changes
         show: Show

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/_create.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/_create.html.twig
@@ -1,3 +1,7 @@
 <div class="ui basic segment">
-    <button class="ui labeled icon primary button" type="submit"><i class="plus icon"></i> {{ 'sylius.ui.create'|trans }}</button>
+    <div class="ui buttons ">
+        <button class="ui labeled icon primary button" type="submit"><i class="plus icon"></i>{{- 'sylius.ui.create'|trans -}}</button>
+        <div class="or" data-text="{{ 'sylius.ui.or'|trans }}"></div>
+        <a href="{{ app.request.headers.get('referer') }}" class="ui button" type="reset">{{ 'sylius.ui.cancel'|trans }}</a>
+    </div>
 </div>

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/_saveChanges.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/_saveChanges.html.twig
@@ -1,3 +1,7 @@
 <div class="ui basic segment">
-    <button class="ui labeled icon primary button" type="submit"><i class="save icon"></i> {{ 'sylius.ui.save_changes'|trans }}</button>
+    <div class="ui buttons ">
+        <button class="ui labeled icon primary button" type="submit"><i class="save icon"></i> {{ 'sylius.ui.save_changes'|trans }}</button>
+        <div class="or" data-text="{{ 'sylius.ui.or'|trans }}"></div>
+        <a href="{{ app.request.headers.get('referer') }}" class="ui button" type="reset">{{ 'sylius.ui.cancel'|trans }}</a>
+    </div>
 </div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

It was annoying, that it wasn't possible to just go back on create/update form. It is not the prettiest solution, but I wasn't able to find a better one. Also I have not add second parameter as a fallback, because I didn't want to add parameter to this templates. But on the other hand I don't have any good idea, how to solve this. 

Before:
![zrzut ekranu 2016-04-12 o 08 19 02](https://cloud.githubusercontent.com/assets/6213903/14451483/c5047074-0087-11e6-969a-82fc1f92c6b3.png)

After:
![zrzut ekranu 2016-04-12 o 08 22 05](https://cloud.githubusercontent.com/assets/6213903/14451485/c908d5e8-0087-11e6-987a-62fdd7bcf831.png)
