### PR TITLE
[Behat][Shop] Added stock level dependant rendering of simple product's details page

### DIFF
--- a/features/cart/shopping_cart/adding_products_with_quantity_to_cart.feature
+++ b/features/cart/shopping_cart/adding_products_with_quantity_to_cart.feature
@@ -1,0 +1,17 @@
+@shopping_cart
+Feature: Adding a simple product of given quantity to the cart
+    In order to buy multiple items at once
+    As a Visitor
+    I want to be able to add a simple product with stated quantity to the cart
+
+    Background:
+        Given the store operates on a single channel in "France"
+        And the store has a product "T-shirt banana" priced at "€12.54"
+
+    @ui
+    Scenario: Adding a product with stated quantity to the cart
+        Given there are 10 items of product "T-shirt banana" available in the inventory
+        When I add 5 of them to my cart
+        Then I should be on my cart summary page
+        And I should be notified that the product has been successfully added
+        And I should see "T-shirt banana" with quantity 5 in my cart

--- a/features/cart/shopping_cart/inability_of_adding_a_product_with_insufficient_stock.feature
+++ b/features/cart/shopping_cart/inability_of_adding_a_product_with_insufficient_stock.feature
@@ -1,0 +1,16 @@
+@shopping_cart
+Feature: Inability to add a specific product to the cart when it is out of stock
+    In order to buy only available products
+    As a Visitor
+    I want to be prevented from adding products which are not available in the inventory
+
+    Background:
+        Given the store operates on a single channel in "France"
+        And the store has a product "T-shirt banana" priced at "€12.54"
+
+    @ui
+    Scenario: Not being able to add a product to the cart when it is out of stock
+        Given the product "T-shirt banana" is not available at the moment
+        When I check this product's details
+        Then I should see that it is out of stock
+        And I should be unable to add it to the cart

--- a/features/cart/shopping_cart/inability_of_adding_a_product_with_insufficient_stock.feature
+++ b/features/cart/shopping_cart/inability_of_adding_a_product_with_insufficient_stock.feature
@@ -10,7 +10,7 @@ Feature: Inability to add a specific product to the cart when it is out of stock
 
     @ui
     Scenario: Not being able to add a product to the cart when it is out of stock
-        Given the product "T-shirt banana" is not available at the moment
+        Given the product "T-shirt banana" is out of stock
         When I check this product's details
         Then I should see that it is out of stock
         And I should be unable to add it to the cart

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -321,6 +321,24 @@ final class ProductContext implements Context
     }
 
     /**
+     * @Given /^there (?:is|are) (\d+) item(?:s) of (product "([^"]+)") available in the inventory$/
+     */
+    public function thereIsQuantityOfProducts($quantity, ProductInterface $product)
+    {
+        $this->setProductsQuantity($product, $quantity);
+    }
+
+    /**
+     * @Given /^the (product "([^"]+)") is not available at the moment$/
+     */
+    public function theProductIsNotAvailable(ProductInterface $product)
+    {
+        $product->getFirstVariant()->setAvailableOnDemand(false);
+
+        $this->setProductsQuantity($product, 0);
+    }
+
+    /**
      * @Given /^(this product) is available in "([^"]+)" size priced at ("[^"]+")$/
      */
     public function thisProductIsAvailableInSize(ProductInterface $product, $optionValueName, $price)
@@ -412,6 +430,17 @@ final class ProductContext implements Context
         $product->getFirstVariant()->setCode($product->getCode());
 
         return $product;
+    }
+
+    /**
+     * @param ProductInterface $product
+     * @param int $quantity
+     */
+    private function setProductsQuantity(ProductInterface $product, $quantity)
+    {
+        $product->getFirstVariant()->setOnHand($quantity);
+
+        $this->saveProduct($product);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -329,7 +329,7 @@ final class ProductContext implements Context
     }
 
     /**
-     * @Given /^the (product "([^"]+)") is not available at the moment$/
+     * @Given /^the (product "([^"]+)") is out of stock$/
      */
     public function theProductIsNotAvailable(ProductInterface $product)
     {

--- a/src/Sylius/Behat/Context/Transform/SharedStorageContext.php
+++ b/src/Sylius/Behat/Context/Transform/SharedStorageContext.php
@@ -34,7 +34,7 @@ final class SharedStorageContext implements Context
     }
 
     /**
-     * @Transform /^(it|its|theirs)$/
+     * @Transform /^(it|its|theirs|them)$/
      */
     public function getLatestResource()
     {

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -294,6 +294,15 @@ final class CartContext implements Context
     }
 
     /**
+     * @When /^I add (\d+) of (them) to (the|my) cart$/
+     */
+    public function iAddQuantityOfProductsToTheCart($quantity, ProductInterface $product)
+    {
+        $this->productShowPage->open(['slug' => $product->getSlug()]);
+        $this->productShowPage->addToCartWithQuantity($quantity);
+    }
+
+    /**
      * @Given I have :quantity products :product in the cart
      * @When I add :quantity products :product to the cart
      */

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -294,7 +294,7 @@ final class CartContext implements Context
     }
 
     /**
-     * @When /^I add (\d+) of (them) to (the|my) cart$/
+     * @When /^I add (\d+) of (them) to (?:the|my) cart$/
      */
     public function iAddQuantityOfProductsToTheCart($quantity, ProductInterface $product)
     {

--- a/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
@@ -163,4 +163,26 @@ final class ProductContext implements Context
             'There should appear information about empty list of products, but it does not.'
         );
     }
+
+    /**
+     * @Then I should see that it is out of stock
+     */
+    public function iShouldSeeItIsOutOfStock()
+    {
+        Assert::true(
+            $this->showPage->isOutOfStock(),
+            'Out of stock label should be visible.'
+        );
+    }
+
+    /**
+     * @Then I should be unable to add it to the cart
+     */
+    public function iShouldBeUnableToAddItToTheCart()
+    {
+        Assert::false(
+            $this->showPage->hasAddToCartButton(),
+            'Add to cart button should not be visible.'
+        );
+    }
 }

--- a/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
+++ b/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
@@ -102,6 +102,22 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
     /**
      * {@inheritdoc}
      */
+    public function isOutOfStock()
+    {
+        return $this->hasElement('out-of-stock');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasAddToCartButton()
+    {
+        return $this->getDocument()->hasButton('Add to cart');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getRouteName()
     {
         return 'sylius_shop_product_show';
@@ -114,7 +130,8 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
     {
         return array_merge(parent::getDefinedElements(), [
             'name' => '#sylius-product-name',
-            'attributes' => '#sylius-product-attributes'
+            'attributes' => '#sylius-product-attributes',
+            'out-of-stock' => '#sylius-product-out-of-stock',
         ]);
     }
 }

--- a/src/Sylius/Behat/Page/Shop/Product/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Product/ShowPageInterface.php
@@ -64,5 +64,15 @@ interface ShowPageInterface extends PageInterface
      *
      * @return bool
      */
-     public function hasAttributeWithValue($attributeName, $AttributeValue);
+    public function hasAttributeWithValue($attributeName, $AttributeValue);
+
+    /**
+     * @return bool
+     */
+    public function isOutOfStock();
+
+    /**
+     * @return bool
+     */
+    public function hasAddToCartButton();
 }

--- a/src/Sylius/Behat/Resources/config/suites/ui/cart/shopping_cart.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/cart/shopping_cart.yml
@@ -16,6 +16,7 @@ default:
                 - sylius.behat.context.setup.product
                 - sylius.behat.context.setup.user
 
+                - sylius.behat.context.ui.shop.product
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.registration
                 - sylius.behat.context.ui.user

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
@@ -76,7 +76,6 @@ sylius_core:
     sitemap: ~
 
 sylius_inventory:
-    backorders: true
     track_inventory: true
     resources:
         inventory_unit:

--- a/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
@@ -35,7 +35,7 @@
 
         <service id="sylius.inventory_operator.noop" class="%sylius.inventory_operator.noop.class%" />
 
-        <service id="sylius.availability_checker.default" class="%sylius.availability_checker.default.class%"/>
+        <service id="sylius.availability_checker.default" class="%sylius.availability_checker.default.class%" />
 
         <service id="sylius.backorders_handler" class="%sylius.backorders_handler.class%">
             <argument type="service" id="sylius.repository.inventory_unit" />

--- a/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
@@ -35,9 +35,7 @@
 
         <service id="sylius.inventory_operator.noop" class="%sylius.inventory_operator.noop.class%" />
 
-        <service id="sylius.availability_checker.default" class="%sylius.availability_checker.default.class%">
-            <argument>%sylius.backorders%</argument>
-        </service>
+        <service id="sylius.availability_checker.default" class="%sylius.availability_checker.default.class%"/>
 
         <service id="sylius.backorders_handler" class="%sylius.backorders_handler.class%">
             <argument type="service" id="sylius.repository.inventory_unit" />

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_addToCart.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_addToCart.html.twig
@@ -2,17 +2,15 @@
 
 {% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
 
-<div class="ui segment">
-    {{ form_start(form, {'action': path('sylius_shop_cart_item_add', {'id': product.id}), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate'}}) }}
-    {% if not product.simple %}
-        {% if product.variantSelectionMethodChoice %}
-            {% include '@SyliusShop/Product/Show/_variants.html.twig' %}
-        {% else %}
-            {% include '@SyliusShop/Product/Show/_options.html.twig' %}
-        {% endif %}
+{{ form_start(form, {'action': path('sylius_shop_cart_item_add', {'id': product.id}), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate'}}) }}
+{% if not product.simple %}
+    {% if product.variantSelectionMethodChoice %}
+        {% include '@SyliusShop/Product/Show/_variants.html.twig' %}
+    {% else %}
+        {% include '@SyliusShop/Product/Show/_options.html.twig' %}
     {% endif %}
-    {{ form_row(form.quantity) }}
-    <button type="submit" class="ui huge primary icon labeled button"><i class="cart icon"></i> {{ 'sylius.ui.add_to_cart'|trans }}</button>
-    {{ form_row(form._token) }}
-    {{ form_end(form, {'render_rest': false}) }}
-</div>
+{% endif %}
+{{ form_row(form.quantity) }}
+<button type="submit" class="ui huge primary icon labeled button"><i class="cart icon"></i> {{ 'sylius.ui.add_to_cart'|trans }}</button>
+{{ form_row(form._token) }}
+{{ form_end(form, {'render_rest': false}) }}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_inventory.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_inventory.html.twig
@@ -1,4 +1,4 @@
-{% if not sylius_inventory_is_available(product.firstVariant) %}
+{% if product.simple and not sylius_inventory_is_available(product.firstVariant) %}
     {% include '@SyliusShop/Product/Show/_outOfStock.html.twig' %}
 {% else %}
     {% include '@SyliusShop/Product/Show/_addToCart.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_inventory.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_inventory.html.twig
@@ -1,0 +1,5 @@
+{% if not sylius_inventory_is_available(product.firstVariant) %}
+    {% include '@SyliusShop/Product/Show/_outOfStock.html.twig' %}
+{% else %}
+    {% include '@SyliusShop/Product/Show/_addToCart.html.twig' %}
+{% endif %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_outOfStock.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_outOfStock.html.twig
@@ -1,0 +1,7 @@
+<div class="ui one column grid">
+    <div class="center aligned column">
+        <div class="ui massive red horizontal label" id="sylius-product-out-of-stock">
+            <i class="remove icon"></i>{{ 'sylius.ui.out_of_stock'|trans }}
+        </div>
+    </div>
+</div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/show.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/show.html.twig
@@ -21,7 +21,9 @@
         <div class="ui basic segment">
             <p>{{ product.shortDescription }}</p>
         </div>
-        {% include '@SyliusShop/Product/Show/_addToCart.html.twig' %}
+        <div class="ui segment">
+            {% include '@SyliusShop/Product/Show/_inventory.html.twig' %}
+        </div>
         <div class="ui hidden divider"></div>
     </div>
 </div>

--- a/src/Sylius/Component/Inventory/Checker/AvailabilityChecker.php
+++ b/src/Sylius/Component/Inventory/Checker/AvailabilityChecker.php
@@ -14,35 +14,16 @@ namespace Sylius\Component\Inventory\Checker;
 use Sylius\Component\Inventory\Model\StockableInterface;
 
 /**
- * Checks availability for given stockable object.
- *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
 class AvailabilityChecker implements AvailabilityCheckerInterface
 {
     /**
-     * Are backorders enabled?
-     *
-     * @var bool
-     */
-    protected $backorders;
-
-    /**
-     * Constructor.
-     *
-     * @param bool $backorders
-     */
-    public function __construct($backorders)
-    {
-        $this->backorders = (bool) $backorders;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function isStockAvailable(StockableInterface $stockable)
     {
-        if ($this->backorders || $stockable->isAvailableOnDemand()) {
+        if ($stockable->isAvailableOnDemand()) {
             return true;
         }
 
@@ -54,7 +35,7 @@ class AvailabilityChecker implements AvailabilityCheckerInterface
      */
     public function isStockSufficient(StockableInterface $stockable, $quantity)
     {
-        if ($this->backorders || $stockable->isAvailableOnDemand()) {
+        if ($stockable->isAvailableOnDemand()) {
             return true;
         }
 

--- a/src/Sylius/Component/Inventory/Checker/AvailabilityChecker.php
+++ b/src/Sylius/Component/Inventory/Checker/AvailabilityChecker.php
@@ -16,18 +16,14 @@ use Sylius\Component\Inventory\Model\StockableInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class AvailabilityChecker implements AvailabilityCheckerInterface
+final class AvailabilityChecker implements AvailabilityCheckerInterface
 {
     /**
      * {@inheritdoc}
      */
     public function isStockAvailable(StockableInterface $stockable)
     {
-        if ($stockable->isAvailableOnDemand()) {
-            return true;
-        }
-
-        return 0 < ($stockable->getOnHand() - $stockable->getOnHold());
+        return $this->isStockSufficient($stockable, 1);
     }
 
     /**

--- a/src/Sylius/Component/Inventory/spec/Checker/AvailabilityCheckerSpec.php
+++ b/src/Sylius/Component/Inventory/spec/Checker/AvailabilityCheckerSpec.php
@@ -20,11 +20,6 @@ use Sylius\Component\Inventory\Model\StockableInterface;
  */
 final class AvailabilityCheckerSpec extends ObjectBehavior
 {
-    function let()
-    {
-        $this->beConstructedWith(true);
-    }
-
     function it_is_initializable()
     {
         $this->shouldHaveType('Sylius\Component\Inventory\Checker\AvailabilityChecker');
@@ -35,30 +30,17 @@ final class AvailabilityCheckerSpec extends ObjectBehavior
         $this->shouldImplement(AvailabilityCheckerInterface::class);
     }
 
-    function it_recognizes_any_stockable_as_available_if_backorders_are_enabled(StockableInterface $stockable)
-    {
-        $this->beConstructedWith(true);
-
-        $stockable->isAvailableOnDemand()->willReturn(false);
-
-        $this->isStockAvailable($stockable)->shouldReturn(true);
-    }
-
-    function it_recognizes_any_stockable_as_available_if_its_on_demand_and_backorders_are_disabled(
+    function it_recognizes_any_stockable_as_available_if_its_on_demand(
         StockableInterface $stockable
     ) {
-        $this->beConstructedWith(false);
-
         $stockable->isAvailableOnDemand()->willReturn(true);
 
         $this->isStockAvailable($stockable)->shouldReturn(true);
     }
 
-    function it_recognizes_any_stockable_as_available_if_its_on_demand_and_backorders_are_disabled_and_on_hand_quantity_insufficient(
+    function it_recognizes_any_stockable_as_available_if_its_on_demand_and_the_on_hand_quantity_is_insufficient(
         StockableInterface $stockable
     ) {
-        $this->beConstructedWith(false);
-
         $stockable->isAvailableOnDemand()->willReturn(true);
         $stockable->getOnHand()->willReturn(0);
 
@@ -72,8 +54,6 @@ final class AvailabilityCheckerSpec extends ObjectBehavior
 
     function it_recognizes_stockable_as_available_if_on_hand_quantity_is_greater_than_0(StockableInterface $stockable)
     {
-        $this->beConstructedWith(false);
-
         $stockable->isAvailableOnDemand()->willReturn(false);
         $stockable->getOnHand()->willReturn(5);
         $stockable->getOnHold()->willReturn(0);
@@ -84,8 +64,6 @@ final class AvailabilityCheckerSpec extends ObjectBehavior
     function it_recognizes_stockable_as_not_available_if_on_hold_quantity_is_same_as_on_hand(
         StockableInterface $stockable
     ) {
-        $this->beConstructedWith(false);
-
         $stockable->isAvailableOnDemand()->willReturn(false);
         $stockable->getOnHand()->willReturn(5);
         $stockable->getOnHold()->willReturn(5);
@@ -96,8 +74,6 @@ final class AvailabilityCheckerSpec extends ObjectBehavior
     function it_recognizes_stockable_as_available_if_on_hold_quantity_is_less_then_on_hand(
         StockableInterface $stockable
     ) {
-        $this->beConstructedWith(false);
-
         $stockable->isAvailableOnDemand()->willReturn(false);
         $stockable->getOnHand()->willReturn(5);
         $stockable->getOnHold()->willReturn(4);
@@ -105,23 +81,9 @@ final class AvailabilityCheckerSpec extends ObjectBehavior
         $this->isStockAvailable($stockable)->shouldReturn(true);
     }
 
-    function it_recognizes_stockable_as_available_even_if_hand_quantity_is_lesser_than_or_equal_to_0_when_backorders_are_enabled(
-        StockableInterface $stockable
-    ) {
-        $this->beConstructedWith(true);
-
-        $stockable->getOnHand()->willReturn(0);
-        $this->isStockAvailable($stockable)->shouldReturn(true);
-
-        $stockable->getOnHand()->willReturn(-5);
-        $this->isStockAvailable($stockable)->shouldReturn(true);
-    }
-
     function it_recognizes_stockable_as_not_available_if_on_hand_quantity_is_lesser_than_or_equal_to_0(
         StockableInterface $stockable
     ) {
-        $this->beConstructedWith(false);
-
         $stockable->isAvailableOnDemand()->willReturn(false);
 
         $stockable->getOnHand()->willReturn(0);
@@ -132,19 +94,9 @@ final class AvailabilityCheckerSpec extends ObjectBehavior
         $this->isStockAvailable($stockable)->shouldReturn(false);
     }
 
-    function it_recognizes_any_stockable_and_quantity_as_sufficient_if_backorders_are_enabled(
-        StockableInterface $stockable
-    ) {
-        $this->beConstructedWith(true);
-
-        $this->isStockSufficient($stockable, 999)->shouldReturn(true);
-    }
-
     function it_recognizes_stockable_stock_sufficient_if_on_hand_quantity_is_greater_than_required_quantity(
         StockableInterface $stockable
     ) {
-        $this->beConstructedWith(false);
-
         $stockable->isAvailableOnDemand()->willReturn(false);
 
         $stockable->getOnHand()->willReturn(10);
@@ -155,11 +107,9 @@ final class AvailabilityCheckerSpec extends ObjectBehavior
         $this->isStockSufficient($stockable, 15)->shouldReturn(true);
     }
 
-    function it_recognizes_stock_sufficient_if_its_available_on_demand_and_backorders_are_disabled(
+    function it_recognizes_stock_sufficient_if_its_available_on_demand(
         StockableInterface $stockable
     ) {
-        $this->beConstructedWith(false);
-
         $stockable->isAvailableOnDemand()->willReturn(true);
 
         $stockable->getOnHand()->willReturn(0);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Related tickets | -
| License         | MIT

[BC Break] - removal of `backorders` flag from sylius configuration, most likely it's going to be brought back to life or replaced after `Inventory`'s refactoring