### PR TITLE
Fixed typo in ArchetypeBundle installation docs

### DIFF
--- a/docs/bundles/SyliusArchetypeBundle/installation.rst
+++ b/docs/bundles/SyliusArchetypeBundle/installation.rst
@@ -41,8 +41,8 @@ Don't worry, everything was automatically installed via Composer.
             new WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
 
             new Sylius\Bundle\AttributeBundle\SyliusAttributeBundle(),
-            new Sylius\Bundle\AttributeBundle\SyliusVariationBundle(),
-            new Sylius\Bundle\AttributeBundle\SyliusArchetypeBundle(),
+            new Sylius\Bundle\VariationBundle\SyliusVariationBundle(),
+            new Sylius\Bundle\ArchetypeBundle\SyliusArchetypeBundle(),
             new Sylius\Bundle\ResourceBundle\SyliusResourceBundle(),
 
             // Other bundles...


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | no
| License         | MIT

VariationBundle and ArchetypeBundle namespaces were wrong