### PR TITLE
[Bug Fix] ShippingCountryRuleChecker, Use the country configuration as a code, instead of it's id

### DIFF
--- a/src/Sylius/Component/Core/Promotion/Checker/Rule/ShippingCountryRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Rule/ShippingCountryRuleChecker.php
@@ -57,7 +57,7 @@ class ShippingCountryRuleChecker implements RuleCheckerInterface
             return false;
         }
 
-        return $country->getId() === $configuration['country'];
+        return $country->getCode() === $configuration['country'];
     }
 
     /**

--- a/src/Sylius/Component/Core/spec/Promotion/Checker/Rule/ShippingCountryRuleCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Checker/Rule/ShippingCountryRuleCheckerSpec.php
@@ -59,9 +59,8 @@ final class ShippingCountryRuleCheckerSpec extends ObjectBehavior
         $subject->getShippingAddress()->willReturn($address);
 
         $countryRepository->findOneBy(['code' => 'IE'])->willReturn($country);
-        $country->getId()->willReturn(2);
 
-        $this->isEligible($subject, ['country' => 1])->shouldReturn(false);
+        $this->isEligible($subject, ['country' => 'IE'])->shouldReturn(false);
     }
 
     function it_should_recognize_subject_as_eligible_if_country_match(
@@ -74,9 +73,8 @@ final class ShippingCountryRuleCheckerSpec extends ObjectBehavior
         $address->getCountryCode()->willReturn('IE');
         $subject->getShippingAddress()->willReturn($address);
 
-        $country->getId()->willReturn(1);
         $countryRepository->findOneBy(['code' => 'IE'])->willReturn($country);
 
-        $this->isEligible($subject, ['country' => 1])->shouldReturn(true);
+        $this->isEligible($subject, ['country' => 'IE'])->shouldReturn(true);
     }
 }

--- a/src/Sylius/Component/Core/spec/Promotion/Checker/Rule/ShippingCountryRuleCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Checker/Rule/ShippingCountryRuleCheckerSpec.php
@@ -60,7 +60,7 @@ final class ShippingCountryRuleCheckerSpec extends ObjectBehavior
 
         $countryRepository->findOneBy(['code' => 'IE'])->willReturn($country);
 
-        $this->isEligible($subject, ['country' => 'IE'])->shouldReturn(false);
+        $this->isEligible($subject, ['country' => 'NL'])->shouldReturn(false);
     }
 
     function it_should_recognize_subject_as_eligible_if_country_match(


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

This promotion rule is currently broken and ignored when used.