### PR TITLE
[Registry] Added service registry context

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/config/services.xml
@@ -35,6 +35,7 @@
 
         <service id="sylius.registry.attribute_type" class="%sylius.registry.attribute_type.class%">
             <argument>%sylius.model.attribute.interface%</argument>
+            <argument>attribute type</argument>
         </service>
         <service id="sylius.form.type.attribute_type_choice" class="%sylius.form.type.attribute_type_choice.class%">
             <argument>%sylius.attribute.attribute_types%</argument>

--- a/src/Sylius/Bundle/GridBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/GridBundle/Resources/config/services.xml
@@ -62,12 +62,15 @@
 
         <service id="sylius.registry.grid_driver" class="%sylius.registry.grid_driver.class%">
             <argument>Sylius\Component\Grid\Data\DriverInterface</argument>
+            <argument>grid driver</argument>
         </service>
         <service id="sylius.registry.grid_filter" class="%sylius.registry.grid_filter.class%">
             <argument>Sylius\Component\Grid\Filtering\FilterInterface</argument>
+            <argument>grid filter</argument>
         </service>
         <service id="sylius.registry.grid_field" class="%sylius.registry.grid_field.class%">
             <argument>Sylius\Component\Grid\FieldTypes\FieldTypeInterface</argument>
+            <argument>grid field</argument>
         </service>
     </services>
 

--- a/src/Sylius/Bundle/PricingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/PricingBundle/Resources/config/services.xml
@@ -33,6 +33,7 @@
     <services>
         <service id="sylius.registry.price_calculator" class="%sylius.registry.price_calculator.class%">
             <argument>Sylius\Component\Pricing\Calculator\CalculatorInterface</argument>
+            <argument>price calculator</argument>
         </service>
 
         <service id="sylius.form.subscriber.priceable" class="%sylius.form.subscriber.priceable.class%">

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
@@ -86,9 +86,11 @@
 
         <service id="sylius.registry.promotion_rule_checker" class="%sylius.registry.promotion_rule_checker.class%">
             <argument>Sylius\Component\Promotion\Checker\RuleCheckerInterface</argument>
+            <argument>rule checker</argument>
         </service>
         <service id="sylius.registry.promotion_action" class="%sylius.registry.promotion_action.class%">
             <argument>Sylius\Component\Promotion\Action\PromotionActionInterface</argument>
+            <argument>promotion action</argument>
         </service>
 
         <service id="sylius.active_promotions_provider" class="%sylius.active_promotions_provider.class%">

--- a/src/Sylius/Bundle/ReportBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ReportBundle/Resources/config/services.xml
@@ -35,10 +35,12 @@
 
         <service id="sylius.registry.report.data_fetcher" class="%sylius.registry.report.class%">
             <argument>Sylius\Component\Report\DataFetcher\DataFetcherInterface</argument>
+            <argument>data fetcher</argument>
         </service>
 
         <service id="sylius.registry.report.renderer" class="%sylius.registry.report.class%">
             <argument>Sylius\Component\Report\Renderer\RendererInterface</argument>
+            <argument>report renderer</argument>
         </service>
 
         <!-- Report -->

--- a/src/Sylius/Bundle/SettingsBundle/Resolver/ResolverServiceRegistry.php
+++ b/src/Sylius/Bundle/SettingsBundle/Resolver/ResolverServiceRegistry.php
@@ -27,10 +27,11 @@ class ResolverServiceRegistry extends ServiceRegistry
     /**
      * @param string $interface
      * @param SettingsResolverInterface $defaultResolver
+     * @param string
      */
-    public function __construct($interface, SettingsResolverInterface $defaultResolver)
+    public function __construct($interface, SettingsResolverInterface $defaultResolver, $context = 'resolver service')
     {
-        parent::__construct($interface);
+        parent::__construct($interface, $context);
 
         $this->defaultResolver = $defaultResolver;
     }

--- a/src/Sylius/Bundle/SettingsBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/SettingsBundle/Resources/config/services.xml
@@ -50,11 +50,13 @@
 
         <service id="sylius.registry.settings_schema" class="%sylius.registry.settings_schema.class%">
             <argument>%sylius.settings.schema_interface%</argument>
+            <argument>Settings schema</argument>
         </service>
 
         <service id="sylius.registry.settings_resolver" class="%sylius.registry.settings_resolver.class%">
             <argument>%sylius.settings.resolver_interface%</argument>
             <argument type="service" id="sylius.settings.default_resolver"/>
+            <argument>settings resolver</argument>
         </service>
 
         <service id="sylius.settings.default_resolver" class="%sylius.settings.default_resolver.class%">

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
@@ -63,7 +63,8 @@
         </service>
 
         <service id="sylius.registry.shipping_rule_checker" class="%sylius.registry.shipping_rule_checker.class%" >
-                <argument>Sylius\Component\Shipping\Checker\RuleCheckerInterface</argument>
+            <argument>Sylius\Component\Shipping\Checker\RuleCheckerInterface</argument>
+            <argument>shipping rule checker</argument>
         </service>
 
         <service id="sylius.shipping_methods_resolver" class="%sylius.shipping_methods_resolver.class%">
@@ -84,6 +85,7 @@
 
         <service id="sylius.registry.shipping_calculator" class="%sylius.registry.shipping_calculator.class%" >
             <argument>Sylius\Component\Shipping\Calculator\CalculatorInterface</argument>
+            <argument>shipping calculator</argument>
         </service>
         <service id="sylius.shipping_calculator" class="%sylius.shipping_calculator.class%">
             <argument type="service" id="sylius.registry.shipping_calculator" />

--- a/src/Sylius/Bundle/TaxationBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/TaxationBundle/Resources/config/services.xml
@@ -39,10 +39,12 @@
 
         <service id="sylius.registry.tax_calculation_strategy" class="%sylius.registry.tax_calculation_strategy.class%">
             <argument>%sylius.tax_calculation_strategy.interface%</argument>
+            <argument>Tax calculation strategy</argument>
         </service>
 
         <service id="sylius.registry.tax_calculator" class="%sylius.registry.tax_calculator.class%">
             <argument>%sylius.tax_calculator.interface%</argument>
+            <argument>Tax calculator</argument>
         </service>
 
         <service id="sylius.tax_calculator" class="%sylius.tax_calculator.class%">

--- a/src/Sylius/Component/Registry/ExistingServiceException.php
+++ b/src/Sylius/Component/Registry/ExistingServiceException.php
@@ -19,8 +19,8 @@ namespace Sylius\Component\Registry;
  */
 class ExistingServiceException extends \InvalidArgumentException
 {
-    public function __construct($type)
+    public function __construct($context, $type)
     {
-        parent::__construct(sprintf('Service of type "%s" already exist.', $type));
+        parent::__construct(sprintf('%s of type "%s" already exists.', $context, $type));
     }
 }

--- a/src/Sylius/Component/Registry/NonExistingServiceException.php
+++ b/src/Sylius/Component/Registry/NonExistingServiceException.php
@@ -19,8 +19,14 @@ namespace Sylius\Component\Registry;
  */
 class NonExistingServiceException extends \InvalidArgumentException
 {
-    public function __construct($type)
+    public function __construct($context, $type, array $existingServices)
     {
-        parent::__construct(sprintf('Service of type "%s" does not exist.', $type));
+        parent::__construct(sprintf(
+            '%s service "%s" does not exist, available %s services: "%s"',
+            ucfirst($context),
+            $type,
+            $context, 
+            implode('", "', $existingServices)
+        ));
     }
 }

--- a/src/Sylius/Component/Registry/PrioritizedServiceRegistry.php
+++ b/src/Sylius/Component/Registry/PrioritizedServiceRegistry.php
@@ -32,12 +32,21 @@ class PrioritizedServiceRegistry implements PrioritizedServiceRegistryInterface
     protected $interface;
 
     /**
-     * @param $interface
+     * Human readable context for these services, e.g. "tax calculation"
+     *
+     * @var string
      */
-    public function __construct($interface)
+    protected $context;
+
+    /**
+     * @param string $interface
+     * @param string $context
+     */
+    public function __construct($interface, $context = 'service')
     {
         $this->interface = $interface;
         $this->services = new PriorityQueue();
+        $this->context = $context;
     }
 
     /**
@@ -63,7 +72,7 @@ class PrioritizedServiceRegistry implements PrioritizedServiceRegistryInterface
     public function unregister($service)
     {
         if (!$this->has($service)) {
-            throw new NonExistingServiceException(gettype($service));
+            throw new NonExistingServiceException($this->context, gettype($service), array_keys($this->services->toArray()));
         }
 
         $this->services->remove($service);
@@ -87,7 +96,7 @@ class PrioritizedServiceRegistry implements PrioritizedServiceRegistryInterface
         Assert::isInstanceOf(
             $service,
             $this->interface,
-            'Service for this registry needs to implement "%2$s", "%s" given.'
+            $this->context . ' needs to implement "%2$s", "%s" given.'
         );
     }
 }

--- a/src/Sylius/Component/Registry/ServiceRegistry.php
+++ b/src/Sylius/Component/Registry/ServiceRegistry.php
@@ -33,13 +33,22 @@ class ServiceRegistry implements ServiceRegistryInterface
     protected $interface;
 
     /**
+     * Human readable context for these services, e.g. "grid field"
+     *
+     * @var string
+     */
+    protected $context;
+
+    /**
      * Constructor.
      *
      * @param string $interface
+     * @param string $context
      */
-    public function __construct($interface)
+    public function __construct($interface, $context = 'service')
     {
         $this->interface = $interface;
+        $this->context = $context;
     }
 
     /**
@@ -56,16 +65,16 @@ class ServiceRegistry implements ServiceRegistryInterface
     public function register($type, $service)
     {
         if ($this->has($type)) {
-            throw new ExistingServiceException($type);
+            throw new ExistingServiceException($this->context, $type);
         }
 
         if (!is_object($service)) {
-            throw new \InvalidArgumentException(sprintf('Service needs to be an object, %s given.', gettype($service)));
+            throw new \InvalidArgumentException(sprintf('%s needs to be an object, %s given.', $this->context, gettype($service)));
         }
 
         if (!in_array($this->interface, class_implements($service))) {
             throw new \InvalidArgumentException(
-                sprintf('Service for this registry needs to implement "%s", "%s" given.', $this->interface, get_class($service))
+                sprintf('%s needs to implement "%s", "%s" given.', $this->context, $this->interface, get_class($service))
             );
         }
 
@@ -78,7 +87,7 @@ class ServiceRegistry implements ServiceRegistryInterface
     public function unregister($type)
     {
         if (!$this->has($type)) {
-            throw new NonExistingServiceException($type);
+            throw new NonExistingServiceException($this->context, $type, array_keys($this->services));
         }
 
         unset($this->services[$type]);
@@ -98,7 +107,7 @@ class ServiceRegistry implements ServiceRegistryInterface
     public function get($type)
     {
         if (!$this->has($type)) {
-            throw new NonExistingServiceException($type);
+            throw new NonExistingServiceException($this->context, $type, array_keys($this->services));
         }
 
         return $this->services[$type];

--- a/src/Sylius/Component/Registry/spec/ExistingServiceExceptionSpec.php
+++ b/src/Sylius/Component/Registry/spec/ExistingServiceExceptionSpec.php
@@ -20,7 +20,7 @@ class ExistingServiceExceptionSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith('foo');
+        $this->beConstructedWith('Service', 'foo');
     }
 
     function it_is_initializable()

--- a/src/Sylius/Component/Registry/spec/NonExistingServiceExceptionSpec.php
+++ b/src/Sylius/Component/Registry/spec/NonExistingServiceExceptionSpec.php
@@ -20,7 +20,7 @@ class NonExistingServiceExceptionSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith('foo');
+        $this->beConstructedWith('renderer', 'foo', ['service1', 'service2']);
     }
 
     function it_is_initializable()
@@ -36,5 +36,10 @@ class NonExistingServiceExceptionSpec extends ObjectBehavior
     function it_is_an_invalid_argument_exception()
     {
         $this->shouldHaveType('InvalidArgumentException');
+    }
+
+    function it_should_show_the_context_and_available_services_in_the_message()
+    {
+        $this->getMessage()->shouldReturn('Renderer service "foo" does not exist, available renderer services: "service1", "service2"');
     }
 }

--- a/src/Sylius/Component/Registry/spec/ServiceRegistrySpec.php
+++ b/src/Sylius/Component/Registry/spec/ServiceRegistrySpec.php
@@ -90,7 +90,7 @@ class ServiceRegistrySpec extends ObjectBehavior
     function it_throws_exception_if_trying_to_get_service_of_non_existing_type()
     {
         $this
-            ->shouldThrow(NonExistingServiceException::class)
+            ->shouldThrow(new NonExistingServiceException('service', 'foo', []))
             ->duringGet('foo')
         ;
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #4814 
| License         | MIT


Added additional argument to the service registry indicating the context in
order to give more helpful exception messages.

So instead of:

```
Service of type "boolean" does not exist.
```

You get:

```
Grid field of type "boolean" does not exist.
```

The context is optional in order to preserve BC (I would personally consider making it mandatory).