### PR TITLE
[Doc][Translation] Add example for usage with SyliusTranslationBundle

### DIFF
--- a/docs/components/Translation/basic_usage.rst
+++ b/docs/components/Translation/basic_usage.rst
@@ -153,6 +153,27 @@ You can always use the ``translate`` method by itself, but the same principal is
 
 .. _\\RuntimeException: https://secure.php.net/manual/pl/class.runtimeexception.php
 
+.. _component_translation_with_bundle:
+
+Usage with SyliusTranslationBundle
+----------------------------------
+
+When using in conjuction with the `SyliusTranslationBundle` and persisting with doctrine
+make sure you have configured your entities under the `sylius_resource` configuration 
+option. For example:
+
+.. code-block:: yaml
+
+   sylius_resource:
+     resources:
+        app.book:
+            classes: 
+              model: Example\Model\Book
+            translation:
+              classes:
+                model: Example\Model\BookTranslation
+
+
 .. _component_translation_provider_locale-provider:
 
 LocaleProvider


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Related tickets |  |
| License | MIT |

After spending an long time figuring out why my translation entities weren't being persisted, I discovered they have to be configured through the SyliusResourceBundle.

Could we add something like this to the Translation component documentation? Hopefully it'll prevent others wasting as much time as I did.

(Unless I've been stupid and this has been documented elsewhere?)
