### PR TITLE
[TaxonomyBundle] adding webmozart/assert on composer.json in sylius/taxonomy-bundle

### DIFF
--- a/src/Sylius/Bundle/TaxonomyBundle/composer.json
+++ b/src/Sylius/Bundle/TaxonomyBundle/composer.json
@@ -26,7 +26,8 @@
         "stof/doctrine-extensions-bundle": "~1.1",
         "sylius/taxonomy": "^0.19",
         "sylius/resource-bundle": "^0.19",
-        "symfony/framework-bundle": "^2.8"
+        "symfony/framework-bundle": "^2.8",
+        "webmozart/assert": "^1.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.4",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

TaxonRepository need Webmozart assertion on findChildrenByRootCode method. This PR adds the dependency on composer.json for sylius/taxonomy-bundle  