### PR TITLE
[Order] Cleanups in Order component

### DIFF
--- a/src/Sylius/Component/Cart/Model/Cart.php
+++ b/src/Sylius/Component/Cart/Model/Cart.php
@@ -14,10 +14,6 @@ namespace Sylius\Component\Cart\Model;
 use Sylius\Component\Order\Model\Order;
 
 /**
- * Model for carts.
- * All driver entities and documents should extend this class or implement
- * proper interface.
- *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
 class Cart extends Order implements CartInterface
@@ -39,7 +35,7 @@ class Cart extends Order implements CartInterface
      */
     public function getIdentifier()
     {
-        return parent::getId();
+        return $this->getId();
     }
 
     /**

--- a/src/Sylius/Component/Cart/Model/CartItem.php
+++ b/src/Sylius/Component/Cart/Model/CartItem.php
@@ -14,8 +14,6 @@ namespace Sylius\Component\Cart\Model;
 use Sylius\Component\Order\Model\OrderItem;
 
 /**
- * Model for cart items.
- *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
 class CartItem extends OrderItem implements CartItemInterface

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -118,8 +118,6 @@ class Order extends Cart implements OrderInterface
     public function setCustomer(BaseCustomerInterface $customer = null)
     {
         $this->customer = $customer;
-
-        return $this;
     }
 
     /**
@@ -399,8 +397,6 @@ class Order extends Cart implements OrderInterface
     public function setCurrency($currency)
     {
         $this->currency = $currency;
-
-        return $this;
     }
 
     /**
@@ -417,8 +413,6 @@ class Order extends Cart implements OrderInterface
     public function setExchangeRate($exchangeRate)
     {
         $this->exchangeRate = (float) $exchangeRate;
-
-        return $this;
     }
 
     /**
@@ -435,8 +429,6 @@ class Order extends Cart implements OrderInterface
     public function setShippingState($state)
     {
         $this->shippingState = $state;
-
-        return $this;
     }
 
     /**
@@ -502,8 +494,6 @@ class Order extends Cart implements OrderInterface
         if (!$this->hasPromotion($promotion)) {
             $this->promotions->add($promotion);
         }
-
-        return $this;
     }
 
     /**
@@ -514,8 +504,6 @@ class Order extends Cart implements OrderInterface
         if ($this->hasPromotion($promotion)) {
             $this->promotions->removeElement($promotion);
         }
-
-        return $this;
     }
 
     /**

--- a/src/Sylius/Component/Core/Model/OrderItemUnit.php
+++ b/src/Sylius/Component/Core/Model/OrderItemUnit.php
@@ -13,6 +13,7 @@ namespace Sylius\Component\Core\Model;
 
 use Sylius\Component\Inventory\Model\InventoryUnitInterface;
 use Sylius\Component\Order\Model\OrderItemUnit as BaseOrderItemUnit;
+use Sylius\Component\Resource\Model\TimestampableTrait;
 use Sylius\Component\Shipping\Model\ShipmentInterface as BaseShipmentInterface;
 
 /**
@@ -20,6 +21,8 @@ use Sylius\Component\Shipping\Model\ShipmentInterface as BaseShipmentInterface;
  */
 class OrderItemUnit extends BaseOrderItemUnit implements OrderItemUnitInterface
 {
+    use TimestampableTrait;
+
     /**
      * @var string InventoryUnitInterface::STATE_*
      */
@@ -34,16 +37,6 @@ class OrderItemUnit extends BaseOrderItemUnit implements OrderItemUnitInterface
      * @var string BaseShipmentInterface::STATE_*
      */
     protected $shippingState = BaseShipmentInterface::STATE_CHECKOUT;
-
-    /**
-     * @var \DateTime
-     */
-    protected $createdAt;
-
-    /**
-     * @var \DateTime
-     */
-    protected $updatedAt;
 
     /**
      * @param OrderItemInterface $orderItem
@@ -141,37 +134,5 @@ class OrderItemUnit extends BaseOrderItemUnit implements OrderItemUnitInterface
     public function setShippingState($state)
     {
         $this->shippingState = $state;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getCreatedAt()
-    {
-        return $this->createdAt;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setCreatedAt(\DateTime $createdAt)
-    {
-        $this->createdAt = $createdAt;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getUpdatedAt()
-    {
-        return $this->updatedAt;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setUpdatedAt(\DateTime $updatedAt)
-    {
-        $this->updatedAt = $updatedAt;
     }
 }

--- a/src/Sylius/Component/Order/Model/AdjustableInterface.php
+++ b/src/Sylius/Component/Order/Model/AdjustableInterface.php
@@ -47,8 +47,6 @@ interface AdjustableInterface
      */
     public function removeAdjustments($type);
 
-    public function clearAdjustments();
-
     /**
      * Recalculates adjustments total. Should be used after adjustment change.
      */

--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -299,14 +299,6 @@ class Order implements OrderInterface
     /**
      * {@inheritdoc}
      */
-    public function getTotalItems()
-    {
-        return $this->countItems();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getTotalQuantity()
     {
         $quantity = 0;
@@ -466,15 +458,6 @@ class Order implements OrderInterface
 
             $this->removeAdjustment($adjustment);
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function clearAdjustments()
-    {
-        $this->adjustments->clear();
-        $this->recalculateAdjustmentsTotal();
     }
 
     /**

--- a/src/Sylius/Component/Order/Model/OrderInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderInterface.php
@@ -92,13 +92,6 @@ interface OrderInterface extends
     public function getTotal();
 
     /**
-     * Alias of {@link countItems()}.
-     *
-     * @deprecated To be removed in 1.0. Use {@link countItems()} instead.
-     */
-    public function getTotalItems();
-
-    /**
      * @return int
      */
     public function getTotalQuantity();

--- a/src/Sylius/Component/Order/Model/OrderItem.php
+++ b/src/Sylius/Component/Order/Model/OrderItem.php
@@ -13,6 +13,7 @@ namespace Sylius\Component\Order\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Webmozart\Assert\Assert;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -140,9 +141,7 @@ class OrderItem implements OrderItemInterface
      */
     public function setUnitPrice($unitPrice)
     {
-        if (!is_int($unitPrice)) {
-            throw new \InvalidArgumentException('Unit price must be an integer.');
-        }
+        Assert::integer($unitPrice, 'Unit price must be an integer.');
 
         $this->unitPrice = $unitPrice;
         $this->recalculateUnitsTotal();
@@ -353,10 +352,6 @@ class OrderItem implements OrderItemInterface
     public function removeAdjustments($type)
     {
         foreach ($this->getAdjustments($type) as $adjustment) {
-            if ($adjustment->isLocked()) {
-                continue;
-            }
-
             $this->removeAdjustment($adjustment);
         }
     }
@@ -370,15 +365,6 @@ class OrderItem implements OrderItemInterface
         foreach ($this->units as $unit) {
             $unit->removeAdjustments($type);
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function clearAdjustments()
-    {
-        $this->adjustments->clear();
-        $this->recalculateAdjustmentsTotal();
     }
 
     /**

--- a/src/Sylius/Component/Order/Model/OrderItemInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderItemInterface.php
@@ -37,8 +37,6 @@ interface OrderItemInterface extends AdjustableInterface, OrderAwareInterface, R
     public function setUnitPrice($unitPrice);
 
     /**
-     * Get item total.
-     *
      * @return int
      */
     public function getTotal();

--- a/src/Sylius/Component/Order/Model/OrderItemUnit.php
+++ b/src/Sylius/Component/Order/Model/OrderItemUnit.php
@@ -157,22 +157,8 @@ class OrderItemUnit implements OrderItemUnitInterface
     public function removeAdjustments($type)
     {
         foreach ($this->getAdjustments($type) as $adjustment) {
-            if ($adjustment->isLocked()) {
-                continue;
-            }
-
             $this->removeAdjustment($adjustment);
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function clearAdjustments()
-    {
-        $this->adjustments->clear();
-        $this->recalculateAdjustmentsTotal();
-        $this->orderItem->recalculateUnitsTotal();
     }
 
     /**

--- a/src/Sylius/Component/Order/Model/OrderItemUnitInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderItemUnitInterface.php
@@ -10,17 +10,13 @@
  */
 
 namespace Sylius\Component\Order\Model;
+use Sylius\Component\Resource\Model\ResourceInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-interface OrderItemUnitInterface extends AdjustableInterface
+interface OrderItemUnitInterface extends ResourceInterface, AdjustableInterface
 {
-    /**
-     * @return mixed
-     */
-    public function getId();
-
     /**
      * @return int
      */

--- a/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
@@ -291,26 +291,6 @@ class OrderItemSpec extends ObjectBehavior
         $this->getTotal()->shouldReturn(0);
     }
 
-    function it_has_correct_total_after_adjustments_clear(
-        AdjustmentInterface $adjustment1,
-        AdjustmentInterface $adjustment2
-    ) {
-        $adjustment1->isNeutral()->willReturn(false);
-        $adjustment1->getAmount()->willReturn(200);
-        $adjustment1->setAdjustable($this)->shouldBeCalled();
-
-        $adjustment2->isNeutral()->willReturn(false);
-        $adjustment2->getAmount()->willReturn(300);
-        $adjustment2->setAdjustable($this)->shouldBeCalled();
-
-        $this->addAdjustment($adjustment1);
-        $this->addAdjustment($adjustment2);
-        $this->getTotal()->shouldReturn(500);
-
-        $this->clearAdjustments();
-        $this->getTotal()->shouldReturn(0);
-    }
-
     function it_has_0_total_when_adjustment_decreases_total_under_0(
         AdjustmentInterface $adjustment,
         OrderItemUnitInterface $orderItemUnit1

--- a/src/Sylius/Component/Order/spec/Model/OrderItemUnitSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemUnitSpec.php
@@ -45,6 +45,34 @@ class OrderItemUnitSpec extends ObjectBehavior
         $this->getTotal()->shouldReturn(1000);
     }
 
+    function it_includes_non_neutral_adjustments_in_total(AdjustmentInterface $adjustment, OrderItemInterface $orderItem)
+    {
+        $adjustment->isNeutral()->willReturn(false);
+        $adjustment->getAmount()->willReturn(400);
+
+        $orderItem->recalculateUnitsTotal()->shouldBeCalled();
+        $adjustment->setAdjustable($this)->shouldBeCalled();
+
+        $this->addAdjustment($adjustment);
+
+        $this->getTotal()->shouldReturn(1400);
+    }
+
+    function it_returns_0_as_total_even_when_adjustments_decreases_it_below_0(
+        AdjustmentInterface $adjustment,
+        OrderItemInterface $orderItem
+    ) {
+        $adjustment->isNeutral()->willReturn(false);
+        $adjustment->getAmount()->willReturn(-1400);
+
+        $orderItem->recalculateUnitsTotal()->shouldBeCalled();
+        $adjustment->setAdjustable($this)->shouldBeCalled();
+
+        $this->addAdjustment($adjustment);
+
+        $this->getTotal()->shouldReturn(0);
+    }
+
     function it_adds_and_removes_adjustments(AdjustmentInterface $adjustment, OrderItemInterface $orderItem)
     {
         $orderItem->recalculateUnitsTotal()->shouldBeCalled();
@@ -111,30 +139,6 @@ class OrderItemUnitSpec extends ObjectBehavior
         $this->removeAdjustment($adjustment1);
 
         $this->getTotal()->shouldReturn(1300);
-    }
-
-    function it_has_correct_total_after_adjustments_clear(
-        AdjustmentInterface $adjustment1,
-        AdjustmentInterface $adjustment2,
-        OrderItemInterface $orderItem
-    ) {
-        $orderItem->recalculateUnitsTotal()->shouldBeCalled(3);
-
-        $adjustment1->isNeutral()->willReturn(false);
-        $adjustment1->getAmount()->willReturn(200);
-        $adjustment1->setAdjustable($this)->shouldBeCalled();
-
-        $adjustment2->isNeutral()->willReturn(false);
-        $adjustment2->getAmount()->willReturn(300);
-        $adjustment2->setAdjustable($this)->shouldBeCalled();
-
-        $this->addAdjustment($adjustment1);
-        $this->addAdjustment($adjustment2);
-
-        $this->getTotal()->shouldReturn(1500);
-
-        $this->clearAdjustments();
-        $this->getTotal()->shouldReturn(1000);
     }
 
     function it_has_correct_total_after_neutral_adjustment_add_and_remove(

--- a/src/Sylius/Component/Order/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderSpec.php
@@ -444,15 +444,4 @@ class OrderSpec extends ObjectBehavior
         $this->clearItems();
         $this->shouldBeEmpty();
     }
-
-    function it_should_be_able_to_clear_adjustments(AdjustmentInterface $adjustment)
-    {
-        $this->hasAdjustment($adjustment)->shouldReturn(false);
-        $this->addAdjustment($adjustment);
-        $this->hasAdjustment($adjustment)->shouldReturn(true);
-
-        $this->clearAdjustments();
-
-        $this->hasAdjustment($adjustment)->shouldReturn(false);
-    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Related tickets |
| License         | MIT

* [x] Removed `clearAdjustments` method from `AdjustableInterface` (it is not used anywhere and shouldn't. I don't see any use case where we would want to remove all adjustments regardless of type)
* [x] Removed `getTotalItems` method from `OrderInterface` (it's not used and it's deprecated)
* [x] Removed redundant check for `isLocked` on adjustment in `removeAdjustments` methods