### PR TITLE
[Taxation] Tax calculation minor enhancements

### DIFF
--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderItemUnitsTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderItemUnitsTaxesApplicator.php
@@ -57,13 +57,7 @@ class OrderItemUnitsTaxesApplicator implements OrderTaxesApplicatorInterface
     public function apply(OrderInterface $order, ZoneInterface $zone)
     {
         foreach ($order->getItems() as $item) {
-            $quantity = $item->getQuantity();
-            if (0 === $quantity) {
-                continue;
-            }
-
             $taxRate = $this->taxRateResolver->resolve($item->getVariant(), ['zone' => $zone]);
-
             if (null === $taxRate) {
                 continue;
             }
@@ -74,7 +68,7 @@ class OrderItemUnitsTaxesApplicator implements OrderTaxesApplicatorInterface
                     continue;
                 }
 
-                $this->addAdjustment($unit, $taxAmount, $taxRate->getLabel(), $taxRate->isIncludedInPrice());
+                $this->addTaxAdjustment($unit, $taxAmount, $taxRate->getLabel(), $taxRate->isIncludedInPrice());
             }
         }
     }
@@ -85,7 +79,7 @@ class OrderItemUnitsTaxesApplicator implements OrderTaxesApplicatorInterface
      * @param string $label
      * @param bool $included
      */
-    private function addAdjustment(OrderItemUnitInterface $unit, $taxAmount, $label, $included)
+    private function addTaxAdjustment(OrderItemUnitInterface $unit, $taxAmount, $label, $included)
     {
         $unitTaxAdjustment = $this->adjustmentFactory->createWithData(AdjustmentInterface::TAX_ADJUSTMENT, $label, $taxAmount, $included);
         $unit->addAdjustment($unitTaxAdjustment);

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
@@ -52,8 +52,12 @@ class OrderItemsTaxesApplicator implements OrderTaxesApplicatorInterface
      * @param IntegerDistributorInterface $distributor
      * @param TaxRateResolverInterface $taxRateResolver
      */
-    public function __construct(CalculatorInterface $calculator, AdjustmentFactoryInterface $adjustmentFactory, IntegerDistributorInterface $distributor, TaxRateResolverInterface $taxRateResolver)
-    {
+    public function __construct(
+        CalculatorInterface $calculator,
+        AdjustmentFactoryInterface $adjustmentFactory,
+        IntegerDistributorInterface $distributor,
+        TaxRateResolverInterface $taxRateResolver
+    ) {
         $this->calculator = $calculator;
         $this->adjustmentFactory = $adjustmentFactory;
         $this->distributor = $distributor;
@@ -68,7 +72,7 @@ class OrderItemsTaxesApplicator implements OrderTaxesApplicatorInterface
         foreach ($order->getItems() as $item) {
             $quantity = $item->getQuantity();
             if (0 === $quantity) {
-                continue;
+                throw new \InvalidArgumentException('Cannot apply tax to order item with 0 quantity.');
             }
 
             $taxRate = $this->taxRateResolver->resolve($item->getVariant(), ['zone' => $zone]);

--- a/src/Sylius/Component/Core/Taxation/Strategy/AbstractTaxCalculationStrategy.php
+++ b/src/Sylius/Component/Core/Taxation/Strategy/AbstractTaxCalculationStrategy.php
@@ -14,6 +14,7 @@ namespace Sylius\Component\Core\Taxation\Strategy;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Taxation\Applicator\OrderTaxesApplicatorInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * @author Mark McKelvie <mark.mckelvie@reiss.com>
@@ -70,15 +71,10 @@ abstract class AbstractTaxCalculationStrategy implements TaxCalculationStrategyI
      */
     private function assertApplicatorsHaveCorrectType(array $applicators)
     {
-        foreach ($applicators as $applicator) {
-            if ($applicator instanceof OrderTaxesApplicatorInterface) {
-                continue;
-            }
-
-            throw new \InvalidArgumentException(sprintf(
-                'Order taxes applicator should have type "%s"',
-                OrderTaxesApplicatorInterface::class
-            ));
-        }
+        Assert::allIsInstanceOf(
+            $applicators,
+            OrderTaxesApplicatorInterface::class,
+            'Order taxes applicator should have type "%2$s". Got: %s'
+        );
     }
 }

--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -51,6 +51,7 @@
         "sylius/association": "^0.18",
         "sylius/review": "^0.18",
         "sylius/metadata": "^0.18",
+        "webmozart/assert": "^1.0",
         "zendframework/zend-stdlib": "^2.0|^3.0"
     },
     "require-dev": {

--- a/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemsTaxesApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemsTaxesApplicatorSpec.php
@@ -11,6 +11,7 @@
 
 namespace spec\Sylius\Component\Core\Taxation\Applicator;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -104,27 +105,17 @@ class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         $this->apply($order, $zone);
     }
 
-    function it_does_nothing_if_order_item_has_no_units(
-        $taxRateResolver,
-        Collection $items,
-        \Iterator $iterator,
+    function it_throws_invalid_argument_exception_if_order_item_has_0_quantity(
         OrderInterface $order,
         OrderItemInterface $orderItem,
         ZoneInterface $zone
     ) {
+        $items = new ArrayCollection([$orderItem->getWrappedObject()]);
         $order->getItems()->willReturn($items);
 
-        $items->count()->willReturn(1);
-        $items->getIterator()->willReturn($iterator);
-        $iterator->rewind()->shouldBeCalled();
-        $iterator->valid()->willReturn(true, false)->shouldBeCalled();
-        $iterator->current()->willReturn($orderItem);
-        $iterator->next()->shouldBeCalled();
-
         $orderItem->getQuantity()->willReturn(0);
-        $taxRateResolver->resolve(Argument::any())->shouldNotBeCalled();
 
-        $this->apply($order, $zone);
+        $this->shouldThrow(\InvalidArgumentException::class)->during('apply', [$order, $zone]);
     }
 
     function it_does_nothing_if_tax_rate_cannot_be_resolved(

--- a/src/Sylius/Component/Registry/PrioritizedServiceRegistry.php
+++ b/src/Sylius/Component/Registry/PrioritizedServiceRegistry.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Registry;
 
+use Webmozart\Assert\Assert;
 use Zend\Stdlib\PriorityQueue;
 
 /**
@@ -83,14 +84,10 @@ class PrioritizedServiceRegistry implements PrioritizedServiceRegistryInterface
      */
     private function assertServiceHaveType($service)
     {
-        if (!is_object($service)) {
-            throw new \InvalidArgumentException(sprintf('Service needs to be an object, %s given.', gettype($service)));
-        }
-
-        if (!in_array($this->interface, class_implements($service))) {
-            throw new \InvalidArgumentException(
-                sprintf('Service for this registry needs to implement "%s", "%s" given.', $this->interface, get_class($service))
-            );
-        }
+        Assert::isInstanceOf(
+            $service,
+            $this->interface,
+            'Service for this registry needs to implement "%2$s", "%s" given.'
+        );
     }
 }

--- a/src/Sylius/Component/Registry/composer.json
+++ b/src/Sylius/Component/Registry/composer.json
@@ -22,11 +22,11 @@
     "require": {
         "php": "^5.5.9|^7.0",
 
+        "webmozart/assert": "^1.0",
         "zendframework/zend-stdlib": "^2.0|^3.0"
     },
     "require-dev": {
-        "phpspec/phpspec": "^2.4",
-        "phpunit/phpunit": "^4.1"
+        "phpspec/phpspec": "^2.4"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Sylius/Component/Registry/spec/PrioritizedServiceRegistrySpec.php
+++ b/src/Sylius/Component/Registry/spec/PrioritizedServiceRegistrySpec.php
@@ -45,11 +45,9 @@ class PrioritizedServiceRegistrySpec extends ObjectBehavior
 
     function it_initializes_services_priority_queue_by_default()
     {
-        $this->all()->shouldReturnAnInstanceOf('Zend\Stdlib\PriorityQueue');
+        $this->all()->shouldReturnAnInstanceOf(PriorityQueue::class);
 
-        /** @var PriorityQueue $services */
-        $services = $this->all()->getWrappedObject();
-        \PHPUnit_Framework_Assert::assertTrue($services->isEmpty());
+        $this->all()->shouldBeEmpty();
     }
 
     function it_registers_services_in_the_correct_prioritized_order(
@@ -69,12 +67,10 @@ class PrioritizedServiceRegistrySpec extends ObjectBehavior
         $this->has($serviceTwo)->shouldReturn(true);
         $this->has($serviceThree)->shouldReturn(true);
 
-        /** @var PriorityQueue $services */
-        $services = $this->all()->getWrappedObject();
-        \PHPUnit_Framework_Assert::assertEquals(3, $services->count());
-        \PHPUnit_Framework_Assert::assertTrue($services->hasPriority(1));
-        \PHPUnit_Framework_Assert::assertTrue($services->hasPriority(0));
-        \PHPUnit_Framework_Assert::assertTrue($services->hasPriority(-1));
+        $this->all()->shouldHaveCount(3);
+        $this->all()->shouldHavePriority(1);
+        $this->all()->shouldHavePriority(0);
+        $this->all()->shouldHavePriority(-1);
     }
 
     function it_throws_exception_when_trying_to_register_service_without_required_interface(\stdClass $service)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Few minor enhancements to #4406:
* Removed check for `0` quantity because order item with this quantity shouldn't ever exist
* Reveal invalid order items (with quantity `0`) passed to order items taxes applicator
* Removed PHPUnit dependency from specs
* Replaced manual assertions with Webmozart library