### PR TITLE
make ValidatorInterface used in  class VariantGenerator  consistent w…

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Generator/VariantGenerator.php
+++ b/src/Sylius/Bundle/ProductBundle/Generator/VariantGenerator.php
@@ -18,7 +18,7 @@ use Sylius\Component\Variation\Model\VariantInterface;
 use Sylius\Component\Variation\SetBuilder\SetBuilderInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
-use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * Default product variants generator. It saves only valid variants.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no|yes
| BC breaks?      | no
| License         | MIT

…ith new API, since symfony 2.5, Symfony\Component\Validator\ValidatorInterface is changed to  Symfony\Component\Validator\Validator\ValidatorInterface