### PR TITLE
[JS] Run gulp script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you want to try out new Sylius UI, please run the following commands:
 
 ```bash
 $ npm install
-$ gulp
+$ npm run gulp
 ```
 
 [Behat](http://behat.org) scenarios

--- a/docs/book/installation.rst
+++ b/docs/book/installation.rst
@@ -126,7 +126,7 @@ And now you can use gulp for installing views, by just running a simple command:
 
 .. code-block:: bash
 
-    $ gulp
+    $ npm run gulp
 
 After you've run the ``gulp`` command please have a look at the ``/admin`` url, where you will find the administration panel.
 

--- a/etc/travis/suites/application/before_script.sh
+++ b/etc/travis/suites/application/before_script.sh
@@ -11,4 +11,4 @@ run_command "app/console doctrine:phpcr:repository:init --env=test_cached --no-d
 print_header "Setting the web assets up" "sylius"
 run_command "app/console assets:install --env=test_cached --no-debug -vvv" || exit $?
 run_command "app/console assetic:dump --env=test_cached --no-debug -vvv" || exit $?
-run_command "gulp" || exit $?
+run_command "npm run gulp" || exit $?

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "gulp-uglifycss": "^1.0.5",
     "merge-stream": "^1.0.0"
   },
+  "scripts": {
+      "gulp": "gulp"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Sylius/Sylius.git"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

It is not always suitable to install a gulp globally. If it is not installed globally, the following command had to be called:
```bash
$ ./node_modules/.bin/gulp
```
This change allows to use more developer friendly command:
```bash
$ npm run gulp
```