### PR TITLE
[Shipping] Add translatable description to ShippingMethod

### DIFF
--- a/features/shipping/managing_shipping_methods/adding_shipping_method.feature
+++ b/features/shipping/managing_shipping_methods/adding_shipping_method.feature
@@ -23,6 +23,19 @@ Feature: Adding a new shipping method
         And the shipment method "FedEx Carrier" should appear in the registry
 
     @ui @javascript
+    Scenario: Adding a new shipping method with description and flat rate per shipment
+        Given I want to create a new shipping method
+        When I specify its code as "FED_EX_CARRIER"
+        And I name it "FedEx Carrier" in "English (United States)"
+        And I describe it as "FedEx Carrier shipping method for European Union" in "English (United States)"
+        And I define it for the "European Union" zone
+        And I choose "Flat rate per shipment" calculator
+        And I specify its amount as 50
+        And I add it
+        Then I should be notified that it has been successfully created
+        And the shipment method "FedEx Carrier" should appear in the registry
+
+    @ui @javascript
     Scenario: Adding a new shipping method with flat rate per unit
         Given I want to create a new shipping method
         When I specify its code as "FED_EX_CARRIER"

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingMethodsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingMethodsContext.php
@@ -109,6 +109,14 @@ final class ManagingShippingMethodsContext implements Context
     }
 
     /**
+     * @When I describe it as :description in :language
+     */
+    public function iDescribeItAsIn($description, $language)
+    {
+        $this->createPage->describeIt($description, $language);
+    }
+
+    /**
      * @When I define it for the :zoneName zone
      */
     public function iDefineItForTheZone($zoneName)

--- a/src/Sylius/Behat/Page/Admin/ShippingMethod/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ShippingMethod/CreatePage.php
@@ -34,6 +34,16 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     /**
      * {@inheritdoc}
      */
+    public function describeIt($description, $languageCode)
+    {
+        $this->getDocument()->fillField(
+            sprintf('sylius_shipping_method_translations_%s_description', $languageCode), $description
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function specifyAmount($amount)
     {
         $this->getDocument()->fillField('Amount', $amount);

--- a/src/Sylius/Behat/Page/Admin/ShippingMethod/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ShippingMethod/CreatePageInterface.php
@@ -30,6 +30,12 @@ interface CreatePageInterface extends BaseCreatePageInterface
     public function nameIt($name, $language);
 
     /**
+     * @param string $description
+     * @param string $languageCode
+     */
+    public function describeIt($description, $languageCode);
+
+    /**
      * @param string $amount
      */
     public function specifyAmount($amount);

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ShippingMethod/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ShippingMethod/_form.html.twig
@@ -38,6 +38,7 @@
                 </div>
                 <div class="content{% if 0 == loop.index0 %} active{% endif %}">
                     {{ form_row(translationForm.name) }}
+                    {{ form_row(translationForm.description) }}
                 </div>
             {% endfor %}
         </div>

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodTranslationType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodTranslationType.php
@@ -30,6 +30,10 @@ class ShippingMethodTranslationType extends AbstractResourceType
             ->add('name', 'text', [
                 'label' => 'sylius.form.shipping_method.name',
             ])
+            ->add('description', 'textarea', [
+                'label' => 'sylius.form.shipping_method.description',
+                'required' => false,
+            ])
         ;
     }
 

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/doctrine/model/ShippingMethodTranslation.orm.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/doctrine/model/ShippingMethodTranslation.orm.xml
@@ -19,6 +19,7 @@
         </id>
 
         <field name="name" column="name" type="string" />
+        <field name="description" column="description" type="string" nullable="true" />
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
@@ -56,6 +56,7 @@ sylius:
             category: Category
             category_requirement: Category requirement
             configuration: Configuration
+            description: Description
             enabled: Enabled
             name: Name
             tax_category: Tax category

--- a/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/ShippingMethodTranslationTypeSpec.php
+++ b/src/Sylius/Bundle/ShippingBundle/spec/Form/Type/ShippingMethodTranslationTypeSpec.php
@@ -39,6 +39,11 @@ class ShippingMethodTranslationTypeSpec extends ObjectBehavior
             ->add('name', 'text', Argument::any())
             ->willReturn($builder)
         ;
+        $builder
+            ->add('description', 'textarea', Argument::any())
+            ->shouldBeCalled()
+            ->willReturn($builder)
+        ;
 
         $this->buildForm($builder, []);
     }

--- a/src/Sylius/Component/Shipping/Model/ShippingMethod.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethod.php
@@ -164,6 +164,22 @@ class ShippingMethod implements ShippingMethodInterface
     /**
      * {@inheritdoc}
      */
+    public function getDescription()
+    {
+        return $this->translate()->getDescription();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDescription($description)
+    {
+        $this->translate()->setDescription($description);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getCalculator()
     {
         return $this->calculator;

--- a/src/Sylius/Component/Shipping/Model/ShippingMethodTranslation.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethodTranslation.php
@@ -29,6 +29,11 @@ class ShippingMethodTranslation extends AbstractTranslation implements ShippingM
     protected $name;
 
     /**
+     * @var string
+     */
+    protected $description;
+
+    /**
      * {@inheritdoc}
      */
     public function __toString()
@@ -58,5 +63,21 @@ class ShippingMethodTranslation extends AbstractTranslation implements ShippingM
     public function setName($name)
     {
         $this->name = $name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
     }
 }

--- a/src/Sylius/Component/Shipping/Model/ShippingMethodTranslationInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethodTranslationInterface.php
@@ -27,4 +27,14 @@ interface ShippingMethodTranslationInterface extends ResourceInterface
      * @param string $name
      */
     public function setName($name);
+
+    /**
+     * @return string
+     */
+    public function getDescription();
+
+    /**
+     * @param string $description
+     */
+    public function setDescription($description);
 }

--- a/src/Sylius/Component/Shipping/spec/Model/ShippingMethodSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Model/ShippingMethodSpec.php
@@ -106,6 +106,12 @@ class ShippingMethodSpec extends ObjectBehavior
         $this->getName()->shouldReturn('Shippable goods');
     }
 
+    function its_description_is_mutable()
+    {
+        $this->setDescription('Very good shipping, cheap price, good delivery time.');
+        $this->getDescription()->shouldReturn('Very good shipping, cheap price, good delivery time.');
+    }
+
     function it_returns_name_when_converted_to_string()
     {
         $this->setName('Shippable goods');

--- a/src/Sylius/Component/Shipping/spec/Model/ShippingMethodTranslationSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Model/ShippingMethodTranslationSpec.php
@@ -45,6 +45,12 @@ class ShippingMethodTranslationSpec extends ObjectBehavior
         $this->getName()->shouldReturn('Shippable goods');
     }
 
+    function its_description_is_mutable()
+    {
+        $this->setDescription('Very good shipping, cheap price, good delivery time.');
+        $this->getDescription()->shouldReturn('Very good shipping, cheap price, good delivery time.');
+    }
+
     function it_returns_name_when_converted_to_string()
     {
         $this->setName('Shippable goods');


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Related tickets |
| License         | MIT

While working on https://github.com/Sylius/Sylius/pull/5220, we've come up with an idea, that it would be nice to have translatable description on ``ShippingMethod`` (as, for example, on ``PaymentMethod``).