### PR TITLE
[Product][Order] Remove Revert and Restore action

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/order.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/order.yml
@@ -15,15 +15,6 @@ sylius_backend_order_index:
             sortable: true
             permission: true
 
-sylius_backend_order_revert:
-    path: /{id}/revert/{version}
-    methods: [PATCH]
-    defaults:
-        _controller: sylius.controller.order:revertAction
-        _sylius:
-            redirect: sylius_backend_order_show
-            permission: true
-
 sylius_backend_order_delete:
     path: /{id}
     methods: [DELETE]

--- a/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/product.yml
+++ b/src/Sylius/Bundle/WebBundle/Resources/config/routing/backend/product.yml
@@ -57,15 +57,6 @@ sylius_backend_product_update:
             form: sylius_product_legacy
             permission: true
 
-sylius_backend_product_revert:
-    path: /{id}/revert/{version}
-    methods: [PATCH]
-    defaults:
-        _controller: sylius.controller.product:revertAction
-        _sylius:
-            redirect: sylius_backend_product_show
-            permission: true
-
 sylius_backend_product_delete:
     path: /{id}
     methods: [DELETE]
@@ -74,15 +65,6 @@ sylius_backend_product_delete:
         _sylius:
             template: SyliusWebBundle:Backend/Misc:delete.html.twig
             redirect: sylius_backend_product_index
-            permission: true
-
-sylius_backend_product_delete_restore:
-    path: /{id}/restore
-    methods: [PATCH]
-    defaults:
-        _controller: sylius.controller.product:restoreAction
-        _sylius:
-            redirect: sylius_backend_product_show
             permission: true
 
 sylius_backend_product_history:

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/history.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/history.html.twig
@@ -33,23 +33,23 @@
 
 <div class="tab-content">
     <div class="tab-pane active" id="main">
-        {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'revert_route': 'sylius_backend_order_revert', 'logs': logs.order, 'disabled': disabled} %}
+        {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'logs': logs.order, 'disabled': disabled} %}
     </div>
 
     <div class="tab-pane" id="items">
         {% for order_item in logs.order_items %}
-            {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'revert_route': 'sylius_backend_order_revert', 'logs': order_item, 'disabled': disabled} %}
+            {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'logs': order_item, 'disabled': disabled} %}
         {% else %}
             {{ alerts.info('sylius.ui.there_are_no_logged_events_to_display'|trans) }}
         {% endfor %}
     </div>
 
     <div class="tab-pane" id="billing_address">
-        {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'revert_route': 'sylius_backend_order_revert', 'logs': logs.billing_address, 'disabled': disabled} %}
+        {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'logs': logs.billing_address, 'disabled': disabled} %}
     </div>
 
     <div class="tab-pane" id="shipping_address">
-        {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'revert_route': 'sylius_backend_order_revert', 'logs': logs.shipping_address} %}
+        {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'logs': logs.shipping_address} %}
     </div>
 </div>
 

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/history.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Product/history.html.twig
@@ -38,13 +38,13 @@
 
 <div class="tab-content">
     <div class="tab-pane active" id="main">
-        {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'revert_route': 'sylius_backend_product_revert', 'logs': logs.product} %}
+        {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'logs': logs.product} %}
 
         <hr>
 
         <h4>{{ 'sylius.ui.variants'|trans }}</h4>
         {% for variant in logs.variants %}
-            {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'revert_route': 'sylius_backend_product_revert', 'logs': variant} %}
+            {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'logs': variant} %}
         {% else %}
             {{ alerts.info('sylius.ui.there_are_no_logged_events_to_display'|trans) }}
         {% endfor %}
@@ -52,7 +52,7 @@
 
     <div class="tab-pane" id="attributes">
         {% for attribute in logs.attributes %}
-            {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'revert_route': 'sylius_backend_product_revert', 'logs': attribute} %}
+            {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'logs': attribute} %}
         {% else %}
             {{ alerts.info('sylius.ui.there_are_no_logged_events_to_display'|trans) }}
         {% endfor %}
@@ -61,7 +61,7 @@
     {% if not product.hasVariants %}
     <div class="tab-pane" id="options">
         {% for option in logs.options %}
-            {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'revert_route': 'sylius_backend_product_revert', 'logs': option} %}
+            {% include "SyliusWebBundle:Backend:_history_table.html.twig" with {'logs': option} %}
         {% else %}
             {{ alerts.info('sylius.ui.there_are_no_logged_events_to_display'|trans) }}
         {% endfor %}

--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/_history_table.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/_history_table.html.twig
@@ -21,7 +21,6 @@
             <th class="logged-at">{{ 'sylius.history.logged_at'|trans }}</th>
             <th class="data">{{ 'sylius.ui.data'|trans }}</th>
             <th class="author">{{ 'sylius.ui.author'|trans }}</th>
-            <th></th>
         </tr>
     </thead>
     <tbody>
@@ -52,11 +51,6 @@
                 {% endif %}
             </td>
             <td>{{ log.username|default('unknown') }}</td>
-            <td>
-                {% if revert_route is defined and (log.version != 1 or length > 1) and not loop.first and not disabled is defined %}
-                    {{ buttons.patch(path(revert_route, {'id': log.objectId, 'version': log.version}), 'sylius.ui.revert'|trans) }}
-                {% endif %}
-            </td>
         </tr>
     {% endfor %}
     </tbody>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #5320
| License         | MIT

Remove revert and restore actions of products and orders.

I do not remove sylius.ui.revert in translations.*.yml