### PR TITLE
[mailer] - fix mailer configuration to allow adding new templates

### DIFF
--- a/src/Sylius/Bundle/MailerBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/MailerBundle/DependencyInjection/Configuration.php
@@ -136,6 +136,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->arrayNode('templates')
+                    ->useAttributeAsKey('name')
                     ->prototype('scalar')->end()
                 ->end()
             ->end()

--- a/src/Sylius/Bundle/MailerBundle/Form/Type/EmailTemplateChoiceType.php
+++ b/src/Sylius/Bundle/MailerBundle/Form/Type/EmailTemplateChoiceType.php
@@ -40,7 +40,8 @@ class EmailTemplateChoiceType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'choices' => array_flip($this->templates),
+            'choices' => $this->templates,
+            'choices_as_values' => true,
         ]);
     }
 

--- a/src/Sylius/Bundle/MailerBundle/spec/Form/Type/EmailTemplateChoiceTypeSpec.php
+++ b/src/Sylius/Bundle/MailerBundle/spec/Form/Type/EmailTemplateChoiceTypeSpec.php
@@ -31,7 +31,8 @@ class EmailTemplateChoiceTypeSpec extends ObjectBehavior
     function it_has_options(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'choices' => ['my_template' => 'template'],
+            'choices' => ['template' => 'my_template'],
+            'choices_as_values' => true,
         ])->shouldBeCalled();
 
         $this->configureOptions($resolver);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

- configuration for templates uses keys now, and new templates can be properly added. Before the fix new templates from the configuration would be resolved only with number index instead of actual key.
- choiceform deprecation fixed.