### PR TITLE
[Fixtures] Allow options to be an array only

### DIFF
--- a/src/Sylius/Bundle/FixturesBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/FixturesBundle/DependencyInjection/Configuration.php
@@ -94,6 +94,6 @@ final class Configuration implements ConfigurationInterface
         $optionsNode = $attributesNodeBuilder->arrayNode('options');
         $optionsNode->addDefaultChildrenIfNoneSet();
         $optionsNode->beforeNormalization()->always(function ($value) { return [$value]; });
-        $optionsNode->prototype('variable');
+        $optionsNode->prototype('array')->ignoreExtraKeys(false);
     }
 }

--- a/src/Sylius/Bundle/FixturesBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Sylius/Bundle/FixturesBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -169,6 +169,46 @@ final class ConfigurationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test
+     */
+    public function fixtures_options_are_an_array()
+    {
+        $this->assertPartialConfigurationIsInvalid(
+            [['suites' => ['suite' => ['fixtures' => ['fixture' => [
+                'options' => 42,
+            ]]]]]],
+            'suites.*.fixtures'
+        );
+
+        $this->assertPartialConfigurationIsInvalid(
+            [['suites' => ['suite' => ['fixtures' => ['fixture' => [
+                'options' => 'string string',
+            ]]]]]],
+            'suites.*.fixtures'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function listeners_options_are_an_array()
+    {
+        $this->assertPartialConfigurationIsInvalid(
+            [['suites' => ['suite' => ['listeners' => ['listener' => [
+                'options' => 42,
+            ]]]]]],
+            'suites.*.listeners'
+        );
+
+        $this->assertPartialConfigurationIsInvalid(
+            [['suites' => ['suite' => ['listeners' => ['listener' => [
+                'options' => 'string string',
+            ]]]]]],
+            'suites.*.listeners'
+        );
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getConfiguration()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Related tickets | -
| License         | MIT
