### PR TITLE
[Bug Fix][ShippingBundle] Default shipping method choice form type set to correct class

### DIFF
--- a/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Configuration.php
@@ -18,6 +18,7 @@ use Sylius\Bundle\ShippingBundle\Controller\ShipmentController;
 use Sylius\Bundle\ShippingBundle\Form\Type\RuleType;
 use Sylius\Bundle\ShippingBundle\Form\Type\ShipmentType;
 use Sylius\Bundle\ShippingBundle\Form\Type\ShippingCategoryType;
+use Sylius\Bundle\ShippingBundle\Form\Type\ShippingMethodChoiceType;
 use Sylius\Bundle\ShippingBundle\Form\Type\ShippingMethodTranslationType;
 use Sylius\Bundle\ShippingBundle\Form\Type\ShippingMethodType;
 use Sylius\Component\Resource\Factory\Factory;
@@ -136,7 +137,7 @@ class Configuration implements ConfigurationInterface
                                             ->addDefaultsIfNotSet()
                                             ->children()
                                                 ->scalarNode('default')->defaultValue(ShippingMethodType::class)->cannotBeEmpty()->end()
-                                                ->scalarNode('choice')->defaultValue(ResourceChoiceType::class)->cannotBeEmpty()->end()
+                                                ->scalarNode('choice')->defaultValue(ShippingMethodChoiceType::class)->cannotBeEmpty()->end()
                                             ->end()
                                         ->end()
                                     ->end()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

Set correct default form choice type for shipping method. It expects this type since it is overriden in the services.xml (https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml#L74); This will prevent some future headaches for other people trying to use standalone shipping bundle.