### PR TITLE
[Behat][Admin] Fix attributes creation on new admin

### DIFF
--- a/features/product/managing_product_attributes/adding_checkbox_product_attribute.feature
+++ b/features/product/managing_product_attributes/adding_checkbox_product_attribute.feature
@@ -15,7 +15,7 @@ Feature: Adding a new checkbox product attribute
         And I name it "T-shirt with cotton" in "English (United States)"
         And I add it
         Then I should be notified that it has been successfully created
-        And the attribute "T-shirt with cotton" should appear in the store
+        And the checkbox attribute "T-shirt with cotton" should appear in the store
 
     @ui
     Scenario: Seeing disabled type field while adding a checkbox product attribute

--- a/features/product/managing_product_attributes/adding_integer_product_attribute.feature
+++ b/features/product/managing_product_attributes/adding_integer_product_attribute.feature
@@ -15,7 +15,7 @@ Feature: Adding a new integer product attribute
         And I name it "Book pages" in "English (United States)"
         And I add it
         Then I should be notified that it has been successfully created
-        And the attribute "Book pages" should appear in the store
+        And the integer attribute "Book pages" should appear in the store
 
     @ui
     Scenario: Seeing disabled type field while adding a integer product attribute

--- a/features/product/managing_product_attributes/adding_percent_product_attribute.feature
+++ b/features/product/managing_product_attributes/adding_percent_product_attribute.feature
@@ -15,7 +15,7 @@ Feature: Adding a new percent product attribute
         And I name it "T-shirt cotton content" in "English (United States)"
         And I add it
         Then I should be notified that it has been successfully created
-        And the attribute "T-shirt cotton content" should appear in the store
+        And the percent attribute "T-shirt cotton content" should appear in the store
 
     @ui
     Scenario: Seeing disabled type field while adding a percent product attribute

--- a/features/product/managing_product_attributes/adding_text_product_attribute.feature
+++ b/features/product/managing_product_attributes/adding_text_product_attribute.feature
@@ -15,7 +15,7 @@ Feature: Adding a new text product attribute
         And I name it "T-shirt brand" in "English (United States)"
         And I add it
         Then I should be notified that it has been successfully created
-        And the attribute "T-shirt brand" should appear in the store
+        And the text attribute "T-shirt brand" should appear in the store
 
     @ui
     Scenario: Seeing disabled type field while adding text a product attribute

--- a/features/product/managing_product_attributes/adding_textarea_product_attribute.feature
+++ b/features/product/managing_product_attributes/adding_textarea_product_attribute.feature
@@ -15,7 +15,7 @@ Feature: Adding a new textarea product attribute
         And I name it "T-shirt details" in "English (United States)"
         And I add it
         Then I should be notified that it has been successfully created
-        And the attribute "T-shirt details" should appear in the store
+        And the textarea attribute "T-shirt details" should appear in the store
 
     @ui
     Scenario: Seeing disabled type field while adding a textarea product attribute

--- a/features/product/managing_product_attributes/edit_text_product_attribute.feature
+++ b/features/product/managing_product_attributes/edit_text_product_attribute.feature
@@ -15,7 +15,7 @@ Feature: Text product attribute edition
         When I change it name to "T-shirt material" in "English (United States)"
         And I save my changes
         Then I should be notified that it has been successfully edited
-        And the attribute "T-shirt material" should appear in the store
+        And the text attribute "T-shirt material" should appear in the store
 
     @ui
     Scenario: Seeing disabled code field while editing a product attribute

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
@@ -97,16 +97,31 @@ final class ManagingProductAttributesContext implements Context
     }
 
     /**
-     * @Then the attribute :name should appear in the store
      * @Then I should see the product attribute :name in the list
      */
-    public function theAttributeShouldAppearInTheStore($name)
+    public function iShouldSeeTheProductAttributeInTheList($name)
     {
         $this->indexPage->open();
 
         Assert::true(
             $this->indexPage->isSingleResourceOnPage(['name' => $name]),
             sprintf('The product attribute with name %s should appear on page, but it does not.', $name)
+        );
+    }
+
+    /**
+     * @Then the :type attribute :name should appear in the store
+     */
+    public function theAttributeShouldAppearInTheStore($type, $name)
+    {
+        $this->indexPage->open();
+
+        Assert::true(
+            $this->indexPage->isSingleResourceWithSpecificElementOnPage(
+                ['name' => $name],
+                sprintf('td span.ui.label:contains("%s")', $type)
+            ),
+            sprintf('The product attribute with name %s and type %s should appear on page, but it does not.', $name, $type)
         );
     }
 

--- a/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
@@ -69,6 +69,26 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function isSingleResourceWithSpecificElementOnPage(array $parameters, $element)
+    {
+        try {
+            $rows = $this->tableAccessor->getRowsWithFields($this->getElement('table'), $parameters);
+
+            if (1 !== count($rows)) {
+                return false;
+            }
+
+            return null !== $rows[0]->find('css', $element);
+        } catch (\InvalidArgumentException $exception) {
+            return false;
+        } catch (ElementNotFoundException $exception) {
+            return false;
+        }
+    }
+
+    /**
      * @return int
      */
     public function countItems()

--- a/src/Sylius/Behat/Page/Admin/Crud/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/IndexPageInterface.php
@@ -27,6 +27,14 @@ interface IndexPageInterface extends SymfonyPageInterface
 
     /**
      * @param array $parameters
+     * @param string $element
+     *
+     * @return bool
+     */
+    public function isSingleResourceWithSpecificElementOnPage(array $parameters, $element);
+
+    /**
+     * @param array $parameters
      *
      * @return bool
      */

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_attribute.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_attribute.yml
@@ -20,7 +20,6 @@ sylius_admin_product_attribute_create:
     methods: [GET, POST]
     defaults:
         _controller: sylius.controller.product_attribute:createAction
-        type: text
         _sylius:
             section: admin
             factory:
@@ -33,6 +32,9 @@ sylius_admin_product_attribute_create:
                 subheader: sylius.ui.manage_attributes_of_your_products
                 templates:
                     form: SyliusAdminBundle:ProductAttribute:_form.html.twig
+                route:
+                    parameters:
+                        type: $type
 
 sylius_admin_get_attribute_types:
     path: /attribute-types


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets |
| License         | MIT

Currently, all created in new *Admin* attributes had ``text`` type.