### PR TITLE
[Bug Fix] Fix elastic search "[ActionRequestValidationException] id is missing" error

### DIFF
--- a/src/Sylius/Bundle/SearchBundle/DependencyInjection/SyliusSearchExtension.php
+++ b/src/Sylius/Bundle/SearchBundle/DependencyInjection/SyliusSearchExtension.php
@@ -85,13 +85,6 @@ class SyliusSearchExtension extends AbstractResourceExtension implements Prepend
         $engine = $syliusSearchConfig['engine'];
 
         if ($engine === 'elasticsearch') {
-            $tags = ['doctrine.event_listener' => [
-                ['name' => 'doctrine.event_listener', 'event' => 'postPersist'],
-                ['name' => 'doctrine.event_listener', 'event' => 'postUpdate'],
-                ['name' => 'doctrine.event_listener', 'event' => 'postRemove'],
-                ['name' => 'doctrine.event_listener', 'event' => 'postFlush'],
-            ]];
-
             $configuration = new FosElasticaConfiguration(false);
             $processor = new Processor();
             $elasticaConfig = $processor->processConfiguration($configuration, $container->getExtensionConfig('fos_elastica'));
@@ -99,7 +92,7 @@ class SyliusSearchExtension extends AbstractResourceExtension implements Prepend
             foreach ($elasticaConfig['indexes'] as $index => $config) {
                 $elasticaProductListenerDefinition = new Definition(ElasticaProductListener::class);
                 $elasticaProductListenerDefinition->addArgument(new Reference('fos_elastica.object_persister.' . $index . '.product'));
-                $elasticaProductListenerDefinition->setTags($tags);
+                $elasticaProductListenerDefinition->addTag('doctrine.event_subscriber');
 
                 $container->setDefinition('sylius_product.listener.index_' . $index . '.product_update', $elasticaProductListenerDefinition);
             }

--- a/src/Sylius/Bundle/SearchBundle/Listener/ElasticaProductListener.php
+++ b/src/Sylius/Bundle/SearchBundle/Listener/ElasticaProductListener.php
@@ -13,7 +13,6 @@ namespace Sylius\Bundle\SearchBundle\Listener;
 
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
-use Doctrine\ORM\Event\PostFlushEventArgs;
 use FOS\ElasticaBundle\Persister\ObjectPersister;
 use Sylius\Component\Product\Model\AttributeValueInterface;
 use Sylius\Component\Product\Model\ProductInterface;
@@ -49,7 +48,7 @@ class ElasticaProductListener implements EventSubscriber
     public function getSubscribedEvents()
     {
         return [
-            'postFlush',
+            'onFlush',
             'postPersist',
             'postUpdate',
             'postRemove',
@@ -80,10 +79,7 @@ class ElasticaProductListener implements EventSubscriber
         $this->update($eventArgs->getObject());
     }
 
-    /**
-     * @param PostFlushEventArgs $args
-     */
-    public function postFlush(PostFlushEventArgs $args)
+    public function onFlush()
     {
         if (!empty($this->scheduledForUpdate)) {
             $this->objectPersister->replaceMany($this->scheduledForUpdate);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in #4525
| License         | MIT

Because the object persister was called on `postFlush` the ids of the objects are `null` and so the elastic search bulk operation fails. By calling the object persister at the `onFlush` event, everything works nicely.