### PR TITLE
[WebBundle] Fix SKU Refactoring

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Shipment/show.html.twig
@@ -98,7 +98,7 @@
         <thead>
             <tr>
                 <th>#</th>
-                <th>{{ 'sylius.ui.sku'|trans }}</th>
+                <th>{{ 'sylius.ui.code'|trans }}</th>
                 <th>{{ 'sylius.ui.name'|trans }}</th>
                 <th>{{ 'sylius.ui.state'|trans }}</th>
                 <th>{{ 'sylius.ui.inventory_state'|trans }}</th>
@@ -110,7 +110,7 @@
         {% for item in shipment.units %}
             <tr>
                 <td>{{ loop.index }}</td>
-                <td>{{ item.stockable.sku }}</td>
+                <td>{{ item.stockable.code }}</td>
                 <td>{{ item.inventoryName }}</td>
                 <td><span class="label label-success">{{ item.shippingState }}</span></td>
                 <td><span class="label label-{{ item.sold ? 'success' : 'important' }}">{{ item.inventoryState }}</span></td>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

Accessing administration/shipments/{shipmentId} currently triggers an exception :

Neither the property "sku" nor one of the methods "sku()", "getsku()"/"issku()" or "__call()" exist and have public access in class "Proxies\__CG__\Sylius\Component\Core\Model\ProductVariant" in SyliusWebBundle:Backend/Shipment:show.html.twig at line 113