### PR TITLE
Array accessible and countable Service Registry.

### DIFF
--- a/src/Sylius/Component/Registry/ServiceRegistry.php
+++ b/src/Sylius/Component/Registry/ServiceRegistry.php
@@ -13,8 +13,9 @@ namespace Sylius\Component\Registry;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Adam Elsodaney <adam.elso@gmail.com>
  */
-class ServiceRegistry implements ServiceRegistryInterface
+class ServiceRegistry implements ServiceRegistryInterface, \ArrayAccess, \Countable
 {
     /**
      * @var array
@@ -58,7 +59,7 @@ class ServiceRegistry implements ServiceRegistryInterface
      */
     public function register($identifier, $service)
     {
-        if ($this->has($identifier)) {
+        if ($this->offsetExists($identifier)) {
             throw new ExistingServiceException($this->context, $identifier);
         }
 
@@ -72,7 +73,7 @@ class ServiceRegistry implements ServiceRegistryInterface
             );
         }
 
-        $this->services[$identifier] = $service;
+        $this->offsetSet($identifier, $service);
     }
 
     /**
@@ -80,11 +81,11 @@ class ServiceRegistry implements ServiceRegistryInterface
      */
     public function unregister($identifier)
     {
-        if (!$this->has($identifier)) {
+        if (!$this->offsetExists($identifier)) {
             throw new NonExistingServiceException($this->context, $identifier, array_keys($this->services));
         }
 
-        unset($this->services[$identifier]);
+        $this->offsetUnset($identifier);
     }
 
     /**
@@ -92,7 +93,7 @@ class ServiceRegistry implements ServiceRegistryInterface
      */
     public function has($identifier)
     {
-        return isset($this->services[$identifier]);
+        return $this->offsetExists($identifier);
     }
 
     /**
@@ -100,10 +101,50 @@ class ServiceRegistry implements ServiceRegistryInterface
      */
     public function get($identifier)
     {
-        if (!$this->has($identifier)) {
+        if (! $this->offsetExists($identifier)) {
             throw new NonExistingServiceException($this->context, $identifier, array_keys($this->services));
         }
 
+        return $this->offsetGet($identifier);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($identifier)
+    {
+        return isset($this->services[$identifier]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($identifier)
+    {
         return $this->services[$identifier];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetSet($identifier, $service)
+    {
+        $this->services[$identifier] = $service;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($identifier)
+    {
+        unset($this->services[$identifier]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        return count($this->services);
     }
 }

--- a/src/Sylius/Component/Registry/spec/ServiceRegistrySpec.php
+++ b/src/Sylius/Component/Registry/spec/ServiceRegistrySpec.php
@@ -94,4 +94,22 @@ class ServiceRegistrySpec extends ObjectBehavior
             ->duringGet('foo')
         ;
     }
+
+    function it_allows_registration_via_ArrayAccess()
+    {
+        $theFooService = new \stdClass();
+
+        $this['foo'] = $theFooService;
+        $this['foo']->shouldBe($theFooService);
+    }
+
+    function it_allows_unregistration_via_ArrayAccess()
+    {
+        $aService = new \stdClass();
+
+        $this['foo'] = $aService;
+        unset($this['foo']);
+
+        $this->offsetExists('foo')->shouldBe(false);
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| BC breaks?      | no
| Related tickets |
| License         | MIT

The idea behind this is to make it almost effortless to replace arrays
of services with a service registry.  The implementations of SPL's
`ArrayAccess` are called from the implementations of the
`RegistryInterface`, the only difference being that the `ArrayAccess`
implementations do not throw exceptions as to align the behavior with
array usage in PHP.

The countable interface allows checking how many items are in the
registry without having to get all of them.