### PR TITLE
Fix Archetype parent field mapping

### DIFF
--- a/src/Sylius/Bundle/ArchetypeBundle/EventListener/LoadMetadataSubscriber.php
+++ b/src/Sylius/Bundle/ArchetypeBundle/EventListener/LoadMetadataSubscriber.php
@@ -142,12 +142,12 @@ class LoadMetadataSubscriber implements EventSubscriber
             'fieldName' => 'parent',
             'type' => ClassMetadataInfo::MANY_TO_ONE,
             'targetEntity' => $class['archetype']['classes']['model'],
-            'joinColumn' => [
+            'joinColumns' => [[
                 'name' => 'parent_id',
                 'referencedColumnName' => 'id',
                 'nullable' => true,
                 'onDelete' => 'SET NULL',
-            ],
+            ]],
         ];
 
         $metadata->mapManyToOne($parentMapping);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets |
| License         | MIT

'joinColumn' key is ignored, so onDelete is not applied in DB.