### PR TITLE
[SingleResourceProvider] Use repository find() method.

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/SingleResourceProvider.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/SingleResourceProvider.php
@@ -33,8 +33,9 @@ class SingleResourceProvider implements SingleResourceProviderInterface
         $request = $requestConfiguration->getRequest();
 
         if ($request->attributes->has('id')) {
-            $criteria = ['id' => $request->attributes->get('id')];
+            return $repository->find($request->attributes->get('id'));
         }
+
         if ($request->attributes->has('slug')) {
             $criteria = ['slug' => $request->attributes->get('slug')];
         }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/SingleResourceProviderSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/SingleResourceProviderSpec.php
@@ -47,7 +47,7 @@ class SingleResourceProviderSpec extends ObjectBehavior
         $requestAttributes->has('slug')->willReturn(false);
         $requestAttributes->get('id')->willReturn(5);
 
-        $repository->findOneBy(['id' => 5])->willReturn(null);
+        $repository->find(5)->willReturn(null);
 
         $this->get($requestConfiguration, $repository)->shouldReturn(null);
     }
@@ -66,7 +66,7 @@ class SingleResourceProviderSpec extends ObjectBehavior
         $requestAttributes->has('slug')->willReturn(false);
         $requestAttributes->get('id')->willReturn(3);
 
-        $repository->findOneBy(['id' => 3])->willReturn($resource);
+        $repository->find(3)->willReturn($resource);
 
         $this->get($requestConfiguration, $repository)->shouldReturn($resource);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


Currently the `SingleResourceProvider` uses the `findBy` method of the repository in order to locate an item by ID - this works fine with the ORM but will fail with the Doctrine PHPCR ODM which does not map the `id` to a field.

This PR changes the behavior to call the `find` method when an ID is given rather than `findBy`