### PR TITLE
Recompile container on configuration class modification

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/DependencyInjection/SyliusAddressingExtension.php
+++ b/src/Sylius/Bundle/AddressingBundle/DependencyInjection/SyliusAddressingExtension.php
@@ -29,7 +29,7 @@ class SyliusAddressingExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $loader->load(sprintf('driver/%s.xml', $config['driver']));

--- a/src/Sylius/Bundle/ApiBundle/DependencyInjection/SyliusApiExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/DependencyInjection/SyliusApiExtension.php
@@ -30,7 +30,7 @@ class SyliusApiExtension extends AbstractResourceExtension implements PrependExt
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/ArchetypeBundle/DependencyInjection/SyliusArchetypeExtension.php
+++ b/src/Sylius/Bundle/ArchetypeBundle/DependencyInjection/SyliusArchetypeExtension.php
@@ -33,7 +33,7 @@ class SyliusArchetypeExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         if (SyliusResourceBundle::DRIVER_DOCTRINE_ORM === $config['driver']) {

--- a/src/Sylius/Bundle/AssociationBundle/DependencyInjection/SyliusAssociationExtension.php
+++ b/src/Sylius/Bundle/AssociationBundle/DependencyInjection/SyliusAssociationExtension.php
@@ -26,11 +26,11 @@ class SyliusAssociationExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $loader->load('services.xml');
 
-        $config = $this->processConfiguration(new Configuration(), $config);
         $this->registerResources('sylius', $config['driver'], $this->resolveResources($config['resources'], $container), $container);
 
         foreach ($config['resources'] as $subjectName => $subjectConfig) {

--- a/src/Sylius/Bundle/AttributeBundle/DependencyInjection/SyliusAttributeExtension.php
+++ b/src/Sylius/Bundle/AttributeBundle/DependencyInjection/SyliusAttributeExtension.php
@@ -26,6 +26,7 @@ class SyliusAttributeExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $configFiles = [
@@ -37,7 +38,6 @@ class SyliusAttributeExtension extends AbstractResourceExtension
             $loader->load($configFile);
         }
 
-        $config = $this->processConfiguration(new Configuration(), $config);
         $this->registerResources('sylius', $config['driver'], $this->resolveResources($config['resources'], $container), $container);
 
         foreach ($config['resources'] as $subjectName => $subjectConfig) {

--- a/src/Sylius/Bundle/CartBundle/DependencyInjection/SyliusCartExtension.php
+++ b/src/Sylius/Bundle/CartBundle/DependencyInjection/SyliusCartExtension.php
@@ -32,7 +32,7 @@ class SyliusCartExtension extends AbstractResourceExtension implements PrependEx
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $loader->load(sprintf('driver/%s.xml', $config['driver']));

--- a/src/Sylius/Bundle/ChannelBundle/DependencyInjection/SyliusChannelExtension.php
+++ b/src/Sylius/Bundle/ChannelBundle/DependencyInjection/SyliusChannelExtension.php
@@ -28,7 +28,7 @@ class SyliusChannelExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $loader->load(sprintf('driver/%s.xml', $config['driver']));

--- a/src/Sylius/Bundle/ContactBundle/DependencyInjection/SyliusContactExtension.php
+++ b/src/Sylius/Bundle/ContactBundle/DependencyInjection/SyliusContactExtension.php
@@ -29,7 +29,7 @@ class SyliusContactExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/ContentBundle/DependencyInjection/SyliusContentExtension.php
+++ b/src/Sylius/Bundle/ContentBundle/DependencyInjection/SyliusContentExtension.php
@@ -29,7 +29,7 @@ class SyliusContentExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
@@ -63,7 +63,7 @@ class SyliusCoreExtension extends AbstractResourceExtension implements PrependEx
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/CurrencyBundle/DependencyInjection/SyliusCurrencyExtension.php
+++ b/src/Sylius/Bundle/CurrencyBundle/DependencyInjection/SyliusCurrencyExtension.php
@@ -29,7 +29,7 @@ class SyliusCurrencyExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/FlowBundle/DependencyInjection/SyliusFlowExtension.php
+++ b/src/Sylius/Bundle/FlowBundle/DependencyInjection/SyliusFlowExtension.php
@@ -29,12 +29,8 @@ class SyliusFlowExtension extends Extension
      */
     public function load(array $config, ContainerBuilder $container)
     {
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config/container'));
-
-        $processor = new Processor();
-        $configuration = new Configuration();
-
-        $config = $processor->processConfiguration($configuration, $config);
 
         $container->setAlias('sylius.process_storage', $config['storage']);
 

--- a/src/Sylius/Bundle/GridBundle/DependencyInjection/SyliusGridExtension.php
+++ b/src/Sylius/Bundle/GridBundle/DependencyInjection/SyliusGridExtension.php
@@ -27,9 +27,7 @@ class SyliusGridExtension extends Extension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $processor = new Processor();
-        $config = $processor->processConfiguration(new Configuration(), $config);
-
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $loader->load('services.xml');

--- a/src/Sylius/Bundle/InventoryBundle/DependencyInjection/SyliusInventoryExtension.php
+++ b/src/Sylius/Bundle/InventoryBundle/DependencyInjection/SyliusInventoryExtension.php
@@ -29,7 +29,7 @@ class SyliusInventoryExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/LocaleBundle/DependencyInjection/SyliusLocaleExtension.php
+++ b/src/Sylius/Bundle/LocaleBundle/DependencyInjection/SyliusLocaleExtension.php
@@ -27,7 +27,7 @@ class SyliusLocaleExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/MailerBundle/DependencyInjection/SyliusMailerExtension.php
+++ b/src/Sylius/Bundle/MailerBundle/DependencyInjection/SyliusMailerExtension.php
@@ -29,7 +29,7 @@ class SyliusMailerExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/MetadataBundle/DependencyInjection/SyliusMetadataExtension.php
+++ b/src/Sylius/Bundle/MetadataBundle/DependencyInjection/SyliusMetadataExtension.php
@@ -28,7 +28,7 @@ class SyliusMetadataExtension extends AbstractResourceExtension implements Prepe
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/MoneyBundle/DependencyInjection/SyliusMoneyExtension.php
+++ b/src/Sylius/Bundle/MoneyBundle/DependencyInjection/SyliusMoneyExtension.php
@@ -29,13 +29,11 @@ class SyliusMoneyExtension extends Extension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $processor = new Processor();
-        $config = $processor->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $container->setParameter('sylius.money.locale', $config['locale']);
         $container->setParameter('sylius.money.currency', $config['currency']);
-
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $loader->load('services.xml');
         $loader->load('templating.xml');

--- a/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
+++ b/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
@@ -27,7 +27,7 @@ class SyliusOrderExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/PaymentBundle/DependencyInjection/SyliusPaymentExtension.php
+++ b/src/Sylius/Bundle/PaymentBundle/DependencyInjection/SyliusPaymentExtension.php
@@ -29,7 +29,7 @@ class SyliusPaymentExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/PayumBundle/DependencyInjection/SyliusPayumExtension.php
+++ b/src/Sylius/Bundle/PayumBundle/DependencyInjection/SyliusPayumExtension.php
@@ -28,7 +28,7 @@ class SyliusPayumExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/PricingBundle/DependencyInjection/SyliusPricingExtension.php
+++ b/src/Sylius/Bundle/PricingBundle/DependencyInjection/SyliusPricingExtension.php
@@ -35,10 +35,10 @@ class SyliusPricingExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $config, ContainerBuilder $container)
     {
-        $processor = new Processor();
-        $config = $processor->processConfiguration(new Configuration(), $configs);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         foreach ($config['forms'] as $formType) {
             $class = '%sylius.form.extension.priceable.class%';
@@ -56,7 +56,6 @@ class SyliusPricingExtension extends Extension
             $container->setDefinition(sprintf('sylius.form.extension.priceable.%s', $formType), $definition);
         }
 
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
         $loader->load('templating.xml');
         $loader->load('twig.xml');

--- a/src/Sylius/Bundle/ProductBundle/DependencyInjection/SyliusProductExtension.php
+++ b/src/Sylius/Bundle/ProductBundle/DependencyInjection/SyliusProductExtension.php
@@ -51,7 +51,7 @@ class SyliusProductExtension extends AbstractResourceExtension implements Prepen
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $loader->load(sprintf('driver/%s.xml', $config['driver']));

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/SyliusPromotionExtension.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/SyliusPromotionExtension.php
@@ -30,7 +30,7 @@ class SyliusPromotionExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/RbacBundle/DependencyInjection/SyliusRbacExtension.php
+++ b/src/Sylius/Bundle/RbacBundle/DependencyInjection/SyliusRbacExtension.php
@@ -27,7 +27,7 @@ class SyliusRbacExtension extends AbstractResourceExtension implements PrependEx
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $loader->load(sprintf('driver/%s.xml', $config['driver']));

--- a/src/Sylius/Bundle/ReportBundle/DependencyInjection/SyliusReportExtension.php
+++ b/src/Sylius/Bundle/ReportBundle/DependencyInjection/SyliusReportExtension.php
@@ -29,7 +29,7 @@ class SyliusReportExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
@@ -31,10 +31,9 @@ class SyliusResourceExtension extends Extension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $processor = new Processor();
-        $config = $processor->processConfiguration(new Configuration(), $config);
-
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        
         $configFiles = [
             'services.xml',
             'controller.xml',

--- a/src/Sylius/Bundle/ReviewBundle/DependencyInjection/SyliusReviewExtension.php
+++ b/src/Sylius/Bundle/ReviewBundle/DependencyInjection/SyliusReviewExtension.php
@@ -32,7 +32,7 @@ class SyliusReviewExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $this->resolveResources($config['resources'], $container), $container);

--- a/src/Sylius/Bundle/SearchBundle/DependencyInjection/SyliusSearchExtension.php
+++ b/src/Sylius/Bundle/SearchBundle/DependencyInjection/SyliusSearchExtension.php
@@ -33,7 +33,7 @@ class SyliusSearchExtension extends AbstractResourceExtension implements Prepend
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/SequenceBundle/DependencyInjection/SyliusSequenceExtension.php
+++ b/src/Sylius/Bundle/SequenceBundle/DependencyInjection/SyliusSequenceExtension.php
@@ -28,7 +28,7 @@ class SyliusSequenceExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/SettingsBundle/DependencyInjection/SyliusSettingsExtension.php
+++ b/src/Sylius/Bundle/SettingsBundle/DependencyInjection/SyliusSettingsExtension.php
@@ -26,7 +26,7 @@ class SyliusSettingsExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);

--- a/src/Sylius/Bundle/ShippingBundle/DependencyInjection/SyliusShippingExtension.php
+++ b/src/Sylius/Bundle/ShippingBundle/DependencyInjection/SyliusShippingExtension.php
@@ -27,7 +27,7 @@ class SyliusShippingExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $loader->load(sprintf('driver/%s.xml', $config['driver']));

--- a/src/Sylius/Bundle/TaxationBundle/DependencyInjection/SyliusTaxationExtension.php
+++ b/src/Sylius/Bundle/TaxationBundle/DependencyInjection/SyliusTaxationExtension.php
@@ -26,7 +26,7 @@ class SyliusTaxationExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $loader->load(sprintf('driver/%s.xml', $config['driver']));

--- a/src/Sylius/Bundle/TaxonomyBundle/DependencyInjection/SyliusTaxonomyExtension.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/DependencyInjection/SyliusTaxonomyExtension.php
@@ -26,7 +26,7 @@ class SyliusTaxonomyExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $loader->load(sprintf('driver/%s.xml', $config['driver']));

--- a/src/Sylius/Bundle/ThemeBundle/DependencyInjection/SyliusThemeExtension.php
+++ b/src/Sylius/Bundle/ThemeBundle/DependencyInjection/SyliusThemeExtension.php
@@ -26,11 +26,11 @@ final class SyliusThemeExtension extends AbstractResourceExtension implements Pr
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $configs);
-
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config/services'));
+
         $loader->load('services.xml');
         $loader->load(sprintf('driver/%s.xml', $config['driver']));
 

--- a/src/Sylius/Bundle/UserBundle/DependencyInjection/SyliusUserExtension.php
+++ b/src/Sylius/Bundle/UserBundle/DependencyInjection/SyliusUserExtension.php
@@ -27,7 +27,7 @@ class SyliusUserExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $loader->load(sprintf('driver/%s.xml', $config['driver']));

--- a/src/Sylius/Bundle/VariationBundle/DependencyInjection/SyliusVariationExtension.php
+++ b/src/Sylius/Bundle/VariationBundle/DependencyInjection/SyliusVariationExtension.php
@@ -33,7 +33,7 @@ class SyliusVariationExtension extends AbstractResourceExtension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $config = $this->processConfiguration(new Configuration(), $config);
+        $config = $this->processConfiguration($this->getConfiguration($config, $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
         $this->registerResources('sylius', $config['driver'], $this->resolveResources($config['resources'], $container), $container);


### PR DESCRIPTION
Fixes #4853, uses [`Symfony\Component\DependencyInjection\Extension\Extension::getConfiguration()`](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/Extension/Extension.php#L79).