### PR TITLE
Make CurrencyContext work correctly without channel

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Context/CurrencyContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Context/CurrencyContext.php
@@ -12,7 +12,6 @@
 namespace Sylius\Bundle\CoreBundle\Context;
 
 use Doctrine\Common\Persistence\ObjectManager;
-use Sylius\Bundle\SettingsBundle\Manager\SettingsManagerInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Channel\Context\ChannelNotFoundException;
 use Sylius\Component\Core\Model\CustomerInterface;
@@ -55,23 +54,22 @@ final class CurrencyContext implements CurrencyContextInterface
     /**
      * @param StorageInterface $storage
      * @param CustomerContextInterface $customerContext
-     * @param SettingsManagerInterface $settingsManager
      * @param ObjectManager $customerManager
      * @param ChannelContextInterface $channelContext
+     * @param string $defaultCurrencyCode
      */
     public function __construct(
         StorageInterface $storage,
         CustomerContextInterface $customerContext,
-        SettingsManagerInterface $settingsManager,
         ObjectManager $customerManager,
-        ChannelContextInterface $channelContext
+        ChannelContextInterface $channelContext,
+        $defaultCurrencyCode
     ) {
         $this->storage = $storage;
         $this->customerContext = $customerContext;
         $this->customerManager = $customerManager;
         $this->channelContext = $channelContext;
-
-        $this->defaultCurrencyCode = $settingsManager->load('sylius_general')->get('currency');
+        $this->defaultCurrencyCode = $defaultCurrencyCode;
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -527,9 +527,9 @@
         <service id="sylius.context.currency" class="%sylius.context.currency.class%">
             <argument /> <!-- Storage service name comes from config -->
             <argument type="service" id="sylius.context.customer" />
-            <argument type="service" id="sylius.settings.manager" />
             <argument type="service" id="sylius.manager.customer" />
             <argument type="service" id="sylius.context.channel" />
+            <argument>%sylius.money.currency%</argument>
         </service>
 
         <service id="sylius.currency_provider" class="%sylius.currency_provider.class%">

--- a/src/Sylius/Bundle/CoreBundle/spec/Context/CurrencyContextSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Context/CurrencyContextSpec.php
@@ -14,8 +14,6 @@ namespace spec\Sylius\Bundle\CoreBundle\Context;
 use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\CoreBundle\Context\CurrencyContext;
-use Sylius\Bundle\SettingsBundle\Manager\SettingsManagerInterface;
-use Sylius\Bundle\SettingsBundle\Model\SettingsInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Channel\Context\ChannelNotFoundException;
 use Sylius\Component\Channel\Model\ChannelInterface;
@@ -32,15 +30,10 @@ class CurrencyContextSpec extends ObjectBehavior
     function let(
         StorageInterface $storage,
         CustomerContextInterface $customerContext,
-        SettingsManagerInterface $settingsManager,
         ObjectManager $customerManager,
-        ChannelContextInterface $channelContext,
-        SettingsInterface $settings
+        ChannelContextInterface $channelContext
     ) {
-        $settingsManager->load('sylius_general')->willReturn($settings);
-        $settings->get('currency')->willReturn('EUR');
-
-        $this->beConstructedWith($storage, $customerContext, $settingsManager, $customerManager, $channelContext);
+        $this->beConstructedWith($storage, $customerContext, $customerManager, $channelContext, 'EUR');
     }
 
     function it_is_initializable()

--- a/src/Sylius/Bundle/CoreBundle/spec/Context/CurrencyContextSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Context/CurrencyContextSpec.php
@@ -17,12 +17,16 @@ use Sylius\Bundle\CoreBundle\Context\CurrencyContext;
 use Sylius\Bundle\SettingsBundle\Manager\SettingsManagerInterface;
 use Sylius\Bundle\SettingsBundle\Model\SettingsInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
 use Sylius\Component\Channel\Model\ChannelInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
-use Sylius\Component\Currency\Context\CurrencyContext as SyliusCurrencyContext;
+use Sylius\Component\Currency\Context\CurrencyContextInterface;
 use Sylius\Component\Storage\StorageInterface;
 use Sylius\Component\User\Context\CustomerContextInterface;
 
+/**
+ * @mixin CurrencyContext
+ */
 class CurrencyContextSpec extends ObjectBehavior
 {
     function let(
@@ -30,8 +34,8 @@ class CurrencyContextSpec extends ObjectBehavior
         CustomerContextInterface $customerContext,
         SettingsManagerInterface $settingsManager,
         ObjectManager $customerManager,
-        SettingsInterface $settings,
-        ChannelContextInterface $channelContext
+        ChannelContextInterface $channelContext,
+        SettingsInterface $settings
     ) {
         $settingsManager->load('sylius_general')->willReturn($settings);
         $settings->get('currency')->willReturn('EUR');
@@ -44,9 +48,9 @@ class CurrencyContextSpec extends ObjectBehavior
         $this->shouldHaveType('Sylius\Bundle\CoreBundle\Context\CurrencyContext');
     }
 
-    function it_extends_Sylius_currency_context()
+    function it_implements_currency_context_interface()
     {
-        $this->shouldHaveType(SyliusCurrencyContext::class);
+        $this->shouldImplement(CurrencyContextInterface::class);
     }
 
     function it_gets_default_currency_code()
@@ -55,10 +59,10 @@ class CurrencyContextSpec extends ObjectBehavior
     }
 
     function it_gets_currency_code_from_session_if_there_is_no_customer(
-        $customerContext,
-        $storage,
-        ChannelInterface $channel,
-        $channelContext
+        StorageInterface $storage,
+        CustomerContextInterface $customerContext,
+        ChannelContextInterface $channelContext,
+        ChannelInterface $channel
     ) {
         $customerContext->getCustomer()->willReturn(null);
 
@@ -70,9 +74,23 @@ class CurrencyContextSpec extends ObjectBehavior
         $this->getCurrencyCode()->shouldReturn('RSD');
     }
 
+    function it_gets_currency_code_from_session_if_there_is_no_customer_and_no_channel(
+        StorageInterface $storage,
+        CustomerContextInterface $customerContext,
+        ChannelContextInterface $channelContext
+    ) {
+        $customerContext->getCustomer()->willReturn(null);
+
+        $channelContext->getChannel()->willThrow(ChannelNotFoundException::class);
+
+        $storage->getData(sprintf(CurrencyContext::STORAGE_KEY, '__DEFAULT__'), 'EUR')->willReturn('RSD');
+
+        $this->getCurrencyCode()->shouldReturn('RSD');
+    }
+
     function it_gets_currency_code_from_customer(
-        CustomerInterface $customer,
-        $customerContext
+        CustomerContextInterface $customerContext,
+        CustomerInterface $customer
     ) {
         $customerContext->getCustomer()->willReturn($customer);
         $customer->getCurrencyCode()->willReturn('PLN');
@@ -81,10 +99,10 @@ class CurrencyContextSpec extends ObjectBehavior
     }
 
     function it_sets_currency_code_to_session_if_there_is_no_customer(
-        $customerContext,
-        $storage,
-        ChannelInterface $channel,
-        $channelContext
+        StorageInterface $storage,
+        CustomerContextInterface $customerContext,
+        ChannelContextInterface $channelContext,
+        ChannelInterface $channel
     ) {
         $customerContext->getCustomer()->willReturn(null);
 
@@ -96,11 +114,25 @@ class CurrencyContextSpec extends ObjectBehavior
         $this->setCurrencyCode('PLN');
     }
 
+    function it_sets_currency_code_to_session_if_there_is_no_customer_and_no_channel(
+        StorageInterface $storage,
+        CustomerContextInterface $customerContext,
+        ChannelContextInterface $channelContext
+    ) {
+        $customerContext->getCustomer()->willReturn(null);
+
+        $channelContext->getChannel()->willThrow(ChannelNotFoundException::class);
+
+        $storage->setData(sprintf(CurrencyContext::STORAGE_KEY, '__DEFAULT__'), 'PLN')->shouldBeCalled();
+
+        $this->setCurrencyCode('PLN');
+    }
+
     function it_sets_currency_code_to_customer(
-        CustomerInterface $customer,
-        $customerContext,
+        CustomerContextInterface $customerContext,
+        ChannelContextInterface $channelContext,
         ChannelInterface $channel,
-        $channelContext
+        CustomerInterface $customer
     ) {
         $customerContext->getCustomer()->willReturn($customer);
         $customer->setCurrencyCode('PLN')->shouldBeCalled();

--- a/src/Sylius/Component/Currency/Context/CurrencyContext.php
+++ b/src/Sylius/Component/Currency/Context/CurrencyContext.php
@@ -13,8 +13,10 @@ namespace Sylius\Component\Currency\Context;
 
 use Sylius\Component\Storage\StorageInterface;
 
-class CurrencyContext implements CurrencyContextInterface
+final class CurrencyContext implements CurrencyContextInterface
 {
+    const STORAGE_KEY = '_sylius_currency';
+
     /**
      * @var string
      */

--- a/src/Sylius/Component/Currency/Context/CurrencyContextInterface.php
+++ b/src/Sylius/Component/Currency/Context/CurrencyContextInterface.php
@@ -16,9 +16,6 @@ namespace Sylius\Component\Currency\Context;
  */
 interface CurrencyContextInterface
 {
-    // Key used to store the currency in storage.
-    const STORAGE_KEY = '_sylius_currency';
-
     /**
      * @return string
      */

--- a/src/Sylius/Component/Currency/spec/Context/CurrencyContextSpec.php
+++ b/src/Sylius/Component/Currency/spec/Context/CurrencyContextSpec.php
@@ -12,9 +12,13 @@
 namespace spec\Sylius\Component\Currency\Context;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Currency\Context\CurrencyContext;
 use Sylius\Component\Currency\Context\CurrencyContextInterface;
 use Sylius\Component\Storage\StorageInterface;
 
+/**
+ * @mixin CurrencyContext
+ */
 class CurrencyContextSpec extends ObjectBehavior
 {
     function let(StorageInterface $storage)
@@ -37,16 +41,16 @@ class CurrencyContextSpec extends ObjectBehavior
         $this->getDefaultCurrencyCode()->shouldReturn('EUR');
     }
 
-    function it_gets_currency_code_from_session($storage)
+    function it_gets_currency_code_from_session(StorageInterface $storage)
     {
-        $storage->getData(CurrencyContextInterface::STORAGE_KEY, 'EUR')->willReturn('RSD');
+        $storage->getData(CurrencyContext::STORAGE_KEY, 'EUR')->willReturn('RSD');
 
         $this->getCurrencyCode()->shouldReturn('RSD');
     }
 
-    function it_sets_currency_code_to_session($storage)
+    function it_sets_currency_code_to_session(StorageInterface $storage)
     {
-        $storage->setData(CurrencyContextInterface::STORAGE_KEY, 'PLN')->shouldBeCalled();
+        $storage->setData(CurrencyContext::STORAGE_KEY, 'PLN')->shouldBeCalled();
 
         $this->setCurrencyCode('PLN');
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Related tickets | -
| License         | MIT

BC breaks:
 - currency contexts made final
 - core currency context no longer extends the one from component
 - constant `STORAGE_KEY` removed from the interface
 - default currency is taken from the `%currency%` parameter, not from the settings