### PR TITLE
Process missing 'permission' parameter in ResourceLoader

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Routing/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Routing/Configuration.php
@@ -36,7 +36,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('redirect')->cannotBeEmpty()->end()
                 ->scalarNode('templates')->cannotBeEmpty()->end()
                 ->scalarNode('grid')->cannotBeEmpty()->end()
-                ->scalarNode('permission')->defaultValue(false)->end()
+                ->booleanNode('permission')->defaultValue(false)->end()
                 ->arrayNode('except')
                     ->prototype('scalar')->end()
                 ->end()

--- a/src/Sylius/Bundle/ResourceBundle/Routing/ResourceLoader.php
+++ b/src/Sylius/Bundle/ResourceBundle/Routing/ResourceLoader.php
@@ -164,6 +164,9 @@ class ResourceLoader implements LoaderInterface
         if (isset($configuration['redirect']) && in_array($actionName, ['create', 'update'])) {
             $defaults['_sylius']['redirect'] = $this->getRouteName($metadata, $configuration, $configuration['redirect']);
         }
+        if (isset($configuration['permission'])) {
+            $defaults['_sylius']['permission'] = $configuration['permission'];
+        }
         if (isset($configuration['vars']['all'])) {
             $defaults['_sylius']['vars'] = $configuration['vars']['all'];
         }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Routing/ResourceLoaderSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Routing/ResourceLoaderSpec.php
@@ -96,30 +96,45 @@ EOT;
 
         $showDefaults = [
             '_controller' => 'sylius.controller.product:showAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])->willReturn($showRoute);
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
             '_controller' => 'sylius.controller.product:indexAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])->willReturn($indexRoute);
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
             '_controller' => 'sylius.controller.product:createAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])->willReturn($createRoute);
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
             '_controller' => 'sylius.controller.product:updateAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])->willReturn($updateRoute);
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
 
         $deleteDefaults = [
             '_controller' => 'sylius.controller.product:deleteAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])->willReturn($deleteRoute);
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
@@ -153,30 +168,45 @@ EOT;
 
         $showDefaults = [
             '_controller' => 'sylius.controller.product_option:showAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/product-options/{id}', $showDefaults, [], [], '', [], ['GET'])->willReturn($showRoute);
         $routeCollection->add('sylius_product_option_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
             '_controller' => 'sylius.controller.product_option:indexAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/product-options/', $indexDefaults, [], [], '', [], ['GET'])->willReturn($indexRoute);
         $routeCollection->add('sylius_product_option_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
             '_controller' => 'sylius.controller.product_option:createAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/product-options/new', $createDefaults, [], [], '', [], ['GET', 'POST'])->willReturn($createRoute);
         $routeCollection->add('sylius_product_option_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
             '_controller' => 'sylius.controller.product_option:updateAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/product-options/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])->willReturn($updateRoute);
         $routeCollection->add('sylius_product_option_update', $updateRoute)->shouldBeCalled();
 
         $deleteDefaults = [
             '_controller' => 'sylius.controller.product_option:deleteAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/product-options/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])->willReturn($deleteRoute);
         $routeCollection->add('sylius_product_option_delete', $deleteRoute)->shouldBeCalled();
@@ -211,30 +241,45 @@ EOT;
 
         $showDefaults = [
             '_controller' => 'sylius.controller.product:showAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/super-duper-products/{id}', $showDefaults, [], [], '', [], ['GET'])->willReturn($showRoute);
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
             '_controller' => 'sylius.controller.product:indexAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/super-duper-products/', $indexDefaults, [], [], '', [], ['GET'])->willReturn($indexRoute);
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
             '_controller' => 'sylius.controller.product:createAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/super-duper-products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])->willReturn($createRoute);
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
             '_controller' => 'sylius.controller.product:updateAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/super-duper-products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])->willReturn($updateRoute);
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
 
         $deleteDefaults = [
             '_controller' => 'sylius.controller.product:deleteAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/super-duper-products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])->willReturn($deleteRoute);
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
@@ -269,12 +314,18 @@ EOT;
 
         $showDefaults = [
             '_controller' => 'sylius.controller.product:showAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])->willReturn($showRoute);
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
             '_controller' => 'sylius.controller.product:indexAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])->willReturn($indexRoute);
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
@@ -282,7 +333,8 @@ EOT;
         $createDefaults = [
             '_controller' => 'sylius.controller.product:createAction',
             '_sylius' => [
-                'form' => 'sylius_product_custom',
+                'form'       => 'sylius_product_custom',
+                'permission' => false,
             ],
         ];
         $routeFactory->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])->willReturn($createRoute);
@@ -291,7 +343,8 @@ EOT;
         $updateDefaults = [
             '_controller' => 'sylius.controller.product:updateAction',
             '_sylius' => [
-                'form' => 'sylius_product_custom',
+                'form'       => 'sylius_product_custom',
+                'permission' => false,
             ],
         ];
         $routeFactory->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])->willReturn($updateRoute);
@@ -299,6 +352,9 @@ EOT;
 
         $deleteDefaults = [
             '_controller' => 'sylius.controller.product:deleteAction',
+            '_sylius' => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])->willReturn($deleteRoute);
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
@@ -334,7 +390,8 @@ EOT;
         $showDefaults = [
             '_controller' => 'sylius.controller.product:showAction',
             '_sylius' => [
-                'section' => 'admin',
+                'section'    => 'admin',
+                'permission' => false,
             ],
         ];
         $routeFactory->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])->willReturn($showRoute);
@@ -343,7 +400,8 @@ EOT;
         $indexDefaults = [
             '_controller' => 'sylius.controller.product:indexAction',
             '_sylius' => [
-                'section' => 'admin',
+                'section'    => 'admin',
+                'permission' => false,
             ],
         ];
         $routeFactory->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])->willReturn($indexRoute);
@@ -352,7 +410,8 @@ EOT;
         $createDefaults = [
             '_controller' => 'sylius.controller.product:createAction',
             '_sylius' => [
-                'section' => 'admin',
+                'section'    => 'admin',
+                'permission' => false,
             ],
         ];
         $routeFactory->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])->willReturn($createRoute);
@@ -361,7 +420,8 @@ EOT;
         $updateDefaults = [
             '_controller' => 'sylius.controller.product:updateAction',
             '_sylius' => [
-                'section' => 'admin',
+                'section'    => 'admin',
+                'permission' => false,
             ],
         ];
         $routeFactory->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])->willReturn($updateRoute);
@@ -370,7 +430,8 @@ EOT;
         $deleteDefaults = [
             '_controller' => 'sylius.controller.product:deleteAction',
             '_sylius' => [
-                'section' => 'admin',
+                'section'    => 'admin',
+                'permission' => false,
             ],
         ];
         $routeFactory->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])->willReturn($deleteRoute);
@@ -407,7 +468,8 @@ EOT;
         $showDefaults = [
             '_controller' => 'sylius.controller.product:showAction',
             '_sylius' => [
-                'template' => 'SyliusAdminBundle:Product:show.html.twig',
+                'template'   => 'SyliusAdminBundle:Product:show.html.twig',
+                'permission' => false,
             ],
         ];
         $routeFactory->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])->willReturn($showRoute);
@@ -416,7 +478,8 @@ EOT;
         $indexDefaults = [
             '_controller' => 'sylius.controller.product:indexAction',
             '_sylius' => [
-                'template' => 'SyliusAdminBundle:Product:index.html.twig',
+                'template'   => 'SyliusAdminBundle:Product:index.html.twig',
+                'permission' => false,
             ],
         ];
         $routeFactory->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])->willReturn($indexRoute);
@@ -425,7 +488,8 @@ EOT;
         $createDefaults = [
             '_controller' => 'sylius.controller.product:createAction',
             '_sylius' => [
-                'template' => 'SyliusAdminBundle:Product:create.html.twig',
+                'template'   => 'SyliusAdminBundle:Product:create.html.twig',
+                'permission' => false,
             ],
         ];
         $routeFactory->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])->willReturn($createRoute);
@@ -434,7 +498,8 @@ EOT;
         $updateDefaults = [
             '_controller' => 'sylius.controller.product:updateAction',
             '_sylius' => [
-                'template' => 'SyliusAdminBundle:Product:update.html.twig',
+                'template'   => 'SyliusAdminBundle:Product:update.html.twig',
+                'permission' => false,
             ],
         ];
         $routeFactory->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])->willReturn($updateRoute);
@@ -442,6 +507,9 @@ EOT;
 
         $deleteDefaults = [
             '_controller' => 'sylius.controller.product:deleteAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])->willReturn($deleteRoute);
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
@@ -474,18 +542,27 @@ EOT;
 
         $indexDefaults = [
             '_controller' => 'sylius.controller.product:indexAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])->willReturn($indexRoute);
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
             '_controller' => 'sylius.controller.product:createAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])->willReturn($createRoute);
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
             '_controller' => 'sylius.controller.product:updateAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])->willReturn($updateRoute);
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
@@ -517,12 +594,18 @@ EOT;
 
         $indexDefaults = [
             '_controller' => 'sylius.controller.product:indexAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])->willReturn($indexRoute);
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
             '_controller' => 'sylius.controller.product:createAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])->willReturn($createRoute);
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
@@ -571,12 +654,18 @@ EOT;
 
         $showDefaults = [
             '_controller' => 'sylius.controller.product:showAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])->willReturn($showRoute);
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
             '_controller' => 'sylius.controller.product:indexAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])->willReturn($indexRoute);
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
@@ -584,7 +673,8 @@ EOT;
         $createDefaults = [
             '_controller' => 'sylius.controller.product:createAction',
             '_sylius' => [
-                'redirect' => 'sylius_product_update',
+                'redirect'   => 'sylius_product_update',
+                'permission' => false,
             ],
         ];
         $routeFactory->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])->willReturn($createRoute);
@@ -593,7 +683,8 @@ EOT;
         $updateDefaults = [
             '_controller' => 'sylius.controller.product:updateAction',
             '_sylius' => [
-                'redirect' => 'sylius_product_update',
+                'redirect'   => 'sylius_product_update',
+                'permission' => false,
             ],
         ];
         $routeFactory->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])->willReturn($updateRoute);
@@ -601,6 +692,9 @@ EOT;
 
         $deleteDefaults = [
             '_controller' => 'sylius.controller.product:deleteAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])->willReturn($deleteRoute);
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
@@ -635,8 +729,9 @@ EOT;
         $showDefaults = [
             '_controller' => 'sylius.controller.product:showAction',
             '_sylius' => [
-                'serialization_groups' => ['Default', 'Detailed']
-            ]
+                'serialization_groups' => ['Default', 'Detailed'],
+                'permission'           => false,
+            ],
         ];
         $routeFactory->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])->willReturn($showRoute);
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
@@ -644,8 +739,9 @@ EOT;
         $indexDefaults = [
             '_controller' => 'sylius.controller.product:indexAction',
             '_sylius' => [
-                'serialization_groups' => ['Default']
-            ]
+                'serialization_groups' => ['Default'],
+                'permission'           => false,
+            ],
         ];
         $routeFactory->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])->willReturn($indexRoute);
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
@@ -653,8 +749,9 @@ EOT;
         $createDefaults = [
             '_controller' => 'sylius.controller.product:createAction',
             '_sylius' => [
-                'serialization_groups' => ['Default', 'Detailed']
-            ]
+                'serialization_groups' => ['Default', 'Detailed'],
+                'permission'           => false,
+            ],
         ];
         $routeFactory->createRoute('/products/', $createDefaults, [], [], '', [], ['POST'])->willReturn($createRoute);
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
@@ -662,14 +759,18 @@ EOT;
         $updateDefaults = [
             '_controller' => 'sylius.controller.product:updateAction',
             '_sylius' => [
-                'serialization_groups' => ['Default', 'Detailed']
-            ]
+                'serialization_groups' => ['Default', 'Detailed'],
+                'permission'           => false,
+            ],
         ];
         $routeFactory->createRoute('/products/{id}', $updateDefaults, [], [], '', [], ['PUT', 'PATCH'])->willReturn($updateRoute);
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
 
         $deleteDefaults = [
             '_controller' => 'sylius.controller.product:deleteAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])->willReturn($deleteRoute);
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
@@ -703,14 +804,18 @@ EOT;
         $indexDefaults = [
             '_controller' => 'sylius.controller.product:indexAction',
             '_sylius' => [
-                'grid' => 'sylius_admin_product',
+                'grid'       => 'sylius_admin_product',
+                'permission' => false,
             ]
         ];
         $routeFactory->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])->willReturn($indexRoute);
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product:createAction'
+            '_controller' => 'sylius.controller.product:createAction',
+            '_sylius'     => [
+                'permission' => false,
+            ],
         ];
         $routeFactory->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])->willReturn($createRoute);
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
@@ -752,7 +857,8 @@ EOT;
         $showDefaults = [
             '_controller' => 'sylius.controller.product:showAction',
             '_sylius' => [
-                'vars' => [
+                'permission' => false,
+                'vars'       => [
                     'foo' => 'bar',
                 ]
             ],
@@ -763,7 +869,8 @@ EOT;
         $indexDefaults = [
             '_controller' => 'sylius.controller.product:indexAction',
             '_sylius' => [
-                'vars' => [
+                'permission' => false,
+                'vars'       => [
                     'foo' => 'bar',
                 ]
             ],
@@ -774,7 +881,8 @@ EOT;
         $createDefaults = [
             '_controller' => 'sylius.controller.product:createAction',
             '_sylius' => [
-                'vars' => [
+                'permission' => false,
+                'vars'       => [
                     'foo' => 'bar',
                     'bar' => 'foo',
                 ]
@@ -786,7 +894,8 @@ EOT;
         $updateDefaults = [
             '_controller' => 'sylius.controller.product:updateAction',
             '_sylius' => [
-                'vars' => [
+                'permission' => false,
+                'vars'       => [
                     'foo' => 'bar',
                     'abc' => 'xyz',
                 ]
@@ -798,12 +907,89 @@ EOT;
         $deleteDefaults = [
             '_controller' => 'sylius.controller.product:deleteAction',
             '_sylius' => [
-                'vars' => [
+                'permission' => false,
+                'vars'       => [
                     'foo' => 'bar',
                 ]
             ],
         ];
         $routeFactory->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])->willReturn($deleteRoute);
+        $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
+
+        $this->load($configuration, 'sylius.resource')->shouldReturn($routeCollection);
+    }
+
+    function it_generates_routing_with_custom_permission(
+        RegistryInterface $resourceRegistry,
+        MetadataInterface $metadata,
+        RouteFactoryInterface $routeFactory,
+        RouteCollection $routeCollection,
+        Route $showRoute,
+        Route $indexRoute,
+        Route $createRoute,
+        Route $updateRoute,
+        Route $deleteRoute
+    ) {
+        $resourceRegistry->get('sylius.product')->willReturn($metadata);
+        $metadata->getApplicationName()->willReturn('sylius');
+        $metadata->getName()->willReturn('product');
+        $metadata->getPluralName()->willReturn('products');
+        $metadata->getServiceId('controller')->willReturn('sylius.controller.product');
+
+        $routeFactory->createRouteCollection()->willReturn($routeCollection);
+
+        $configuration =
+<<<EOT
+alias: sylius.product
+permission: true
+EOT;
+
+        $showDefaults = [
+            '_controller' => 'sylius.controller.product:showAction',
+            '_sylius'     => [
+                'permission' => true,
+            ],
+        ];
+        $routeFactory->createRoute('/products/{id}', $showDefaults, [], [], '', [], ['GET'])->willReturn($showRoute);
+        $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
+
+        $indexDefaults = [
+            '_controller' => 'sylius.controller.product:indexAction',
+            '_sylius'     => [
+                'permission' => true,
+            ],
+        ];
+        $routeFactory->createRoute('/products/', $indexDefaults, [], [], '', [], ['GET'])->willReturn($indexRoute);
+        $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
+
+        $createDefaults = [
+            '_controller' => 'sylius.controller.product:createAction',
+            '_sylius'     => [
+                'permission' => true,
+            ],
+        ];
+        $routeFactory->createRoute('/products/new', $createDefaults, [], [], '', [], ['GET', 'POST'])
+                     ->willReturn($createRoute);
+        $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
+
+        $updateDefaults = [
+            '_controller' => 'sylius.controller.product:updateAction',
+            '_sylius'     => [
+                'permission' => true,
+            ],
+        ];
+        $routeFactory->createRoute('/products/{id}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])
+                     ->willReturn($updateRoute);
+        $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
+
+        $deleteDefaults = [
+            '_controller' => 'sylius.controller.product:deleteAction',
+            '_sylius'     => [
+                'permission' => true,
+            ],
+        ];
+        $routeFactory->createRoute('/products/{id}', $deleteDefaults, [], [], '', [], ['DELETE'])
+                     ->willReturn($deleteRoute);
         $routeCollection->add('sylius_product_delete', $deleteRoute)->shouldBeCalled();
 
         $this->load($configuration, 'sylius.resource')->shouldReturn($routeCollection);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

At \Sylius\Bundle\ResourceBundle\Routing\Configuration 
> ->scalarNode('permission')->defaultValue(false)->end()

Should this node have boolean type?