### PR TITLE
[Behat] Do not test "cli" suites by default

### DIFF
--- a/etc/behat/profiles/default.yml
+++ b/etc/behat/profiles/default.yml
@@ -51,4 +51,4 @@ default:
 
     gherkin:
         filters:
-            tags: "~@todo"
+            tags: "~@todo && ~@cli" # CLI is excluded as it registers an error handler that mutes fatal errors


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Running Symfony-based commands inside Behat registers an error handler that mutes fatal errors