### PR TITLE
[Translations] Add required locales option sylius translations type

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Form/Type/ResourceTranslationsType.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/Type/ResourceTranslationsType.php
@@ -15,6 +15,7 @@ use Sylius\Bundle\ResourceBundle\Form\EventSubscriber\ResourceTranslationsSubscr
 use Sylius\Component\Locale\Provider\LocaleProviderInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Anna Walasek <anna.walasek@lakion.com>

--- a/src/Sylius/Bundle/ResourceBundle/Form/Type/ResourceTranslationsType.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/Type/ResourceTranslationsType.php
@@ -44,13 +44,39 @@ final class ResourceTranslationsType extends AbstractType
 
         foreach ($locales as $locale) {
             $localesWithRequirement[$locale] = false;
-            if ($this->localeProvider->getDefaultLocaleCode() === $locale) {
+            if ($this->isLocaleRequired($locale, $options)) {
                 $localesWithRequirement[$locale] = true;
                 $localesWithRequirement = array_reverse($localesWithRequirement, true);
             }
         }
 
         $builder->addEventSubscriber(new ResourceTranslationsSubscriber($localesWithRequirement));
+    }
+
+    /**
+     * @param string $locale
+     * @param array  $options
+     *
+     * @return boolean
+     */
+    private function isLocaleRequired($locale, array $options = [])
+    {
+        if (isset($options['required_locales'])) {
+            return in_array($locale, $options['required_locales']);
+        }
+
+        return $this->localeProvider->getDefaultLocaleCode() === $locale;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefined('required_locales')
+            ->setAllowedTypes('required_locales', ['array'])
+        ;
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/Form/Type/ResourceTranslationsType.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/Type/ResourceTranslationsType.php
@@ -57,7 +57,7 @@ final class ResourceTranslationsType extends AbstractType
      * @param string $locale
      * @param array $options
      *
-     * @return boolean
+     * @return bool
      */
     private function isLocaleRequired($locale, array $options = [])
     {

--- a/src/Sylius/Bundle/ResourceBundle/Form/Type/ResourceTranslationsType.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/Type/ResourceTranslationsType.php
@@ -55,7 +55,7 @@ final class ResourceTranslationsType extends AbstractType
 
     /**
      * @param string $locale
-     * @param array  $options
+     * @param array $options
      *
      * @return boolean
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Related tickets | fixes #4822 |
| License | MIT |

This adds a `required_locales` option to the `sylius_translations` form type. This can be very useful for when you want to define what locales are required at runtime. For example, I have a use case where I want to make the locales required of a product based on the unique sum of locales of all linked channels.
