### PR TITLE
[ResourceBundle] Use default manager as configured by Doctrine

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/AbstractDoctrineDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/AbstractDoctrineDriver.php
@@ -53,13 +53,16 @@ abstract class AbstractDoctrineDriver extends AbstractDriver
     }
 
     /**
+     * Return the configured object managre name, or NULL if the default
+     * manager should be used.
+     *
      * @param MetadataInterface $metadata
      *
-     * @return string
+     * @return string|null
      */
     protected function getObjectManagerName(MetadataInterface $metadata)
     {
-        $objectManagerName = 'default';
+        $objectManagerName = null;
 
         if ($metadata->hasParameter('options') && isset($metadata->getParameter('options')['object_manager'])) {
             $objectManagerName = $metadata->getParameter('options')['object_manager'];

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineODMDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineODMDriver.php
@@ -78,7 +78,11 @@ class DoctrineODMDriver extends AbstractDoctrineDriver
      */
     protected function getManagerServiceId(MetadataInterface $metadata)
     {
-        return sprintf('doctrine_mongodb.odm.%s_document_manager', $this->getObjectManagerName($metadata));
+        if ($objectManagerName = $this->getObjectManagerName($metadata)) {
+            return sprintf('doctrine_mongodb.odm.%s_document_manager', $objectManagerName);
+        }
+
+        return 'doctrine_mongodb.odm.document_manager';
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineORMDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineORMDriver.php
@@ -85,7 +85,11 @@ class DoctrineORMDriver extends AbstractDoctrineDriver
      */
     protected function getManagerServiceId(MetadataInterface $metadata)
     {
-        return sprintf('doctrine.orm.%s_entity_manager', $this->getObjectManagerName($metadata));
+        if ($objectManagerName = $this->getObjectManagerName($metadata)) {
+            return sprintf('doctrine.orm.%s_entity_manager', $objectManagerName);
+        }
+
+        return 'doctrine.orm.entity_manager';
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrinePHPCRDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrinePHPCRDriver.php
@@ -75,7 +75,11 @@ class DoctrinePHPCRDriver extends AbstractDoctrineDriver
      */
     protected function getManagerServiceId(MetadataInterface $metadata)
     {
-        return sprintf('doctrine_phpcr.odm.%s_document_manager', $this->getObjectManagerName($metadata));
+        if ($objectManagerName = $this->getObjectManagerName($metadata)) {
+            return sprintf('doctrine_phpcr.odm.%s_document_manager', $objectManagerName);
+        }
+
+        return 'doctrine_phpcr.odm.document_manager';
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

Currently the ResourceBundle uses the entity manager named "default" by default - this is wrong as the "default" entity manager can be called anything and it
is only "default" by default.

This PR changes the logic to use the alias of the default manager (e.g. `doctrine.entity_manager`) 
when no object manager name has been explicitly configured.

