### PR TITLE
Make sure no master variants are returned in the getAvailableVariants method

### DIFF
--- a/src/Sylius/Component/Product/Model/Product.php
+++ b/src/Sylius/Component/Product/Model/Product.php
@@ -363,7 +363,7 @@ class Product implements ProductInterface
     public function getAvailableVariants()
     {
         return $this->variants->filter(function (BaseVariantInterface $variant) {
-            return $variant->isMaster() && $variant->isAvailable();
+            return !$variant->isMaster() && $variant->isAvailable();
         });
     }
 

--- a/src/Sylius/Component/Product/Model/Product.php
+++ b/src/Sylius/Component/Product/Model/Product.php
@@ -362,7 +362,7 @@ class Product implements ProductInterface
      */
     public function getAvailableVariants()
     {
-        return $this->variants->filter(function (BaseVariantInterface $variant) {
+        return $this->variants->filter(function (VariantInterface $variant) {
             return !$variant->isMaster() && $variant->isAvailable();
         });
     }

--- a/src/Sylius/Component/Product/spec/Model/ProductSpec.php
+++ b/src/Sylius/Component/Product/spec/Model/ProductSpec.php
@@ -204,6 +204,50 @@ class ProductSpec extends ObjectBehavior
     function it_should_initialize_variants_collection_by_default()
     {
         $this->getVariants()->shouldHaveType('Doctrine\Common\Collections\Collection');
+        $this->getAvailableVariants()->shouldHaveType('Doctrine\Common\Collections\Collection');
+    }
+
+    function it_should_exclude_unavailable_variants_when_available_variants_are_called(VariantInterface $variant)
+    {
+        $variant->isMaster()->willReturn(false);
+        $variant->isAvailable()->willReturn(false);
+
+        $variant->setProduct($this)->shouldBeCalled();
+
+        $this->addVariant($variant);
+        $this->getAvailableVariants()->shouldHaveCount(0);
+    }
+
+    function it_should_exclude_master_variants_when_available_variants_are_called(VariantInterface $variant)
+    {
+        $variant->isMaster()->willReturn(true);
+
+        $variant->setProduct($this)->shouldBeCalled();
+
+        $this->addVariant($variant);
+        $this->getAvailableVariants()->shouldHaveCount(0);
+    }
+
+    function it_should_return_available_variants_when_available_variants_are_called(
+        VariantInterface $masterVariant,
+        VariantInterface $unavailableVariant,
+        VariantInterface $variant
+    ) {
+        $masterVariant->isMaster()->willReturn(true);
+        $unavailableVariant->isMaster()->willReturn(false);
+        $unavailableVariant->isAvailable()->willReturn(false);
+        $variant->isMaster()->willReturn(false);
+        $variant->isAvailable()->willReturn(true);
+
+        $masterVariant->setProduct($this)->shouldBeCalled();
+        $unavailableVariant->setProduct($this)->shouldBeCalled();
+        $variant->setProduct($this)->shouldBeCalled();
+
+        $this->addVariant($masterVariant);
+        $this->addVariant($unavailableVariant);
+        $this->addVariant($variant);
+
+        $this->getAvailableVariants()->shouldHaveCount(1);
     }
 
     function it_should_initialize_option_collection_by_default()

--- a/src/Sylius/Component/Product/spec/Model/ProductSpec.php
+++ b/src/Sylius/Component/Product/spec/Model/ProductSpec.php
@@ -11,6 +11,7 @@
 
 namespace spec\Sylius\Component\Product\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Association\Model\AssociableInterface;
@@ -207,7 +208,7 @@ class ProductSpec extends ObjectBehavior
         $this->getAvailableVariants()->shouldHaveType('Doctrine\Common\Collections\Collection');
     }
 
-    function it_should_exclude_unavailable_variants_when_available_variants_are_called(VariantInterface $variant)
+    function it_does_not_include_unavailable_variants_in_available_variants(VariantInterface $variant)
     {
         $variant->isMaster()->willReturn(false);
         $variant->isAvailable()->willReturn(false);
@@ -218,7 +219,7 @@ class ProductSpec extends ObjectBehavior
         $this->getAvailableVariants()->shouldHaveCount(0);
     }
 
-    function it_should_exclude_master_variants_when_available_variants_are_called(VariantInterface $variant)
+    function it_does_not_include_master_variant_in_available_variants(VariantInterface $variant)
     {
         $variant->isMaster()->willReturn(true);
 
@@ -228,7 +229,7 @@ class ProductSpec extends ObjectBehavior
         $this->getAvailableVariants()->shouldHaveCount(0);
     }
 
-    function it_should_return_available_variants_when_available_variants_are_called(
+    function it_returns_available_variants(
         VariantInterface $masterVariant,
         VariantInterface $unavailableVariant,
         VariantInterface $variant
@@ -248,6 +249,7 @@ class ProductSpec extends ObjectBehavior
         $this->addVariant($variant);
 
         $this->getAvailableVariants()->shouldHaveCount(1);
+        $this->getAvailableVariants()->first()->shouldReturn($variant);
     }
 
     function it_should_initialize_option_collection_by_default()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | somehow related to #4980 
| License         | MIT

Stumbled upon this issue while debugging for ticket https://github.com/Sylius/Sylius/issues/4980, this bug was introduced in 3b35136919e9ede77cb38ea595c78d19ae97668c.