### PR TITLE
[Behat] Username typo

### DIFF
--- a/features/account/sign_in.feature
+++ b/features/account/sign_in.feature
@@ -11,7 +11,7 @@ Feature: Sign in to the store
     @ui
     Scenario: Sign in with email and password
         Given I want to log in
-        When I specify the user name as "ted@example.com"
+        When I specify the username as "ted@example.com"
         And I specify the password as "bear"
         And I log in
         Then I should be logged in
@@ -19,7 +19,7 @@ Feature: Sign in to the store
     @ui
     Scenario: Sign in with bad credentials
         Given I want to log in
-        When I specify the user name as "bear@example.com"
+        When I specify the username as "bear@example.com"
         And I specify the password as "pswd"
         And I log in
         Then I should be notified about bad credentials

--- a/src/Sylius/Behat/Context/Ui/Shop/LoginContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/LoginContext.php
@@ -97,12 +97,12 @@ class LoginContext implements Context
     }
 
     /**
-     * @When I specify the user name as :userName
+     * @When I specify the username as :username
      * @When I do not specify the user name
      */
-    public function iSpecifyTheUserName($userName = null)
+    public function iSpecifyTheUsername($username = null)
     {
-        $this->loginPage->specifyUserName($userName);
+        $this->loginPage->specifyUsername($username);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/UserContext.php
+++ b/src/Sylius/Behat/Context/Ui/UserContext.php
@@ -69,7 +69,7 @@ final class UserContext implements Context
     public function iLogInAsWithPassword($email, $password)
     {
         $this->loginPage->open();
-        $this->loginPage->specifyUserName($email);
+        $this->loginPage->specifyUsername($email);
         $this->loginPage->specifyPassword($password);
         $this->loginPage->logIn();
     }

--- a/src/Sylius/Behat/Page/Shop/Account/LoginPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/LoginPage.php
@@ -42,9 +42,9 @@ class LoginPage extends SymfonyPage implements LoginPageInterface
     /**
      * {@inheritdoc}
      */
-    public function specifyUserName($userName)
+    public function specifyUsername($username)
     {
-        $this->getDocument()->fillField('Username', $userName);
+        $this->getDocument()->fillField('Username', $username);
     }
 
     /**

--- a/src/Sylius/Behat/Page/Shop/Account/LoginPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Account/LoginPageInterface.php
@@ -33,7 +33,7 @@ interface LoginPageInterface extends SymfonyPageInterface
     public function specifyPassword($password);
 
     /**
-     * @param string $userName
+     * @param string $username
      */
-    public function specifyUserName($userName);
+    public function specifyUsername($username);
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

Small typo. I bet we have meant [username instead of user name](http://english.stackexchange.com/a/43470).