### PR TITLE
[Fixtures] Allow for nested array nodes at sylius_fixtures.**.options and taxon.children

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/TaxonFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/TaxonFixture.php
@@ -36,7 +36,7 @@ final class TaxonFixture extends AbstractResourceFixture
                 ->scalarNode('name')->cannotBeEmpty()->end()
                 ->scalarNode('code')->cannotBeEmpty()->end()
                 ->scalarNode('description')->cannotBeEmpty()->end()
-                ->arrayNode('children')->ignoreExtraKeys()->end()
+                ->variableNode('children')->cannotBeEmpty()->defaultValue([])->end()
         ;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/TaxonFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/TaxonFixtureTest.php
@@ -57,6 +57,18 @@ final class TaxonFixtureTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test
+     */
+    public function taxon_children_may_contain_nested_array()
+    {
+        $this->assertProcessedConfigurationEquals(
+            [['custom' => [['children' => [['nested' => ['key' => 'value']]]]]]],
+            ['custom' => [['children' => [['nested' => ['key' => 'value']]]]]],
+            'custom.*.children'
+        );
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getConfiguration()

--- a/src/Sylius/Bundle/FixturesBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/FixturesBundle/DependencyInjection/Configuration.php
@@ -113,7 +113,18 @@ final class Configuration implements ConfigurationInterface
         /** @var ArrayNodeDefinition $optionsNode */
         $optionsNode = $attributesNodeBuilder->arrayNode('options');
         $optionsNode->addDefaultChildrenIfNoneSet();
-        $optionsNode->beforeNormalization()->always(function ($value) { return [$value]; });
-        $optionsNode->prototype('array')->ignoreExtraKeys(false);
+
+        $optionsNode
+            ->validate()
+                ->ifTrue(function ($value) { return !is_array($value); })
+                ->thenInvalid('Options have to be an array!')
+        ;
+
+        $optionsNode
+            ->beforeNormalization()
+                ->always(function ($value) { return is_array($value) ? [$value] : $value; })
+        ;
+
+        $optionsNode->prototype('variable')->cannotBeEmpty()->defaultValue([]);
     }
 }

--- a/src/Sylius/Bundle/FixturesBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Sylius/Bundle/FixturesBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -211,6 +211,39 @@ final class ConfigurationTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function fixtures_options_may_contain_nested_arrays()
+    {
+        $this->assertProcessedConfigurationEquals(
+            [['suites' => ['suite' => ['fixtures' => ['fixture' => [
+                'options' => ['nested' => ['key' => 'value']],
+            ]]]]]],
+            ['suites' => ['suite' => ['fixtures' => ['fixture' => [
+                'options' => [['nested' => ['key' => 'value']]],
+                'name' => 'fixture', // FIXME: something is wrong inside the test library and it's not excluded
+            ]]]]],
+            'suites.*.fixtures.*.options'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function listeners_options_may_contain_nested_arrays()
+    {
+        $this->assertProcessedConfigurationEquals(
+            [['suites' => ['suite' => ['listeners' => ['listener' => [
+                'options' => ['nested' => ['key' => 'value']],
+            ]]]]]],
+            ['suites' => ['suite' => ['listeners' => ['listener' => [
+                'options' => [['nested' => ['key' => 'value']]],
+            ]]]]],
+            'suites.*.listeners.*.options'
+        );
+    }
+
+    /**
+     * @test
+     */
     public function fixtures_can_be_aliased_with_different_names()
     {
         $this->assertProcessedConfigurationEquals(


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #5572
| License         | MIT
