### PR TITLE
[WIP] Taxon images refactoring

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -15,6 +15,8 @@ use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Sylius\Component\Core\Model\ProductVariantImage;
 use Sylius\Component\Core\Model\ProductVariantImageInterface;
+use Sylius\Component\Core\Model\TaxonImage;
+use Sylius\Component\Core\Model\TaxonImageInterface;
 use Sylius\Component\Resource\Factory\Factory;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
@@ -66,6 +68,21 @@ class Configuration implements ConfigurationInterface
                                     ->children()
                                         ->scalarNode('model')->defaultValue(ProductVariantImage::class)->cannotBeEmpty()->end()
                                         ->scalarNode('interface')->defaultValue(ProductVariantImageInterface::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('factory')->defaultValue(Factory::class)->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('taxon_image')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->variableNode('options')->end()
+                                ->arrayNode('classes')
+                                    ->addDefaultsIfNotSet()
+                                    ->children()
+                                        ->scalarNode('model')->defaultValue(TaxonImage::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('interface')->defaultValue(TaxonImageInterface::class)->cannotBeEmpty()->end()
                                         ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
                                         ->scalarNode('factory')->defaultValue(Factory::class)->end()
                                     ->end()

--- a/src/Sylius/Bundle/CoreBundle/EventListener/ImageUploadListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/ImageUploadListener.php
@@ -65,12 +65,24 @@ class ImageUploadListener
         $subject = $event->getSubject();
         Assert::isInstanceOf($subject, TaxonInterface::class);
 
-        if ($subject->hasImage()) {
-            $this->uploader->upload($subject->getImage());
+        $this->uploadTaxonImages($subject);
+    }
+
+
+    /**
+     * @param TaxonInterface $taxon
+     */
+    private function uploadTaxonImages(TaxonInterface $taxon)
+    {
+        $images = $taxon->getImages();
+        foreach ($images as $image) {
+            if ($image->hasFile()) {
+                $this->uploader->upload($image);
+            }
 
             // Upload failed? Let's remove that image.
-            if (null === $subject->getImage()->getPath()) {
-                $subject->removeImage();
+            if (null === $image->getPath()) {
+                $images->removeElement($image);
             }
         }
     }

--- a/src/Sylius/Bundle/CoreBundle/EventListener/ImageUploadListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/ImageUploadListener.php
@@ -65,8 +65,13 @@ class ImageUploadListener
         $subject = $event->getSubject();
         Assert::isInstanceOf($subject, TaxonInterface::class);
 
-        if ($subject->hasImage() && $subject->getImage()->hasFile()) {
+        if ($subject->hasImage()) {
             $this->uploader->upload($subject->getImage());
+
+            // Upload failed? Let's remove that image.
+            if (null === $subject->getImage()->getPath()) {
+                $subject->removeImage();
+            }
         }
     }
 

--- a/src/Sylius/Bundle/CoreBundle/EventListener/ImageUploadListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/ImageUploadListener.php
@@ -14,7 +14,7 @@ namespace Sylius\Bundle\CoreBundle\EventListener;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Uploader\ImageUploaderInterface;
-use Sylius\Component\Taxonomy\Model\TaxonInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Webmozart\Assert\Assert;
 
@@ -65,8 +65,8 @@ class ImageUploadListener
         $subject = $event->getSubject();
         Assert::isInstanceOf($subject, TaxonInterface::class);
 
-        if ($subject->hasFile()) {
-            $this->uploader->upload($subject);
+        if ($subject->hasImage() && $subject->getImage()->hasFile()) {
+            $this->uploader->upload($subject->getImage());
         }
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/TaxonImageType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/TaxonImageType.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Form\Type;
+
+
+class TaxonImageType extends ImageType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sylius_image_taxon';
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/TaxonType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/TaxonType.php
@@ -23,6 +23,6 @@ class TaxonType extends BaseTaxonType
     {
         parent::buildForm($builder, $options);
 
-        $builder->add('image', 'sylius_image', ['label' => 'sylius.form.taxon.file']);
+        $builder->add('image', 'sylius_image_taxon', ['label' => 'sylius.form.taxon.file']);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/TaxonType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/TaxonType.php
@@ -23,6 +23,6 @@ class TaxonType extends BaseTaxonType
     {
         parent::buildForm($builder, $options);
 
-        $builder->add('image', 'sylius_image_taxon', ['label' => 'sylius.form.taxon.file']);
+        $builder->add('image', 'sylius_image', ['label' => 'sylius.form.taxon.file']);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/TaxonType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/TaxonType.php
@@ -23,6 +23,6 @@ class TaxonType extends BaseTaxonType
     {
         parent::buildForm($builder, $options);
 
-        $builder->add('file', 'file', ['label' => 'sylius.form.taxon.file']);
+        $builder->add('image', 'sylius_image_taxon', ['label' => 'sylius.form.taxon.file']);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
@@ -17,7 +17,14 @@
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <mapped-superclass name="Sylius\Component\Core\Model\Taxon" table="sylius_taxon">
-        <field name="path" nullable="true" />
+
+        <one-to-one field="image" target-entity="Sylius\Component\Core\Model\Image">
+            <cascade>
+                <cascade-persist/>
+                <cascade-remove />
+            </cascade>
+            <join-column name="image_id" referenced-column-name="id" nullable="true" />
+        </one-to-one>
 
        <many-to-many field="products" mapped-by="taxons" target-entity="Sylius\Component\Product\Model\ProductInterface"/>
     </mapped-superclass>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
@@ -18,11 +18,11 @@
 
     <mapped-superclass name="Sylius\Component\Core\Model\Taxon" table="sylius_taxon">
 
-        <one-to-one field="image" target-entity="Sylius\Component\Core\Model\TaxonImageInterface" mapped-by="taxon">
+        <one-to-many field="image" target-entity="Sylius\Component\Core\Model\TaxonImageInterface" mapped-by="taxon">
             <cascade>
                 <cascade-all/>
             </cascade>
-        </one-to-one>
+        </one-to-many>
 
        <many-to-many field="products" mapped-by="taxons" target-entity="Sylius\Component\Product\Model\ProductInterface"/>
     </mapped-superclass>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
@@ -18,7 +18,7 @@
 
     <mapped-superclass name="Sylius\Component\Core\Model\Taxon" table="sylius_taxon">
 
-        <one-to-many field="image" target-entity="Sylius\Component\Core\Model\TaxonImageInterface" mapped-by="taxon">
+        <one-to-many field="images" target-entity="Sylius\Component\Core\Model\TaxonImageInterface" mapped-by="taxon">
             <cascade>
                 <cascade-all/>
             </cascade>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
@@ -20,8 +20,7 @@
 
         <one-to-one field="image" target-entity="Sylius\Component\Core\Model\TaxonImageInterface" mapped-by="taxon">
             <cascade>
-                <cascade-persist/>
-                <cascade-remove />
+                <cascade-all/>
             </cascade>
         </one-to-one>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
@@ -18,12 +18,11 @@
 
     <mapped-superclass name="Sylius\Component\Core\Model\Taxon" table="sylius_taxon">
 
-        <one-to-one field="image" target-entity="Sylius\Component\Core\Model\Image">
+        <one-to-one field="image" target-entity="Sylius\Component\Core\Model\TaxonImageInterface" mapped-by="taxon">
             <cascade>
                 <cascade-persist/>
                 <cascade-remove />
             </cascade>
-            <join-column name="image_id" referenced-column-name="id" nullable="true" />
         </one-to-one>
 
        <many-to-many field="products" mapped-by="taxons" target-entity="Sylius\Component\Product\Model\ProductInterface"/>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/TaxonImage.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/TaxonImage.orm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <mapped-superclass name="Sylius\Component\Core\Model\TaxonImage" table="sylius_taxon_image">
+        <many-to-one field="taxon" target-entity="Sylius\Component\Taxonomy\Model\TaxonInterface" inversed-by="image" />
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/TaxonImage.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/TaxonImage.orm.xml
@@ -19,7 +19,7 @@
     <mapped-superclass name="Sylius\Component\Core\Model\TaxonImage" table="sylius_taxon_image">
 
         <unique-constraints>
-            <unique-constraint columns="id,code" name="code_idx" />
+            <unique-constraint columns="taxon_id,code" name="code_idx" />
         </unique-constraints>
 
         <field name="code" column="code" type="string" unique="false" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/TaxonImage.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/TaxonImage.orm.xml
@@ -17,7 +17,16 @@
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <mapped-superclass name="Sylius\Component\Core\Model\TaxonImage" table="sylius_taxon_image">
-        <many-to-one field="taxon" target-entity="Sylius\Component\Taxonomy\Model\TaxonInterface" inversed-by="image" />
+
+        <unique-constraints>
+            <unique-constraint columns="id,code" name="code_idx" />
+        </unique-constraints>
+
+        <field name="code" column="code" type="string" unique="false" />
+
+        <many-to-one field="taxon" target-entity="Sylius\Component\Taxonomy\Model\TaxonInterface" inversed-by="images" >
+            <join-column name="taxon_id" referenced-column-name="id"/>
+        </many-to-one>
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/form.xml
@@ -109,6 +109,12 @@
             <argument>%sylius.model.product_variant_image.class%</argument>
             <tag name="form.type" alias="sylius_image" />
         </service>
+
+        <service id="sylius.form.type.taxon_image" class="%sylius.form.type.image.class%">
+            <argument>%sylius.model.taxon_image.class%</argument>
+            <tag name="form.type" alias="sylius_image_taxon" />
+        </service>
+
         <service id="sylius.form.type.list" class="%sylius.form.type.list.class%">
             <tag name="form.type" alias="list" />
         </service>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/form.xml
@@ -27,6 +27,7 @@
         <parameter key="sylius.checkout_form.summary.class">Sylius\Bundle\CoreBundle\Form\Type\Checkout\SummaryType</parameter>
 
         <parameter key="sylius.form.type.image.class">Sylius\Bundle\CoreBundle\Form\Type\ImageType</parameter>
+        <parameter key="sylius.form.type.image_taxon.class">Sylius\Bundle\CoreBundle\Form\Type\TaxonImageType</parameter>
         <parameter key="sylius.form.type.list.class">Sylius\Bundle\CoreBundle\Form\Type\ListType</parameter>
         <parameter key="sylius.form.type.advanced_order.class">Sylius\Bundle\CoreBundle\Form\Type\AdvancedOrderType</parameter>
         <parameter key="sylius.form.type.country.class">Sylius\Bundle\CoreBundle\Form\Type\CountryType</parameter>
@@ -110,7 +111,7 @@
             <tag name="form.type" alias="sylius_image" />
         </service>
 
-        <service id="sylius.form.type.taxon_image" class="%sylius.form.type.image.class%">
+        <service id="sylius.form.type.image_taxon" class="%sylius.form.type.image_taxon.class%">
             <argument>%sylius.model.taxon_image.class%</argument>
             <tag name="form.type" alias="sylius_image_taxon" />
         </service>

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/ImageUploadListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/ImageUploadListenerSpec.php
@@ -80,11 +80,14 @@ class ImageUploadListenerSpec extends ObjectBehavior
     function it_uses_image_uploader_to_upload_taxon_image(
         GenericEvent $event,
         Taxon $taxon,
-        ImageUploaderInterface $uploader
+        ImageUploaderInterface $uploader,
+        ImageInterface $image
     ) {
         $event->getSubject()->willReturn($taxon);
-        $uploader->upload($taxon)->shouldBeCalled();
-        $taxon->hasFile()->willReturn(true);
+        $taxon->hasImage()->willReturn(true);
+        $taxon->getImage()->willReturn($image);
+        $uploader->upload($taxon->getImage())->shouldBeCalled();
+        $image->getPath()->willReturn('some_path');
 
         $this->uploadTaxonImage($event);
     }

--- a/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
@@ -260,8 +260,8 @@ class FrontendMenuBuilder extends MenuBuilder
         foreach ($taxons as $taxon) {
             $child = $menu->addChild($taxon->getName(), $childOptions);
 
-            if ($taxon->hasPath()) {
-                $child->setLabelAttribute('data-image', $taxon->getPath());
+            if ($taxon->hasImage()) {
+                $child->setLabelAttribute('data-image', $taxon->getImage()->getPath());
             }
 
             $this->createTaxonsMenuNode($child, $taxon);
@@ -371,8 +371,8 @@ class FrontendMenuBuilder extends MenuBuilder
                 'route' => $child,
                 'labelAttributes' => ['icon' => 'icon-angle-right'],
             ]);
-            if ($child->getPath()) {
-                $childMenu->setLabelAttribute('data-image', $child->getPath());
+            if ($child->hasImage()) {
+                $childMenu->setLabelAttribute('data-image', $child->getImage()->getPath());
             }
 
             $this->createTaxonsMenuNode($childMenu, $child);

--- a/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
+++ b/src/Sylius/Bundle/WebBundle/Menu/FrontendMenuBuilder.php
@@ -260,8 +260,8 @@ class FrontendMenuBuilder extends MenuBuilder
         foreach ($taxons as $taxon) {
             $child = $menu->addChild($taxon->getName(), $childOptions);
 
-            if ($taxon->hasImage()) {
-                $child->setLabelAttribute('data-image', $taxon->getImage()->getPath());
+            if ($taxon->hasImages()) {
+                $child->setLabelAttribute('data-image', $taxon->getImages()->first()->getPath());
             }
 
             $this->createTaxonsMenuNode($child, $taxon);
@@ -371,8 +371,8 @@ class FrontendMenuBuilder extends MenuBuilder
                 'route' => $child,
                 'labelAttributes' => ['icon' => 'icon-angle-right'],
             ]);
-            if ($child->hasImage()) {
-                $childMenu->setLabelAttribute('data-image', $child->getImage()->getPath());
+            if ($child->hasImages()) {
+                $childMenu->setLabelAttribute('data-image', $child->getImages()->first()->getPath());
             }
 
             $this->createTaxonsMenuNode($childMenu, $child);

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/_form.html.twig
@@ -4,7 +4,7 @@
     {{ form_row(form.code, {'attr': {'class': 'input-lg'}}) }}
     {{ form_row(form.translations, {'attr': {'class': 'input-lg'}}) }}
     {{ form_row(form.parent, {'attr': {'class': 'input-lg'} }) }}
-    {{ form_row(form.file) }}
+    {{ form_row(form.image) }}
 </fieldset>
 
 {{ form_rest(form) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Taxon/macros.html.twig
@@ -30,9 +30,9 @@
             </td>
             <td>
                 <span style="border-left: {{ taxon.level * 20}}px solid #f1f1f1; padding-left: 10px;">
-                    {% if taxon.path|length > 0 %}
-                        <a href="{{ taxon.path|imagine_filter('sylius_large') }}" title="{{ taxon.name }}">
-                            <img src="{{ taxon.path|imagine_filter('sylius_small') }}" alt="" class="img-rounded" />
+                    {% if taxon.image is not empty %}
+                        <a href="{{ taxon.image.path|imagine_filter('sylius_large') }}" title="{{ taxon.name }}">
+                            <img src="{{ taxon.image.path|imagine_filter('sylius_small') }}" alt="" class="img-rounded" />
                         </a>
                     {% endif %}
                     <a href="{{ path('sylius_backend_taxon_show', {'id': taxon.id}) }}">{{ taxon.name }}</a>

--- a/src/Sylius/Component/Core/Model/Taxon.php
+++ b/src/Sylius/Component/Core/Model/Taxon.php
@@ -26,9 +26,9 @@ class Taxon extends BaseTaxon implements TaxonInterface
     protected $products;
 
     /**
-     * @var ImageInterface
+     * @var ArrayCollection
      */
-    protected $image;
+    protected $images;
 
     public function __construct()
     {
@@ -36,38 +36,52 @@ class Taxon extends BaseTaxon implements TaxonInterface
 
         $this->createdAt = new \DateTime();
         $this->products = new ArrayCollection();
+        $this->images = new ArrayCollection();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function hasImage()
+    public function hasImages()
     {
-        return null !== $this->image;
+        return !$this->images->isEmpty();
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getImage()
+    public function getImages()
     {
-        return $this->image;
+        return $this->images;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function setImage(ImageInterface $image)
+    public function getImageByCode($code)
+    {
+        foreach ($this->images as $image) {
+            if($image->getCode() === $code) {
+                return $image;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addImage(TaxonImageInterface $image)
     {
         $image->setTaxon($this);
-        $this->image = $image;
+        $this->images->add($image);
     }
 
-    public function removeImage()
+    public function removeImage(TaxonImageInterface $image)
     {
-        if($this->hasImage()) {
-            $this->image->setTaxon(null);
-            $this->image = null;
+        if($this->images->contains($image)) {
+            $image->setTaxon(null);
+            $this->images->remove($image);
         }
     }
 

--- a/src/Sylius/Component/Core/Model/Taxon.php
+++ b/src/Sylius/Component/Core/Model/Taxon.php
@@ -16,24 +16,19 @@ use Sylius\Component\Resource\Model\TimestampableTrait;
 use Sylius\Component\Taxonomy\Model\Taxon as BaseTaxon;
 use Sylius\Component\Taxonomy\Model\TaxonTranslation;
 
-class Taxon extends BaseTaxon implements ImageInterface, TaxonInterface
+class Taxon extends BaseTaxon implements TaxonInterface
 {
     use TimestampableTrait;
-
-    /**
-     * @var \SplFileInfo
-     */
-    protected $file;
-
-    /**
-     * @var string
-     */
-    protected $path;
 
     /**
      * @var ArrayCollection
      */
     protected $products;
+
+    /**
+     * @var ImageInterface
+     */
+    protected $image;
 
     public function __construct()
     {
@@ -46,49 +41,25 @@ class Taxon extends BaseTaxon implements ImageInterface, TaxonInterface
     /**
      * {@inheritdoc}
      */
-    public function hasFile()
+    public function hasImage()
     {
-        return null !== $this->file;
+        return null !== $this->image;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getFile()
+    public function getImage()
     {
-        return $this->file;
+        return $this->image;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function setFile(\SplFileInfo $file)
+    public function setImage(ImageInterface $image)
     {
-        $this->file = $file;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasPath()
-    {
-        return null !== $this->path;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getPath()
-    {
-        return $this->path;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setPath($path)
-    {
-        $this->path = $path;
+        $this->image = $image;
     }
 
     /**

--- a/src/Sylius/Component/Core/Model/Taxon.php
+++ b/src/Sylius/Component/Core/Model/Taxon.php
@@ -59,7 +59,16 @@ class Taxon extends BaseTaxon implements TaxonInterface
      */
     public function setImage(ImageInterface $image)
     {
+        $image->setTaxon($this);
         $this->image = $image;
+    }
+
+    public function removeImage()
+    {
+        if($this->hasImage()) {
+            $this->image->setTaxon(null);
+            $this->image = null;
+        }
     }
 
     /**

--- a/src/Sylius/Component/Core/Model/TaxonImage.php
+++ b/src/Sylius/Component/Core/Model/TaxonImage.php
@@ -19,6 +19,11 @@ class TaxonImage extends Image implements TaxonImageInterface
     protected $taxon;
 
     /**
+     * @var string
+     */
+    protected $code;
+
+    /**
      * {@inheritdoc}
      */
     public function getTaxon()
@@ -33,4 +38,22 @@ class TaxonImage extends Image implements TaxonImageInterface
     {
         $this->taxon = $taxon;
     }
+
+    /**
+     * @return string
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * @param string $code
+     */
+    public function setCode($code)
+    {
+        $this->code = $code;
+    }
+
+
 }

--- a/src/Sylius/Component/Core/Model/TaxonImage.php
+++ b/src/Sylius/Component/Core/Model/TaxonImage.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Model;
+
+class TaxonImage extends Image implements TaxonImageInterface
+{
+    /**
+     * @var ProductVariantInterface
+     */
+    protected $taxon;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTaxon()
+    {
+        return $this->taxon;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setTaxon(TaxonInterface $taxon = null)
+    {
+        $this->taxon = $taxon;
+    }
+}

--- a/src/Sylius/Component/Core/Model/TaxonImageInterface.php
+++ b/src/Sylius/Component/Core/Model/TaxonImageInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Model;
+
+interface TaxonImageInterface extends ImageInterface
+{
+    /**
+     * @return TaxonInterface
+     */
+    public function getTaxon();
+
+    /**
+     * @param TaxonInterface $taxon
+     */
+    public function setTaxon(TaxonInterface $taxon = null);
+}

--- a/src/Sylius/Component/Core/Model/TaxonInterface.php
+++ b/src/Sylius/Component/Core/Model/TaxonInterface.php
@@ -32,18 +32,27 @@ interface TaxonInterface extends VariableTaxonInterface
     /**
      * @return bool
      */
-    public function hasImage();
+    public function hasImages();
     
     /**
-     * @return ImageInterface
+     * @return Collection|TaxonImageInterface[]
      */
-    public function getImage();
-
-    public function removeImage();
+    public function getImages();
 
     /**
-     * @param ImageInterface $image
+     * @param $code
+     * @return TaxonImageInterface|null;
      */
-    public function setImage(ImageInterface $image);
+    public function getImageByCode($code);
+
+    /**
+     * @param TaxonImageInterface $image
+     */
+    public function removeImage(TaxonImageInterface $image);
+
+    /**
+     * @param TaxonImageInterface $image
+     */
+    public function addImagae(TaxonImageInterface $image);
 
 }

--- a/src/Sylius/Component/Core/Model/TaxonInterface.php
+++ b/src/Sylius/Component/Core/Model/TaxonInterface.php
@@ -28,4 +28,20 @@ interface TaxonInterface extends VariableTaxonInterface
      * @param ProductInterface[] $products
      */
     public function setProducts($products);
+
+    /**
+     * @return bool
+     */
+    public function hasImage();
+    
+    /**
+     * @return ImageInterface
+     */
+    public function getImage();
+
+    /**
+     * @param ImageInterface $image
+     */
+    public function setImage(ImageInterface $image);
+
 }

--- a/src/Sylius/Component/Core/Model/TaxonInterface.php
+++ b/src/Sylius/Component/Core/Model/TaxonInterface.php
@@ -39,6 +39,8 @@ interface TaxonInterface extends VariableTaxonInterface
      */
     public function getImage();
 
+    public function removeImage();
+
     /**
      * @param ImageInterface $image
      */

--- a/src/Sylius/Component/Core/Model/TaxonInterface.php
+++ b/src/Sylius/Component/Core/Model/TaxonInterface.php
@@ -53,6 +53,6 @@ interface TaxonInterface extends VariableTaxonInterface
     /**
      * @param TaxonImageInterface $image
      */
-    public function addImagae(TaxonImageInterface $image);
+    public function addImage(TaxonImageInterface $image);
 
 }

--- a/src/Sylius/Component/Core/spec/Model/TaxonSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/TaxonSpec.php
@@ -25,11 +25,10 @@ class TaxonSpec extends ObjectBehavior
     function it_is_Sylius_Taxon()
     {
         $this->shouldImplement(TaxonInterface::class);
-        $this->shouldImplement(ImageInterface::class);
     }
 
-    function it_should_not_path_defined_by_default()
+    function it_should_not_image_defined_by_default()
     {
-        $this->getPath()->shouldReturn(null);
+        $this->getImage()->shouldReturn(null);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Related tickets | n/a
| License         | MIT

Ok folks i think this time to show some love for taxons and their images in particullar.
Our current Taxon image feature was implemented in ancient #92 and obviously needs to be refactored, hence this PR. 

The goal of this PR is to allow reusing `SyliusImageUploader` to manage Taxon images programmatically consistent and make working with images less painful overall.

TODO:
- [x] Replace ImageInterface stuff with proper `Image` property in Taxon model.
- [x] Update doctrine mappings.
- [x] Update TaxonInterface.
- [x] Introduce TaxonImage model & interface.
- [x] Add form type.
- [ ] Fix backend forms
- [x] Update Taxon & image relations to O2M
- [ ] Fix specs.

I guess i need a little help with specs and forms to finish this PR since i havent touched them yet.
Please, tell me what you think.
Cheers!