### PR TITLE
[Attrbiute] Use value setter & fix properties visibility

### DIFF
--- a/src/Sylius/Component/Attribute/Model/AttributeValue.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeValue.php
@@ -40,32 +40,32 @@ class AttributeValue implements AttributeValueInterface
     /**
      * @var string
      */
-    protected $text;
+    private $text;
 
     /**
      * @var bool
      */
-    protected $boolean;
+    private $boolean;
 
     /**
      * @var int
      */
-    protected $integer;
+    private $integer;
 
     /**
      * @var float
      */
-    protected $float;
+    private $float;
 
     /**
      * @var \DateTime
      */
-    protected $datetime;
+    private $datetime;
 
     /**
      * @var \DateTime
      */
-    protected $date;
+    private $date;
 
     /**
      * {@inheritdoc}
@@ -116,7 +116,7 @@ class AttributeValue implements AttributeValueInterface
             return null;
         }
 
-        $getter = 'get'.ucfirst($this->attribute->getStorageType());
+        $getter = 'get' . $this->attribute->getStorageType();
 
         return $this->$getter();
     }
@@ -128,8 +128,9 @@ class AttributeValue implements AttributeValueInterface
     {
         $this->assertAttributeIsSet();
 
-        $property = $this->attribute->getStorageType();
-        $this->$property = $value;
+        $setter = 'set' . $this->attribute->getStorageType();
+
+        $this->$setter($value);
     }
 
     /**
@@ -165,7 +166,7 @@ class AttributeValue implements AttributeValueInterface
     /**
      * @return bool
      */
-    public function getBoolean()
+    protected function getBoolean()
     {
         return $this->boolean;
     }
@@ -173,7 +174,7 @@ class AttributeValue implements AttributeValueInterface
     /**
      * @param bool $boolean
      */
-    public function setBoolean($boolean)
+    protected function setBoolean($boolean)
     {
         $this->boolean = $boolean;
     }
@@ -181,7 +182,7 @@ class AttributeValue implements AttributeValueInterface
     /**
      * @return string
      */
-    public function getText()
+    protected function getText()
     {
         return $this->text;
     }
@@ -189,7 +190,7 @@ class AttributeValue implements AttributeValueInterface
     /**
      * @param string $text
      */
-    public function setText($text)
+    protected function setText($text)
     {
         $this->text = $text;
     }
@@ -197,7 +198,7 @@ class AttributeValue implements AttributeValueInterface
     /**
      * @return int
      */
-    public function getInteger()
+    protected function getInteger()
     {
         return $this->integer;
     }
@@ -205,7 +206,7 @@ class AttributeValue implements AttributeValueInterface
     /**
      * @param int $integer
      */
-    public function setInteger($integer)
+    protected function setInteger($integer)
     {
         $this->integer = $integer;
     }
@@ -213,7 +214,7 @@ class AttributeValue implements AttributeValueInterface
     /**
      * @return float
      */
-    public function getFloat()
+    protected function getFloat()
     {
         return $this->float;
     }
@@ -221,7 +222,7 @@ class AttributeValue implements AttributeValueInterface
     /**
      * @param float $float
      */
-    public function setFloat($float)
+    protected function setFloat($float)
     {
         $this->float = $float;
     }
@@ -229,7 +230,7 @@ class AttributeValue implements AttributeValueInterface
     /**
      * @return \DateTime
      */
-    public function getDatetime()
+    protected function getDatetime()
     {
         return $this->datetime;
     }
@@ -237,7 +238,7 @@ class AttributeValue implements AttributeValueInterface
     /**
      * @param \DateTime $datetime
      */
-    public function setDatetime(\DateTime $datetime)
+    protected function setDatetime(\DateTime $datetime)
     {
         $this->datetime = $datetime;
     }
@@ -245,7 +246,7 @@ class AttributeValue implements AttributeValueInterface
     /**
      * @return \DateTime
      */
-    public function getDate()
+    protected function getDate()
     {
         return $this->date;
     }
@@ -253,10 +254,11 @@ class AttributeValue implements AttributeValueInterface
     /**
      * @param \DateTime $date
      */
-    public function setDate(\DateTime $date)
+    protected function setDate(\DateTime $date)
     {
         $this->date = $date;
     }
+
     /**
      * @throws \BadMethodCallException
      */


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes (uses setter method, changes visibility)
| Related tickets | -
| License         | MIT

`AttributeValue` is currently using getter to get the value and does not use setter to set the value. 

Moreover, it changes visibility of `get%type%()` methods from public to protected and their properties from protected to private (all modifications should be done through setter methods).