### PR TITLE
[Resource] Allow to redirect to route without default query parameters

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfiguration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfiguration.php
@@ -234,7 +234,11 @@ class RequestConfiguration
     {
         $redirect = $this->parameters->get('redirect');
 
-        if (!is_array($redirect) || empty($redirect['parameters'])) {
+        if ($this->areParametersIntentionallyEmptyArray($redirect)) {
+            return [];
+        }
+
+        if (!is_array($redirect)) {
             $redirect = ['parameters' => []];
         }
 
@@ -586,5 +590,15 @@ class RequestConfiguration
     public function getStateMachineTransition()
     {
         return $this->parameters->get('state_machine[transition]', null, true);
+    }
+
+    /**
+     * @param mixed $redirect
+     *
+     * @return bool
+     */
+    private function areParametersIntentionallyEmptyArray($redirect)
+    {
+        return isset($redirect['parameters']) && is_array($redirect['parameters']) && empty($redirect['parameters']);
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationSpec.php
@@ -185,6 +185,9 @@ class RequestConfigurationSpec extends ObjectBehavior
         $parameters->get('redirect')->willReturn('string');
         $this->getRedirectParameters()->shouldReturn([]);
 
+        $parameters->get('redirect')->willReturn(['parameters' => []]);
+        $this->getRedirectParameters()->shouldReturn([]);
+
         $parameters->get('redirect')->willReturn(['parameters' => ['myParameter']]);
         $this->getRedirectParameters()->shouldReturn(['myParameter']);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets |
| License         | MIT

Default redirect route parameters are useful, but sometimes can lead to errors (for example with ``isOpen()`` method on *Behat* ``Page``) and it should be possible to define them as empty array.