### PR TITLE
Added has and hasByClass methods to Metadata registry

### DIFF
--- a/src/Sylius/Component/Resource/Metadata/Registry.php
+++ b/src/Sylius/Component/Resource/Metadata/Registry.php
@@ -22,6 +22,11 @@ class Registry implements RegistryInterface
     private $metadata = [];
 
     /**
+     * @var array
+     */
+    private $metadataByClass = [];
+
+    /**
      * {@inheritdoc}
      */
     public function getAll()
@@ -34,7 +39,7 @@ class Registry implements RegistryInterface
      */
     public function get($alias)
     {
-        if (!array_key_exists($alias, $this->metadata)) {
+        if (!isset($this->metadata[$alias])) {
             throw new \InvalidArgumentException(sprintf('Resource "%s" does not exist.', $alias));
         }
 
@@ -44,15 +49,29 @@ class Registry implements RegistryInterface
     /**
      * {@inheritdoc}
      */
+    public function has($alias)
+    {
+        return isset($this->metadata[$alias]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getByClass($className)
     {
-        foreach ($this->metadata as $metadata) {
-            if ($className === $metadata->getClass('model')) {
-                return $metadata;
-            }
+        if (!isset($this->metadataByClass[$className])) {
+            throw new \InvalidArgumentException(sprintf('Resource with model class "%s" does not exist.', $className));
         }
 
-        throw new \InvalidArgumentException(sprintf('Resource with model class "%s" does not exist.', $className));
+        return $this->metadataByClass[$className];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasByClass($className)
+    {
+        return isset($this->metadataByClass[$className]);
     }
 
     /**
@@ -61,6 +80,7 @@ class Registry implements RegistryInterface
     public function add(MetadataInterface $metadata)
     {
         $this->metadata[$metadata->getAlias()] = $metadata;
+        $this->metadataByClass[$metadata->getClass('model')] = $metadata;
     }
 
     /**

--- a/src/Sylius/Component/Resource/Metadata/RegistryInterface.php
+++ b/src/Sylius/Component/Resource/Metadata/RegistryInterface.php
@@ -31,11 +31,25 @@ interface RegistryInterface
     public function get($alias);
 
     /**
+     * @param string $alias
+     *
+     * @return bool
+     */
+    public function has($alias);
+
+    /**
      * @param string $className
      *
      * @return MetadataInterface
      */
     public function getByClass($className);
+
+    /**
+     * @param string $className
+     * 
+     * @return bool
+     */
+    public function hasByClass($className);
 
     /**
      * @param MetadataInterface $metadata

--- a/src/Sylius/Component/Resource/spec/Metadata/RegistrySpec.php
+++ b/src/Sylius/Component/Resource/spec/Metadata/RegistrySpec.php
@@ -33,7 +33,9 @@ class RegistrySpec extends ObjectBehavior
     function it_returns_all_resources_metadata(MetadataInterface $metadata1, MetadataInterface $metadata2)
     {
         $metadata1->getAlias()->willReturn('app.product');
+        $metadata1->getClass('model')->willReturn('Product');
         $metadata2->getAlias()->willReturn('app.order');
+        $metadata2->getClass('model')->willReturn('Order');
 
         $this->add($metadata1);
         $this->add($metadata2);
@@ -52,10 +54,22 @@ class RegistrySpec extends ObjectBehavior
     function it_returns_specific_metadata(MetadataInterface $metadata)
     {
         $metadata->getAlias()->willReturn('app.shipping_method');
+        $metadata->getClass('model')->willReturn('ShippingMethod');
 
         $this->add($metadata);
 
         $this->get('app.shipping_method')->shouldReturn($metadata);
+    }
+
+    function it_should_say_if_it_has_metadata_for_a_specific_alias(MetadataInterface $metadata)
+    {
+        $metadata->getAlias()->willReturn('app.shipping_method');
+        $metadata->getClass('model')->willReturn('ShippingMethod');
+
+        $this->add($metadata);
+
+        $this->has('app.shipping_method')->shouldReturn(true);
+        $this->has('app.order')->shouldReturn(false);
     }
 
     function it_throws_an_exception_if_resource_is_not_registered_with_class()
@@ -78,6 +92,17 @@ class RegistrySpec extends ObjectBehavior
         $this->add($metadata2);
 
         $this->getByClass('App\Model\Order')->shouldReturn($metadata2);
+    }
+
+    function it_can_say_if_it_contains_metadata_for_a_model_class(MetadataInterface $metadata)
+    {
+        $metadata->getAlias()->willReturn('app.product');
+        $metadata->getClass('model')->willReturn('App\Model\Product');
+
+        $this->add($metadata);
+
+        $this->hasByClass('App\Model\Product')->shouldReturn(true);
+        $this->hasByClass('App\Model\Order')->shouldReturn(false);
     }
 
     function it_adds_metadata_from_configuration_array()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no/yes |
| Related tickets | fixes #5135 |
| License | MIT |
- Adds `has` and `hasByClass` methods to registry and registry interface.
- Indexes by class in addition to alias.

Potential BC break if anybody was implementing the `RegistryInterface`
