### PR TITLE
[Core] Fix Order's state machine

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine.yml
@@ -126,7 +126,7 @@ winzou_state_machine:
         callbacks:
             after:
                 sylius_update_inventory:
-                    on: "create"
+                    on: "confirm"
                     do: ["@sylius.order_processing.inventory_handler", "updateInventory"]
                     args: ["object"]
                 sylius_update_shipment:

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/app/state_machine.yml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/app/state_machine.yml
@@ -11,7 +11,6 @@ winzou_state_machine:
             new: ~
             cart: ~
             cart_locked: ~
-            pending: ~
             released: ~
             confirmed: ~
             shipped: ~
@@ -29,19 +28,19 @@ winzou_state_machine:
                 from: [cart]
                 to: new
             release:
-                from: [pending]
+                from: [new]
                 to: released
             confirm:
-                from: [cart, pending, released]
+                from: [cart, new, released]
                 to: confirmed
             ship:
                 from: [confirmed]
                 to: shipped
             abandon:
-                from: [cart, pending]
+                from: [cart, new]
                 to: abandoned
             cancel:
-                from: [confirmed]
+                from: [new, confirmed]
                 to: cancelled
             return:
                 from: [shipped]


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Related tickets | #5274
| License         | MIT

After changes in https://github.com/Sylius/Sylius/pull/5274 the inventory is not updated after payment is completed. This PR fixes that and temporary removes "pending" state as it is currently not used anymore. The whole state machine will be reworked soon (see https://github.com/Sylius/Sylius/issues/4060).