### PR TITLE
[UiBundle] Fix choice type hardcoded class

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -38,7 +38,8 @@
 {% block choice_row -%}
     <div class="{% if required %}required {% endif %}field{% if (not compound or force_error|default(false)) and not valid %} error{% endif %}">
         {{- form_label(form) -}}
-        {{- form_widget(form, {'attr': {'class': 'ui dropdown'}}) -}}
+        {% set attr = attr|merge({'class': attr.class|default ~ ' ui dropdown'}) %}
+        {{- form_widget(form, {'attr': attr}) -}}
         {{- form_errors(form) -}}
     </div>
 {%- endblock choice_row %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

Using twig form type rendering we couldn't overwrite the class of Choice Types' rows. Now it will append the class.

