### PR TITLE
[Fixture] Set EUR as base currency in fixtures

### DIFF
--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadCurrencyData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadCurrencyData.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\FixturesBundle\DataFixtures\ORM;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Bundle\FixturesBundle\DataFixtures\DataFixture;
+use Sylius\Component\Currency\Model\CurrencyInterface;
 
 /**
  * Default currency fixtures.
@@ -21,6 +22,11 @@ use Sylius\Bundle\FixturesBundle\DataFixtures\DataFixture;
  */
 class LoadCurrencyData extends DataFixture
 {
+    const BASE_CURRENCY = 'EUR';
+
+    /**
+     * @var array
+     */
     protected $currencies = [
         'EUR' => 1.00,
         'USD' => 1.30,
@@ -40,6 +46,9 @@ class LoadCurrencyData extends DataFixture
             $currency->setCode($code);
             $currency->setExchangeRate($rate);
             $currency->setEnabled(true);
+            if (self::BASE_CURRENCY === $code) {
+                $currency->setBase(true);
+            }
 
             $this->setReference('Sylius.Currency.'.$code, $currency);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

While loading fixtures (without *Sylius* installation) none of currencies has been set as **base**, which led to some nasty bugs like this one:
![zrzut ekranu 2016-05-25 o 10 52 51](https://cloud.githubusercontent.com/assets/6212718/15534698/74e4e4ac-226a-11e6-82ec-076f66a1e2b2.png)
