### PR TITLE
[ResourceBundle]Add the ability to register a custom AuthorizationChecker for a resource

### DIFF
--- a/docs/bundles/SyliusResourceBundle/services.rst
+++ b/docs/bundles/SyliusResourceBundle/services.rst
@@ -6,4 +6,5 @@ When you register an entity as a resource, there are several services registered
 * ``app.controller.book`` instanceof ``ResourceController``;
 * ``app.factory.book`` instance of :ref:`component_resource_factory_factory-interface`;
 * ``app.repository.book`` instance of :ref:`component_resource_repository_repository-interface`;
-* ``app.manager.book`` alias to appropriate Doctrine's ``ObjectManager``.
+* ``app.manager.book`` alias to appropriate Doctrine's ``ObjectManager``;
+* ``app.authorization_checker.book instance of :ref: `bundle_resource_controller_authorization-checker-interface`.

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration.php
@@ -75,6 +75,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
                                     ->scalarNode('repository')->cannotBeEmpty()->end()
                                     ->scalarNode('factory')->defaultValue(Factory::class)->end()
+                                    ->scalarNode('authorization_checker')->cannotBeEmpty()->end()
                                     ->arrayNode('form')
                                         ->prototype('scalar')->end()
                                     ->end()

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
@@ -47,6 +47,8 @@ abstract class AbstractDriver implements DriverInterface
         if ($metadata->hasClass('form')) {
             $this->addForms($container, $metadata);
         }
+
+        $this->addAuthorizationChecker($container, $metadata);
     }
 
     /**
@@ -101,7 +103,7 @@ abstract class AbstractDriver implements DriverInterface
                 new Reference('sylius.resource_controller.form_factory'),
                 new Reference('sylius.resource_controller.redirect_handler'),
                 new Reference('sylius.resource_controller.flash_helper'),
-                new Reference('sylius.resource_controller.authorization_checker'),
+                new Reference($metadata->getServiceId('authorization_checker')),
                 new Reference('sylius.resource_controller.event_dispatcher'),
                 new Reference('sylius.resource_controller.state_machine'),
             ])
@@ -185,6 +187,18 @@ abstract class AbstractDriver implements DriverInterface
 
         if (!$container->hasDefinition(sprintf('%s.form.type.%s', $metadata->getApplicationName(), $metadata->getName()))) {
             $this->addDefaultForm($container, $metadata);
+        }
+    }
+
+    protected function addAuthorizationChecker(ContainerBuilder $container, MetadataInterface $metadata)
+    {
+        $authorizationCheckerServiceId = $metadata->getServiceId('authorization_checker');
+
+        if ($metadata->hasClass('authorization_checker')) {
+            $definition = new Definition($metadata->getClass('authorization_checker'));
+            $container->setDefinition($authorizationCheckerServiceId, $definition);
+        } else {
+            $container->setAlias($authorizationCheckerServiceId, 'sylius.resource_controller.authorization_checker');
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Related tickets | None |
| License | MIT |

Heys guys,

With this pull request, we give the ability to register a custom authorization checker on a case by case basis following the same way as other services :

``` yml
sylius_resource:
    resources:
        app.book:
            classes:
                model: AppBundle\Entity\Book
                authorization_checker: AppBundle\Authorization\BookAuthorizationChecker
```

For example, it could be useful to implement an AuthorizationChecker which checks if the logged user has the ownership of a resource.
Could you provide me some hints if I need to implement tests please ?
