### PR TITLE
[Order] [WIP/RFC] Add state machine to order state resolver

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -243,7 +243,9 @@
             <argument type="service" id="sylius.factory.order_item_unit" />
             <argument type="service" id="sm.factory" />
         </service>
-        <service id="sylius.order_processing.state_resolver" class="%sylius.order_processing.state_resolver.class%" />
+        <service id="sylius.order_processing.state_resolver" class="%sylius.order_processing.state_resolver.class%">
+            <argument type="service" id="sm.factory" />
+        </service>
         <service id="sylius.order_processing.shipment_processor" class="%sylius.order_processing.shipment_processor.class%">
             <argument type="service" id="sylius.resolver.default_shipping_method" />
             <argument type="service" id="sylius.factory.shipment" />

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/app/state_machine.yml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/app/state_machine.yml
@@ -56,3 +56,20 @@ winzou_state_machine:
                     on: "create"
                     do: ["@sylius.sequence.doctrine_number_listener", "enableEntity"]
                     args: ["object"]
+
+    sylius_order_payment:
+        class: "%sylius.model.order.class%"
+        property_path: payment_state
+        graph: sylius_order_payment
+        state_machine_class: "%sylius.state_machine.class%"
+        states:
+            new: ~
+            pending: ~
+            completed: ~
+        transitions:
+            wait:
+                from: [new]
+                to: pending
+            complete:
+                from: [new, pending]
+                to: completed

--- a/src/Sylius/Component/Order/Model/OrderInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderInterface.php
@@ -36,6 +36,9 @@ interface OrderInterface extends
     const STATE_CANCELLED = 'cancelled';
     const STATE_RETURNED = 'returned';
 
+    const STATE_PAYMENT_COMPLETED = 'completed';
+    const STATE_PAYMENT_PENDING = 'pending';
+
     /**
      * @return bool
      */

--- a/src/Sylius/Component/Order/OrderTransitions.php
+++ b/src/Sylius/Component/Order/OrderTransitions.php
@@ -22,4 +22,7 @@ class OrderTransitions
     const SYLIUS_ABANDON = 'abandon';
     const SYLIUS_CANCEL = 'cancel';
     const SYLIUS_RETURN = 'return';
+
+    const SYLIUS_PAYMENT_COMPLETE = 'complete';
+    const SYLIUS_PAYMENT_WAIT = 'wait';
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Related tickets | fixes #5366 
| License         | MIT

This PR adds the state machine to the order payment status, as decided by the StateResolver.

