### PR TITLE
[Behat] Refactor checkValidationMessageFor to getValidationMessage

### DIFF
--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
@@ -178,12 +178,10 @@ final class ManagingChannelsContext implements Context
      */
     public function iShouldBeNotifiedThatAtLeastOneChannelHasToBeDefinedIsRequired()
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor('enabled', 'Must have at least one enabled entity'),
-            sprintf('Channels enabled field should be required.')
-        );
+        Assert::same($currentPage->getValidationMessage('enabled'), 'Must have at least one enabled entity');
     }
 
     /**
@@ -204,12 +202,10 @@ final class ManagingChannelsContext implements Context
      */
     public function iShouldBeNotifiedThatIsRequired($element)
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor($element, sprintf('Please enter channel %s.', $element)),
-            sprintf('Tax category %s should be required.', $element)
-        );
+        Assert::same($currentPage->getValidationMessage($element), sprintf('Please enter channel %s.', $element));
     }
 
     /**
@@ -254,10 +250,7 @@ final class ManagingChannelsContext implements Context
      */
     public function iShouldBeNotifiedThatChannelWithThisCodeAlreadyExists()
     {
-        Assert::true(
-            $this->createPage->checkValidationMessageFor('code', 'Channel code has to be unique.'),
-            'Unique code violation message should appear on page, but it does not.'
-        );
+        Assert::same($this->createPage->getValidationMessage('code'), 'Channel code has to be unique.');
     }
 
     /**
@@ -349,7 +342,7 @@ final class ManagingChannelsContext implements Context
     public function iShouldBeNotifiedThatItCannotBeDeleted()
     {
         $this->notificationChecker->checkNotification(
-            "The channel cannot be deleted. At least one enabled channel is required.", 
+            "The channel cannot be deleted. At least one enabled channel is required.",
             NotificationType::failure()
         );
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCountriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCountriesContext.php
@@ -297,7 +297,7 @@ final class ManagingCountriesContext implements Context
      */
     public function iShouldBeNotifiedThatElementIsRequired($element)
     {
-        $this->assertFieldValidationMessage($element, sprintf('Please enter province %s.', $element));
+        Assert::same($this->updatePage->getValidationMessage($element), sprintf('Please enter province %s.', $element));
     }
 
     /**
@@ -309,25 +309,10 @@ final class ManagingCountriesContext implements Context
     }
 
     /**
-     * @param string $element
-     * @param string $expectedMessage
-     */
-    private function assertFieldValidationMessage($element, $expectedMessage)
-    {
-        Assert::true(
-            $this->updatePage->checkValidationMessageFor($element, $expectedMessage),
-            sprintf('Province %s should be required.', $element)
-        );
-    }
-
-    /**
      * @Then /^I should be notified that province code must be unique$/
      */
     public function iShouldBeNotifiedThatProvinceCodeMustBeUnique()
     {
-        Assert::true(
-            $this->updatePage->checkValidationMessageFor('code', 'Province code must be unique.'),
-            'Unique code violation message should appear on page, but it does not.'
-        );
+        Assert::same($this->updatePage->getValidationMessage('code'), 'Province code must be unique.');
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCurrenciesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCurrenciesContext.php
@@ -209,10 +209,7 @@ final class ManagingCurrenciesContext implements Context
      */
     public function iShouldBeNotifiedThatCurrencyCodeMustBeUnique()
     {
-        Assert::true(
-            $this->createPage->checkValidationMessageFor('code', 'Currency code must be unique.'),
-            'Unique code violation message should appear on page, but it does not.'
-        );
+        Assert::same($this->createPage->getValidationMessage('code'), 'Currency code must be unique.');
     }
 
     /**
@@ -233,12 +230,10 @@ final class ManagingCurrenciesContext implements Context
      */
     public function iShouldBeNotifiedThatExchangeRateIsRequired()
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor('exchangeRate', 'Please enter exchange rate.'),
-            'Currency exchange rate should be required.'
-        );
+        Assert::same($currentPage->getValidationMessage('exchangeRate'), 'Please enter exchange rate.');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomersContext.php
@@ -202,10 +202,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldBeNotifiedThatFirstNameIsRequired($elementName)
     {
-        Assert::true(
-            $this->createPage->checkValidationMessageFor($elementName, sprintf('Please enter your %s.', $elementName)),
-            sprintf('Customer %s should be required.', $elementName)
-        );
+        Assert::same($this->createPage->getValidationMessage($elementName), sprintf('Please enter your %s.', $elementName));
     }
 
     /**
@@ -213,12 +210,9 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldBeNotifiedThatTheElementShouldBe($elementName, $validationMessage)
     {
-        Assert::true(
-            $this->updatePage->checkValidationMessageFor(
-                $elementName,
-                sprintf('%s must be %s.', ucfirst($elementName), $validationMessage)
-            ),
-            sprintf('Customer %s should be %s.', $elementName, $validationMessage)
+        Assert::same(
+            $this->updatePage->getValidationMessage($elementName),
+            sprintf('%s must be %s.', ucfirst($elementName), $validationMessage)
         );
     }
 
@@ -294,10 +288,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldBeNotifiedThatEmailIsNotValid()
     {
-        Assert::true(
-            $this->createPage->checkValidationMessageFor('email', 'This email is invalid.'),
-            sprintf('Customer should have required form of email.')
-        );
+        Assert::same($this->createPage->getValidationMessage('email'), 'This email is invalid.');
     }
 
     /**
@@ -305,10 +296,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldBeNotifiedThatEmailMustBeUnique()
     {
-        Assert::true(
-            $this->createPage->checkValidationMessageFor('email', 'This email is already used.'),
-            sprintf('Unique email violation message should appear on page, but it does not.')
-        );
+        Assert::same($this->createPage->getValidationMessage('email'), 'This email is already used.');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentMethodsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentMethodsContext.php
@@ -259,12 +259,10 @@ final class ManagingPaymentMethodsContext implements Context
      */
     private function assertFieldValidationMessage($element, $expectedMessage)
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor($element, $expectedMessage),
-            sprintf('Payment method %s should be required.', $element)
-        );
+        Assert::same($currentPage->getValidationMessage($element), $expectedMessage);
     }
 
     /**
@@ -316,10 +314,7 @@ final class ManagingPaymentMethodsContext implements Context
      */
     public function iShouldBeNotifiedThatPaymentMethodWithThisCodeAlreadyExists()
     {
-        Assert::true(
-            $this->createPage->checkValidationMessageFor('code', 'The payment method with given code already exists.'),
-            'Unique code violation message should appear on page, but it does not.'
-        );
+        Assert::same($this->createPage->getValidationMessage('code'), 'The payment method with given code already exists.');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
@@ -179,10 +179,7 @@ final class ManagingProductAttributesContext implements Context
      */
     public function iShouldBeNotifiedThatProductAttributeWithThisCodeAlreadyExists()
     {
-        Assert::true(
-            $this->updatePage->checkValidationMessageFor('code', 'This code is already in use.'),
-            'Unique code violation message should appear on page, but it does not.'
-        );
+        Assert::same($this->updatePage->getValidationMessage('code'), 'This code is already in use.');
     }
 
     /**
@@ -281,11 +278,9 @@ final class ManagingProductAttributesContext implements Context
      */
     private function assertFieldValidationMessage($element, $expectedMessage)
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor($element, $expectedMessage),
-            sprintf('Product attribute %s should be required.', $element)
-        );
+        Assert::same($currentPage->getValidationMessage($element), $expectedMessage);
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductOptionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductOptionsContext.php
@@ -55,7 +55,8 @@ final class ManagingProductOptionsContext implements Context
         CreatePageInterface $createPage,
         UpdatePageInterface $updatePage,
         CurrentPageResolverInterface $currentPageResolver
-    ) {
+    )
+    {
         $this->indexPage = $indexPage;
         $this->createPage = $createPage;
         $this->updatePage = $updatePage;
@@ -175,10 +176,7 @@ final class ManagingProductOptionsContext implements Context
      */
     public function iShouldBeNotifiedThatProductOptionWithThisCodeAlreadyExists()
     {
-        Assert::true(
-            $this->createPage->checkValidationMessageFor('code', 'The option with given code already exists.'),
-            'Unique code violation message should appear on page, but it does not.'
-        );
+        Assert::same($this->createPage->getValidationMessage('code'), 'The option with given code already exists.');
     }
 
     /**
@@ -199,7 +197,7 @@ final class ManagingProductOptionsContext implements Context
      */
     public function iShouldBeNotifiedThatElementIsRequired($element)
     {
-        $this->assertFieldValidationMessage($element, sprintf('Please enter option %s.', $element));
+        Assert::same($this->createPage->getValidationMessage($element), sprintf('Please enter option %s.', $element));
     }
 
     /**
@@ -299,18 +297,6 @@ final class ManagingProductOptionsContext implements Context
         Assert::false(
             $this->updatePage->isThereOptionValue($optionValue),
             sprintf('%s is a value of this product option, but it should not.', $optionValue)
-        );
-    }
-
-    /**
-     * @param string $element
-     * @param string $expectedMessage
-     */
-    private function assertFieldValidationMessage($element, $expectedMessage)
-    {
-        Assert::true(
-            $this->createPage->checkValidationMessageFor($element, $expectedMessage),
-            sprintf('Product option %s should be required.', $element)
         );
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsContext.php
@@ -266,31 +266,13 @@ final class ManagingProductVariantsContext implements Context
 
     /**
      * @param string $element
-     * @param string $value
-     */
-    private function assertElementValue($element, $value)
-    {
-        Assert::true(
-            $this->updatePage->hasResourceValues(
-                [$element => $value]
-            ),
-            sprintf('Product should have %s with %s value.', $element, $value)
-        );
-    }
-
-    /**
-     * @param string $element
+     * @param $message
      */
     private function assertValidationMessage($element, $message)
     {
-        $currentPage = $this->currentPageResolver->getCurrentPageWithForm([
-            $this->createPage,
-            $this->updatePage,
-        ]);
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
+        $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor($element, $message),
-            sprintf('Product %s should be required.', $element)
-        );
+        Assert::same($currentPage->getValidationMessage($element), $message);
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -461,7 +461,7 @@ final class ManagingProductsContext implements Context
             $this->updateSimpleProductPage,
             $this->updateConfigurableProductPage,
         ], $this->sharedStorage->get('product'));
-        
+
         $currentPage->selectMainTaxon($taxon);
     }
 
@@ -477,7 +477,7 @@ final class ManagingProductsContext implements Context
         ], $this->sharedStorage->get('product'));
 
         $currentPage->open(['id' => $product->getId()]);
-        
+
         Assert::true(
             $this->updateConfigurableProductPage->isMainTaxonChosen($taxonName),
             sprintf('The main taxon %s should be chosen, but it does not.', $taxonName)
@@ -514,6 +514,7 @@ final class ManagingProductsContext implements Context
     {
         $product = $this->sharedStorage->has('product') ? $this->sharedStorage->get('product') : null;
 
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([
             $this->createSimpleProductPage,
             $this->createConfigurableProductPage,
@@ -521,9 +522,6 @@ final class ManagingProductsContext implements Context
             $this->updateConfigurableProductPage,
         ], $product);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor($element, $message),
-            sprintf('Product %s should be required.', $element)
-        );
+        Assert::same($currentPage->getValidationMessage($element), $message);
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionCouponsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionCouponsContext.php
@@ -316,12 +316,10 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function iShouldBeNotifiedThatCouponWithThisCodeAlreadyExists()
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor('code', 'This coupon already exists.'),
-            'Unique code violation message should appear on page, but it does not.'
-        );
+        Assert::same($currentPage->getValidationMessage('code'), 'This coupon already exists.');
     }
 
     /**
@@ -329,12 +327,10 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function iShouldBeNotifiedThatIsRequired($element)
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor($element, sprintf('Please enter coupon %s.', $element)),
-            sprintf('I should be notified that coupon %s should be required.', $element)
-        );
+        Assert::same($currentPage->getValidationMessage($element), sprintf('Please enter coupon %s.', $element));
     }
 
     /**
@@ -377,12 +373,10 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function iShouldBeNotifiedThatCouponUsageLimitMustBeAtLeast()
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor('usage_limit', 'Coupon usage limit must be at least 1.'),
-            'Min usage limit violation message should appear on page, but it did not.'
-        );
+        Assert::same($currentPage->getValidationMessage('usage_limit'), 'Coupon usage limit must be at least 1.');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -231,10 +231,7 @@ final class ManagingPromotionsContext implements Context
      */
     public function iShouldBeNotifiedThatPromotionWithThisCodeAlreadyExists()
     {
-        Assert::true(
-            $this->createPage->checkValidationMessageFor('code', 'The promotion with given code already exists.'),
-            'Unique code violation message should appear on page, but it does not.'
-        );
+        Assert::same($this->createPage->getValidationMessage('code'), 'The promotion with given code already exists.');
     }
 
     /**
@@ -444,12 +441,10 @@ final class ManagingPromotionsContext implements Context
      */
     public function iShouldBeNotifiedThatPromotionCannotEndBeforeItsEvenStart()
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor('ends_at', 'End date cannot be set prior start date.'),
-            'Start date was set after ends date, but it should not be possible.'
-        );
+        Assert::same($currentPage->getValidationMessage('ends_at'), 'End date cannot be set prior start date.');
     }
 
     /**
@@ -458,12 +453,10 @@ final class ManagingPromotionsContext implements Context
      */
     private function assertFieldValidationMessage($element, $expectedMessage)
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor($element, $expectedMessage),
-            sprintf('Promotion %s should be required.', $element)
-        );
+        Assert::same($currentPage->getValidationMessage($element), $expectedMessage);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingMethodsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingMethodsContext.php
@@ -177,10 +177,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function iShouldBeNotifiedThatShippingMethodWithThisCodeAlreadyExists()
     {
-        Assert::true(
-            $this->createPage->checkValidationMessageFor('code', 'The shipping method with given code already exists.'),
-            'Unique code violation message should appear on page, but it does not.'
-        );
+        Assert::same($this->createPage->getValidationMessage('code'), 'The shipping method with given code already exists.');
     }
 
     /**
@@ -392,12 +389,10 @@ final class ManagingShippingMethodsContext implements Context
      */
     private function assertFieldValidationMessage($element, $expectedMessage)
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor($element, $expectedMessage),
-            sprintf('Shipping method %s should be required.', $element)
-        );
+        Assert::same($currentPage->getValidationMessage($element), $expectedMessage);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxCategoriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxCategoriesContext.php
@@ -186,10 +186,7 @@ final class ManagingTaxCategoriesContext implements Context
      */
     public function iShouldBeNotifiedThatTaxCategoryWithThisCodeAlreadyExists()
     {
-        Assert::true(
-            $this->createPage->checkValidationMessageFor('code', 'The tax category with given code already exists.'),
-            'Unique code violation message should appear on page, but it does not.'
-        );
+        Assert::same($this->createPage->getValidationMessage('code'), 'The tax category with given code already exists.');
     }
 
     /**
@@ -209,12 +206,10 @@ final class ManagingTaxCategoriesContext implements Context
      */
     public function iShouldBeNotifiedThatIsRequired($element)
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor($element, sprintf('Please enter tax category %s.', $element)),
-            sprintf('Tax category %s should be required.', $element)
-        );
+        Assert::same($currentPage->getValidationMessage($element), sprintf('Please enter tax category %s.', $element));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxRateContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxRateContext.php
@@ -221,10 +221,7 @@ final class ManagingTaxRateContext implements Context
      */
     public function iShouldBeNotifiedThatTaxRateWithThisCodeAlreadyExists()
     {
-        Assert::true(
-            $this->createPage->checkValidationMessageFor('code', 'The tax rate with given code already exists.'),
-            'Unique code violation message should appear on page, but it does not.'
-        );
+        Assert::same($this->createPage->getValidationMessage('code'), 'The tax rate with given code already exists.');
     }
 
     /**
@@ -327,11 +324,9 @@ final class ManagingTaxRateContext implements Context
      */
     private function assertFieldValidationMessage($element, $expectedMessage)
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor($element, $expectedMessage),
-            sprintf('Tax rate %s should be required.', $element)
-        );
+        Assert::same($currentPage->getValidationMessage($element), $expectedMessage);
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
@@ -235,12 +235,10 @@ final class ManagingTaxonsContext implements Context
      */
     public function iShouldBeNotifiedThatTaxonWithThisCodeAlreadyExists()
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor('code', 'Taxon with given code already exists.'),
-            'Unique code violation message should appear on page, but it does not.'
-        );
+        Assert::same($currentPage->getValidationMessage('code'), 'Taxon with given code already exists.');
     }
 
     /**
@@ -248,12 +246,10 @@ final class ManagingTaxonsContext implements Context
      */
     public function iShouldBeNotifiedThatIsRequired($element)
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor($element, sprintf('Please enter taxon %s.', $element)),
-            sprintf('I should be notified that taxon %s should be required.', $element)
-        );
+        Assert::same($currentPage->getValidationMessage($element), sprintf('Please enter taxon %s.', $element));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingZonesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingZonesContext.php
@@ -237,12 +237,10 @@ final class ManagingZonesContext implements Context
      */
     public function iShouldBeNotifiedThatZoneWithThisCodeAlreadyExists()
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor('code', 'Zone code must be unique.'),
-            'Unique code violation message should appear on page, but it does not.'
-        );
+        Assert::same($currentPage->getValidationMessage('code'), 'Zone code must be unique.');
     }
 
     /**
@@ -263,12 +261,10 @@ final class ManagingZonesContext implements Context
      */
     public function iShouldBeNotifiedThatIsRequired($element)
     {
+        /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->checkValidationMessageFor($element, sprintf('Please enter zone %s.', $element)),
-            sprintf('I should be notified that zone %s should be required.', $element)
-        );
+        Assert::same($currentPage->getValidationMessage($element), sprintf('Please enter zone %s.', $element));
     }
 
     /**

--- a/src/Sylius/Behat/Page/Admin/Country/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Country/UpdatePage.php
@@ -155,7 +155,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     /**
      * {@inheritdoc}
      */
-    public function checkValidationMessageFor($element, $message)
+    public function getValidationMessage($element)
     {
         $provinceForm = $this->getLastProvinceElement();
 
@@ -164,7 +164,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
             throw new ElementNotFoundException($this->getSession(), 'Tag', 'css', '.pointing');
         }
 
-        return $message === $foundElement->getText();
+        return $foundElement->getText();
     }
 
     /**

--- a/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
@@ -49,10 +49,8 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @throws ElementNotFoundException
      */
-    public function checkValidationMessageFor($element, $message)
+    public function getValidationMessage($element)
     {
         $foundElement = $this->getFieldElement($element);
         if (null === $foundElement) {
@@ -64,7 +62,7 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
             throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '.pointing');
         }
 
-        return $message === $validationMessage->getText();
+        return $validationMessage->getText();
     }
 
     /**

--- a/src/Sylius/Behat/Page/Admin/Crud/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/CreatePageInterface.php
@@ -21,11 +21,12 @@ interface CreatePageInterface extends SymfonyPageInterface
 {
     /**
      * @param string $element
-     * @param string $message
      *
-     * @return bool
+     * @return string
+     * 
+     * @throws ElementNotFoundException
      */
-    public function checkValidationMessageFor($element, $message);
+    public function getValidationMessage($element);
 
     /**
      * @throws ElementNotFoundException

--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
@@ -49,10 +49,8 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
 
     /**
      * {@inheritdoc}
-     * 
-     * @throws ElementNotFoundException
      */
-    public function checkValidationMessageFor($element, $message)
+    public function getValidationMessage($element)
     {
         $foundElement = $this->getFieldElement($element);
         if (null === $foundElement) {
@@ -64,7 +62,7 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
             throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '.pointing');
         }
 
-        return $message === $validationMessage->getText();
+        return $validationMessage->getText();
     }
 
     /**

--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePageInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Behat\Page\Admin\Crud;
 
+use Behat\Mink\Exception\ElementNotFoundException;
 use Sylius\Behat\Page\SymfonyPageInterface;
 
 /**
@@ -20,11 +21,12 @@ interface UpdatePageInterface extends SymfonyPageInterface
 {
     /**
      * @param string $element
-     * @param string $message
      *
-     * @return bool
+     * @return string
+     *
+     * @throws ElementNotFoundException
      */
-    public function checkValidationMessageFor($element, $message);
+    public function getValidationMessage($element);
 
     /**
      * @param array $parameters where keys are some of arbitrary elements defined by user and values are expected values


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Related tickets | -
| License         | MIT

There are assertions like:

```php
Assert::true(
    $this->updatePage->checkValidationMessageFor('code', 'This code is already in use.'),
    'Unique code violation message should appear on page, but it does not.'
);
```

We are getting "Unique code violation message should appear on page, but it does not." when the validation message differs from "This code is already in use.". If the validation message gets changed, we will get an exception, that there is no unique code violation on the page, but there will be.

I've changed it to:

```php
Assert::same($this->updatePage->getValidationMessage('code'), 'This code is already in use.');
```

It will throw an exception with the actual message and the asserted message. If there is no validation message found, `ElementNotFoundException` will be thrown inside `getValidationMessage`.