### PR TITLE
[User] Make HWIOAuthBundle a little bit more optional

### DIFF
--- a/src/Sylius/Bundle/UserBundle/DependencyInjection/SyliusUserExtension.php
+++ b/src/Sylius/Bundle/UserBundle/DependencyInjection/SyliusUserExtension.php
@@ -13,14 +13,16 @@ namespace Sylius\Bundle\UserBundle\DependencyInjection;
 
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractResourceExtension;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class SyliusUserExtension extends AbstractResourceExtension
+class SyliusUserExtension extends AbstractResourceExtension implements PrependExtensionInterface
 {
     /**
      * {@inheritdoc}
@@ -34,13 +36,7 @@ class SyliusUserExtension extends AbstractResourceExtension
 
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);
 
-        $configFiles = [
-            'services.xml',
-        ];
-
-        foreach ($configFiles as $configFile) {
-            $loader->load($configFile);
-        }
+        $loader->load('services.xml');
 
         $container->setParameter('sylius.user.resetting.token_ttl', $config['resetting']['token']['ttl']);
         $container->setParameter('sylius.user.resetting.token_length', $config['resetting']['token']['length']);
@@ -62,5 +58,28 @@ class SyliusUserExtension extends AbstractResourceExtension
             ->getDefinition('sylius.form.type.customer')
             ->addArgument(new Reference('sylius.form.event_subscriber.add_user_type'))
         ;
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+
+        $this->prependHwiOauth($container, $loader);
+    }
+
+    /**
+     * @param ContainerBuilder $container
+     * @param LoaderInterface $loader
+     */
+    private function prependHwiOauth(ContainerBuilder $container, LoaderInterface $loader)
+    {
+        if (!$container->hasExtension('hwi_oauth')) {
+            return;
+        }
+
+        $loader->load('integration/hwi_oauth.xml');
     }
 }

--- a/src/Sylius/Bundle/UserBundle/Resources/config/integration/hwi_oauth.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/integration/hwi_oauth.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="sylius.oauth.user_provider.class">Sylius\Bundle\UserBundle\OAuth\UserProvider</parameter>
+    </parameters>
+
+    <services>
+        <service id="sylius.oauth.user_provider" class="%sylius.oauth.user_provider.class%" lazy="true">
+            <argument type="service" id="sylius.factory.customer" />
+            <argument type="service" id="sylius.repository.customer" />
+            <argument type="service" id="sylius.factory.user" />
+            <argument type="service" id="sylius.repository.user" />
+            <argument type="service" id="sylius.factory.user_oauth" />
+            <argument type="service" id="sylius.repository.user_oauth" />
+            <argument type="service" id="sylius.manager.user" />
+            <argument type="service" id="sylius.user.canonicalizer" />
+        </service>
+    </services>
+</container>

--- a/src/Sylius/Bundle/UserBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/services.xml
@@ -33,7 +33,6 @@
 
         <parameter key="sylius.user_provider.name.class">Sylius\Bundle\UserBundle\Provider\UsernameProvider</parameter>
         <parameter key="sylius.user_provider.name_or_email.class">Sylius\Bundle\UserBundle\Provider\UsernameOrEmailProvider</parameter>
-        <parameter key="sylius.oauth.user_provider.class">Sylius\Bundle\UserBundle\OAuth\UserProvider</parameter>
         <parameter key="sylius.user_provider.email.class">Sylius\Bundle\UserBundle\Provider\EmailProvider</parameter>
 
         <parameter key="sylius.form.type.user_login.class">Sylius\Bundle\UserBundle\Form\Type\UserLoginType</parameter>
@@ -164,16 +163,6 @@
         </service>
         <service id="sylius.user_provider.name" class="%sylius.user_provider.name.class%">
             <argument type="service" id="sylius.repository.user" />
-            <argument type="service" id="sylius.user.canonicalizer" />
-        </service>
-        <service id="sylius.oauth.user_provider" class="%sylius.oauth.user_provider.class%" lazy="true">
-            <argument type="service" id="sylius.factory.customer" />
-            <argument type="service" id="sylius.repository.customer" />
-            <argument type="service" id="sylius.factory.user" />
-            <argument type="service" id="sylius.repository.user" />
-            <argument type="service" id="sylius.factory.user_oauth" />
-            <argument type="service" id="sylius.repository.user_oauth" />
-            <argument type="service" id="sylius.manager.user" />
             <argument type="service" id="sylius.user.canonicalizer" />
         </service>
 

--- a/src/Sylius/Bundle/UserBundle/composer.json
+++ b/src/Sylius/Bundle/UserBundle/composer.json
@@ -37,12 +37,15 @@
         "sylius/user": "^0.18",
         "sylius/resource-bundle": "^0.18",
         "sylius/mailer-bundle": "^0.18",
-        "symfony/framework-bundle": "^2.7.7",
-        "hwi/oauth-bundle": "~0.3"
+        "symfony/framework-bundle": "^2.7.7"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.4",
-        "symfony/form": "^2.7"
+        "symfony/form": "^2.7",
+        "hwi/oauth-bundle": "~0.3"
+    },
+    "suggest": {
+        "hwi/oauth-bundle": "For OAuth integration"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Related tickets | -
| License         | MIT

There's still some room for improvements e.g. the configuration defines `user_oauth` resource, but HWIOAuthBundle isn't required now.