### PR TITLE
[Resource] use a more appropriate response code on foreign key constraint violation exception

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/EventListener/ResourceDeleteSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/ResourceDeleteSubscriber.php
@@ -98,7 +98,7 @@ class ResourceDeleteSubscriber implements EventSubscriberInterface
                         'code' => $exception->getSQLState(),
                         'message' => $this->translator->trans('sylius.resource.delete_error', ['%resource%' => $resourceName], 'flashes'),
                     ]
-                ], 500))
+                ], 409))
             );
 
             return;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

500 is totally wrong. 409 seems to make the most sense to me.  
https://httpstatuses.com/409