### PR TITLE
[Translations] - frontend/legacy admin fix unnecessary double translating

### DIFF
--- a/src/Sylius/Bundle/CartBundle/Form/Type/CartType.php
+++ b/src/Sylius/Bundle/CartBundle/Form/Type/CartType.php
@@ -31,7 +31,9 @@ class CartType extends AbstractResourceType
             ->add('items', 'collection', [
                 'type' => 'sylius_cart_item',
             ])
-            ->add('additionalInformation')
+            ->add('additionalInformation', 'textarea', [
+                'label' => 'sylius.form.cart.additional_information'
+            ])
         ;
     }
 

--- a/src/Sylius/Bundle/CartBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/CartBundle/Resources/translations/messages.en.yml
@@ -1,5 +1,7 @@
 sylius:
     form:
+        cart:
+            additional_information: Additional Information
         cart_item:
             quantity: Quantity
             

--- a/src/Sylius/Bundle/CartBundle/spec/Form/Type/CartTypeSpec.php
+++ b/src/Sylius/Bundle/CartBundle/spec/Form/Type/CartTypeSpec.php
@@ -44,7 +44,7 @@ class CartTypeSpec extends ObjectBehavior
         ;
 
         $builder
-            ->add('additionalInformation')
+            ->add('additionalInformation', 'textarea', ['label' => 'sylius.form.cart.additional_information'])
             ->willReturn($builder)
         ;
 

--- a/src/Sylius/Bundle/VariationBundle/Form/Type/VariantMatchType.php
+++ b/src/Sylius/Bundle/VariationBundle/Form/Type/VariantMatchType.php
@@ -46,6 +46,7 @@ class VariantMatchType extends AbstractType
                 'label' => $option->getName(),
                 'option' => $option,
                 'property_path' => '['.$i.']',
+                'translation_domain' => false,
             ]);
         }
 

--- a/src/Sylius/Bundle/VariationBundle/spec/Form/Type/VariantMatchTypeSpec.php
+++ b/src/Sylius/Bundle/VariationBundle/spec/Form/Type/VariantMatchTypeSpec.php
@@ -47,6 +47,7 @@ class VariantMatchTypeSpec extends ObjectBehavior
             'label' => 'option_name',
             'option' => $option,
             'property_path' => '[0]',
+            'translation_domain' => false,
         ])->shouldBeCalled();
 
         $builder->addModelTransformer(

--- a/src/Sylius/Bundle/WebBundle/Menu/BackendMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/BackendMenuBuilder.php
@@ -42,7 +42,7 @@ class BackendMenuBuilder extends MenuBuilder
 
         $menu->addChild('dashboard', [
             'route' => 'sylius_backend_dashboard',
-        ])->setLabel($this->translate('sylius.backend.menu.main.dashboard'));
+        ])->setLabel('sylius.backend.menu.main.dashboard');
 
         $this->addAssortmentMenu($menu, $childOptions, 'main');
         $this->addSalesMenu($menu, $childOptions, 'main');
@@ -55,11 +55,11 @@ class BackendMenuBuilder extends MenuBuilder
 
         $menu->addChild('homepage', [
             'route' => 'sylius_homepage',
-        ])->setLabel($this->translate('sylius.backend.menu.main.homepage'));
+        ])->setLabel('sylius.backend.menu.main.homepage');
 
         $menu->addChild('logout', [
             'route' => 'sylius_user_security_logout',
-        ])->setLabel($this->translate('sylius.backend.logout'));
+        ])->setLabel('sylius.backend.logout');
 
         $this->eventDispatcher->dispatch(MenuBuilderEvent::BACKEND_MAIN, new MenuBuilderEvent($this->factory, $menu));
 
@@ -112,53 +112,53 @@ class BackendMenuBuilder extends MenuBuilder
     {
         $child = $menu
             ->addChild('assortment', $childOptions)
-            ->setLabel($this->translate(sprintf('sylius.backend.menu.%s.assortment', $section)))
+            ->setLabel(sprintf('sylius.backend.menu.%s.assortment', $section))
         ;
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.taxon.index')) {
             $child->addChild('taxons', [
                 'route' => 'sylius_backend_taxon_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-folder-close'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.taxons', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.taxons', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.product.index')) {
             $child->addChild('products', [
                 'route' => 'sylius_backend_product_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-th-list'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.products', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.products', $section));
             $child->addChild('inventory', [
                 'route' => 'sylius_backend_inventory_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-tasks'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.stockables', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.stockables', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.product_option.index')) {
             $child->addChild('options', [
                 'route' => 'sylius_backend_product_option_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-th'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.options', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.options', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.product_attribute.index')) {
             $child->addChild('product_attributes', [
                 'route' => 'sylius_backend_product_attribute_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-list-alt'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.attributes', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.attributes', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.product_archetype.index')) {
             $child->addChild('product_archetypes', [
                 'route' => 'sylius_backend_product_archetype_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-compressed'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.archetypes', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.archetypes', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.product_association_type.index')) {
             $child->addChild('product_association_types', [
                 'route' => 'sylius_backend_product_association_type_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-th-list'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.association_types', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.association_types', $section));
         }
 
         if (!$child->hasChildren()) {
@@ -177,38 +177,38 @@ class BackendMenuBuilder extends MenuBuilder
     {
         $child = $menu
             ->addChild('content', $childOptions)
-            ->setLabel($this->translate(sprintf('sylius.backend.menu.%s.content', $section)))
+            ->setLabel(sprintf('sylius.backend.menu.%s.content', $section))
         ;
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.simple_block.index')) {
             $child->addChild('blocks', [
                 'route' => 'sylius_backend_block_overview',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-th-large'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.blocks', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.blocks', $section));
         }
         if ($this->rbacAuthorizationChecker->isGranted('sylius.static_content.index')) {
             $child->addChild('Pages', [
                 'route' => 'sylius_backend_static_content_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-file'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.pages', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.pages', $section));
         }
         if ($this->rbacAuthorizationChecker->isGranted('sylius.menu.index')) {
             $child->addChild('Menus', [
                 'route' => 'sylius_backend_menu_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-list-alt'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.menus', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.menus', $section));
         }
         if ($this->rbacAuthorizationChecker->isGranted('sylius.slideshow.index')) {
             $child->addChild('Slideshow', [
                 'route' => 'sylius_backend_slideshow_block_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-film'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.slideshow', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.slideshow', $section));
         }
         if ($this->rbacAuthorizationChecker->isGranted('sylius.route.index')) {
             $child->addChild('Routes', [
                 'route' => 'sylius_backend_route_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-random'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.routes', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.routes', $section));
         }
 
         if (!$child->hasChildren()) {
@@ -227,26 +227,26 @@ class BackendMenuBuilder extends MenuBuilder
     {
         $child = $menu
             ->addChild('marketing', $childOptions)
-            ->setLabel($this->translate(sprintf('sylius.backend.menu.%s.marketing', $section)))
+            ->setLabel(sprintf('sylius.backend.menu.%s.marketing', $section))
         ;
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.promotion.index')) {
             $child->addChild('promotions', [
                 'route' => 'sylius_backend_promotion_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-bullhorn'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.promotions', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.promotions', $section));
         }
         if ($this->rbacAuthorizationChecker->isGranted('sylius.promotion.create')) {
             $child->addChild('new_promotion', [
                 'route' => 'sylius_backend_promotion_create',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-plus-sign'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.new_promotion', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.new_promotion', $section));
         }
         if ($this->rbacAuthorizationChecker->isGranted('sylius.manage.email')) {
             $child->addChild('emails', [
                 'route' => 'sylius_backend_email_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-envelope'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.emails', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.emails', $section));
         }
 
         if (!$child->hasChildren()) {
@@ -265,20 +265,20 @@ class BackendMenuBuilder extends MenuBuilder
     {
         $child = $menu
             ->addChild('support', $childOptions)
-            ->setLabel($this->translate(sprintf('sylius.backend.menu.%s.support', $section)))
+            ->setLabel(sprintf('sylius.backend.menu.%s.support', $section))
         ;
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.contact_request.index')) {
             $child->addChild('contact_requests', [
                 'route' => 'sylius_backend_contact_request_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-envelope'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.contact_requests', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.contact_requests', $section));
         }
         if ($this->rbacAuthorizationChecker->isGranted('sylius.contact_topic.index')) {
             $child->addChild('contact_topics', [
                 'route' => 'sylius_backend_contact_topic_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-align-justify'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.contact_topics', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.contact_topics', $section));
         }
 
         if (!$child->hasChildren()) {
@@ -297,32 +297,32 @@ class BackendMenuBuilder extends MenuBuilder
     {
         $child = $menu
             ->addChild('customer', $childOptions)
-            ->setLabel($this->translate(sprintf('sylius.backend.menu.%s.customer', $section)))
+            ->setLabel(sprintf('sylius.backend.menu.%s.customer', $section))
         ;
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.customer.index')) {
             $child->addChild('customers', [
                 'route' => 'sylius_backend_customer_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-user'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.customers', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.customers', $section));
         }
         if ($this->rbacAuthorizationChecker->isGranted('sylius.group.index')) {
             $child->addChild('groups', [
                 'route' => 'sylius_backend_group_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-home'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.groups', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.groups', $section));
         }
         if ($this->rbacAuthorizationChecker->isGranted('sylius.role.index')) {
             $child->addChild('roles', [
                 'route' => 'sylius_backend_role_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-sort-by-attributes'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.roles', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.roles', $section));
         }
         if ($this->rbacAuthorizationChecker->isGranted('sylius.permission.index')) {
             $child->addChild('permissions', [
                 'route' => 'sylius_backend_permission_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-lock'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.permissions', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.permissions', $section));
         }
 
         if (!$child->hasChildren()) {
@@ -341,32 +341,32 @@ class BackendMenuBuilder extends MenuBuilder
     {
         $child = $menu
             ->addChild('sales', $childOptions)
-            ->setLabel($this->translate(sprintf('sylius.backend.menu.%s.sales', $section)))
+            ->setLabel(sprintf('sylius.backend.menu.%s.sales', $section))
         ;
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.order.index')) {
             $child->addChild('orders', [
                 'route' => 'sylius_backend_order_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-shopping-cart'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.orders', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.orders', $section));
         }
         if ($this->rbacAuthorizationChecker->isGranted('sylius.shipment.index')) {
             $child->addChild('shipments', [
                 'route' => 'sylius_backend_shipment_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-plane'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.shipments', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.shipments', $section));
         }
         if ($this->rbacAuthorizationChecker->isGranted('sylius.payment.index')) {
             $child->addChild('payments', [
                 'route' => 'sylius_backend_payment_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-credit-card'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.payments', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.payments', $section));
         }
         if ($this->rbacAuthorizationChecker->isGranted('sylius.report.index')) {
             $child->addChild('reports', [
                 'route' => 'sylius_backend_report_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-stats'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.report', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.report', $section));
         }
 
         if (!$child->hasChildren()) {
@@ -383,14 +383,14 @@ class BackendMenuBuilder extends MenuBuilder
     {
         $child = $menu
             ->addChild('review', $childOptions)
-            ->setLabel($this->translate(sprintf('sylius.backend.menu.%s.review', $section)))
+            ->setLabel(sprintf('sylius.backend.menu.%s.review', $section))
         ;
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.product_review.index')) {
             $child->addChild('reviews', [
                 'route' => 'sylius_backend_product_review_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-pencil'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.product_review', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.product_review', $section));
         }
 
         if (!$child->hasChildren()) {
@@ -409,112 +409,112 @@ class BackendMenuBuilder extends MenuBuilder
     {
         $child = $menu
             ->addChild('configuration', $childOptions)
-            ->setLabel($this->translate(sprintf('sylius.backend.menu.%s.configuration', $section)))
+            ->setLabel(sprintf('sylius.backend.menu.%s.configuration', $section))
         ;
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.settings.sylius_general')) {
             $child->addChild('general_settings', [
                 'route' => 'sylius_backend_general_settings',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-info-sign'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.general_settings', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.general_settings', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.settings.sylius_security')) {
             $child->addChild('security_settings', [
                 'route' => 'sylius_backend_security_settings',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-lock'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.security_settings', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.security_settings', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.channel.index')) {
             $child->addChild('channels', [
                 'route' => 'sylius_backend_channel_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-cog'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.channels', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.channels', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.metadata_container.index')) {
             $child->addChild('metadata', [
                 'route' => 'sylius_backend_metadata_container_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-file'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.metadata', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.metadata', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.locale.index')) {
             $child->addChild('locales', [
                 'route' => 'sylius_backend_locale_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-flag'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.locales', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.locales', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.payment_method.index')) {
             $child->addChild('payment_methods', [
                 'route' => 'sylius_backend_payment_method_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-credit-card'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.payment_methods', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.payment_methods', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.currency.index')) {
             $child->addChild('currencies', [
                 'route' => 'sylius_backend_currency_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-usd'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.currencies', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.currencies', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.settings.sylius_taxation')) {
             $child->addChild('taxation_settings', [
                 'route' => 'sylius_backend_taxation_settings',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-cog'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.taxation_settings', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.taxation_settings', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.tax_category.index')) {
             $child->addChild('tax_categories', [
                 'route' => 'sylius_backend_tax_category_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-cog'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.tax_categories', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.tax_categories', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.tax_rate.index')) {
             $child->addChild('tax_rates', [
                 'route' => 'sylius_backend_tax_rate_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-cog'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.tax_rates', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.tax_rates', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.shipping_category.index')) {
             $child->addChild('shipping_categories', [
                 'route' => 'sylius_backend_shipping_category_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-cog'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.shipping_categories', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.shipping_categories', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.shipping_method.index')) {
             $child->addChild('shipping_methods', [
                 'route' => 'sylius_backend_shipping_method_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-cog'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.shipping_methods', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.shipping_methods', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.country.index')) {
             $child->addChild('countries', [
                 'route' => 'sylius_backend_country_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-flag'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.countries', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.countries', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.zone.index')) {
             $child->addChild('zones', [
                 'route' => 'sylius_backend_zone_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-globe'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.zones', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.zones', $section));
         }
 
         if ($this->rbacAuthorizationChecker->isGranted('sylius.api_client.index')) {
             $child->addChild('api_clients', [
                 'route' => 'sylius_backend_api_client_index',
                 'labelAttributes' => ['icon' => 'glyphicon glyphicon-globe'],
-            ])->setLabel($this->translate(sprintf('sylius.backend.menu.%s.api_clients', $section)));
+            ])->setLabel(sprintf('sylius.backend.menu.%s.api_clients', $section));
         }
 
         if (!$child->hasChildren()) {

--- a/src/Sylius/Bundle/WebBundle/Menu/LocaleMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/LocaleMenuBuilder.php
@@ -35,7 +35,6 @@ class LocaleMenuBuilder extends MenuBuilder
     /**
      * @param FactoryInterface $factory
      * @param AuthorizationCheckerInterface $authorizationChecker
-     * @param TranslatorInterface $translator
      * @param EventDispatcherInterface $eventDispatcher
      * @param LocaleProviderInterface $localeProvider
      * @param RbacAuthorizationCheckerInterface $rbacAuthorizationChecker
@@ -43,12 +42,11 @@ class LocaleMenuBuilder extends MenuBuilder
     public function __construct(
         FactoryInterface $factory,
         AuthorizationCheckerInterface $authorizationChecker,
-        TranslatorInterface $translator,
         EventDispatcherInterface $eventDispatcher,
         LocaleProviderInterface $localeProvider,
         RbacAuthorizationCheckerInterface $rbacAuthorizationChecker
     ) {
-        parent::__construct($factory, $authorizationChecker, $translator, $eventDispatcher, $rbacAuthorizationChecker);
+        parent::__construct($factory, $authorizationChecker, $eventDispatcher, $rbacAuthorizationChecker);
 
         $this->localeProvider = $localeProvider;
     }
@@ -77,7 +75,10 @@ class LocaleMenuBuilder extends MenuBuilder
             $menu->addChild($locale, [
                 'route' => 'sylius_locale_change',
                 'routeParameters' => ['locale' => $locale],
-            ])->setLabel(Intl::getLocaleBundle()->getLocaleName($locale));
+            ])
+                ->setLabel(Intl::getLocaleBundle()->getLocaleName($locale))
+                ->setExtra('translation_domain', false)
+            ;
         }
 
         return $menu;

--- a/src/Sylius/Bundle/WebBundle/Menu/MenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/MenuBuilder.php
@@ -40,13 +40,6 @@ abstract class MenuBuilder
     protected $authorizationChecker;
 
     /**
-     * Translator instance.
-     *
-     * @var TranslatorInterface
-     */
-    protected $translator;
-
-    /**
      * Request.
      *
      * @var Request
@@ -68,20 +61,17 @@ abstract class MenuBuilder
      *
      * @param FactoryInterface $factory
      * @param AuthorizationCheckerInterface $authorizationChecker
-     * @param TranslatorInterface $translator
      * @param EventDispatcherInterface $eventDispatcher
      * @param RbacAuthorizationCheckerInterface $rbacAuthorizationChecker
      */
     public function __construct(
         FactoryInterface $factory,
         AuthorizationCheckerInterface $authorizationChecker,
-        TranslatorInterface $translator,
         EventDispatcherInterface $eventDispatcher,
         RbacAuthorizationCheckerInterface $rbacAuthorizationChecker
     ) {
         $this->factory = $factory;
         $this->authorizationChecker = $authorizationChecker;
-        $this->translator = $translator;
         $this->eventDispatcher = $eventDispatcher;
         $this->rbacAuthorizationChecker = $rbacAuthorizationChecker;
     }
@@ -94,18 +84,5 @@ abstract class MenuBuilder
     public function setRequest(Request $request = null)
     {
         $this->request = $request;
-    }
-
-    /**
-     * Translate label.
-     *
-     * @param string $label
-     * @param array  $parameters
-     *
-     * @return string
-     */
-    protected function translate($label, $parameters = [])
-    {
-        return $this->translator->trans(/* @Ignore */ $label, $parameters, 'menu');
     }
 }

--- a/src/Sylius/Bundle/WebBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/services.xml
@@ -65,7 +65,6 @@
         <service id="sylius.menu_builder.frontend" class="%sylius.menu_builder.frontend.class%">
             <argument type="service" id="knp_menu.factory" />
             <argument type="service" id="security.authorization_checker" />
-            <argument type="service" id="translator" />
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="sylius.authorization_checker" />
             <argument type="service" id="sylius.currency_provider" />
@@ -81,7 +80,6 @@
         <service id="sylius.menu_builder.backend" class="%sylius.menu_builder.backend.class%">
             <argument type="service" id="knp_menu.factory" />
             <argument type="service" id="security.authorization_checker" />
-            <argument type="service" id="translator" />
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="sylius.authorization_checker" />
             <call method="setRequest">
@@ -91,7 +89,6 @@
         <service id="sylius.menu_builder.locale" class="%sylius.menu_builder.locale.class%">
             <argument type="service" id="knp_menu.factory" />
             <argument type="service" id="security.authorization_checker" />
-            <argument type="service" id="translator" />
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="sylius.channel_aware_locale_provider" />
             <argument type="service" id="sylius.authorization_checker" />

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
@@ -20,7 +20,7 @@
     </div>
     <div class="col-md-9">
         <a href="{{ path(product) }}" class="btn btn-link"><h3>{{ product.name }}</h3></a>
-        <p>{{ product.shortDescription|default('sylius.product.no_description')|trans|raw }}</p>
+        <p>{{ product.shortDescription|default('sylius.ui.no_description'|trans)|raw }}</p>
         {% if product.averageRating %}
         <h3>{{ 'sylius.ui.rating'|trans }}: {{ product.averageRating|round(2, 'floor') }}</h3>
         {% endif %}
@@ -60,7 +60,7 @@
     </div>
     <div class="col-md-6">
         <h4>{{ 'sylius.ui.description'|trans }}</h4>
-        <p>{{ product.description|default('sylius.product.no_description')|trans|raw }}</p>
+        <p>{{ product.description|default('sylius.ui.no_description'|trans)|raw }}</p>
     </div>
 </div>
 <hr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/menu.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/menu.html.twig
@@ -3,7 +3,13 @@
 {% block label %}
     {% if item.labelAttribute('icon') %}<i class="{{ item.labelAttribute('icon') }}"></i>{% endif %}
     {% if not item.labelAttribute('iconOnly') %}
-        <span>{% if options.allow_safe_labels and item.getExtra('safe_label', false) %}{{ item.label|trans|raw }}{% else %}{{ item.label|trans }}{% endif %}</span>
+        {% set label = item.label %}
+        {% if item.extra('translation_domain') is not same as(false)%}
+            {% set translation_parameters = item.extra('translation_parameters')|default({}) %}
+            {% set translation_domain = item.extra('translation_domain')|default('menu') %}
+            {% set label = item.label|trans(translation_parameters, translation_domain) %}
+        {% endif %}
+        <span>{{ options.allow_safe_labels ? label|raw : label }}</span>
     {% endif %}
     {% if item.labelAttribute('data-image') %}<img src="{{ item.labelAttribute('data-image')|imagine_filter('sylius_small') }}" alt="{{ item.name }}" class="menu-thumbnail"/>{% endif %}
 {% endblock %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes? |
| New feature? | no |
| BC breaks? | yes - menubuilders |
| Related tickets | # |
| License | MIT |

Mainly changed menu builder label translation and moved it to template, similar as in new admin.
Added new argument in Menu - to control if string should be translated or not
- translation_domain (similar as in forms)
- translation_parameters - to pass variables
- see menu.html.twig

99% percent of missing translation that where false possitives are now removed.
-> tiny performance boost + easier to identify string for translation that are missing for real
