### PR TITLE
Fix showing channel in the collector

### DIFF
--- a/src/Sylius/Bundle/ChannelBundle/Collector/ChannelCollector.php
+++ b/src/Sylius/Bundle/ChannelBundle/Collector/ChannelCollector.php
@@ -75,7 +75,7 @@ final class ChannelCollector extends DataCollector
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
         try {
-            $this->data['current_channel'] = $this->channelContext->getChannel();
+            $this->data['channel'] = $this->channelContext->getChannel();
         } catch (ChannelNotFoundException $exception) {}
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | -
| License         | MIT

Right now, it always has `null` as channel.