### PR TITLE
Add missing setter method

### DIFF
--- a/src/Sylius/Component/Promotion/Model/PromotionCouponAwareSubjectInterface.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionCouponAwareSubjectInterface.php
@@ -20,4 +20,9 @@ interface PromotionCouponAwareSubjectInterface extends PromotionSubjectInterface
      * @return null|CouponInterface
      */
     public function getPromotionCoupon();
+    
+    /**
+     * @param CouponInterface $coupon
+     */
+    public function setPromotionCoupon(CouponInterface $coupon);
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

One would expect this method to be present in the interface. In fact, Sylius\Component\Core\Model\Order implements this method and uses an @inheritdoc annotation.