### PR TITLE
[Docs] Added missing bundle in SyliusResourceBundle installation docs

### DIFF
--- a/docs/bundles/SyliusResourceBundle/installation.rst
+++ b/docs/bundles/SyliusResourceBundle/installation.rst
@@ -36,6 +36,7 @@ You need to enable the bundle and its dependencies in the kernel:
             new Sylius\Bundle\ResourceBundle\SyliusResourceBundle(),
             new WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
             new Bazinga\Bundle\HateoasBundle\BazingaHateoasBundle(),
+            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
         );
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Doc fix?        | yes
| New docs?    | no
| BC breaks?      | no
| Related tickets |
| License         | MIT

``winzouStateMachineBundle`` is also required, as ``ResourceController`` depends on ``sm.factory`` service.