### PR TITLE
Windows path compatibility:

### DIFF
--- a/src/Sylius/Bundle/GridBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/GridBundle/DependencyInjection/Configuration.php
@@ -48,7 +48,7 @@ class Configuration implements ConfigurationInterface
 
             // we use the parent directory name in addition to the filename to
             // determine the name of the driver (e.g. doctrine/orm)
-            $validDrivers[] = substr($file->getPathname(), 1 + strlen($driverDir), -4);
+            $validDrivers[] = str_replace('\\','/',substr($file->getPathname(), 1 + strlen($driverDir), -4));
         }
 
         $node

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration.php
@@ -188,7 +188,7 @@ class Configuration implements ConfigurationInterface
 
             // we use the parent directory name in addition to the filename to
             // determine the name of the driver (e.g. doctrine/orm)
-            $validDrivers[] = substr($file->getPathname(), 1 + strlen($driverDir), -4);
+            $validDrivers[] = str_replace('\\','/',substr($file->getPathname(), 1 + strlen($driverDir), -4));
         }
 
         $node


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

Updated driver detection to work with Windows file paths, which have "\" instead of "/".