### PR TITLE
[Bug Fix] Elastica product listener orphaned objects throws error

### DIFF
--- a/src/Sylius/Bundle/SearchBundle/Listener/ElasticaProductListener.php
+++ b/src/Sylius/Bundle/SearchBundle/Listener/ElasticaProductListener.php
@@ -107,9 +107,9 @@ class ElasticaProductListener implements EventSubscriber
     }
 
     /**
-     * @param ProductInterface $product
+     * @param ProductInterface|null $product
      */
-    private function addScheduledForUpdate(ProductInterface $product)
+    private function addScheduledForUpdate(ProductInterface $product = null)
     {
         if ($this->objectPersister->handlesObject($product)) {
             $this->scheduledForUpdate[] = $product;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

Fixes bug where a "product aware" object that has it's product detached (such as an attribute value) throwed an error when updating ES product index.

If you would for example remove an attribute value object from a product and save that product the listener will fail, since the `ProductAttributeValue` has been orphaned (ready to be deleted). 