### PR TITLE
[Travis] Disable documentation cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ cache:
         - vendor
         - bin
         - node_modules
-        - docs/build
         - $SYLIUS_CACHE_DIR
 
 before_install:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | #5020
| License         | MIT

Since documentation is build only while it was changed, caching, that may cause some serious issues while building (like hiding previous warnings, not regenerating the root toctree), is disabled as it will no longer affect the performance of non-documentation builds.