### PR TITLE
[Core] Fix nth order rule checker for new guest customers

### DIFF
--- a/src/Sylius/Component/Core/Promotion/Checker/NthOrderRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/NthOrderRuleChecker.php
@@ -53,7 +53,8 @@ class NthOrderRuleChecker implements RuleCheckerInterface
         }
 
         $customer = $subject->getCustomer();
-        if (null === $customer) {
+
+        if (null === $customer || null === $customer->getId()) {
             return false;
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | -
| License         | MIT

This is for our new checkout, when promotions are applied before new customer is flushed.

