### PR TITLE
[ResourceBundle] Allow arguments with expression service accept parameters.

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ParametersParser.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ParametersParser.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Dosena Ishmael <nukboon@gmail.com>
  */
 class ParametersParser implements ParametersParserInterface
 {
@@ -48,7 +49,17 @@ class ParametersParser implements ParametersParserInterface
             }
 
             if (is_string($value) && 0 === strpos($value, 'expr:')) {
-                $parameters[$key] = $this->expression->evaluate(substr($value, 5));
+                $service = substr($value, 5);
+
+                if (preg_match_all('/(\$\w+)\W/', $service, $match)) {
+                    foreach ($match[1] as $parameterName) {
+                        $parameter = $request->get(substr(trim($parameterName), 1));
+                        $parameter = is_string($parameter) ? sprintf('"%s"', $parameter) : $parameter;
+                        $service = str_replace($parameterName, $parameter, $service);
+                    }
+                }
+
+                $parameters[$key] = $this->expression->evaluate($service);
             }
         }
 

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ParametersParserSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ParametersParserSpec.php
@@ -87,7 +87,7 @@ class ParametersParserSpec extends ObjectBehavior
                 'factory' => [
                     'method' => 'createByParameter',
                     'arguments' => [
-                        'expr:service("demo_service")'
+                        'expr:service("demo_service")',
                     ],
                 ],
             ],
@@ -97,7 +97,7 @@ class ParametersParserSpec extends ObjectBehavior
                 'factory' => [
                     'method' => 'createByParameter',
                     'arguments' => [
-                        'demo_object'
+                        'demo_object',
                     ],
                 ],
             ]
@@ -110,7 +110,7 @@ class ParametersParserSpec extends ObjectBehavior
                 'factory' => [
                     'method' => 'createByParameter',
                     'arguments' => [
-                        'expr:service("demo_service")->getWith($foo)'
+                        'expr:service("demo_service")->getWith($foo)',
                     ],
                 ],
             ],
@@ -120,7 +120,7 @@ class ParametersParserSpec extends ObjectBehavior
                 'factory' => [
                     'method' => 'createByParameter',
                     'arguments' => [
-                        'demo_object->getWith("bar")'
+                        'demo_object->getWith("bar")',
                     ],
                 ],
             ]
@@ -133,7 +133,7 @@ class ParametersParserSpec extends ObjectBehavior
                 'factory' => [
                     'method' => 'createByParameter',
                     'arguments' => [
-                        'expr:service("demo_service")->getWith($foo, $baz)'
+                        'expr:service("demo_service")->getWith($foo, $baz)',
                     ],
                 ],
             ],
@@ -143,7 +143,7 @@ class ParametersParserSpec extends ObjectBehavior
                 'factory' => [
                     'method' => 'createByParameter',
                     'arguments' => [
-                        'demo_object->getWith("bar", 1)'
+                        'demo_object->getWith("bar", 1)',
                     ],
                 ],
             ]
@@ -156,7 +156,7 @@ class ParametersParserSpec extends ObjectBehavior
                 'factory' => [
                     'method' => 'createByParameter',
                     'arguments' => [
-                        'expr:service("demo_service")->getWith($foo)->andGet($baz)'
+                        'expr:service("demo_service")->getWith($foo)->andGet($baz)',
                     ],
                 ],
             ],
@@ -166,7 +166,7 @@ class ParametersParserSpec extends ObjectBehavior
                 'factory' => [
                     'method' => 'createByParameter',
                     'arguments' => [
-                        'demo_object->getWith("bar")->andGet(1)'
+                        'demo_object->getWith("bar")->andGet(1)',
                     ],
                 ],
             ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | ~
| License       | MIT
| Doc PR        | no

To decouple our service from other services, we just simply use standard Sylius service configuration without registering unnecessary service by compile pass or manual configure by using services file.

For example, we want to create new product with `archetype`, no need to couple `ProductFactory` with `ArchetypeRepository` to find `archetype`. We just inject the real `ArchetypeObject` into factory method directly as parameter.

Factory

```php
public function createFromArchetype($archetypeCode)

// refactoring
public function createFromArchetype(ArchetypeInterface $archetype)
```

Routing configuration

```yaml
# from
sylius_admin_product_create_from_archetype:
	path: /product/create/{archetypeCode}
	# ...
	_sylius:
		factory:
			method: createFromArchetype
			arguments: [ $archetypeCode ]

# to
sylius_admin_product_create_from_archetype:
	path: /product/create/{archetypeCode}
	# ...
	_sylius:
		factory:
			method: createFromArchetype
			arguments:
				- expr:service('sylius.repository.archetype').findOneByCode($archetypeCode)
			
```

Nothing more to do from here.
