### PR TITLE
[Metadata] Add hierarchical archetype support to Product Metadata

### DIFF
--- a/src/Sylius/Component/Core/Metadata/HierarchyProvider/ProductHierarchyProvider.php
+++ b/src/Sylius/Component/Core/Metadata/HierarchyProvider/ProductHierarchyProvider.php
@@ -34,6 +34,10 @@ class ProductHierarchyProvider implements MetadataHierarchyProviderInterface
         $productArchetype = $product->getArchetype();
         if (null !== $productArchetype) {
             $hierarchy[] = $productArchetype->getMetadataIdentifier();
+            
+            while ($productArchetype = $productArchetype->getParent()) {
+                $hierarchy[] = $productArchetype->getMetadataIdentifier();
+            }
         }
 
         $hierarchy[] = $product->getMetadataClassIdentifier();

--- a/src/Sylius/Component/Core/spec/Metadata/HierarchyProvider/ProductHierarchyProviderSpec.php
+++ b/src/Sylius/Component/Core/spec/Metadata/HierarchyProvider/ProductHierarchyProviderSpec.php
@@ -53,10 +53,39 @@ class ProductHierarchyProviderSpec extends ObjectBehavior
         $archetype->getMetadataIdentifier()->shouldBeCalled()->willReturn('Archetype-42');
 
         $product->getArchetype()->shouldBeCalled()->willReturn($archetype);
+        $archetype->getParent()->shouldBeCalled()->willReturn(false);
 
         $this->getHierarchyByMetadataSubject($product)->shouldReturn([
             'Product-42',
             'Archetype-42',
+            'Product',
+            'DefaultPage',
+        ]);
+    }
+
+    function it_generates_correct_hierarchy_when_product_has_archetype_hierarcy(
+        ProductInterface $product,
+        ArchetypeInterface $archetype,
+        ArchetypeInterface $parentArchetype,
+        ArchetypeInterface $grandparentArchetype
+    ) {
+        $product->getMetadataIdentifier()->shouldBeCalled()->willReturn('Product-42');
+        $product->getMetadataClassIdentifier()->shouldBeCalled()->willReturn('Product');
+
+        $archetype->getMetadataIdentifier()->shouldBeCalled()->willReturn('Archetype-42');
+        $archetype->getParent()->shouldBeCalled()->willReturn($parentArchetype);
+        $parentArchetype->getMetadataIdentifier()->shouldBeCalled()->willReturn('Archetype-21');
+        $parentArchetype->getParent()->shouldBeCalled()->willReturn($grandparentArchetype);
+        $grandparentArchetype->getMetadataIdentifier()->shouldBeCalled()->willReturn('Archetype-10');
+        $grandparentArchetype->getParent()->shouldBeCalled()->willReturn(false);
+
+        $product->getArchetype()->shouldBeCalled()->willReturn($archetype);
+
+        $this->getHierarchyByMetadataSubject($product)->shouldReturn([
+            'Product-42',
+            'Archetype-42',
+            'Archetype-21',
+            'Archetype-10',
             'Product',
             'DefaultPage',
         ]);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Related tickets | fixes #4483 
| License         | MIT

Allows you to define and use product metadata at any level of the Archetype hierarchy.