### PR TITLE
make ValidatorInterface used in  class VariantGenerator  consistent w…

### DIFF
--- a/src/Sylius/Bundle/CartBundle/EventListener/CartSubscriber.php
+++ b/src/Sylius/Bundle/CartBundle/EventListener/CartSubscriber.php
@@ -18,7 +18,7 @@ use Sylius\Component\Cart\Event\CartItemEvent;
 use Sylius\Component\Cart\Provider\CartProviderInterface;
 use Sylius\Component\Cart\SyliusCartEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @author Joseph Bielawski <stloyd@gmail.com>

--- a/src/Sylius/Bundle/CartBundle/spec/EventListener/CartSubscriberSpec.php
+++ b/src/Sylius/Bundle/CartBundle/spec/EventListener/CartSubscriberSpec.php
@@ -22,7 +22,7 @@ use Sylius\Component\Cart\Model\CartItemInterface;
 use Sylius\Component\Cart\Provider\CartProviderInterface;
 use Sylius\Component\Order\Model\OrderItemInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
-use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @author Joseph Bielawski <stloyd@gmail.com>

--- a/src/Sylius/Bundle/ProductBundle/Generator/VariantGenerator.php
+++ b/src/Sylius/Bundle/ProductBundle/Generator/VariantGenerator.php
@@ -18,7 +18,7 @@ use Sylius\Component\Variation\Model\VariantInterface;
 use Sylius\Component\Variation\SetBuilder\SetBuilderInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
-use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * Default product variants generator. It saves only valid variants.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

…ith new API, since symfony 2.5, Symfony\Component\Validator\ValidatorInterface is changed to  Symfony\Component\Validator\Validator\ValidatorInterface