### PR TITLE
[TaxonomyBundle] Fix display bug in choice list and enlarge area

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/LegacyProductType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/LegacyProductType.php
@@ -42,6 +42,7 @@ class LegacyProductType extends BaseProductType
             ->add('taxons', 'sylius_taxon_choice', [
                 'label' => 'sylius.form.product.taxons',
                 'multiple' => true,
+                'attr' => ['style' => 'height: 30%']
             ])
             ->add('variantSelectionMethod', 'choice', [
                 'label' => 'sylius.form.product.variant_selection_method',

--- a/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
@@ -100,6 +100,20 @@ class TaxonRepository extends EntityRepository implements TaxonRepositoryInterfa
     /**
      * {@inheritdoc}
      */
+    public function findNodesTreeSorted()
+    {
+        $queryBuilder = $this->createQueryBuilder('o');
+        $queryBuilder
+            ->orderBy('o.root')
+            ->addOrderBy('o.left')
+        ;
+    
+        return $queryBuilder->getQuery()->getResult();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getFormQueryBuilder()
     {
         return $this->createQueryBuilder('o');

--- a/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonChoiceType.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonChoiceType.php
@@ -114,7 +114,15 @@ class TaxonChoiceType extends AbstractType
                     $taxons = $repository->findChildren($options['root']);
                 }
             } else {
-                $taxons = $repository->findAll();
+                $taxons = array();
+                $rootTaxons = $repository->findRootNodes();
+                foreach ($rootTaxons as $rootTaxon) {
+                    $taxons[] = $rootTaxon;
+                    $childTaxons = $repository->findChildren($rootTaxon);
+                    foreach ($childTaxons as $childTaxon) {
+                        $taxons[] = $childTaxon;
+                    }
+                }
             }
 
             if (null !== $options['filter']) {

--- a/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonChoiceType.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonChoiceType.php
@@ -114,15 +114,7 @@ class TaxonChoiceType extends AbstractType
                     $taxons = $repository->findChildren($options['root']);
                 }
             } else {
-                $taxons = array();
-                $rootTaxons = $repository->findRootNodes();
-                foreach ($rootTaxons as $rootTaxon) {
-                    $taxons[] = $rootTaxon;
-                    $childTaxons = $repository->findChildren($rootTaxon);
-                    foreach ($childTaxons as $childTaxon) {
-                        $taxons[] = $childTaxon;
-                    }
-                }
+                $taxons = $repository->findNodesTreeSorted();
             }
 
             if (null !== $options['filter']) {

--- a/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
+++ b/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
@@ -43,6 +43,11 @@ interface TaxonRepositoryInterface extends RepositoryInterface
     public function findRootNodes();
 
     /**
+     * @return TaxonInterface[]
+     */
+    public function findNodesTreeSorted();
+    
+    /**
      * @param string $permalink
      *
      * @return TaxonInterface|null


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | none
| License         | MIT

Taxon choice list is badly sorted by id.
To keep tree consistent I've made this PR

**My taxon list**
![selection_490](https://cloud.githubusercontent.com/assets/1230954/15536340/377f1536-2271-11e6-9f45-19c8d50cb5c9.jpg)

**Before PR**
![selection_488](https://cloud.githubusercontent.com/assets/1230954/15536352/41792d92-2271-11e6-9b1e-e0e46228b3d7.jpg)

**After PR**
![selection_489](https://cloud.githubusercontent.com/assets/1230954/15536403/4b2fa172-2271-11e6-8df6-c4cb9e9d875c.jpg)

I've also enlarge the choice list height on product page, it's more readable whan you have a lot of taxons

Enjoy ;)