### PR TITLE
Do not redefine constant

### DIFF
--- a/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadProductsData.php
+++ b/src/Sylius/Bundle/FixturesBundle/DataFixtures/ORM/LoadProductsData.php
@@ -382,7 +382,9 @@ class LoadProductsData extends DataFixture
      */
     protected function defineTotalVariants()
     {
-        define('SYLIUS_FIXTURES_TOTAL_VARIANTS', $this->totalVariants);
+        if (!defined('SYLIUS_FIXTURES_TOTAL_VARIANTS')) {
+            define('SYLIUS_FIXTURES_TOTAL_VARIANTS', $this->totalVariants);
+        }
     }
 
     protected function addTranslatedFields(ProductInterface $product, $translatedNames)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

I am using the fixutres in functional tests, this hack prevents the constant from being redefined (ofc it would be better if it were not required).