### PR TITLE
[Core] Add missing configuration parameters

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/parameters.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/parameters.yml
@@ -2,7 +2,10 @@
 # (c) Paweł Jędrzejewski
 
 parameters:
+    sylius.inventory.backorders_enabled: true
+    sylius.inventory.tracking_enabled: true
     sylius.inventory.holding.duration: 15 minutes
+    sylius.order.allow_guest_order: false
     sylius.order.pending.duration: 3 hours
     sylius.cache:
         type: file_system


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | #5058 
| License         | MIT

The parameters where moved to Core [in this commit](https://github.com/Sylius/Sylius/commit/03ca4609da4d33c4d18693f6d500967b7810dada), but were skipped during configuration changes in #5058. You can't move through the checkout without this parameter.