### PR TITLE
Added resource debug command

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Command/DebugResourceCommand.php
+++ b/src/Sylius/Bundle/ResourceBundle/Command/DebugResourceCommand.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\Table;
+use Sylius\Component\Resource\Metadata\MetadataInterface;
+use Sylius\Component\Resource\Metadata\RegistryInterface;
+
+/**
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class DebugResourceCommand extends Command
+{
+    /**
+     * @var RegistryInterface
+     */
+    private $registry;
+
+    /**
+     * @param RegistryInterface $registry
+     */
+    public function __construct(RegistryInterface $registry)
+    {
+        parent::__construct();
+        $this->registry = $registry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure()
+    {
+        $this->setName('sylius:debug:resource');
+        $this->setDescription('Debug resource metadata.');
+        $this->setHelp(<<<'EOT'
+List or show resource metadata.
+
+To list run the command without an agrument:
+
+    $ php %command.full_name%
+
+To show the metadata for a resource, pass its alias:
+
+    $ php %command.full_name% sylius.user
+EOT
+        );
+        $this->addArgument('resource', InputArgument::OPTIONAL, 'Resource to debug');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $resource = $input->getArgument('resource');
+
+        if (null === $resource) {
+            return $this->listResources($output);
+        }
+
+        $metadata = $this->registry->get($resource);
+
+        $this->debugResource($metadata, $output);
+    }
+
+    /**
+     * @param OutputInterface $output
+     */
+    private function listResources(OutputInterface $output)
+    {
+        $resources = $this->registry->getAll();
+        ksort($resources);
+        $table = new Table($output);
+        $table->setHeaders(['Alias']);
+
+        foreach ($resources as $resource) {
+            $table->addRow([$resource->getAlias()]);
+        }
+        $table->render();
+    }
+
+    /**
+     * @param MetadataInterface $metadata
+     * @param OutputInterface $output
+     */
+    private function debugResource(MetadataInterface $metadata, OutputInterface $output)
+    {
+        $table = new Table($output);
+        $information = [
+            'name' => $metadata->getName(),
+            'application' => $metadata->getApplicationName(),
+            'driver' => $metadata->getDriver(),
+        ];
+
+        $parameters = $this->flattenParameters($metadata->getParameters());
+
+        foreach ($parameters as $key => $value) {
+            $information[$key] = $value;
+        }
+
+        foreach ($information as $key => $value) {
+            $table->addRow([$key, $value]);
+        }
+
+        $table->render();
+    }
+
+    /**
+     * @param array $parameters
+     * @param array $flattened
+     * @param string $prefix
+     */
+    private function flattenParameters(array $parameters, array $flattened = [], $prefix = '')
+    {
+        foreach ($parameters as $key => $value) {
+            if (is_array($value)) {
+                $flattened = $this->flattenParameters($value, $flattened, $prefix.$key.'.');
+                continue;
+            }
+
+            $flattened[$prefix.$key] = $value;
+        }
+
+        return $flattened;
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
@@ -42,6 +42,7 @@ class SyliusResourceExtension extends Extension
             'storage.xml',
             'routing.xml',
             'twig.xml',
+            'console.xml',
         ];
 
         foreach ($configFiles as $configFile) {

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/console.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/console.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+                               http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sylius.resource_console.command.debug">Sylius\Bundle\ResourceBundle\Command\DebugResourceCommand</parameter>
+    </parameters>
+
+    <services>
+        <service id="sylius.resource_console.command.debug" class="%sylius.resource_console.command.debug%">
+            <argument type="service" id="sylius.resource_registry" />
+            <tag name="console.command" />
+        </service>
+    </services>
+
+</container>

--- a/src/Sylius/Bundle/ResourceBundle/Tests/Command/DebugResourceCommandTest.php
+++ b/src/Sylius/Bundle/ResourceBundle/Tests/Command/DebugResourceCommandTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\Tests\Command;
+
+use Sylius\Component\Resource\Metadata\RegistryInterface;
+use Sylius\Bundle\ResourceBundle\Command\DebugResourceCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+use Sylius\Component\Resource\Metadata\Metadata;
+
+/**
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class DebugResourceCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RegistryInterface
+     */
+    private $registry;
+
+    /**
+     * @var CommandTester
+     */
+    private $tester;
+
+    public function setUp()
+    {
+        $this->registry = $this->prophesize(RegistryInterface::class);
+
+        $command = new DebugResourceCommand($this->registry->reveal());
+        $this->tester = new CommandTester($command);
+    }
+
+    /**
+     * It should list all resources if no argument is given.
+     */
+    public function testListAll()
+    {
+        $metadata1 = $this->createMetadata('one');
+        $metadata2 = $this->createMetadata('two');
+
+        $this->registry->getAll()->willReturn([
+            $metadata1->reveal(),
+            $metadata2->reveal(),
+        ]);
+        $this->tester->execute([]);
+        $display = $this->tester->getDisplay();
+
+        $this->assertEquals(<<<'EOT'
++------------+
+| Alias      |
++------------+
+| sylius.one |
+| sylius.two |
++------------+
+
+EOT
+        , $display);
+    }
+
+    /**
+     * It should display the metadata for a given resource alias.
+     */
+    public function testDebugResource()
+    {
+        $metadata1 = $this->createMetadata('one');
+
+        $this->registry->get('metadata.one')->willReturn($metadata1->reveal());
+        $this->tester->execute([
+            'resource' => 'metadata.one',
+        ]);
+
+        $display = $this->tester->getDisplay();
+
+        $this->assertEquals(<<<'EOT'
++------------------------------+-----------------+
+| name                         | one             |
+| application                  | sylius          |
+| driver                       | doctrine/foobar |
+| classes.foo                  | bar             |
+| classes.bar                  | foo             |
+| whatever.something.elephants | camels          |
++------------------------------+-----------------+
+
+EOT
+        , $display);
+    }
+
+    /**
+     * @param mixed $suffix
+     */
+    private function createMetadata($suffix)
+    {
+        $metadata = $this->prophesize(Metadata::class);
+        $metadata->getName()->willReturn($suffix);
+        $metadata->getApplicationName()->willReturn('sylius');
+        $metadata->getAlias()->willReturn('sylius.'.$suffix);
+        $metadata->getDriver()->willReturn('doctrine/foobar');
+        $metadata->getParameters()->willReturn([
+            'classes' => [
+                'foo' => 'bar',
+                'bar' => 'foo',
+            ],
+            'whatever' => [
+                'something' => [
+                    'elephants' => 'camels',
+                ],
+            ],
+        ]);
+
+        return $metadata;
+    }
+}

--- a/src/Sylius/Component/Resource/Metadata/Metadata.php
+++ b/src/Sylius/Component/Resource/Metadata/Metadata.php
@@ -151,6 +151,14 @@ class Metadata implements MetadataInterface
     /**
      * {@inheritdoc}
      */
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getClass($name)
     {
         if (!$this->hasClass($name)) {

--- a/src/Sylius/Component/Resource/Metadata/MetadataInterface.php
+++ b/src/Sylius/Component/Resource/Metadata/MetadataInterface.php
@@ -61,6 +61,13 @@ interface MetadataInterface
     public function getParameter($name);
 
     /**
+     * Return all the metadata parameters.
+     *
+     * @return array
+     */
+    public function getParameters();
+
+    /**
      * @param $name
      *
      * @return bool


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Related tickets | fixes #5191
| License         | MIT

This PR adds a command to debug resources:

```bash
~/w/s/sylius ❯❯❯ ./app/console sylius:debug:resource
Select a resource to debug: 
  [0 ] sylius.order
  [1 ] sylius.order_item
  [2 ] sylius.order_item_unit
  ...
  [84] sylius.api_refresh_token
  [85] sylius.api_auth_code
  [86] sylius.payment_security_token
  [87] sylius.gateway_config
 > 42
+--------------------+------------------------------------------------------------+
| name               | promotion                                                  |
| application        | sylius                                                     |
| driver             | doctrine/orm                                               |
| classes.model      | Sylius\Component\Core\Model\Promotion                      |
| classes.repository | Sylius\Bundle\CoreBundle\Doctrine\ORM\PromotionRepository  |
| form.default       | Sylius\Bundle\CoreBundle\Form\Type\PromotionType           |
| form.choice        | Sylius\Bundle\ResourceBundle\Form\Type\ResourceChoiceType  |
| classes.interface  | Sylius\Component\Promotion\Model\PromotionInterface        |
| classes.controller | Sylius\Bundle\ResourceBundle\Controller\ResourceController |
| classes.factory    | Sylius\Component\Resource\Factory\Factory                  |
| default.0          | sylius                                                     |
+--------------------+------------------------------------------------------------+
```

The above should dumps all of the information in the `metadata` class. We could go further and show the routes associated with the resource, WDYT?
