### PR TITLE
remove unused doctrine/doctrine-cache-bundle

### DIFF
--- a/src/Sylius/Bundle/SettingsBundle/composer.json
+++ b/src/Sylius/Bundle/SettingsBundle/composer.json
@@ -22,7 +22,6 @@
     "require": {
         "php": "^5.6|^7.0",
 
-        "doctrine/doctrine-cache-bundle": "~1.0",
         "sylius/registry": "^0.19",
         "sylius/resource-bundle": "^0.19",
         "symfony/framework-bundle": "^2.8"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT


looks like caching support was removed in a refactor.
