### PR TITLE
[Variation] - return transformed options as array to avoid side-effects

### DIFF
--- a/src/Sylius/Bundle/VariationBundle/Form/DataTransformer/VariantToCombinationTransformer.php
+++ b/src/Sylius/Bundle/VariationBundle/Form/DataTransformer/VariantToCombinationTransformer.php
@@ -52,7 +52,7 @@ class VariantToCombinationTransformer implements DataTransformerInterface
             throw new UnexpectedTypeException($value, VariantInterface::class);
         }
 
-        return $value->getOptions();
+        return $value->getOptions()->toArray();
     }
 
     /**

--- a/src/Sylius/Bundle/VariationBundle/spec/Form/DataTransformer/VariantToCombinationTransformerSpec.php
+++ b/src/Sylius/Bundle/VariationBundle/spec/Form/DataTransformer/VariantToCombinationTransformerSpec.php
@@ -11,6 +11,7 @@
 
 namespace spec\Sylius\Bundle\VariationBundle\Form\DataTransformer;
 
+use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Variation\Model\OptionValueInterface;
 use Sylius\Component\Variation\Model\VariableInterface;
@@ -45,9 +46,10 @@ class VariantToCombinationTransformerSpec extends ObjectBehavior
         $this->shouldThrow(UnexpectedTypeException::class)->duringTransform([]);
     }
 
-    function it_should_transform_variant_into_variant_options(VariantInterface $variant)
+    function it_should_transform_variant_into_variant_options(VariantInterface $variant, Collection $options)
     {
-        $variant->getOptions()->willReturn([]);
+        $variant->getOptions()->willReturn($options);
+        $options->toArray()->willReturn([]);
 
         $this->transform($variant)->shouldReturn([]);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | partially #4791
| License         | MIT

As described in #4791 - when changes are made on `Option` returned from the transformer, it can have side effects - eg. `Variant` option values will change upon persist

Returning options as array will, remove reference of the persistent collection and no side effects will occur.