### PR TITLE
[Variation] Rename presentation to name

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -18,6 +18,7 @@ UPGRADE
 ### Variation and VariationBundle
 
 * Removed concept of master variant (removed ``$master`` flag from ``Sylius\Component\Variation\Model\Variant``), all usages of **master** variant has been, for now, replaced with **first** variant;
+* Renamed `presentation` to `name` (`VariantInterface`, `OptionValueInterface`) 
 
 ### Payment
 

--- a/app/migrations/Version20140409203042.php
+++ b/app/migrations/Version20140409203042.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20140424094036.php
+++ b/app/migrations/Version20140424094036.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20140430223207.php
+++ b/app/migrations/Version20140430223207.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20140508090448.php
+++ b/app/migrations/Version20140508090448.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20140620085516.php
+++ b/app/migrations/Version20140620085516.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20140708143228.php
+++ b/app/migrations/Version20140708143228.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20140710152234.php
+++ b/app/migrations/Version20140710152234.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20140724192706.php
+++ b/app/migrations/Version20140724192706.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20140904095124.php
+++ b/app/migrations/Version20140904095124.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20140909144526.php
+++ b/app/migrations/Version20140909144526.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20140930184010.php
+++ b/app/migrations/Version20140930184010.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20141001095847.php
+++ b/app/migrations/Version20141001095847.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20141203091118.php
+++ b/app/migrations/Version20141203091118.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20141214134644.php
+++ b/app/migrations/Version20141214134644.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20141225005106.php
+++ b/app/migrations/Version20141225005106.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20141226173325.php
+++ b/app/migrations/Version20141226173325.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150102104334.php
+++ b/app/migrations/Version20150102104334.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150102133831.php
+++ b/app/migrations/Version20150102133831.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150102184826.php
+++ b/app/migrations/Version20150102184826.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150102191232.php
+++ b/app/migrations/Version20150102191232.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150127131103.php
+++ b/app/migrations/Version20150127131103.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150128131714.php
+++ b/app/migrations/Version20150128131714.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150202213852.php
+++ b/app/migrations/Version20150202213852.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150206094603.php
+++ b/app/migrations/Version20150206094603.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150531210410.php
+++ b/app/migrations/Version20150531210410.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150616155405.php
+++ b/app/migrations/Version20150616155405.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150629123648.php
+++ b/app/migrations/Version20150629123648.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150630213802.php
+++ b/app/migrations/Version20150630213802.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150722115433.php
+++ b/app/migrations/Version20150722115433.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150722152840.php
+++ b/app/migrations/Version20150722152840.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150817113941.php
+++ b/app/migrations/Version20150817113941.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150818142828.php
+++ b/app/migrations/Version20150818142828.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150901104436.php
+++ b/app/migrations/Version20150901104436.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20150901113105.php
+++ b/app/migrations/Version20150901113105.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151015181310.php
+++ b/app/migrations/Version20151015181310.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151019160305.php
+++ b/app/migrations/Version20151019160305.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151024153713.php
+++ b/app/migrations/Version20151024153713.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151028183600.php
+++ b/app/migrations/Version20151028183600.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151110183626.php
+++ b/app/migrations/Version20151110183626.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151118223453.php
+++ b/app/migrations/Version20151118223453.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151129155421.php
+++ b/app/migrations/Version20151129155421.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151203134947.php
+++ b/app/migrations/Version20151203134947.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151208100841.php
+++ b/app/migrations/Version20151208100841.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151209104639.php
+++ b/app/migrations/Version20151209104639.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151209104827.php
+++ b/app/migrations/Version20151209104827.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151210134607.php
+++ b/app/migrations/Version20151210134607.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151216125201.php
+++ b/app/migrations/Version20151216125201.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151221084137.php
+++ b/app/migrations/Version20151221084137.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151221121710.php
+++ b/app/migrations/Version20151221121710.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151228162916.php
+++ b/app/migrations/Version20151228162916.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151228175507.php
+++ b/app/migrations/Version20151228175507.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151229134904.php
+++ b/app/migrations/Version20151229134904.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20151231002659.php
+++ b/app/migrations/Version20151231002659.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160104133517.php
+++ b/app/migrations/Version20160104133517.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160112125003.php
+++ b/app/migrations/Version20160112125003.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160112145643.php
+++ b/app/migrations/Version20160112145643.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160112154949.php
+++ b/app/migrations/Version20160112154949.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160114113257.php
+++ b/app/migrations/Version20160114113257.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160115104455.php
+++ b/app/migrations/Version20160115104455.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160118140609.php
+++ b/app/migrations/Version20160118140609.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160118160103.php
+++ b/app/migrations/Version20160118160103.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160118174656.php
+++ b/app/migrations/Version20160118174656.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160122143514.php
+++ b/app/migrations/Version20160122143514.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160203224648.php
+++ b/app/migrations/Version20160203224648.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160205083520.php
+++ b/app/migrations/Version20160205083520.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160205134111.php
+++ b/app/migrations/Version20160205134111.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160208122721.php
+++ b/app/migrations/Version20160208122721.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160210132042.php
+++ b/app/migrations/Version20160210132042.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160211130526.php
+++ b/app/migrations/Version20160211130526.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160212150554.php
+++ b/app/migrations/Version20160212150554.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160216172655.php
+++ b/app/migrations/Version20160216172655.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160220110242.php
+++ b/app/migrations/Version20160220110242.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160225115200.php
+++ b/app/migrations/Version20160225115200.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160226091855.php
+++ b/app/migrations/Version20160226091855.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160226092329.php
+++ b/app/migrations/Version20160226092329.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160229091707.php
+++ b/app/migrations/Version20160229091707.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160229125721.php
+++ b/app/migrations/Version20160229125721.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160229145014.php
+++ b/app/migrations/Version20160229145014.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160305114253.php
+++ b/app/migrations/Version20160305114253.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160305115221.php
+++ b/app/migrations/Version20160305115221.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160308211004.php
+++ b/app/migrations/Version20160308211004.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160309144959.php
+++ b/app/migrations/Version20160309144959.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160310181749.php
+++ b/app/migrations/Version20160310181749.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Migrations;
+namespace Sylius\Migrations;
 
 use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema;

--- a/app/migrations/Version20160621211112.php
+++ b/app/migrations/Version20160621211112.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20160621211112 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_product_variant CHANGE presentation name VARCHAR(255) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_product_variant CHANGE name presentation VARCHAR(255) DEFAULT NULL COLLATE utf8_unicode_ci');
+    }
+}

--- a/app/migrations/Version20160621212538.php
+++ b/app/migrations/Version20160621212538.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20160621212538 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_product_option_translation CHANGE presentation name VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE sylius_product_option_value_translation CHANGE presentation value VARCHAR(255) NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_product_option_translation CHANGE name presentation VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci');
+        $this->addSql('ALTER TABLE sylius_product_option_value_translation CHANGE value presentation VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci');
+    }
+}

--- a/features/legacy/backend/product_archetypes.feature
+++ b/features/legacy/backend/product_archetypes.feature
@@ -15,7 +15,7 @@ Feature: Product archetypes
             | O5   | Beverage milk  | None[OV12], Whole[OV13], Skinny[OV14], Soya[OV15] |
             | O6   | Coffee variety | Colombian[OV16], Ethiopian[OV17]                  |
         And there are following attributes:
-            | name               | name           | type     |
+            | name               | presentation   | type     |
             | T-Shirt collection | Collection     | text     |
             | T-Shirt fabric     | T-Shirt fabric | text     |
             | Bag material       | Material       | text     |

--- a/features/legacy/backend/product_archetypes.feature
+++ b/features/legacy/backend/product_archetypes.feature
@@ -15,7 +15,7 @@ Feature: Product archetypes
             | O5   | Beverage milk  | None[OV12], Whole[OV13], Skinny[OV14], Soya[OV15] |
             | O6   | Coffee variety | Colombian[OV16], Ethiopian[OV17]                  |
         And there are following attributes:
-            | name               | presentation   | type     |
+            | name               | name           | type     |
             | T-Shirt collection | Collection     | text     |
             | T-Shirt fabric     | T-Shirt fabric | text     |
             | Bag material       | Material       | text     |

--- a/features/legacy/frontend/products_i18n.feature
+++ b/features/legacy/frontend/products_i18n.feature
@@ -39,8 +39,8 @@ Feature: Browse products, categories, attributes and options in preferred langua
             | attribute      | name     | locale |
             | T-Shirt fabric | Material | es_ES  |
         And the following option translations exist:
-            | option | presentation | locale |
-            | O2     | Talla        | es_ES  |
+            | option | name  | locale |
+            | O2     | Talla | es_ES  |
         And all products are assigned to the default channel
 
     Scenario: Seeing translated product name, options and attributes

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -165,7 +165,7 @@ final class ProductContext implements Context
         /** @var ProductVariantInterface $variant */
         $variant = $this->productVariantFactory->createNew();
 
-        $variant->setPresentation($productVariantName);
+        $variant->setName($productVariantName);
         $variant->setCode($this->convertToCode($productVariantName));
         $variant->setPrice($price);
         $variant->setProduct($product);
@@ -208,7 +208,7 @@ final class ProductContext implements Context
             /** @var ProductVariantInterface $variant */
             $variant = $this->productVariantFactory->createNew();
 
-            $variant->setPresentation($variantHash['name']);
+            $variant->setName($variantHash['name']);
             $variant->setCode($this->convertToCode($variantHash['name']));
             $variant->setPrice($this->getPriceFromString(str_replace(['$', '€', '£'], '', $variantHash['price'])));
             $variant->setProduct($product);

--- a/src/Sylius/Behat/Context/Transform/ProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductVariantContext.php
@@ -50,7 +50,7 @@ final class ProductVariantContext implements Context
             throw new \InvalidArgumentException(sprintf('Product with name "%s" does not exist', $productName));
         }
 
-        $productVariant = $this->productVariantRepository->findOneBy(['presentation' => $variantName, 'object' => $product]);
+        $productVariant = $this->productVariantRepository->findOneBy(['name' => $variantName, 'object' => $product]);
         if (null === $productVariant) {
             throw new \InvalidArgumentException(sprintf('Product variant with name "%s" of product "%s" does not exist', $variantName, $productName));
         }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsContext.php
@@ -187,8 +187,8 @@ final class ManagingProductVariantsContext implements Context
         $this->iWantToViewAllVariantsOfThisProduct($productVariant->getProduct());
 
         Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['presentation' => $productVariant->getPresentation()]),
-            sprintf('Product variant with code %s exists but should not.', $productVariant->getPresentation())
+            $this->indexPage->isSingleResourceOnPage(['name' => $productVariant->getName()]),
+            sprintf('Product variant with code %s exists but should not.', $productVariant->getName())
         );
     }
 

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/CreatePage.php
@@ -34,7 +34,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
      */
     public function nameIt($name)
     {
-        $this->getDocument()->fillField('Presentation', $name);
+        $this->getDocument()->fillField('Name', $name);
     }
 
     /**

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product_variant.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product_variant.yml
@@ -45,7 +45,7 @@ sylius_grid:
                     type: string
                     label: sylius.ui.name
                     options:
-                        fields: [presentation]
+                        fields: [name]
             actions:
                 main:
                     create:

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_item.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_item.html.twig
@@ -25,10 +25,10 @@
                     </div>
                 {% endfor %}
             </div>
-        {% elseif variant.presentation is not null %}
+        {% elseif variant.name is not null %}
             <div class="ui horizontal divided list">
                 <div class="item sylius-product-variant-name">
-                    {{ variant.presentation }}
+                    {{ variant.name }}
                 </div>
             </div>
         {% endif %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_item.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_item.html.twig
@@ -20,7 +20,7 @@
         {% if product.hasOptions() %}
             <div class="ui horizontal divided list sylius-product-options">
                 {% for option in variant.options %}
-                    <div class="item" data-sylius-option-name="{{ option.presentation }}">
+                    <div class="item" data-sylius-option-name="{{ option.name }}">
                         {{ option.value }}
                     </div>
                 {% endfor %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Field/name.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Field/name.html.twig
@@ -1,6 +1,6 @@
 <span class="ui small header">
     {% set product = data.product %}
-    {{ data.presentation is null ? product.name : data.presentation }}
+    {{ data.name is null ? product.name : data.name }}
 </span>
 {% if data.options|length > 0 %}
     <br>

--- a/src/Sylius/Bundle/ProductBundle/Behat/ProductContext.php
+++ b/src/Sylius/Bundle/ProductBundle/Behat/ProductContext.php
@@ -282,7 +282,7 @@ class ProductContext extends DefaultContext
             $option = $this->findOneBy('product_option', ['code' => $data['option']]);
             $option->setCurrentLocale($data['locale']);
             $option->setFallbackLocale($data['locale']);
-            $option->setName($data['presentation']);
+            $option->setName($data['name']);
         }
 
         $manager->flush();

--- a/src/Sylius/Bundle/SearchBundle/README.md
+++ b/src/Sylius/Bundle/SearchBundle/README.md
@@ -133,7 +133,7 @@ fos_elastica:
                                  availableOn: { type: date, index: not_analyzed }
                                  availableUntil: { type: date }
                                  availableOnDemand: { type: boolean }
-                                 presentation: { type: string }
+                                 name: { type: string }
                                  onHand: { type: integer, index: not_analyzed }
                                  onHold: { type: integer, index: not_analyzed }
                          attributes:

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_item.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_item.html.twig
@@ -16,7 +16,7 @@
         {% if product.hasOptions() %}
             <div class="ui horizontal divided list sylius-product-options">
                 {% for option in variant.options %}
-                    <div class="item" data-sylius-option-name="{{ option.presentation }}">
+                    <div class="item" data-sylius-option-name="{{ option.name }}">
                         {{ option.value }}
                     </div>
                 {% endfor %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_item.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_item.html.twig
@@ -21,10 +21,10 @@
                     </div>
                 {% endfor %}
             </div>
-        {% elseif variant.presentation is not null %}
+        {% elseif variant.name is not null %}
             <div class="ui horizontal divided list">
                 <div class="item sylius-product-variant-name">
-                    {{ variant.presentation }}
+                    {{ variant.name }}
                 </div>
             </div>
         {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_variants.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_variants.html.twig
@@ -10,7 +10,7 @@
     {% for variant in product.variants %}
         <tr>
             <td>
-                {{ variant.presentation }}
+                {{ variant.name }}
                 {% if product.hasOptions() %}
                     <div class="ui horizontal divided list">
                         {% for option in variant.options %}

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
@@ -5,7 +5,7 @@ sylius:
             password: Password
             remember_me: Remember me
         option:
-            presentation: Presentation
+            name: Name
     ui:
         about: About
         account_credentials: Account credentials

--- a/src/Sylius/Bundle/VariationBundle/Form/ChoiceList/VariantChoiceList.php
+++ b/src/Sylius/Bundle/VariationBundle/Form/ChoiceList/VariantChoiceList.php
@@ -24,6 +24,6 @@ class VariantChoiceList extends ObjectChoiceList
      */
     public function __construct(VariableInterface $variable)
     {
-        parent::__construct($variable->getVariants(), 'presentation', [], null, 'id');
+        parent::__construct($variable->getVariants(), 'name', [], null, 'id');
     }
 }

--- a/src/Sylius/Bundle/VariationBundle/Form/Type/OptionValueType.php
+++ b/src/Sylius/Bundle/VariationBundle/Form/Type/OptionValueType.php
@@ -45,7 +45,7 @@ class OptionValueType extends AbstractResourceType
         $builder
             ->add('translations', 'sylius_translations', [
                 'type' => sprintf('sylius_%s_option_value_translation', $this->variableName),
-                'label' => 'sylius.form.option.presentation',
+                'label' => 'sylius.form.option.name',
             ])
             ->addEventSubscriber(new AddCodeFormSubscriber())
         ;

--- a/src/Sylius/Bundle/VariationBundle/Form/Type/VariantType.php
+++ b/src/Sylius/Bundle/VariationBundle/Form/Type/VariantType.php
@@ -45,9 +45,9 @@ class VariantType extends AbstractResourceType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('presentation', 'text', [
+            ->add('name', 'text', [
                 'required' => false,
-                'label' => 'sylius.form.variant.presentation',
+                'label' => 'sylius.form.variant.name',
             ])
             ->addEventSubscriber(new AddCodeFormSubscriber())
         ;

--- a/src/Sylius/Bundle/VariationBundle/Resources/config/doctrine/model/OptionTranslation.orm.xml
+++ b/src/Sylius/Bundle/VariationBundle/Resources/config/doctrine/model/OptionTranslation.orm.xml
@@ -21,7 +21,7 @@
             <generator strategy="AUTO" />
         </id>
 
-        <field name="name" column="presentation" type="string" />
+        <field name="name" column="name" type="string" />
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Bundle/VariationBundle/Resources/config/doctrine/model/OptionValueTranslation.orm.xml
+++ b/src/Sylius/Bundle/VariationBundle/Resources/config/doctrine/model/OptionValueTranslation.orm.xml
@@ -18,7 +18,7 @@
             <generator strategy="AUTO" />
         </id>
 
-        <field name="value" column="presentation" type="string" />
+        <field name="value" column="value" type="string" />
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Bundle/VariationBundle/Resources/config/doctrine/model/Variant.orm.xml
+++ b/src/Sylius/Bundle/VariationBundle/Resources/config/doctrine/model/Variant.orm.xml
@@ -25,7 +25,7 @@
 
         <field name="code" column="code" type="string" unique="true"  nullable="false"/>
 
-        <field name="presentation" column="presentation" type="string" nullable="true" />
+        <field name="name" column="name" type="string" nullable="true" />
 
         <field name="createdAt" column="created_at" type="datetime">
             <gedmo:timestampable on="create"/>

--- a/src/Sylius/Bundle/VariationBundle/Resources/config/serializer/Model.OptionValue.yml
+++ b/src/Sylius/Bundle/VariationBundle/Resources/config/serializer/Model.OptionValue.yml
@@ -9,5 +9,5 @@ Sylius\Component\Variation\Model\OptionValue:
             expose: true
             type: string
     virtual_properties:
-        getPresentation:
+        getName:
             serialized_name: name

--- a/src/Sylius/Bundle/VariationBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/VariationBundle/Resources/translations/messages.en.yml
@@ -1,7 +1,7 @@
 sylius:
     form:
         variant:
-            presentation: Presentation
+            name: Name
         option:
             name: Name
             values: Possible values

--- a/src/Sylius/Bundle/VariationBundle/Resources/translations/validators.en.yml
+++ b/src/Sylius/Bundle/VariationBundle/Resources/translations/validators.en.yml
@@ -7,10 +7,6 @@ sylius:
             not_blank: Please enter option name.
             min_length: Option name must be at least 1 character long.|Option name must be at least {{ limit }} characters long.
             max_length: Option name must not be longer than 1 character.|Option name must not be longer than {{ limit }} characters.
-        presentation:
-            not_blank: Please enter option presentation.
-            min_length: Option presentation must be at least 1 character long.|Option presentation must be at least {{ limit }} characters long.
-            max_length: Option presentation must not be longer than 1 character.|Option presentation must not be longer than {{ limit }} characters.
         values:
             min_count: Please add at least {{ limit }} option value.|Please add at least {{ limit }} option values.
     option_value:

--- a/src/Sylius/Bundle/VariationBundle/spec/Validator/VariantUniqueValidatorSpec.php
+++ b/src/Sylius/Bundle/VariationBundle/spec/Validator/VariantUniqueValidatorSpec.php
@@ -49,14 +49,14 @@ class VariantUniqueValidatorSpec extends ObjectBehavior
         $context
     ) {
         $constraint = new VariantUnique([
-            'property' => 'presentation',
-            'message' => 'Variant with given presentation already exists',
+            'property' => 'name',
+            'message' => 'Variant with given name already exists',
         ]);
 
-        $variant->getPresentation()->willReturn('IPHONE5WHITE');
-        $variantRepository->findOneBy(['presentation' => 'IPHONE5WHITE'])->willReturn($conflictualVariant);
+        $variant->getName()->willReturn('IPHONE5WHITE');
+        $variantRepository->findOneBy(['name' => 'IPHONE5WHITE'])->willReturn($conflictualVariant);
 
-        $context->addViolationAt('presentation', 'Variant with given presentation already exists', Argument::any())->shouldBeCalled();
+        $context->addViolationAt('name', 'Variant with given name already exists', Argument::any())->shouldBeCalled();
 
         $this->validate($variant, $constraint);
     }
@@ -67,12 +67,12 @@ class VariantUniqueValidatorSpec extends ObjectBehavior
         $context
     ) {
         $constraint = new VariantUnique([
-            'property' => 'presentation',
-            'message' => 'Variant with given presentation already exists',
+            'property' => 'name',
+            'message' => 'Variant with given name already exists',
         ]);
 
-        $variant->getPresentation()->willReturn('111AAA');
-        $variantRepository->findOneBy(['presentation' => '111AAA'])->willReturn(null);
+        $variant->getName()->willReturn('111AAA');
+        $variantRepository->findOneBy(['name' => '111AAA'])->willReturn(null);
 
         $context->addViolationAt(Argument::any())->shouldNotBeCalled();
 
@@ -85,12 +85,12 @@ class VariantUniqueValidatorSpec extends ObjectBehavior
         $context
     ) {
         $constraint = new VariantUnique([
-            'property' => 'presentation',
-            'message' => 'Variant with given presentation already exists',
+            'property' => 'name',
+            'message' => 'Variant with given name already exists',
         ]);
 
-        $variant->getPresentation()->willReturn('111AAA');
-        $variantRepository->findOneBy(['presentation' => '111AAA'])->willReturn($variant);
+        $variant->getName()->willReturn('111AAA');
+        $variantRepository->findOneBy(['name' => '111AAA'])->willReturn($variant);
 
         $context->addViolationAt(Argument::any())->shouldNotBeCalled();
 

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Inventory/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Inventory/macros.html.twig
@@ -72,7 +72,7 @@
                                     <td>
                                         <ul>
                                         {% for option in variant.options %}
-                                            <li><strong>{{ option.presentation }}</strong>: {{ option.value }}</li>
+                                            <li><strong>{{ option.name }}</strong>: {{ option.value }}</li>
                                         {% endfor %}
                                         </ul>
                                     </td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/show.html.twig
@@ -92,7 +92,7 @@
                 <ul class="list-unstyled">
                     <li class="code"><strong>{{ 'sylius.ui.code'|trans }}</strong>: <code>{{ variant.code|default('SKU') }}</code></li>
                     {% for option in variant.options %}
-                    <li><strong>{{ option.presentation }}</strong>: {{ option.value  }}</li>
+                    <li><strong>{{ option.name }}</strong>: {{ option.value  }}</li>
                     {% endfor %}
                 </ul>
                 {% endif %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/_form.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/_form.html.twig
@@ -8,7 +8,7 @@
                 {{ form_row(optionForm) }}
             {% endfor %}
         {% endif %}
-        {{ form_row(form.presentation) }}
+        {{ form_row(form.name) }}
         {{ form_row(form.code) }}
 
         {{ form_row(form.availableOn) }}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/generate.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/generate.html.twig
@@ -20,7 +20,7 @@
     {%- for variant in form.variants %}
         <div class="row">
             <div class="col-md-6">
-                {{- form_row(variant.presentation) -}}
+                {{- form_row(variant.name) -}}
             </div>
             <div class="col-md-6">
                 {{- form_row(variant.onHand) -}}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/macros.html.twig
@@ -35,7 +35,7 @@
             <td>
                 <ul>
                 {% for option in variant.options %}
-                    <li><strong>{{ option.presentation|default(option.optionCode) }}</strong>: {{ option.value }}</li>
+                    <li><strong>{{ option.name|default(option.optionCode) }}</strong>: {{ option.value }}</li>
                 {% endfor %}
                 </ul>
             </td>

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_variant.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/_variant.html.twig
@@ -4,12 +4,12 @@
 </a>
 <div>
     <a href="{{ path(product) }}"><strong>{{ product.name }}</strong></a>
-    {% if variant.presentation is not empty %}
-        <strong>{{ variant.presentation }}</strong>
+    {% if variant.name is not empty %}
+        <strong>{{ variant.name }}</strong>
     {% elseif product.hasOptions %}
         <ul class="list-unstyled">
             {% for option in variant.options %}
-                <li><strong>{{ option.presentation }}</strong>: {{ option.value }}</li>
+                <li><strong>{{ option.name }}</strong>: {{ option.value }}</li>
             {% endfor %}
         </ul>
     {% endif %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Frontend/Product/show.html.twig
@@ -72,14 +72,14 @@
                     {% for variant in product.variants if variant.available %}
                     <tr>
                         <td>
-                            {% if variant.presentation is empty %}
+                            {% if variant.name is empty %}
                             <ul class="unstyled">
                                 {% for option in variant.options %}
-                                <li><strong>{{ option.presentation }}</strong>: {{ option.value }}</li>
+                                <li><strong>{{ option.name }}</strong>: {{ option.value }}</li>
                                 {% endfor %}
                             </ul>
                             {% else %}
-                                {{ variant.presentation }}
+                                {{ variant.name }}
                             {% endif %}
                         </td>
                         <td>

--- a/src/Sylius/Component/Variation/Model/OptionValue.php
+++ b/src/Sylius/Component/Variation/Model/OptionValue.php
@@ -126,7 +126,7 @@ class OptionValue implements OptionValueInterface
     /**
      * {@inheritdoc}
      */
-    public function getPresentation()
+    public function getName()
     {
         if (null === $this->option) {
             throw new \BadMethodCallException('The option have not been created yet so you cannot access proxy methods.');

--- a/src/Sylius/Component/Variation/Model/OptionValueInterface.php
+++ b/src/Sylius/Component/Variation/Model/OptionValueInterface.php
@@ -52,9 +52,9 @@ interface OptionValueInterface extends ResourceInterface, CodeAwareInterface, Tr
     public function getOptionCode();
 
     /**
-     * Proxy method to access the presentation of real option object.
+     * Proxy method to access the name of real option object.
      *
-     * @return string The presentation of object
+     * @return string The name of object
      */
-    public function getPresentation();
+    public function getName();
 }

--- a/src/Sylius/Component/Variation/Model/Variant.php
+++ b/src/Sylius/Component/Variation/Model/Variant.php
@@ -35,7 +35,7 @@ class Variant implements VariantInterface
     /**
      * @var string
      */
-    protected $presentation;
+    protected $name;
 
     /**
      * @var VariableInterface
@@ -80,17 +80,17 @@ class Variant implements VariantInterface
     /**
      * {@inheritdoc}
      */
-    public function getPresentation()
+    public function getName()
     {
-        return $this->presentation;
+        return $this->name;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function setPresentation($presentation)
+    public function setName($name)
     {
-        $this->presentation = $presentation;
+        $this->name = $name;
     }
 
     /**

--- a/src/Sylius/Component/Variation/Model/VariantInterface.php
+++ b/src/Sylius/Component/Variation/Model/VariantInterface.php
@@ -27,12 +27,12 @@ interface VariantInterface extends TimestampableInterface, ResourceInterface, Co
      *
      * @return string
      */
-    public function getPresentation();
+    public function getName();
 
     /**
-     * @param string $presentation
+     * @param string $name
      */
-    public function setPresentation($presentation);
+    public function setName($name);
 
     /**
      * @return VariableInterface

--- a/src/Sylius/Component/Variation/spec/Model/OptionValueSpec.php
+++ b/src/Sylius/Component/Variation/spec/Model/OptionValueSpec.php
@@ -13,9 +13,12 @@ namespace spec\Sylius\Component\Variation\Model;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Variation\Model\OptionInterface;
+use Sylius\Component\Variation\Model\OptionValue;
 use Sylius\Component\Variation\Model\OptionValueInterface;
 
 /**
+ * @mixin OptionValue
+ *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
 class OptionValueSpec extends ObjectBehavior
@@ -100,19 +103,19 @@ class OptionValueSpec extends ObjectBehavior
         $this->getOptionCode()->shouldReturn('01');
     }
 
-    function it_throws_exception_when_trying_to_get_presentation_without_option_being_assigned()
+    function it_throws_exception_when_trying_to_get_name_without_option_being_assigned()
     {
         $this
             ->shouldThrow(\BadMethodCallException::class)
-            ->duringGetPresentation()
+            ->during('getName')
         ;
     }
 
-    function it_returns_its_option_presentation(OptionInterface $option)
+    function it_returns_its_option_name(OptionInterface $option)
     {
         $option->getName()->willReturn('Size');
         $this->setOption($option);
 
-        $this->getPresentation()->shouldReturn('Size');
+        $this->getName()->shouldReturn('Size');
     }
 }

--- a/src/Sylius/Component/Variation/spec/Model/VariantSpec.php
+++ b/src/Sylius/Component/Variation/spec/Model/VariantSpec.php
@@ -57,15 +57,15 @@ class VariantSpec extends ObjectBehavior
         $this->getObject()->shouldReturn(null);
     }
 
-    function it_should_not_have_presentation_by_default()
+    function it_should_not_have_name_by_default()
     {
-        $this->getPresentation()->shouldReturn(null);
+        $this->getName()->shouldReturn(null);
     }
 
-    function its_presentation_should_be_mutable()
+    function its_name_should_be_mutable()
     {
-        $this->setPresentation('Super variant');
-        $this->getPresentation()->shouldReturn('Super variant');
+        $this->setName('Super variant');
+        $this->getName()->shouldReturn('Super variant');
     }
 
     function it_should_initialize_option_values_collection_by_default()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Related tickets | fixes #5313
| License         | MIT

Requires #5315. Renames `presentation` to `name` in `VariantInterface` and `OptionValueInterface` and its usages.
