### PR TITLE
[Attribute] Unsupport ``createNew()`` method of attribute factory

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Behat/ProductContext.php
+++ b/src/Sylius/Bundle/ProductBundle/Behat/ProductContext.php
@@ -206,9 +206,8 @@ class ProductContext extends DefaultContext
         $code = (null === $code) ? strtolower(str_replace(' ', '_', $name)) : $code;
         $storageType = (CheckboxAttributeType::TYPE === $type) ? 'boolean' : $type;
 
-        $attribute = $this->getFactory('product_attribute')->createNew();
+        $attribute = $this->getFactory('product_attribute')->createTyped($type);
         $attribute->setName($name);
-        $attribute->setType($type);
         $attribute->setCode($code);
         $attribute->setStorageType($storageType);
 

--- a/src/Sylius/Component/Attribute/Factory/AttributeFactory.php
+++ b/src/Sylius/Component/Attribute/Factory/AttributeFactory.php
@@ -56,9 +56,8 @@ class AttributeFactory implements AttributeFactoryInterface
      */
     public function createNew()
     {
-        $attribute = $this->factory->createNew();
-        $attribute->setStorageType($this->attributeTypesRegistry->get($attribute->getType())->getStorageType());
-
-        return $attribute;
+        throw new \BadMethodCallException(
+            'Method "createNew()" is not supported for attribute factory. Use "createTyped($type)" instead.'
+        );
     }
 }

--- a/src/Sylius/Component/Attribute/spec/Factory/AttributeFactorySpec.php
+++ b/src/Sylius/Component/Attribute/spec/Factory/AttributeFactorySpec.php
@@ -38,17 +38,14 @@ class AttributeFactorySpec extends ObjectBehavior
         $this->shouldImplement(AttributeFactoryInterface::class);
     }
 
-    function it_creates_new_attribute($attributeTypesRegistry, $factory, Attribute $attribute, AttributeTypeInterface $attributeType)
+    function it_does_not_allow_to_create_new_attribute()
     {
-        $factory->createNew()->willReturn($attribute);
-
-        $attributeType->getStorageType()->willReturn('text');
-        $attributeTypesRegistry->get('text')->willReturn($attributeType);
-
-        $attribute->getType()->willReturn('text');
-        $attribute->setStorageType('text')->shouldBeCalled();
-
-        $this->createNew()->shouldReturn($attribute);
+        $this
+            ->shouldThrow(new \BadMethodCallException(
+                'Method "createNew()" is not supported for attribute factory. Use "createTyped($type)" instead.'
+            ))
+            ->during('createNew')
+        ;
     }
 
     function it_creates_typed_attribute($attributeTypesRegistry, $factory, Attribute $typedAttribute, AttributeTypeInterface $attributeType)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Related tickets |
| License         | MIT