### PR TITLE
[Metadata] Add hierarchical archetype support to ProductVariant Metadata

### DIFF
--- a/src/Sylius/Component/Core/Metadata/HierarchyProvider/ProductVariantHierarchyProvider.php
+++ b/src/Sylius/Component/Core/Metadata/HierarchyProvider/ProductVariantHierarchyProvider.php
@@ -42,10 +42,13 @@ class ProductVariantHierarchyProvider implements MetadataHierarchyProviderInterf
         $productArchetype = $product->getArchetype();
         if (null !== $productArchetype) {
             $hierarchy[] = $productArchetype->getMetadataIdentifier();
+
+            while ($productArchetype = $productArchetype->getParent()) {
+                $hierarchy[] = $productArchetype->getMetadataIdentifier();
+            }
         }
 
         $hierarchy[] = $product->getMetadataClassIdentifier();
-
         $hierarchy[] = 'DefaultPage';
 
         return $hierarchy;

--- a/src/Sylius/Component/Core/spec/Metadata/HierarchyProvider/ProductVariantHierarchyProviderSpec.php
+++ b/src/Sylius/Component/Core/spec/Metadata/HierarchyProvider/ProductVariantHierarchyProviderSpec.php
@@ -53,6 +53,7 @@ class ProductVariantHierarchyProviderSpec extends ObjectBehavior
         $product->getMetadataIdentifier()->shouldBeCalled()->willReturn('Product-42');
         $product->getMetadataClassIdentifier()->shouldBeCalled()->willReturn('Product');
 
+        $archetype->getParent()->shouldBeCalled()->willReturn(null);
         $archetype->getMetadataIdentifier()->shouldBeCalled()->willReturn('Archetype-42');
 
         $productVariant->getProduct()->shouldBeCalled()->willReturn($product);
@@ -63,6 +64,40 @@ class ProductVariantHierarchyProviderSpec extends ObjectBehavior
             'ProductVariant-42',
             'Product-42',
             'Archetype-42',
+            'Product',
+            'DefaultPage',
+        ]);
+    }
+
+    function it_generates_correct_hierarchy_when_product_variant_has_archetype_hierarcy(
+        ProductVariantInterface $productVariant,
+        ProductInterface $product,
+        ArchetypeInterface $archetype,
+        ArchetypeInterface $parentArchetype,
+        ArchetypeInterface $grandparentArchetype
+    ) {
+        $productVariant->getMetadataIdentifier()->shouldBeCalled()->willReturn('ProductVariant-42');
+
+        $product->getMetadataIdentifier()->shouldBeCalled()->willReturn('Product-42');
+        $product->getMetadataClassIdentifier()->shouldBeCalled()->willReturn('Product');
+
+        $archetype->getMetadataIdentifier()->shouldBeCalled()->willReturn('Archetype-42');
+        $archetype->getParent()->shouldBeCalled()->willReturn($parentArchetype);
+        $parentArchetype->getMetadataIdentifier()->shouldBeCalled()->willReturn('Archetype-21');
+        $parentArchetype->getParent()->shouldBeCalled()->willReturn($grandparentArchetype);
+        $grandparentArchetype->getMetadataIdentifier()->shouldBeCalled()->willReturn('Archetype-10');
+        $grandparentArchetype->getParent()->shouldBeCalled()->willReturn(null);
+
+        $productVariant->getProduct()->shouldBeCalled()->willReturn($product);
+
+        $product->getArchetype()->shouldBeCalled()->willReturn($archetype);
+
+        $this->getHierarchyByMetadataSubject($productVariant)->shouldReturn([
+            'ProductVariant-42',
+            'Product-42',
+            'Archetype-42',
+            'Archetype-21',
+            'Archetype-10',
             'Product',
             'DefaultPage',
         ]);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| License         | MIT

The same as #5069, but for ProductVariant - keeping them consistent.

Could consider injecting the Product in here and using that at some point in future to stop the duplication but this should be fine for now.