### PR TITLE
[WIP] [Order] Order improvements

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/_items.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/_items.html.twig
@@ -89,8 +89,7 @@
         </th>
         <th colspan="4" id="shipping-total" class="right aligned">
             <strong>{{ 'sylius.ui.shipping_total'|trans }}</strong>:
-            {% set shippingTotal = order.adjustmentsTotal(taxAdjustment) + order.adjustmentsTotal(shippingAdjustment) %}
-            {{ shippingTotal|sylius_price(order.currency) }}
+            {{ order.shippingTotal|sylius_price(order.currency) }}
         </th>
     </tr>
     <tr>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/_items.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/_items.html.twig
@@ -130,7 +130,7 @@
         </th>
         <th colspan="4" id="promotion-total" class="right aligned">
             <strong>{{ 'sylius.ui.promotion_total'|trans }}</strong>:
-            {% set orderDiscount = order.adjustmentsTotal(orderPromotionAdjustment) %}
+            {% set orderDiscount = order.orderPromotionTotal %}
             {% if not orderDiscount == 0 %}-{% endif %}{{ (-1 * orderDiscount)|sylius_price(order.currency) }}
         </th>
     </tr>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/_items.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/_items.html.twig
@@ -53,7 +53,7 @@
                 {{ (item.unitPrice * item.quantity)|sylius_price(order.currency) }}
             </td>
             <td class="center aligned">
-                {{ item.getAdjustmentsTotalRecursively(taxAdjustment)|sylius_price(order.currency) }}
+                {{ item.taxTotal|sylius_price(order.currency) }}
             </td>
             <td class="center aligned discount">
                 {% set itemDiscount = item.getAdjustmentsTotalRecursively(itemPromotionAdjustment) %}
@@ -111,7 +111,7 @@
         </th>
         <th colspan="4" id="tax-total" class="right aligned">
             <strong>{{ 'sylius.ui.tax_total'|trans }}</strong>:
-            {{ order.getAdjustmentsTotalRecursively(taxAdjustment)|sylius_price(order.currency) }}
+            {{ order.taxTotal|sylius_price(order.currency) }}
         </th>
     </tr>
     <tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
@@ -148,7 +148,7 @@
         </td>
         <td class="text-right" colspan="3">
             <strong>{{ 'sylius.ui.shipping_total'|trans }}</strong>:
-            <span class="amount">{{ order.adjustmentsTotal(shippingAdjustment)|sylius_price(order.currency) }}</span>
+            <span class="amount">{{ order.shippingTotal|sylius_price(order.currency) }}</span>
         </td>
     </tr>
     <tr class="promotion-discount">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
@@ -130,7 +130,7 @@
         </td>
         <td class="text-right" colspan="3">
             <strong>{{ 'sylius.ui.tax_total'|trans }}</strong>:
-            <span class="amount">{{ order.getAdjustmentsTotalRecursively(taxAdjustment)|sylius_price(order.currency) }}</span>
+            <span class="amount">{{ order.taxTotal|sylius_price(order.currency) }}</span>
         </td>
     </tr>
     <tr class="shipping-charges">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
@@ -166,7 +166,7 @@
         </td>
         <td class="text-right" colspan="3">
             <strong>{{ 'sylius.ui.promotion_total'|trans }}</strong>:
-            <span class="amount">{{ order.adjustmentsTotal(promotionAdjustment)|sylius_price(order.currency) }}</span>
+            <span class="amount">{{ order.orderPromotionTotal|sylius_price(order.currency) }}</span>
         </td>
     </tr>
     {% if not order.adjustments.isEmpty() %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
@@ -139,7 +139,7 @@
             </td>
             <td class="text-right" colspan="3">
                 <strong>{{ 'sylius.ui.tax_total'|trans }}</strong>:
-                <span class="amount">{{ order.getAdjustmentsTotalRecursively(taxAdjustment)|sylius_price(order.currency) }}</span>
+                <span class="amount">{{ order.taxTotal|sylius_price(order.currency) }}</span>
             </td>
         </tr>
         <tr class="shipping-charges">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
@@ -157,7 +157,7 @@
             </td>
             <td class="text-right" colspan="3">
                 <strong>{{ 'sylius.ui.shipping_total'|trans }}</strong>:
-                <span class="amount">{{ order.adjustmentsTotal(shippingAdjustment)|sylius_price(order.currency) }}</span>
+                <span class="amount">{{ order.shippingTotal|sylius_price(order.currency) }}</span>
             </td>
         </tr>
         <tr class="promotion-discount">
@@ -175,7 +175,7 @@
             </td>
             <td class="text-right" colspan="3">
                 <strong>{{ 'sylius.ui.promotion_total'|trans }}</strong>:
-                <span class="amount">{{ order.getPromotionsTotalRecursively()|sylius_price(order.currency) }}</span>
+                <span class="amount">{{ order.orderPromotionTotal|sylius_price(order.currency) }}</span>
             </td>
         </tr>
         {% if not order.adjustments().isEmpty() %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/show.html.twig
@@ -51,7 +51,7 @@
                 </tr>
                 <tr>
                     <td><strong>{{ 'sylius.ui.shipping_total'|trans }}</strong></td>
-                    <td>{{ order.adjustmentsTotal(shippingAdjustment)|sylius_price(order.currency) }}</td>
+                    <td>{{ order.shippingTotal|sylius_price(order.currency) }}</td>
                 </tr>
                 <tr>
                     <td><strong>{{ 'sylius.ui.state'|trans }}</strong></td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
@@ -72,7 +72,7 @@
                         {{ 'sylius.ui.shipping_total'|trans }}
                     </span>
                 </td>
-                <td>{{ order.adjustmentsTotal(shippingAdjustment)|sylius_money(order.currency) }}</td>
+                <td>{{ order.shippingTotal|sylius_money(order.currency) }}</td>
             </tr>
             <tr>
                 <td colspan="3">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
@@ -80,7 +80,7 @@
                         {{ 'sylius.ui.promotion_total'|trans }}
                     </span>
                 </td>
-                <td>{{ order.getPromotionsTotalRecursively()|sylius_money(order.currency) }}</td>
+                <td>{{ order.orderPromotionTotal|sylius_money(order.currency) }}</td>
             </tr>
             <tr>
                 <th colspan="3">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
@@ -64,7 +64,7 @@
                         {{ 'sylius.ui.tax_total'|trans }}
                     </span>
                 </td>
-                <td>{{ order.getAdjustmentsTotalRecursively(taxAdjustment)|sylius_money(order.currency) }}</td>
+                <td>{{ order.taxTotal|sylius_money(order.currency) }}</td>
             </tr>
             <tr>
                 <td colspan="3">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
@@ -52,8 +52,7 @@
         {% endif %}
         <tr>
             <td colspan="6" style="text-align: right;">
-                {% set shippingTotal = cart.adjustmentsTotal(taxAdjustment) + cart.adjustmentsTotal(shippingAdjustment) %}
-                <strong>{{ 'sylius.ui.shipping_total'|trans }}</strong>: {{ shippingTotal|sylius_price }}
+                <strong>{{ 'sylius.ui.shipping_total'|trans }}</strong>: {{ cart.shippingTotal|sylius_price }}
             </td>
         </tr>
         <tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
@@ -68,7 +68,7 @@
                 </ul>
             </td>
             <td colspan="2" style="text-align: right;">
-                <strong>{{ 'sylius.ui.tax_total'|trans }}</strong>: {{ cart.getAdjustmentsTotalRecursively(taxAdjustment)|sylius_price }}
+                <strong>{{ 'sylius.ui.tax_total'|trans }}</strong>: {{ cart.taxTotal|sylius_price }}
             </td>
         </tr>
         <tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
@@ -42,7 +42,7 @@
         {% endfor %}
     </tbody>
     <tfoot>
-        {% set promotionTotal = cart.getPromotionsTotalRecursively() %}
+        {% set promotionTotal = cart.orderPromotionTotal %}
         {% if promotionTotal %}
         <tr>
             <td colspan="6" style="text-align: right;">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
@@ -65,7 +65,7 @@
             </td>
             <td colspan="2">
                 <span class="pull-right">
-                <strong>{{ 'sylius.ui.tax_total'|trans }}</strong>: {{ order.getAdjustmentsTotalRecursively(taxAdjustment)|sylius_price }}
+                <strong>{{ 'sylius.ui.tax_total'|trans }}</strong>: {{ order.taxTotal|sylius_price }}
                 </span>
             </td>
         </tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
@@ -96,10 +96,9 @@
                 {% endfor %}
                 </ul>
                 </td>
-                {% set promotionTotal = order.getPromotionsTotalRecursively() %}
                 <td colspan="2">
                     <span class="pull-right">
-                    <strong>{{ 'sylius.ui.promotion_total'|trans }}</strong>: -{{ (-1 * promotionTotal)|sylius_price }}
+                    <strong>{{ 'sylius.ui.promotion_total'|trans }}</strong>: -{{ (-1 * order.orderPromotionTotal)|sylius_price }}
                     </span>
                 </td>
             </tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
@@ -82,8 +82,7 @@
             </td>
             <td colspan="2">
                 <span class="pull-right">
-                    {% set shippingTotal = order.adjustmentsTotal(taxAdjustment) + order.adjustmentsTotal(shippingAdjustment) %}
-                    <strong>{{ 'sylius.ui.shipping_total'|trans }}</strong>: {{ shippingTotal|sylius_price }}
+                    <strong>{{ 'sylius.ui.shipping_total'|trans }}</strong>: {{ order.shippingTotal|sylius_price }}
                 </span>
             </td>
         </tr>

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -527,17 +527,6 @@ class Order extends Cart implements OrderInterface
     }
 
     /**
-     * @return int
-     */
-    public function getPromotionsTotalRecursively()
-    {
-        return
-            $this->getAdjustmentsTotalRecursively(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT) +
-            $this->getAdjustmentsTotalRecursively(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)
-        ;
-    }
-
-    /**
      * Returns sum of neutral and non neutral tax adjustments on order and total tax of order items.
      *
      * {@inheritdoc}
@@ -556,14 +545,36 @@ class Order extends Cart implements OrderInterface
         return $taxTotal;
     }
 
+    /**
+     * Returns shipping fee together with taxes decreased by shipping discount.
+     *
+     * @return int
+     */
     public function getShippingTotal()
     {
         $shippingTotal = $this->getAdjustmentsTotal(AdjustmentInterface::TAX_ADJUSTMENT);
+        $shippingTotal += $this->getAdjustmentsTotal(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT);
 
         foreach ($this->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT) as $shippingAdjustment) {
             $shippingTotal += $shippingAdjustment->getAmount();
         }
 
         return $shippingTotal;
+    }
+
+    /**
+     * Returns amount of order discount. Does not include order item and shipping discounts.
+     *
+     * @return int
+     */
+    public function getOrderPromotionTotal()
+    {
+        $orderPromotionTotal = 0;
+
+        foreach ($this->items as $item) {
+            $orderPromotionTotal += $item->getAdjustmentsTotalRecursively(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT);
+        }
+
+        return $orderPromotionTotal;
     }
 }

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -536,4 +536,24 @@ class Order extends Cart implements OrderInterface
             $this->getAdjustmentsTotalRecursively(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)
         ;
     }
+
+    /**
+     * Returns sum of neutral and non neutral tax adjustments on order and total tax of order items.
+     *
+     * {@inheritdoc}
+     */
+    public function getTaxTotal()
+    {
+        $taxTotal = 0;
+
+        foreach ($this->getAdjustments(AdjustmentInterface::TAX_ADJUSTMENT) as $taxAdjustment) {
+            $taxTotal += $taxAdjustment->getAmount();
+        }
+
+        foreach ($this->items as $item) {
+            $taxTotal += $item->getTaxTotal();
+        }
+
+        return $taxTotal;
+    }
 }

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -549,11 +549,21 @@ class Order extends Cart implements OrderInterface
         foreach ($this->getAdjustments(AdjustmentInterface::TAX_ADJUSTMENT) as $taxAdjustment) {
             $taxTotal += $taxAdjustment->getAmount();
         }
-
         foreach ($this->items as $item) {
             $taxTotal += $item->getTaxTotal();
         }
 
         return $taxTotal;
+    }
+
+    public function getShippingTotal()
+    {
+        $shippingTotal = $this->getAdjustmentsTotal(AdjustmentInterface::TAX_ADJUSTMENT);
+
+        foreach ($this->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT) as $shippingAdjustment) {
+            $shippingTotal += $shippingAdjustment->getAmount();
+        }
+
+        return $shippingTotal;
     }
 }

--- a/src/Sylius/Component/Core/Model/OrderInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderInterface.php
@@ -178,4 +178,9 @@ interface OrderInterface extends
      * @return bool
      */
     public function isInvoiceAvailable();
+
+    /**
+     * @return int
+     */
+    public function getTaxTotal();
 }

--- a/src/Sylius/Component/Core/Model/OrderInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderInterface.php
@@ -143,11 +143,6 @@ interface OrderInterface extends
     public function setPromotionCoupon(BaseCouponInterface $coupon = null);
 
     /**
-     * @return int
-     */
-    public function getPromotionsTotalRecursively();
-
-    /**
      * @return string
      */
     public function getShippingState();
@@ -183,4 +178,14 @@ interface OrderInterface extends
      * @return int
      */
     public function getTaxTotal();
+
+    /**
+     * @return int
+     */
+    public function getShippingTotal();
+
+    /**
+     * @return int
+     */
+    public function getOrderPromotionTotal();
 }

--- a/src/Sylius/Component/Core/Model/OrderItem.php
+++ b/src/Sylius/Component/Core/Model/OrderItem.php
@@ -57,4 +57,24 @@ class OrderItem extends CartItem implements OrderItemInterface
             && $item->getVariant() === $this->variant
         );
     }
+
+    /**
+     * Returns sum of neutral and non neutral tax adjustments on order item and total tax of units.
+     *
+     * {@inheritdoc}
+     */
+    public function getTaxTotal()
+    {
+        $taxTotal = 0;
+
+        foreach ($this->getAdjustments(AdjustmentInterface::TAX_ADJUSTMENT) as $taxAdjustment) {
+            $taxTotal += $taxAdjustment->getAmount();
+        }
+
+        foreach ($this->units as $unit) {
+            $taxTotal += $unit->getTaxTotal();
+        }
+
+        return $taxTotal;
+    }
 }

--- a/src/Sylius/Component/Core/Model/OrderItemInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderItemInterface.php
@@ -32,4 +32,9 @@ interface OrderItemInterface extends CartItemInterface
      * @param ProductVariantInterface $variant
      */
     public function setVariant(ProductVariantInterface $variant);
+
+    /**
+     * @return int
+     */
+    public function getTaxTotal();
 }

--- a/src/Sylius/Component/Core/Model/OrderItemUnit.php
+++ b/src/Sylius/Component/Core/Model/OrderItemUnit.php
@@ -174,4 +174,20 @@ class OrderItemUnit extends BaseOrderItemUnit implements OrderItemUnitInterface
     {
         $this->updatedAt = $updatedAt;
     }
+
+    /**
+     * Returns sum of neutral and non neutral tax adjustments.
+     *
+     * {@inheritdoc}
+     */
+    public function getTaxTotal()
+    {
+        $taxTotal = 0;
+
+        foreach ($this->getAdjustments(AdjustmentInterface::TAX_ADJUSTMENT) as $taxAdjustment) {
+            $taxTotal += $taxAdjustment->getAmount();
+        }
+
+        return $taxTotal;
+    }
 }

--- a/src/Sylius/Component/Core/Model/OrderItemUnitInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderItemUnitInterface.php
@@ -20,4 +20,8 @@ use Sylius\Component\Shipping\Model\ShipmentUnitInterface;
  */
 interface OrderItemUnitInterface extends BaseOrderItemUnitInterface, InventoryUnitInterface, ShipmentUnitInterface
 {
+    /**
+     * @return int
+     */
+    public function getTaxTotal();
 }

--- a/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace spec\Sylius\Component\Core\Model;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Core\Model\OrderItemUnitInterface;
+
+/**
+ * @mixin \Sylius\Component\Core\Model\OrderItem
+ */
+class OrderItemSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Core\Model\OrderItem');
+    }
+
+    function it_returns_0_tax_total_when_there_are_no_units()
+    {
+        $this->getTaxTotal()->shouldReturn(0);
+    }
+
+    function it_returns_tax_of_all_unit(OrderItemUnitInterface $orderItemUnit1, OrderItemUnitInterface $orderItemUnit2)
+    {
+        $orderItemUnit1->getTotal()->willReturn(1200);
+        $orderItemUnit1->getTaxTotal()->willReturn(200);
+        $orderItemUnit1->getOrderItem()->willReturn($this);
+        $orderItemUnit2->getTotal()->willReturn(1120);
+        $orderItemUnit2->getTaxTotal()->willReturn(120);
+        $orderItemUnit2->getOrderItem()->willReturn($this);
+
+        $this->addUnit($orderItemUnit1);
+        $this->addUnit($orderItemUnit2);
+
+        $this->getTaxTotal()->shouldReturn(320);
+    }
+
+    function it_returns_tax_of_all_units_and_both_neutral_and_non_neutral_tax_adjustments(
+        OrderItemUnitInterface $orderItemUnit1,
+        OrderItemUnitInterface $orderItemUnit2,
+        AdjustmentInterface $nonNeutralTaxAdjustment,
+        AdjustmentInterface $neutralTaxAdjustment
+    ) {
+        $orderItemUnit1->getTotal()->willReturn(1200);
+        $orderItemUnit1->getTaxTotal()->willReturn(200);
+        $orderItemUnit1->getOrderItem()->willReturn($this);
+        $orderItemUnit2->getTotal()->willReturn(1120);
+        $orderItemUnit2->getTaxTotal()->willReturn(120);
+        $orderItemUnit2->getOrderItem()->willReturn($this);
+
+        $this->addUnit($orderItemUnit1);
+        $this->addUnit($orderItemUnit2);
+
+        $neutralTaxAdjustment->isNeutral()->willReturn(true);
+        $neutralTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $neutralTaxAdjustment->getAmount()->willReturn(200);
+        $nonNeutralTaxAdjustment->isNeutral()->willReturn(false);
+        $nonNeutralTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $nonNeutralTaxAdjustment->getAmount()->willReturn(300);
+
+        $neutralTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $nonNeutralTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $this->addAdjustment($neutralTaxAdjustment);
+        $this->addAdjustment($nonNeutralTaxAdjustment);
+
+        $this->getTaxTotal()->shouldReturn(820);
+    }
+}

--- a/src/Sylius/Component/Core/spec/Model/OrderItemUnitSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderItemUnitSpec.php
@@ -13,6 +13,7 @@ namespace spec\Sylius\Component\Core\Model;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -22,6 +23,8 @@ use Sylius\Component\Shipping\Model\ShipmentInterface;
 use Sylius\Component\Shipping\Model\ShipmentUnitInterface;
 
 /**
+ * @mixin \Sylius\Component\Core\Model\OrderItemUnit
+ *
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
 class OrderItemUnitSpec extends ObjectBehavior
@@ -110,5 +113,58 @@ class OrderItemUnitSpec extends ObjectBehavior
     {
         $this->setShippingState(ShipmentInterface::STATE_SHIPPED);
         $this->getShippingState()->shouldReturn(ShipmentInterface::STATE_SHIPPED);
+    }
+
+    function it_returns_0_tax_total_when_there_are_no_tax_adjustments()
+    {
+        $this->getTaxTotal()->shouldReturn(0);
+    }
+
+    function it_returns_sum_of_neutral_and_non_neutral_tax_adjustments_as_tax_total(
+        OrderItemInterface $orderItem,
+        AdjustmentInterface $nonNeutralTaxAdjustment,
+        AdjustmentInterface $neutralTaxAdjustment
+    ) {
+        $neutralTaxAdjustment->isNeutral()->willReturn(true);
+        $neutralTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $neutralTaxAdjustment->getAmount()->willReturn(200);
+        $nonNeutralTaxAdjustment->isNeutral()->willReturn(false);
+        $nonNeutralTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $nonNeutralTaxAdjustment->getAmount()->willReturn(300);
+
+        $orderItem->recalculateUnitsTotal()->shouldBeCalled();
+        $neutralTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $nonNeutralTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $this->addAdjustment($neutralTaxAdjustment);
+        $this->addAdjustment($nonNeutralTaxAdjustment);
+
+        $this->getTaxTotal()->shouldReturn(500);
+    }
+
+    function it_returns_only_sum_of_neutral_and_non_neutral_tax_adjustments_as_tax_total(
+        OrderItemInterface $orderItem,
+        AdjustmentInterface $nonNeutralTaxAdjustment,
+        AdjustmentInterface $neutralTaxAdjustment,
+        AdjustmentInterface $notTaxAdjustment
+    ) {
+        $neutralTaxAdjustment->isNeutral()->willReturn(true);
+        $neutralTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $neutralTaxAdjustment->getAmount()->willReturn(200);
+        $nonNeutralTaxAdjustment->isNeutral()->willReturn(false);
+        $nonNeutralTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $nonNeutralTaxAdjustment->getAmount()->willReturn(300);
+        $notTaxAdjustment->isNeutral()->willReturn(false);
+        $notTaxAdjustment->getType()->willReturn(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT);
+        $notTaxAdjustment->getAmount()->willReturn(100);
+
+        $orderItem->recalculateUnitsTotal()->shouldBeCalled();
+        $neutralTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $nonNeutralTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $notTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $this->addAdjustment($neutralTaxAdjustment);
+        $this->addAdjustment($nonNeutralTaxAdjustment);
+        $this->addAdjustment($notTaxAdjustment);
+
+        $this->getTaxTotal()->shouldReturn(500);
     }
 }

--- a/src/Sylius/Component/Core/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderSpec.php
@@ -443,6 +443,46 @@ class OrderSpec extends ObjectBehavior
         $this->getTaxTotal()->shouldReturn(220);
     }
 
+    function it_includes_non_neutral_tax_adjustments_in_shipping_total(
+        AdjustmentInterface $shippingAdjustment,
+        AdjustmentInterface $shippingTaxAdjustment
+    ) {
+        $shippingAdjustment->getType()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
+        $shippingAdjustment->isNeutral()->willReturn(false);
+        $shippingAdjustment->getAmount()->willReturn(1000);
+
+        $shippingTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $shippingTaxAdjustment->isNeutral()->willReturn(false);
+        $shippingTaxAdjustment->getAmount()->willReturn(70);
+
+        $shippingAdjustment->setAdjustable($this)->shouldBeCalled();
+        $shippingTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $this->addAdjustment($shippingAdjustment);
+        $this->addAdjustment($shippingTaxAdjustment);
+
+        $this->getShippingTotal()->shouldReturn(1070);
+    }
+
+    function it_does_not_include_neutral_tax_adjustments_in_shipping_total(
+        AdjustmentInterface $shippingAdjustment,
+        AdjustmentInterface $neutralShippingTaxAdjustment
+    ) {
+        $shippingAdjustment->getType()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
+        $shippingAdjustment->isNeutral()->willReturn(false);
+        $shippingAdjustment->getAmount()->willReturn(1000);
+
+        $neutralShippingTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $neutralShippingTaxAdjustment->isNeutral()->willReturn(true);
+        $neutralShippingTaxAdjustment->getAmount()->willReturn(70);
+
+        $shippingAdjustment->setAdjustable($this)->shouldBeCalled();
+        $neutralShippingTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $this->addAdjustment($shippingAdjustment);
+        $this->addAdjustment($neutralShippingTaxAdjustment);
+
+        $this->getShippingTotal()->shouldReturn(1000);
+    }
+
     function it_returns_promotions_total_recursively(
         AdjustmentInterface $orderPromotionAdjustment,
         AdjustmentInterface $orderItemPromotionAdjustment,

--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -435,7 +435,9 @@ class Order implements OrderInterface
 
         $total = 0;
         foreach ($this->getAdjustments($type) as $adjustment) {
-            $total += $adjustment->getAmount();
+            if (!$adjustment->isNeutral()) {
+                $total += $adjustment->getAmount();
+            }
         }
 
         return $total;
@@ -448,7 +450,9 @@ class Order implements OrderInterface
     {
         $total = 0;
         foreach ($this->getAdjustmentsRecursively($type) as $adjustment) {
-            $total += $adjustment->getAmount();
+            if (!$adjustment->isNeutral()) {
+                $total += $adjustment->getAmount();
+            }
         }
 
         return $total;

--- a/src/Sylius/Component/Order/Model/OrderItem.php
+++ b/src/Sylius/Component/Order/Model/OrderItem.php
@@ -328,7 +328,9 @@ class OrderItem implements OrderItemInterface
 
         $total = 0;
         foreach ($this->getAdjustments($type) as $adjustment) {
-            $total += $adjustment->getAmount();
+            if (!$adjustment->isNeutral()) {
+                $total += $adjustment->getAmount();
+            }
         }
 
         return $total;
@@ -339,9 +341,12 @@ class OrderItem implements OrderItemInterface
      */
     public function getAdjustmentsTotalRecursively($type = null)
     {
-        $total = $this->getAdjustmentsTotal($type);
-        foreach ($this->units as $unit) {
-            $total += $unit->getAdjustmentsTotal($type);
+        $total = 0;
+
+        foreach ($this->getAdjustmentsRecursively($type) as $adjustment) {
+            if (!$adjustment->isNeutral()) {
+                $total += $adjustment->getAmount();
+            }
         }
 
         return $total;

--- a/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
@@ -11,6 +11,7 @@
 
 namespace spec\Sylius\Component\Order\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Order\Model\AdjustableInterface;
@@ -426,6 +427,8 @@ class OrderItemSpec extends ObjectBehavior
 
     function it_returns_correct_adjustments_total_recursively(
         AdjustmentInterface $adjustment1,
+        AdjustmentInterface $taxAdjustment1,
+        AdjustmentInterface $taxAdjustment2,
         OrderItemUnitInterface $orderItemUnit1,
         OrderItemUnitInterface $orderItemUnit2
     ) {
@@ -433,12 +436,17 @@ class OrderItemSpec extends ObjectBehavior
         $adjustment1->isNeutral()->willReturn(false);
         $adjustment1->setAdjustable($this)->shouldBeCalled();
 
+        $taxAdjustment1->getAmount()->willReturn(150);
+        $taxAdjustment1->isNeutral()->willReturn(false);
+        $taxAdjustment2->getAmount()->willReturn(100);
+        $taxAdjustment2->isNeutral()->willReturn(false);
+
         $orderItemUnit1->getOrderItem()->willReturn($this->getWrappedObject());
         $orderItemUnit1->getTotal()->willReturn(500);
-        $orderItemUnit1->getAdjustmentsTotal(null)->willReturn(150);
+        $orderItemUnit1->getAdjustments(null)->willReturn(new ArrayCollection([$taxAdjustment1->getWrappedObject()]));
         $orderItemUnit2->getOrderItem()->willReturn($this->getWrappedObject());
         $orderItemUnit2->getTotal()->willReturn(300);
-        $orderItemUnit2->getAdjustmentsTotal(null)->willReturn(100);
+        $orderItemUnit2->getAdjustments(null)->willReturn(new ArrayCollection([$taxAdjustment2->getWrappedObject()]));
 
         $this->addAdjustment($adjustment1);
         $this->addUnit($orderItemUnit1);
@@ -449,6 +457,9 @@ class OrderItemSpec extends ObjectBehavior
 
     function it_returns_correct_adjustments_total_by_type_recursively(
         AdjustmentInterface $adjustment1,
+        AdjustmentInterface $promotionAdjustment,
+        AdjustmentInterface $taxAdjustment1,
+        AdjustmentInterface $taxAdjustment2,
         OrderItemUnitInterface $orderItemUnit1,
         OrderItemUnitInterface $orderItemUnit2
     ) {
@@ -457,14 +468,21 @@ class OrderItemSpec extends ObjectBehavior
         $adjustment1->isNeutral()->willReturn(false);
         $adjustment1->setAdjustable($this)->shouldBeCalled();
 
+        $promotionAdjustment->getAmount()->willReturn(30);
+        $promotionAdjustment->isNeutral()->willReturn(false);
+        $taxAdjustment1->getAmount()->willReturn(150);
+        $taxAdjustment1->isNeutral()->willReturn(false);
+        $taxAdjustment2->getAmount()->willReturn(100);
+        $taxAdjustment2->isNeutral()->willReturn(false);
+
         $orderItemUnit1->getOrderItem()->willReturn($this->getWrappedObject());
         $orderItemUnit1->getTotal()->willReturn(500);
-        $orderItemUnit1->getAdjustmentsTotal('tax')->willReturn(150);
-        $orderItemUnit1->getAdjustmentsTotal('promotion')->willReturn(30);
+        $orderItemUnit1->getAdjustments('tax')->willReturn(new ArrayCollection([$taxAdjustment1->getWrappedObject()]));
+        $orderItemUnit1->getAdjustments('promotion')->willReturn(new ArrayCollection([$promotionAdjustment->getWrappedObject()]));
         $orderItemUnit2->getOrderItem()->willReturn($this->getWrappedObject());
         $orderItemUnit2->getTotal()->willReturn(300);
-        $orderItemUnit2->getAdjustmentsTotal('tax')->willReturn(100);
-        $orderItemUnit2->getAdjustmentsTotal('promotion')->willReturn(0);
+        $orderItemUnit2->getAdjustments('tax')->willReturn(new ArrayCollection([$taxAdjustment2->getWrappedObject()]));
+        $orderItemUnit2->getAdjustments('promotion')->willReturn(new ArrayCollection());
 
         $this->addAdjustment($adjustment1);
         $this->addUnit($orderItemUnit1);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Related tickets | 
| License         | MIT

This PR will be included in #4768. It is a first step to get proper amounts for all the stuff on order that we want.

* [x] Added `getTaxTotal` method to `Order` which returns sum of tax adjustments regardless neutrality - useful when you want to know the value of tax that was charged
* [x] Added `getShippingTotal` method to `Order` which returns shipping fee together with shipping tax decreased by shipping discount - useful when you want to know the end value that was charged for shipping
* [x] Made `getAdjustmentsTotal` and `getAdjustmentsTotalRecursively` methods consistent - when called without argument they returned sum of only non neutral adjustments, when called with `$type` argument all adjustments were summed (both non neutral and neutral). Right now always only non neutral adjustments are summed.
* [x] Removed `getPromotionsTotalRecursively` in favor of `getOrderPromotionTotal` - this method returns total amount of order level promotion (e.g. $5 off to every order with items total at least $50.00). This does not include item level promotions (e.g. $1 off every T-Shirt) and does not include shipping discount which is included in `getShippingTotal`.
* [ ] Add `getDiscountedUnitPrice` method to `OrderItem` that will return the unit price decreased by item promotions.
* [ ] Add `getSubtotal` method to `OrderItem` that will return `discountedUnitPrice * quantity`

/cc @peteward 