### PR TITLE
[WebBundle] Fix account order detail page

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
@@ -81,7 +81,7 @@
                         {{ 'sylius.ui.promotion_total'|trans }}
                     </span>
                 </td>
-                <td>{{ order.adjustmentsTotal(promotionAdjustment)|sylius_money(order.currency) }}</td>
+                <td>{{ order.getPromotionsTotalRecursively()|sylius_money(order.currency) }}</td>
             </tr>
             <tr>
                 <th colspan="3">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
@@ -1,6 +1,5 @@
 {% set taxAdjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::TAX_ADJUSTMENT') %}
 {% set shippingAdjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::SHIPPING_ADJUSTMENT') %}
-{% set promotionAdjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT') %}
 
 <div class="row well well-sm" id="information">
     <div class="col-md-6">


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

The promotion total was not recursive, and thus incorrect when you had item level promotions.
