### PR TITLE
Allow multiple search indexes

### DIFF
--- a/src/Sylius/Bundle/SearchBundle/DependencyInjection/SyliusSearchExtension.php
+++ b/src/Sylius/Bundle/SearchBundle/DependencyInjection/SyliusSearchExtension.php
@@ -90,11 +90,13 @@ class SyliusSearchExtension extends AbstractResourceExtension implements Prepend
             $elasticaConfig = $processor->processConfiguration($configuration, $container->getExtensionConfig('fos_elastica'));
 
             foreach ($elasticaConfig['indexes'] as $index => $config) {
-                $elasticaProductListenerDefinition = new Definition(ElasticaProductListener::class);
-                $elasticaProductListenerDefinition->addArgument(new Reference('fos_elastica.object_persister.' . $index . '.product'));
-                $elasticaProductListenerDefinition->addTag('doctrine.event_subscriber');
+                if (array_key_exists('product', $config['types'])) {
+                    $elasticaProductListenerDefinition = new Definition(ElasticaProductListener::class);
+                    $elasticaProductListenerDefinition->addArgument(new Reference('fos_elastica.object_persister.' . $index . '.product'));
+                    $elasticaProductListenerDefinition->addTag('doctrine.event_subscriber');
 
-                $container->setDefinition('sylius_product.listener.index_' . $index . '.product_update', $elasticaProductListenerDefinition);
+                    $container->setDefinition('sylius_product.listener.index_' . $index . '.product_update', $elasticaProductListenerDefinition);
+                }
             }
         }
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

If you have two search indexes, eg. 'sylius' and 'site', this patch prevents sylius from loading an event listener for site.product if the product type doesn't exists.   It is not the ideal patch, but at least now you can use multiple FOS indexes.