### PR TITLE
[ThemeBundle] fixed assets re-installation

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Asset/Installer/AssetsInstaller.php
+++ b/src/Sylius/Bundle/ThemeBundle/Asset/Installer/AssetsInstaller.php
@@ -141,7 +141,7 @@ class AssetsInstaller implements AssetsInstallerInterface
             $targetFile = $targetDir.'/'.$originFile->getRelativePathname();
             $targetFile = $this->pathResolver->resolve($targetFile, $theme);
 
-            if (file_exists($targetFile)) {
+            if (file_exists($targetFile) && AssetsInstallerInterface::HARD_COPY !== $symlinkMask) {
                 continue;
             }
 

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/AssetTest.php
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/AssetTest.php
@@ -18,12 +18,78 @@ use Sylius\Bundle\ThemeBundle\Asset\Installer\AssetsInstallerInterface;
  */
 class AssetTest extends ThemeBundleTestCase
 {
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        file_put_contents(__DIR__.'/../Fixtures/themes/FirstTestTheme/TestBundle/public/theme_asset.txt', 'Theme asset'.PHP_EOL);
+    }
+
     /**
      * @dataProvider getSymlinkMasks
      *
      * @param int $symlinkMask
      */
     public function testAssets($symlinkMask)
+    {
+        $webDirectory = $this->createWebDirectory();
+
+        $client = $this->getClient();
+
+        $client->getContainer()->get('sylius.theme.asset.assets_installer')->installAssets($webDirectory, $symlinkMask);
+
+        $crawler = $client->request('GET', '/template/:Asset:assetsTest.txt.twig');
+        $lines = explode("\n", $crawler->text());
+
+        $this->assertFileContent($lines, $webDirectory);
+    }
+
+    /**
+     * @dataProvider getSymlinkMasks
+     *
+     * @param int $symlinkMask
+     */
+    public function testAssetsWhenModifiedAndReinstalled($symlinkMask)
+    {
+        $webDirectory = $this->createWebDirectory();
+
+        $client = $this->getClient();
+
+        $client->getContainer()->get('sylius.theme.asset.assets_installer')->installAssets($webDirectory, $symlinkMask);
+
+        sleep(1);
+        file_put_contents(__DIR__.'/../Fixtures/themes/FirstTestTheme/TestBundle/public/theme_asset.txt', 'Theme asset modified');
+        clearstatcache();
+
+        $client->getContainer()->get('sylius.theme.asset.assets_installer')->installAssets($webDirectory, $symlinkMask);
+
+        $crawler = $client->request('GET', '/template/:Asset:modifiedAssetsTest.txt.twig');
+        $lines = explode("\n", $crawler->text());
+
+        $this->assertFileContent($lines, $webDirectory);
+    }
+
+    /**
+     * @dataProvider getSymlinkMasks
+     *
+     * @param int $symlinkMask
+     */
+    public function testAssetsWhenReinstalled($symlinkMask)
+    {
+        $webDirectory = $this->createWebDirectory();
+
+        $client = $this->getClient();
+
+        $client->getContainer()->get('sylius.theme.asset.assets_installer')->installAssets($webDirectory, $symlinkMask);
+        $client->getContainer()->get('sylius.theme.asset.assets_installer')->installAssets($webDirectory, $symlinkMask);
+
+        $crawler = $client->request('GET', '/template/:Asset:assetsTest.txt.twig');
+        $lines = explode("\n", $crawler->text());
+
+        $this->assertFileContent($lines, $webDirectory);
+    }
+
+    private function createWebDirectory()
     {
         $webDirectory = $this->getTmpDirPath(self::TEST_CASE).'/web';
         if (!is_dir($webDirectory)) {
@@ -32,12 +98,11 @@ class AssetTest extends ThemeBundleTestCase
 
         chdir($webDirectory);
 
-        $client = $this->getClient();
+        return $webDirectory;
+    }
 
-        $client->getContainer()->get('sylius.theme.asset.assets_installer')->installAssets($webDirectory, $symlinkMask);
-
-        $crawler = $client->request('GET', '/template/:Asset:assetsTest.txt.twig');
-        $lines = explode("\n", $crawler->text());
+    private function assertFileContent($lines, $webDirectory)
+    {
         foreach ($lines as $line) {
             if (empty($line)) {
                 continue;

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/Resources/views/Asset/modifiedAssetsTest.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/Resources/views/Asset/modifiedAssetsTest.txt.twig
@@ -1,0 +1,1 @@
+Theme asset modified: {{ asset('bundles/test/theme_asset.txt') }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

This PR fixes an issue when you want to update your assets once they were already installed at least one time. Let's say I have installed assets, I edit one of the asset files in my theme and run `sylius:theme:assets:install` command again - the updated asset file won't be copied over to the `web` directory, thus I still get the old version.