### PR TITLE
[Migration] Auto-generate product code in db field while running doctrine

### DIFF
--- a/app/migrations/Version20160516131553.php
+++ b/app/migrations/Version20160516131553.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20160516131553 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_product ADD code VARCHAR(255) NOT NULL');
+        $this->addSql('UPDATE sylius_product s,
+                           (SELECT @n := 0) m
+                           SET s.`code` = CONCAT("PR", @n := @n + 1)         
+                      ');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_677B9B7477153098 ON sylius_product (code)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX UNIQ_677B9B7477153098 ON sylius_product');
+        $this->addSql('ALTER TABLE sylius_product DROP code');
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | none
| License         | MIT

Introduced by @lchrusciel in PR #4947 

Same problem as PR #4688 
This is to prevent migration fails due to the UNIQUE INDEX statement.