### PR TITLE
[RBAC] Ensure Permissions::__toString() returns a string 

### DIFF
--- a/src/Sylius/Component/Rbac/Model/Permission.php
+++ b/src/Sylius/Component/Rbac/Model/Permission.php
@@ -78,7 +78,7 @@ class Permission implements PermissionInterface
 
     public function __toString()
     {
-        return $this->description;
+        return $this->code;
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

Since the description field is nullable, it's possible that description could be null.

If so it blows up the Edit Role form as Symfony ChoiceType requires a string representation.
