### PR TITLE
[GridBundle] [WIP] PHPCR-ODM Driver

### DIFF
--- a/src/Sylius/Bundle/GridBundle/Doctrine/ORM/ExpressionBuilder.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/ORM/ExpressionBuilder.php
@@ -27,7 +27,7 @@ class ExpressionBuilder implements ExpressionBuilderInterface
     /**
      * @param QueryBuilder $queryBuilder
      */
-    function __construct(QueryBuilder $queryBuilder)
+    public function __construct(QueryBuilder $queryBuilder)
     {
         $this->queryBuilder = $queryBuilder;
     }

--- a/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/DataSource.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/DataSource.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\GridBundle\Doctrine\PHPCRODM;
+
+use Pagerfanta\Adapter\DoctrineORMAdapter;
+use Pagerfanta\Pagerfanta;
+use Sylius\Component\Grid\Data\DataSourceInterface;
+use Sylius\Component\Grid\Data\ExpressionBuilderInterface;
+use Sylius\Component\Grid\Parameters;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Pagerfanta\Adapter\DoctrineODMPhpcrAdapter;
+
+class DataSource implements DataSourceInterface
+{
+    /**
+     * @var QueryBuilder
+     */
+    private $queryBuilder;
+
+    /**
+     * @var ExpressionBuilder
+     */
+    private $expressionBuilder;
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @param ExpressionBuilder $expressionBuilder
+     */
+    public function __construct(QueryBuilder $queryBuilder, ExpressionBuilder $expressionBuilder = null)
+    {
+        $this->queryBuilder = $queryBuilder;
+        $this->expressionBuilder = $expressionBuilder ?: new ExpressionBuilder();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function restrict($expression, $condition = DataSourceInterface::CONDITION_AND)
+    {
+        switch ($condition) {
+            case DataSourceInterface::CONDITION_AND:
+                $parentNode = $this->queryBuilder->andWhere();
+                break;
+            case DataSourceInterface::CONDITION_OR:
+                $parentNode = $this->queryBuilder->orWhere();
+                break;
+            default:
+                throw new \RuntimeException(sprintf(
+                    'Unknown restrict condition "%s"',
+                    $condition
+                ));
+        }
+
+        $visitor = new ExpressionVisitor($this->queryBuilder);
+        $visitor->dispatch($expression, $parentNode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExpressionBuilder()
+    {
+        return $this->expressionBuilder;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(Parameters $parameters)
+    {
+        $orderBy = $this->queryBuilder->orderBy();
+        foreach ($this->expressionBuilder->getOrderBys() as $field => $direction) {
+            if (is_integer($field)) {
+                $field = $direction;
+                $direction = 'asc';
+            }
+
+            // todo: validate direction?
+            $direction = strtolower($direction);
+            $orderBy->{$direction}()->field(sprintf('%s.%s', Driver::QB_SOURCE_ALIAS, $field));
+        }
+
+        $paginator = new Pagerfanta(new DoctrineODMPhpcrAdapter($this->queryBuilder));
+        $paginator->setCurrentPage($parameters->get('page', 1));
+
+        return $paginator;
+   }
+}

--- a/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/Driver.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/Driver.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\GridBundle\Doctrine\PHPCRODM;
+
+use Sylius\Component\Grid\Data\DriverInterface;
+use Sylius\Component\Grid\Parameters;
+use Doctrine\ODM\PHPCR\DocumentManagerInterface;
+
+class Driver implements DriverInterface
+{
+    /**
+     * Driver name
+     */
+    const NAME = 'doctrine/phpcr-odm';
+
+    /**
+     * Alias to use to reference fields from the data source class.
+     */
+    const QB_SOURCE_ALIAS = 'o';
+
+    /**
+     * @var DocumentManagerInterface
+     */
+    private $documentManager;
+
+    /**
+     * @param DocumentManagerInterface $documentManager
+     */
+    public function __construct(DocumentManagerInterface $documentManager)
+    {
+        $this->documentManager = $documentManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDataSource(array $configuration, Parameters $parameters)
+    {
+        if (!array_key_exists('class', $configuration)) {
+            throw new \InvalidArgumentException('"class" must be configured.');
+        }
+
+        $repository = $this->documentManager->getRepository($configuration['class']);
+        $queryBuilder = $repository->createQueryBuilder(self::QB_SOURCE_ALIAS);
+
+        return new DataSource($queryBuilder);
+    }
+}

--- a/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/ExpressionBuilder.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/ExpressionBuilder.php
@@ -1,0 +1,184 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\GridBundle\Doctrine\PHPCRODM;
+
+use Sylius\Component\Grid\Data\ExpressionBuilderInterface;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Doctrine\Common\Collections\ExpressionBuilder as CollectionsExpressionBuilder;
+use Sylius\Bundle\GridBundle\Doctrine\PHPCRODM\ExtraComparison;
+use Doctrine\Common\Collections\Expr\Comparison;
+
+/**
+ * Creates an object graph (using Doctrine\Commons\Collections\Expr\*) which we
+ * can then walk in order to build up the PHPCR-ODM query builder.
+ */
+class ExpressionBuilder implements ExpressionBuilderInterface
+{
+    /**
+     * @var CollectionsExpressionBuilder
+     */
+    private $expressionBuilder;
+
+    /**
+     * @var array
+     */
+    private $orderBys = [];
+
+    public function __construct(CollectionsExpressionBuilder $expressionBuilder = null)
+    {
+        $this->expressionBuilder = $expressionBuilder ?: new CollectionsExpressionBuilder();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function andX($expressions)
+    {
+        return $this->expressionBuilder->andX($expressions);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function orX($expressions)
+    {
+        return $this->expressionBuilder->orX($expressions);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function comparison($field, $operator, $value)
+    {
+        throw new \BadMethodCallException('Not supported yet.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function equals($field, $value)
+    {
+        return $this->expressionBuilder->eq($field, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function notEquals($field, $value)
+    {
+        return $this->expressionBuilder->neq($field, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lessThan($field, $value)
+    {
+        return $this->expressionBuilder->lt($field, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function lessThanOrEqual($field, $value)
+    {
+        return $this->expressionBuilder->lte($field, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function greaterThan($field, $value)
+    {
+        return $this->expressionBuilder->gt($field, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function greaterThanOrEqual($field, $value)
+    {
+        return $this->expressionBuilder->gte($field, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function in($field, array $values)
+    {
+        return $this->expressionBuilder->in($field, $values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function notIn($field, array $values)
+    {
+        return $this->expressionBuilder->notIn($field, $values);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isNull($field)
+    {
+        return new Comparison($field, ExtraComparison::IS_NULL, null);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isNotNull($field)
+    {
+        return new Comparison($field, ExtraComparison::IS_NOT_NULL, null);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function like($field, $pattern)
+    {
+        return $this->expressionBuilder->contains($field, $pattern);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function notLike($field, $pattern)
+    {
+        return new Comparison($field, ExtraComparison::NOT_CONTAINS, $pattern);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function orderBy($field, $direction)
+    {
+        $this->orderBys = [ $field => $direction ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addOrderBy($field, $direction)
+    {
+        $this->orderBys[$field] = $direction;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOrderBys()
+    {
+        return $this->orderBys;
+    }
+}

--- a/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/ExpressionVisitor.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/ExpressionVisitor.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\GridBundle\Doctrine\PHPCRODM;
+
+use Sylius\Component\Grid\Data\ExpressionBuilderInterface;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Doctrine\Common\Collections\Expr\CompositeExpression;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Common\Collections\Expr\Value;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
+use Doctrine\ODM\PHPCR\Query\Builder\OperandFactory;
+use Doctrine\Common\Collections\Expr\Expression;
+use Sylius\Bundle\GridBundle\Doctrine\PHPCRODM\ExtraComparison;
+
+/**
+ * Walks a Doctrine\Commons\Expr object graph and builds up a PHPCR-ODM
+ * query using the (fluent) PHPCR-ODM query builder.
+ */
+class ExpressionVisitor
+{
+    private $queryBuilder;
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     */
+    public function __construct(QueryBuilder $queryBuilder)
+    {
+        $this->queryBuilder = $queryBuilder;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function walkComparison(Comparison $comparison, AbstractNode $parentNode)
+    {
+        $field = $comparison->getField();
+        $value = $comparison->getValue()->getValue(); // shortcut for walkValue()
+
+        switch ($comparison->getOperator()) {
+            case Comparison::EQ:
+                return $parentNode->eq()->field($this->getField($field))->literal($value)->end();
+
+            case Comparison::NEQ:
+                return $parentNode->neq()->field($this->getField($field))->literal($value)->end();
+
+            case Comparison::LT:
+                return $parentNode->lt()->field($this->getField($field))->literal($value)->end();
+
+            case Comparison::LTE:
+                return $parentNode->lte()->field($this->getField($field))->literal($value)->end();
+
+            case Comparison::GT:
+                return $parentNode->gt()->field($this->getField($field))->literal($value)->end();
+
+            case Comparison::GTE:
+                return $parentNode->gte()->field($this->getField($field))->literal($value)->end();
+
+            case Comparison::IN:
+                return $this->getInConstraint($parentNode, $field, $value);
+
+            case Comparison::NIN:
+                $node = $parentNode->not();
+                $this->getInConstraint($node, $field, $value);
+                return $node->end();
+
+            case Comparison::CONTAINS:
+                return $parentNode->like()->field($this->getField($field))->literal($value)->end();
+
+            case ExtraComparison::NOT_CONTAINS:
+                return $parentNode->not()->like()->field($this->getField($field))->literal($value)->end()->end();
+
+            case ExtraComparison::IS_NULL:
+                return $parentNode->not()->fieldIsset($this->getField($field))->end();
+
+            case ExtraComparison::IS_NOT_NULL:
+                return $parentNode->fieldIsset($this->getField($field));
+
+            default:
+                throw new \RuntimeException("Unknown comparison operator: " . $comparison->getOperator());
+        }
+
+        return $parentNode;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function walkValue(Value $value, OperandFactory $parentNode)
+    {
+        throw new \BadMethodCallException('What is this even used for?');
+        return $parentNode->literal($value->getValue());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function walkCompositeExpression(CompositeExpression $expr, AbstractNode $parentNode)
+    {
+        switch($expr->getType()) {
+            case CompositeExpression::TYPE_AND:
+                $node = $parentNode->andX();
+                break;
+            case CompositeExpression::TYPE_OR:
+                $node = $parentNode->orX();
+                break;
+            default:
+                throw new \RuntimeException('Unknown composite: ' . $expr->getType());
+        }
+
+        $expressions = $expr->getExpressionList();
+
+        $leftExpression = array_shift($expressions);
+        $this->dispatch($leftExpression, $node);
+
+        $parentNode = $node;
+        foreach ($expressions as $index => $expression) {
+            if (count($expressions) === $index + 1) {
+                $this->dispatch($expression, $parentNode);
+                break;
+            }
+
+            switch($expr->getType()) {
+                case CompositeExpression::TYPE_AND:
+                    $parentNode = $parentNode->andX();
+                    break;
+                case CompositeExpression::TYPE_OR:
+                    $parentNode = $parentNode->orX();
+                    break;
+            }
+
+            $this->dispatch($expression, $parentNode);
+        }
+
+        return $node;
+    }
+
+    /**
+     * Walk the given expression to build up the PHPCR-ODM query builder.
+     *
+     * @param Expression $expr
+     * @param AbstractNode $parentNode
+     */
+    public function dispatch(Expression $expr, AbstractNode $parentNode = null)
+    {
+        if ($parentNode === null) {
+            $parentNode = $this->queryBuilder->where();
+        }
+
+        switch (true) {
+            case ($expr instanceof Comparison):
+                return $this->walkComparison($expr, $parentNode);
+
+            case ($expr instanceof Value):
+                return $this->walkValue($expr, $parentNode);
+
+            case ($expr instanceof CompositeExpression):
+                return $this->walkCompositeExpression($expr, $parentNode);
+
+            default:
+                throw new \RuntimeException("Unknown Expression " . get_class($expr));
+        }
+    }
+
+    private function getField($field)
+    {
+        return Driver::QB_SOURCE_ALIAS . '.' . $field;
+    }
+
+    private function getInConstraint(AbstractNode $parentNode, $field, array $values)
+    {
+        $orNode = $parentNode->orx();
+
+        foreach ($values as $value) {
+            $orNode->eq()->field($this->getField($field))->literal($value);
+        }
+
+        $orNode->end();
+    }
+}

--- a/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/ExtraComparison.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/ExtraComparison.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\GridBundle\Doctrine\PHPCRODM;
+
+/**
+ * Contains constants values for comparisons which are not supported
+ * by the Doctrine\Common\Colletion\Expr\Comparison class.
+ */
+class ExtraComparison
+{
+    const NOT_CONTAINS = 'NOT_CONTAINS';
+    const IS_NULL = 'IS_NULL';
+    const IS_NOT_NULL = 'IS_NOT_NULL';
+}

--- a/src/Sylius/Bundle/GridBundle/Resources/config/driver/doctrine/phpcr-odm.xml
+++ b/src/Sylius/Bundle/GridBundle/Resources/config/driver/doctrine/phpcr-odm.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+                               http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
+
+    <parameters>
+        <parameter key="sylius.grid_driver.doctrine.phpcrodm.class">Sylius\Bundle\GridBundle\Doctrine\PHPCRODM\Driver</parameter>
+    </parameters>
+
+    <services>
+        <service id="sylius.grid_driver.doctrine.phpcrodm" class="%sylius.grid_driver.doctrine.phpcrodm.class%">
+            <argument type="service" id="doctrine_phpcr.odm.document_manager" />
+            <tag name="sylius.grid_driver" alias="doctrine/phpcr-odm" />
+        </service>
+    </services>
+
+</container>

--- a/src/Sylius/Bundle/GridBundle/Tests/Doctrine/PHPCRODM/ExpressionVisitorTest.php
+++ b/src/Sylius/Bundle/GridBundle/Tests/Doctrine/PHPCRODM/ExpressionVisitorTest.php
@@ -1,0 +1,246 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\GridBundle\Tests\DependencyInjection;
+
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Sylius\Bundle\GridBundle\Doctrine\PHPCRODM\ExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
+use Doctrine\ODM\PHPCR\Query\Builder\OperandDynamicField;
+use Doctrine\ODM\PHPCR\Query\Builder\ConstraintComparison;
+use Doctrine\ODM\PHPCR\Query\Builder\OperandStaticLiteral;
+use Doctrine\Common\Collections\Expr\CompositeExpression;
+use Sylius\Bundle\GridBundle\Doctrine\PHPCRODM\ExtraComparison;
+
+require(__DIR__ . '/QueryBuilderWalker.php');
+
+class ExpressionVisitorTest extends \PHPUnit_Framework_TestCase
+{
+    private $queryBuilder;
+    private $visitor;
+
+    public function setUp()
+    {
+        $this->queryBuilder = new QueryBuilder();
+        $this->visitor = new ExpressionVisitor($this->queryBuilder);
+    }
+
+    /**
+     * @dataProvider provideComparisons
+     */
+    public function test_it_should_handle_comparisons($comparator, $expected)
+    {
+        $expr = new Comparison('hello', $comparator, 'world');
+        $this->visitor->dispatch($expr);
+
+        $this->assertQueryBuilderState($expected);
+    }
+
+    public function provideComparisons()
+    {
+        return [
+            [
+                Comparison::EQ,
+                'jcr.operator.equal.to ( OperandDynamicField(o.hello) OperandStaticLiteral("world") )',
+            ],
+            [
+                Comparison::NEQ,
+                'jcr.operator.not.equal.to ( OperandDynamicField(o.hello) OperandStaticLiteral("world") )',
+            ],
+            [
+                Comparison::LT,
+                'jcr.operator.less.than ( OperandDynamicField(o.hello) OperandStaticLiteral("world") )',
+            ],
+            [
+                Comparison::LTE,
+                'jcr.operator.less.than.or.equal.to ( OperandDynamicField(o.hello) OperandStaticLiteral("world") )',
+            ],
+            [
+                Comparison::GT,
+                'jcr.operator.greater.than ( OperandDynamicField(o.hello) OperandStaticLiteral("world") )',
+            ],
+            [
+                Comparison::GTE,
+                'jcr.operator.greater.than.or.equal.to ( OperandDynamicField(o.hello) OperandStaticLiteral("world") )',
+            ],
+            [
+                Comparison::CONTAINS,
+                'jcr.operator.like ( OperandDynamicField(o.hello) OperandStaticLiteral("world") )',
+            ],
+            [
+                ExtraComparison::NOT_CONTAINS,
+                'ConstraintNot ( jcr.operator.like ( OperandDynamicField(o.hello) OperandStaticLiteral("world") ) )',
+            ],
+            [
+                ExtraComparison::IS_NULL,
+                'ConstraintNot ( ConstraintFieldIsset("hello") )'
+            ],
+            [
+                ExtraComparison::IS_NOT_NULL,
+                'ConstraintFieldIsset("hello")'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideEmulateIn
+     */
+    public function test_it_should_emulate_in($comparator, array $values, $expected)
+    {
+        $expr = new Comparison('hello', $comparator, $values);
+        $this->visitor->dispatch($expr);
+
+        $this->assertQueryBuilderState($expected);
+    }
+
+    public function provideEmulateIn()
+    {
+        return [
+            [
+                Comparison::IN,
+                [ 'one' ],
+                'ConstraintOrx ( jcr.operator.equal.to ( OperandDynamicField(o.hello) OperandStaticLiteral("one") ) )'
+            ],
+            [
+                Comparison::IN,
+                [ 'one', 'two', 'three' ],
+                'ConstraintOrx ( jcr.operator.equal.to ( OperandDynamicField(o.hello) OperandStaticLiteral("one") ) jcr.operator.equal.to ( OperandDynamicField(o.hello) OperandStaticLiteral("two") ) jcr.operator.equal.to ( OperandDynamicField(o.hello) OperandStaticLiteral("three") ) )',
+            ],
+            [
+                Comparison::NIN,
+                [ 'one' ],
+                'ConstraintNot ( ConstraintOrx ( jcr.operator.equal.to ( OperandDynamicField(o.hello) OperandStaticLiteral("one") ) ) )'
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideComposite
+     */
+    public function test_it_should_handle_a_composite_with_an_arity_of_2($type, $expectedType)
+    {
+        $expr1 = new Comparison('hello', Comparison::EQ, 'world');
+        $expr2 = new Comparison('number', Comparison::GT, 8);
+        $expr = new CompositeExpression(
+            $type,
+            [ $expr1, $expr2 ]
+        );
+
+        $this->visitor->dispatch($expr);
+        $this->assertQueryBuilderState(<<<EOT
+$expectedType ( 
+    jcr.operator.equal.to (
+        OperandDynamicField(o.hello) OperandStaticLiteral("world") 
+    ) 
+    jcr.operator.greater.than ( 
+        OperandDynamicField(o.number) OperandStaticLiteral("8") 
+    ) 
+)
+EOT
+        );
+    }
+
+    public function provideComposite()
+    {
+        return [
+            [ CompositeExpression::TYPE_AND, 'ConstraintAndx' ],
+            [ CompositeExpression::TYPE_OR, 'ConstraintOrx' ]
+        ];
+    }
+
+    public function test_it_should_handle_a_composite_with_an_arity_of_3()
+    {
+        $type = CompositeExpression::TYPE_AND;
+        $expr1 = new Comparison('hello', Comparison::EQ, 'world');
+        $expr2 = new Comparison('number', Comparison::GT, 8);
+        $expr3 = new Comparison('date', Comparison::GT, '2015-12-10');
+        $expr = new CompositeExpression(
+            $type,
+            [ $expr1, $expr2, $expr3 ]
+        );
+
+        $this->visitor->dispatch($expr);
+        $this->assertQueryBuilderState(<<<'EOT'
+ConstraintAndx ( 
+    jcr.operator.equal.to ( 
+        OperandDynamicField(o.hello) OperandStaticLiteral("world") 
+    ) 
+    ConstraintAndx ( 
+        jcr.operator.greater.than ( 
+            OperandDynamicField(o.number) OperandStaticLiteral("8") 
+        ) 
+        jcr.operator.greater.than ( 
+            OperandDynamicField(o.date) OperandStaticLiteral("2015-12-10")
+        )
+    ) 
+)
+EOT
+        );
+    }
+
+    public function test_it_should_handle_a_nested_composites()
+    {
+        $type = CompositeExpression::TYPE_AND;
+        $expr1 = new Comparison('hello', Comparison::EQ, 'world');
+        $expr2 = new Comparison('number', Comparison::GT, 8);
+        $expr3 = new Comparison('date', Comparison::GT, '2015-12-10');
+        $expr4 = new Comparison('date', Comparison::LT, '2016-12-10');
+        $expr5 = new Comparison('date', Comparison::NEQ, '2016-12-10');
+
+        $comp2 = new CompositeExpression(CompositeExpression::TYPE_AND, [ $expr2, $expr5 ]);
+        $comp1 = new CompositeExpression(CompositeExpression::TYPE_OR, [ $expr1, $comp2 ]);
+
+        $expr = new CompositeExpression(
+            $type,
+            [ $comp1, $expr3, $expr4 ]
+        );
+
+        $this->visitor->dispatch($expr);
+        $this->assertQueryBuilderState(<<<EOT
+ConstraintAndx ( 
+    ConstraintOrx ( 
+        jcr.operator.equal.to ( 
+            OperandDynamicField(o.hello) OperandStaticLiteral("world") 
+        ) 
+        ConstraintAndx ( 
+            jcr.operator.greater.than ( 
+                OperandDynamicField(o.number) OperandStaticLiteral("8") 
+            ) 
+            jcr.operator.not.equal.to ( 
+                OperandDynamicField(o.date) OperandStaticLiteral("2016-12-10")
+            )
+        ) 
+    )
+    ConstraintAndx ( 
+        jcr.operator.greater.than ( 
+            OperandDynamicField(o.date) OperandStaticLiteral("2015-12-10")
+        )
+        jcr.operator.less.than ( 
+            OperandDynamicField(o.date) OperandStaticLiteral("2016-12-10")
+        )
+    ) 
+)
+EOT
+        );
+    }
+
+    private function assertQueryBuilderState($expected)
+    {
+        $converter = new QueryBuilderWalker();
+        $result = $converter->toString($this->queryBuilder->getChild('where')->getChild());
+        $expected = preg_replace('{\s{2,}}', ' ', $expected);
+        $expected = str_replace("\n", ' ', $expected);
+
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/src/Sylius/Bundle/GridBundle/Tests/Doctrine/PHPCRODM/QueryBuilderWalker.php
+++ b/src/Sylius/Bundle/GridBundle/Tests/Doctrine/PHPCRODM/QueryBuilderWalker.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\GridBundle\Tests\DependencyInjection;
+
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Sylius\Bundle\GridBundle\Doctrine\PHPCRODM\ExpressionVisitor;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\ODM\PHPCR\Query\Builder\ConverterInterface;
+use Doctrine\ODM\PHPCR\Query\Builder\OperandStaticLiteral;
+use Doctrine\ODM\PHPCR\Query\Builder\OperandDynamicField;
+use Doctrine\ODM\PHPCR\Query\Builder\ConstraintComparison;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractLeafNode;
+use Doctrine\ODM\PHPCR\Query\Builder\ConstraintFieldIsset;
+
+/**
+ * Creates a string representation of any given PHPCR-ODM QueryBuilder
+ * node in order that the tests can clearly assert the state of it.
+ */
+class QueryBuilderWalker
+{
+    /**
+     * Create a stirng representation of the given query builder node.
+     *
+     * @param AbstractNode $node
+     *
+     * @return string
+     */
+    public function toString(AbstractNode $node)
+    {
+        return implode(' ', $this->walk($node));
+    }
+
+    private function walk(AbstractNode $node, $elements = [])
+    {
+        $elements[] = $this->stringValue($node);
+
+        if ($node instanceof AbstractLeafNode) {
+            return $elements;
+        }
+
+        $elements[] = '(';
+
+        foreach ($node->getChildren() as $childNode) {
+            $elements = $this->walk($childNode, $elements);
+        }
+
+        $elements[] = ')';
+
+        return $elements;
+    }
+
+    private function stringValue(AbstractNode $node)
+    {
+        $refl = new \ReflectionClass(get_class($node));
+        $nodeName = $refl->getShortName();
+        if ($node instanceof ConstraintComparison) {
+            return sprintf('%s', $node->getOperator());
+        }
+
+        if ($node instanceof OperandDynamicField) {
+            return sprintf('%s(%s.%s)', $nodeName, $node->getAlias(), $node->getField());
+        }
+
+        if ($node instanceof OperandStaticLiteral) {
+            return sprintf('%s("%s")', $nodeName, $node->getValue());
+        }
+
+        if ($node instanceof ConstraintFieldIsset) {
+            return sprintf('%s("%s")', $nodeName, $node->getField());
+        }
+
+        return $nodeName;
+    }
+}

--- a/src/Sylius/Bundle/GridBundle/composer.json
+++ b/src/Sylius/Bundle/GridBundle/composer.json
@@ -29,11 +29,14 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.4.8,<2.5",
+        "jackalope/jackalope-doctrine-dbal": "^1.2",
+        "doctrine/phpcr-odm": "^1.3.0",
         "matthiasnoback/symfony-dependency-injection-test": "0.*",
         "phpspec/phpspec": "^2.4",
         "phpunit/phpunit": "^4.8",
         "twig/twig": "~1.11",
-        "matthiasnoback/symfony-config-test": "^1.4"
+        "matthiasnoback/symfony-config-test": "^1.4",
+        "pagerfanta/pagerfanta": "^1.0"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Sylius/Bundle/GridBundle/phpunit.xml.dist
+++ b/src/Sylius/Bundle/GridBundle/phpunit.xml.dist
@@ -3,8 +3,8 @@
 <!-- http://phpunit.de/manual/4.1/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
          backupGlobals="false"
+         bootstrap="vendor/autoload.php"
          colors="true"
 >
     <testsuites>

--- a/src/Sylius/Bundle/GridBundle/spec/Doctrine/PHPCRODM/DataSourceSpec.php
+++ b/src/Sylius/Bundle/GridBundle/spec/Doctrine/PHPCRODM/DataSourceSpec.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\GridBundle\Doctrine\PHPCRODM;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Doctrine\ODM\PHPCR\DocumentManagerInterface;
+use Sylius\Bundle\GridBundle\Doctrine\PHPCRODM\DataSource;
+use Sylius\Component\Grid\Data\DataSourceInterface;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Sylius\Bundle\GridBundle\Doctrine\PHPCRODM\ExpressionBuilder;
+use Doctrine\ODM\PHPCR\Query\Builder\ConstraintAndx;
+use Doctrine\Common\Collections\Expr\Value;
+use Doctrine\ODM\PHPCR\Query\Builder\ConstraintComparison;
+use Doctrine\ODM\PHPCR\Query\Builder\ConstraintOrx;
+use Sylius\Component\Grid\Parameters;
+use Pagerfanta\Pagerfanta;
+use Doctrine\ODM\PHPCR\Query\Builder\OrderBy;
+use Doctrine\ODM\PHPCR\Query\Builder\Ordering;
+
+/**
+ * @mixin Driver
+ */
+class DataSourceSpec extends ObjectBehavior
+{
+    function let(QueryBuilder $queryBuilder, ExpressionBuilder $expressionBuilder)
+    {
+        $this->beConstructedWith($queryBuilder, $expressionBuilder);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(DataSource::class);
+    }
+
+    function it_implements_data_source()
+    {
+        $this->shouldImplement(DataSourceInterface::class);
+    }
+
+    function it_should_restrict_with_or_condition(
+        Comparison $comparison,
+        Value $value,
+        QueryBuilder $queryBuilder,
+        ConstraintOrx $constraint,
+        ConstraintComparison $comparisonConstraint
+    )
+    {
+        $queryBuilder->orWhere()->willReturn($constraint);
+        $value->getValue()->willReturn('value');
+        $comparison->getValue()->willReturn($value);
+        $comparison->getField()->willReturn('foo');
+        $comparison->getOperator()->willReturn('=');
+
+        $constraint->eq()->willReturn($comparisonConstraint);
+        $comparisonConstraint->field('o.foo')->willReturn($comparisonConstraint);
+        $comparisonConstraint->literal('value')->shouldBeCalled()->willReturn($comparisonConstraint);
+        $comparisonConstraint->end()->shouldBeCalled();
+
+        $this->restrict($comparison, DataSourceInterface::CONDITION_OR);
+    }
+
+    function it_should_throw_an_exception_if_an_unknown_condition_is_passed(
+        Comparison $comparison
+    )
+    {
+        $this->shouldThrow(
+            new \RuntimeException('Unknown restrict condition "foo"')
+        )->during('restrict', [ $comparison, 'foo' ]);
+    }
+
+    function it_should_return_the_expression_builder(
+        ExpressionBuilder $expressionBuilder
+    )
+    {
+        $this->getExpressionBuilder()->shouldReturn($expressionBuilder);
+    }
+
+    function it_should_get_the_data(
+        ExpressionBuilder $expressionBuilder,
+        Parameters $parameters
+    )
+    {
+        $expressionBuilder->getOrderBys()->willReturn([]);
+        $parameters->get('page', 1)->willReturn(1);
+        $this->getData($parameters)->shouldHaveType(Pagerfanta::class);
+    }
+
+    function it_should_set_the_order_on_the_query_builder(
+        QueryBuilder $queryBuilder,
+        ExpressionBuilder $expressionBuilder,
+        Parameters $parameters,
+        OrderBy $orderBy,
+        Ordering $ordering
+    )
+    {
+        $expressionBuilder->getOrderBys()->willReturn([
+            'foo' => 'asc',
+            'bar' => 'desc'
+        ]);
+        $queryBuilder->orderBy()->willReturn($orderBy);
+        $orderBy->asc()->willReturn($ordering);
+        $orderBy->desc()->willReturn($ordering);
+        $ordering->field('o.foo')->shouldBeCalled();
+        $ordering->field('o.bar')->shouldBeCalled();
+
+        $parameters->get('page', 1)->willReturn(1);
+        $this->getData($parameters)->shouldHaveType(Pagerfanta::class);
+    }
+
+    function it_should_set_the_order_on_the_query_builder_as_fields_only(
+        QueryBuilder $queryBuilder,
+        ExpressionBuilder $expressionBuilder,
+        Parameters $parameters,
+        OrderBy $orderBy,
+        Ordering $ordering
+    )
+    {
+        $expressionBuilder->getOrderBys()->willReturn([
+            'foo',
+            'bar',
+        ]);
+        $queryBuilder->orderBy()->willReturn($orderBy);
+        $orderBy->asc()->willReturn($ordering);
+        $orderBy->asc()->willReturn($ordering);
+        $ordering->field('o.foo')->shouldBeCalled();
+        $ordering->field('o.bar')->shouldBeCalled();
+
+        $parameters->get('page', 1)->willReturn(1);
+        $this->getData($parameters)->shouldHaveType(Pagerfanta::class);
+    }
+}

--- a/src/Sylius/Bundle/GridBundle/spec/Doctrine/PHPCRODM/DriverSpec.php
+++ b/src/Sylius/Bundle/GridBundle/spec/Doctrine/PHPCRODM/DriverSpec.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\GridBundle\Doctrine\PHPCRODM;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Grid\Data\DriverInterface;
+use Sylius\Component\Grid\Parameters;
+use Doctrine\ODM\PHPCR\DocumentManagerInterface;
+use Doctrine\ODM\PHPCR\DocumentRepository;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Sylius\Bundle\GridBundle\Doctrine\PHPCRODM\DataSource;
+
+/**
+ * @mixin Driver
+ */
+class DriverSpec extends ObjectBehavior
+{
+    function let(DocumentManagerInterface $documentManager)
+    {
+        $this->beConstructedWith($documentManager);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\GridBundle\Doctrine\PHPCRODM\Driver');
+    }
+
+    function it_implements_grid_driver()
+    {
+        $this->shouldImplement(DriverInterface::class);
+    }
+
+    function it_throws_exception_if_class_is_undefined(Parameters $parameters)
+    {
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('getDataSource', [[], $parameters]);
+        ;
+    }
+
+    function it_creates_data_source_via_doctrine_phpcrodm_query_builder(
+        DocumentManagerInterface $documentManager,
+        DocumentRepository $documentRepository,
+        QueryBuilder $queryBuilder,
+        Parameters $parameters
+    ) {
+        $documentManager->getRepository('App:Book')->willReturn($documentRepository);
+        $documentRepository->createQueryBuilder('o')->willReturn($queryBuilder);
+        
+        $this->getDataSource(['class' => 'App:Book'], $parameters)->shouldHaveType(DataSource::class);
+    }
+}

--- a/src/Sylius/Bundle/GridBundle/spec/Doctrine/PHPCRODM/ExpressionBuilderSpec.php
+++ b/src/Sylius/Bundle/GridBundle/spec/Doctrine/PHPCRODM/ExpressionBuilderSpec.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\GridBundle\Doctrine\PHPCRODM;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Doctrine\Common\Collections\ExpressionBuilder as CollectionsExpressionBuilder;
+use Sylius\Bundle\GridBundle\Doctrine\PHPCRODM\ExpressionBuilder;
+use Doctrine\Common\Collections\Expr\Comparison;
+use Sylius\Bundle\GridBundle\Doctrine\PHPCRODM\ExtraComparison;
+
+class ExpressionBuilderSpec extends ObjectBehavior
+{
+    function let(CollectionsExpressionBuilder $expressionBuilder)
+    {
+        $this->beConstructedWith($expressionBuilder);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ExpressionBuilder::class);
+    }
+
+    function it_builds_andx(
+        Comparison $comparison,
+        CollectionsExpressionBuilder $expressionBuilder
+    )
+    {
+        $this->andX([$comparison]);
+        $expressionBuilder->andX([$comparison])->shouldHaveBeenCalled();
+    }
+
+    function it_builds_orx(
+        Comparison $comparison,
+        CollectionsExpressionBuilder $expressionBuilder
+    )
+    {
+        $this->orX([$comparison]);
+        $expressionBuilder->orX([$comparison])->shouldHaveBeenCalled();
+    }
+
+    function it_builds_equals(
+        CollectionsExpressionBuilder $expressionBuilder
+    )
+    {
+        $this->equals('o.foo', 'value');
+        $expressionBuilder->eq('o.foo', 'value')->shouldHaveBeenCalled();
+    }
+
+    function it_builds_not_equals(
+        CollectionsExpressionBuilder $expressionBuilder
+    )
+    {
+        $this->notEquals('o.foo', 'value');
+        $expressionBuilder->neq('o.foo', 'value')->shouldHaveBeenCalled();
+    }
+
+    function it_builds_less_than_or_equal(
+        CollectionsExpressionBuilder $expressionBuilder
+    )
+    {
+        $this->lessThanOrEqual('o.foo', 'value');
+        $expressionBuilder->lte('o.foo', 'value')->shouldHaveBeenCalled();
+    }
+
+    function it_builds_greater_than(
+        CollectionsExpressionBuilder $expressionBuilder
+    )
+    {
+        $this->greaterThan('o.foo', 'value');
+        $expressionBuilder->gt('o.foo', 'value')->shouldHaveBeenCalled();
+    }
+
+    function it_builds_greater_than_or_equal(
+        CollectionsExpressionBuilder $expressionBuilder
+    )
+    {
+        $this->greaterThanOrequal('o.foo', 'value');
+        $expressionBuilder->gte('o.foo', 'value')->shouldHaveBeenCalled();
+    }
+
+    function it_builds_in(
+        CollectionsExpressionBuilder $expressionBuilder
+    )
+    {
+        $this->in('o.foo', ['value']);
+        $expressionBuilder->in('o.foo', ['value'])->shouldHaveBeenCalled();
+    }
+
+    function it_builds_not_in(
+        CollectionsExpressionBuilder $expressionBuilder
+    )
+    {
+        $this->notIn('o.foo', ['value']);
+        $expressionBuilder->notIn('o.foo', ['value'])->shouldHaveBeenCalled();
+    }
+
+    function it_builds_is_null()
+    {
+        $expr = $this->isNull('o.foo');
+        $expr->getOperator()->shouldReturn(ExtraComparison::IS_NULL);
+        $expr->getField()->shouldReturn('o.foo');
+    }
+
+    function it_builds_is_not_null()
+    {
+        $expr = $this->isNotNull('o.foo');
+        $expr->getOperator()->shouldReturn(ExtraComparison::IS_NOT_NULL);
+        $expr->getField()->shouldReturn('o.foo');
+    }
+
+    function it_builds_like(
+        CollectionsExpressionBuilder $expressionBuilder
+    )
+    {
+        $this->like('o.foo', 'value');
+        $expressionBuilder->contains('o.foo', 'value')->shouldHaveBeenCalled();
+    }
+
+    function it_builds_not_like()
+    {
+        $expr = $this->notLike('o.foo', 'value');
+        $expr->getOperator()->shouldReturn(ExtraComparison::NOT_CONTAINS);
+        $expr->getField()->shouldReturn('o.foo');
+    }
+
+    function it_orders_by()
+    {
+        $this->orderBy('o.foo', 'asc');
+        $this->getOrderBys()->shouldReturn([
+            'o.foo' => 'asc',
+        ]);
+    }
+
+    function it_adds_order_by()
+    {
+        $this->orderBy('o.foo', 'asc');
+        $this->addOrderBy('o.bar', 'desc');
+        $this->getOrderBys()->shouldReturn([
+            'o.foo' => 'asc',
+            'o.bar' => 'desc',
+        ]);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| BC breaks?      | no|yes
| Deprecations?   | no|yes
| Related tickets | 
| License         | MIT

This PR would introduce a PHPCR-ODM driver.

The main problem is building the query builder - the PHPCR-ODM query builder uses a [different design](https://gist.github.com/dantleech/298c9618b5889bddeb87) than that of the standard Doctrine Query Builder, which makes building the query more difficult.

In order to solve this this PR uses the Doctrine Commons expresion builder and implements a visitor for that to build the PHPCR-ODM query.

If this approach seems reasonable I will finish this off and add the tests (PHPSpec or PHPUnit?)