### PR TITLE
[Behat] Make crud page objects extendable

### DIFF
--- a/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
@@ -24,7 +24,7 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
     /**
      * @var string
      */
-    private $resourceName;
+    protected $resourceName;
 
     /**
      * @param Session $session

--- a/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
@@ -25,12 +25,12 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
     /**
      * @var TableAccessorInterface
      */
-    private $tableAccessor;
+    protected $tableAccessor;
 
     /**
      * @var string
      */
-    private $resourceName;
+    protected $resourceName;
 
     /**
      * @param Session $session

--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
@@ -24,7 +24,7 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
     /**
      * @var string
      */
-    private $resourceName;
+    protected $resourceName;
 
     /**
      * @param Session $session


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | -
| License         | MIT

In order to keep testing consistency I need to extend crud pages object and override only some methods of them like `getRouteName()`, hence I have to set protected access on some properties. WDYT?
