### PR TITLE
[Order][Core] Order improvements

### DIFF
--- a/features/order/managing_orders/seeing_order_discounts.feature
+++ b/features/order/managing_orders/seeing_order_discounts.feature
@@ -31,7 +31,6 @@ Feature: Seeing discounts of an order
         Given the promotion gives "€10.00" off on every product classified as "T-Shirts"
         And the customer bought a single "Angel T-Shirt"
         When I view the summary of the order "#00000666"
-        Then the "Angel T-Shirt" should have "-€10.00" discount
-        And the order's items total should be "€29.00"
+        Then the order's items total should be "€29.00"
         And the order's promotion total should be "€0.00"
         And the order's total should be "€29.00"

--- a/features/order/managing_orders/seeing_order_item_detailed_data.feature
+++ b/features/order/managing_orders/seeing_order_item_detailed_data.feature
@@ -1,4 +1,4 @@
-@managing_order
+@managing_orders
 Feature: Seeing order item detailed data
     In order to be aware of the every important information about each order item
     As an Administrator
@@ -6,31 +6,30 @@ Feature: Seeing order item detailed data
 
     Background:
         Given the store operates on a single channel in "France"
-        And the store classifies its products as "T-Shirts"
-        And the store has a product "Iron Man T-Shirt" priced at "€39.00"
-        And it belongs to "T-Shirts"
-        And the store ships everywhere for free
-        And the store allows paying with "Cash on Delivery"
         And there is a zone "EU" containing all members of the European Union
         And default tax zone is "EU"
         And the store has "EU VAT" tax rate of 10% for "T-Shirts" within "EU" zone
-        And there is a customer "tony@stark.com" that placed an order "#00000666"
-        And the customer bought 4 "Iron Man T-Shirt" products
-        And the customer chose "Free" shipping method to "United Kingdom" with "Cash on Delivery" payment
+        And the store classifies its products as "T-Shirts"
+        And the store has a product "Iron Man T-Shirt" priced at "€39.00"
+        And it belongs to "T-Shirts" tax category
+        And the store ships everything for free within "EU" zone
+        And the store allows paying with "Cash on Delivery"
         And there is a promotion "#teamIronMan promotion"
         And it gives "€12.00" discount to every order with quantity at least 3
         And there is a promotion "T-Shirts promotion"
         And it gives "€2.00" off on every product with minimum price at "€20.00"
+        And there is a customer "tony@stark.com" that placed an order "#00000666"
+        And the customer bought 4 "Iron Man T-Shirt" products
+        And the customer chose "Free" shipping method to "France" with "Cash on Delivery" payment
         And I am logged in as an administrator
 
-    @todo
+    @ui
     Scenario: Seeing details of item in one row
-        And the customer bought 4 "Angel T-Shirt" products
-        When I view the summary of the order "#00000666"
-        Then "Iron Man T-Shirt" item's unit price should be "€39.00"
-        And its discounted unit price should be "€37.00"
+        Given I view the summary of the order "#00000666"
+        When I check "Iron Man T-Shirt" data
+        Then its unit price should be €39.00
         And its quantity should be 4
-        And its subtotal should be "€148.00"
-        And its discount should be "€12.00"
-        And its tax should be "€13.60"
-        And its total should be "€149.60"
+        And its subtotal should be €148.00
+        And its discount should be -€12.00
+        And its tax should be €13.60
+        And its total should be €149.60

--- a/features/order/managing_orders/seeing_order_item_detailed_data.feature
+++ b/features/order/managing_orders/seeing_order_item_detailed_data.feature
@@ -1,0 +1,36 @@
+@managing_order
+Feature: Seeing order item detailed data
+    In order to be aware of the every important information about each order item
+    As an Administrator
+    I want to see detailed data about items in order
+
+    Background:
+        Given the store operates on a single channel in "France"
+        And the store classifies its products as "T-Shirts"
+        And the store has a product "Iron Man T-Shirt" priced at "€39.00"
+        And it belongs to "T-Shirts"
+        And the store ships everywhere for free
+        And the store allows paying with "Cash on Delivery"
+        And there is a zone "EU" containing all members of the European Union
+        And default tax zone is "EU"
+        And the store has "EU VAT" tax rate of 10% for "T-Shirts" within "EU" zone
+        And there is a customer "tony@stark.com" that placed an order "#00000666"
+        And the customer bought 4 "Iron Man T-Shirt" products
+        And the customer chose "Free" shipping method to "United Kingdom" with "Cash on Delivery" payment
+        And there is a promotion "#teamIronMan promotion"
+        And it gives "€12.00" discount to every order with quantity at least 3
+        And there is a promotion "T-Shirts promotion"
+        And it gives "€2.00" off on every product with minimum price at "€20.00"
+        And I am logged in as an administrator
+
+    @todo
+    Scenario: Seeing details of item in one row
+        And the customer bought 4 "Angel T-Shirt" products
+        When I view the summary of the order "#00000666"
+        Then "Iron Man T-Shirt" item's unit price should be "€39.00"
+        And its discounted unit price should be "€37.00"
+        And its quantity should be 4
+        And its subtotal should be "€148.00"
+        And its discount should be "€12.00"
+        And its tax should be "€13.60"
+        And its total should be "€149.60"

--- a/features/promotion/applying_promotion_rules/reapplying_promotion_on_cart_change.feature
+++ b/features/promotion/applying_promotion_rules/reapplying_promotion_on_cart_change.feature
@@ -30,8 +30,7 @@ Feature: Reapplying promotion on cart change
         And I chose "DHL" shipping method
         When I change shipping method to "FedEx"
         Then my cart total should be "€100.00"
-        And my cart shipping fee should be "€30.00"
-        And my discount should be "-€30.00"
+        And my cart shipping fee should be "€0.00"
 
     @ui
     Scenario: Receiving discount after removing an item from the cart and then adding another one

--- a/features/promotion/applying_promotion_rules/reapplying_promotion_on_cart_change.feature
+++ b/features/promotion/applying_promotion_rules/reapplying_promotion_on_cart_change.feature
@@ -30,7 +30,7 @@ Feature: Reapplying promotion on cart change
         And I chose "DHL" shipping method
         When I change shipping method to "FedEx"
         Then my cart total should be "€100.00"
-        And my cart shipping fee should be "€0.00"
+        And my cart shipping should be for free
 
     @ui
     Scenario: Receiving discount after removing an item from the cart and then adding another one

--- a/features/promotion/complex_promotions.feature
+++ b/features/promotion/complex_promotions.feature
@@ -46,7 +46,7 @@ Feature: Receiving a discount based on a configured promotion
         Then theirs price should be decreased by "€70.00"
         And my cart total should be "€630.00"
         And my discount should be "-€80.00"
-        And my cart shipping fee should be "€10.00"
+        And my cart shipping total should be "€10.00"
 
     @ui
     Scenario: Receiving a discount on items and the whole order from one promotion based on items total

--- a/features/promotion/receiving_discount/receiving_fixed_discount_on_cart.feature
+++ b/features/promotion/receiving_discount/receiving_fixed_discount_on_cart.feature
@@ -43,5 +43,5 @@ Feature: Receiving fixed discount on cart
         When I add product "PHP T-Shirt" to the cart
         And I proceed selecting "DHL" shipping method
         Then my cart total should be "€100.00"
-        And my cart shipping fee should be "€10.00"
+        And my cart shipping total should be "€10.00"
         And my discount should be "-€10.00"

--- a/features/promotion/receiving_discount/receiving_fixed_discount_on_items_on_price_range.feature
+++ b/features/promotion/receiving_discount/receiving_fixed_discount_on_items_on_price_range.feature
@@ -16,7 +16,6 @@ Feature: Receiving fixed discount on products from specific price range
         When I add product "PHP T-Shirt" to the cart
         Then its price should be decreased by "€10.00"
         And my cart total should be "€90.00"
-        And my discount should be "-€10.00"
 
     @ui
     Scenario: Receiving fixed discount on a single item with price equal to filter minimum criteria
@@ -24,7 +23,6 @@ Feature: Receiving fixed discount on products from specific price range
         When I add product "PHP T-Shirt" to the cart
         Then its price should be decreased by "€10.00"
         And my cart total should be "€90.00"
-        And my discount should be "-€10.00"
 
     @ui
     Scenario: Receiving fixed discount on a single item fulfilling range price criteria
@@ -32,7 +30,6 @@ Feature: Receiving fixed discount on products from specific price range
         When I add product "PHP Mug" to the cart
         Then its price should be decreased by "€10.00"
         And my cart total should be "€10.00"
-        And my discount should be "-€10.00"
 
     @ui
     Scenario: Receiving fixed discount on a single item with price equal to filter range minimum criteria
@@ -40,7 +37,6 @@ Feature: Receiving fixed discount on products from specific price range
         When I add product "PHP Mug" to the cart
         Then its price should be decreased by "€10.00"
         And my cart total should be "€10.00"
-        And my discount should be "-€10.00"
 
     @ui
     Scenario: Receiving fixed discount on a single item with price equal to filter range maximum criteria
@@ -48,7 +44,6 @@ Feature: Receiving fixed discount on products from specific price range
         When I add product "PHP Mug" to the cart
         Then its price should be decreased by "€10.00"
         And my cart total should be "€10.00"
-        And my discount should be "-€10.00"
 
     @ui
     Scenario: Receiving fixed discount on multiple items fulfilling range price criteria
@@ -56,7 +51,6 @@ Feature: Receiving fixed discount on products from specific price range
         When I add 3 products "PHP T-Shirt" to the cart
         Then theirs price should be decreased by "€30.00"
         And my cart total should be "€270.00"
-        And my discount should be "-€30.00"
 
     @ui
     Scenario: Receiving fixed discount equal to the items total of my cart
@@ -64,7 +58,6 @@ Feature: Receiving fixed discount on products from specific price range
         When I add 3 products "PHP Mug" to the cart
         Then theirs price should be decreased by "€60.00"
         And my cart total should be "€0.00"
-        And my discount should be "-€60.00"
 
     @ui
     Scenario: Receiving fixed discount equal to the items total of my cart even if the discount is bigger than the items total
@@ -72,7 +65,6 @@ Feature: Receiving fixed discount on products from specific price range
         When I add 2 products "PHP Mug" to the cart
         Then theirs price should be decreased by "€40.00"
         Then my cart total should be "€0.00"
-        And my discount should be "-€40.00"
 
     @ui
     Scenario: Receiving fixed discount only on items that fit price range criteria
@@ -82,7 +74,6 @@ Feature: Receiving fixed discount on products from specific price range
         Then product "PHP T-Shirt" price should be decreased by "€10.00"
         And product "PHP Mug" price should not be decreased
         And my cart total should be "€110.00"
-        And my discount should be "-€10.00"
 
     @ui
     Scenario: Receiving different discounts on items from different price ranges
@@ -94,4 +85,3 @@ Feature: Receiving fixed discount on products from specific price range
         Then product "PHP T-Shirt" price should be decreased by "€10.00"
         And product "PHP Mug" price should be decreased by "€5.00"
         And my cart total should be "€105.00"
-        And my discount should be "-€15.00"

--- a/features/promotion/receiving_discount/receiving_fixed_discount_on_products_from_specific_taxon.feature
+++ b/features/promotion/receiving_discount/receiving_fixed_discount_on_products_from_specific_taxon.feature
@@ -19,14 +19,12 @@ Feature: Receiving fixed discount on products from specific taxon
         When I add product "PHP T-Shirt" to the cart
         Then its price should be decreased by "€10.00"
         And my cart total should be "€90.00"
-        And my discount should be "-€10.00"
 
     @ui
     Scenario: Receiving percentage discount on a multiple items from specific taxon
         When I add 3 products "PHP T-Shirt" to the cart
         Then theirs price should be decreased by "€30.00"
         And my cart total should be "€270.00"
-        And my discount should be "-€30.00"
 
     @ui
     Scenario: Receiving fixed discount equal to the items total of my cart
@@ -35,7 +33,6 @@ Feature: Receiving fixed discount on products from specific taxon
         When I add 3 products "PHP Mug" to the cart
         Then theirs price should be decreased by "€60.00"
         And my cart total should be "€0.00"
-        And my discount should be "-€60.00"
 
     @ui
     Scenario: Receiving fixed discount equal to the items total of my cart even if the discount is bigger than the items total
@@ -44,7 +41,6 @@ Feature: Receiving fixed discount on products from specific taxon
         When I add 2 products "PHP Mug" to the cart
         Then theirs price should be decreased by "€40.00"
         And my cart total should be "€0.00"
-        And my discount should be "-€40.00"
 
     @ui
     Scenario: Receiving fixed discount only on items from specific taxon
@@ -53,7 +49,6 @@ Feature: Receiving fixed discount on products from specific taxon
         Then product "PHP T-Shirt" price should be decreased by "€10.00"
         And product "PHP Mug" price should not be decreased
         And my cart total should be "€110.00"
-        And my discount should be "-€10.00"
 
     @ui
     Scenario: Receiving different discounts on items from different taxons
@@ -64,4 +59,3 @@ Feature: Receiving fixed discount on products from specific taxon
         Then product "PHP T-Shirt" price should be decreased by "€10.00"
         And product "PHP Mug" price should be decreased by "€2.00"
         And my cart total should be "€108.00"
-        And my discount should be "-€12.00"

--- a/features/promotion/receiving_discount/receiving_percentage_discount_on_items_on_price_range.feature
+++ b/features/promotion/receiving_discount/receiving_percentage_discount_on_items_on_price_range.feature
@@ -16,7 +16,6 @@ Feature: Receiving percentage discount on products from specific price range
         When I add product "PHP T-Shirt" to the cart
         Then its price should be decreased by "€10.00"
         And my cart total should be "€90.00"
-        And my discount should be "-€10.00"
 
     @ui
     Scenario: Receiving percentage discount on a single item with price equal to filter minimum criteria
@@ -24,7 +23,6 @@ Feature: Receiving percentage discount on products from specific price range
         When I add product "PHP T-Shirt" to the cart
         Then its price should be decreased by "€10.00"
         And my cart total should be "€90.00"
-        And my discount should be "-€10.00"
 
     @ui
     Scenario: Receiving percentage discount on a single item fulfilling range price criteria
@@ -32,7 +30,6 @@ Feature: Receiving percentage discount on products from specific price range
         When I add product "PHP Mug" to the cart
         Then its price should be decreased by "€10.00"
         And my cart total should be "€10.00"
-        And my discount should be "-€10.00"
 
     @ui
     Scenario: Receiving percentage discount on a single item with price equal to filter range minimum criteria
@@ -40,7 +37,6 @@ Feature: Receiving percentage discount on products from specific price range
         When I add product "PHP Mug" to the cart
         Then its price should be decreased by "€10.00"
         And my cart total should be "€10.00"
-        And my discount should be "-€10.00"
 
     @ui
     Scenario: Receiving percentage discount on a single item with price equal to filter range maximum criteria
@@ -48,7 +44,6 @@ Feature: Receiving percentage discount on products from specific price range
         When I add product "PHP Mug" to the cart
         Then its price should be decreased by "€10.00"
         And my cart total should be "€10.00"
-        And my discount should be "-€10.00"
 
     @ui
     Scenario: Receiving percentage discount on multiple items fulfilling range price criteria
@@ -56,7 +51,6 @@ Feature: Receiving percentage discount on products from specific price range
         When I add 3 products "PHP T-Shirt" to the cart
         Then theirs price should be decreased by "€150.00"
         And my cart total should be "€150.00"
-        And my discount should be "-€150.00"
 
     @ui
     Scenario: Receiving percentage discount only on items that fit price range criteria
@@ -66,7 +60,6 @@ Feature: Receiving percentage discount on products from specific price range
         Then product "PHP T-Shirt" price should be decreased by "€25.00"
         And product "PHP Mug" price should not be decreased
         And my cart total should be "€95.00"
-        And my discount should be "-€25.00"
 
     @ui
     Scenario: Receiving different discounts on items from different price ranges
@@ -78,4 +71,3 @@ Feature: Receiving percentage discount on products from specific price range
         Then product "PHP T-Shirt" price should be decreased by "€10.00"
         And product "PHP Mug" price should be decreased by "€18.00"
         And my cart total should be "€92.00"
-        And my discount should be "-€28.00"

--- a/features/promotion/receiving_discount/receiving_percentage_discount_on_products_from_specific_taxon.feature
+++ b/features/promotion/receiving_discount/receiving_percentage_discount_on_products_from_specific_taxon.feature
@@ -19,14 +19,12 @@ Feature: Receiving percentage discount on products from specific taxon
         When I add product "PHP T-Shirt" to the cart
         Then its price should be decreased by "€20.00"
         And my cart total should be "€80.00"
-        And my discount should be "-€20.00"
 
     @ui
     Scenario: Receiving percentage discount on a multiple items from specific taxon
         When I add 3 products "PHP T-Shirt" to the cart
         Then theirs price should be decreased by "€60.00"
         And my cart total should be "€240.00"
-        And my discount should be "-€60.00"
 
     @ui
     Scenario: Receiving percentage discount only on items from specific taxon
@@ -35,7 +33,6 @@ Feature: Receiving percentage discount on products from specific taxon
         Then product "PHP T-Shirt" price should be decreased by "€20.00"
         And product "PHP Mug" price should not be decreased
         And my cart total should be "€100.00"
-        And my discount should be "-€20.00"
 
     @ui
     Scenario: Receiving different discounts on items from different taxons
@@ -46,4 +43,3 @@ Feature: Receiving percentage discount on products from specific taxon
         Then product "PHP T-Shirt" price should be decreased by "€20.00"
         And product "PHP Mug" price should be decreased by "€10.00"
         And my cart total should be "€90.00"
-        And my discount should be "-€30.00"

--- a/features/promotion/receiving_discount/receiving_percentage_discount_on_shipping.feature
+++ b/features/promotion/receiving_discount/receiving_percentage_discount_on_shipping.feature
@@ -17,7 +17,7 @@ Feature: Receiving percentage discount on shipping
         When I add product "PHP T-Shirt" to the cart
         And I proceed selecting "DHL" shipping method
         Then my cart total should be "€108.00"
-        And my cart shipping fee should be "€8.00"
+        And my cart shipping total should be "€8.00"
 
     @ui
     Scenario: Receiving free shipping
@@ -25,4 +25,4 @@ Feature: Receiving percentage discount on shipping
         When I add product "PHP T-Shirt" to the cart
         And I proceed selecting "DHL" shipping method
         Then my cart total should be "€100.00"
-        And my cart shipping fee should be "€0.00"
+        And my cart shipping total should be "€0.00"

--- a/features/promotion/receiving_discount/receiving_percentage_discount_on_shipping.feature
+++ b/features/promotion/receiving_discount/receiving_percentage_discount_on_shipping.feature
@@ -17,8 +17,7 @@ Feature: Receiving percentage discount on shipping
         When I add product "PHP T-Shirt" to the cart
         And I proceed selecting "DHL" shipping method
         Then my cart total should be "€108.00"
-        And my cart shipping fee should be "€10.00"
-        And my discount should be "-€2.00"
+        And my cart shipping fee should be "€8.00"
 
     @ui
     Scenario: Receiving free shipping
@@ -26,13 +25,4 @@ Feature: Receiving percentage discount on shipping
         When I add product "PHP T-Shirt" to the cart
         And I proceed selecting "DHL" shipping method
         Then my cart total should be "€100.00"
-        And my cart shipping fee should be "€10.00"
-        And my discount should be "-€10.00"
-
-    @ui
-    Scenario: Not receiving percentage discount on shipping before selecting shipping method
-        Given the promotion gives "100%" discount on shipping to every order
-        When I add product "PHP T-Shirt" to the cart
-        Then my cart total should be "€100.00"
         And my cart shipping fee should be "€0.00"
-        And there should be no discount

--- a/features/promotion/receiving_discount/receiving_percentage_discount_promotion_on_order.feature
+++ b/features/promotion/receiving_discount/receiving_percentage_discount_promotion_on_order.feature
@@ -23,5 +23,5 @@ Feature: Receiving percentage discount promotion on order
         When I add product "PHP T-Shirt" to the cart
         And I proceed selecting "DHL" shipping method
         Then my cart total should be "€90.00"
-        And my cart shipping fee should be "€10.00"
+        And my cart shipping total should be "€10.00"
         And my discount should be "-€20.00"

--- a/features/shipping/applying_shipping_fee/applying_correct_shipping_fee_on_order.feature
+++ b/features/shipping/applying_shipping_fee/applying_correct_shipping_fee_on_order.feature
@@ -16,7 +16,7 @@ Feature: Apply correct shipping fee on order
         Given I have product "PHP T-Shirt" in the cart
         When I proceed selecting "DHL" shipping method
         Then my cart total should be "€110.00"
-        And my cart shipping fee should be "€10.00"
+        And my cart shipping total should be "€10.00"
 
     @ui
     Scenario: Changing shipping fee after shipping method change
@@ -24,4 +24,4 @@ Feature: Apply correct shipping fee on order
         And I chose "DHL" shipping method
         When I change shipping method to "FedEx"
         Then my cart total should be "€130.00"
-        And my cart shipping fee should be "€30.00"
+        And my cart shipping total should be "€30.00"

--- a/features/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_product_taxes_on_order.feature
+++ b/features/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_product_taxes_on_order.feature
@@ -31,7 +31,7 @@ Feature: Apply correct shipping fee with product taxes on order
         And I choose "Offline" payment method
         Then my cart total should be "€135.30"
         And my cart taxes should be "€25.30"
-        And my cart shipping fee should be "€12.30"
+        And my cart shipping total should be "€12.30"
 
     @ui
     Scenario: Proper shipping fee, tax and products' taxes after addressing
@@ -40,4 +40,4 @@ Feature: Apply correct shipping fee with product taxes on order
         And I choose "Offline" payment method
         Then my cart total should be "€352.00"
         And my cart taxes should be "€32.00"
-        And my cart shipping fee should be "€22.00"
+        And my cart shipping total should be "€22.00"

--- a/features/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_taxes_on_order.feature
+++ b/features/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_taxes_on_order.feature
@@ -30,7 +30,7 @@ Feature: Apply correct shipping fee with taxes on order
         And I choose "Offline" payment method
         Then my cart total should be "€112.30"
         And my cart taxes should be "€2.30"
-        And my cart shipping fee should be "€12.30"
+        And my cart shipping total should be "€12.30"
 
     @ui
     Scenario: Proper shipping fee and tax after addressing
@@ -39,4 +39,4 @@ Feature: Apply correct shipping fee with taxes on order
         And I choose "Offline" payment method
         Then my cart total should be "€122.00"
         And my cart taxes should be "€2.00"
-        And my cart shipping fee should be "€22.00"
+        And my cart shipping total should be "€22.00"

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -256,16 +256,95 @@ final class ManagingOrdersContext implements Context
     }
 
     /**
+     * @When I check :itemName data
+     */
+    public function iCheckData($itemName)
+    {
+        $this->sharedStorage->set('item', $itemName);
+    }
+
+    /**
+     * @Then /^(its) unit price should be ([^"]+)$/
+     */
+    public function itemUnitPriceShouldBe($itemName, $unitPrice)
+    {
+        $itemUnitPriceOnPage = $this->showPage->getItemUnitPrice($itemName);
+
+        Assert::eq(
+            $itemUnitPriceOnPage,
+            $unitPrice,
+            'Item unit price is %s, but should be %s.'
+        );
+    }
+
+    /**
+     * @Then /^(its) quantity should be ([^"]+)$/
+     */
+    public function itemQuantityShouldBe($itemName, $quantity)
+    {
+        $itemQuantityOnPage = $this->showPage->getItemQuantity($itemName);
+
+        Assert::eq(
+            $itemQuantityOnPage,
+            $quantity,
+            'Item quantity is %s, but should be %s.'
+        );
+    }
+
+    /**
+     * @Then /^(its) subtotal should be ([^"]+)$/
+     */
+    public function itemSubtotalShouldBe($itemName, $subtotal)
+    {
+        $itemSubtotalOnPage = $this->showPage->getItemSubtotal($itemName);
+
+        Assert::eq(
+            $itemSubtotalOnPage,
+            $subtotal,
+            'Item subtotal is %s, but should be %s.'
+        );
+    }
+
+    /**
+     * @Then /^(its) discount should be ([^"]+)$/
      * @Then the :itemName should have :discount discount
      */
-    public function theItemShouldHaveDiscount($itemName, $itemDiscount)
+    public function theItemShouldHaveDiscount($itemName, $discount)
     {
         $itemDiscountOnPage = $this->showPage->getItemDiscount($itemName);
 
         Assert::eq(
             $itemDiscountOnPage,
-            $itemDiscount,
+            $discount,
             'Item discount is %s, but should be %s.'
+        );
+    }
+
+    /**
+     * @Then /^(its) tax should be ([^"]+)$/
+     */
+    public function itemTaxShouldBe($itemName, $tax)
+    {
+        $itemTaxOnPage = $this->showPage->getItemTax($itemName);
+
+        Assert::eq(
+            $itemTaxOnPage,
+            $tax,
+            'Item tax is %s, but should be %s.'
+        );
+    }
+
+    /**
+     * @Then /^(its) total should be ([^"]+)$/
+     */
+    public function itemTotalShouldBe($itemName, $total)
+    {
+        $itemTotalOnPage = $this->showPage->getItemTotal($itemName);
+
+        Assert::eq(
+            $itemTotalOnPage,
+            $total,
+            'Item total is %s, but should be %s.'
         );
     }
 

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -137,9 +137,10 @@ final class CartContext implements Context
 
     /**
      * @Then shipping total value should be :shippingTotal
-     * @Then my cart shipping fee should be :shippingTotal
+     * @Then my cart shipping total should be :shippingTotal
+     * @Then my cart shipping should be for free
      */
-    public function myCartShippingFeeShouldBe($shippingTotal)
+    public function myCartShippingFeeShouldBe($shippingTotal = '€0.00')
     {
         $this->summaryPage->open();
 

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
@@ -196,16 +196,59 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
      *
      * @return string
      */
+    public function getItemUnitPrice($itemName)
+    {
+        return $this->getItemProperty($itemName, 'unit-price');
+    }
+
+    /**
+     * @param string $itemName
+     *
+     * @return string
+     */
+    public function getItemQuantity($itemName)
+    {
+        return $this->getItemProperty($itemName, 'quantity');
+    }
+
+    /**
+     * @param string $itemName
+     *
+     * @return string
+     */
+    public function getItemSubtotal($itemName)
+    {
+        return $this->getItemProperty($itemName, 'subtotal');
+    }
+
+    /**
+     * @param string $itemName
+     *
+     * @return string
+     */
     public function getItemDiscount($itemName)
     {
-        $rows = $this->tableAccessor->getRowsWithFields(
-            $this->getElement('table'),
-            ['item' => $itemName]
-        );
+        return $this->getItemProperty($itemName, 'discount');
+    }
 
-        $discount = $rows[0]->find('css', '.discount')->getText();
+    /**
+     * @param string $itemName
+     *
+     * @return string
+     */
+    public function getItemTax($itemName)
+    {
+        return $this->getItemProperty($itemName, 'tax');
+    }
 
-        return $discount;
+    /**
+     * @param string $itemName
+     *
+     * @return string
+     */
+    public function getItemTotal($itemName)
+    {
+        return $this->getItemProperty($itemName, 'total');
     }
 
     /**
@@ -222,19 +265,19 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
     protected function getDefinedElements()
     {
         return array_merge(parent::getDefinedElements(), [
-            'customer' => '#customer',
-            'shipping_address' => '#shipping-address',
             'billing_address' => '#billing-address',
-            'payments' => '#payments',
-            'shipments' => '#shipments',
-            'table' => '.table',
+            'customer' => '#customer',
             'items_total' => '#items-total',
-            'total' => '#total',
-            'shipping_total' => '#shipping-total',
-            'shipping_charges' => '#shipping-charges',
-            'tax_total' => '#tax-total',
-            'promotion_total' => '#promotion-total',
+            'payments' => '#payments',
             'promotion_discounts' => '#promotion-discounts',
+            'promotion_total' => '#promotion-total',
+            'shipments' => '#shipments',
+            'shipping_address' => '#shipping-address',
+            'shipping_charges' => '#shipping-charges',
+            'shipping_total' => '#shipping-total',
+            'table' => '.table',
+            'tax_total' => '#tax-total',
+            'total' => '#total',
         ]);
     }
 
@@ -264,5 +307,21 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
             (stripos($elementText, $city) !== false) &&
             (stripos($elementText, $countryName.' '.$postcode) !== false)
         ;
+    }
+
+    /**
+     * @param string $itemName
+     * @param string $property
+     *
+     * @return string
+     */
+    private function getItemProperty($itemName, $property)
+    {
+        $rows = $this->tableAccessor->getRowsWithFields(
+            $this->getElement('table'),
+            ['item' => $itemName]
+        );
+
+        return $rows[0]->find('css', '.'.$property)->getText();
     }
 }

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
@@ -108,5 +108,40 @@ interface ShowPageInterface extends SymfonyPageInterface
      *
      * @return string
      */
+    public function getItemUnitPrice($itemName);
+
+    /**
+     * @param string $itemName
+     *
+     * @return string
+     */
+    public function getItemQuantity($itemName);
+
+    /**
+     * @param string $itemName
+     *
+     * @return string
+     */
+    public function getItemSubtotal($itemName);
+
+    /**
+     * @param string $itemName
+     *
+     * @return string
+     */
     public function getItemDiscount($itemName);
+
+    /**
+     * @param string $itemName
+     *
+     * @return string
+     */
+    public function getItemTax($itemName);
+
+    /**
+     * @param string $itemName
+     *
+     * @return string
+     */
+    public function getItemTotal($itemName);
 }

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_item.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_item.html.twig
@@ -24,23 +24,23 @@
             </div>
         {% endif %}
     </td>
-    <td class="right aligned">
-        {{ item.quantity }}
-    </td>
-    <td class="right aligned">
+    <td class="right aligned unit-price">
         {{ item.unitPrice|sylius_price(order.currency) }}
     </td>
-    <td class="right aligned">
-        {{ (item.unitPrice * item.quantity)|sylius_price(order.currency) }}
+    <td class="right aligned quantity">
+        {{ item.quantity }}
     </td>
-    <td class="right aligned">
-        {{ item.getAdjustmentsTotalRecursively(taxAdjustment)|sylius_price(order.currency) }}
+    <td class="right aligned subtotal">
+        {{ item.subtotal|sylius_price(order.currency) }}
     </td>
     <td class="right aligned discount">
-        {% set itemDiscount = item.getAdjustmentsTotalRecursively(itemPromotionAdjustment) %}
+        {% set itemDiscount = item.getAdjustmentsTotalRecursively(orderPromotionAdjustment) %}
         {% if not itemDiscount == 0 %}-{% endif %}{{ (-1 * itemDiscount)|sylius_price(order.currency) }}
     </td>
-    <td class="right aligned">
+    <td class="right aligned tax">
+        {{ item.taxTotal|sylius_price(order.currency) }}
+    </td>
+    <td class="right aligned total">
         {{ item.total|sylius_price(order.currency) }}
     </td>
 </tr>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_summary.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_summary.html.twig
@@ -2,11 +2,11 @@
     <thead>
     <tr>
         <th>{{ 'sylius.ui.order_item_product'|trans }}</th>
-        <th class="one wide center aligned">{{ 'sylius.ui.quantity'|trans }}</th>
         <th class="two wide center aligned">{{ 'sylius.ui.unit_price'|trans }}</th>
+        <th class="one wide center aligned">{{ 'sylius.ui.quantity'|trans }}</th>
         <th class="two wide center aligned">{{ 'sylius.ui.subtotal'|trans }}</th>
-        <th class="one wide center aligned">{{ 'sylius.ui.tax'|trans }}</th>
         <th class="one wide center aligned">{{ 'sylius.ui.discount'|trans }}</th>
+        <th class="one wide center aligned">{{ 'sylius.ui.tax'|trans }}</th>
         <th class="two wide center aligned">{{ 'sylius.ui.total'|trans }}</th>
     </tr>
     </thead>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/summary.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/summary.html.twig
@@ -41,7 +41,7 @@
             <div class="column">
                 <table class="ui single line table" id="cart-summary">
                     <tbody>
-                        {% set promotionTotal =  cart.getPromotionsTotalRecursively() %}
+                        {% set promotionTotal =  cart.orderPromotionTotal %}
                         {% if promotionTotal %}
                             <tr>
                                 <td colspan="6" style="text-align: right;">
@@ -51,8 +51,7 @@
                         {% endif %}
                         <tr>
                             <td colspan="6" style="text-align: right;">
-                                {% set shippingTotal = cart.adjustmentsTotal(taxAdjustment) + cart.adjustmentsTotal(shippingAdjustment) %}
-                                <strong>{{ 'sylius.ui.shipping_total'|trans }}</strong>: {{ shippingTotal|sylius_price }}
+                                <strong>{{ 'sylius.ui.shipping_total'|trans }}</strong>: {{ cart.shippingTotal|sylius_price }}
                             </td>
                         </tr>
                         <tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/translations/messages.en.yml
@@ -305,6 +305,7 @@ sylius:
         description: Description
         details: Details
         disable: Disable
+        discounted_unit_price: 'Discounted unit price'
         edit: Edit
         edit_association_type: 'Edit Association type'
         edit_group: 'Edit group'

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
@@ -148,7 +148,7 @@
         </td>
         <td class="text-right" colspan="3">
             <strong>{{ 'sylius.ui.shipping_total'|trans }}</strong>:
-            <span class="amount">{{ order.adjustmentsTotal(shippingAdjustment)|sylius_price(order.currency) }}</span>
+            <span class="amount">{{ order.shippingTotal|sylius_price(order.currency) }}</span>
         </td>
     </tr>
     <tr class="promotion-discount">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
@@ -130,7 +130,7 @@
         </td>
         <td class="text-right" colspan="3">
             <strong>{{ 'sylius.ui.tax_total'|trans }}</strong>:
-            <span class="amount">{{ order.getAdjustmentsTotalRecursively(taxAdjustment)|sylius_price(order.currency) }}</span>
+            <span class="amount">{{ order.taxTotal|sylius_price(order.currency) }}</span>
         </td>
     </tr>
     <tr class="shipping-charges">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/_form.html.twig
@@ -166,7 +166,7 @@
         </td>
         <td class="text-right" colspan="3">
             <strong>{{ 'sylius.ui.promotion_total'|trans }}</strong>:
-            <span class="amount">{{ order.adjustmentsTotal(promotionAdjustment)|sylius_price(order.currency) }}</span>
+            <span class="amount">{{ order.orderPromotionTotal|sylius_price(order.currency) }}</span>
         </td>
     </tr>
     {% if not order.adjustments.isEmpty() %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
@@ -139,7 +139,7 @@
             </td>
             <td class="text-right" colspan="3">
                 <strong>{{ 'sylius.ui.tax_total'|trans }}</strong>:
-                <span class="amount">{{ order.getAdjustmentsTotalRecursively(taxAdjustment)|sylius_price(order.currency) }}</span>
+                <span class="amount">{{ order.taxTotal|sylius_price(order.currency) }}</span>
             </td>
         </tr>
         <tr class="shipping-charges">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
@@ -157,7 +157,7 @@
             </td>
             <td class="text-right" colspan="3">
                 <strong>{{ 'sylius.ui.shipping_total'|trans }}</strong>:
-                <span class="amount">{{ order.adjustmentsTotal(shippingAdjustment)|sylius_price(order.currency) }}</span>
+                <span class="amount">{{ order.shippingTotal|sylius_price(order.currency) }}</span>
             </td>
         </tr>
         <tr class="promotion-discount">
@@ -175,7 +175,7 @@
             </td>
             <td class="text-right" colspan="3">
                 <strong>{{ 'sylius.ui.promotion_total'|trans }}</strong>:
-                <span class="amount">{{ order.getPromotionsTotalRecursively()|sylius_price(order.currency) }}</span>
+                <span class="amount">{{ order.orderPromotionTotal|sylius_price(order.currency) }}</span>
             </td>
         </tr>
         {% if not order.adjustments().isEmpty() %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/show.html.twig
@@ -51,7 +51,7 @@
                 </tr>
                 <tr>
                     <td><strong>{{ 'sylius.ui.shipping_total'|trans }}</strong></td>
-                    <td>{{ order.adjustmentsTotal(shippingAdjustment)|sylius_price(order.currency) }}</td>
+                    <td>{{ order.shippingTotal|sylius_price(order.currency) }}</td>
                 </tr>
                 <tr>
                     <td><strong>{{ 'sylius.ui.state'|trans }}</strong></td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
@@ -72,7 +72,7 @@
                         {{ 'sylius.ui.shipping_total'|trans }}
                     </span>
                 </td>
-                <td>{{ order.adjustmentsTotal(shippingAdjustment)|sylius_money(order.currency) }}</td>
+                <td>{{ order.shippingTotal|sylius_money(order.currency) }}</td>
             </tr>
             <tr>
                 <td colspan="3">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
@@ -80,7 +80,7 @@
                         {{ 'sylius.ui.promotion_total'|trans }}
                     </span>
                 </td>
-                <td>{{ order.getPromotionsTotalRecursively()|sylius_money(order.currency) }}</td>
+                <td>{{ order.orderPromotionTotal|sylius_money(order.currency) }}</td>
             </tr>
             <tr>
                 <th colspan="3">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Account/Order/_detail.html.twig
@@ -64,7 +64,7 @@
                         {{ 'sylius.ui.tax_total'|trans }}
                     </span>
                 </td>
-                <td>{{ order.getAdjustmentsTotalRecursively(taxAdjustment)|sylius_money(order.currency) }}</td>
+                <td>{{ order.taxTotal|sylius_money(order.currency) }}</td>
             </tr>
             <tr>
                 <td colspan="3">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
@@ -52,8 +52,7 @@
         {% endif %}
         <tr>
             <td colspan="6" style="text-align: right;">
-                {% set shippingTotal = cart.adjustmentsTotal(taxAdjustment) + cart.adjustmentsTotal(shippingAdjustment) %}
-                <strong>{{ 'sylius.ui.shipping_total'|trans }}</strong>: {{ shippingTotal|sylius_price }}
+                <strong>{{ 'sylius.ui.shipping_total'|trans }}</strong>: {{ cart.shippingTotal|sylius_price }}
             </td>
         </tr>
         <tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
@@ -68,7 +68,7 @@
                 </ul>
             </td>
             <td colspan="2" style="text-align: right;">
-                <strong>{{ 'sylius.ui.tax_total'|trans }}</strong>: {{ cart.getAdjustmentsTotalRecursively(taxAdjustment)|sylius_price }}
+                <strong>{{ 'sylius.ui.tax_total'|trans }}</strong>: {{ cart.taxTotal|sylius_price }}
             </td>
         </tr>
         <tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Cart/summary.html.twig
@@ -42,7 +42,7 @@
         {% endfor %}
     </tbody>
     <tfoot>
-        {% set promotionTotal = cart.getPromotionsTotalRecursively() %}
+        {% set promotionTotal = cart.orderPromotionTotal %}
         {% if promotionTotal %}
         <tr>
             <td colspan="6" style="text-align: right;">

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
@@ -65,7 +65,7 @@
             </td>
             <td colspan="2">
                 <span class="pull-right">
-                <strong>{{ 'sylius.ui.tax_total'|trans }}</strong>: {{ order.getAdjustmentsTotalRecursively(taxAdjustment)|sylius_price }}
+                <strong>{{ 'sylius.ui.tax_total'|trans }}</strong>: {{ order.taxTotal|sylius_price }}
                 </span>
             </td>
         </tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
@@ -96,10 +96,9 @@
                 {% endfor %}
                 </ul>
                 </td>
-                {% set promotionTotal = order.getPromotionsTotalRecursively() %}
                 <td colspan="2">
                     <span class="pull-right">
-                    <strong>{{ 'sylius.ui.promotion_total'|trans }}</strong>: -{{ (-1 * promotionTotal)|sylius_price }}
+                    <strong>{{ 'sylius.ui.promotion_total'|trans }}</strong>: -{{ (-1 * order.orderPromotionTotal)|sylius_price }}
                     </span>
                 </td>
             </tr>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
@@ -82,8 +82,7 @@
             </td>
             <td colspan="2">
                 <span class="pull-right">
-                    {% set shippingTotal = order.adjustmentsTotal(taxAdjustment) + order.adjustmentsTotal(shippingAdjustment) %}
-                    <strong>{{ 'sylius.ui.shipping_total'|trans }}</strong>: {{ shippingTotal|sylius_price }}
+                    <strong>{{ 'sylius.ui.shipping_total'|trans }}</strong>: {{ order.shippingTotal|sylius_price }}
                 </span>
             </td>
         </tr>

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -542,10 +542,7 @@ class Order extends Cart implements OrderInterface
     {
         $shippingTotal = $this->getAdjustmentsTotal(AdjustmentInterface::TAX_ADJUSTMENT);
         $shippingTotal += $this->getAdjustmentsTotal(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT);
-
-        foreach ($this->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT) as $shippingAdjustment) {
-            $shippingTotal += $shippingAdjustment->getAmount();
-        }
+        $shippingTotal += $this->getAdjustmentsTotal(AdjustmentInterface::SHIPPING_ADJUSTMENT);
 
         return $shippingTotal;
     }

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -515,17 +515,6 @@ class Order extends Cart implements OrderInterface
     }
 
     /**
-     * @return int
-     */
-    public function getPromotionsTotalRecursively()
-    {
-        return
-            $this->getAdjustmentsTotalRecursively(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT) +
-            $this->getAdjustmentsTotalRecursively(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)
-        ;
-    }
-
-    /**
      * Returns sum of neutral and non neutral tax adjustments on order and total tax of order items.
      *
      * {@inheritdoc}
@@ -544,14 +533,36 @@ class Order extends Cart implements OrderInterface
         return $taxTotal;
     }
 
+    /**
+     * Returns shipping fee together with taxes decreased by shipping discount.
+     *
+     * @return int
+     */
     public function getShippingTotal()
     {
         $shippingTotal = $this->getAdjustmentsTotal(AdjustmentInterface::TAX_ADJUSTMENT);
+        $shippingTotal += $this->getAdjustmentsTotal(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT);
 
         foreach ($this->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT) as $shippingAdjustment) {
             $shippingTotal += $shippingAdjustment->getAmount();
         }
 
         return $shippingTotal;
+    }
+
+    /**
+     * Returns amount of order discount. Does not include order item and shipping discounts.
+     *
+     * @return int
+     */
+    public function getOrderPromotionTotal()
+    {
+        $orderPromotionTotal = 0;
+
+        foreach ($this->items as $item) {
+            $orderPromotionTotal += $item->getAdjustmentsTotalRecursively(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT);
+        }
+
+        return $orderPromotionTotal;
     }
 }

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -524,4 +524,24 @@ class Order extends Cart implements OrderInterface
             $this->getAdjustmentsTotalRecursively(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)
         ;
     }
+
+    /**
+     * Returns sum of neutral and non neutral tax adjustments on order and total tax of order items.
+     *
+     * {@inheritdoc}
+     */
+    public function getTaxTotal()
+    {
+        $taxTotal = 0;
+
+        foreach ($this->getAdjustments(AdjustmentInterface::TAX_ADJUSTMENT) as $taxAdjustment) {
+            $taxTotal += $taxAdjustment->getAmount();
+        }
+
+        foreach ($this->items as $item) {
+            $taxTotal += $item->getTaxTotal();
+        }
+
+        return $taxTotal;
+    }
 }

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -537,11 +537,21 @@ class Order extends Cart implements OrderInterface
         foreach ($this->getAdjustments(AdjustmentInterface::TAX_ADJUSTMENT) as $taxAdjustment) {
             $taxTotal += $taxAdjustment->getAmount();
         }
-
         foreach ($this->items as $item) {
             $taxTotal += $item->getTaxTotal();
         }
 
         return $taxTotal;
+    }
+
+    public function getShippingTotal()
+    {
+        $shippingTotal = $this->getAdjustmentsTotal(AdjustmentInterface::TAX_ADJUSTMENT);
+
+        foreach ($this->getAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT) as $shippingAdjustment) {
+            $shippingTotal += $shippingAdjustment->getAmount();
+        }
+
+        return $shippingTotal;
     }
 }

--- a/src/Sylius/Component/Core/Model/OrderInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderInterface.php
@@ -178,4 +178,9 @@ interface OrderInterface extends
      * @return bool
      */
     public function isInvoiceAvailable();
+
+    /**
+     * @return int
+     */
+    public function getTaxTotal();
 }

--- a/src/Sylius/Component/Core/Model/OrderInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderInterface.php
@@ -143,11 +143,6 @@ interface OrderInterface extends
     public function setPromotionCoupon(BaseCouponInterface $coupon = null);
 
     /**
-     * @return int
-     */
-    public function getPromotionsTotalRecursively();
-
-    /**
      * @return string
      */
     public function getShippingState();
@@ -183,4 +178,14 @@ interface OrderInterface extends
      * @return int
      */
     public function getTaxTotal();
+
+    /**
+     * @return int
+     */
+    public function getShippingTotal();
+
+    /**
+     * @return int
+     */
+    public function getOrderPromotionTotal();
 }

--- a/src/Sylius/Component/Core/Model/OrderItem.php
+++ b/src/Sylius/Component/Core/Model/OrderItem.php
@@ -81,21 +81,13 @@ class OrderItem extends CartItem implements OrderItemInterface
     /**
      * {@inheritdoc}
      */
-    public function getDiscountedUnitPrice()
-    {
-        $orderItemDiscounts = 0;
-        foreach ($this->units as $unit) {
-            $orderItemDiscounts += $unit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT);
-        }
-
-        return $this->unitPrice - $orderItemDiscounts;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getSubtotal()
     {
-        return $this->getDiscountedUnitPrice() * $this->quantity;
+        $subtotal = $this->unitPrice * $this->quantity;
+        foreach ($this->units as $unit) {
+            $subtotal += $unit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT);
+        }
+
+        return $subtotal;
     }
 }

--- a/src/Sylius/Component/Core/Model/OrderItem.php
+++ b/src/Sylius/Component/Core/Model/OrderItem.php
@@ -77,4 +77,25 @@ class OrderItem extends CartItem implements OrderItemInterface
 
         return $taxTotal;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDiscountedUnitPrice()
+    {
+        $orderItemDiscounts = 0;
+        foreach ($this->units as $unit) {
+            $orderItemDiscounts += $unit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT);
+        }
+
+        return $this->unitPrice - $orderItemDiscounts;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubtotal()
+    {
+        return $this->getDiscountedUnitPrice() * $this->quantity;
+    }
 }

--- a/src/Sylius/Component/Core/Model/OrderItem.php
+++ b/src/Sylius/Component/Core/Model/OrderItem.php
@@ -57,4 +57,24 @@ class OrderItem extends CartItem implements OrderItemInterface
             && $item->getVariant() === $this->variant
         );
     }
+
+    /**
+     * Returns sum of neutral and non neutral tax adjustments on order item and total tax of units.
+     *
+     * {@inheritdoc}
+     */
+    public function getTaxTotal()
+    {
+        $taxTotal = 0;
+
+        foreach ($this->getAdjustments(AdjustmentInterface::TAX_ADJUSTMENT) as $taxAdjustment) {
+            $taxTotal += $taxAdjustment->getAmount();
+        }
+
+        foreach ($this->units as $unit) {
+            $taxTotal += $unit->getTaxTotal();
+        }
+
+        return $taxTotal;
+    }
 }

--- a/src/Sylius/Component/Core/Model/OrderItemInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderItemInterface.php
@@ -32,4 +32,9 @@ interface OrderItemInterface extends CartItemInterface
      * @param ProductVariantInterface $variant
      */
     public function setVariant(ProductVariantInterface $variant);
+
+    /**
+     * @return int
+     */
+    public function getTaxTotal();
 }

--- a/src/Sylius/Component/Core/Model/OrderItemInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderItemInterface.php
@@ -41,10 +41,5 @@ interface OrderItemInterface extends CartItemInterface
     /**
      * @return int
      */
-    public function getDiscountedUnitPrice();
-
-    /**
-     * @return int
-     */
     public function getSubtotal();
 }

--- a/src/Sylius/Component/Core/Model/OrderItemInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderItemInterface.php
@@ -37,4 +37,14 @@ interface OrderItemInterface extends CartItemInterface
      * @return int
      */
     public function getTaxTotal();
+
+    /**
+     * @return int
+     */
+    public function getDiscountedUnitPrice();
+
+    /**
+     * @return int
+     */
+    public function getSubtotal();
 }

--- a/src/Sylius/Component/Core/Model/OrderItemUnit.php
+++ b/src/Sylius/Component/Core/Model/OrderItemUnit.php
@@ -135,4 +135,20 @@ class OrderItemUnit extends BaseOrderItemUnit implements OrderItemUnitInterface
     {
         $this->shippingState = $state;
     }
+
+    /**
+     * Returns sum of neutral and non neutral tax adjustments.
+     *
+     * {@inheritdoc}
+     */
+    public function getTaxTotal()
+    {
+        $taxTotal = 0;
+
+        foreach ($this->getAdjustments(AdjustmentInterface::TAX_ADJUSTMENT) as $taxAdjustment) {
+            $taxTotal += $taxAdjustment->getAmount();
+        }
+
+        return $taxTotal;
+    }
 }

--- a/src/Sylius/Component/Core/Model/OrderItemUnitInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderItemUnitInterface.php
@@ -20,4 +20,8 @@ use Sylius\Component\Shipping\Model\ShipmentUnitInterface;
  */
 interface OrderItemUnitInterface extends BaseOrderItemUnitInterface, InventoryUnitInterface, ShipmentUnitInterface
 {
+    /**
+     * @return int
+     */
+    public function getTaxTotal();
 }

--- a/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
@@ -68,26 +68,6 @@ class OrderItemSpec extends ObjectBehavior
         $this->getTaxTotal()->shouldReturn(820);
     }
 
-    function it_returns_discounted_unit_price_which_consist_of_unit_price_decreased_by_item_promotions(
-        OrderItemUnitInterface $firstUnit,
-        OrderItemUnitInterface $secondUnit
-    ) {
-        $this->setUnitPrice(10000);
-
-        $firstUnit->getOrderItem()->willReturn($this);
-        $firstUnit->getTotal()->willReturn(9000);
-        $firstUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn(1000);
-
-        $secondUnit->getOrderItem()->willReturn($this);
-        $secondUnit->getTotal()->willReturn(9500);
-        $secondUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn(500);
-
-        $this->addUnit($firstUnit);
-        $this->addUnit($secondUnit);
-
-        $this->getDiscountedUnitPrice()->shouldReturn(8500);
-    }
-
     function it_returns_subtotal_which_consist_of_discounted_unit_price_multiplied_by_quantity(
         OrderItemUnitInterface $firstUnit,
         OrderItemUnitInterface $secondUnit
@@ -96,15 +76,15 @@ class OrderItemSpec extends ObjectBehavior
 
         $firstUnit->getOrderItem()->willReturn($this);
         $firstUnit->getTotal()->willReturn(9000);
-        $firstUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn(1000);
+        $firstUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn(-1000);
 
         $secondUnit->getOrderItem()->willReturn($this);
         $secondUnit->getTotal()->willReturn(9500);
-        $secondUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn(500);
+        $secondUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn(-500);
 
         $this->addUnit($firstUnit);
         $this->addUnit($secondUnit);
 
-        $this->getSubtotal()->shouldReturn(17000);
+        $this->getSubtotal()->shouldReturn(18500);
     }
 }

--- a/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace spec\Sylius\Component\Core\Model;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Core\Model\OrderItemUnitInterface;
+
+/**
+ * @mixin \Sylius\Component\Core\Model\OrderItem
+ */
+class OrderItemSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Core\Model\OrderItem');
+    }
+
+    function it_returns_0_tax_total_when_there_are_no_units()
+    {
+        $this->getTaxTotal()->shouldReturn(0);
+    }
+
+    function it_returns_tax_of_all_unit(OrderItemUnitInterface $orderItemUnit1, OrderItemUnitInterface $orderItemUnit2)
+    {
+        $orderItemUnit1->getTotal()->willReturn(1200);
+        $orderItemUnit1->getTaxTotal()->willReturn(200);
+        $orderItemUnit1->getOrderItem()->willReturn($this);
+        $orderItemUnit2->getTotal()->willReturn(1120);
+        $orderItemUnit2->getTaxTotal()->willReturn(120);
+        $orderItemUnit2->getOrderItem()->willReturn($this);
+
+        $this->addUnit($orderItemUnit1);
+        $this->addUnit($orderItemUnit2);
+
+        $this->getTaxTotal()->shouldReturn(320);
+    }
+
+    function it_returns_tax_of_all_units_and_both_neutral_and_non_neutral_tax_adjustments(
+        OrderItemUnitInterface $orderItemUnit1,
+        OrderItemUnitInterface $orderItemUnit2,
+        AdjustmentInterface $nonNeutralTaxAdjustment,
+        AdjustmentInterface $neutralTaxAdjustment
+    ) {
+        $orderItemUnit1->getTotal()->willReturn(1200);
+        $orderItemUnit1->getTaxTotal()->willReturn(200);
+        $orderItemUnit1->getOrderItem()->willReturn($this);
+        $orderItemUnit2->getTotal()->willReturn(1120);
+        $orderItemUnit2->getTaxTotal()->willReturn(120);
+        $orderItemUnit2->getOrderItem()->willReturn($this);
+
+        $this->addUnit($orderItemUnit1);
+        $this->addUnit($orderItemUnit2);
+
+        $neutralTaxAdjustment->isNeutral()->willReturn(true);
+        $neutralTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $neutralTaxAdjustment->getAmount()->willReturn(200);
+        $nonNeutralTaxAdjustment->isNeutral()->willReturn(false);
+        $nonNeutralTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $nonNeutralTaxAdjustment->getAmount()->willReturn(300);
+
+        $neutralTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $nonNeutralTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $this->addAdjustment($neutralTaxAdjustment);
+        $this->addAdjustment($nonNeutralTaxAdjustment);
+
+        $this->getTaxTotal()->shouldReturn(820);
+    }
+}

--- a/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
@@ -67,4 +67,44 @@ class OrderItemSpec extends ObjectBehavior
 
         $this->getTaxTotal()->shouldReturn(820);
     }
+
+    function it_returns_discounted_unit_price_which_consist_of_unit_price_decreased_by_item_promotions(
+        OrderItemUnitInterface $firstUnit,
+        OrderItemUnitInterface $secondUnit
+    ) {
+        $this->setUnitPrice(10000);
+
+        $firstUnit->getOrderItem()->willReturn($this);
+        $firstUnit->getTotal()->willReturn(9000);
+        $firstUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn(1000);
+
+        $secondUnit->getOrderItem()->willReturn($this);
+        $secondUnit->getTotal()->willReturn(9500);
+        $secondUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn(500);
+
+        $this->addUnit($firstUnit);
+        $this->addUnit($secondUnit);
+
+        $this->getDiscountedUnitPrice()->shouldReturn(8500);
+    }
+
+    function it_returns_subtotal_which_consist_of_discounted_unit_price_multiplied_by_quantity(
+        OrderItemUnitInterface $firstUnit,
+        OrderItemUnitInterface $secondUnit
+    ) {
+        $this->setUnitPrice(10000);
+
+        $firstUnit->getOrderItem()->willReturn($this);
+        $firstUnit->getTotal()->willReturn(9000);
+        $firstUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn(1000);
+
+        $secondUnit->getOrderItem()->willReturn($this);
+        $secondUnit->getTotal()->willReturn(9500);
+        $secondUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn(500);
+
+        $this->addUnit($firstUnit);
+        $this->addUnit($secondUnit);
+
+        $this->getSubtotal()->shouldReturn(17000);
+    }
 }

--- a/src/Sylius/Component/Core/spec/Model/OrderItemUnitSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderItemUnitSpec.php
@@ -13,6 +13,7 @@ namespace spec\Sylius\Component\Core\Model;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -22,6 +23,8 @@ use Sylius\Component\Shipping\Model\ShipmentInterface;
 use Sylius\Component\Shipping\Model\ShipmentUnitInterface;
 
 /**
+ * @mixin \Sylius\Component\Core\Model\OrderItemUnit
+ *
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
 class OrderItemUnitSpec extends ObjectBehavior
@@ -110,5 +113,58 @@ class OrderItemUnitSpec extends ObjectBehavior
     {
         $this->setShippingState(ShipmentInterface::STATE_SHIPPED);
         $this->getShippingState()->shouldReturn(ShipmentInterface::STATE_SHIPPED);
+    }
+
+    function it_returns_0_tax_total_when_there_are_no_tax_adjustments()
+    {
+        $this->getTaxTotal()->shouldReturn(0);
+    }
+
+    function it_returns_sum_of_neutral_and_non_neutral_tax_adjustments_as_tax_total(
+        OrderItemInterface $orderItem,
+        AdjustmentInterface $nonNeutralTaxAdjustment,
+        AdjustmentInterface $neutralTaxAdjustment
+    ) {
+        $neutralTaxAdjustment->isNeutral()->willReturn(true);
+        $neutralTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $neutralTaxAdjustment->getAmount()->willReturn(200);
+        $nonNeutralTaxAdjustment->isNeutral()->willReturn(false);
+        $nonNeutralTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $nonNeutralTaxAdjustment->getAmount()->willReturn(300);
+
+        $orderItem->recalculateUnitsTotal()->shouldBeCalled();
+        $neutralTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $nonNeutralTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $this->addAdjustment($neutralTaxAdjustment);
+        $this->addAdjustment($nonNeutralTaxAdjustment);
+
+        $this->getTaxTotal()->shouldReturn(500);
+    }
+
+    function it_returns_only_sum_of_neutral_and_non_neutral_tax_adjustments_as_tax_total(
+        OrderItemInterface $orderItem,
+        AdjustmentInterface $nonNeutralTaxAdjustment,
+        AdjustmentInterface $neutralTaxAdjustment,
+        AdjustmentInterface $notTaxAdjustment
+    ) {
+        $neutralTaxAdjustment->isNeutral()->willReturn(true);
+        $neutralTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $neutralTaxAdjustment->getAmount()->willReturn(200);
+        $nonNeutralTaxAdjustment->isNeutral()->willReturn(false);
+        $nonNeutralTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $nonNeutralTaxAdjustment->getAmount()->willReturn(300);
+        $notTaxAdjustment->isNeutral()->willReturn(false);
+        $notTaxAdjustment->getType()->willReturn(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT);
+        $notTaxAdjustment->getAmount()->willReturn(100);
+
+        $orderItem->recalculateUnitsTotal()->shouldBeCalled();
+        $neutralTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $nonNeutralTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $notTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $this->addAdjustment($neutralTaxAdjustment);
+        $this->addAdjustment($nonNeutralTaxAdjustment);
+        $this->addAdjustment($notTaxAdjustment);
+
+        $this->getTaxTotal()->shouldReturn(500);
     }
 }

--- a/src/Sylius/Component/Core/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderSpec.php
@@ -443,6 +443,46 @@ class OrderSpec extends ObjectBehavior
         $this->getTaxTotal()->shouldReturn(220);
     }
 
+    function it_includes_non_neutral_tax_adjustments_in_shipping_total(
+        AdjustmentInterface $shippingAdjustment,
+        AdjustmentInterface $shippingTaxAdjustment
+    ) {
+        $shippingAdjustment->getType()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
+        $shippingAdjustment->isNeutral()->willReturn(false);
+        $shippingAdjustment->getAmount()->willReturn(1000);
+
+        $shippingTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $shippingTaxAdjustment->isNeutral()->willReturn(false);
+        $shippingTaxAdjustment->getAmount()->willReturn(70);
+
+        $shippingAdjustment->setAdjustable($this)->shouldBeCalled();
+        $shippingTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $this->addAdjustment($shippingAdjustment);
+        $this->addAdjustment($shippingTaxAdjustment);
+
+        $this->getShippingTotal()->shouldReturn(1070);
+    }
+
+    function it_does_not_include_neutral_tax_adjustments_in_shipping_total(
+        AdjustmentInterface $shippingAdjustment,
+        AdjustmentInterface $neutralShippingTaxAdjustment
+    ) {
+        $shippingAdjustment->getType()->willReturn(AdjustmentInterface::SHIPPING_ADJUSTMENT);
+        $shippingAdjustment->isNeutral()->willReturn(false);
+        $shippingAdjustment->getAmount()->willReturn(1000);
+
+        $neutralShippingTaxAdjustment->getType()->willReturn(AdjustmentInterface::TAX_ADJUSTMENT);
+        $neutralShippingTaxAdjustment->isNeutral()->willReturn(true);
+        $neutralShippingTaxAdjustment->getAmount()->willReturn(70);
+
+        $shippingAdjustment->setAdjustable($this)->shouldBeCalled();
+        $neutralShippingTaxAdjustment->setAdjustable($this)->shouldBeCalled();
+        $this->addAdjustment($shippingAdjustment);
+        $this->addAdjustment($neutralShippingTaxAdjustment);
+
+        $this->getShippingTotal()->shouldReturn(1000);
+    }
+
     function it_returns_promotions_total_recursively(
         AdjustmentInterface $orderPromotionAdjustment,
         AdjustmentInterface $orderItemPromotionAdjustment,

--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -427,7 +427,9 @@ class Order implements OrderInterface
 
         $total = 0;
         foreach ($this->getAdjustments($type) as $adjustment) {
-            $total += $adjustment->getAmount();
+            if (!$adjustment->isNeutral()) {
+                $total += $adjustment->getAmount();
+            }
         }
 
         return $total;
@@ -440,7 +442,9 @@ class Order implements OrderInterface
     {
         $total = 0;
         foreach ($this->getAdjustmentsRecursively($type) as $adjustment) {
-            $total += $adjustment->getAmount();
+            if (!$adjustment->isNeutral()) {
+                $total += $adjustment->getAmount();
+            }
         }
 
         return $total;

--- a/src/Sylius/Component/Order/Model/OrderItem.php
+++ b/src/Sylius/Component/Order/Model/OrderItem.php
@@ -327,7 +327,9 @@ class OrderItem implements OrderItemInterface
 
         $total = 0;
         foreach ($this->getAdjustments($type) as $adjustment) {
-            $total += $adjustment->getAmount();
+            if (!$adjustment->isNeutral()) {
+                $total += $adjustment->getAmount();
+            }
         }
 
         return $total;
@@ -338,9 +340,12 @@ class OrderItem implements OrderItemInterface
      */
     public function getAdjustmentsTotalRecursively($type = null)
     {
-        $total = $this->getAdjustmentsTotal($type);
-        foreach ($this->units as $unit) {
-            $total += $unit->getAdjustmentsTotal($type);
+        $total = 0;
+
+        foreach ($this->getAdjustmentsRecursively($type) as $adjustment) {
+            if (!$adjustment->isNeutral()) {
+                $total += $adjustment->getAmount();
+            }
         }
 
         return $total;

--- a/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
@@ -11,6 +11,7 @@
 
 namespace spec\Sylius\Component\Order\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Order\Model\AdjustableInterface;
@@ -406,6 +407,8 @@ class OrderItemSpec extends ObjectBehavior
 
     function it_returns_correct_adjustments_total_recursively(
         AdjustmentInterface $adjustment1,
+        AdjustmentInterface $taxAdjustment1,
+        AdjustmentInterface $taxAdjustment2,
         OrderItemUnitInterface $orderItemUnit1,
         OrderItemUnitInterface $orderItemUnit2
     ) {
@@ -413,12 +416,17 @@ class OrderItemSpec extends ObjectBehavior
         $adjustment1->isNeutral()->willReturn(false);
         $adjustment1->setAdjustable($this)->shouldBeCalled();
 
+        $taxAdjustment1->getAmount()->willReturn(150);
+        $taxAdjustment1->isNeutral()->willReturn(false);
+        $taxAdjustment2->getAmount()->willReturn(100);
+        $taxAdjustment2->isNeutral()->willReturn(false);
+
         $orderItemUnit1->getOrderItem()->willReturn($this->getWrappedObject());
         $orderItemUnit1->getTotal()->willReturn(500);
-        $orderItemUnit1->getAdjustmentsTotal(null)->willReturn(150);
+        $orderItemUnit1->getAdjustments(null)->willReturn(new ArrayCollection([$taxAdjustment1->getWrappedObject()]));
         $orderItemUnit2->getOrderItem()->willReturn($this->getWrappedObject());
         $orderItemUnit2->getTotal()->willReturn(300);
-        $orderItemUnit2->getAdjustmentsTotal(null)->willReturn(100);
+        $orderItemUnit2->getAdjustments(null)->willReturn(new ArrayCollection([$taxAdjustment2->getWrappedObject()]));
 
         $this->addAdjustment($adjustment1);
         $this->addUnit($orderItemUnit1);
@@ -429,6 +437,9 @@ class OrderItemSpec extends ObjectBehavior
 
     function it_returns_correct_adjustments_total_by_type_recursively(
         AdjustmentInterface $adjustment1,
+        AdjustmentInterface $promotionAdjustment,
+        AdjustmentInterface $taxAdjustment1,
+        AdjustmentInterface $taxAdjustment2,
         OrderItemUnitInterface $orderItemUnit1,
         OrderItemUnitInterface $orderItemUnit2
     ) {
@@ -437,14 +448,21 @@ class OrderItemSpec extends ObjectBehavior
         $adjustment1->isNeutral()->willReturn(false);
         $adjustment1->setAdjustable($this)->shouldBeCalled();
 
+        $promotionAdjustment->getAmount()->willReturn(30);
+        $promotionAdjustment->isNeutral()->willReturn(false);
+        $taxAdjustment1->getAmount()->willReturn(150);
+        $taxAdjustment1->isNeutral()->willReturn(false);
+        $taxAdjustment2->getAmount()->willReturn(100);
+        $taxAdjustment2->isNeutral()->willReturn(false);
+
         $orderItemUnit1->getOrderItem()->willReturn($this->getWrappedObject());
         $orderItemUnit1->getTotal()->willReturn(500);
-        $orderItemUnit1->getAdjustmentsTotal('tax')->willReturn(150);
-        $orderItemUnit1->getAdjustmentsTotal('promotion')->willReturn(30);
+        $orderItemUnit1->getAdjustments('tax')->willReturn(new ArrayCollection([$taxAdjustment1->getWrappedObject()]));
+        $orderItemUnit1->getAdjustments('promotion')->willReturn(new ArrayCollection([$promotionAdjustment->getWrappedObject()]));
         $orderItemUnit2->getOrderItem()->willReturn($this->getWrappedObject());
         $orderItemUnit2->getTotal()->willReturn(300);
-        $orderItemUnit2->getAdjustmentsTotal('tax')->willReturn(100);
-        $orderItemUnit2->getAdjustmentsTotal('promotion')->willReturn(0);
+        $orderItemUnit2->getAdjustments('tax')->willReturn(new ArrayCollection([$taxAdjustment2->getWrappedObject()]));
+        $orderItemUnit2->getAdjustments('promotion')->willReturn(new ArrayCollection());
 
         $this->addAdjustment($adjustment1);
         $this->addUnit($orderItemUnit1);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Related tickets |
| License         | MIT

This is continuation of PR https://github.com/Sylius/Sylius/pull/5062.

Already done:
- ``getTaxTotal`` method to Order which returns sum of tax adjustments regardless neutrality - useful when you want to know the value of tax that was charged
- ``getShippingTotal`` method to Order which returns shipping fee together with shipping tax decreased by shipping discount - useful when you want to know the end value that was charged for shipping
- made ``getAdjustmentsTotal`` and ``getAdjustmentsTotalRecursively`` methods consistent - when called without argument they returned sum of only non neutral adjustments, when called with ``$type`` argument all adjustments were summed (both non neutral and neutral)
- removed ``getPromotionsTotalRecursively`` in favor of ``getOrderPromotionTotal`` - this method returns total amount of order level promotion, but does not include item level promotions and does not include shipping discount which is included in ``getShippingTotal``.
- ``getDiscountedUnitPrice`` method to OrderItem that will return the unit price decreased by item promotions.
- ``getSubtotal`` method to OrderItem that will return ``$discountedUnitPrice`` * ``$quantity``

To do:
- [x] use newly implemented methods in **order** template
- [x] write scenarios for checking new **order** template data