### PR TITLE
[Core] Rewrite ChannelBasedCurrencyProvider

### DIFF
--- a/src/Sylius/Component/Core/Provider/ChannelBasedCurrencyProvider.php
+++ b/src/Sylius/Component/Core/Provider/ChannelBasedCurrencyProvider.php
@@ -45,18 +45,16 @@ final class ChannelBasedCurrencyProvider implements CurrencyProviderInterface
             /** @var ChannelInterface $channel */
             $channel = $this->channelContext->getChannel();
 
-            $currencies = $channel
+            return $channel
                 ->getCurrencies()
                 ->filter(function (CurrencyInterface $currency) {
                     return $currency->isEnabled();
                 })
+                ->map(function (CurrencyInterface $currency) {
+                    return $currency->getCode();
+                })
                 ->toArray()
             ;
-
-            return array_map(
-                function (CurrencyInterface $currency) { return $currency->getCode(); },
-                $currencies
-            );
         } catch (ChannelNotFoundException $exception) {
             throw new CurrencyNotFoundException(null, $exception);
         }


### PR DESCRIPTION
There's no reason not to use `map` on Collection instead of `array_map` on array (nice chaining included).