### PR TITLE
Do no translate choice form type values that do not need it

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
@@ -52,6 +52,7 @@ class CountryChoiceType extends AbstractType
 
         $resolver
             ->setDefaults([
+                'choice_translation_domain' => false,
                 'choice_list' => $choices,
                 'enabled' => true,
                 'label' => 'sylius.form.address.country',

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceChoiceType.php
@@ -53,6 +53,7 @@ class ProvinceChoiceType extends AbstractType
 
         $resolver
             ->setDefaults([
+                'choice_translation_domain' => false,
                 'choice_list' => $choices,
                 'country' => null,
                 'label' => 'sylius.form.address.province',

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneCodeChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneCodeChoiceType.php
@@ -42,6 +42,7 @@ class ZoneCodeChoiceType extends AbstractType
         $resolver
             ->setDefaults([
                 'choices' => $this->getZoneCodes(),
+                'choice_translation_domain' => false,
                 'label' => 'sylius.form.zone.types.zone',
                 'empty_value' => 'sylius.form.zone.select',
             ])

--- a/src/Sylius/Bundle/AddressingBundle/spec/Form/Type/ZoneCodeChoiceTypeSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/Form/Type/ZoneCodeChoiceTypeSpec.php
@@ -48,6 +48,7 @@ class ZoneCodeChoiceTypeSpec extends ObjectBehavior
 
         $resolver
             ->setDefaults([
+                'choice_translation_domain' => false,
                 'choices' => ['EU' => 'European Union'],
                 'label' => 'sylius.form.zone.types.zone',
                 'empty_value' => 'sylius.form.zone.select',

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeTypeChoiceType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeTypeChoiceType.php
@@ -38,9 +38,10 @@ class AttributeTypeChoiceType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
-            ->setDefaults(
-                ['choices' => $this->attributeTypes]
-            )
+            ->setDefaults([
+                'choice_translation_domain' => false,
+                'choices' => $this->attributeTypes
+            ])
         ;
     }
 

--- a/src/Sylius/Bundle/AttributeBundle/spec/Form/Type/AttributeTypeChoiceTypeSpec.php
+++ b/src/Sylius/Bundle/AttributeBundle/spec/Form/Type/AttributeTypeChoiceTypeSpec.php
@@ -37,7 +37,10 @@ class AttributeTypeChoiceTypeSpec extends ObjectBehavior
 
     function it_configures_proper_options(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(['choices' => ['test' => 'Test attribute type']])->shouldBeCalled();
+        $resolver->setDefaults([
+            'choice_translation_domain' => false,
+            'choices' => ['test' => 'Test attribute type']
+        ])->shouldBeCalled();
 
         $this->configureOptions($resolver);
     }

--- a/src/Sylius/Bundle/CurrencyBundle/Form/Type/CurrencyCodeChoiceType.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Form/Type/CurrencyCodeChoiceType.php
@@ -47,6 +47,7 @@ class CurrencyCodeChoiceType extends AbstractType
         }
 
         $resolver->setDefaults([
+            'choice_translation_domain' => false,
             'choices' => $choices,
         ]);
     }

--- a/src/Sylius/Bundle/CurrencyBundle/spec/Form/Type/CurrencyCodeChoiceTypeSpec.php
+++ b/src/Sylius/Bundle/CurrencyBundle/spec/Form/Type/CurrencyCodeChoiceTypeSpec.php
@@ -48,6 +48,7 @@ class CurrencyCodeChoiceTypeSpec extends ObjectBehavior
 
         $resolver
             ->setDefaults([
+                'choice_translation_domain' => false,
                 'choices' => ['EUR' => 'EUR - Euro'],
             ])
             ->shouldBeCalled();

--- a/src/Sylius/Bundle/LocaleBundle/Form/Type/LocaleChoiceType.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/Type/LocaleChoiceType.php
@@ -66,6 +66,7 @@ class LocaleChoiceType extends AbstractType
 
         $resolver
             ->setDefaults([
+                'choice_translation_domain' => false,
                 'choice_list' => $choiceList,
                 'enabled' => null,
                 'label' => 'sylius.form.locale.locale',

--- a/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonChoiceType.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonChoiceType.php
@@ -126,6 +126,7 @@ class TaxonChoiceType extends AbstractType
 
         $resolver
             ->setDefaults([
+                'choice_translation_domain' => false,
                 'choice_list' => $choiceList,
                 'root' => null,
                 'filter' => null,

--- a/src/Sylius/Bundle/VariationBundle/Form/Type/OptionValueChoiceType.php
+++ b/src/Sylius/Bundle/VariationBundle/Form/Type/OptionValueChoiceType.php
@@ -54,6 +54,7 @@ class OptionValueChoiceType extends AbstractType
 
         $resolver
             ->setDefaults([
+                'choice_translation_domain' => false,
                 'choice_list' => $choiceList,
             ])
             ->setRequired([

--- a/src/Sylius/Bundle/VariationBundle/Form/Type/VariantChoiceType.php
+++ b/src/Sylius/Bundle/VariationBundle/Form/Type/VariantChoiceType.php
@@ -58,6 +58,7 @@ class VariantChoiceType extends AbstractType
 
         $resolver
             ->setDefaults([
+                'choice_translation_domain' => false,
                 'multiple' => false,
                 'expanded' => true,
                 'choice_list' => $choiceList,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #4995 
| License         | MIT

Disable choice_translation_domain on choice form types that do not need translation (e.g. entity names that are translated at source)

