### PR TITLE
Generic controller events

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/EventDispatcher.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/EventDispatcher.php
@@ -14,12 +14,20 @@ namespace Sylius\Bundle\ResourceBundle\Controller;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface as SymfonyEventDispatcherInterface;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
+use Sylius\Bundle\ResourceBundle\ResourceControllerEvents;
+use Sylius\Component\Resource\ResourceActions;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Daniel Leech <daniel@dantleech.com>
  */
 class EventDispatcher implements EventDispatcherInterface
 {
+    const PRE_PREFIX = 'pre_';
+    const POST_PREFIX = 'post_';
+    const NO_PREFIX = '';
+
     /**
      * @var SymfonyEventDispatcherInterface
      */
@@ -38,50 +46,61 @@ class EventDispatcher implements EventDispatcherInterface
      */
     public function dispatch($eventName, RequestConfiguration $requestConfiguration, ResourceInterface $resource)
     {
-        $eventName = $requestConfiguration->getEvent() ?: $eventName;
-        $metadata = $requestConfiguration->getMetadata();
-        $event = $this->getEvent($resource);
-
-        $this->eventDispatcher->dispatch(sprintf('%s.%s.%s', $metadata->getApplicationName(), $metadata->getName(), $eventName), $event);
+        $event = new ResourceControllerEvent($resource, $requestConfiguration);
+        $this->eventDispatcher->dispatch($eventName, $event);
+        $this->dispatchResourceEvent($eventName, $event);
 
         return $event;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatchPreEvent($eventName, RequestConfiguration $requestConfiguration, ResourceInterface $resource)
+    private function dispatchResourceEvent($eventName, ResourceControllerEvent $event)
     {
-        $eventName = $requestConfiguration->getEvent() ?: $eventName;
-        $metadata = $requestConfiguration->getMetadata();
-        $event = $this->getEvent($resource);
+        switch ($eventName) {
+            case ResourceControllerEvents::SHOW:
+                $this->doDispatchResourceEvent(self::NO_PREFIX, ResourceActions::SHOW, $event);
+                return;
+            case ResourceControllerEvents::INDEX:
+                $this->doDispatchResourceEvent(self::NO_PREFIX, ResourceActions::INDEX, $event);
+                return;
+            case ResourceControllerEvents::PRE_UPDATE:
+                $this->doDispatchResourceEvent(self::PRE_PREFIX, ResourceActions::UPDATE, $event);
+                return;
+            case ResourceControllerEvents::POST_UPDATE:
+                $this->doDispatchResourceEvent(self::POST_PREFIX, ResourceActions::UPDATE, $event);
+                return;
+            case ResourceControllerEvents::PRE_CREATE:
+                $this->doDispatchResourceEvent(self::PRE_PREFIX, ResourceActions::CREATE, $event);
+                return;
+            case ResourceControllerEvents::POST_CREATE:
+                $this->doDispatchResourceEvent(self::POST_PREFIX, ResourceActions::CREATE, $event);
+                return;
+            case ResourceControllerEvents::PRE_DELETE:
+                $this->doDispatchResourceEvent(self::PRE_PREFIX, ResourceActions::DELETE, $event);
+                return;
+            case ResourceControllerEvents::POST_DELETE:
+                $this->doDispatchResourceEvent(self::POST_PREFIX, ResourceActions::DELETE, $event);
+                return;
+        }
 
-        $this->eventDispatcher->dispatch(sprintf('%s.%s.pre_%s', $metadata->getApplicationName(), $metadata->getName(), $eventName), $event);
-
-        return $event;
+        throw new \RuntimeException(sprintf(
+            'Do not know how to dispatch resource event "%s"', $eventName
+        ));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function dispatchPostEvent($eventName, RequestConfiguration $requestConfiguration, ResourceInterface $resource)
+    private function doDispatchResourceEvent($prefix, $eventName, ResourceControllerEvent $event)
     {
+        $requestConfiguration = $event->getRequestConfiguration();
         $eventName = $requestConfiguration->getEvent() ?: $eventName;
         $metadata = $requestConfiguration->getMetadata();
-        $event = $this->getEvent($resource);
 
-        $this->eventDispatcher->dispatch(sprintf('%s.%s.post_%s', $metadata->getApplicationName(), $metadata->getName(), $eventName), $event);
+        $this->eventDispatcher->dispatch(sprintf(
+            '%s.%s.%s%s',
+            $metadata->getApplicationName(),
+            $metadata->getName(),
+            $prefix,
+            $eventName
+        ), $event);
 
         return $event;
-    }
-
-    /**
-     * @param ResourceInterface $resource
-     *
-     * @return ResourceControllerEvent
-     */
-    private function getEvent(ResourceInterface $resource)
-    {
-        return new ResourceControllerEvent($resource);
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/Controller/EventDispatcherInterface.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/EventDispatcherInterface.php
@@ -27,22 +27,4 @@ interface EventDispatcherInterface
      * @return ResourceControllerEvent
      */
     public function dispatch($eventName, RequestConfiguration $requestConfiguration, ResourceInterface $resource);
-
-    /**
-     * @param string $eventName
-     * @param RequestConfiguration $requestConfiguration
-     * @param ResourceInterface $resource
-     *
-     * @return ResourceControllerEvent
-     */
-    public function dispatchPreEvent($eventName, RequestConfiguration $requestConfiguration, ResourceInterface $resource);
-
-    /**
-     * @param string $eventName
-     * @param RequestConfiguration $requestConfiguration
-     * @param ResourceInterface $resource
-     *
-     * @return ResourceControllerEvent
-     */
-    public function dispatchPostEvent($eventName, RequestConfiguration $requestConfiguration, ResourceInterface $resource);
 }

--- a/src/Sylius/Bundle/ResourceBundle/Event/ResourceControllerEvent.php
+++ b/src/Sylius/Bundle/ResourceBundle/Event/ResourceControllerEvent.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\ResourceBundle\Event;
 
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
 
 /**
  * @author Jérémy Leherpeur <jeremy@leherpeur.net>
@@ -42,6 +43,21 @@ class ResourceControllerEvent extends GenericEvent
      * @var int
      */
     protected $errorCode = 500;
+
+    /**
+     * @var RequestConfiguration
+     */
+    protected $requestConfiguration;
+
+    /**
+     * @param mixed $subject
+     * @param RequestConfiguration $requestConfiguration
+     */
+    public function __construct($subject, RequestConfiguration $requestConfiguration)
+    {
+        parent::__construct($subject);
+        $this->requestConfiguration = $requestConfiguration;
+    }
 
     /**
      * Stop event propagation
@@ -156,5 +172,15 @@ class ResourceControllerEvent extends GenericEvent
     public function setErrorCode($errorCode)
     {
         $this->errorCode = $errorCode;
+    }
+
+    /**
+     * Return the request configuration.
+     *
+     * @return RequestConfiguration
+     */
+    public function getRequestConfiguration()
+    {
+        return $this->requestConfiguration;
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/ResourceControllerEvents.php
+++ b/src/Sylius/Bundle/ResourceBundle/ResourceControllerEvents.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Sylius\Bundle\ResourceBundle;
+
+/**
+ * Events that are issued by the resource controller.
+ */
+final class ResourceControllerEvents
+{
+    /**
+     * Issued when a resource is shown.
+     */
+    const SHOW = 'sylius.resource.controller.show';
+
+    /**
+     * Issued when the index page of a resource is displayed.
+     */
+    const INDEX  = 'sylius.resource.controller.index';
+
+    /**
+     * Issued before a resource is updated.
+     */
+    const PRE_UPDATE = 'sylius.resource.controller.pre_update';
+
+    /**
+     * Issued after a resource has been updated.
+     */
+    const POST_UPDATE = 'sylius.resource.controller.post_update';
+
+    /**
+     * Issued before a resource is deleted.
+     */
+    const PRE_DELETE = 'sylius.resource.controller.pre_delete';
+
+    /**
+     * Issued after a resource has been deleted.
+     */
+    const POST_DELETE = 'sylius.resource.controller.post_delete';
+
+    /**
+     * Issued after a resource is created.
+     */
+    const PRE_CREATE = 'sylius.resource.controller.pre_create';
+
+    /**
+     * Issued after a resource has been created.
+     */
+    const POST_CREATE = 'sylius.resource.controller.post_create';
+}

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
@@ -57,7 +57,6 @@
             <tag name="kernel.event_subscriber" event="kernel.exception" />
         </service>
 
-
         <service id="sylius.form.extension.collection"
                  class="%sylius.form.extension.collection.class%">
             <tag name="form.type_extension" alias="collection" />

--- a/src/Sylius/Bundle/ResourceBundle/spec/Event/ResourceControllerEventSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Event/ResourceControllerEventSpec.php
@@ -13,15 +13,17 @@ namespace spec\Sylius\Bundle\ResourceBundle\Event;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Resource\Event\ResourceEvent;
+use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
 final class ResourceControllerEventSpec extends ObjectBehavior
 {
-    function let()
-    {
-        $this->beConstructedWith('message');
+    function let(
+        RequestConfiguration $requestConfiguration
+    ) {
+        $this->beConstructedWith('message', $requestConfiguration);
     }
 
     function it_is_initializable()
@@ -76,5 +78,11 @@ final class ResourceControllerEventSpec extends ObjectBehavior
     {
         $this->setMessageParameters(['parameters']);
         $this->getMessageParameters()->shouldReturn(['parameters']);
+    }
+
+    function it_should_return_the_request_configuration(
+        RequestConfiguration $requestConfiguration
+    ) {
+        $this->getRequestConfiguration()->shouldReturn($requestConfiguration);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Related tickets | fixes #5456 |

This PR explores dispatching general, constantly named events, from the resource controller instead of events named after the type of resource, application name etc. for reasons explained in the related issue.

Backwards compatiblity is here maintained through a new event subscriber which dispatches the resource-application specific events. From my POV we could remove these events completely, but I don't know the full context of the problem.

<strike>This is not at all tested or code-reviewed - and is just here to see what people think.</strike>
