### PR TITLE
Fix and refactor Load*MetadataSubscriber 

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/EventListener/AbstractDoctrineSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/AbstractDoctrineSubscriber.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\EventListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Sylius\Component\Resource\Metadata\RegistryInterface;
+
+/**
+ * @author Ben Davies <ben.davies@gmail.org>
+ */
+abstract class AbstractDoctrineSubscriber implements EventSubscriber
+{
+    /**
+     * @var RegistryInterface
+     */
+    protected $resourceRegistry;
+
+    /**
+     * @param RegistryInterface $resourceRegistry
+     */
+    public function __construct(RegistryInterface $resourceRegistry)
+    {
+        $this->resourceRegistry = $resourceRegistry;
+    }
+
+    /**
+     * @param ClassMetadata $metadata
+     *
+     * @return bool
+     */
+    protected function isSyliusClass(ClassMetadata $metadata)
+    {
+        return 0 === strpos($metadata->getName(), 'Sylius\\');
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/EventListener/ODMMappedSuperClassSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/ODMMappedSuperClassSubscriber.php
@@ -62,10 +62,6 @@ class ODMMappedSuperClassSubscriber extends AbstractDoctrineSubscriber
                 continue;
             }
 
-            if ($resourceMetadata->hasClass('repository')) {
-                $metadata->setCustomRepositoryClass($resourceMetadata->getClass('repository'));
-            }
-
             $metadata->isMappedSuperclass = false;
         }
     }

--- a/src/Sylius/Bundle/ResourceBundle/EventListener/ODMRepositoryClassSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/ODMRepositoryClassSubscriber.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\EventListener;
+
+use Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs;
+use Doctrine\ODM\MongoDB\Events;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+
+/**
+ * @author Ben Davies <ben.davies@gmail.org>
+ */
+class ODMRepositoryClassSubscriber extends AbstractDoctrineSubscriber
+{
+    /**
+     * @return array
+     */
+    public function getSubscribedEvents()
+    {
+        return [
+            Events::loadClassMetadata,
+        ];
+    }
+
+    /**
+     * @param LoadClassMetadataEventArgs $eventArgs
+     */
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
+    {
+        $this->setCustomRepositoryClass($eventArgs->getClassMetadata());
+    }
+
+    /**
+     * @param ClassMetadata $metadata
+     */
+    private function setCustomRepositoryClass(ClassMetadata $metadata)
+    {
+        try {
+            $resourceMetadata = $this->resourceRegistry->getByClass($metadata->getName());
+        } catch (\InvalidArgumentException $exception) {
+            return;
+        }
+
+        if ($resourceMetadata->hasClass('repository')) {
+            $metadata->setCustomRepositoryClass($resourceMetadata->getClass('repository'));
+        }
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/EventListener/ORMMappedSuperClassSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/ORMMappedSuperClassSubscriber.php
@@ -61,10 +61,6 @@ class ORMMappedSuperClassSubscriber extends AbstractDoctrineSubscriber
                 continue;
             }
 
-            if ($resourceMetadata->hasClass('repository')) {
-                $metadata->setCustomRepositoryClass($resourceMetadata->getClass('repository'));
-            }
-
             $metadata->isMappedSuperclass = false;
         }
     }

--- a/src/Sylius/Bundle/ResourceBundle/EventListener/ORMRepositoryClassSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/ORMRepositoryClassSubscriber.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\EventListener;
+
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+/**
+ * @author Ben Davies <ben.davies@gmail.org>
+ */
+class ORMRepositoryClassSubscriber extends AbstractDoctrineSubscriber
+{
+    /**
+     * @return array
+     */
+    public function getSubscribedEvents()
+    {
+        return [
+            Events::loadClassMetadata,
+        ];
+    }
+
+    /**
+     * @param LoadClassMetadataEventArgs $eventArgs
+     */
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
+    {
+        $this->setCustomRepositoryClass($eventArgs->getClassMetadata());
+    }
+
+    /**
+     * @param ClassMetadata $metadata
+     */
+    private function setCustomRepositoryClass(ClassMetadata $metadata)
+    {
+        try {
+            $resourceMetadata = $this->resourceRegistry->getByClass($metadata->getName());
+        } catch (\InvalidArgumentException $exception) {
+            return;
+        }
+
+        if ($resourceMetadata->hasClass('repository')) {
+            $metadata->setCustomRepositoryClass($resourceMetadata->getClass('repository'));
+        }
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
@@ -33,8 +33,8 @@
 
         <parameter key="sylius.event_subscriber.resource_delete.class">Sylius\Bundle\ResourceBundle\EventListener\ResourceDeleteSubscriber</parameter>
 
-        <parameter key="sylius.event_subscriber.load_orm_metadata.class">Sylius\Bundle\ResourceBundle\EventListener\LoadORMMetadataSubscriber</parameter>
-        <parameter key="sylius.event_subscriber.load_odm_metadata.class">Sylius\Bundle\ResourceBundle\EventListener\LoadODMMetadataSubscriber</parameter>
+        <parameter key="sylius.event_subscriber.orm_mapped_super_class.class">Sylius\Bundle\ResourceBundle\EventListener\ORMMappedSuperClassSubscriber</parameter>
+        <parameter key="sylius.event_subscriber.odm_mapped_super_class.class">Sylius\Bundle\ResourceBundle\EventListener\ODMMappedSuperClassSubscriber</parameter>
 
         <parameter key="sylius.validator.enabled.class">Sylius\Bundle\ResourceBundle\Validator\EnabledValidator</parameter>
         <parameter key="sylius.validator.disabled.class">Sylius\Bundle\ResourceBundle\Validator\DisabledValidator</parameter>
@@ -65,11 +65,11 @@
             <tag name="kernel.event_subscriber" event="kernel.exception" />
         </service>
 
-        <service id="sylius.event_subscriber.load_orm_metadata" class="%sylius.event_subscriber.load_orm_metadata.class%">
+        <service id="sylius.event_subscriber.orm_mapped_super_class" class="%sylius.event_subscriber.orm_mapped_super_class.class%">
             <argument type="service" id="sylius.resource_registry" />
             <tag name="doctrine.event_subscriber" priority="8192" />
         </service>
-        <service id="sylius.event_subscriber.load_odm_metadata" class="%sylius.event_subscriber.load_odm_metadata.class%">
+        <service id="sylius.event_subscriber.odm_mapped_super_class" class="%sylius.event_subscriber.odm_mapped_super_class.class%">
             <argument type="service" id="sylius.resource_registry" />
             <tag name="doctrine_mongodb.odm.event_subscriber" priority="8192" />
         </service>

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
@@ -36,6 +36,9 @@
         <parameter key="sylius.event_subscriber.orm_mapped_super_class.class">Sylius\Bundle\ResourceBundle\EventListener\ORMMappedSuperClassSubscriber</parameter>
         <parameter key="sylius.event_subscriber.odm_mapped_super_class.class">Sylius\Bundle\ResourceBundle\EventListener\ODMMappedSuperClassSubscriber</parameter>
 
+        <parameter key="sylius.event_subscriber.orm_repository_class.class">Sylius\Bundle\ResourceBundle\EventListener\ORMRepositoryClassSubscriber</parameter>
+        <parameter key="sylius.event_subscriber.odm_repository_class.class">Sylius\Bundle\ResourceBundle\EventListener\ODMRepositoryClassSubscriber</parameter>
+
         <parameter key="sylius.validator.enabled.class">Sylius\Bundle\ResourceBundle\Validator\EnabledValidator</parameter>
         <parameter key="sylius.validator.disabled.class">Sylius\Bundle\ResourceBundle\Validator\DisabledValidator</parameter>
 
@@ -70,6 +73,15 @@
             <tag name="doctrine.event_subscriber" priority="8192" />
         </service>
         <service id="sylius.event_subscriber.odm_mapped_super_class" class="%sylius.event_subscriber.odm_mapped_super_class.class%">
+            <argument type="service" id="sylius.resource_registry" />
+            <tag name="doctrine_mongodb.odm.event_subscriber" priority="8192" />
+        </service>
+
+        <service id="sylius.event_subscriber.orm_repository_class" class="%sylius.event_subscriber.orm_repository_class.class%">
+            <argument type="service" id="sylius.resource_registry" />
+            <tag name="doctrine.event_subscriber" priority="8192" />
+        </service>
+        <service id="sylius.event_subscriber.odm_repository_class" class="%sylius.event_subscriber.odm_repository_class.class%">
             <argument type="service" id="sylius.resource_registry" />
             <tag name="doctrine_mongodb.odm.event_subscriber" priority="8192" />
         </service>

--- a/src/Sylius/Bundle/ResourceBundle/spec/EventListener/ODMRepositoryClassSubscriberSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/EventListener/ODMRepositoryClassSubscriberSpec.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\EventListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ODM\MongoDB\Event\LoadClassMetadataEventArgs;
+use Doctrine\ODM\MongoDB\Events;
+use Doctrine\ODM\MongoDB\Mapping\ClassMetadata;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\ResourceBundle\EventListener\ODMRepositoryClassSubscriber;
+use Sylius\Component\Resource\Metadata\MetadataInterface;
+use Sylius\Component\Resource\Metadata\RegistryInterface;
+
+/**
+ * @author Ben Davies <ben.davies@gmail.org>
+ * @mixin ODMRepositoryClassSubscriber
+ *
+ * @require Doctrine\ODM\MongoDB\Events
+ */
+class ODMRepositoryClassSubscriberSpec extends ObjectBehavior
+{
+    function let(RegistryInterface $registry, LoadClassMetadataEventArgs $event, ClassMetadata $classMetadata)
+    {
+        $classMetadata->getName()->willReturn('Foo');
+        $event->getClassMetadata()->willReturn($classMetadata);
+
+        $this->beConstructedWith($registry);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\EventListener\ODMRepositoryClassSubscriber');
+    }
+
+    function it_implements_event_subscriber_interface()
+    {
+        $this->shouldImplement(EventSubscriber::class);
+    }
+
+    function it_is_subscribed_to_load_class_metadata_doctrine_orm_event()
+    {
+        $this->getSubscribedEvents()->shouldReturn([Events::loadClassMetadata]);
+    }
+
+    function it_sets_custom_repository_class(LoadClassMetadataEventArgs $event, RegistryInterface $registry, ClassMetadata $classMetadata, MetadataInterface $metadata)
+    {
+        $registry->getByClass('Foo')->willReturn($metadata);
+        $metadata->hasClass('repository')->willReturn(true);
+        $metadata->getClass('repository')->willReturn('FooRepository');
+
+        $classMetadata->setCustomRepositoryClass('FooRepository')->shouldBeCalled();
+
+        $this->loadClassMetadata($event);
+    }
+
+    function it_does_not_set_custom_repository_class_if_not_configured(LoadClassMetadataEventArgs $event, RegistryInterface $registry, ClassMetadata $classMetadata, MetadataInterface $metadata)
+    {
+        $registry->getByClass('Foo')->willReturn($metadata);
+        $metadata->hasClass('repository')->willReturn(false);
+
+        $classMetadata->setCustomRepositoryClass(Argument::any())->shouldNotBeCalled();
+
+        $this->loadClassMetadata($event);
+    }
+
+    function it_does_not_set_custom_repository_class_if_registry_does_not_have_class(LoadClassMetadataEventArgs $event, RegistryInterface $registry, ClassMetadata $classMetadata)
+    {
+        $registry->getByClass('Foo')->willThrow(\InvalidArgumentException::class);
+
+        $classMetadata->setCustomRepositoryClass(Argument::any())->shouldNotBeCalled();
+
+        $this->loadClassMetadata($event);
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/spec/EventListener/ORMRepositoryClassSubscriberSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/EventListener/ORMRepositoryClassSubscriberSpec.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\ResourceBundle\EventListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\ResourceBundle\EventListener\ORMRepositoryClassSubscriber;
+use Sylius\Component\Resource\Metadata\MetadataInterface;
+use Sylius\Component\Resource\Metadata\RegistryInterface;
+
+/**
+ * @author Ben Davies <ben.davies@gmail.org>
+ * @mixin ORMRepositoryClassSubscriber
+ */
+class ORMRepositoryClassSubscriberSpec extends ObjectBehavior
+{
+    function let(RegistryInterface $registry, LoadClassMetadataEventArgs $event, ClassMetadata $classMetadata)
+    {
+        $classMetadata->getName()->willReturn('Foo');
+        $event->getClassMetadata()->willReturn($classMetadata);
+
+        $this->beConstructedWith($registry);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Bundle\ResourceBundle\EventListener\ORMRepositoryClassSubscriber');
+    }
+
+    function it_implements_event_subscriber_interface()
+    {
+        $this->shouldImplement(EventSubscriber::class);
+    }
+
+    function it_is_subscribed_to_load_class_metadata_doctrine_orm_event()
+    {
+        $this->getSubscribedEvents()->shouldReturn([Events::loadClassMetadata]);
+    }
+
+    function it_sets_custom_repository_class(LoadClassMetadataEventArgs $event, RegistryInterface $registry, ClassMetadata $classMetadata, MetadataInterface $metadata)
+    {
+        $registry->getByClass('Foo')->willReturn($metadata);
+        $metadata->hasClass('repository')->willReturn(true);
+        $metadata->getClass('repository')->willReturn('FooRepository');
+
+        $classMetadata->setCustomRepositoryClass('FooRepository')->shouldBeCalled();
+
+        $this->loadClassMetadata($event);
+    }
+
+    function it_does_not_set_custom_repository_class_if_not_configured(LoadClassMetadataEventArgs $event, RegistryInterface $registry, ClassMetadata $classMetadata, MetadataInterface $metadata)
+    {
+        $registry->getByClass('Foo')->willReturn($metadata);
+        $metadata->hasClass('repository')->willReturn(false);
+
+        $classMetadata->setCustomRepositoryClass(Argument::any())->shouldNotBeCalled();
+
+        $this->loadClassMetadata($event);
+    }
+
+    function it_does_not_set_custom_repository_class_if_registry_does_not_have_class(LoadClassMetadataEventArgs $event, RegistryInterface $registry, ClassMetadata $classMetadata)
+    {
+        $registry->getByClass('Foo')->willThrow(\InvalidArgumentException::class);
+
+        $classMetadata->setCustomRepositoryClass(Argument::any())->shouldNotBeCalled();
+
+        $this->loadClassMetadata($event);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?      |  yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #5040
| License         | MIT


I've split the `Load*MetadataSubscriber` out into two different subscribers.
`*MappedSuperClassSubscriber`, which should only run on Sylius entities.
`*RepositoryClassSubscriber`, which should run on all entities.

Unfortunately there are no existing specs for mapped super class stuff.