### PR TITLE
[API] Fix api authenticator

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -25,6 +25,10 @@ security:
                 target: sylius_admin_login
             anonymous: true
 
+        oauth_token:
+            pattern:  ^/api/oauth/v2/token
+            security: false
+
         api:
             pattern:    ^/api
             fos_oauth:  true
@@ -55,10 +59,6 @@ security:
                 path: sylius_shop_logout
                 target: sylius_shop_login
             anonymous: true
-
-        oauth_token:
-            pattern:  ^/oauth/v2/token
-            security: false
 
         dev:
             pattern:  ^/(_(profiler|wdt)|css|images|js)/

--- a/docs/api/authorization.rst
+++ b/docs/api/authorization.rst
@@ -52,7 +52,7 @@ Definition
 
 .. code-block:: text
 
-    GET /oauth/v2/token
+    GET /api/oauth/v2/token
 
 +---------------+----------------+--------------------------------------------------------------------------------------------------+
 | Parameter     | Parameter type | Description                                                                                      |
@@ -77,7 +77,7 @@ Example
 
 .. code-block:: bash
 
-    curl http://sylius.dev/oauth/v2/token
+    curl http://sylius.dev/api/oauth/v2/token
         -d "client_id"=demo_client
         -d "client_secret"=secret_demo_client
         -d "grant_type"=password
@@ -137,7 +137,7 @@ Definition
 
 .. code-block:: text
 
-    GET /oauth/v2/token
+    GET /api/oauth/v2/token
 
 +---------------+----------------+---------------------------------------------------+
 | Parameter     | Parameter type |  Description                                      |
@@ -156,7 +156,7 @@ Example
 
 .. code-block:: bash
 
-    curl http://sylius.dev/oauth/v2/token
+    curl http://sylius.dev/api/oauth/v2/token
         -d "client_id"=demo_client
         -d "client_secret"=secret_demo_client
         -d "grant_type"=refresh_token

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/main.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/main.yml
@@ -1,5 +1,7 @@
 # This file is part of the Sylius package.
 # (c) Paweł Jędrzejewski
+fos_oauth_server_token:
+  resource: "@FOSOAuthServerBundle/Resources/config/routing/token.xml"
 
 sylius_api_product:
     resource: @SyliusApiBundle/Resources/config/routing/product.yml

--- a/tests/Controller/OauthTokenApiTest.php
+++ b/tests/Controller/OauthTokenApiTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Tests\Controller;
+
+use Lakion\ApiTestCase\JsonApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ */
+final class OauthTokenApiTest extends JsonApiTestCase
+{
+    /**
+     * @test
+     */
+    public function it_provides_an_access_token()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $data =
+<<<EOT
+        {
+            "client_id": "client_id",
+            "client_secret": "secret",
+            "grant_type": "password",
+            "username": "api@sylius.com",
+            "password": "sylius"
+        }
+EOT;
+
+        $this->client->request('POST', '/api/oauth/v2/token', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
+
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/new_access_token', Response::HTTP_OK);
+    }
+    /**
+     * @test
+     */
+    public function it_allows_to_refresh_an_access_token()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $data =
+<<<EOT
+        {
+            "client_id": "client_id",
+            "client_secret": "secret",
+            "grant_type": "refresh_token",
+            "refresh_token": "SampleRefreshTokenODllODY4ZTQyOThlNWIyMjA1ZDhmZjE1ZDYyMGMwOTUxOWM2NGFmNGRjNjQ2NDBhMDVlNGZjMmQ0YzgyNDM2Ng"
+        }
+EOT;
+
+        $this->client->request('POST', '/api/oauth/v2/token', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
+
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/new_access_token', Response::HTTP_OK);
+    }
+}

--- a/tests/DataFixtures/ORM/authentication/api_administrator.yml
+++ b/tests/DataFixtures/ORM/authentication/api_administrator.yml
@@ -5,10 +5,16 @@ Sylius\Bundle\ApiBundle\Model\Client:
         allowedGrantTypes: [password, access_token, refresh_token]
 
 Sylius\Bundle\ApiBundle\Model\AccessToken:
-    oauth_token:
+    oauth_access_token:
         client: @oauth
         user: @admin
         token: SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ
+
+Sylius\Bundle\ApiBundle\Model\RefreshToken:
+    oauth_refresh_token:
+        client: @oauth
+        user: @admin
+        token: SampleRefreshTokenODllODY4ZTQyOThlNWIyMjA1ZDhmZjE1ZDYyMGMwOTUxOWM2NGFmNGRjNjQ2NDBhMDVlNGZjMmQ0YzgyNDM2Ng
 
 Sylius\Component\Core\Model\User:
     admin:

--- a/tests/Responses/Expected/authentication/new_access_token.json
+++ b/tests/Responses/Expected/authentication/new_access_token.json
@@ -1,0 +1,7 @@
+{
+  "access_token": @string@,
+  "expires_in": 3600,
+  "token_type": "bearer",
+  "scope": null,
+  "refresh_token": @string@
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Related tickets | 
| License         | MIT

BC Break included. Before, access token was available under `/oauth/v2/token` path. Now, it is available under `/api/oauth/v2/token`. 