### PR TITLE
[Resource] gracefully handle state machine transitions that cannot be applied

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -21,6 +21,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -396,6 +397,10 @@ class ResourceController extends Controller
             $this->flashHelper->addFlashFromEvent($configuration, $event);
 
             return $this->redirectHandler->redirectToResource($configuration, $resource);
+        }
+
+        if (!$this->stateMachine->can($configuration, $resource)) {
+            throw new BadRequestHttpException();
         }
 
         $this->stateMachine->apply($configuration, $resource);

--- a/src/Sylius/Bundle/ResourceBundle/Controller/StateMachine.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/StateMachine.php
@@ -35,6 +35,18 @@ class StateMachine implements StateMachineInterface
     /**
      * {@inheritdoc}
      */
+    public function can(RequestConfiguration $configuration, ResourceInterface $resource)
+    {
+        if (!$configuration->hasStateMachine()) {
+            throw new \InvalidArgumentException('State machine must be configured to apply transition, check your routing.');
+        }
+
+        return $this->stateMachineFactory->get($resource, $configuration->getStateMachineGraph())->can($configuration->getStateMachineTransition());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function apply(RequestConfiguration $configuration, ResourceInterface $resource)
     {
         if (!$configuration->hasStateMachine()) {

--- a/src/Sylius/Bundle/ResourceBundle/Controller/StateMachineInterface.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/StateMachineInterface.php
@@ -21,6 +21,14 @@ interface StateMachineInterface
     /**
      * @param RequestConfiguration $configuration
      * @param ResourceInterface $resource
+     *
+     * @return bool
+     */
+    public function can(RequestConfiguration $configuration, ResourceInterface $resource);
+
+    /**
+     * @param RequestConfiguration $configuration
+     * @param ResourceInterface $resource
      */
     public function apply(RequestConfiguration $configuration, ResourceInterface $resource);
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Related tickets | 
| License         | MIT

At the moment, the `applyStateMachineTransitionAction` endpoint will throw a `500` Internal Server Error if a transition cannot be applied. This isn't very nice at all.

Propose returning a `400` Bad Request instead.
