### PR TITLE
Update LoadUsersData.php

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/DataFixtures/ORM/LoadUsersData.php
+++ b/src/Sylius/Bundle/CoreBundle/DataFixtures/ORM/LoadUsersData.php
@@ -90,7 +90,7 @@ class LoadUsersData extends DataFixture
      *
      * @return UserInterface
      */
-    protected function createUser($email, $password, $enabled = true, array $roles = ['ROLE_USER'], $currencyCode = 'EUR')
+    protected function createUser($email, $password, $enabled = true, array $roles = ['ROLE_USER'])
     {
         $canonicalizer = $this->get('sylius.user.canonicalizer');
 
@@ -99,7 +99,6 @@ class LoadUsersData extends DataFixture
         $customer = $this->getCustomerFactory()->createNew();
         $customer->setFirstname($this->faker->firstName);
         $customer->setLastname($this->faker->lastName);
-        $customer->setCurrencyCode($currencyCode);
         $user->setCustomer($customer);
         $user->setUsername($email);
         $user->setEmail($email);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

Remove `$customer->setCurrencyCode($currencyCode) ` because currency has been removed from customer. (203019cd6ca17b6241b33fe7cdb962709507bb5c)