### PR TITLE
[Resource] Check for ResourceInterface during resource registration

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Model/PaymentSecurityToken.php
+++ b/src/Sylius/Bundle/PayumBundle/Model/PaymentSecurityToken.php
@@ -14,8 +14,11 @@ namespace Sylius\Bundle\PayumBundle\Model;
 use Payum\Core\Security\TokenInterface;
 use Payum\Core\Security\Util\Random;
 use Payum\Core\Storage\IdentityInterface;
+use Sylius\Component\Resource\Model\ResourceInterface;
 
-class PaymentSecurityToken implements TokenInterface
+class PaymentSecurityToken implements
+    ResourceInterface,
+    TokenInterface
 {
     /**
      * @var string

--- a/src/Sylius/Bundle/PayumBundle/Model/PaymentSecurityToken.php
+++ b/src/Sylius/Bundle/PayumBundle/Model/PaymentSecurityToken.php
@@ -53,6 +53,14 @@ class PaymentSecurityToken implements
     /**
      * {@inheritdoc}
      */
+    public function getId()
+    {
+        return $this->hash;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setDetails($details)
     {
         $this->details = $details;

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Compiler/RegisterResourcesPass.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Compiler/RegisterResourcesPass.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler;
 
+use Sylius\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
@@ -35,7 +36,22 @@ class RegisterResourcesPass implements CompilerPassInterface
         }
 
         foreach ($resources as $alias => $configuration) {
+            $this->validateSyliusResource($configuration['classes']['model']);
             $registry->addMethodCall('addFromAliasAndConfiguration', [$alias, $configuration]);
+        }
+    }
+
+    /**
+     * @param string $class
+     */
+    private function validateSyliusResource($class)
+    {
+        if (!in_array(ResourceInterface::class, class_implements($class), true)) {
+            throw new InvalidArgumentException(sprintf(
+                'Class "%s" must implement "%s" to be registered as a Sylius resource.',
+                $class,
+                ResourceInterface::class
+            ));
         }
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/EventListener/AbstractDoctrineSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/AbstractDoctrineSubscriber.php
@@ -14,6 +14,7 @@ namespace Sylius\Bundle\ResourceBundle\EventListener;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Sylius\Component\Resource\Metadata\RegistryInterface;
+use Sylius\Component\Resource\Model\ResourceInterface;
 
 /**
  * @author Ben Davies <ben.davies@gmail.com>
@@ -40,6 +41,10 @@ abstract class AbstractDoctrineSubscriber implements EventSubscriber
      */
     protected function isSyliusClass(ClassMetadata $metadata)
     {
-        return 0 === strpos($metadata->getName(), 'Sylius\\');
+        if (!$reflClass = $metadata->getReflectionClass()) {
+            return false;
+        }
+
+        return $reflClass->implementsInterface(ResourceInterface::class);
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Entity/BookTranslation.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Entity/BookTranslation.php
@@ -12,11 +12,12 @@
 namespace AppBundle\Entity;
 
 use Sylius\Component\Resource\Model\AbstractTranslation;
+use Sylius\Component\Resource\Model\ResourceInterface;
 
 /**
  * @author Anna Walasek <anna.walasek@lakion.com>
  */
-class BookTranslation extends AbstractTranslation
+class BookTranslation extends AbstractTranslation implements ResourceInterface
 {
     /**
      * @var mixed
@@ -52,4 +53,3 @@ class BookTranslation extends AbstractTranslation
         $this->title = $title;
     }
 }
-

--- a/src/Sylius/Bundle/ResourceBundle/test/src/Tests/DependencyInjection/Compiler/RegisterResourcesPassTest.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/Tests/DependencyInjection/Compiler/RegisterResourcesPassTest.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\ResourceBundle\Tests\DependencyInjection\Compiler;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\RegisterResourcesPass;
+use Sylius\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
@@ -32,8 +33,8 @@ class RegisterResourcesPassTest extends AbstractCompilerPassTestCase
         $this->setParameter(
             'sylius.resources',
             [
-                'app.book' => ['classes' => ['model' => \stdClass::class]],
-                'app.author' => ['classes' => ['interface' => \Countable::class]],
+                'app.book' => ['classes' => ['model' => BookClass::class]],
+                'app.author' => ['classes' => ['model' => AuthorClass::class]],
             ]
         );
 
@@ -42,13 +43,13 @@ class RegisterResourcesPassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'sylius.resource_registry',
             'addFromAliasAndConfiguration',
-            ['app.book', ['classes' => ['model' => \stdClass::class]]]
+            ['app.book', ['classes' => ['model' => BookClass::class]]]
         );
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'sylius.resource_registry',
             'addFromAliasAndConfiguration',
-            ['app.author', ['classes' => ['interface' => \Countable::class]]]
+            ['app.author', ['classes' => ['model' => AuthorClass::class]]]
         );
     }
 
@@ -59,4 +60,18 @@ class RegisterResourcesPassTest extends AbstractCompilerPassTestCase
     {
         $container->addCompilerPass(new RegisterResourcesPass());
     }
+}
+
+class AbstractResource implements ResourceInterface
+{
+    public function getId()
+    {
+        return;
+    }
+}
+class BookClass extends AbstractResource
+{
+}
+class AuthorClass extends AbstractResource
+{
 }

--- a/src/Sylius/Bundle/SearchBundle/Model/SearchIndexInterface.php
+++ b/src/Sylius/Bundle/SearchBundle/Model/SearchIndexInterface.php
@@ -11,15 +11,17 @@
 
 namespace Sylius\Bundle\SearchBundle\Model;
 
+use Sylius\Component\Resource\Model\ResourceInterface;
+
 /**
- * SearchIndex interface
+ * SearchIndex interface.
  *
  * @author Argyrios Gounaris <agounaris@gmail.com>
  */
-interface SearchIndexInterface
+interface SearchIndexInterface extends ResourceInterface
 {
     /**
-     * Set itemId
+     * Set itemId.
      *
      * @param int $itemId
      *
@@ -28,14 +30,14 @@ interface SearchIndexInterface
     public function setItemId($itemId);
 
     /**
-     * Get itemId
+     * Get itemId.
      *
      * @return int
      */
     public function getItemId();
 
     /**
-     * Set entity
+     * Set entity.
      *
      * @param string $entity
      *
@@ -44,14 +46,14 @@ interface SearchIndexInterface
     public function setEntity($entity);
 
     /**
-     * Get entity
+     * Get entity.
      *
      * @return string
      */
     public function getEntity();
 
     /**
-     * Set value
+     * Set value.
      *
      * @param string $value
      *
@@ -60,7 +62,7 @@ interface SearchIndexInterface
     public function setValue($value);
 
     /**
-     * Get value
+     * Get value.
      *
      * @return string
      */
@@ -74,14 +76,14 @@ interface SearchIndexInterface
     public function setTags($tags);
 
     /**
-     * Get value
+     * Get value.
      *
      * @return string
      */
     public function getTags();
 
     /**
-     * Set createdAt
+     * Set createdAt.
      *
      * @param \DateTime $createdAt
      *
@@ -90,7 +92,7 @@ interface SearchIndexInterface
     public function setCreatedAt($createdAt);
 
     /**
-     * Get createdAt
+     * Get createdAt.
      *
      * @return \DateTime
      */

--- a/src/Sylius/Bundle/SearchBundle/Model/SearchLogInterface.php
+++ b/src/Sylius/Bundle/SearchBundle/Model/SearchLogInterface.php
@@ -11,15 +11,17 @@
 
 namespace Sylius\Bundle\SearchBundle\Model;
 
+use Sylius\Component\Resource\Model\ResourceInterface;
+
 /**
- * SearchLog entity
+ * SearchLog entity.
  *
  * @author Argyrios Gounaris <agounaris@gmail.com>
  */
-interface SearchLogInterface
+interface SearchLogInterface extends ResourceInterface
 {
     /**
-     * Set searchString
+     * Set searchString.
      *
      * @param string $searchString
      *
@@ -42,14 +44,14 @@ interface SearchLogInterface
     public function setRemoteAddress($remoteAddress);
 
     /**
-     * Get remoteAddress
+     * Get remoteAddress.
      *
      * @return string
      */
     public function getRemoteAddress();
 
     /**
-     * Set createdAt
+     * Set createdAt.
      *
      * @param \DateTime $createdAt
      *
@@ -58,7 +60,7 @@ interface SearchLogInterface
     public function setCreatedAt($createdAt);
 
     /**
-     * Get createdAt
+     * Get createdAt.
      *
      * @return \DateTime
      */

--- a/src/Sylius/Component/Core/Model/ImageInterface.php
+++ b/src/Sylius/Component/Core/Model/ImageInterface.php
@@ -11,9 +11,12 @@
 
 namespace Sylius\Component\Core\Model;
 
+use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 
-interface ImageInterface extends TimestampableInterface
+interface ImageInterface extends
+    ResourceInterface,
+    TimestampableInterface
 {
     /**
      * @return bool

--- a/src/Sylius/Component/Order/Model/Identity.php
+++ b/src/Sylius/Component/Order/Model/Identity.php
@@ -39,6 +39,14 @@ class Identity implements IdentityInterface
     /**
      * {@inheritdoc}
      */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return $this->name;

--- a/src/Sylius/Component/Order/Model/IdentityInterface.php
+++ b/src/Sylius/Component/Order/Model/IdentityInterface.php
@@ -11,10 +11,12 @@
 
 namespace Sylius\Component\Order\Model;
 
+use Sylius\Component\Resource\Model\ResourceInterface;
+
 /**
  * @author Daniel Kucharski <daniel@xerias.be>
  */
-interface IdentityInterface
+interface IdentityInterface extends ResourceInterface
 {
     /**
      * @return string $name


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

This is a suggestion to correct the fact that `SyliusResourceBundle` expects resources to live in the `Sylius\\` namespace, as mentioned [here](https://github.com/Sylius/Sylius/pull/5075#issuecomment-223984424).