### PR TITLE
[Settings] Make schema & resolver registries lazy

### DIFF
--- a/src/Sylius/Bundle/SettingsBundle/Resolver/ResolverServiceRegistry.php
+++ b/src/Sylius/Bundle/SettingsBundle/Resolver/ResolverServiceRegistry.php
@@ -18,7 +18,7 @@ use Sylius\Component\Registry\ServiceRegistryInterface;
 /**
  * @author Steffen Brem <steffenbrem@gmail.com>
  */
-final class ResolverServiceRegistry implements ServiceRegistryInterface
+/* final */class ResolverServiceRegistry implements ServiceRegistryInterface
 {
     /**
      * @var ServiceRegistryInterface

--- a/src/Sylius/Bundle/SettingsBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/SettingsBundle/Resources/config/services.xml
@@ -48,12 +48,12 @@
             <argument type="service" id="event_dispatcher" />
         </service>
 
-        <service id="sylius.registry.settings_schema" class="%sylius.registry.settings_schema.class%">
+        <service id="sylius.registry.settings_schema" class="%sylius.registry.settings_schema.class%" lazy="true">
             <argument>%sylius.settings.schema_interface%</argument>
             <argument>Settings schema</argument>
         </service>
 
-        <service id="sylius.registry.settings_resolver" class="%sylius.registry.settings_resolver.class%">
+        <service id="sylius.registry.settings_resolver" class="%sylius.registry.settings_resolver.class%" lazy="true">
             <argument type="service">
                 <service class="Sylius\Component\Registry\ServiceRegistry">
                     <argument>%sylius.settings.resolver_interface%</argument>


### PR DESCRIPTION
Schema or resolvers depending on the Doctrine repositories throws an exception about unexisting database during cache warmup.