### PR TITLE
[GridBundle] Remove unsupported drivers during container compilation

### DIFF
--- a/src/Sylius/Bundle/GridBundle/DependencyInjection/Compiler/RegisterDriversPass.php
+++ b/src/Sylius/Bundle/GridBundle/DependencyInjection/Compiler/RegisterDriversPass.php
@@ -36,6 +36,19 @@ class RegisterDriversPass implements CompilerPassInterface
                 throw new \InvalidArgumentException('Tagged grid drivers needs to have `alias` attribute.');
             }
 
+            // if the driver has an unavailable dependency, remove it.
+            $definition = $container->getDefinition($id);
+            foreach ($definition->getArguments() as $argument) {
+                if (false === $argument instanceof Reference) {
+                    continue;
+                }
+
+                if (!$container->has((string) $argument)) {
+                    $container->removeDefinition($id);
+                    continue 2;
+                }
+            }
+
             $registry->addMethodCall('register', [$attributes[0]['alias'], new Reference($id)]);
         }
     }

--- a/src/Sylius/Bundle/GridBundle/Tests/DependencyInjection/Compiler/RegisterDriversPassTest.php
+++ b/src/Sylius/Bundle/GridBundle/Tests/DependencyInjection/Compiler/RegisterDriversPassTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\GridBundle\Tests\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Container;
+use Sylius\Bundle\GridBundle\DependencyInjection\Compiler\RegisterDriversPass;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RegisterDriversPassTest extends \PHPUnit_Framework_TestCase
+{
+    private $container;
+    private $pass;
+
+    public function setUp()
+    {
+        $this->container = new ContainerBuilder();
+        $this->container->register('sylius.registry.grid_driver', '\stdClass');
+        $this->pass = new RegisterDriversPass();
+    }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage needs to have `alias` attribute
+     */
+    public function it_should_throw_an_exception_if_the_driver_has_no_alias_attribute()
+    {
+        $definition = $this->container->register('driver.1', '\stdClass');
+        $definition->addTag(
+            'sylius.grid_driver'
+        );
+
+        $this->pass->process($this->container);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_register_drivers()
+    {
+        $definition = $this->container->register('driver.1', '\stdClass');
+        $definition->addTag(
+            'sylius.grid_driver',
+            [
+                'alias' => 'foobar',
+            ]
+        );
+
+        $this->pass->process($this->container);
+
+        $definition = $this->container->getDefinition('sylius.registry.grid_driver');
+        $calls = $definition->getMethodCalls();
+        $this->assertCount(1, $calls);
+        $this->assertEquals(
+            [
+                'register',
+                [
+                    'foobar',
+                    new Reference('driver.1')
+                ]
+            ],
+            $calls[0]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_remove_drivers_with_unavailable_dependencies()
+    {
+        $definition = $this->container->register('driver.1', '\stdClass');
+        $definition->addArgument(new Reference('unavailable.service'));
+        $definition->addTag(
+            'sylius.grid_driver',
+            [
+                'alias' => 'foobar',
+            ]
+        );
+
+        $this->pass->process($this->container);
+
+        $definition = $this->container->getDefinition('sylius.registry.grid_driver');
+        $calls = $definition->getMethodCalls();
+        $this->assertCount(0, $calls);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | -
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #4809 
| License         | MIT

This PR allows the drivers in the GridBundle to be explicitly enable.

The default behavior is to enable both dbal and orm drivers:

```yaml
sylius_grid:
    drivers: [ "doctrine/orm", "doctrine/dbal" ]
```
