### PR TITLE
Remove right trim in order list

### DIFF
--- a/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/macros.html.twig
+++ b/src/Sylius/Bundle/WebBundle/Resources/views/Backend/Order/macros.html.twig
@@ -28,7 +28,7 @@
             <td class="center-text"><input type="checkbox" value="{{ order.id }}" /></td>
             <td>{{ order.createdAt|format_date }}</td>
             <td>
-                <span {%- if order.channel.color -%} style="color: {{ order.channel.color }};"{%- endif -%}>{{ order.channel.code }}</span>
+                <span {%- if order.channel.color %} style="color: {{ order.channel.color }};"{%- endif -%}>{{ order.channel.code }}</span>
             </td>
             <td>
                 <a href="{{ path('sylius_backend_order_show', {'id': order.id}) }}">


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets |
| License         | MIT


When you define a channel color in the backend order list we need add a right space:

```
<spanstyle="color: Green;">default</span>
```
