### PR TITLE
Update OrderRepository.php

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -180,7 +180,7 @@ class OrderRepository extends CartRepository implements OrderRepositoryInterface
         $queryBuilder = $this->createQueryBuilder('o')
             ->select('count(o.id)')
             ->leftJoin('o.items', 'item')
-            ->innerJoin('o.promotionCoupons', 'coupons')
+            ->innerJoin('o.promotionCoupon', 'coupon')
             ->andWhere('o.customer = :customer')
             ->andWhere('o.completedAt IS NOT NULL')
             ->andWhere('coupon = :coupon')


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #5130 
| License         | MIT

[Semantical Error] line 0, col 113 near 'coupons WHERE': Error: Class Sylius\Component\Core\Model\Order has no association named promotionCoupons on version 0.18