### PR TITLE
[Core][Promotion] Distribute promotions on units

### DIFF
--- a/features/legacy/frontend/cart_promotions_complex.feature
+++ b/features/legacy/frontend/cart_promotions_complex.feature
@@ -37,8 +37,8 @@ Feature: Checkout promotions with multiple rules and actions
         And I added product "Sarge" to cart, with quantity "5"
         When I add product "Lenny" to cart, with quantity "2"
         Then I should be on the cart summary page
-        And "Promotion total: -€27.75" should appear on the page
-        And "Grand total: €127.25" should appear on the page
+        And "Promotion total: -€26.75" should appear on the page
+        And "Grand total: €128.25" should appear on the page
 
     Scenario: Promotion is not applied when one of the cart does not
             fulfills one of the rule

--- a/features/legacy/frontend/cart_promotions_percentage.feature
+++ b/features/legacy/frontend/cart_promotions_percentage.feature
@@ -8,12 +8,12 @@ Feature: Checkout percentage discount promotions
         Given store has default configuration
         And the following promotions exist:
             | code | name    | description                                   |
-            | PR1  | 5 items | 25% Discount for orders with at least 5 items |
+            | PR1  | 5 units | 25% Discount for orders with at least 5 units |
             | PR2  | 300 EUR | 10% Discount for orders over 300 EUR          |
-        And promotion "5 items" has following rules defined:
+        And promotion "5 units" has following rules defined:
             | type          | configuration |
             | Cart quantity | Count: 5      |
-        And promotion "5 items" has following actions defined:
+        And promotion "5 units" has following actions defined:
             | type                      | configuration  |
             | Order percentage discount | percentage: 25 |
         And promotion "300 EUR" has following rules defined:
@@ -69,5 +69,5 @@ Feature: Checkout percentage discount promotions
         And I added product "Buzz" to cart, with quantity "1"
         When I add product "Woody" to cart, with quantity "3"
         Then I should still be on the cart summary page
-        And "Promotion total: -€586.25" should appear on the page
-        And "Grand total: €1,088.75" should appear on the page
+        And "Promotion total: -€544.38" should appear on the page
+        And "Grand total: €1,130.62" should appear on the page

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/_items.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/_items.html.twig
@@ -69,7 +69,7 @@
     <tr>
         <th colspan="8" id="items-total" class="right aligned">
             <strong>{{ 'sylius.ui.items_total'|trans }}</strong>:
-            {{ order.itemsTotal|sylius_price(order.currency) }}
+            {{ (order.itemsTotal - order.getAdjustmentsTotalRecursively(orderPromotionAdjustment))|sylius_price(order.currency) }}
         </th>
     </tr>
     <tr>
@@ -117,11 +117,12 @@
     <tr>
         <th colspan="4" id="promotion-discounts">
             <h5>{{ 'sylius.checkout.finalize.order.promotion_discount'|trans }}</h5>
-            {% if not order.adjustments(orderPromotionAdjustment).isEmpty() %}
+            {% set orderPromotions = sylius_aggregate_adjustments(order.getAdjustmentsRecursively(orderPromotionAdjustment)) %}
+            {% if not orderPromotions is empty %}
                 <div class="ui relaxed list">
-                    {% for adjustment in order.adjustments(orderPromotionAdjustment) %}
+                    {% for label, amount in orderPromotions %}
                         <div class="item">
-                            {{ adjustment.label }} {% if not adjustment.amount == 0 %}-{% endif %}{{ (-1 * adjustment.amount)|sylius_price(order.currency) }}
+                            {{ label }} {% if not amount == 0 %}-{% endif %}{{ (-1 * amount)|sylius_price(order.currency) }}
                         </div>
                     {% endfor %}
                 </div>
@@ -131,7 +132,7 @@
         </th>
         <th colspan="4" id="promotion-total" class="right aligned">
             <strong>{{ 'sylius.ui.promotion_total'|trans }}</strong>:
-            {% set orderDiscount = order.adjustmentsTotal(orderPromotionAdjustment) %}
+            {% set orderDiscount = order.adjustmentsTotalRecursively(orderPromotionAdjustment) %}
             {% if not orderDiscount == 0 %}-{% endif %}{{ (-1 * orderDiscount)|sylius_price(order.currency) }}
         </th>
     </tr>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -88,6 +88,8 @@
         <parameter key="sylius.promotion_filter.taxon.class">Sylius\Component\Core\Promotion\Filter\TaxonFilter</parameter>
         <parameter key="sylius.promotion_filter.price_range.class">Sylius\Component\Core\Promotion\Filter\PriceRangeFilter</parameter>
 
+        <parameter key="sylius.promotion.units_promotion_adjustments_applicator.class">Sylius\Component\Core\Promotion\Applicator\UnitsPromotionAdjustmentsApplicator</parameter>
+
         <parameter key="sylius.order.purger.class">Sylius\Bundle\CoreBundle\Purger\ExpiredOrdersPurger</parameter>
         <parameter key="sylius.order.releaser.class">Sylius\Bundle\CoreBundle\Releaser\ExpiredOrdersReleaser</parameter>
         <parameter key="sylius.image_uploader.class">Sylius\Component\Core\Uploader\ImageUploader</parameter>
@@ -115,7 +117,9 @@
         <parameter key="sylius.purger.orm_purger.class">Sylius\Bundle\CoreBundle\Purger\ORMPurger</parameter>
 
         <parameter key="sylius.provider.default_zone_provider.class">Sylius\Bundle\CoreBundle\Provider\DefaultTaxZoneProvider</parameter>
+
         <parameter key="sylius.integer_distributor.class">Sylius\Component\Core\Distributor\IntegerDistributor</parameter>
+        <parameter key="sylius.proportional_integer_distributor.class">Sylius\Component\Core\Distributor\ProportionalIntegerDistributor</parameter>
 
         <!-- Data fetchers -->
         <parameter key="sylius.form.type.data_fetcher.number_of_orders.class">Sylius\Bundle\CoreBundle\Form\Type\DataFetcher\NumberOfOrdersType</parameter>
@@ -223,6 +227,7 @@
             </argument>
         </service>
         <service id="sylius.integer_distributor" class="%sylius.integer_distributor.class%" />
+        <service id="sylius.proportional_integer_distributor" class="%sylius.proportional_integer_distributor.class%" />
 
         <service id="sylius.invoice_number_generator" class="%sylius.based_on_id_invoice_number_generator.class%" />
 
@@ -483,6 +488,8 @@
         <service id="sylius.promotion_action.fixed_discount" class="%sylius.promotion_action.fixed_discount.class%">
             <argument type="service" id="sylius.factory.adjustment" />
             <argument type="service" id="sylius.originator" />
+            <argument type="service" id="sylius.proportional_integer_distributor" />
+            <argument type="service" id="sylius.promotion.units_promotion_adjustments_applicator" />
             <tag name="sylius.promotion_action" type="order_fixed_discount" label="Order fixed discount" />
         </service>
         <service id="sylius.promotion_action.item_fixed_discount" class="%sylius.promotion_action.item_fixed_discount.class%">
@@ -524,6 +531,12 @@
 
         <service id="sylius.promotion_filter.taxon" class="%sylius.promotion_filter.taxon.class%" />
         <service id="sylius.promotion_filter.price_range" class="%sylius.promotion_filter.price_range.class%" />
+
+        <service id="sylius.promotion.units_promotion_adjustments_applicator" class="%sylius.promotion.units_promotion_adjustments_applicator.class%">
+            <argument type="service" id="sylius.factory.adjustment" />
+            <argument type="service" id="sylius.integer_distributor" />
+            <argument type="service" id="sylius.originator" />
+        </service>
 
         <service id="sylius.price_calculator.channel_based" class="%sylius.price_calculator.channel_based.class%" lazy="true">
             <argument type="service" id="sylius.context.channel" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -486,7 +486,6 @@
             <tag name="sylius.promotion_rule_checker" type="total_of_items_from_taxon" label="Total of items from taxon" />
         </service>
         <service id="sylius.promotion_action.fixed_discount" class="%sylius.promotion_action.fixed_discount.class%">
-            <argument type="service" id="sylius.factory.adjustment" />
             <argument type="service" id="sylius.originator" />
             <argument type="service" id="sylius.proportional_integer_distributor" />
             <argument type="service" id="sylius.promotion.units_promotion_adjustments_applicator" />
@@ -500,8 +499,9 @@
             <tag name="sylius.promotion_action" type="item_fixed_discount" label="Item fixed discount" />
         </service>
         <service id="sylius.promotion_action.percentage_discount" class="%sylius.promotion_action.percentage_discount.class%">
-            <argument type="service" id="sylius.factory.adjustment" />
             <argument type="service" id="sylius.originator" />
+            <argument type="service" id="sylius.integer_distributor" />
+            <argument type="service" id="sylius.promotion.units_promotion_adjustments_applicator" />
             <tag name="sylius.promotion_action" type="order_percentage_discount" label="Order percentage discount" />
         </service>
         <service id="sylius.promotion_action.item_percentage_discount" class="%sylius.promotion_action.item_percentage_discount.class%">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/_item.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/_item.html.twig
@@ -18,11 +18,11 @@
     </td>
     <td class="col-md-1" style="text-align: right">
         {% set regularPrice = item.vars.value|sylius_regular_price %}
-        {% if regularPrice != item.vars.value.total %}
+        {% if 0 != item.vars.value.getAdjustmentsTotalRecursively('order_item_promotion') %}
             <span class="regular-price" style="text-decoration: line-through">{{ regularPrice|sylius_price }}</span>
             <span class="discount-price">{{ item.vars.value.total|sylius_price }}</span>
         {% else %}
-            <span>{{ item.vars.value.total|sylius_price }}</span>
+            <span>{{ regularPrice|sylius_price }}</span>
         {% endif %}
     </td>
 </tr>

--- a/src/Sylius/Component/Core/Distributor/ProportionalIntegerDistributor.php
+++ b/src/Sylius/Component/Core/Distributor/ProportionalIntegerDistributor.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Distributor;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class ProportionalIntegerDistributor implements ProportionalIntegerDistributorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function distribute($total, array $elements, $amount)
+    {
+        if ($total !== array_sum($elements)) {
+            throw new \InvalidArgumentException('Element sum should be equal with total.');
+        }
+
+        $distributedAmounts = [];
+
+        $sign = $amount < 0 ? -1 : 1;
+        $amount = abs($amount);
+
+        $distributedSum = 0;
+        foreach ($elements as $element) {
+            $distributedAmount = (int) ($sign * floor(($element * $amount) / $total));
+            $distributedSum += $distributedAmount;
+
+            $distributedAmounts[] = $distributedAmount;
+        }
+
+        if ($distributedSum < $amount) {
+            for ($i = 0; $i < ($amount - $distributedSum); $i++) {
+                $distributedAmounts[$i]++;
+            }
+        }
+
+        return $distributedAmounts;
+    }
+}

--- a/src/Sylius/Component/Core/Distributor/ProportionalIntegerDistributor.php
+++ b/src/Sylius/Component/Core/Distributor/ProportionalIntegerDistributor.php
@@ -11,22 +11,25 @@
 
 namespace Sylius\Component\Core\Distributor;
 
+use Webmozart\Assert\Assert;
+
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class ProportionalIntegerDistributor implements ProportionalIntegerDistributorInterface
+final class ProportionalIntegerDistributor implements ProportionalIntegerDistributorInterface
 {
     /**
      * {@inheritdoc}
      */
-    public function distribute($total, array $elements, $amount)
+    public function distribute(array $integers, $amount)
     {
-        if ($total !== array_sum($elements)) {
-            throw new \InvalidArgumentException('Element sum should be equal with total.');
-        }
+        Assert::allInteger($integers);
+        Assert::integer($amount);
 
+        $total = array_sum($integers);
         $distributedAmounts = [];
-        foreach ($elements as $element) {
+
+        foreach ($integers as $element) {
             $distributedAmounts[] = (int) round(($element * $amount) / $total, 0, PHP_ROUND_HALF_DOWN);
         }
 

--- a/src/Sylius/Component/Core/Distributor/ProportionalIntegerDistributor.php
+++ b/src/Sylius/Component/Core/Distributor/ProportionalIntegerDistributor.php
@@ -26,22 +26,13 @@ class ProportionalIntegerDistributor implements ProportionalIntegerDistributorIn
         }
 
         $distributedAmounts = [];
-
-        $sign = $amount < 0 ? -1 : 1;
-        $amount = abs($amount);
-
-        $distributedSum = 0;
         foreach ($elements as $element) {
-            $distributedAmount = (int) ($sign * floor(($element * $amount) / $total));
-            $distributedSum += $distributedAmount;
-
-            $distributedAmounts[] = $distributedAmount;
+            $distributedAmounts[] = (int) round(($element * $amount) / $total, 0, PHP_ROUND_HALF_DOWN);
         }
 
-        if (abs($distributedSum) < $amount) {
-            for ($i = 0; $i < ($amount - abs($distributedSum)); $i++) {
-                (1 === $sign) ? $distributedAmounts[$i]++ : $distributedAmounts[$i]--;
-            }
+        $missingAmount = $amount - array_sum($distributedAmounts);
+        for ($i = 0; $i < abs($missingAmount); $i++) {
+            $distributedAmounts[$i] += $missingAmount >= 0 ? 1 : -1;
         }
 
         return $distributedAmounts;

--- a/src/Sylius/Component/Core/Distributor/ProportionalIntegerDistributor.php
+++ b/src/Sylius/Component/Core/Distributor/ProportionalIntegerDistributor.php
@@ -40,7 +40,7 @@ class ProportionalIntegerDistributor implements ProportionalIntegerDistributorIn
 
         if (abs($distributedSum) < $amount) {
             for ($i = 0; $i < ($amount - abs($distributedSum)); $i++) {
-                (1 === $sign) ? $distributedAmounts[$i]++ : $distributedAmounts[$i]++;
+                (1 === $sign) ? $distributedAmounts[$i]++ : $distributedAmounts[$i]--;
             }
         }
 

--- a/src/Sylius/Component/Core/Distributor/ProportionalIntegerDistributor.php
+++ b/src/Sylius/Component/Core/Distributor/ProportionalIntegerDistributor.php
@@ -38,9 +38,9 @@ class ProportionalIntegerDistributor implements ProportionalIntegerDistributorIn
             $distributedAmounts[] = $distributedAmount;
         }
 
-        if ($distributedSum < $amount) {
-            for ($i = 0; $i < ($amount - $distributedSum); $i++) {
-                $distributedAmounts[$i]++;
+        if (abs($distributedSum) < $amount) {
+            for ($i = 0; $i < ($amount - abs($distributedSum)); $i++) {
+                (1 === $sign) ? $distributedAmounts[$i]++ : $distributedAmounts[$i]++;
             }
         }
 

--- a/src/Sylius/Component/Core/Distributor/ProportionalIntegerDistributorInterface.php
+++ b/src/Sylius/Component/Core/Distributor/ProportionalIntegerDistributorInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Distributor;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+interface ProportionalIntegerDistributorInterface
+{
+    /**
+     * @param int $total
+     * @param array $elements
+     * @param int $amount
+     *
+     * @return array
+     */
+    public function distribute($total, array $elements, $amount);
+}

--- a/src/Sylius/Component/Core/Distributor/ProportionalIntegerDistributorInterface.php
+++ b/src/Sylius/Component/Core/Distributor/ProportionalIntegerDistributorInterface.php
@@ -17,11 +17,10 @@ namespace Sylius\Component\Core\Distributor;
 interface ProportionalIntegerDistributorInterface
 {
     /**
-     * @param int $total
-     * @param array $elements
+     * @param array $integers
      * @param int $amount
      *
      * @return array
      */
-    public function distribute($total, array $elements, $amount);
+    public function distribute(array $integers, $amount);
 }

--- a/src/Sylius/Component/Core/Promotion/Action/DiscountAction.php
+++ b/src/Sylius/Component/Core/Promotion/Action/DiscountAction.php
@@ -13,36 +13,28 @@ namespace Sylius\Component\Core\Promotion\Action;
 
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Originator\Originator\OriginatorInterface;
 use Sylius\Component\Promotion\Action\PromotionActionInterface;
 use Sylius\Component\Promotion\Model\PromotionInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
-use Sylius\Component\Resource\Factory\FactoryInterface;
 
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
 abstract class DiscountAction implements PromotionActionInterface
 {
-    /**
-     * @var FactoryInterface
-     */
-    protected $adjustmentFactory;
-
     /**
      * @var OriginatorInterface
      */
     protected $originator;
 
     /**
-     * @param FactoryInterface $adjustmentFactory
      * @param OriginatorInterface $originator
      */
-    public function __construct(FactoryInterface $adjustmentFactory, OriginatorInterface $originator)
+    public function __construct(OriginatorInterface $originator)
     {
-        $this->adjustmentFactory = $adjustmentFactory;
         $this->originator = $originator;
     }
 
@@ -51,34 +43,41 @@ abstract class DiscountAction implements PromotionActionInterface
      */
     public function revert(PromotionSubjectInterface $subject, array $configuration, PromotionInterface $promotion)
     {
-        if (!$subject instanceof OrderInterface && !$subject instanceof OrderItemInterface) {
-            throw new UnexpectedTypeException(
-                $subject,
-                'Sylius\Component\Core\Model\OrderInterface or Sylius\Component\Core\Model\OrderItemInterface'
-            );
+        if (!$this->isSubjectValid($subject)) {
+            return;
         }
 
-        foreach ($subject->getAdjustments(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT) as $adjustment) {
-            if ($promotion === $this->originator->getOrigin($adjustment)) {
-                $subject->removeAdjustment($adjustment);
+        foreach ($subject->getItems() as $item) {
+            foreach ($item->getUnits() as $unit) {
+                foreach ($unit->getAdjustments(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT) as $adjustment) {
+                    if ($promotion === $this->originator->getOrigin($adjustment)) {
+                        $unit->removeAdjustment($adjustment);
+                    }
+                }
             }
         }
     }
 
     /**
-     * @param PromotionInterface $promotion
-     * @param string $type
+     * @param PromotionSubjectInterface $subject
      *
-     * @return AdjustmentInterface
+     * @return bool
      */
-    protected function createAdjustment(PromotionInterface $promotion, $type = AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT)
+    protected function isSubjectValid(PromotionSubjectInterface $subject)
     {
-        $adjustment = $this->adjustmentFactory->createNew();
-        $adjustment->setType($type);
-        $adjustment->setLabel($promotion->getName());
+        if (!$subject instanceof OrderInterface) {
+            throw new UnexpectedTypeException($subject, OrderInterface::class);
+        }
 
-        $this->originator->setOrigin($adjustment, $promotion);
+        if (0 === $subject->countItems()) {
+            return false;
+        }
 
-        return $adjustment;
+        return true;
     }
+
+    /**
+     * @param array $configuration
+     */
+    protected abstract function isConfigurationValid(array $configuration);
 }

--- a/src/Sylius/Component/Core/Promotion/Action/FixedDiscountAction.php
+++ b/src/Sylius/Component/Core/Promotion/Action/FixedDiscountAction.php
@@ -11,11 +11,15 @@
 
 namespace Sylius\Component\Core\Promotion\Action;
 
+use Sylius\Component\Core\Distributor\ProportionalIntegerDistributorInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Promotion\Applicator\UnitsPromotionAdjustmentsApplicatorInterface;
+use Sylius\Component\Originator\Originator\OriginatorInterface;
 use Sylius\Component\Promotion\Model\PromotionInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
+use Sylius\Component\Resource\Factory\FactoryInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -26,23 +30,50 @@ class FixedDiscountAction extends DiscountAction
     const TYPE = 'order_fixed_discount';
 
     /**
+     * @var ProportionalIntegerDistributorInterface
+     */
+    private $distributor;
+
+    /**
+     * @var UnitsPromotionAdjustmentsApplicatorInterface
+     */
+    private $unitsPromotionAdjustmentsApplicator;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param ProportionalIntegerDistributorInterface $proportionalIntegerDistributor
+     */
+    public function __construct(
+        FactoryInterface $adjustmentFactory,
+        OriginatorInterface $originator,
+        ProportionalIntegerDistributorInterface $proportionalIntegerDistributor,
+        UnitsPromotionAdjustmentsApplicatorInterface $unitsPromotionAdjustmentsApplicator
+    ) {
+        parent::__construct($adjustmentFactory, $originator);
+
+        $this->distributor = $proportionalIntegerDistributor;
+        $this->unitsPromotionAdjustmentsApplicator = $unitsPromotionAdjustmentsApplicator;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function execute(PromotionSubjectInterface $subject, array $configuration, PromotionInterface $promotion)
     {
-        if (!$subject instanceof OrderInterface && !$subject instanceof OrderItemInterface) {
-            throw new UnexpectedTypeException(
-                $subject,
-                'Sylius\Component\Core\Model\OrderInterface or Sylius\Component\Core\Model\OrderItemInterface'
-            );
+        if (!$subject instanceof OrderInterface) {
+            throw new UnexpectedTypeException($subject, OrderInterface::class);
         }
 
-        $adjustment = $this->createAdjustment($promotion);
-        $adjustment->setAmount(
-            $this->calculateAdjustmentAmount($subject->getPromotionSubjectTotal(), $configuration['amount'])
-        );
+        $promotionAmount = $this->calculateAdjustmentAmount($subject->getPromotionSubjectTotal(), $configuration['amount']);
 
-        $subject->addAdjustment($adjustment);
+        $itemsTotals = [];
+        foreach ($subject->getItems() as $item) {
+            $itemsTotals[] = $item->getTotal();
+        }
+
+        $splitPromotion = $this->distributor->distribute($subject->getPromotionSubjectTotal(), $itemsTotals, $promotionAmount);
+        $this->unitsPromotionAdjustmentsApplicator->apply($subject, $promotion, $splitPromotion);
     }
 
     /**

--- a/src/Sylius/Component/Core/Promotion/Action/FixedDiscountAction.php
+++ b/src/Sylius/Component/Core/Promotion/Action/FixedDiscountAction.php
@@ -16,6 +16,7 @@ use Sylius\Component\Core\Promotion\Applicator\UnitsPromotionAdjustmentsApplicat
 use Sylius\Component\Originator\Originator\OriginatorInterface;
 use Sylius\Component\Promotion\Model\PromotionInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -74,7 +75,7 @@ class FixedDiscountAction extends DiscountAction
             $itemsTotals[] = $item->getTotal();
         }
 
-        $splitPromotion = $this->distributor->distribute($subject->getPromotionSubjectTotal(), $itemsTotals, $promotionAmount);
+        $splitPromotion = $this->distributor->distribute($itemsTotals, $promotionAmount);
         $this->unitsPromotionAdjustmentsApplicator->apply($subject, $promotion, $splitPromotion);
     }
 
@@ -91,9 +92,8 @@ class FixedDiscountAction extends DiscountAction
      */
     protected function isConfigurationValid(array $configuration)
     {
-        if (!isset($configuration['amount']) || !is_int($configuration['amount'])) {
-            throw new \InvalidArgumentException('"amount" must be set and must be an integer.');
-        }
+        Assert::keyExists($configuration, 'amount');
+        Assert::integer($configuration['amount']);
     }
 
     /**

--- a/src/Sylius/Component/Core/Promotion/Action/FixedDiscountAction.php
+++ b/src/Sylius/Component/Core/Promotion/Action/FixedDiscountAction.php
@@ -30,7 +30,7 @@ class FixedDiscountAction extends DiscountAction
     /**
      * @var ProportionalIntegerDistributorInterface
      */
-    private $distributor;
+    private $proportionalDistributor;
 
     /**
      * @var UnitsPromotionAdjustmentsApplicatorInterface
@@ -50,7 +50,7 @@ class FixedDiscountAction extends DiscountAction
     ) {
         parent::__construct($originator);
 
-        $this->distributor = $proportionalIntegerDistributor;
+        $this->proportionalDistributor = $proportionalIntegerDistributor;
         $this->unitsPromotionAdjustmentsApplicator = $unitsPromotionAdjustmentsApplicator;
     }
 
@@ -75,7 +75,7 @@ class FixedDiscountAction extends DiscountAction
             $itemsTotals[] = $item->getTotal();
         }
 
-        $splitPromotion = $this->distributor->distribute($itemsTotals, $promotionAmount);
+        $splitPromotion = $this->proportionalDistributor->distribute($itemsTotals, $promotionAmount);
         $this->unitsPromotionAdjustmentsApplicator->apply($subject, $promotion, $splitPromotion);
     }
 
@@ -104,6 +104,6 @@ class FixedDiscountAction extends DiscountAction
      */
     private function calculateAdjustmentAmount($promotionSubjectTotal, $targetPromotionAmount)
     {
-        return -1 * min(abs($promotionSubjectTotal), abs($targetPromotionAmount));
+        return -1 * min($promotionSubjectTotal, $targetPromotionAmount);
     }
 }

--- a/src/Sylius/Component/Core/Promotion/Action/PercentageDiscountAction.php
+++ b/src/Sylius/Component/Core/Promotion/Action/PercentageDiscountAction.php
@@ -11,35 +11,66 @@
 
 namespace Sylius\Component\Core\Promotion\Action;
 
-use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\Model\OrderItemInterface;
-use Sylius\Component\Order\Model\OrderItemUnitInterface;
+use Sylius\Component\Core\Distributor\IntegerDistributorInterface;
+use Sylius\Component\Core\Promotion\Applicator\UnitsPromotionAdjustmentsApplicatorInterface;
+use Sylius\Component\Originator\Originator\OriginatorInterface;
 use Sylius\Component\Promotion\Model\PromotionInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
-use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Saša Stamenković <umpirsky@gmail.com>
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
 class PercentageDiscountAction extends DiscountAction
 {
     const TYPE = 'order_percentage_discount';
 
     /**
+     * @var IntegerDistributorInterface
+     */
+    private $distributor;
+
+    /**
+     * @var UnitsPromotionAdjustmentsApplicatorInterface
+     */
+    private $unitsPromotionAdjustmentsApplicator;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param IntegerDistributorInterface $distributor
+     * @param UnitsPromotionAdjustmentsApplicatorInterface $unitsPromotionAdjustmentsApplicator
+     */
+    public function __construct(
+        OriginatorInterface $originator,
+        IntegerDistributorInterface $distributor,
+        UnitsPromotionAdjustmentsApplicatorInterface $unitsPromotionAdjustmentsApplicator
+    ) {
+        parent::__construct($originator);
+
+        $this->distributor = $distributor;
+        $this->unitsPromotionAdjustmentsApplicator = $unitsPromotionAdjustmentsApplicator;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function execute(PromotionSubjectInterface $subject, array $configuration, PromotionInterface $promotion)
     {
-        if (!$subject instanceof OrderInterface) {
-            throw new UnexpectedTypeException($subject, OrderInterface::class);
+        if (!$this->isSubjectValid($subject)) {
+            return;
         }
 
-        $adjustment = $this->createAdjustment($promotion);
-        $adjustmentAmount = (int) round($subject->getPromotionSubjectTotal() * $configuration['percentage']);
-        $adjustment->setAmount(-$adjustmentAmount);
+        $this->isConfigurationValid($configuration);
 
-        $subject->addAdjustment($adjustment);
+        $promotionAmount = $this->calculateAdjustmentAmount($subject->getPromotionSubjectTotal(), $configuration['percentage']);
+        if (0 === $promotionAmount) {
+            return;
+        }
+
+        $splitPromotion = $this->distributor->distribute($promotionAmount, $subject->countItems());
+        $this->unitsPromotionAdjustmentsApplicator->apply($subject, $promotion, $splitPromotion);
     }
 
     /**
@@ -48,5 +79,26 @@ class PercentageDiscountAction extends DiscountAction
     public function getConfigurationFormType()
     {
         return 'sylius_promotion_action_percentage_discount_configuration';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function isConfigurationValid(array $configuration)
+    {
+        if (!isset($configuration['percentage']) || !is_float($configuration['percentage'])) {
+            throw new \InvalidArgumentException('"percentage" must be set and must be a float.');
+        }
+    }
+
+    /**
+     * @param int $promotionSubjectTotal
+     * @param int $percentage
+     *
+     * @return int
+     */
+    private function calculateAdjustmentAmount($promotionSubjectTotal, $percentage)
+    {
+        return -1 * (int) round($promotionSubjectTotal * $percentage);
     }
 }

--- a/src/Sylius/Component/Core/Promotion/Action/ShippingDiscountAction.php
+++ b/src/Sylius/Component/Core/Promotion/Action/ShippingDiscountAction.php
@@ -13,16 +13,40 @@ namespace Sylius\Component\Core\Promotion\Action;
 
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Originator\Originator\OriginatorInterface;
+use Sylius\Component\Promotion\Action\PromotionActionInterface;
 use Sylius\Component\Promotion\Model\PromotionInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
+use Sylius\Component\Resource\Factory\FactoryInterface;
 
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class ShippingDiscountAction extends DiscountAction
+class ShippingDiscountAction implements PromotionActionInterface
 {
     const TYPE = 'shipping_discount';
+
+    /**
+     * @var FactoryInterface
+     */
+    protected $adjustmentFactory;
+
+    /**
+     * @var OriginatorInterface
+     */
+    protected $originator;
+
+    /**
+     * @param FactoryInterface $adjustmentFactory
+     * @param OriginatorInterface $originator
+     */
+    public function __construct(FactoryInterface $adjustmentFactory, OriginatorInterface $originator)
+    {
+        $this->adjustmentFactory = $adjustmentFactory;
+        $this->originator = $originator;
+    }
 
     /**
      * {@inheritdoc}
@@ -43,8 +67,44 @@ class ShippingDiscountAction extends DiscountAction
     /**
      * {@inheritdoc}
      */
+    public function revert(PromotionSubjectInterface $subject, array $configuration, PromotionInterface $promotion)
+    {
+        if (!$subject instanceof OrderInterface && !$subject instanceof OrderItemInterface) {
+            throw new UnexpectedTypeException(
+                $subject,
+                'Sylius\Component\Core\Model\OrderInterface or Sylius\Component\Core\Model\OrderItemInterface'
+            );
+        }
+
+        foreach ($subject->getAdjustments(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT) as $adjustment) {
+            if ($promotion === $this->originator->getOrigin($adjustment)) {
+                $subject->removeAdjustment($adjustment);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getConfigurationFormType()
     {
         return 'sylius_promotion_action_shipping_discount_configuration';
+    }
+
+    /**
+     * @param PromotionInterface $promotion
+     * @param string $type
+     *
+     * @return AdjustmentInterface
+     */
+    protected function createAdjustment(PromotionInterface $promotion, $type = AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT)
+    {
+        $adjustment = $this->adjustmentFactory->createNew();
+        $adjustment->setType($type);
+        $adjustment->setLabel($promotion->getName());
+
+        $this->originator->setOrigin($adjustment, $promotion);
+
+        return $adjustment;
     }
 }

--- a/src/Sylius/Component/Core/Promotion/Applicator/UnitsPromotionAdjustmentsApplicator.php
+++ b/src/Sylius/Component/Core/Promotion/Applicator/UnitsPromotionAdjustmentsApplicator.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Promotion\Applicator;
+
+use Sylius\Component\Core\Distributor\IntegerDistributorInterface;
+use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
+use Sylius\Component\Order\Model\OrderItemUnitInterface;
+use Sylius\Component\Originator\Originator\OriginatorInterface;
+use Sylius\Component\Promotion\Model\PromotionInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class UnitsPromotionAdjustmentsApplicator implements UnitsPromotionAdjustmentsApplicatorInterface
+{
+    /**
+     * @var AdjustmentFactoryInterface
+     */
+    private $adjustmentFactory;
+
+    /**
+     * @var IntegerDistributorInterface
+     */
+    private $distributor;
+
+    /**
+     * @var OriginatorInterface
+     */
+    private $originator;
+
+    /**
+     * @param AdjustmentFactoryInterface $adjustmentFactory
+     * @param IntegerDistributorInterface $distributor
+     * @param OriginatorInterface $originator
+     */
+    public function __construct(
+        AdjustmentFactoryInterface $adjustmentFactory,
+        IntegerDistributorInterface $distributor,
+        OriginatorInterface $originator
+    ) {
+        $this->adjustmentFactory = $adjustmentFactory;
+        $this->distributor = $distributor;
+        $this->originator = $originator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function apply(OrderInterface $order, PromotionInterface $promotion, array $adjustmentsAmounts)
+    {
+        if ($order->countItems() !== count($adjustmentsAmounts)) {
+            throw new \InvalidArgumentException(
+                'Number of adjustments amount to distribute must be equal with number of order items.'
+            );
+        }
+
+        $i = 0;
+        foreach ($order->getItems() as $item) {
+            if (0 === $adjustmentsAmounts[$i]) {
+                continue;
+            }
+
+            $this->applyAdjustmentsOnItemUnits($item, $promotion, $adjustmentsAmounts[$i]);
+            $i++;
+        }
+    }
+
+    /**
+     * @param OrderItemInterface $item
+     * @param PromotionInterface $promotion
+     * @param int $itemPromotionAmount
+     */
+    private function applyAdjustmentsOnItemUnits(OrderItemInterface $item, PromotionInterface $promotion, $itemPromotionAmount)
+    {
+        $splitPromotionAmount = $this->distributor->distribute($itemPromotionAmount, $item->getQuantity());
+
+        $i = 0;
+        foreach ($item->getUnits() as $unit) {
+            if (0 === $splitPromotionAmount[$i]) {
+                continue;
+            }
+
+            $this->addAdjustment($promotion, $unit, $splitPromotionAmount[$i]);
+            $i++;
+        }
+    }
+
+    /**
+     * @param PromotionInterface $promotion
+     * @param OrderItemUnitInterface $unit
+     * @param int $amount
+     */
+    private function addAdjustment(PromotionInterface $promotion, OrderItemUnitInterface $unit, $amount)
+    {
+        $adjustment = $this->adjustmentFactory
+            ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, $promotion->getName(), $amount)
+        ;
+
+        $this->originator->setOrigin($adjustment, $promotion);
+
+        $unit->addAdjustment($adjustment);
+    }
+}

--- a/src/Sylius/Component/Core/Promotion/Applicator/UnitsPromotionAdjustmentsApplicator.php
+++ b/src/Sylius/Component/Core/Promotion/Applicator/UnitsPromotionAdjustmentsApplicator.php
@@ -19,6 +19,7 @@ use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
 use Sylius\Component\Order\Model\OrderItemUnitInterface;
 use Sylius\Component\Originator\Originator\OriginatorInterface;
 use Sylius\Component\Promotion\Model\PromotionInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -60,11 +61,7 @@ class UnitsPromotionAdjustmentsApplicator implements UnitsPromotionAdjustmentsAp
      */
     public function apply(OrderInterface $order, PromotionInterface $promotion, array $adjustmentsAmounts)
     {
-        if ($order->countItems() !== count($adjustmentsAmounts)) {
-            throw new \InvalidArgumentException(
-                'Number of adjustments amount to distribute must be equal with number of order items.'
-            );
-        }
+        Assert::eq($order->countItems(), count($adjustmentsAmounts));
 
         $i = 0;
         foreach ($order->getItems() as $item) {

--- a/src/Sylius/Component/Core/Promotion/Applicator/UnitsPromotionAdjustmentsApplicator.php
+++ b/src/Sylius/Component/Core/Promotion/Applicator/UnitsPromotionAdjustmentsApplicator.php
@@ -65,12 +65,12 @@ class UnitsPromotionAdjustmentsApplicator implements UnitsPromotionAdjustmentsAp
 
         $i = 0;
         foreach ($order->getItems() as $item) {
-            if (0 === $adjustmentsAmounts[$i]) {
+            $adjustmentAmount = $adjustmentsAmounts[$i++];
+            if (0 === $adjustmentAmount) {
                 continue;
             }
 
-            $this->applyAdjustmentsOnItemUnits($item, $promotion, $adjustmentsAmounts[$i]);
-            $i++;
+            $this->applyAdjustmentsOnItemUnits($item, $promotion, $adjustmentAmount);
         }
     }
 
@@ -85,12 +85,12 @@ class UnitsPromotionAdjustmentsApplicator implements UnitsPromotionAdjustmentsAp
 
         $i = 0;
         foreach ($item->getUnits() as $unit) {
-            if (0 === $splitPromotionAmount[$i]) {
+            $promotionAmount = $splitPromotionAmount[$i++];
+            if (0 === $promotionAmount) {
                 continue;
             }
 
-            $this->addAdjustment($promotion, $unit, $splitPromotionAmount[$i]);
-            $i++;
+            $this->addAdjustment($promotion, $unit, $promotionAmount);
         }
     }
 

--- a/src/Sylius/Component/Core/Promotion/Applicator/UnitsPromotionAdjustmentsApplicatorInterface.php
+++ b/src/Sylius/Component/Core/Promotion/Applicator/UnitsPromotionAdjustmentsApplicatorInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Promotion\Applicator;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Promotion\Model\PromotionInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+interface UnitsPromotionAdjustmentsApplicatorInterface
+{
+    /**
+     * @param OrderInterface $order
+     * @param PromotionInterface $promotion
+     * @param array $adjustmentsAmounts
+     */
+    public function apply(OrderInterface $order, PromotionInterface $promotion, array $adjustmentsAmounts);
+}

--- a/src/Sylius/Component/Core/spec/Distributor/ProportionalIntegerDistributorSpec.php
+++ b/src/Sylius/Component/Core/spec/Distributor/ProportionalIntegerDistributorSpec.php
@@ -31,29 +31,37 @@ class ProportionalIntegerDistributorSpec extends ObjectBehavior
 
     function it_distributes_integer_based_on_elements_participation_in_total()
     {
-        $this->distribute(8000, [4000, 2000, 2000], 300)->shouldReturn([150, 75, 75]);
+        $this->distribute([4000, 2000, 2000], 300)->shouldReturn([150, 75, 75]);
     }
 
     function it_distributes_negative_integer_based_on_elements_participation_in_total()
     {
-        $this->distribute(8000, [4000, 2000, 2000], -300)->shouldReturn([-150, -75, -75]);
+        $this->distribute([4000, 2000, 2000], -300)->shouldReturn([-150, -75, -75]);
     }
 
     function it_distributes_integer_based_on_elements_participation_in_total_even_if_it_can_be_divided_easily()
     {
-        $this->distribute(8000, [4300, 1400, 2300], 300)->shouldReturn([162, 52, 86]);
+        $this->distribute([4300, 1400, 2300], 300)->shouldReturn([162, 52, 86]);
     }
 
     function it_distributes_negative_integer_based_on_elements_participation_in_total_even_if_it_can_be_divided_easily()
     {
-        $this->distribute(8000, [4300, 1400, 2300], -300)->shouldReturn([-162, -52, -86]);
+        $this->distribute([4300, 1400, 2300], -300)->shouldReturn([-162, -52, -86]);
     }
 
-    function it_throws_exception_if_elements_sum_is_not_equal_with_total()
+    function it_throws_exception_if_amount_is_not_integer()
     {
         $this
-            ->shouldThrow(new \InvalidArgumentException('Element sum should be equal with total.'))
-            ->during('distribute', [1000, [500, 400], 200])
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('distribute', [[4300, 1400, 2300], 'string'])
+        ;
+    }
+
+    function it_throws_exception_if_any_of_integers_array_element_is_not_integer()
+    {
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('distribute', [[4300, '1400', 2300], 300])
         ;
     }
 }

--- a/src/Sylius/Component/Core/spec/Distributor/ProportionalIntegerDistributorSpec.php
+++ b/src/Sylius/Component/Core/spec/Distributor/ProportionalIntegerDistributorSpec.php
@@ -49,6 +49,11 @@ class ProportionalIntegerDistributorSpec extends ObjectBehavior
         $this->distribute([4300, 1400, 2300], -300)->shouldReturn([-162, -52, -86]);
     }
 
+    function it_distributes_integer_even_if_its_indivisible_by_number_of_items()
+    {
+        $this->distribute([4300, 1400, 2300], -299)->shouldReturn([-161, -52, -86]);
+    }
+
     function it_throws_exception_if_amount_is_not_integer()
     {
         $this

--- a/src/Sylius/Component/Core/spec/Distributor/ProportionalIntegerDistributorSpec.php
+++ b/src/Sylius/Component/Core/spec/Distributor/ProportionalIntegerDistributorSpec.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Core\Distributor;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Distributor\ProportionalIntegerDistributorInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class ProportionalIntegerDistributorSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Core\Distributor\ProportionalIntegerDistributor');
+    }
+
+    function it_implements_integer_proportional_distributor_interface()
+    {
+        $this->shouldImplement(ProportionalIntegerDistributorInterface::class);
+    }
+
+    function it_distributes_integer_based_on_elements_participation_in_total()
+    {
+        $this->distribute(8000, [4000, 2000, 2000], 300)->shouldReturn([150, 75, 75]);
+    }
+
+    function it_distributes_integer_based_on_elements_participation_in_total_even_if_it_can_be_divided_easily()
+    {
+        $this->distribute(8000, [4300, 1400, 2300], 300)->shouldReturn([162, 52, 86]);
+    }
+
+    function it_throws_exception_if_elements_sum_is_not_equal_with_total()
+    {
+        $this
+            ->shouldThrow(new \InvalidArgumentException('Element sum should be equal with total.'))
+            ->during('distribute', [1000, [500, 400], 200])
+        ;
+    }
+}

--- a/src/Sylius/Component/Core/spec/Distributor/ProportionalIntegerDistributorSpec.php
+++ b/src/Sylius/Component/Core/spec/Distributor/ProportionalIntegerDistributorSpec.php
@@ -34,9 +34,19 @@ class ProportionalIntegerDistributorSpec extends ObjectBehavior
         $this->distribute(8000, [4000, 2000, 2000], 300)->shouldReturn([150, 75, 75]);
     }
 
+    function it_distributes_negative_integer_based_on_elements_participation_in_total()
+    {
+        $this->distribute(8000, [4000, 2000, 2000], -300)->shouldReturn([-150, -75, -75]);
+    }
+
     function it_distributes_integer_based_on_elements_participation_in_total_even_if_it_can_be_divided_easily()
     {
         $this->distribute(8000, [4300, 1400, 2300], 300)->shouldReturn([162, 52, 86]);
+    }
+
+    function it_distributes_negative_integer_based_on_elements_participation_in_total_even_if_it_can_be_divided_easily()
+    {
+        $this->distribute(8000, [4300, 1400, 2300], -300)->shouldReturn([-162, -52, -86]);
     }
 
     function it_throws_exception_if_elements_sum_is_not_equal_with_total()

--- a/src/Sylius/Component/Core/spec/Promotion/Action/FixedDiscountActionSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/FixedDiscountActionSpec.php
@@ -12,10 +12,12 @@
 namespace spec\Sylius\Component\Core\Promotion\Action;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Sylius\Component\Core\Distributor\ProportionalIntegerDistributorInterface;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Core\Promotion\Action\FixedDiscountAction;
 use Sylius\Component\Core\Promotion\Applicator\UnitsPromotionAdjustmentsApplicatorInterface;
 use Sylius\Component\Originator\Originator\OriginatorInterface;
@@ -23,24 +25,22 @@ use Sylius\Component\Promotion\Action\PromotionActionInterface;
 use Sylius\Component\Promotion\Model\PromotionInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
-use Sylius\Component\Resource\Factory\FactoryInterface;
 
 /**
  * @mixin FixedDiscountAction
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Saša Stamenković <umpirsky@gmail.com>
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
 class FixedDiscountActionSpec extends ObjectBehavior
 {
     function let(
-        FactoryInterface $adjustmentFactory,
         OriginatorInterface $originator,
         ProportionalIntegerDistributorInterface $proportionalIntegerDistributor,
         UnitsPromotionAdjustmentsApplicatorInterface $unitsPromotionAdjustmentsApplicator
     ) {
         $this->beConstructedWith(
-            $adjustmentFactory,
             $originator,
             $proportionalIntegerDistributor,
             $unitsPromotionAdjustmentsApplicator
@@ -52,12 +52,12 @@ class FixedDiscountActionSpec extends ObjectBehavior
         $this->shouldHaveType('Sylius\Component\Core\Promotion\Action\FixedDiscountAction');
     }
 
-    function it_implements_Sylius_promotion_action_interface()
+    function it_implements_promotion_action_interface()
     {
         $this->shouldImplement(PromotionActionInterface::class);
     }
 
-    function it_applies_fixed_discount_as_promotion_adjustment(
+    function it_uses_distributor_and_applicator_to_execute_promotion_action(
         OrderInterface $order,
         OrderItemInterface $firstItem,
         OrderItemInterface $secondItem,
@@ -65,23 +65,24 @@ class FixedDiscountActionSpec extends ObjectBehavior
         ProportionalIntegerDistributorInterface $proportionalIntegerDistributor,
         UnitsPromotionAdjustmentsApplicatorInterface $unitsPromotionAdjustmentsApplicator
     ) {
+        $order->countItems()->willReturn(2);
+
         $order
             ->getItems()
             ->willReturn(new \ArrayIterator([$firstItem->getWrappedObject(), $secondItem->getWrappedObject()]))
         ;
 
-        $order->getPromotionSubjectTotal()->willReturn(5000);
+        $order->getPromotionSubjectTotal()->willReturn(10000);
+        $firstItem->getTotal()->willReturn(6000);
+        $secondItem->getTotal()->willReturn(4000);
 
-        $firstItem->getTotal()->willReturn(3000);
-        $secondItem->getTotal()->willReturn(2000);
+        $proportionalIntegerDistributor->distribute(10000, [6000, 4000], -1000)->willReturn([-600, -400]);
+        $unitsPromotionAdjustmentsApplicator->apply($order, $promotion, [-600, -400])->shouldBeCalled();
 
-        $proportionalIntegerDistributor->distribute(5000, [3000, 2000], -500)->willReturn([-300, -200]);
-        $unitsPromotionAdjustmentsApplicator->apply($order, $promotion, [-300, -200]);
-
-        $this->execute($order, ['amount' => 500], $promotion);
+        $this->execute($order, ['amount' => 1000], $promotion);
     }
 
-    function it_does_not_applies_bigger_discount_than_promotion_subject_total(
+    function it_does_not_apply_bigger_promotion_than_promotion_subject_total(
         OrderInterface $order,
         OrderItemInterface $firstItem,
         OrderItemInterface $secondItem,
@@ -89,20 +90,66 @@ class FixedDiscountActionSpec extends ObjectBehavior
         ProportionalIntegerDistributorInterface $proportionalIntegerDistributor,
         UnitsPromotionAdjustmentsApplicatorInterface $unitsPromotionAdjustmentsApplicator
     ) {
+        $order->countItems()->willReturn(2);
+
         $order
             ->getItems()
             ->willReturn(new \ArrayIterator([$firstItem->getWrappedObject(), $secondItem->getWrappedObject()]))
         ;
 
-        $order->getPromotionSubjectTotal()->willReturn(5000);
+        $order->getPromotionSubjectTotal()->willReturn(10000);
+        $firstItem->getTotal()->willReturn(6000);
+        $secondItem->getTotal()->willReturn(4000);
 
-        $firstItem->getTotal()->willReturn(3000);
-        $secondItem->getTotal()->willReturn(2000);
+        $proportionalIntegerDistributor->distribute(10000, [6000, 4000], -10000)->willReturn([-6000, -4000]);
+        $unitsPromotionAdjustmentsApplicator->apply($order, $promotion, [-6000, -4000])->shouldBeCalled();
 
-        $proportionalIntegerDistributor->distribute(5000, [3000, 2000], -5000)->willReturn([-3000, -2000]);
-        $unitsPromotionAdjustmentsApplicator->apply($order, $promotion, [-3000, -2000]);
+        $this->execute($order, ['amount' => 15000], $promotion);
+    }
 
-        $this->execute($order, ['amount' => 10000], $promotion);
+    function it_does_nothing_if_order_has_no_items(OrderInterface $order, PromotionInterface $promotion)
+    {
+        $order->countItems()->willReturn(0);
+        $order->getPromotionSubjectTotal()->shouldNotBeCalled();
+
+        $this->execute($order, ['amount' => 1000], $promotion);
+    }
+
+    function it_does_nothing_if_subject_total_is_0(
+        OrderInterface $order,
+        PromotionInterface $promotion,
+        ProportionalIntegerDistributorInterface $proportionalIntegerDistributor
+    ) {
+        $order->countItems()->willReturn(0);
+        $order->getPromotionSubjectTotal()->willReturn(0);
+        $proportionalIntegerDistributor->distribute(Argument::any())->shouldNotBeCalled();
+
+        $this->execute($order, ['amount' => 1000], $promotion);
+    }
+
+    function it_does_nothing_if_promotion_amount_is_0(
+        OrderInterface $order,
+        PromotionInterface $promotion,
+        ProportionalIntegerDistributorInterface $proportionalIntegerDistributor
+    ) {
+        $order->countItems()->willReturn(0);
+        $order->getPromotionSubjectTotal()->willReturn(1000);
+        $proportionalIntegerDistributor->distribute(Argument::any())->shouldNotBeCalled();
+
+        $this->execute($order, ['amount' => 0], $promotion);
+    }
+
+    function it_throws_exception_if_configuration_is_invalid(OrderInterface $order, PromotionInterface $promotion)
+    {
+        $this
+            ->shouldThrow(new \InvalidArgumentException('"amount" must be set and must be an integer.'))
+            ->during('execute', [$order, [], $promotion])
+        ;
+
+        $this
+            ->shouldThrow(new \InvalidArgumentException('"amount" must be set and must be an integer.'))
+            ->during('execute', [$order, ['amount' => 'string'], $promotion])
+        ;
     }
 
     function it_throws_exception_if_subject_is_not_an_order(
@@ -113,5 +160,57 @@ class FixedDiscountActionSpec extends ObjectBehavior
             ->shouldThrow(new UnexpectedTypeException($subject->getWrappedObject(), OrderInterface::class))
             ->during('execute', [$subject, [], $promotion])
         ;
+    }
+
+    function it_reverts_order_units_order_promotion_adjustments(
+        AdjustmentInterface $firstAdjustment,
+        AdjustmentInterface $secondAdjustment,
+        OrderInterface $order,
+        OrderItemInterface $item,
+        OrderItemUnitInterface $unit,
+        OriginatorInterface $originator,
+        PromotionInterface $otherPromotion,
+        PromotionInterface $promotion
+    ) {
+        $order->countItems()->willReturn(1);
+        $order->getItems()->willReturn(new \ArrayIterator([$item->getWrappedObject()]));
+
+        $item->getUnits()->willReturn(new \ArrayIterator([$unit->getWrappedObject()]));
+
+        $unit
+            ->getAdjustments(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT)
+            ->willReturn(new \ArrayIterator([$firstAdjustment->getWrappedObject(), $secondAdjustment->getWrappedObject()]))
+        ;
+
+        $originator->getOrigin($firstAdjustment)->willReturn($promotion);
+        $originator->getOrigin($secondAdjustment)->willReturn($otherPromotion);
+
+        $unit->removeAdjustment($firstAdjustment)->shouldBeCalled();
+        $unit->removeAdjustment($secondAdjustment)->shouldNotBeCalled();
+
+        $this->revert($order, [], $promotion);
+    }
+
+    function it_does_not_revert_if_order_has_no_items(OrderInterface $order, PromotionInterface $promotion)
+    {
+        $order->countItems()->willReturn(0);
+        $order->getItems()->shouldNotBeCalled();
+
+        $this->revert($order, [], $promotion);
+    }
+
+    function it_throws_exception_while_reverting_subject_which_is_not_order(
+        PromotionInterface $promotion,
+        PromotionSubjectInterface $subject
+    ) {
+        $this
+            ->shouldThrow(new UnexpectedTypeException($subject->getWrappedObject(), OrderInterface::class))
+            ->during('revert', [$subject, [], $promotion])
+        ;
+    }
+
+    function it_has_configuration_form_type()
+    {
+        $this->getConfigurationFormType()->shouldReturn('sylius_promotion_action_fixed_discount_configuration');
     }
 }

--- a/src/Sylius/Component/Core/spec/Promotion/Action/FixedDiscountActionSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/FixedDiscountActionSpec.php
@@ -14,13 +14,14 @@ namespace spec\Sylius\Component\Core\Promotion\Action;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Promotion\Action\FixedDiscountAction;
 use Sylius\Component\Originator\Originator\OriginatorInterface;
 use Sylius\Component\Promotion\Action\PromotionActionInterface;
 use Sylius\Component\Promotion\Model\PromotionInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 
 /**
- * @mixin \Sylius\Component\Core\Promotion\Action\FixedDiscountAction
+ * @mixin FixedDiscountAction
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Saša Stamenković <umpirsky@gmail.com>

--- a/src/Sylius/Component/Core/spec/Promotion/Action/FixedDiscountActionSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/FixedDiscountActionSpec.php
@@ -76,7 +76,7 @@ class FixedDiscountActionSpec extends ObjectBehavior
         $firstItem->getTotal()->willReturn(6000);
         $secondItem->getTotal()->willReturn(4000);
 
-        $proportionalIntegerDistributor->distribute(10000, [6000, 4000], -1000)->willReturn([-600, -400]);
+        $proportionalIntegerDistributor->distribute([6000, 4000], -1000)->willReturn([-600, -400]);
         $unitsPromotionAdjustmentsApplicator->apply($order, $promotion, [-600, -400])->shouldBeCalled();
 
         $this->execute($order, ['amount' => 1000], $promotion);
@@ -101,7 +101,7 @@ class FixedDiscountActionSpec extends ObjectBehavior
         $firstItem->getTotal()->willReturn(6000);
         $secondItem->getTotal()->willReturn(4000);
 
-        $proportionalIntegerDistributor->distribute(10000, [6000, 4000], -10000)->willReturn([-6000, -4000]);
+        $proportionalIntegerDistributor->distribute([6000, 4000], -10000)->willReturn([-6000, -4000]);
         $unitsPromotionAdjustmentsApplicator->apply($order, $promotion, [-6000, -4000])->shouldBeCalled();
 
         $this->execute($order, ['amount' => 15000], $promotion);
@@ -142,12 +142,12 @@ class FixedDiscountActionSpec extends ObjectBehavior
     function it_throws_exception_if_configuration_is_invalid(OrderInterface $order, PromotionInterface $promotion)
     {
         $this
-            ->shouldThrow(new \InvalidArgumentException('"amount" must be set and must be an integer.'))
+            ->shouldThrow(\InvalidArgumentException::class)
             ->during('execute', [$order, [], $promotion])
         ;
 
         $this
-            ->shouldThrow(new \InvalidArgumentException('"amount" must be set and must be an integer.'))
+            ->shouldThrow(\InvalidArgumentException::class)
             ->during('execute', [$order, ['amount' => 'string'], $promotion])
         ;
     }
@@ -157,7 +157,7 @@ class FixedDiscountActionSpec extends ObjectBehavior
         PromotionSubjectInterface $subject
     ) {
         $this
-            ->shouldThrow(new UnexpectedTypeException($subject->getWrappedObject(), OrderInterface::class))
+            ->shouldThrow(\InvalidArgumentException::class)
             ->during('execute', [$subject, [], $promotion])
         ;
     }
@@ -204,7 +204,7 @@ class FixedDiscountActionSpec extends ObjectBehavior
         PromotionSubjectInterface $subject
     ) {
         $this
-            ->shouldThrow(new UnexpectedTypeException($subject->getWrappedObject(), OrderInterface::class))
+            ->shouldThrow(\InvalidArgumentException::class)
             ->during('revert', [$subject, [], $promotion])
         ;
     }

--- a/src/Sylius/Component/Core/spec/Promotion/Action/PercentageDiscountActionSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/PercentageDiscountActionSpec.php
@@ -12,22 +12,39 @@
 namespace spec\Sylius\Component\Core\Promotion\Action;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Core\Distributor\IntegerDistributorInterface;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\OrderItemUnitInterface;
+use Sylius\Component\Core\Promotion\Action\PercentageDiscountAction;
+use Sylius\Component\Core\Promotion\Applicator\UnitsPromotionAdjustmentsApplicatorInterface;
 use Sylius\Component\Originator\Originator\OriginatorInterface;
 use Sylius\Component\Promotion\Action\PromotionActionInterface;
 use Sylius\Component\Promotion\Model\PromotionInterface;
-use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 
 /**
+ * @mixin PercentageDiscountAction
+ *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Saša Stamenković <umpirsky@gmail.com>
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
 class PercentageDiscountActionSpec extends ObjectBehavior
 {
-    function let(FactoryInterface $adjustmentFactory, OriginatorInterface $originator)
-    {
-        $this->beConstructedWith($adjustmentFactory, $originator);
+    function let(
+        OriginatorInterface $originator,
+        IntegerDistributorInterface $integerDistributor,
+        UnitsPromotionAdjustmentsApplicatorInterface $unitsPromotionAdjustmentsApplicator
+    ) {
+        $this->beConstructedWith(
+            $originator,
+            $integerDistributor,
+            $unitsPromotionAdjustmentsApplicator
+        );
     }
 
     function it_is_initializable()
@@ -35,32 +52,126 @@ class PercentageDiscountActionSpec extends ObjectBehavior
         $this->shouldHaveType('Sylius\Component\Core\Promotion\Action\PercentageDiscountAction');
     }
 
-    function it_implements_Sylius_promotion_action_interface()
+    function it_implements_promotion_action_interface()
     {
         $this->shouldImplement(PromotionActionInterface::class);
     }
 
-    function it_applies_percentage_discount_as_promotion_adjustment(
-        FactoryInterface $adjustmentFactory,
-        $originator,
+    function it_uses_distributor_and_applicator_to_execute_promotion_action(
         OrderInterface $order,
-        AdjustmentInterface $adjustment,
+        OrderItemInterface $firstItem,
+        OrderItemInterface $secondItem,
+        PromotionInterface $promotion,
+        IntegerDistributorInterface $integerDistributor,
+        UnitsPromotionAdjustmentsApplicatorInterface $unitsPromotionAdjustmentsApplicator
+    ) {
+        $order->countItems()->willReturn(2);
+
+        $order
+            ->getItems()
+            ->willReturn(new \ArrayIterator([$firstItem->getWrappedObject(), $secondItem->getWrappedObject()]))
+        ;
+
+        $order->getPromotionSubjectTotal()->willReturn(10000);
+
+        $integerDistributor->distribute(-1000, 2)->willReturn([-500, -500]);
+        $unitsPromotionAdjustmentsApplicator->apply($order, $promotion, [-500, -500])->shouldBeCalled();
+
+        $this->execute($order, ['percentage' => 0.1], $promotion);
+    }
+
+    function it_does_nothing_if_order_has_no_items(OrderInterface $order, PromotionInterface $promotion)
+    {
+        $order->countItems()->willReturn(0);
+        $order->getPromotionSubjectTotal()->shouldNotBeCalled();
+
+        $this->execute($order, ['percentage' => 0.1], $promotion);
+    }
+
+    function it_does_nothing_if_adjustment_amount_would_be_0(
+        IntegerDistributorInterface $integerDistributor,
+        OrderInterface $order,
         PromotionInterface $promotion
     ) {
-        $order->getPromotionSubjectTotal()->willReturn(10000);
-        $adjustmentFactory->createNew()->willReturn($adjustment);
-        $promotion->getName()->willReturn('Test promotion');
+        $order->countItems()->willReturn(0);
+        $order->getPromotionSubjectTotal()->willReturn(0);
+        $integerDistributor->distribute(Argument::any())->shouldNotBeCalled();
 
-        $adjustment->setAmount(-2500)->shouldBeCalled();
-        $adjustment->setType(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT)->shouldBeCalled();
-        $adjustment->setLabel('Test promotion')->shouldBeCalled();
+        $this->execute($order, ['percentage' => 0.1], $promotion);
+    }
 
-        $originator->setOrigin($adjustment, $promotion)->shouldBeCalled();
+    function it_throws_exception_if_configuration_is_invalid(OrderInterface $order, PromotionInterface $promotion)
+    {
+        $this
+            ->shouldThrow(new \InvalidArgumentException('"percentage" must be set and must be a float.'))
+            ->during('execute', [$order, [], $promotion])
+        ;
 
-        $order->addAdjustment($adjustment)->shouldBeCalled();
+        $this
+            ->shouldThrow(new \InvalidArgumentException('"percentage" must be set and must be a float.'))
+            ->during('execute', [$order, ['percentage' => 'string'], $promotion])
+        ;
+    }
 
-        $configuration = ['percentage' => 0.25];
+    function it_throws_exception_if_subject_is_not_an_order(
+        PromotionInterface $promotion,
+        PromotionSubjectInterface $subject
+    ) {
+        $this
+            ->shouldThrow(new UnexpectedTypeException($subject->getWrappedObject(), OrderInterface::class))
+            ->during('execute', [$subject, [], $promotion])
+        ;
+    }
 
-        $this->execute($order, $configuration, $promotion);
+    function it_reverts_order_units_order_promotion_adjustments(
+        AdjustmentInterface $firstAdjustment,
+        AdjustmentInterface $secondAdjustment,
+        OrderInterface $order,
+        OrderItemInterface $item,
+        OrderItemUnitInterface $unit,
+        OriginatorInterface $originator,
+        PromotionInterface $otherPromotion,
+        PromotionInterface $promotion
+    ) {
+        $order->countItems()->willReturn(1);
+        $order->getItems()->willReturn(new \ArrayIterator([$item->getWrappedObject()]));
+
+        $item->getUnits()->willReturn(new \ArrayIterator([$unit->getWrappedObject()]));
+
+        $unit
+            ->getAdjustments(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT)
+            ->willReturn(new \ArrayIterator([$firstAdjustment->getWrappedObject(), $secondAdjustment->getWrappedObject()]))
+        ;
+
+        $originator->getOrigin($firstAdjustment)->willReturn($promotion);
+        $originator->getOrigin($secondAdjustment)->willReturn($otherPromotion);
+
+        $unit->removeAdjustment($firstAdjustment)->shouldBeCalled();
+        $unit->removeAdjustment($secondAdjustment)->shouldNotBeCalled();
+
+        $this->revert($order, [], $promotion);
+    }
+
+    function it_does_not_revert_if_order_has_no_items(OrderInterface $order, PromotionInterface $promotion)
+    {
+        $order->countItems()->willReturn(0);
+        $order->getItems()->shouldNotBeCalled();
+
+        $this->revert($order, [], $promotion);
+    }
+
+    function it_throws_exception_while_reverting_subject_which_is_not_order(
+        PromotionInterface $promotion,
+        PromotionSubjectInterface $subject
+    ) {
+        $this
+            ->shouldThrow(new UnexpectedTypeException($subject->getWrappedObject(), OrderInterface::class))
+            ->during('revert', [$subject, [], $promotion])
+        ;
+    }
+
+    function it_has_configuration_form_type()
+    {
+        $this->getConfigurationFormType()->shouldReturn('sylius_promotion_action_percentage_discount_configuration');
     }
 }

--- a/src/Sylius/Component/Core/spec/Promotion/Action/PercentageDiscountActionSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/PercentageDiscountActionSpec.php
@@ -103,12 +103,12 @@ class PercentageDiscountActionSpec extends ObjectBehavior
     function it_throws_exception_if_configuration_is_invalid(OrderInterface $order, PromotionInterface $promotion)
     {
         $this
-            ->shouldThrow(new \InvalidArgumentException('"percentage" must be set and must be a float.'))
+            ->shouldThrow(\InvalidArgumentException::class)
             ->during('execute', [$order, [], $promotion])
         ;
 
         $this
-            ->shouldThrow(new \InvalidArgumentException('"percentage" must be set and must be a float.'))
+            ->shouldThrow(\InvalidArgumentException::class)
             ->during('execute', [$order, ['percentage' => 'string'], $promotion])
         ;
     }
@@ -118,7 +118,7 @@ class PercentageDiscountActionSpec extends ObjectBehavior
         PromotionSubjectInterface $subject
     ) {
         $this
-            ->shouldThrow(new UnexpectedTypeException($subject->getWrappedObject(), OrderInterface::class))
+            ->shouldThrow(\InvalidArgumentException::class)
             ->during('execute', [$subject, [], $promotion])
         ;
     }
@@ -165,7 +165,7 @@ class PercentageDiscountActionSpec extends ObjectBehavior
         PromotionSubjectInterface $subject
     ) {
         $this
-            ->shouldThrow(new UnexpectedTypeException($subject->getWrappedObject(), OrderInterface::class))
+            ->shouldThrow(\InvalidArgumentException::class)
             ->during('revert', [$subject, [], $promotion])
         ;
     }

--- a/src/Sylius/Component/Core/spec/Promotion/Applicator/UnitsPromotionAdjustmentsApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Applicator/UnitsPromotionAdjustmentsApplicatorSpec.php
@@ -205,9 +205,7 @@ class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
         $order->countItems()->willReturn(2);
 
         $this
-            ->shouldThrow(new \InvalidArgumentException(
-                'Number of adjustments amount to distribute must be equal with number of order items.'
-            ))
+            ->shouldThrow(\InvalidArgumentException::class)
             ->during('apply', [$order, $promotion, [1999]])
         ;
     }

--- a/src/Sylius/Component/Core/spec/Promotion/Applicator/UnitsPromotionAdjustmentsApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Applicator/UnitsPromotionAdjustmentsApplicatorSpec.php
@@ -1,0 +1,214 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Core\Promotion\Applicator;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Core\Distributor\IntegerDistributorInterface;
+use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\OrderItemUnitInterface;
+use Sylius\Component\Core\Promotion\Applicator\UnitsPromotionAdjustmentsApplicator;
+use Sylius\Component\Core\Promotion\Applicator\UnitsPromotionAdjustmentsApplicatorInterface;
+use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
+use Sylius\Component\Originator\Originator\OriginatorInterface;
+use Sylius\Component\Promotion\Model\PromotionInterface;
+
+/**
+ * @mixin UnitsPromotionAdjustmentsApplicator
+ *
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class UnitsPromotionAdjustmentsApplicatorSpec extends ObjectBehavior
+{
+    function let(
+        AdjustmentFactoryInterface $adjustmentFactory,
+        IntegerDistributorInterface $distributor,
+        OriginatorInterface $originator
+    ) {
+        $this->beConstructedWith($adjustmentFactory, $distributor, $originator);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Core\Promotion\Applicator\UnitsPromotionAdjustmentsApplicator');
+    }
+
+    function it_implements_units_promotion_adjustments_applicator_interface()
+    {
+        $this->shouldImplement(UnitsPromotionAdjustmentsApplicatorInterface::class);
+    }
+
+    function it_applies_promotion_adjustments_on_all_units_of_given_order(
+        AdjustmentFactoryInterface $adjustmentFactory,
+        AdjustmentInterface $firstAdjustment,
+        AdjustmentInterface $secondAdjustment,
+        AdjustmentInterface $thirdAdjustment,
+        IntegerDistributorInterface $distributor,
+        OrderInterface $order,
+        OrderItemInterface $coltItem,
+        OrderItemInterface $magnumItem,
+        OrderItemUnitInterface $firstColtUnit,
+        OrderItemUnitInterface $magnumUnit,
+        OrderItemUnitInterface $secondColtUnit,
+        OriginatorInterface $originator,
+        PromotionInterface $promotion
+    ) {
+        $order->countItems()->willReturn(2);
+
+        $order
+            ->getItems()
+            ->willReturn(new \ArrayIterator([$coltItem->getWrappedObject(), $magnumItem->getWrappedObject()]))
+        ;
+
+        $coltItem->getQuantity()->willReturn(2);
+        $magnumItem->getQuantity()->willReturn(1);
+
+        $distributor->distribute(1000, 2)->willReturn([500, 500]);
+        $distributor->distribute(999, 1)->willReturn([999]);
+
+        $coltItem
+            ->getUnits()
+            ->willReturn(new \ArrayIterator([$firstColtUnit->getWrappedObject(), $secondColtUnit->getWrappedObject()]))
+        ;
+        $magnumItem
+            ->getUnits()
+            ->willReturn(new \ArrayIterator([$magnumUnit->getWrappedObject()]))
+        ;
+
+        $promotion->getName()->willReturn('Winter guns promotion!');
+
+        $adjustmentFactory
+            ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, 'Winter guns promotion!', 500)
+            ->willReturn($firstAdjustment, $secondAdjustment)
+        ;
+        $adjustmentFactory
+            ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, 'Winter guns promotion!', 999)
+            ->willReturn($thirdAdjustment)
+        ;
+
+        $originator->setOrigin($firstAdjustment, $promotion)->shouldBeCalled();
+        $originator->setOrigin($secondAdjustment, $promotion)->shouldBeCalled();
+        $originator->setOrigin($thirdAdjustment, $promotion)->shouldBeCalled();
+
+        $firstColtUnit->addAdjustment($firstAdjustment)->shouldBeCalled();
+        $secondColtUnit->addAdjustment($secondAdjustment)->shouldBeCalled();
+        $magnumUnit->addAdjustment($thirdAdjustment)->shouldBeCalled();
+
+        $this->apply($order, $promotion, [1000, 999]);
+    }
+
+    function it_does_not_distribute_0_amount_to_item(
+        AdjustmentFactoryInterface $adjustmentFactory,
+        AdjustmentInterface $adjustment,
+        IntegerDistributorInterface $distributor,
+        OrderInterface $order,
+        OrderItemInterface $coltItem,
+        OrderItemInterface $magnumItem,
+        OrderItemUnitInterface $coltUnit,
+        OrderItemUnitInterface $magnumUnit,
+        OriginatorInterface $originator,
+        PromotionInterface $promotion
+    ) {
+        $order->countItems()->willReturn(2);
+
+        $order
+            ->getItems()
+            ->willReturn(new \ArrayIterator([$coltItem->getWrappedObject(), $magnumItem->getWrappedObject()]))
+        ;
+
+        $coltItem->getQuantity()->willReturn(1);
+        $magnumItem->getQuantity()->willReturn(1);
+
+        $distributor->distribute(1, 1)->willReturn([1]);
+
+        $coltItem
+            ->getUnits()
+            ->willReturn(new \ArrayIterator([$coltUnit->getWrappedObject()]))
+        ;
+        $magnumItem
+            ->getUnits()
+            ->willReturn(new \ArrayIterator([$magnumUnit->getWrappedObject()]))
+        ;
+
+        $promotion->getName()->willReturn('Winter guns promotion!');
+
+        $adjustmentFactory
+            ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, 'Winter guns promotion!', 1)
+            ->willReturn($adjustment)
+        ;
+
+        $originator->setOrigin($adjustment, $promotion)->shouldBeCalled();
+
+        $coltUnit->addAdjustment($adjustment)->shouldBeCalled();
+        $magnumUnit->addAdjustment(Argument::any())->shouldNotBeCalled();
+
+        $this->apply($order, $promotion, [1, 0]);
+    }
+
+    function it_does_not_distribute_0_amount_to_unit(
+        AdjustmentFactoryInterface $adjustmentFactory,
+        AdjustmentInterface $adjustment,
+        IntegerDistributorInterface $distributor,
+        OrderInterface $order,
+        OrderItemInterface $coltItem,
+        OrderItemUnitInterface $firstColtUnit,
+        OrderItemUnitInterface $secondColtUnit,
+        OriginatorInterface $originator,
+        PromotionInterface $promotion
+    ) {
+        $order->countItems()->willReturn(1);
+
+        $order
+            ->getItems()
+            ->willReturn(new \ArrayIterator([$coltItem->getWrappedObject()]))
+        ;
+
+        $coltItem->getQuantity()->willReturn(2);
+
+        $distributor->distribute(1, 2)->willReturn([1, 0]);
+
+        $coltItem
+            ->getUnits()
+            ->willReturn(new \ArrayIterator([$firstColtUnit->getWrappedObject(), $secondColtUnit->getWrappedObject()]))
+        ;
+
+        $promotion->getName()->willReturn('Winter guns promotion!');
+
+        $adjustmentFactory
+            ->createWithData(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, 'Winter guns promotion!', 1)
+            ->willReturn($adjustment)
+        ;
+
+        $originator->setOrigin($adjustment, $promotion)->shouldBeCalled();
+
+        $firstColtUnit->addAdjustment($adjustment)->shouldBeCalled();
+        $secondColtUnit->addAdjustment(Argument::any())->shouldNotBeCalled();
+
+        $this->apply($order, $promotion, [1]);
+    }
+
+    function it_throws_exception_if_items_count_is_different_than_adjustment_amounts(
+        PromotionInterface $promotion,
+        OrderInterface $order
+    ) {
+        $order->countItems()->willReturn(2);
+
+        $this
+            ->shouldThrow(new \InvalidArgumentException(
+                'Number of adjustments amount to distribute must be equal with number of order items.'
+            ))
+            ->during('apply', [$order, $promotion, [1999]])
+        ;
+    }
+}

--- a/src/Sylius/Component/Order/Factory/AdjustmentFactory.php
+++ b/src/Sylius/Component/Order/Factory/AdjustmentFactory.php
@@ -42,7 +42,7 @@ class AdjustmentFactory implements AdjustmentFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createWithData($type, $label, $amount, $neutral)
+    public function createWithData($type, $label, $amount, $neutral = false)
     {
         $adjustment = $this->createNew();
         $adjustment->setType($type);

--- a/src/Sylius/Component/Order/Factory/AdjustmentFactoryInterface.php
+++ b/src/Sylius/Component/Order/Factory/AdjustmentFactoryInterface.php
@@ -27,5 +27,5 @@ interface AdjustmentFactoryInterface extends FactoryInterface
      *
      * @return AdjustmentInterface
      */
-    public function createWithData($type, $label, $amount, $neutral);
+    public function createWithData($type, $label, $amount, $neutral = false);
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets |
| License         | MIT

To fulfill new order units approach, we should distribute promotions into units not only in ``item`` promotions, but also in those applied on ``Order`` level. Therefore, in ``fixed_discount`` and ``percentage_discount`` promotions, ``order_promotion`` adjustments are added on order units (while applying percentage discount distribution is equal, while applying fixed discount - promotion amount is distributed on order's items proportionally and then equally on units).