### PR TITLE
use code to show shipping method options

### DIFF
--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
@@ -86,7 +86,7 @@ class ShippingMethodChoiceType extends AbstractType
                 $methods = $this->repository->findAll();
             }
 
-            return new ObjectChoiceList($methods, null, [], null, 'id');
+            return new ObjectChoiceList($methods, null, [], null, 'code');
         };
 
         $resolver


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

use code to show shipping method options, because id will change when we generate sample data each time , but  code is fixed ,it  is much easier for api.