### PR TITLE
[ReportBundle] Get default configuration for embedAction if no config…

### DIFF
--- a/src/Sylius/Bundle/ReportBundle/Controller/ReportController.php
+++ b/src/Sylius/Bundle/ReportBundle/Controller/ReportController.php
@@ -74,7 +74,7 @@ class ReportController extends ResourceController
             return $this->container->get('templating')->renderResponse('SyliusReportBundle::noDataTemplate.html.twig');
         }
 
-        $configuration = $request->query->get('configuration', $configuration);
+        $configuration = ($request->query->has('configuration')) ? $request->query->get('configuration', $configuration) : $report->getDataFetcherConfiguration();
         $configuration['baseCurrency'] = $currencyProvider->getBaseCurrency();
 
         $data = $this->getReportDataFetcher()->fetch($report, $configuration);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #5341 
| License         | MIT

Add default configuration from report if no configuration provided from $request query