### PR TITLE
Default to empty array on translator resource provider

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Translation/Provider/TranslatorResourceProvider.php
+++ b/src/Sylius/Bundle/ThemeBundle/Translation/Provider/TranslatorResourceProvider.php
@@ -19,7 +19,7 @@ final class TranslatorResourceProvider implements TranslatorResourceProviderInte
     /**
      * @var TranslationResourceInterface[]
      */
-    private $resources;
+    private $resources = [];
 
     /**
      * @var array


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

`$resources` is an array, but it defaults to NULL.

If no resources are available, an `array_merge` action is later performed and an error occurs.

This PR changes the default to an empty array.

