### PR TITLE
[Core] Cleanup inventory and guest order paramaters

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/parameters.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/parameters.yml
@@ -2,8 +2,6 @@
 # (c) Paweł Jędrzejewski
 
 parameters:
-    sylius.inventory.backorders_enabled: true
-    sylius.inventory.tracking_enabled: true
     sylius.inventory.holding.duration: 15 minutes
     sylius.order.allow_guest_order: false
     sylius.order.pending.duration: 3 hours

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
@@ -147,7 +147,6 @@ sylius_money:
     locale: "%locale%"
 
 sylius_order:
-    guest_order: false
     resources:
         order:
             classes:

--- a/src/Sylius/Bundle/OrderBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/OrderBundle/DependencyInjection/Configuration.php
@@ -60,13 +60,6 @@ class Configuration implements ConfigurationInterface
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('driver')->defaultValue(SyliusResourceBundle::DRIVER_DOCTRINE_ORM)->end()
-                ->booleanNode('guest_order')
-                    ->beforeNormalization()
-                        ->ifString()
-                        ->then(function ($v) { return (bool) $v; })
-                    ->end()
-                    ->defaultFalse()
-                ->end()
             ->end()
         ;
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets |
| License         | MIT

- [x] Removed invalid parameters - backorders and inventory tracking is now [configured in the bundle](https://github.com/michalmarcinkowski/Sylius/blob/386c226db60cc37c7e4cd0bf632caa95ccfad2d8/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml#L99) and there is no need for invalid parameters in the Core.
- [x] Removed guest checkout parameter from OrderBundle - the parameter from bundle isn't even registered in the container, so it is redundant. The `sylius.order.allow_guest_order` is now used in the `CheckoutStep`, so it can temporary stay, but will be removed together with the old checkout flow.