### PR TITLE
[Currency] Do not use booleans as money formatter's locales

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Controller/ProductController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/ProductController.php
@@ -278,7 +278,7 @@ class ProductController extends ResourceController
                 'image' => $product->getImage() ? $product->getImage()->getPath() : null,
                 'price' => $helper->convertAndFormatAmount($product->getMasterVariant()->getPrice()),
                 'original_price' => $helper->convertAndFormatAmount($product->getMasterVariant()->getOriginalPrice()),
-                'raw_price' => $helper->convertAndFormatAmount($product->getMasterVariant()->getPrice(), null, true),
+                'raw_price' => $helper->convertAmount($product->getMasterVariant()->getPrice(), null),
                 'desc' => $product->getShortDescription(),
             ];
         }

--- a/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/CurrencyHelper.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/CurrencyHelper.php
@@ -74,12 +74,12 @@ class CurrencyHelper extends Helper implements CurrencyHelperInterface
     /**
      * {@inheritdoc}
      */
-    public function convertAndFormatAmount($amount, $currency = null, $decimal = false)
+    public function convertAndFormatAmount($amount, $currency = null)
     {
         $currency = $currency ?: $this->currencyContext->getCurrency();
         $amount = $this->currencyConverter->convertFromBase($amount, $currency);
 
-        return $this->moneyFormatter->format($amount, $currency, $decimal);
+        return $this->moneyFormatter->format($amount, $currency);
     }
 
     /**

--- a/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/CurrencyHelperInterface.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Templating/Helper/CurrencyHelperInterface.php
@@ -32,11 +32,10 @@ interface CurrencyHelperInterface
     /**
      * @param int $amount
      * @param string|null $currency
-     * @param bool $decimal
      *
      * @return string
      */
-    public function convertAndFormatAmount($amount, $currency = null, $decimal = false);
+    public function convertAndFormatAmount($amount, $currency = null);
 
     /**
      * @return string

--- a/src/Sylius/Bundle/CurrencyBundle/spec/Templating/Helper/CurrencyHelperSpec.php
+++ b/src/Sylius/Bundle/CurrencyBundle/spec/Templating/Helper/CurrencyHelperSpec.php
@@ -23,7 +23,7 @@ use Symfony\Component\Templating\Helper\Helper;
 
 /**
  * @mixin CurrencyHelper
- * 
+ *
  * @author Paweł Jędrzejewski <pjedrzejewski@diweb.pl>
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
@@ -82,10 +82,10 @@ class CurrencyHelperSpec extends ObjectBehavior
         $converter->convertFromBase(312, 'PLN')->willReturn(407);
         $converter->convertFromBase(500, 'PLN')->willReturn(653);
 
-        $moneyFormatter->format(19, 'USD', false)->willReturn('$0.19');
-        $moneyFormatter->format(1913, 'USD', false)->willReturn('$19.13');
-        $moneyFormatter->format(407, 'PLN', false)->willReturn('4.07 zł');
-        $moneyFormatter->format(653, 'PLN', false)->willReturn('6.53 zł');
+        $moneyFormatter->format(19, 'USD')->willReturn('$0.19');
+        $moneyFormatter->format(1913, 'USD')->willReturn('$19.13');
+        $moneyFormatter->format(407, 'PLN')->willReturn('4.07 zł');
+        $moneyFormatter->format(653, 'PLN')->willReturn('6.53 zł');
 
         $this->convertAndFormatAmount(15, 'USD')->shouldReturn('$0.19');
         $this->convertAndFormatAmount(2500, 'USD')->shouldReturn('$19.13');


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | -
| License         | MIT

It crashes when `ext-intl` is not available. Anyway, `false` and `true` does not look like a valid locales :)