### PR TITLE
[Taxation] Entrepreneur tax rate setting

### DIFF
--- a/app/migrations/Version20160418191631.php
+++ b/app/migrations/Version20160418191631.php
@@ -19,7 +19,7 @@ class Version20160418191631 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_customer ADD vat_number VARCHAR(255) DEFAULT NULL, ADD reseller_id VARCHAR(255) DEFAULT NULL');
-        $this->addSql('ALTER TABLE sylius_tax_rate ADD applied_to_individuals VARCHAR(255) NOT NULL, ADD applied_to_resellers VARCHAR(255) NOT NULL, ADD applied_to_entrepreneurs VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE sylius_tax_rate ADD applied_to_individuals TINYINT(1) DEFAULT \'1\' NOT NULL, ADD applied_to_entrepreneurs_and_resellers TINYINT(1) DEFAULT \'1\' NOT NULL');
     }
 
     /**
@@ -31,6 +31,6 @@ class Version20160418191631 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_customer DROP vat_number, DROP reseller_id');
-        $this->addSql('ALTER TABLE sylius_tax_rate DROP applied_to_individuals, DROP applied_to_resellers, DROP applied_to_entrepreneurs');
+        $this->addSql('ALTER TABLE sylius_tax_rate DROP applied_to_individuals, DROP applied_to_entrepreneurs_and_resellers');
     }
 }

--- a/app/migrations/Version20160418191631.php
+++ b/app/migrations/Version20160418191631.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20160418191631 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_customer ADD vat_number VARCHAR(255) DEFAULT NULL, ADD reseller_id VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE sylius_tax_rate ADD applied_to_individuals VARCHAR(255) NOT NULL, ADD applied_to_resellers VARCHAR(255) NOT NULL, ADD applied_to_entrepreneurs VARCHAR(255) NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_customer DROP vat_number, DROP reseller_id');
+        $this->addSql('ALTER TABLE sylius_tax_rate DROP applied_to_individuals, DROP applied_to_resellers, DROP applied_to_entrepreneurs');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/TaxRateType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/TaxRateType.php
@@ -28,6 +28,14 @@ class TaxRateType extends BaseTaxRateType
     {
         parent::buildForm($builder, $options);
 
-        $builder->add('zone', 'sylius_zone_choice');
+        $builder
+            ->add('zone', 'sylius_zone_choice')
+            ->add('appliedToIndividuals', 'checkbox', [
+                'label' => 'Apply to individuals',
+            ])
+            ->add('appliedToEntrepreneursAndResellers', 'checkbox', [
+                'label' => 'Apply to entrepreneurs and resellers'
+            ])
+        ;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/TaxRate.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/TaxRate.orm.xml
@@ -17,6 +17,10 @@
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <mapped-superclass name="Sylius\Component\Core\Model\TaxRate" table="sylius_tax_rate">
+        <field name="appliedToIndividuals" column="applied_to_individuals" />
+        <field name="appliedToResellers" column="applied_to_resellers" />
+        <field name="appliedToEntrepreneurs" column="applied_to_entrepreneurs" />
+
         <many-to-one field="zone" target-entity="Sylius\Component\Addressing\Model\ZoneInterface">
             <join-column name="zone_id" referenced-column-name="id" nullable="false" />
         </many-to-one>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/TaxRate.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/TaxRate.orm.xml
@@ -17,9 +17,16 @@
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <mapped-superclass name="Sylius\Component\Core\Model\TaxRate" table="sylius_tax_rate">
-        <field name="appliedToIndividuals" column="applied_to_individuals" />
-        <field name="appliedToResellers" column="applied_to_resellers" />
-        <field name="appliedToEntrepreneurs" column="applied_to_entrepreneurs" />
+        <field name="appliedToIndividuals" column="applied_to_individuals" type="boolean">
+            <options>
+                <option name="default">1</option>
+            </options>
+        </field>
+        <field name="appliedToEntrepreneursAndResellers" column="applied_to_entrepreneurs_and_resellers" type="boolean">
+            <options>
+                <option name="default">1</option>
+            </options>
+        </field>
 
         <many-to-one field="zone" target-entity="Sylius\Component\Addressing\Model\ZoneInterface">
             <join-column name="zone_id" referenced-column-name="id" nullable="false" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -243,18 +243,18 @@
         <service id="sylius.taxation.order_shipment_taxes_applicator" class="%sylius.taxation.order_shipment_taxes_applicator.class%">
             <argument type="service" id="sylius.tax_calculator" />
             <argument type="service" id="sylius.factory.adjustment" />
-            <argument type="service" id="sylius.tax_rate_resolver" />
+            <argument type="service" id="sylius.tax_rates_resolver" />
         </service>
         <service id="sylius.taxation.order_items_taxes_applicator" class="%sylius.taxation.order_items_taxes_applicator.class%">
             <argument type="service" id="sylius.tax_calculator" />
             <argument type="service" id="sylius.factory.adjustment" />
             <argument type="service" id="sylius.integer_distributor" />
-            <argument type="service" id="sylius.tax_rate_resolver" />
+            <argument type="service" id="sylius.tax_rates_resolver" />
         </service>
         <service id="sylius.taxation.order_item_units_taxes_applicator" class="%sylius.taxation.order_item_units_taxes_applicator.class%">
             <argument type="service" id="sylius.tax_calculator" />
             <argument type="service" id="sylius.factory.adjustment" />
-            <argument type="service" id="sylius.tax_rate_resolver" />
+            <argument type="service" id="sylius.tax_rates_resolver" />
         </service>
 
         <service id="sylius.taxation.order_taxes_processor" class="%sylius.taxation.order_taxes_processor.class%">

--- a/src/Sylius/Bundle/TaxationBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/TaxationBundle/Resources/config/services.xml
@@ -28,7 +28,7 @@
         <parameter key="sylius.tax_calculator.class">Sylius\Component\Taxation\Calculator\DelegatingCalculator</parameter>
         <parameter key="sylius.tax_calculator.default.class">Sylius\Component\Taxation\Calculator\DefaultCalculator</parameter>
 
-        <parameter key="sylius.tax_rate_resolver.class">Sylius\Component\Taxation\Resolver\TaxRateResolver</parameter>
+        <parameter key="sylius.tax_rates_resolver.class">Sylius\Component\Taxation\Resolver\TaxRatesResolver</parameter>
     </parameters>
 
     <services>
@@ -53,7 +53,7 @@
             <tag name="sylius.tax_calculator" calculator="default" />
         </service>
 
-        <service id="sylius.tax_rate_resolver" class="%sylius.tax_rate_resolver.class%">
+        <service id="sylius.tax_rates_resolver" class="%sylius.tax_rates_resolver.class%">
             <argument type="service" id="sylius.repository.tax_rate" />
         </service>
     </services>

--- a/src/Sylius/Bundle/UserBundle/Form/Type/CustomerProfileType.php
+++ b/src/Sylius/Bundle/UserBundle/Form/Type/CustomerProfileType.php
@@ -46,6 +46,14 @@ class CustomerProfileType extends AbstractResourceType
                 'required' => false,
                 'label' => 'sylius.form.customer.phone_number',
             ])
+            ->add('vatNumber', 'text', [
+                'required' => false,
+                'label' => 'sylius.form.customer.vat_number'
+            ])
+            ->add('resellerId', 'text', [
+                'required' => false,
+                'label' => 'sylius.form.customer.reseller_id'
+            ])
         ;
     }
 

--- a/src/Sylius/Bundle/UserBundle/Resources/config/doctrine/model/Customer.orm.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/doctrine/model/Customer.orm.xml
@@ -33,6 +33,8 @@
                 <option name="default">u</option>
             </options>
         </field>
+        <field name="vatNumber" column="vat_number" type="string" nullable="true"/>
+        <field name="resellerId" column="reseller_id" type="string" nullable="true"/>
 
         <field name="createdAt" column="created_at" type="datetime">
             <gedmo:timestampable on="create"/>

--- a/src/Sylius/Bundle/UserBundle/spec/Form/Type/CustomerProfileTypeSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/Form/Type/CustomerProfileTypeSpec.php
@@ -35,6 +35,8 @@ class CustomerProfileTypeSpec extends ObjectBehavior
 
     function it_builds_a_form(FormBuilderInterface $builder)
     {
+        $builder->add('vatNumber', 'text', Argument::type('array'))->shouldbeCalled()->willReturn($builder);
+        $builder->add('resellerId', 'text', Argument::type('array'))->shouldbeCalled()->willReturn($builder);
         $builder->add('firstName', 'text', Argument::type('array'))->shouldbeCalled()->willReturn($builder);
         $builder->add('lastName', 'text', Argument::type('array'))->shouldbeCalled()->willReturn($builder);
         $builder->add('email', 'email', Argument::type('array'))->shouldbeCalled()->willReturn($builder);

--- a/src/Sylius/Bundle/UserBundle/spec/Form/Type/CustomerTypeSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/Form/Type/CustomerTypeSpec.php
@@ -45,6 +45,8 @@ class CustomerTypeSpec extends ObjectBehavior
 
     function it_builds_form(FormBuilderInterface $builder, EventSubscriberInterface $addUserTypeSubscriber)
     {
+        $builder->add('resellerId', 'text', Argument::any())->shouldBeCalled()->willReturn($builder);
+        $builder->add('vatNumber', 'text', Argument::any())->shouldBeCalled()->willReturn($builder);
         $builder->add('firstName', 'text', Argument::any())->shouldBeCalled()->willReturn($builder);
         $builder->add('lastName', 'text', Argument::any())->shouldBeCalled()->willReturn($builder);
         $builder->add('email', 'email', Argument::any())->shouldBeCalled()->willReturn($builder);

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/_form.html.twig
@@ -4,6 +4,8 @@
     <div class="col-md-12">
         <fieldset>
             {{ form_row(form.email) }}
+            {{ form_row(form.vatNumber) }}
+            {{ form_row(form.resellerId) }}
             {{ form_row(form.firstName) }}
             {{ form_row(form.lastName) }}
             {{ form_row(form.birthday) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Customer/show.html.twig
@@ -39,6 +39,18 @@
                 <td><strong>{{ 'sylius.ui.id'|trans }}</strong></td>
                 <td>{{ customer.id }}</td>
             </tr>
+            {% if customer.vatNumber %}
+                <tr>
+                    <td><strong>{{ 'sylius.ui.vat_number'|trans }}</strong></td>
+                    <td>{{ customer.vatNumber }}</td>
+                </tr>
+            {% endif %}
+            {% if customer.resellerId %}
+                <tr>
+                    <td><strong>{{ 'sylius.ui.reseller_id'|trans }}</strong></td>
+                    <td>{{ customer.resellerId }}</td>
+                </tr>
+            {% endif %}
             {% if customer.firstName %}
                 <tr>
                     <td><strong>{{ 'sylius.ui.first_name'|trans }}</strong></td>

--- a/src/Sylius/Component/Core/Model/TaxRate.php
+++ b/src/Sylius/Component/Core/Model/TaxRate.php
@@ -30,23 +30,17 @@ class TaxRate extends BaseTaxRate implements TaxRateInterface
     protected $zone;
 
     /**
-     * @var string
+     * @var bool
      */
     protected $appliedToIndividuals = true;
 
     /**
-     * Used in United States
+     * Resale Certificate is used in United States
+     * VAT (entrepreneur) is used in European Union
      *
-     * @var string
+     * @var bool
      */
-    protected $appliedToResellers = true;
-
-    /**
-     * Used in European Union
-     *
-     * @var string
-     */
-    protected $appliedToEntrepreneurs = true;
+    protected $appliedToEntrepreneursAndResellers = true;
 
     /**
      * {@inheritdoc}
@@ -93,49 +87,24 @@ class TaxRate extends BaseTaxRate implements TaxRateInterface
     /**
      * {@inheritdoc}
      */
-    public function IsAppliedToResellers()
+    public function isAppliedToEntrepreneursAndResellers()
     {
-        return $this->appliedToResellers;
+        return $this->appliedToEntrepreneursAndResellers;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getAppliedToResellers()
+    public function getAppliedToEntrepreneursAndResellers()
     {
-        return $this->appliedToResellers;
+        return $this->appliedToEntrepreneursAndResellers;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function setAppliedToResellers($appliedToResellers)
+    public function setAppliedToEntrepreneursAndResellers($appliedToEntrepreneursAndResellers)
     {
-        $this->appliedToResellers = $appliedToResellers;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isAppliedToEntrepreneurs()
-    {
-        return $this->appliedToEntrepreneurs;
-    }
-
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getAppliedToEntrepreneurs()
-    {
-        return $this->appliedToEntrepreneurs;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setAppliedToEntrepreneurs($appliedToEntrepreneurs)
-    {
-        $this->appliedToEntrepreneurs = $appliedToEntrepreneurs;
+        $this->appliedToEntrepreneursAndResellers = $appliedToEntrepreneursAndResellers;
     }
 }

--- a/src/Sylius/Component/Core/Model/TaxRate.php
+++ b/src/Sylius/Component/Core/Model/TaxRate.php
@@ -18,6 +18,7 @@ use Sylius\Component\Taxation\Model\TaxRate as BaseTaxRate;
  * Tax rate applicable to selected zone.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Robin Jansen <robinjansen51@gmail.com>
  */
 class TaxRate extends BaseTaxRate implements TaxRateInterface
 {
@@ -27,6 +28,25 @@ class TaxRate extends BaseTaxRate implements TaxRateInterface
      * @var ZoneInterface
      */
     protected $zone;
+
+    /**
+     * @var string
+     */
+    protected $appliedToIndividuals = true;
+
+    /**
+     * Used in United States
+     *
+     * @var string
+     */
+    protected $appliedToResellers = true;
+
+    /**
+     * Used in European Union
+     *
+     * @var string
+     */
+    protected $appliedToEntrepreneurs = true;
 
     /**
      * {@inheritdoc}
@@ -44,5 +64,78 @@ class TaxRate extends BaseTaxRate implements TaxRateInterface
         $this->zone = $zone;
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAppliedToIndividuals()
+    {
+        return $this->appliedToIndividuals;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAppliedToIndividuals()
+    {
+        return $this->appliedToIndividuals;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAppliedToIndividuals($appliedToIndividuals)
+    {
+        $this->appliedToIndividuals = $appliedToIndividuals;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function IsAppliedToResellers()
+    {
+        return $this->appliedToResellers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAppliedToResellers()
+    {
+        return $this->appliedToResellers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAppliedToResellers($appliedToResellers)
+    {
+        $this->appliedToResellers = $appliedToResellers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAppliedToEntrepreneurs()
+    {
+        return $this->appliedToEntrepreneurs;
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAppliedToEntrepreneurs()
+    {
+        return $this->appliedToEntrepreneurs;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAppliedToEntrepreneurs($appliedToEntrepreneurs)
+    {
+        $this->appliedToEntrepreneurs = $appliedToEntrepreneurs;
     }
 }

--- a/src/Sylius/Component/Core/Model/TaxRateInterface.php
+++ b/src/Sylius/Component/Core/Model/TaxRateInterface.php
@@ -54,30 +54,15 @@ interface TaxRateInterface extends BaseTaxRateInterface
     /**
      * @return bool
      */
-    public function isAppliedToResellers();
+    public function isAppliedToEntrepreneursAndResellers();
 
     /**
      * @return bool
      */
-    public function getAppliedToResellers();
+    public function getAppliedToEntrepreneursAndResellers();
 
     /**
      * @param bool $appliedToResellers
      */
-    public function setAppliedToResellers($appliedToResellers);
-
-    /**
-     * @return bool
-     */
-    public function isAppliedToEntrepreneurs();
-
-    /**
-     * @return bool
-     */
-    public function getAppliedToEntrepreneurs();
-
-    /**
-     * @param bool $appliedToEntrepreneurs
-     */
-    public function setAppliedToEntrepreneurs($appliedToEntrepreneurs);
+    public function setAppliedToEntrepreneursAndResellers($appliedToResellers);
 }

--- a/src/Sylius/Component/Core/Model/TaxRateInterface.php
+++ b/src/Sylius/Component/Core/Model/TaxRateInterface.php
@@ -18,6 +18,7 @@ use Sylius\Component\Taxation\Model\TaxRateInterface as BaseTaxRateInterface;
  * Tax rate interface.
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Robin Jansen <robinjansen51@gmail.com>
  */
 interface TaxRateInterface extends BaseTaxRateInterface
 {
@@ -34,4 +35,49 @@ interface TaxRateInterface extends BaseTaxRateInterface
      * @param ZoneInterface $zone
      */
     public function setZone(ZoneInterface $zone);
+
+    /**
+     * @return bool
+     */
+    public function isAppliedToIndividuals();
+
+    /**
+     * @return bool
+     */
+    public function getAppliedToIndividuals();
+
+    /**
+     * @param bool $appliedToIndividuals
+     */
+    public function setAppliedToIndividuals($appliedToIndividuals);
+
+    /**
+     * @return bool
+     */
+    public function isAppliedToResellers();
+
+    /**
+     * @return bool
+     */
+    public function getAppliedToResellers();
+
+    /**
+     * @param bool $appliedToResellers
+     */
+    public function setAppliedToResellers($appliedToResellers);
+
+    /**
+     * @return bool
+     */
+    public function isAppliedToEntrepreneurs();
+
+    /**
+     * @return bool
+     */
+    public function getAppliedToEntrepreneurs();
+
+    /**
+     * @param bool $appliedToEntrepreneurs
+     */
+    public function setAppliedToEntrepreneurs($appliedToEntrepreneurs);
 }

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
@@ -14,11 +14,14 @@ namespace Sylius\Component\Core\Taxation\Applicator;
 use Sylius\Component\Core\Distributor\IntegerDistributorInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
+use Sylius\Component\Core\Model\TaxRateInterface;
 use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
 use Sylius\Component\Taxation\Calculator\CalculatorInterface;
-use Sylius\Component\Taxation\Resolver\TaxRateResolverInterface;
+use Sylius\Component\Taxation\Resolver\TaxRatesResolverInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -42,26 +45,26 @@ class OrderItemsTaxesApplicator implements OrderTaxesApplicatorInterface
     private $distributor;
 
     /**
-     * @var TaxRateResolverInterface
+     * @var TaxRatesResolverInterface
      */
-    private $taxRateResolver;
+    private $taxRatesResolver;
 
     /**
      * @param CalculatorInterface $calculator
      * @param AdjustmentFactoryInterface $adjustmentFactory
      * @param IntegerDistributorInterface $distributor
-     * @param TaxRateResolverInterface $taxRateResolver
+     * @param TaxRatesResolverInterface $taxRatesResolver
      */
     public function __construct(
         CalculatorInterface $calculator,
         AdjustmentFactoryInterface $adjustmentFactory,
         IntegerDistributorInterface $distributor,
-        TaxRateResolverInterface $taxRateResolver
+        TaxRatesResolverInterface $taxRatesResolver
     ) {
         $this->calculator = $calculator;
         $this->adjustmentFactory = $adjustmentFactory;
         $this->distributor = $distributor;
-        $this->taxRateResolver = $taxRateResolver;
+        $this->taxRatesResolver = $taxRatesResolver;
     }
 
     /**
@@ -75,25 +78,58 @@ class OrderItemsTaxesApplicator implements OrderTaxesApplicatorInterface
                 throw new \InvalidArgumentException('Cannot apply tax to order item with 0 quantity.');
             }
 
-            $taxRate = $this->taxRateResolver->resolve($item->getVariant(), ['zone' => $zone]);
+            $taxRates = $this->taxRatesResolver->resolve($item->getVariant(), ['zone' => $zone]);
 
-            if (null === $taxRate) {
-                continue;
-            }
-
-            $totalTaxAmount = $this->calculator->calculate($item->getTotal(), $taxRate);
-            $splitTaxes = $this->distributor->distribute($totalTaxAmount, $quantity);
-
-            $i = 0;
-            foreach ($item->getUnits() as $unit) {
-                if (0 === $splitTaxes[$i]) {
+            foreach ($taxRates as $taxRate) {
+                if ($this->removeUnnecessaryIncludedTax($taxRate, $item, $order->getCustomer())) {
                     continue;
                 }
 
-                $this->addAdjustment($unit, $splitTaxes[$i], $taxRate->getLabel(), $taxRate->isIncludedInPrice());
-                $i++;
+                $totalTaxAmount = $this->calculator->calculate($item->getTotal(), $taxRate);
+
+                $splitTaxes = $this->distributor->distribute($totalTaxAmount, $quantity);
+
+                $i = 0;
+                foreach ($item->getUnits() as $unit) {
+                    if (0 === $splitTaxes[$i] && $taxRate->getAmount() > 0) {
+                        continue;
+                    }
+
+                    $this->addAdjustment($unit, $splitTaxes[$i], $taxRate->getLabel(), $taxRate->isIncludedInPrice());
+                    $i++;
+                }
             }
         }
+    }
+
+    /**
+     * @param TaxRateInterface       $taxRate
+     * @param OrderItemInterface     $item
+     * @param CustomerInterface|null $customer
+     *
+     * @return bool
+     */
+    private function removeUnnecessaryIncludedTax(
+        TaxRateInterface $taxRate,
+        OrderItemInterface $item,
+        CustomerInterface $customer = null
+    ) {
+        if (!$taxRate->isIncludedInPrice() || !$customer) {
+            return false;
+        }
+
+        if ($customer->isEntrepreneurOrReseller() && $taxRate->isAppliedToEntrepreneursAndResellers()) {
+            return false;
+        }
+
+        if ($customer->isIndividual() && $taxRate->isAppliedToIndividuals()) {
+            return false;
+        }
+
+        $includedTaxAmount = $this->calculator->calculate($item->getUnitPrice(), $taxRate);
+        $item->setUnitPrice($item->getUnitPrice() - $includedTaxAmount);
+
+        return true;
     }
 
     /**

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderShipmentTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderShipmentTaxesApplicator.php
@@ -13,10 +13,14 @@ namespace Sylius\Component\Core\Taxation\Applicator;
 
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+use Sylius\Component\Core\Model\TaxRatesInterface;
 use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
 use Sylius\Component\Taxation\Calculator\CalculatorInterface;
-use Sylius\Component\Taxation\Resolver\TaxRateResolverInterface;
+use Sylius\Component\Taxation\Resolver\TaxRatesResolverInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -35,20 +39,23 @@ class OrderShipmentTaxesApplicator implements OrderTaxesApplicatorInterface
     private $adjustmentFactory;
 
     /**
-     * @var TaxRateResolverInterface
+     * @var TaxRatesResolverInterface
      */
-    private $taxRateResolver;
+    private $taxRatesResolver;
 
     /**
      * @param CalculatorInterface $calculator
      * @param AdjustmentFactoryInterface $adjustmentFactory
-     * @param TaxRateResolverInterface $taxRateResolver
+     * @param TaxRatesResolverInterface $taxRatesResolver
      */
-    public function __construct(CalculatorInterface $calculator, AdjustmentFactoryInterface $adjustmentFactory, TaxRateResolverInterface $taxRateResolver)
-    {
+    public function __construct(
+        CalculatorInterface $calculator,
+        AdjustmentFactoryInterface $adjustmentFactory,
+        TaxRatesResolverInterface $taxRatesResolver
+    ) {
         $this->calculator = $calculator;
         $this->adjustmentFactory = $adjustmentFactory;
-        $this->taxRateResolver = $taxRateResolver;
+        $this->taxRatesResolver = $taxRatesResolver;
     }
 
     /**
@@ -66,18 +73,52 @@ class OrderShipmentTaxesApplicator implements OrderTaxesApplicatorInterface
             return;
         }
 
-        $taxRate = $this->taxRateResolver->resolve($lastShipment->getMethod(), ['zone' => $zone]);
-        if (null === $taxRate) {
-            return;
+        $taxRates = $this->taxRatesResolver->resolve($lastShipment->getMethod(), ['zone' => $zone]);
+
+        foreach($taxRates as $taxRate) {
+            $lastShippingAdjustment = $shippingAdjustments->last();
+
+//            if ($this->removeUnnecessaryIncludedTax($taxRate, $lastShippingAdjustment, $order->getCustomer())) {
+//                continue;
+//            }
+
+            $taxAmount = $this->calculator->calculate($lastShippingAdjustment->getAmount(), $taxRate);
+            if (0 === $taxAmount && $taxRate->getAmount() > 0) {
+                return;
+            }
+
+            $this->addAdjustment($order, $taxAmount, $taxRate->getLabel(), $taxRate->isIncludedInPrice());
+        }
+    }
+
+    /**
+     * @param TaxRateInterface       $taxRate
+     * @param AdjustmentInterface    $adjustment
+     * @param CustomerInterface|null $customer
+     *
+     * @return bool
+     */
+    private function removeUnnecessaryIncludedTax(
+        TaxRateInterface $taxRate,
+        AdjustmentInterface $adjustment,
+        CustomerInterface $customer = null
+    ) {
+        if (!$taxRate->isIncludedInPrice() || !$customer) {
+            return false;
         }
 
-        $lastShippingAdjustment = $shippingAdjustments->last();
-        $taxAmount = $this->calculator->calculate($lastShippingAdjustment->getAmount(), $taxRate);
-        if (0 === $taxAmount) {
-            return;
+        if ($customer->isEntrepreneurOrReseller() && $taxRate->isAppliedToEntrepreneursAndResellers()) {
+            return false;
         }
 
-        $this->addAdjustment($order, $taxAmount, $taxRate->getLabel(), $taxRate->isIncludedInPrice());
+        if ($customer->isIndividual() && $taxRate->isAppliedToIndividuals()) {
+            return false;
+        }
+
+        $includedTaxAmount = $this->calculator->calculate($adjustment->getAmount(), $taxRate);
+        $adjustment->setAmount($adjustment->getAmount() - $includedTaxAmount);
+
+        return true;
     }
 
     /**

--- a/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemUnitsTaxesApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemUnitsTaxesApplicatorSpec.php
@@ -26,7 +26,7 @@ use Sylius\Component\Core\Taxation\Applicator\OrderTaxesApplicatorInterface;
 use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
 use Sylius\Component\Taxation\Calculator\CalculatorInterface;
 use Sylius\Component\Taxation\Model\TaxRateInterface;
-use Sylius\Component\Taxation\Resolver\TaxRateResolverInterface;
+use Sylius\Component\Taxation\Resolver\TaxRatesResolverInterface;
 
 /**
  * @mixin OrderItemUnitsTaxesApplicator
@@ -38,9 +38,9 @@ class OrderItemUnitsTaxesApplicatorSpec extends ObjectBehavior
     function let(
         CalculatorInterface $calculator,
         AdjustmentFactoryInterface $adjustmentsFactory,
-        TaxRateResolverInterface $taxRateResolver
+        TaxRatesResolverInterface $taxRatesResolver
     ) {
-        $this->beConstructedWith($calculator, $adjustmentsFactory, $taxRateResolver);
+        $this->beConstructedWith($calculator, $adjustmentsFactory, $taxRatesResolver);
     }
 
     function it_is_initializable()
@@ -56,7 +56,7 @@ class OrderItemUnitsTaxesApplicatorSpec extends ObjectBehavior
     function it_applies_taxes_on_units_based_on_item_total_and_rate(
         $adjustmentsFactory,
         $calculator,
-        $taxRateResolver,
+        $taxRatesResolver,
         AdjustmentInterface $taxAdjustment1,
         AdjustmentInterface $taxAdjustment2,
         Collection $items,
@@ -75,7 +75,7 @@ class OrderItemUnitsTaxesApplicatorSpec extends ObjectBehavior
         $items->getIterator()->willReturn(new \ArrayIterator([$orderItem->getWrappedObject()]));
 
         $orderItem->getVariant()->willReturn($productVariant);
-        $taxRateResolver->resolve($productVariant, ['zone' => $zone])->willReturn($taxRate);
+        $taxRatesResolver->resolve($productVariant, ['zone' => $zone])->willReturn([$taxRate]);
 
         $taxRate->getLabel()->willReturn('Simple tax (10%)');
         $taxRate->isIncludedInPrice()->willReturn(false);
@@ -107,7 +107,7 @@ class OrderItemUnitsTaxesApplicatorSpec extends ObjectBehavior
     function it_does_nothing_if_order_item_has_no_units(
         CalculatorInterface $calculator,
         AdjustmentFactoryInterface $adjustmentsFactory,
-        TaxRateResolverInterface $taxRateResolver,
+        TaxRatesResolverInterface $taxRatesResolver,
         OrderInterface $order,
         OrderItemInterface $orderItem,
         ProductVariantInterface $productVariant,
@@ -119,7 +119,7 @@ class OrderItemUnitsTaxesApplicatorSpec extends ObjectBehavior
 
         $orderItem->getVariant()->willReturn($productVariant);
         $orderItem->getUnits()->willReturn(new ArrayCollection());
-        $taxRateResolver->resolve(Argument::cetera())->willReturn($taxRate);
+        $taxRatesResolver->resolve(Argument::cetera())->willReturn([$taxRate]);
 
         $calculator->calculate(Argument::cetera())->shouldNotBeCalled();
         $adjustmentsFactory->createWithData(Argument::cetera())->shouldNotBeCalled();
@@ -129,7 +129,7 @@ class OrderItemUnitsTaxesApplicatorSpec extends ObjectBehavior
 
     function it_does_nothing_if_tax_rate_cannot_be_resolved(
         $calculator,
-        $taxRateResolver,
+        $taxRatesResolver,
         Collection $items,
         OrderInterface $order,
         OrderItemInterface $orderItem,
@@ -144,7 +144,7 @@ class OrderItemUnitsTaxesApplicatorSpec extends ObjectBehavior
         $orderItem->getQuantity()->willReturn(1);
 
         $orderItem->getVariant()->willReturn($productVariant);
-        $taxRateResolver->resolve($productVariant, ['zone' => $zone])->willReturn(null);
+        $taxRatesResolver->resolve($productVariant, ['zone' => $zone])->willReturn([]);
 
         $orderItem->getUnits()->shouldNotBeCalled();
         $calculator->calculate(Argument::cetera())->shouldNotBeCalled();
@@ -155,7 +155,7 @@ class OrderItemUnitsTaxesApplicatorSpec extends ObjectBehavior
     function it_does_not_apply_taxes_with_amount_0(
         $adjustmentsFactory,
         $calculator,
-        $taxRateResolver,
+        $taxRatesResolver,
         Collection $items,
         Collection $units,
         OrderInterface $order,
@@ -174,7 +174,7 @@ class OrderItemUnitsTaxesApplicatorSpec extends ObjectBehavior
         $orderItem->getQuantity()->willReturn(2);
 
         $orderItem->getVariant()->willReturn($productVariant);
-        $taxRateResolver->resolve($productVariant, ['zone' => $zone])->willReturn($taxRate);
+        $taxRatesResolver->resolve($productVariant, ['zone' => $zone])->willReturn([$taxRate]);
 
         $orderItem->getUnits()->willReturn($units);
         $units->getIterator()->willReturn(new \ArrayIterator([$unit1->getWrappedObject(), $unit2->getWrappedObject()]));

--- a/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemsTaxesApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemsTaxesApplicatorSpec.php
@@ -27,7 +27,7 @@ use Sylius\Component\Core\Taxation\Applicator\OrderTaxesApplicatorInterface;
 use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
 use Sylius\Component\Taxation\Calculator\CalculatorInterface;
 use Sylius\Component\Taxation\Model\TaxRateInterface;
-use Sylius\Component\Taxation\Resolver\TaxRateResolverInterface;
+use Sylius\Component\Taxation\Resolver\TaxRatesResolverInterface;
 
 /**
  * @mixin OrderItemsTaxesApplicator
@@ -41,9 +41,9 @@ class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         CalculatorInterface $calculator,
         AdjustmentFactoryInterface $adjustmentsFactory,
         IntegerDistributorInterface $distributor,
-        TaxRateResolverInterface $taxRateResolver
+        TaxRatesResolverInterface $taxRatesResolver
     ) {
-        $this->beConstructedWith($calculator, $adjustmentsFactory, $distributor, $taxRateResolver);
+        $this->beConstructedWith($calculator, $adjustmentsFactory, $distributor, $taxRatesResolver);
     }
 
     function it_is_initializable()
@@ -60,7 +60,7 @@ class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         $adjustmentsFactory,
         $calculator,
         $distributor,
-        $taxRateResolver,
+        $taxRatesResolver,
         AdjustmentInterface $taxAdjustment1,
         AdjustmentInterface $taxAdjustment2,
         Collection $items,
@@ -81,7 +81,7 @@ class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         $orderItem->getQuantity()->willReturn(2);
 
         $orderItem->getVariant()->willReturn($productVariant);
-        $taxRateResolver->resolve($productVariant, ['zone' => $zone])->willReturn($taxRate);
+        $taxRatesResolver->resolve($productVariant, ['zone' => $zone])->willReturn([$taxRate]);
 
         $orderItem->getTotal()->willReturn(1000);
         $calculator->calculate(1000, $taxRate)->willReturn(100);
@@ -119,7 +119,7 @@ class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
     }
 
     function it_does_nothing_if_tax_rate_cannot_be_resolved(
-        $taxRateResolver,
+        $taxRatesResolver,
         Collection $items,
         \Iterator $iterator,
         OrderInterface $order,
@@ -139,7 +139,7 @@ class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         $orderItem->getQuantity()->willReturn(5);
 
         $orderItem->getVariant()->willReturn($productVariant);
-        $taxRateResolver->resolve($productVariant, ['zone' => $zone])->willReturn(null);
+        $taxRatesResolver->resolve($productVariant, ['zone' => $zone])->willReturn([]);
 
         $orderItem->getUnits()->shouldNotBeCalled();
 
@@ -150,7 +150,7 @@ class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         $adjustmentsFactory,
         $calculator,
         $distributor,
-        $taxRateResolver,
+        $taxRatesResolver,
         Collection $items,
         Collection $units,
         OrderInterface $order,
@@ -169,7 +169,7 @@ class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         $orderItem->getQuantity()->willReturn(2);
         $orderItem->getVariant()->willReturn($productVariant);
 
-        $taxRateResolver->resolve($productVariant, ['zone' => $zone])->willReturn($taxRate);
+        $taxRatesResolver->resolve($productVariant, ['zone' => $zone])->willReturn([$taxRate]);
 
         $orderItem->getTotal()->willReturn(1000);
         $calculator->calculate(1000, $taxRate)->willReturn(0);

--- a/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderShipmentTaxesApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderShipmentTaxesApplicatorSpec.php
@@ -37,9 +37,9 @@ class OrderShipmentTaxesApplicatorSpec extends ObjectBehavior
     function let(
         CalculatorInterface $calculator,
         AdjustmentFactoryInterface $adjustmentsFactory,
-        TaxRateResolverInterface $taxRateResolver
+        TaxRatesResolverInterface $taxRatesResolver
     ) {
-        $this->beConstructedWith($calculator, $adjustmentsFactory, $taxRateResolver);
+        $this->beConstructedWith($calculator, $adjustmentsFactory, $taxRatesResolver);
     }
 
     function it_is_initializable()
@@ -55,7 +55,7 @@ class OrderShipmentTaxesApplicatorSpec extends ObjectBehavior
     function it_applies_shipment_taxes_on_order_based_on_shipment_adjustments_and_rate(
         $adjustmentsFactory,
         $calculator,
-        $taxRateResolver,
+        $taxRatesResolver,
         AdjustmentInterface $shippingAdjustment,
         AdjustmentInterface $shippingTaxAdjustment,
         Collection $shippingAdjustments,
@@ -67,7 +67,7 @@ class OrderShipmentTaxesApplicatorSpec extends ObjectBehavior
     ) {
         $order->getLastShipment()->willReturn($shipment);
         $shipment->getMethod()->willReturn($shippingMethod);
-        $taxRateResolver->resolve($shippingMethod, ['zone' => $zone])->willReturn($taxRate);
+        $taxRatesResolver->resolve($shippingMethod, ['zone' => $zone])->willReturn([$taxRate]);
 
         $taxRate->getLabel()->willReturn('Simple tax (10%)');
         $taxRate->isIncludedInPrice()->willReturn(false);
@@ -88,7 +88,7 @@ class OrderShipmentTaxesApplicatorSpec extends ObjectBehavior
     function it_does_nothing_if_there_are_no_shipment_taxes_on_order(
         $adjustmentsFactory,
         $calculator,
-        $taxRateResolver,
+        $taxRatesResolver,
         AdjustmentInterface $shippingAdjustment,
         Collection $shippingAdjustments,
         OrderInterface $order,
@@ -99,7 +99,7 @@ class OrderShipmentTaxesApplicatorSpec extends ObjectBehavior
     ) {
         $order->getLastShipment()->willReturn($shipment);
         $shipment->getMethod()->willReturn($shippingMethod);
-        $taxRateResolver->resolve($shippingMethod, ['zone' => $zone])->willReturn($taxRate);
+        $taxRatesResolver->resolve($shippingMethod, ['zone' => $zone])->willReturn([$taxRate]);
 
         $order->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->willReturn($shippingAdjustments);
         $shippingAdjustments->isEmpty()->willReturn(false);
@@ -114,16 +114,16 @@ class OrderShipmentTaxesApplicatorSpec extends ObjectBehavior
         $this->apply($order, $zone);
     }
 
-    function it_does_nothing_if_order_has_no_shipment($taxRateResolver, OrderInterface $order, ZoneInterface $zone)
+    function it_does_nothing_if_order_has_no_shipment($taxRatesResolver, OrderInterface $order, ZoneInterface $zone)
     {
         $order->getLastShipment()->willReturn(null);
-        $taxRateResolver->resolve(Argument::any())->shouldNotBeCalled();
+        $taxRatesResolver->resolve(Argument::any())->shouldNotBeCalled();
 
         $this->apply($order, $zone);
     }
 
     function it_does_nothing_if_tax_rate_cannot_be_resolved(
-        $taxRateResolver,
+        $taxRatesResolver,
         Collection $shippingAdjustments,
         OrderInterface $order,
         ShipmentInterface $shipment,
@@ -136,7 +136,7 @@ class OrderShipmentTaxesApplicatorSpec extends ObjectBehavior
         $order->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->willReturn($shippingAdjustments);
         $shippingAdjustments->isEmpty()->willReturn(false);
 
-        $taxRateResolver->resolve($shippingMethod, ['zone' => $zone])->willReturn(null);
+        $taxRatesResolver->resolve($shippingMethod, ['zone' => $zone])->willReturn([]);
 
         $this->apply($order, $zone);
     }

--- a/src/Sylius/Component/Taxation/Model/TaxRate.php
+++ b/src/Sylius/Component/Taxation/Model/TaxRate.php
@@ -177,7 +177,7 @@ class TaxRate implements TaxRateInterface
     }
 
     /**
-     * @return string
+     * {@inheritdoc}
      */
     public function getLabel()
     {

--- a/src/Sylius/Component/Taxation/Resolver/TaxRatesResolver.php
+++ b/src/Sylius/Component/Taxation/Resolver/TaxRatesResolver.php
@@ -17,7 +17,7 @@ use Sylius\Component\Taxation\Model\TaxableInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class TaxRateResolver implements TaxRateResolverInterface
+class TaxRatesResolver implements TaxRatesResolverInterface
 {
     /**
      * @var RepositoryInterface
@@ -43,6 +43,6 @@ class TaxRateResolver implements TaxRateResolverInterface
 
         $criteria = array_merge(['category' => $category], $criteria);
 
-        return $this->taxRateRepository->findOneBy($criteria);
+        return $this->taxRateRepository->findBy($criteria);
     }
 }

--- a/src/Sylius/Component/Taxation/Resolver/TaxRatesResolverInterface.php
+++ b/src/Sylius/Component/Taxation/Resolver/TaxRatesResolverInterface.php
@@ -17,13 +17,13 @@ use Sylius\Component\Taxation\Model\TaxRateInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface TaxRateResolverInterface
+interface TaxRatesResolverInterface
 {
     /**
      * @param TaxableInterface $taxable
      * @param array            $criteria
      *
-     * @return null|TaxRateInterface
+     * @return null|TaxRateInterface[]
      */
     public function resolve(TaxableInterface $taxable, array $criteria = []);
 }

--- a/src/Sylius/Component/Taxation/spec/Resolver/TaxRatesResolverSpec.php
+++ b/src/Sylius/Component/Taxation/spec/Resolver/TaxRatesResolverSpec.php
@@ -16,12 +16,12 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Taxation\Model\TaxableInterface;
 use Sylius\Component\Taxation\Model\TaxCategoryInterface;
 use Sylius\Component\Taxation\Model\TaxRateInterface;
-use Sylius\Component\Taxation\Resolver\TaxRateResolverInterface;
+use Sylius\Component\Taxation\Resolver\TaxRatesResolverInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class TaxRateResolverSpec extends ObjectBehavior
+class TaxRatesResolverSpec extends ObjectBehavior
 {
     function let(RepositoryInterface $taxRateRepository)
     {
@@ -30,35 +30,35 @@ class TaxRateResolverSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Component\Taxation\Resolver\TaxRateResolver');
+        $this->shouldHaveType('Sylius\Component\Taxation\Resolver\TaxRatesResolver');
     }
 
-    function it_implements_Sylius_tax_rate_resolver_interface()
+    function it_implements_Sylius_tax_rates_resolver_interface()
     {
-        $this->shouldImplement(TaxRateResolverInterface::class);
+        $this->shouldImplement(TaxRatesResolverInterface::class);
     }
 
-    function it_returns_tax_rate_for_given_taxable_category(
+    function it_returns_tax_rates_for_given_taxable_category(
         $taxRateRepository,
         TaxableInterface $taxable,
         TaxCategoryInterface $taxCategory,
         TaxRateInterface $taxRate
     ) {
         $taxable->getTaxCategory()->willReturn($taxCategory);
-        $taxRateRepository->findOneBy(['category' => $taxCategory])->shouldBeCalled()->willReturn($taxRate);
+        $taxRateRepository->findBy(['category' => $taxCategory])->shouldBeCalled()->willReturn([$taxRate]);
 
-        $this->resolve($taxable)->shouldReturn($taxRate);
+        $this->resolve($taxable)->shouldReturn([$taxRate]);
     }
 
-    function it_returns_null_if_tax_rate_for_given_taxable_category_does_not_exist(
+    function it_returns_null_if_tax_rates_for_given_taxable_category_does_not_exist(
         $taxRateRepository,
         TaxableInterface $taxable,
         TaxCategoryInterface $taxCategory
     ) {
         $taxable->getTaxCategory()->willReturn($taxCategory);
-        $taxRateRepository->findOneBy(['category' => $taxCategory])->shouldBeCalled()->willReturn(null);
+        $taxRateRepository->findBy(['category' => $taxCategory])->shouldBeCalled()->willReturn([]);
 
-        $this->resolve($taxable)->shouldReturn(null);
+        $this->resolve($taxable)->shouldReturn([]);
     }
 
     function it_returns_null_if_taxable_does_not_belong_to_any_category(

--- a/src/Sylius/Component/User/Model/Customer.php
+++ b/src/Sylius/Component/User/Model/Customer.php
@@ -72,6 +72,26 @@ class Customer implements CustomerInterface, GroupableInterface
      */
     protected $phoneNumber;
 
+    /**
+     * VAT number is used in the European Union
+     * to proof that you are a company. This is
+     * noticed at the invoice so the buyer can
+     * recover the VAT later on.
+     *
+     * @var string
+     */
+    protected $vatNumber;
+
+    /**
+     * Resale Certificate is used in the US
+     * to proof that you are a reseller and
+     * therefore you don't have to pay Sales Tax
+     * at the point of purchase
+     *
+     * @var string
+     */
+    protected $resellerId;
+
     public function __construct()
     {
         $this->groups = new ArrayCollection();
@@ -311,5 +331,37 @@ class Customer implements CustomerInterface, GroupableInterface
         if (null !== $user) {
             $user->setCustomer($this);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVatNumber()
+    {
+        return $this->vatNumber;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setVatNumber($vatNumber)
+    {
+        $this->vatNumber = $vatNumber;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResellerId()
+    {
+        return $this->resellerId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setResellerId($resellerId)
+    {
+        $this->resellerId = $resellerId;
     }
 }

--- a/src/Sylius/Component/User/Model/Customer.php
+++ b/src/Sylius/Component/User/Model/Customer.php
@@ -313,29 +313,6 @@ class Customer implements CustomerInterface, GroupableInterface
     /**
      * {@inheritdoc}
      */
-    public function setPhoneNumber($phoneNumber)
-    {
-        $this->phoneNumber = $phoneNumber;
-    }
-
-    public function __toString()
-    {
-        return (string) $this->getEmail();
-    }
-
-    /**
-     * @param UserInterface $user
-     */
-    protected function assignCustomer(UserInterface $user = null)
-    {
-        if (null !== $user) {
-            $user->setCustomer($this);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getVatNumber()
     {
         return $this->vatNumber;
@@ -363,5 +340,44 @@ class Customer implements CustomerInterface, GroupableInterface
     public function setResellerId($resellerId)
     {
         $this->resellerId = $resellerId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEntrepreneurOrReseller()
+    {
+        return !!$this->getResellerId() || !!$this->getVatNumber();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isIndividual()
+    {
+        return !$this->isEntrepreneurOrReseller();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPhoneNumber($phoneNumber)
+    {
+        $this->phoneNumber = $phoneNumber;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->getEmail();
+    }
+
+    /**
+     * @param UserInterface $user
+     */
+    protected function assignCustomer(UserInterface $user = null)
+    {
+        if (null !== $user) {
+            $user->setCustomer($this);
+        }
     }
 }

--- a/src/Sylius/Component/User/Model/CustomerInterface.php
+++ b/src/Sylius/Component/User/Model/CustomerInterface.php
@@ -141,4 +141,14 @@ interface CustomerInterface extends
      * @param null|string $resellerId
      */
     public function setResellerId($resellerId);
+
+    /**
+     * @return bool
+     */
+    public function isEntrepreneurOrReseller();
+
+    /**
+     * @return bool
+     */
+    public function isIndividual();
 }

--- a/src/Sylius/Component/User/Model/CustomerInterface.php
+++ b/src/Sylius/Component/User/Model/CustomerInterface.php
@@ -121,4 +121,24 @@ interface CustomerInterface extends
      * @param string $phoneNumber
      */
     public function setPhoneNumber($phoneNumber);
+
+    /**
+     * @return string
+     */
+    public function getVatNumber();
+
+    /**
+     * @param null|string $vatNumber
+     */
+    public function setVatNumber($vatNumber);
+
+    /**
+     * @return string
+     */
+    public function getResellerId();
+
+    /**
+     * @param null|string $resellerId
+     */
+    public function setResellerId($resellerId);
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Related tickets |  |
| License | MIT |
### Tax rate settings for individuals or entrepreneurs / resellers

It is currently not possible to apply taxes only to entrepreneurs or individuals. When you sell to a country within the European Union, the tax rate changes if you are an entrepreneur. Therefore I added two properties to the `tax rate` model; `applyToIndividuals` and `applyToEntrepreneursAndResellers`. With this it's possible to assign specific tax rates especially to individuals or entrepreneurs / resellers only.

**Examples**

| Origin | Destination | Legal form | Tax Rate |
| --- | --- | --- | --- |
| The Netherlands (EU) | The Netherlands (EU) | individual | 21% |
| The Netherlands (EU) | The Netherlands (EU) | entrepreneur | 21% |
| The Netherlands (EU) | The Germany (EU) | individual | 21% |
| The Netherlands (EU) | The Germany (EU) | entrepreneur | 0% |
| The Netherlands (EU) | Switzerland (NON EU) | individual | 0% |
| The Netherlands (EU) | Switzerland (NON EU) | entrepreneur | 0% |
| US | US | individual | (differs per state) |
| US | US | reseller | 0% |

In the EU there is always a VAT even if it is 0%.
More information about tax rates can be found [here](https://gist.github.com/sjonkeesse/9253ebfe9c8df9693a6e096955edb38e).
#### Calculations

In Sylius it's possible to create `tax rates` that are already included in the product or shipping price. So if you have a `tax rate` that is based on an `individual` only and the customer is an `entrepreneur/reseller` than the amount of calculated taxes should be taken of the order item price and visa versa.
