### PR TITLE
[WebBundle][ProductVariant] Add form errors for class constraints

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/generate.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/ProductVariant/generate.html.twig
@@ -16,6 +16,7 @@
     <h1><i class="glyphicon glyphicon-pencil"></i> {{ 'sylius.ui.generate_variants'|trans|raw }}</h1>
 </div>
 <form action="{{ path('sylius_backend_product_variant_generate', {'productId': product.id}) }}" method="post" class="form-horizontal" {{ form_enctype(form) }} novalidate>
+    {{ form_errors(form) }}
     <input type="hidden" name="_method" value="PUT">
     {%- for variant in form.variants %}
         <div class="row">


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #5325
| License         | MIT

Just add form error for class constraint in product variant generation