### PR TITLE
[Order] Add custom repository methods to obtain only placed orders

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
@@ -50,4 +50,23 @@ class OrderRepository extends EntityRepository implements OrderRepositoryInterfa
             ->getSingleScalarResult() > 0
         ;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findOneByNumber($orderNumber)
+    {
+        $queryBuilder = $this->createQueryBuilder('o');
+
+        $queryBuilder
+            ->andWhere($queryBuilder->expr()->isNotNull('o.completedAt'))
+            ->andWhere('o.number = :orderNumber')
+            ->setParameter('orderNumber', $orderNumber)
+        ;
+
+        return $queryBuilder
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
 }

--- a/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/OrderController.php
+++ b/src/Sylius/Bundle/WebBundle/Controller/Frontend/Account/OrderController.php
@@ -41,7 +41,12 @@ class OrderController extends FOSRestController
      */
     public function indexAction()
     {
-        $orders = $this->getOrderRepository()->findBy(['customer' => $this->getCustomer()], ['updatedAt' => 'desc']);
+        $user = $this->getUser();
+        if (null === $user) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $orders = $this->getOrderRepository()->findByCustomer($user->getCustomer(), ['updatedAt' => 'desc']);
 
         $view = $this
             ->view()
@@ -216,7 +221,7 @@ class OrderController extends FOSRestController
     protected function findOrderOr404($number)
     {
         /* @var $order OrderInterface */
-        if (null === $order = $this->getOrderRepository()->findOneBy(['number' => $number])) {
+        if (null === $order = $this->getOrderRepository()->findOneByNumber($number)) {
             throw $this->createNotFoundException('The order does not exist.');
         }
 

--- a/src/Sylius/Component/Order/Repository/OrderRepositoryInterface.php
+++ b/src/Sylius/Component/Order/Repository/OrderRepositoryInterface.php
@@ -33,4 +33,11 @@ interface OrderRepositoryInterface extends RepositoryInterface, HashSubjectRepos
      * @return bool
      */
     public function isNumberUsed($number);
+
+    /**
+     * @param string $orderNumber
+     *
+     * @return OrderInterface|null
+     */
+    public function findOneByNumber($orderNumber);
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Related tickets |
| License         | MIT

Currently used repository methods in `.../Frontend/OrderController` also find carts. That is not a desired behavior since they are used in "My account" section where only placed orders should appear. When a user has a cart the page breaks because carts don't have `number` which is required by order details route.