### PR TITLE
[ResourceBundle] Fix template not found issue

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfiguration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfiguration.php
@@ -98,7 +98,13 @@ class RequestConfiguration
      */
     public function getDefaultTemplate($name)
     {
-        return sprintf('%s:%s.%s', $this->metadata->getTemplatesNamespace() ?: ':', $name, 'twig');
+        $templatesNamespace = $this->metadata->getTemplatesNamespace();
+
+        if (false !== strpos($templatesNamespace, ':')) {
+            return sprintf('%s:%s.%s', $templatesNamespace ?: ':', $name, 'twig');
+        }
+
+        return sprintf('%s/%s.%s', $templatesNamespace, $name, 'twig');
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -168,7 +168,7 @@ class ResourceController extends Controller
 
         if ($configuration->isHtmlRequest()) {
             $view
-                ->setTemplate($configuration->getTemplate(ResourceActions::SHOW))
+                ->setTemplate($configuration->getTemplate(ResourceActions::SHOW . '.html'))
                 ->setTemplateVar($this->metadata->getName())
                 ->setData([
                     'configuration' => $configuration,
@@ -198,7 +198,7 @@ class ResourceController extends Controller
 
         if ($configuration->isHtmlRequest()) {
             $view
-                ->setTemplate($configuration->getTemplate(ResourceActions::INDEX))
+                ->setTemplate($configuration->getTemplate(ResourceActions::INDEX . '.html'))
                 ->setTemplateVar($this->metadata->getPluralName())
                 ->setData([
                     'configuration' => $configuration,
@@ -264,7 +264,7 @@ class ResourceController extends Controller
                 $this->metadata->getName() => $newResource,
                 'form' => $form->createView(),
             ])
-            ->setTemplate($configuration->getTemplate(ResourceActions::CREATE))
+            ->setTemplate($configuration->getTemplate(ResourceActions::CREATE . '.html'))
         ;
 
         return $this->viewHandler->handle($configuration, $view);
@@ -322,7 +322,7 @@ class ResourceController extends Controller
                 $this->metadata->getName() => $resource,
                 'form' => $form->createView(),
             ])
-            ->setTemplate($configuration->getTemplate(ResourceActions::UPDATE))
+            ->setTemplate($configuration->getTemplate(ResourceActions::UPDATE . '.html'))
         ;
 
         return $this->viewHandler->handle($configuration, $view);

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationSpec.php
@@ -72,6 +72,17 @@ class RequestConfigurationSpec extends ObjectBehavior
         $this->getDefaultTemplate('custom.html')->shouldReturn('SyliusAdminBundle:Product:custom.html.twig');
     }
 
+    function it_returns_default_template_names_for_a_directory_based_templates(MetadataInterface $metadata)
+    {
+        $metadata->getTemplatesNamespace()->willReturn('book/Backend');
+
+        $this->getDefaultTemplate('index.html')->shouldReturn('book/Backend/index.html.twig');
+        $this->getDefaultTemplate('show.html')->shouldReturn('book/Backend/show.html.twig');
+        $this->getDefaultTemplate('create.html')->shouldReturn('book/Backend/create.html.twig');
+        $this->getDefaultTemplate('update.html')->shouldReturn('book/Backend/update.html.twig');
+        $this->getDefaultTemplate('custom.html')->shouldReturn('book/Backend/custom.html.twig');
+    }
+
     function it_takes_the_custom_template_if_specified(MetadataInterface $metadata, Parameters $parameters)
     {
         $metadata->getTemplatesNamespace()->willReturn('SyliusAdminBundle:Product');

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
@@ -165,7 +165,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::SHOW)->willReturn('SyliusShopBundle:Product:show.html.twig');
+        $configuration->getTemplate(ResourceActions::SHOW . '.html')->willReturn('SyliusShopBundle:Product:show.html.twig');
 
         $eventDispatcher->dispatch(ResourceActions::SHOW, $configuration, $resource)->shouldBeCalled();
 
@@ -262,7 +262,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.index')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::INDEX)->willReturn('SyliusShopBundle:Product:index.html.twig');
+        $configuration->getTemplate(ResourceActions::INDEX . '.html')->willReturn('SyliusShopBundle:Product:index.html.twig');
         $resourcesCollectionProvider->get($configuration, $repository)->willReturn([$resource1, $resource2]);
 
         $expectedView = View::create()
@@ -325,7 +325,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::CREATE)->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -374,7 +374,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::CREATE)->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -424,7 +424,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(false);
-        $configuration->getTemplate(ResourceActions::CREATE)->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -469,7 +469,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::CREATE)->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -522,7 +522,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::CREATE)->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -572,7 +572,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(false);
-        $configuration->getTemplate(ResourceActions::CREATE)->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -623,7 +623,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(false);
-        $configuration->getTemplate(ResourceActions::CREATE)->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -714,7 +714,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::UPDATE)->willReturn('SyliusShopBundle:Product:update.html.twig');
+        $configuration->getTemplate(ResourceActions::UPDATE . '.html')->willReturn('SyliusShopBundle:Product:update.html.twig');
 
         $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
         $resourceFormFactory->create($configuration, $resource)->willReturn($form);
@@ -766,7 +766,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::UPDATE)->willReturn('SyliusShopBundle:Product:update.html.twig');
+        $configuration->getTemplate(ResourceActions::UPDATE . '.html')->willReturn('SyliusShopBundle:Product:update.html.twig');
 
         $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
         $resourceFormFactory->create($configuration, $resource)->willReturn($form);
@@ -916,7 +916,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::UPDATE)->willReturn('SyliusShopBundle:Product:update.html.twig');
+        $configuration->getTemplate(ResourceActions::UPDATE . '.html')->willReturn('SyliusShopBundle:Product:update.html.twig');
 
         $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
         $resourceFormFactory->create($configuration, $resource)->willReturn($form);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #4800 
| License         | MIT

Fixes errors raised for a new resource with custom template path different than a default one (with colons, e.g. `SyliusAdminBundle:Product`).  
Now the template is being found also under `app/Resources/views` directory.
I've noticed also a `.html` part was lost during one of the last commits in `ResourceController`. That's fixed as well.

All configurations should work now assuming correct twig files in place:
```
sylius_resource:
    resources:
        app.book:
            templates: book/Backend
            classes:
                model: AppBundle\Entity\Book
        app.artist:
            templates: AppBundle:artist
            classes:
                model: AppBundle\Entity\Artist
        app.author:
            classes:
                model: AppBundle\Entity\Author
```
