### PR TITLE
[Core] Implement simple ShopperContext

### DIFF
--- a/src/Sylius/Bundle/ChannelBundle/Resources/views/FakeChannelCollector/layout.html.twig
+++ b/src/Sylius/Bundle/ChannelBundle/Resources/views/FakeChannelCollector/layout.html.twig
@@ -14,7 +14,7 @@
 
     {% set text %}
         <div class="sf-toolbar-info-piece">
-            <table style="background-color: #FFF !important;">
+            <table>
                 <tr>
                     <td>Name</td>
                     <td>Hostname</td>

--- a/src/Sylius/Bundle/CoreBundle/DataCollector/SyliusDataCollector.php
+++ b/src/Sylius/Bundle/CoreBundle/DataCollector/SyliusDataCollector.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\CoreBundle\DataCollector;
 
 use Sylius\Bundle\CoreBundle\Application\Kernel;
+use Sylius\Component\Core\Context\ShopperContextInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
@@ -19,11 +20,41 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 class SyliusDataCollector extends DataCollector
 {
     /**
-     * {@inheritdoc}
+     * @var ShopperContextInterface
      */
-    public function collect(Request $request, Response $response, \Exception $exception = null)
+    private $shopperContext;
+
+    /**
+     * @var string
+     */
+    private $version;
+
+    /**
+     * @var string
+     */
+    private $channelCode;
+
+    /**
+     * @var string
+     */
+    private $currencyCode;
+
+    /**
+     * @var string
+     */
+    private $localeCode;
+
+    /**
+     * @var string
+     */
+    private $customerEmail;
+
+    /**
+     * @param ShopperContextInterface $shopperContext
+     */
+    public function __construct(ShopperContextInterface $shopperContext)
     {
-        $this->data['version'] = Kernel::VERSION;
+        $this->shopperContext = $shopperContext;
     }
 
     /**
@@ -31,7 +62,73 @@ class SyliusDataCollector extends DataCollector
      */
     public function getVersion()
     {
-        return $this->data['version'];
+        return $this->version;
+    }
+
+    /**
+     * @return string
+     */
+    public function getChannelCode()
+    {
+        return $this->channelCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrencyCode()
+    {
+        return $this->currencyCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCustomerEmail()
+    {
+        return $this->customerEmail;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLocaleCode()
+    {
+        return $this->localeCode;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function collect(Request $request, Response $response, \Exception $exception = null)
+    {
+        $this->version = Kernel::VERSION;
+
+        $this->channelCode = $this->shopperContext->getChannel()->getCode();
+        $this->currencyCode = $this->shopperContext->getCurrencyCode();
+        $this->localeCode = $this->shopperContext->getLocaleCode();
+
+        $customer = $this->shopperContext->getCustomer();
+
+        if (null !== $customer) {
+            $this->customerEmail = $customer->getEmail();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return serialize([$this->version, $this->channelCode, $this->currencyCode, $this->localeCode, $this->customerEmail]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        list($this->version, $this->channelCode, $this->currencyCode, $this->localeCode, $this->customerEmail) = unserialize($serialized);
     }
 
     /**
@@ -39,6 +136,6 @@ class SyliusDataCollector extends DataCollector
      */
     public function getName()
     {
-        return 'sylius';
+        return 'sylius_core';
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
@@ -71,6 +71,7 @@ class SyliusCoreExtension extends AbstractResourceExtension implements PrependEx
         $configFiles = [
             'services.xml',
             'controller.xml',
+            'context.xml',
             'form.xml',
             'api_form.xml',
             'templating.xml',

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/context.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/context.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+                               http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sylius.context.shopper.class">Sylius\Component\Core\Context\ShopperContext</parameter>
+    </parameters>
+
+    <services>
+        <service id="sylius.context.shopper" class="%sylius.context.shopper.class%">
+            <argument type="service" id="sylius.context.channel" />
+            <argument type="service" id="sylius.context.currency" />
+            <argument type="service" id="sylius.context.locale" />
+            <argument type="service" id="sylius.context.customer" />
+        </service>
+    </services>
+
+</container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -576,7 +576,8 @@
         </service>
 
         <service id="sylius.data_collector" class="%sylius.data_collector.class%" public="false">
-            <tag name="data_collector" template="SyliusCoreBundle:Collector:sylius" id="sylius" priority="255" />
+            <argument type="service" id="sylius.context.shopper" />
+            <tag name="data_collector" template="SyliusCoreBundle:Collector:sylius" id="sylius_core" priority="255" />
         </service>
 
         <service id="sylius.dynamic_router" class="%sylius.dynamic_router.class%">

--- a/src/Sylius/Bundle/CoreBundle/Resources/views/Collector/sylius.html.twig
+++ b/src/Sylius/Bundle/CoreBundle/Resources/views/Collector/sylius.html.twig
@@ -1,7 +1,6 @@
 {% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
 
 {% block toolbar %}
-    {# Sylius Logo #}
     {% set icon %}
         <a href="http://sylius.org/">
             <img width="26" height="28" alt="Sylius" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAcCAYAAAB/E6/TAAAFS0lEQVRIx61WaUxcVRRmGEqtCyaaGBP/maYxsdX0B5RSQKBlhmFtC7QspbRoAdHQ2EhqK8u0oGUX2afDOkOHZXDCvradYbZSmFJAxEawGqppqv5qMBFm3lzPue8NDiCGgi85efe9e3K/833n3HOvg8MzPmf6JDxBe64TjtsWJnZF6GqUEfpaI52sjeM5/B/PMa2U79mdz8fxcWWRe+BQ2axQU0mE6goSZai/hP+DR6qdtgxw/t43vJDhcrpAo+n2zsD2/PxDN8SMqzyDCPtL/hCNVC2LAPDD8RY/9Im/I+NvCShAU0klSZho8RT2FM+6yTKImzxj2aMpi4Qri/wSTM1RgZoqEjJS/ZN4uu8V9E0aa9m8jMl3m6mz5IF2R6SupjBQU8kI1OXkUGv2X66N6SRAmddp8001KfeGjkgWwnU1w/i9u0vsuGmgpDEWqGB22AWifeR/u5wAu+Ujw6XEU3FlMVJV8jbOh9+sdsZ31y/TO0/q6/rijI1imkeddPMSgiQ0N6eMjRcw6WBLAniHqqtN1EH+AY08xtDAd+vP5XEBJuXMDLyL44v3OzcnYfI4q3Xx97deAmkeonQAZsbkRxvqL9NK07CVlgx52d+f6wggfMXPppefuRiAFZUgxthwnmNlFoCMQZoqBqL3xbnTdpUWt9WqS4Xyxrd0Tv9imPb6j8gqAMHgHaaVzGdO99BKSzG1rcikXJjY2uaFjUijBLlSAlhWFsoMxpH6WiXO7ekU87fdFS5NddEIVY8mXwBWcygdADEIFqCuJLHGxtRtdwbbYytXYJWIi3OsrCChFQCWoTMc2FZnsD0ZUz2U1ciTueeB1QOuApEVgwzh30zlD1oX9Em73/HfOYLqcQQZNowIujWdA59zIs0KK1qJQjZfDTjvPlS4eo3Y7gp+REfJunaxp1vMg/J1+tjUtmoubZLdgKO/P3wO9tWMHSsChWFBSePvyBPRBxiuz9c+xed8rmfFgMYi+zn3gXz+SUM93yYdRM3n2L+/hhXmi0C+FiFf79Dza1TOBnq6tyowuqv8Tduin052uEEk2ImnovX1n6TdU71Bo9PV8PYqP+NBaTudG1NQoPmnv+0I1Uqm7FkhKObrmE460fvrzC70uzwNAUZ1lUW/15y95K3IHhUq8wpPKUv2xxoamgWaCgLnDBOslSxCR1aeMcpEdbM6Z1tAInWFM1th8rN2FUjW5KsSfbyGi1kJ4SC7eECeScCYg01ZjJfi6lOv9i8Zn+4C8+Ghr1F7a6C2moTppPMnDPXilLHW3TZAQggfFFjLiuYLjhUC0sVQx9fLkqkMgrZchRsLtkQPtka0dPy2Hmy+YvZSXWN8+4qI4GYZCYI9c9xQOxg/foMuEm+UHeW6BWPHypavJxcmVG85JA7W0ASXmgZcfFtyphDEXZ5p4RhSY4HTEZyBb7NHa7bVuzOP+A+WkCB11ePYUdlXR/XSx1y3sNqB0YPyhL5OS1lFdpZSVmf7JPtQNlwYmdiDrQG2ArAFzV0hJp7tXxC/3iIi1KwA2OSzYlXCWZawUsLCNvYKFd5REuXRJMY7gWUjoFUmy2QA0IyMDwPDAO5WZCsIYFOzbi9BpE5cceRyC5k3BQaXFFTBU5ljA6KS4WUla7L71X/vMeIQusH8W6/1AytcaHPMKLsMcgRYwV3PKsKOrm8QUpW4trXqieutokBpasVrPs05866ydIyWcYVF0Nw2MgDCm5FHW7YFL5XQEwtwHb9bpRsfG2GqIhoBbGYfqEQrbGYCm9oKRnDsrbi6yrz+MQZuRyR4qOzb2j+/o13ho7vsneNvcYu7Y+75gz8AAAAASUVORK5CYII=" />
@@ -13,8 +12,25 @@
             Sylius <b>{{ collector.version }}</b>
         </div>
         <div class="sf-toolbar-info-piece">
+            <b>Channel</b>
+            <span class="sf-toolbar-status">{{ collector.channelCode }}</span>
+        </div>
+        <div class="sf-toolbar-info-piece">
+            <b>Currency</b>
+            <span class="sf-toolbar-status">{{ collector.currencyCode }}</span>
+        </div>
+        <div class="sf-toolbar-info-piece">
+            <b>Locale</b>
+            <span class="sf-toolbar-status">{{ collector.localeCode }}</span>
+        </div>
+        <div class="sf-toolbar-info-piece">
+            <b>Customer</b>
+            <span class="sf-toolbar-status">{{ collector.customerEmail|default('None') }}</span>
+        </div>
+        <div class="sf-toolbar-info-piece">
             <a href="http://docs.sylius.org/en/latest/" rel="help">Sylius Documentation</a>
         </div>
     {% endset %}
+
     {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with {'link': false} %}
 {% endblock %}

--- a/src/Sylius/Component/Core/Context/ShopperContext.php
+++ b/src/Sylius/Component/Core/Context/ShopperContext.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Context;
+
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Currency\Context\CurrencyContextInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Sylius\Component\User\Context\CustomerContextInterface;
+
+/**
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+final class ShopperContext implements ShopperContextInterface
+{
+    /**
+     * @var ChannelContextInterface
+     */
+    private $channelContext;
+
+    /**
+     * @var CurrencyContextInterface
+     */
+    private $currencyContext;
+
+    /**
+     * @var LocaleContextInterface
+     */
+    private $localeContext;
+
+    /**
+     * @var CustomerContextInterface
+     */
+    private $customerContext;
+
+    /**
+     * @param ChannelContextInterface $channelContext
+     * @param CurrencyContextInterface $currencyContext
+     * @param LocaleContextInterface $localeContext
+     * @param CustomerContextInterface $customerContext
+     */
+    public function __construct(
+        ChannelContextInterface $channelContext,
+        CurrencyContextInterface $currencyContext,
+        LocaleContextInterface $localeContext,
+        CustomerContextInterface $customerContext
+    ) {
+        $this->channelContext = $channelContext;
+        $this->currencyContext = $currencyContext;
+        $this->localeContext = $localeContext;
+        $this->customerContext = $customerContext;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChannel()
+    {
+        return $this->channelContext->getChannel();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCurrencyCode()
+    {
+        return $this->currencyContext->getCurrency();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLocaleCode()
+    {
+        return $this->localeContext->getCurrentLocale();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCustomer()
+    {
+        return $this->customerContext->getCustomer();
+    }
+}

--- a/src/Sylius/Component/Core/Context/ShopperContextInterface.php
+++ b/src/Sylius/Component/Core/Context/ShopperContextInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Context;
+
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\CustomerInterface;
+
+/**
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+interface ShopperContextInterface
+{
+    /**
+     * @return ChannelInterface
+     */
+    public function getChannel();
+
+    /**
+     * @return string
+     */
+    public function getCurrencyCode();
+
+    /**
+     * @return string
+     */
+    public function getLocaleCode();
+
+    /**
+     * @return CustomerInterface|null
+     */
+    public function getCustomer();
+}

--- a/src/Sylius/Component/Core/spec/Context/ShopperContextSpec.php
+++ b/src/Sylius/Component/Core/spec/Context/ShopperContextSpec.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Core\Context;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Core\Context\ShopperContext;
+use Sylius\Component\Core\Context\ShopperContextInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Currency\Context\CurrencyContextInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Sylius\Component\User\Context\CustomerContextInterface;
+
+/**
+ * @mixin ShopperContext
+ *
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+class ShopperContextSpec extends ObjectBehavior
+{
+    function let(
+        ChannelContextInterface $channelContext,
+        CurrencyContextInterface $currencyContext,
+        LocaleContextInterface $localeContext,
+        CustomerContextInterface $customerContext
+    ) {
+        $this->beConstructedWith($channelContext, $currencyContext, $localeContext, $customerContext);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('Sylius\Component\Core\Context\ShopperContext');
+    }
+    
+    function it_implements_a_shopper_context_interface()
+    {
+        $this->shouldImplement(ShopperContextInterface::class);
+    }
+    
+    function it_gets_current_channel_from_context(ChannelContextInterface $channelContext, ChannelInterface $channel)
+    {
+        $channelContext->getChannel()->willReturn($channel);
+        
+        $this->getChannel()->shouldReturn($channel);
+    }
+    
+    function it_gets_current_currency_code_from_context(CurrencyContextInterface $currencyContext)
+    {
+        $currencyContext->getCurrency()->willReturn('USD');
+        
+        $this->getCurrencyCode()->shouldReturn('USD');
+    }
+    
+    function it_gets_current_locale_code_from_context(LocaleContextInterface $localeContext)
+    {
+        $localeContext->getCurrentLocale()->willReturn('en_US');
+        
+        $this->getLocaleCode()->shouldReturn('en_US');
+    }
+    
+    function it_gets_current_customer_from_context(CustomerContextInterface $customerContext, CustomerInterface $customer)
+    {
+        $customerContext->getCustomer()->willReturn($customer);
+        
+        $this->getCustomer()->shouldReturn($customer);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Related tickets | -
| License         | MIT

All services, form types, etc. should be stateless, but sometimes we need to have access (in routing, or other contexts) to currently active channel, currency, locale and customer. This service simplifies this and I have also added this info to the web debug toolbar. So as a developer, you can always check the currently selected context.

This is the first step to clean up all the contexts together and unify their behavior and usage.

![zrzut ekranu 2016-06-07 o 23 20 22](https://cloud.githubusercontent.com/assets/614970/15875052/813764b8-2d06-11e6-8abf-88462a6bb880.png)
