### PR TITLE
Only add steps that are active

### DIFF
--- a/src/Sylius/Bundle/FlowBundle/Process/Builder/ProcessBuilder.php
+++ b/src/Sylius/Bundle/FlowBundle/Process/Builder/ProcessBuilder.php
@@ -79,6 +79,10 @@ class ProcessBuilder implements ProcessBuilderInterface
             throw new \InvalidArgumentException('Step added via builder must implement "Sylius\Bundle\FlowBundle\Process\Step\StepInterface"');
         }
 
+        if (!$step->isActive()) {
+            return $this;
+        }
+
         if ($step instanceof ContainerAwareInterface) {
             $step->setContainer($this->container);
         }

--- a/src/Sylius/Bundle/FlowBundle/spec/Process/Builder/ProcessBuilderSpec.php
+++ b/src/Sylius/Bundle/FlowBundle/spec/Process/Builder/ProcessBuilderSpec.php
@@ -14,6 +14,9 @@ namespace spec\Sylius\Bundle\FlowBundle\Process\Builder;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\FlowBundle\Process\Builder\ProcessBuilderInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Sylius\Bundle\FlowBundle\Process\Step\StepInterface;
+use Sylius\Bundle\FlowBundle\Process\Scenario\ProcessScenarioInterface;
+use Prophecy\Argument;
 
 class ProcessBuilderSpec extends ObjectBehavior
 {
@@ -30,5 +33,28 @@ class ProcessBuilderSpec extends ObjectBehavior
     function it_is_process_builder()
     {
         $this->shouldImplement(ProcessBuilderInterface::class);
+    }
+
+    function it_should_not_add_inactive_steps(
+        StepInterface $step,
+        ProcessScenarioInterface $scenario
+    ) {
+        $this->build($scenario);
+        $step->isActive()->willReturn(false);
+        $step->setName(Argument::any())->shouldNotBeCalled();
+
+        $this->add('foobar', $step);
+    }
+
+    function it_should_add_active_steps(
+        StepInterface $step,
+        ProcessScenarioInterface $scenario
+    ) {
+        $step->getName()->willReturn(null);
+        $this->build($scenario);
+        $step->isActive()->willReturn(true);
+        $step->setName('foobar')->shouldBeCalled();
+
+        $this->add('foobar', $step);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no/hope not
| Related tickets | 
| License         | MIT

Currently the `isActive` method of the `StepInterface` is not used.

We have a situation where we would like to "remove" a checkout step based on a certain condition.

I assume that this is what the `isActive()` method was intended for, it is here added to the `ProcessBuilder`.