### PR TITLE
[Promotion][Core] Discounted unit price feature

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,12 @@ UPGRADE
 
 ## From 0.18 to 0.19.x
 
+### Core and CoreBundle
+
+* Introduced new adjustments type ``ORDER_UNIT_PROMOTION``
+* Changed current *item* promotion actions to *unit* promotion actions (as they're applied on ``OrderItemUnit`` level)
+* Introduced ``getDiscountedUnitPrice`` method on ``OrderItem``, which returns single *unit* price lowered by ``ORDER_UNIT_PROMOTION`` adjustments
+
 ### Variation and VariationBundle
 
 * Removed concept of master variant (removed ``$master`` flag from ``Sylius\Component\Variation\Model\Variant``), all usages of **master** variant has been, for now, replaced with **first** variant;

--- a/features/order/managing_orders/seeing_order_item_detailed_data.feature
+++ b/features/order/managing_orders/seeing_order_item_detailed_data.feature
@@ -28,6 +28,7 @@ Feature: Seeing order item detailed data
         Given I view the summary of the order "#00000666"
         When I check "Iron Man T-Shirt" data
         Then its unit price should be €39.00
+        And its discounted unit price should be €37.00
         And its quantity should be 4
         And its subtotal should be €148.00
         And its discount should be -€12.00

--- a/src/Sylius/Behat/Context/Setup/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/PromotionContext.php
@@ -200,7 +200,7 @@ final class PromotionContext implements Context
         $discount,
         TaxonInterface $taxon
     ) {
-        $this->createItemPercentagePromotion($promotion, $discount, $this->getTaxonFilterConfiguration([$taxon->getCode()]));
+        $this->createUnitPercentagePromotion($promotion, $discount, $this->getTaxonFilterConfiguration([$taxon->getCode()]));
     }
 
     /**
@@ -211,7 +211,7 @@ final class PromotionContext implements Context
         $discount,
         TaxonInterface $taxon
     ) {
-        $this->createItemFixedPromotion($promotion, $discount, $this->getTaxonFilterConfiguration([$taxon->getCode()]));
+        $this->createUnitFixedPromotion($promotion, $discount, $this->getTaxonFilterConfiguration([$taxon->getCode()]));
     }
 
     /**
@@ -222,7 +222,7 @@ final class PromotionContext implements Context
         $discount,
         $amount
     ) {
-        $this->createItemFixedPromotion($promotion, $discount, $this->getPriceRangeFilterConfiguration($amount));
+        $this->createUnitFixedPromotion($promotion, $discount, $this->getPriceRangeFilterConfiguration($amount));
     }
 
     /**
@@ -234,7 +234,7 @@ final class PromotionContext implements Context
         $minAmount,
         $maxAmount
     ) {
-        $this->createItemFixedPromotion(
+        $this->createUnitFixedPromotion(
             $promotion,
             $discount,
             $this->getPriceRangeFilterConfiguration($minAmount, $maxAmount)
@@ -249,7 +249,7 @@ final class PromotionContext implements Context
         $discount,
         $amount
     ) {
-        $this->createItemPercentagePromotion($promotion, $discount, $this->getPriceRangeFilterConfiguration($amount));
+        $this->createUnitPercentagePromotion($promotion, $discount, $this->getPriceRangeFilterConfiguration($amount));
     }
 
     /**
@@ -261,7 +261,7 @@ final class PromotionContext implements Context
         $minAmount,
         $maxAmount
     ) {
-        $this->createItemPercentagePromotion(
+        $this->createUnitPercentagePromotion(
             $promotion,
             $discount,
             $this->getPriceRangeFilterConfiguration($minAmount, $maxAmount)
@@ -353,7 +353,7 @@ final class PromotionContext implements Context
     ) {
         $rule = $this->ruleFactory->createContainsTaxon($targetTaxon->getCode(), 1);
 
-        $this->createItemPercentagePromotion($promotion, $discount, $this->getTaxonFilterConfiguration([$discountTaxon->getCode()]), $rule);
+        $this->createUnitPercentagePromotion($promotion, $discount, $this->getTaxonFilterConfiguration([$discountTaxon->getCode()]), $rule);
     }
 
     /**
@@ -370,7 +370,7 @@ final class PromotionContext implements Context
 
         $rule = $this->ruleFactory->createItemTotal($targetAmount);
 
-        $this->createItemFixedPromotion($promotion, $discount, [], $rule);
+        $this->createUnitFixedPromotion($promotion, $discount, [], $rule);
     }
 
     /**
@@ -388,7 +388,7 @@ final class PromotionContext implements Context
 
         $rule = $this->ruleFactory->createItemTotal($targetAmount);
 
-        $this->createItemPercentagePromotion(
+        $this->createUnitPercentagePromotion(
             $promotion,
             $taxonDiscount,
             $this->getTaxonFilterConfiguration([$taxon->getCode()]),
@@ -410,7 +410,7 @@ final class PromotionContext implements Context
 
         $rule = $this->ruleFactory->createTaxon($targetTaxonsCodes);
 
-        $this->createItemPercentagePromotion(
+        $this->createUnitPercentagePromotion(
             $promotion,
             $discount,
             $this->getTaxonFilterConfiguration($discountTaxonsCodes),
@@ -459,9 +459,9 @@ final class PromotionContext implements Context
      * @param int $discount
      * @param array $configuration
      */
-    private function createItemFixedPromotion(PromotionInterface $promotion, $discount, array $configuration = [], $rule = null)
+    private function createUnitFixedPromotion(PromotionInterface $promotion, $discount, array $configuration = [], $rule = null)
     {
-        $this->persistPromotion($promotion, $this->actionFactory->createItemFixedDiscount($discount), $configuration, $rule);
+        $this->persistPromotion($promotion, $this->actionFactory->createUnitFixedDiscount($discount), $configuration, $rule);
     }
 
     /**
@@ -469,9 +469,9 @@ final class PromotionContext implements Context
      * @param int $discount
      * @param array $configuration
      */
-    private function createItemPercentagePromotion(PromotionInterface $promotion, $discount, array $configuration = [], $rule = null)
+    private function createUnitPercentagePromotion(PromotionInterface $promotion, $discount, array $configuration = [], $rule = null)
     {
-        $this->persistPromotion($promotion, $this->actionFactory->createItemPercentageDiscount($discount), $configuration, $rule);
+        $this->persistPromotion($promotion, $this->actionFactory->createUnitPercentageDiscount($discount), $configuration, $rule);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -278,6 +278,20 @@ final class ManagingOrdersContext implements Context
     }
 
     /**
+     * @Then /^(its) discounted unit price should be ([^"]+)$/
+     */
+    public function itemDiscountedUnitPriceShouldBe($itemName, $discountedUnitPrice)
+    {
+        $itemUnitPriceOnPage = $this->showPage->getItemDiscountedUnitPrice($itemName);
+
+        Assert::eq(
+            $itemUnitPriceOnPage,
+            $discountedUnitPrice,
+            'Item discounted unit price is %s, but should be %s.'
+        );
+    }
+
+    /**
      * @Then /^(its) quantity should be ([^"]+)$/
      */
     public function itemQuantityShouldBe($itemName, $quantity)

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
@@ -206,6 +206,16 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
      *
      * @return string
      */
+    public function getItemDiscountedUnitPrice($itemName)
+    {
+        return $this->getItemProperty($itemName, 'discounted-unit-price');
+    }
+
+    /**
+     * @param string $itemName
+     *
+     * @return string
+     */
     public function getItemQuantity($itemName)
     {
         return $this->getItemProperty($itemName, 'quantity');

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
@@ -115,6 +115,13 @@ interface ShowPageInterface extends SymfonyPageInterface
      *
      * @return string
      */
+    public function getItemDiscountedUnitPrice($itemName);
+
+    /**
+     * @param string $itemName
+     *
+     * @return string
+     */
     public function getItemQuantity($itemName);
 
     /**

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_item.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_item.html.twig
@@ -27,6 +27,9 @@
     <td class="right aligned unit-price">
         {{ item.unitPrice|sylius_price(order.currency) }}
     </td>
+    <td class="right aligned discounted-unit-price">
+        {{ item.discountedUnitPrice|sylius_price(order.currency) }}
+    </td>
     <td class="right aligned quantity">
         {{ item.quantity }}
     </td>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_summary.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_summary.html.twig
@@ -3,6 +3,7 @@
     <tr>
         <th>{{ 'sylius.ui.order_item_product'|trans }}</th>
         <th class="two wide center aligned">{{ 'sylius.ui.unit_price'|trans }}</th>
+        <th class="two wide center aligned">{{ 'sylius.ui.discounted_unit_price'|trans }}</th>
         <th class="one wide center aligned">{{ 'sylius.ui.quantity'|trans }}</th>
         <th class="two wide center aligned">{{ 'sylius.ui.subtotal'|trans }}</th>
         <th class="one wide center aligned">{{ 'sylius.ui.discount'|trans }}</th>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -515,7 +515,6 @@
         <service id="sylius.promotion_action.unit_percentage_discount" class="%sylius.promotion_action.unit_percentage_discount.class%">
             <argument type="service" id="sylius.factory.adjustment" />
             <argument type="service" id="sylius.originator" />
-            <argument type="service" id="sylius.integer_distributor" />
             <argument type="service" id="sylius.promotion_filter.price_range" />
             <argument type="service" id="sylius.promotion_filter.taxon" />
             <tag name="sylius.promotion_action" type="unit_percentage_discount" label="Item percentage discount" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -80,9 +80,9 @@
         <parameter key="sylius.promotion_rule_checker.customer_group.class">Sylius\Component\Core\Promotion\Checker\CustomerGroupRuleChecker</parameter>
         <parameter key="sylius.promotion_rule_checker.total_of_items_from_taxon.class">Sylius\Component\Core\Promotion\Checker\TotalOfItemsFromTaxonRuleChecker</parameter>
         <parameter key="sylius.promotion_action.fixed_discount.class">Sylius\Component\Core\Promotion\Action\FixedDiscountAction</parameter>
-        <parameter key="sylius.promotion_action.item_fixed_discount.class">Sylius\Component\Core\Promotion\Action\ItemFixedDiscountAction</parameter>
+        <parameter key="sylius.promotion_action.unit_fixed_discount.class">Sylius\Component\Core\Promotion\Action\UnitFixedDiscountAction</parameter>
         <parameter key="sylius.promotion_action.percentage_discount.class">Sylius\Component\Core\Promotion\Action\PercentageDiscountAction</parameter>
-        <parameter key="sylius.promotion_action.item_percentage_discount.class">Sylius\Component\Core\Promotion\Action\ItemPercentageDiscountAction</parameter>
+        <parameter key="sylius.promotion_action.unit_percentage_discount.class">Sylius\Component\Core\Promotion\Action\UnitPercentageDiscountAction</parameter>
         <parameter key="sylius.promotion_action.shipping_discount.class">Sylius\Component\Core\Promotion\Action\ShippingDiscountAction</parameter>
         <parameter key="sylius.promotion_action.add_product.class">Sylius\Component\Core\Promotion\Action\AddProductAction</parameter>
         <parameter key="sylius.promotion.eligibility_checker.coupons.class">Sylius\Component\Core\Promotion\Checker\CouponsEligibilityChecker</parameter>
@@ -499,12 +499,12 @@
             <argument type="service" id="sylius.promotion.units_promotion_adjustments_applicator" />
             <tag name="sylius.promotion_action" type="order_fixed_discount" label="Order fixed discount" />
         </service>
-        <service id="sylius.promotion_action.item_fixed_discount" class="%sylius.promotion_action.item_fixed_discount.class%">
+        <service id="sylius.promotion_action.unit_fixed_discount" class="%sylius.promotion_action.unit_fixed_discount.class%">
             <argument type="service" id="sylius.factory.adjustment" />
             <argument type="service" id="sylius.originator" />
             <argument type="service" id="sylius.promotion_filter.price_range" />
             <argument type="service" id="sylius.promotion_filter.taxon" />
-            <tag name="sylius.promotion_action" type="item_fixed_discount" label="Item fixed discount" />
+            <tag name="sylius.promotion_action" type="unit_fixed_discount" label="Item fixed discount" />
         </service>
         <service id="sylius.promotion_action.percentage_discount" class="%sylius.promotion_action.percentage_discount.class%">
             <argument type="service" id="sylius.originator" />
@@ -512,13 +512,13 @@
             <argument type="service" id="sylius.promotion.units_promotion_adjustments_applicator" />
             <tag name="sylius.promotion_action" type="order_percentage_discount" label="Order percentage discount" />
         </service>
-        <service id="sylius.promotion_action.item_percentage_discount" class="%sylius.promotion_action.item_percentage_discount.class%">
+        <service id="sylius.promotion_action.unit_percentage_discount" class="%sylius.promotion_action.unit_percentage_discount.class%">
             <argument type="service" id="sylius.factory.adjustment" />
             <argument type="service" id="sylius.originator" />
             <argument type="service" id="sylius.integer_distributor" />
             <argument type="service" id="sylius.promotion_filter.price_range" />
             <argument type="service" id="sylius.promotion_filter.taxon" />
-            <tag name="sylius.promotion_action" type="item_percentage_discount" label="Item percentage discount" />
+            <tag name="sylius.promotion_action" type="unit_percentage_discount" label="Item percentage discount" />
         </service>
         <service id="sylius.promotion_action.shipping_discount" class="%sylius.promotion_action.shipping_discount.class%">
             <argument type="service" id="sylius.factory.adjustment" />

--- a/src/Sylius/Component/Core/Factory/ActionFactory.php
+++ b/src/Sylius/Component/Core/Factory/ActionFactory.php
@@ -12,8 +12,8 @@
 namespace Sylius\Component\Core\Factory;
 
 use Sylius\Component\Core\Promotion\Action\FixedDiscountAction;
-use Sylius\Component\Core\Promotion\Action\ItemFixedDiscountAction;
-use Sylius\Component\Core\Promotion\Action\ItemPercentageDiscountAction;
+use Sylius\Component\Core\Promotion\Action\UnitFixedDiscountAction;
+use Sylius\Component\Core\Promotion\Action\UnitPercentageDiscountAction;
 use Sylius\Component\Core\Promotion\Action\PercentageDiscountAction;
 use Sylius\Component\Core\Promotion\Action\ShippingDiscountAction;
 use Sylius\Component\Promotion\Model\ActionInterface;
@@ -56,9 +56,9 @@ class ActionFactory implements ActionFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createItemFixedDiscount($amount)
+    public function createUnitFixedDiscount($amount)
     {
-        return $this->createAction(ItemFixedDiscountAction::TYPE, ['amount' => $amount]);
+        return $this->createAction(UnitFixedDiscountAction::TYPE, ['amount' => $amount]);
     }
 
     /**
@@ -72,9 +72,9 @@ class ActionFactory implements ActionFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createItemPercentageDiscount($percentage)
+    public function createUnitPercentageDiscount($percentage)
     {
-        return $this->createAction(ItemPercentageDiscountAction::TYPE, ['percentage' => $percentage]);
+        return $this->createAction(UnitPercentageDiscountAction::TYPE, ['percentage' => $percentage]);
     }
 
     /**

--- a/src/Sylius/Component/Core/Factory/ActionFactoryInterface.php
+++ b/src/Sylius/Component/Core/Factory/ActionFactoryInterface.php
@@ -31,7 +31,7 @@ interface ActionFactoryInterface extends FactoryInterface
      *
      * @return ActionInterface
      */
-    public function createItemFixedDiscount($amount);
+    public function createUnitFixedDiscount($amount);
 
     /**
      * @param float $percentage
@@ -45,7 +45,7 @@ interface ActionFactoryInterface extends FactoryInterface
      *
      * @return ActionInterface
      */
-    public function createItemPercentageDiscount($percentage);
+    public function createUnitPercentageDiscount($percentage);
 
     /**
      * @param float $percentage

--- a/src/Sylius/Component/Core/Model/AdjustmentInterface.php
+++ b/src/Sylius/Component/Core/Model/AdjustmentInterface.php
@@ -20,4 +20,5 @@ interface AdjustmentInterface extends BaseAdjustmentInterface
     const SHIPPING_ADJUSTMENT = 'shipping';
     const ORDER_PROMOTION_ADJUSTMENT = 'order_promotion';
     const ORDER_ITEM_PROMOTION_ADJUSTMENT = 'order_item_promotion';
+    const ORDER_UNIT_PROMOTION_ADJUSTMENT = 'order_unit_promotion';
 }

--- a/src/Sylius/Component/Core/Model/OrderItem.php
+++ b/src/Sylius/Component/Core/Model/OrderItem.php
@@ -79,10 +79,16 @@ class OrderItem extends CartItem implements OrderItemInterface
     }
 
     /**
+     * Returns single unit price lowered by order unit promotions (each unit must have the same unit promotion discount)
+     *
      * {@inheritdoc}
      */
     public function getDiscountedUnitPrice()
     {
+        if ($this->units->isEmpty()) {
+            return $this->unitPrice;
+        }
+
         return
             $this->unitPrice +
             $this->units->first()->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)

--- a/src/Sylius/Component/Core/Model/OrderItem.php
+++ b/src/Sylius/Component/Core/Model/OrderItem.php
@@ -86,6 +86,7 @@ class OrderItem extends CartItem implements OrderItemInterface
         $subtotal = $this->unitPrice * $this->quantity;
         foreach ($this->units as $unit) {
             $subtotal += $unit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT);
+            $subtotal += $unit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
         }
 
         return $subtotal;

--- a/src/Sylius/Component/Core/Model/OrderItem.php
+++ b/src/Sylius/Component/Core/Model/OrderItem.php
@@ -81,14 +81,19 @@ class OrderItem extends CartItem implements OrderItemInterface
     /**
      * {@inheritdoc}
      */
+    public function getDiscountedUnitPrice()
+    {
+        return
+            $this->unitPrice +
+            $this->units->first()->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getSubtotal()
     {
-        $subtotal = $this->unitPrice * $this->quantity;
-        foreach ($this->units as $unit) {
-            $subtotal += $unit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT);
-            $subtotal += $unit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
-        }
-
-        return $subtotal;
+        return $this->getDiscountedUnitPrice() * $this->quantity;
     }
 }

--- a/src/Sylius/Component/Core/Model/OrderItemInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderItemInterface.php
@@ -41,5 +41,10 @@ interface OrderItemInterface extends CartItemInterface
     /**
      * @return int
      */
+    public function getDiscountedUnitPrice();
+
+    /**
+     * @return int
+     */
     public function getSubtotal();
 }

--- a/src/Sylius/Component/Core/Promotion/Action/UnitDiscountAction.php
+++ b/src/Sylius/Component/Core/Promotion/Action/UnitDiscountAction.php
@@ -25,7 +25,7 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-abstract class ItemDiscountAction implements PromotionActionInterface
+abstract class UnitDiscountAction implements PromotionActionInterface
 {
     /**
      * @var FactoryInterface
@@ -78,7 +78,7 @@ abstract class ItemDiscountAction implements PromotionActionInterface
      */
     protected function removeUnitOrderItemAdjustments(OrderItemUnitInterface $unit, PromotionInterface $promotion)
     {
-        foreach ($unit->getAdjustments(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT) as $adjustment) {
+        foreach ($unit->getAdjustments(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT) as $adjustment) {
             if ($promotion === $this->originator->getOrigin($adjustment)) {
                 $unit->removeAdjustment($adjustment);
             }
@@ -92,7 +92,7 @@ abstract class ItemDiscountAction implements PromotionActionInterface
      */
     protected function addAdjustmentToUnit(OrderItemUnitInterface $unit, $amount, PromotionInterface $promotion)
     {
-        $adjustment = $this->createAdjustment($promotion, AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT);
+        $adjustment = $this->createAdjustment($promotion, AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT);
         $adjustment->setAmount(-$amount);
 
         $unit->addAdjustment($adjustment);

--- a/src/Sylius/Component/Core/Promotion/Action/UnitFixedDiscountAction.php
+++ b/src/Sylius/Component/Core/Promotion/Action/UnitFixedDiscountAction.php
@@ -23,9 +23,9 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class ItemFixedDiscountAction extends ItemDiscountAction
+class UnitFixedDiscountAction extends UnitDiscountAction
 {
-    const TYPE = 'item_fixed_discount';
+    const TYPE = 'unit_fixed_discount';
 
     /**
      * @var FilterInterface

--- a/src/Sylius/Component/Core/Promotion/Action/UnitPercentageDiscountAction.php
+++ b/src/Sylius/Component/Core/Promotion/Action/UnitPercentageDiscountAction.php
@@ -29,11 +29,6 @@ class UnitPercentageDiscountAction extends UnitDiscountAction
     const TYPE = 'unit_percentage_discount';
 
     /**
-     * @var IntegerDistributorInterface
-     */
-    private $distributor;
-
-    /**
      * @var FilterInterface
      */
     private $priceRangeFilter;
@@ -46,20 +41,17 @@ class UnitPercentageDiscountAction extends UnitDiscountAction
     /**
      * @param FactoryInterface $adjustmentFactory
      * @param OriginatorInterface $originator
-     * @param IntegerDistributorInterface $distributor
      * @param FilterInterface $priceRangeFilter
      * @param FilterInterface $taxonFilter
      */
     public function __construct(
         FactoryInterface $adjustmentFactory,
         OriginatorInterface $originator,
-        IntegerDistributorInterface $distributor,
         FilterInterface $priceRangeFilter,
         FilterInterface $taxonFilter
     ) {
         parent::__construct($adjustmentFactory, $originator);
 
-        $this->distributor = $distributor;
         $this->priceRangeFilter = $priceRangeFilter;
         $this->taxonFilter = $taxonFilter;
     }
@@ -77,10 +69,8 @@ class UnitPercentageDiscountAction extends UnitDiscountAction
         $filteredItems = $this->taxonFilter->filter($filteredItems, $configuration);
 
         foreach ($filteredItems as $item) {
-            $promotionAmount = (int) round($item->getTotal() * $configuration['percentage']);
-            $distributedAmounts = $this->distributor->distribute($promotionAmount, $item->getQuantity());
-
-            $this->setUnitsAdjustments($item, $distributedAmounts, $promotion);
+            $promotionAmount = (int) round($item->getUnitPrice() * $configuration['percentage']);
+            $this->setUnitsAdjustments($item, $promotionAmount, $promotion);
         }
     }
 
@@ -94,19 +84,13 @@ class UnitPercentageDiscountAction extends UnitDiscountAction
 
     /**
      * @param OrderItemInterface $item
-     * @param array $distributedAmounts
+     * @param int $promotionAmount
      * @param PromotionInterface $promotion
      */
-    private function setUnitsAdjustments(OrderItemInterface $item, array $distributedAmounts, PromotionInterface $promotion)
+    private function setUnitsAdjustments(OrderItemInterface $item, $promotionAmount, PromotionInterface $promotion)
     {
-        $i = 0;
         foreach ($item->getUnits() as $unit) {
-            if (0 === $distributedAmounts[$i]) {
-                break;
-            }
-
-            $this->addAdjustmentToUnit($unit, $distributedAmounts[$i], $promotion);
-            $i++;
+            $this->addAdjustmentToUnit($unit, $promotionAmount, $promotion);
         }
     }
 }

--- a/src/Sylius/Component/Core/Promotion/Action/UnitPercentageDiscountAction.php
+++ b/src/Sylius/Component/Core/Promotion/Action/UnitPercentageDiscountAction.php
@@ -24,9 +24,9 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class ItemPercentageDiscountAction extends ItemDiscountAction
+class UnitPercentageDiscountAction extends UnitDiscountAction
 {
-    const TYPE = 'item_percentage_discount';
+    const TYPE = 'unit_percentage_discount';
 
     /**
      * @var IntegerDistributorInterface

--- a/src/Sylius/Component/Core/Remover/AdjustmentsRemover.php
+++ b/src/Sylius/Component/Core/Remover/AdjustmentsRemover.php
@@ -28,6 +28,7 @@ class AdjustmentsRemover implements AdjustmentsRemoverInterface
         $adjustmentsToRemove = [
             AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT,
             AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT,
+            AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT,
             AdjustmentInterface::TAX_ADJUSTMENT
         ];
 

--- a/src/Sylius/Component/Core/spec/Factory/ActionFactorySpec.php
+++ b/src/Sylius/Component/Core/spec/Factory/ActionFactorySpec.php
@@ -12,16 +12,19 @@
 namespace spec\Sylius\Component\Core\Factory;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Factory\ActionFactory;
 use Sylius\Component\Core\Factory\ActionFactoryInterface;
 use Sylius\Component\Core\Promotion\Action\FixedDiscountAction;
-use Sylius\Component\Core\Promotion\Action\ItemFixedDiscountAction;
-use Sylius\Component\Core\Promotion\Action\ItemPercentageDiscountAction;
+use Sylius\Component\Core\Promotion\Action\UnitFixedDiscountAction;
+use Sylius\Component\Core\Promotion\Action\UnitPercentageDiscountAction;
 use Sylius\Component\Core\Promotion\Action\PercentageDiscountAction;
 use Sylius\Component\Core\Promotion\Action\ShippingDiscountAction;
 use Sylius\Component\Promotion\Model\ActionInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 
 /**
+ * @mixin ActionFactory
+ *
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
 class ActionFactorySpec extends ObjectBehavior
@@ -58,14 +61,14 @@ class ActionFactorySpec extends ObjectBehavior
         $this->createFixedDiscount(1000)->shouldReturn($action);
     }
 
-    function it_creates_item_fixed_discount_action_with_given_amount($decoratedFactory, ActionInterface $action)
+    function it_creates_unit_fixed_discount_action_with_given_amount($decoratedFactory, ActionInterface $action)
     {
         $decoratedFactory->createNew()->willReturn($action);
 
-        $action->setType(ItemFixedDiscountAction::TYPE)->shouldBeCalled();
+        $action->setType(UnitFixedDiscountAction::TYPE)->shouldBeCalled();
         $action->setConfiguration(['amount' => 1000])->shouldBeCalled();
 
-        $this->createItemFixedDiscount(1000)->shouldReturn($action);
+        $this->createUnitFixedDiscount(1000)->shouldReturn($action);
     }
 
     function it_creates_percentage_discount_action_with_given_discount_rate($decoratedFactory, ActionInterface $action)
@@ -78,14 +81,14 @@ class ActionFactorySpec extends ObjectBehavior
         $this->createPercentageDiscount(0.1)->shouldReturn($action);
     }
 
-    function it_creates_item_percentage_discount_action_with_given_discount_rate($decoratedFactory, ActionInterface $action)
+    function it_creates_unit_percentage_discount_action_with_given_discount_rate($decoratedFactory, ActionInterface $action)
     {
         $decoratedFactory->createNew()->willReturn($action);
 
-        $action->setType(ItemPercentageDiscountAction::TYPE)->shouldBeCalled();
+        $action->setType(UnitPercentageDiscountAction::TYPE)->shouldBeCalled();
         $action->setConfiguration(['percentage' => 0.1])->shouldBeCalled();
 
-        $this->createItemPercentageDiscount(0.1)->shouldReturn($action);
+        $this->createUnitPercentageDiscount(0.1)->shouldReturn($action);
     }
 
     function it_creates_shipping_discount_action_with_given_discount_rate($decoratedFactory, ActionInterface $action)

--- a/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
@@ -68,6 +68,20 @@ class OrderItemSpec extends ObjectBehavior
         $this->getTaxTotal()->shouldReturn(820);
     }
 
+    function it_returns_discounted_unit_price_which_is_first_unit_price_lowered_by_unit_promotions(
+        OrderItemUnitInterface $unit
+    ) {
+        $this->setUnitPrice(10000);
+
+        $unit->getOrderItem()->willReturn($this);
+        $unit->getTotal()->willReturn(9000);
+        $unit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->willReturn(-500);
+
+        $this->addUnit($unit);
+
+        $this->getDiscountedUnitPrice()->shouldReturn(9500);
+    }
+
     function it_returns_subtotal_which_consist_of_discounted_unit_price_multiplied_by_quantity(
         OrderItemUnitInterface $firstUnit,
         OrderItemUnitInterface $secondUnit
@@ -76,17 +90,15 @@ class OrderItemSpec extends ObjectBehavior
 
         $firstUnit->getOrderItem()->willReturn($this);
         $firstUnit->getTotal()->willReturn(9000);
-        $firstUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn(-1000);
-        $firstUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->willReturn(0);
+        $firstUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->willReturn(-500);
 
         $secondUnit->getOrderItem()->willReturn($this);
-        $secondUnit->getTotal()->willReturn(9500);
-        $secondUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn(-500);
-        $secondUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->willReturn(-1000);
+        $secondUnit->getTotal()->willReturn(9000);
+        $secondUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->willReturn(-500);
 
         $this->addUnit($firstUnit);
         $this->addUnit($secondUnit);
 
-        $this->getSubtotal()->shouldReturn(17500);
+        $this->getSubtotal()->shouldReturn(19000);
     }
 }

--- a/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
@@ -82,6 +82,13 @@ class OrderItemSpec extends ObjectBehavior
         $this->getDiscountedUnitPrice()->shouldReturn(9500);
     }
 
+    function it_returns_unit_price_as_discounted_unit_price_if_there_are_no_units()
+    {
+        $this->setUnitPrice(10000);
+
+        $this->getDiscountedUnitPrice()->shouldReturn(10000);
+    }
+
     function it_returns_subtotal_which_consist_of_discounted_unit_price_multiplied_by_quantity(
         OrderItemUnitInterface $firstUnit,
         OrderItemUnitInterface $secondUnit

--- a/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
@@ -77,14 +77,16 @@ class OrderItemSpec extends ObjectBehavior
         $firstUnit->getOrderItem()->willReturn($this);
         $firstUnit->getTotal()->willReturn(9000);
         $firstUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn(-1000);
+        $firstUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->willReturn(0);
 
         $secondUnit->getOrderItem()->willReturn($this);
         $secondUnit->getTotal()->willReturn(9500);
         $secondUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn(-500);
+        $secondUnit->getAdjustmentsTotal(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->willReturn(-1000);
 
         $this->addUnit($firstUnit);
         $this->addUnit($secondUnit);
 
-        $this->getSubtotal()->shouldReturn(18500);
+        $this->getSubtotal()->shouldReturn(17500);
     }
 }

--- a/src/Sylius/Component/Core/spec/Promotion/Action/UnitFixedDiscountActionSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/UnitFixedDiscountActionSpec.php
@@ -19,7 +19,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Core\Model\PromotionInterface;
-use Sylius\Component\Core\Promotion\Action\ItemDiscountAction;
+use Sylius\Component\Core\Promotion\Action\UnitDiscountAction;
 use Sylius\Component\Core\Promotion\Filter\FilterInterface;
 use Sylius\Component\Originator\Originator\OriginatorInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
@@ -29,7 +29,7 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class ItemFixedDiscountActionSpec extends ObjectBehavior
+class UnitFixedDiscountActionSpec extends ObjectBehavior
 {
     function let(
         FactoryInterface $adjustmentFactory,
@@ -42,12 +42,12 @@ class ItemFixedDiscountActionSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Component\Core\Promotion\Action\ItemFixedDiscountAction');
+        $this->shouldHaveType('Sylius\Component\Core\Promotion\Action\UnitFixedDiscountAction');
     }
 
     function it_is_discount_action()
     {
-        $this->shouldHaveType(ItemDiscountAction::class);
+        $this->shouldHaveType(UnitDiscountAction::class);
     }
 
     function it_applies_fixed_discount_on_every_unit_in_order(
@@ -88,14 +88,14 @@ class ItemFixedDiscountActionSpec extends ObjectBehavior
         $adjustmentFactory->createNew()->willReturn($promotionAdjustment1, $promotionAdjustment2);
 
         $unit1->getTotal()->willReturn(1000);
-        $promotionAdjustment1->setType(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->shouldBeCalled();
+        $promotionAdjustment1->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $promotionAdjustment1->setLabel('Test promotion')->shouldBeCalled();
         $promotionAdjustment1->setAmount(-500)->shouldBeCalled();
 
         $originator->setOrigin($promotionAdjustment1, $promotion)->shouldBeCalled();
 
         $unit2->getTotal()->willReturn(1000);
-        $promotionAdjustment2->setType(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->shouldBeCalled();
+        $promotionAdjustment2->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $promotionAdjustment2->setLabel('Test promotion')->shouldBeCalled();
         $promotionAdjustment2->setAmount(-500)->shouldBeCalled();
 
@@ -160,14 +160,14 @@ class ItemFixedDiscountActionSpec extends ObjectBehavior
         $adjustmentFactory->createNew()->willReturn($promotionAdjustment1, $promotionAdjustment2);
 
         $unit1->getTotal()->willReturn(300);
-        $promotionAdjustment1->setType(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->shouldBeCalled();
+        $promotionAdjustment1->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $promotionAdjustment1->setLabel('Test promotion')->shouldBeCalled();
         $promotionAdjustment1->setAmount(-300)->shouldBeCalled();
 
         $originator->setOrigin($promotionAdjustment1, $promotion)->shouldBeCalled();
 
         $unit2->getTotal()->willReturn(200);
-        $promotionAdjustment2->setType(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->shouldBeCalled();
+        $promotionAdjustment2->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $promotionAdjustment2->setLabel('Test promotion')->shouldBeCalled();
         $promotionAdjustment2->setAmount(-200)->shouldBeCalled();
 
@@ -208,7 +208,7 @@ class ItemFixedDiscountActionSpec extends ObjectBehavior
         $orderItem->getUnits()->willReturn($units);
         $units->getIterator()->willReturn(new \ArrayIterator([$unit->getWrappedObject()]));
 
-        $unit->getAdjustments(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn($adjustments);
+        $unit->getAdjustments(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->willReturn($adjustments);
         $adjustments
             ->getIterator()
             ->willReturn(new \ArrayIterator([$promotionAdjustment1->getWrappedObject(), $promotionAdjustment2->getWrappedObject()]))

--- a/src/Sylius/Component/Core/spec/Promotion/Action/UnitPercentageDiscountActionSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/UnitPercentageDiscountActionSpec.php
@@ -20,7 +20,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Core\Model\PromotionInterface;
-use Sylius\Component\Core\Promotion\Action\ItemDiscountAction;
+use Sylius\Component\Core\Promotion\Action\UnitDiscountAction;
 use Sylius\Component\Core\Promotion\Filter\FilterInterface;
 use Sylius\Component\Originator\Originator\OriginatorInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
@@ -30,7 +30,7 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class ItemPercentageDiscountActionSpec extends ObjectBehavior
+class UnitPercentageDiscountActionSpec extends ObjectBehavior
 {
     function let(
         FactoryInterface $adjustmentFactory,
@@ -44,12 +44,12 @@ class ItemPercentageDiscountActionSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Component\Core\Promotion\Action\ItemPercentageDiscountAction');
+        $this->shouldHaveType('Sylius\Component\Core\Promotion\Action\UnitPercentageDiscountAction');
     }
 
     function it_is_item_discount_action()
     {
-        $this->shouldHaveType(ItemDiscountAction::class);
+        $this->shouldHaveType(UnitDiscountAction::class);
     }
 
     function it_applies_percentage_discount_on_every_unit_in_order(
@@ -93,13 +93,13 @@ class ItemPercentageDiscountActionSpec extends ObjectBehavior
 
         $adjustmentFactory->createNew()->willReturn($promotionAdjustment1, $promotionAdjustment2);
 
-        $promotionAdjustment1->setType(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->shouldBeCalled();
+        $promotionAdjustment1->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $promotionAdjustment1->setLabel('Test promotion')->shouldBeCalled();
         $promotionAdjustment1->setAmount(-100)->shouldBeCalled();
 
         $originator->setOrigin($promotionAdjustment1, $promotion)->shouldBeCalled();
 
-        $promotionAdjustment2->setType(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->shouldBeCalled();
+        $promotionAdjustment2->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $promotionAdjustment2->setLabel('Test promotion')->shouldBeCalled();
         $promotionAdjustment2->setAmount(-100)->shouldBeCalled();
 
@@ -151,7 +151,7 @@ class ItemPercentageDiscountActionSpec extends ObjectBehavior
 
         $adjustmentFactory->createNew()->willReturn($promotionAdjustment1);
 
-        $promotionAdjustment1->setType(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->shouldBeCalled();
+        $promotionAdjustment1->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $promotionAdjustment1->setLabel('Test promotion')->shouldBeCalled();
         $promotionAdjustment1->setAmount(-1)->shouldBeCalled();
 
@@ -192,7 +192,7 @@ class ItemPercentageDiscountActionSpec extends ObjectBehavior
         $orderItem->getUnits()->willReturn($units);
         $units->getIterator()->willReturn(new \ArrayIterator([$unit->getWrappedObject()]));
 
-        $unit->getAdjustments(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->willReturn($adjustments);
+        $unit->getAdjustments(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->willReturn($adjustments);
         $adjustments
             ->getIterator()
             ->willReturn(new \ArrayIterator([$promotionAdjustment1->getWrappedObject(), $promotionAdjustment2->getWrappedObject()]))

--- a/src/Sylius/Component/Core/spec/Promotion/Action/UnitPercentageDiscountActionSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/UnitPercentageDiscountActionSpec.php
@@ -35,11 +35,10 @@ class UnitPercentageDiscountActionSpec extends ObjectBehavior
     function let(
         FactoryInterface $adjustmentFactory,
         OriginatorInterface $originator,
-        IntegerDistributorInterface $distributor,
         FilterInterface $priceRangeFilter,
         FilterInterface $taxonFilter
     ) {
-        $this->beConstructedWith($adjustmentFactory, $originator, $distributor, $priceRangeFilter, $taxonFilter);
+        $this->beConstructedWith($adjustmentFactory, $originator, $priceRangeFilter, $taxonFilter);
     }
 
     function it_is_initializable()
@@ -54,7 +53,6 @@ class UnitPercentageDiscountActionSpec extends ObjectBehavior
 
     function it_applies_percentage_discount_on_every_unit_in_order(
         $adjustmentFactory,
-        $distributor,
         $originator,
         $priceRangeFilter,
         $taxonFilter,
@@ -86,8 +84,7 @@ class UnitPercentageDiscountActionSpec extends ObjectBehavior
         $orderItem1->getUnits()->willReturn($units);
         $units->getIterator()->willReturn(new \ArrayIterator([$unit1->getWrappedObject(), $unit2->getWrappedObject()]));
 
-        $orderItem1->getTotal()->willReturn(1000);
-        $distributor->distribute(200, 2)->willReturn([100, 100]);
+        $orderItem1->getUnitPrice()->willReturn(500);
 
         $promotion->getName()->willReturn('Test promotion');
 
@@ -107,58 +104,6 @@ class UnitPercentageDiscountActionSpec extends ObjectBehavior
 
         $unit1->addAdjustment($promotionAdjustment1)->shouldBeCalled();
         $unit2->addAdjustment($promotionAdjustment2)->shouldBeCalled();
-
-        $this->execute($order, ['percentage' => 0.2, 'filters' => ['taxons' => ['testTaxon']]], $promotion);
-    }
-
-    function it_does_not_apply_promotions_with_amount_0(
-        $adjustmentFactory,
-        $distributor,
-        $originator,
-        $priceRangeFilter,
-        $taxonFilter,
-        AdjustmentInterface $promotionAdjustment1,
-        Collection $originalItems,
-        Collection $units,
-        OrderInterface $order,
-        OrderItemInterface $orderItem1,
-        OrderItemInterface $orderItem2,
-        OrderItemInterface $orderItem3,
-        OrderItemUnitInterface $unit1,
-        OrderItemUnitInterface $unit2,
-        PromotionInterface $promotion
-    ) {
-        $order->getItems()->willReturn($originalItems);
-        $originalItems->toArray()->willReturn([$orderItem1, $orderItem2, $orderItem3]);
-
-        $priceRangeFilter
-            ->filter([$orderItem1, $orderItem2, $orderItem3], ['percentage' => 0.2, 'filters' => ['taxons' => ['testTaxon']]])
-            ->willReturn([$orderItem1, $orderItem2])
-        ;
-        $taxonFilter
-            ->filter([$orderItem1, $orderItem2], ['percentage' => 0.2, 'filters' => ['taxons' => ['testTaxon']]])
-            ->willReturn([$orderItem1])
-        ;
-
-        $orderItem1->getQuantity()->willReturn(2);
-        $orderItem1->getUnits()->willReturn($units);
-        $units->getIterator()->willReturn(new \ArrayIterator([$unit1->getWrappedObject(), $unit2->getWrappedObject()]));
-
-        $orderItem1->getTotal()->willReturn(5);
-        $distributor->distribute(1, 2)->willReturn([1, 0]);
-
-        $promotion->getName()->willReturn('Test promotion');
-
-        $adjustmentFactory->createNew()->willReturn($promotionAdjustment1);
-
-        $promotionAdjustment1->setType(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->shouldBeCalled();
-        $promotionAdjustment1->setLabel('Test promotion')->shouldBeCalled();
-        $promotionAdjustment1->setAmount(-1)->shouldBeCalled();
-
-        $originator->setOrigin($promotionAdjustment1, $promotion)->shouldBeCalled();
-
-        $unit1->addAdjustment($promotionAdjustment1)->shouldBeCalled();
-        $unit2->addAdjustment(Argument::any())->shouldNotBeCalled();
 
         $this->execute($order, ['percentage' => 0.2, 'filters' => ['taxons' => ['testTaxon']]], $promotion);
     }

--- a/src/Sylius/Component/Core/spec/Remover/AdjustmentsRemoverSpec.php
+++ b/src/Sylius/Component/Core/spec/Remover/AdjustmentsRemoverSpec.php
@@ -39,6 +39,7 @@ class AdjustmentsRemoverSpec extends ObjectBehavior
     {
         $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->shouldBeCalled();
+        $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $order->removeAdjustmentsRecursively(AdjustmentInterface::TAX_ADJUSTMENT)->shouldBeCalled();
 
         $this->removeFrom($order);

--- a/src/Sylius/Component/Order/Model/OrderItemUnitInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderItemUnitInterface.php
@@ -10,6 +10,7 @@
  */
 
 namespace Sylius\Component\Order\Model;
+
 use Sylius\Component\Resource\Model\ResourceInterface;
 
 /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Related tickets | 
| License         | MIT

- changed ``item promotions`` to ``unit promotions`` as they're applied on unit level
- changed ``UnitPercentageDiscountAction`` to count discount on unit level, rather than on item
- implement ``getDiscountedUnitPrice`` method on ``OrderItem``, which consist of unit price lowered by ``ORDER_UNIT_PROMOTION``s on one unit