### PR TITLE
fix SetupCommand 'tax_calculation_strategy' should not be null

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Command/SetupCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/SetupCommand.php
@@ -204,6 +204,7 @@ EOT
         $channel = $channelFactory->createNew();
         $channel->setCode('default');
         $channel->setName('Default');
+        $channel->setTaxCalculationStrategy('order_items_based');
 
         $channel->addCurrency($this->currency);
         $channel->addLocale($this->locale);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

When run sylius:install step 3 fails because tax_calculation_strategy is null.

Step 1: It appears that your database already exists. Would you like to reset it? (y/N) y
Step 2: Load sample data? (y/N) N
Step 3: fails because tax_calculation_strategy is null