### PR TITLE
[CRITICAL] Prevent SyliusDataCollector from breaking the whole app if channel cannot be found

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/DataCollector/SyliusDataCollector.php
+++ b/src/Sylius/Bundle/CoreBundle/DataCollector/SyliusDataCollector.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\CoreBundle\DataCollector;
 
 use Sylius\Bundle\CoreBundle\Application\Kernel;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
 use Sylius\Component\Core\Context\ShopperContextInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -104,9 +105,17 @@ class SyliusDataCollector extends DataCollector
     {
         $this->version = Kernel::VERSION;
 
-        $this->channelCode = $this->shopperContext->getChannel()->getCode();
-        $this->currencyCode = $this->shopperContext->getCurrencyCode();
-        $this->localeCode = $this->shopperContext->getLocaleCode();
+        try {
+            $this->channelCode = $this->shopperContext->getChannel()->getCode();
+        } catch (ChannelNotFoundException $exception) {}
+
+        try {
+            $this->currencyCode = $this->shopperContext->getCurrencyCode();
+        } catch (ChannelNotFoundException $exception) {}
+
+        try {
+            $this->localeCode = $this->shopperContext->getLocaleCode();
+        } catch (ChannelNotFoundException $exception) {}
 
         $customer = $this->shopperContext->getCustomer();
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/views/Collector/sylius.html.twig
+++ b/src/Sylius/Bundle/CoreBundle/Resources/views/Collector/sylius.html.twig
@@ -13,15 +13,15 @@
         </div>
         <div class="sf-toolbar-info-piece">
             <b>Channel</b>
-            <span class="sf-toolbar-status">{{ collector.channelCode }}</span>
+            <span class="sf-toolbar-status">{{ collector.channelCode|default('Undefined') }}</span>
         </div>
         <div class="sf-toolbar-info-piece">
             <b>Currency</b>
-            <span class="sf-toolbar-status">{{ collector.currencyCode }}</span>
+            <span class="sf-toolbar-status">{{ collector.currencyCode|default('Undefined') }}</span>
         </div>
         <div class="sf-toolbar-info-piece">
             <b>Locale</b>
-            <span class="sf-toolbar-status">{{ collector.localeCode }}</span>
+            <span class="sf-toolbar-status">{{ collector.localeCode|default('Undefined') }}</span>
         </div>
         <div class="sf-toolbar-info-piece">
             <b>Customer</b>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | -
| License         | MIT

Built-in server can't be run on `dev` environment if channel was not found.