### PR TITLE
[Doc][ThemeBundle] renamed theme assets command

### DIFF
--- a/docs/bundles/SyliusThemeBundle/important_changes.rst
+++ b/docs/bundles/SyliusThemeBundle/important_changes.rst
@@ -31,7 +31,7 @@ Changed loading order (priority descending):
 Assets
 ------
 
-Theme assets are installed by ``sylius:assets:install`` command, which is supplementary for and should be used after ``assets:install``.
+Theme assets are installed by ``sylius:theme:assets:install`` command, which is supplementary for and should be used after ``assets:install``.
 
 The command run with ``--symlink`` or ``--relative`` parameters creates symlinks for every installed asset file,
 not for entire asset directory (eg. if ``AcmeBundle/Resources/public/asset.js`` exists, it creates symlink ``web/bundles/acme/asset.js`` 


### PR DESCRIPTION
Command `sylius:assets:install` does not exist when using ThemeBundle in a standalone mode. Thus, `sylius:theme:assets:install` should be used.