### PR TITLE
Correct a typo in word "troubleshooting"

### DIFF
--- a/docs/book/payments.rst
+++ b/docs/book/payments.rst
@@ -99,8 +99,8 @@ Learn more
 
 * ...
 
-Troubleshoooting
-================
+Troubleshooting
+===============
 
 Sylius stores payment output inside the **details** column of the **sylius_payment** table. It can provide valuable info when debugging the payment process.
 


### PR DESCRIPTION
Troubleshooting was misspelled "troubleshoooting"