### PR TITLE
[Resource] Updating resources response code

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -314,7 +314,7 @@ class ResourceController extends Controller
             $this->eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource);
 
             if (!$configuration->isHtmlRequest()) {
-                return $this->viewHandler->handle($configuration, View::create($resource, 204));
+                return $this->viewHandler->handle($configuration, View::create(null, 204));
             }
 
             $this->flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource);
@@ -451,7 +451,7 @@ class ResourceController extends Controller
         $this->eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource);
 
         if (!$configuration->isHtmlRequest()) {
-            return $this->viewHandler->handle($configuration, View::create($resource, 204));
+            return $this->viewHandler->handle($configuration, View::create(null, 204));
         }
 
         $this->flashHelper->addSuccessFlash($configuration, $enabled ? 'enable' : 'disable', $resource);
@@ -503,7 +503,7 @@ class ResourceController extends Controller
         $this->eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource);
 
         if (!$configuration->isHtmlRequest()) {
-            return $this->viewHandler->handle($configuration, View::create($resource, 204));
+            return $this->viewHandler->handle($configuration, View::create(null, 204));
         }
 
         $this->flashHelper->addSuccessFlash($configuration, 'move', $resource);

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
@@ -991,7 +991,7 @@ class ResourceControllerSpec extends ObjectBehavior
         $manager->flush()->shouldBeCalled();
         $eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource)->shouldBeCalled();
 
-        $expectedView = View::create($resource, 204);
+        $expectedView = View::create(null, 204);
         $viewHandler->handle($configuration, Argument::that($this->getViewComparingCallback($expectedView)))->willReturn($response);
 
         $this->updateAction($request)->shouldReturn($response);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no?
| Related tickets | 
| License         | MIT

When updating resources, either 200 `OK` or 204 `No Content` can be returned. But we were mixing them, returning content with 204.