### PR TITLE
[RFC] [Settings] Change Settings parameters type to json_array

### DIFF
--- a/src/Sylius/Bundle/SettingsBundle/Resources/config/doctrine/model/Settings.orm.xml
+++ b/src/Sylius/Bundle/SettingsBundle/Resources/config/doctrine/model/Settings.orm.xml
@@ -24,7 +24,7 @@
 
         <field name="schemaAlias" column="schema_alias" type="string" nullable="false"/>
         <field name="namespace" type="string" nullable="true"/>
-        <field name="parameters" type="array"/>
+        <field name="parameters" type="json_array"/>
     </mapped-superclass>
 
 </doctrine-mapping>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      |yes
| Related tickets | 
| License         | MIT

I'm overriding this in my own app, because:

1. json is easily manually manipulated in the db directly. serialized data is not. (not recommended i know, but a use case nonetheless) 
2. json is easily query-able by RDBMS engines that support json natively, i.e postgres and mysql 5.7.

Opening it up here for RFC to see if it might be thought useful.