### PR TITLE
[RBAC] Use a cache-key prefix for improved namespacing

### DIFF
--- a/src/Sylius/Component/Rbac/Authorization/CachedPermissionMap.php
+++ b/src/Sylius/Component/Rbac/Authorization/CachedPermissionMap.php
@@ -22,6 +22,7 @@ use Sylius\Component\Rbac\Model\RoleInterface;
 class CachedPermissionMap implements PermissionMapInterface
 {
     const DEFAULT_TTL = 60;
+    const CACHE_KEY_PREFIX = 'rbac_role:';
 
     /**
      * @var PermissionMapInterface
@@ -86,6 +87,6 @@ class CachedPermissionMap implements PermissionMapInterface
      */
     private function getCacheKey(RoleInterface $role)
     {
-        return $role->getCode();
+        return self::CACHE_KEY_PREFIX . $role->getCode();
     }
 }

--- a/src/Sylius/Component/Rbac/spec/Authorization/CachedPermissionMapSpec.php
+++ b/src/Sylius/Component/Rbac/spec/Authorization/CachedPermissionMapSpec.php
@@ -48,8 +48,8 @@ class CachedPermissionMapSpec extends ObjectBehavior
     {
         $role->getCode()->shouldBeCalled()->willReturn('catalog_manager');
 
-        $cache->contains('catalog_manager')->shouldBeCalled()->willReturn(true);
-        $cache->fetch('catalog_manager')->shouldBeCalled()->willReturn(['can_eat_bananas', 'can_smash_bananas']);
+        $cache->contains('rbac_role:catalog_manager')->shouldBeCalled()->willReturn(true);
+        $cache->fetch('rbac_role:catalog_manager')->shouldBeCalled()->willReturn(['can_eat_bananas', 'can_smash_bananas']);
 
         $this->hasPermission($role, 'can_eat_bananas')->shouldReturn(true);
         $this->hasPermission($role, 'can_eat_oranges')->shouldReturn(false);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

Most caching uses prefixes for namespacing, you can see below before this is applied how you can't easily identify the RBAC role cache keys in my redis example (87, 91, 96):

```
 86) "sylius[nodes:_/cms/routes/shop/mediache/resolve/product/244984/rc,_default][1]"
 87) "sylius[reiss_offline_marketer][18]"
 88) "sylius[workspace:_default][7]"
 89) "sylius[nodes:_/cms/routes/shop/mediache/resolve/product/237852/rc/2,_default][1]"
 90) "sylius[nodes:_/cms/routes/ui/prod/js,_default][7]"
 91) "sylius[reiss_super_admin][18]"
 92) "sylius[nodes:_/cms/routes/shop/mediache/resolve/product/222392,_default][1]"
 93) "sylius[nodes:_/cms/routes/dresses,_default][7]"
 94) "sylius[nodes:_/cms/routes/spain,_default][7]"
 95) "sylius[nodes:_/cms/routes/@SyliusWebBundle/Resources/public/img/logo.png,_default][1]"
 96) "sylius[reiss_warehouse_supervisor][18]"
 97) "sylius[workspace:_default][16]"
 98) "sylius[nodes:_/cms/routes/shop/mediache/resolve/product/222392/rc/5,_default][1]"
 99) "sylius[nodes:_/cms/routes/ui,_default][16]"
100) "sylius[nodes:_/cms/routes/get/1232445,_default][7]"
```

