### PR TITLE
Fix setup command issues

### DIFF
--- a/src/Sylius/Bundle/InstallerBundle/Command/SetupCommand.php
+++ b/src/Sylius/Bundle/InstallerBundle/Command/SetupCommand.php
@@ -157,10 +157,17 @@ EOT
      */
     protected function setupCurrency(InputInterface $input, OutputInterface $output)
     {
+        $currencyRepository = $this->get('sylius.repository.currency');
         $currencyManager = $this->get('sylius.manager.currency');
         $currencyFactory = $this->get('sylius.factory.currency');
 
         $code = trim($this->getContainer()->getParameter('currency'));
+        $this->currency = $currencyRepository->findOneByCode($code);
+
+        if(null !== $this->currency) {
+            return;
+        }
+
         $name = Intl::getCurrencyBundle()->getCurrencyName($code);
         $output->writeln(sprintf('Adding <info>%s</info> currency.', $name));
 
@@ -192,6 +199,7 @@ EOT
         $channel->setName('Default');
         $channel->setTaxCalculationStrategy('order_items_based');
 
+        $channel->setDefaultCurrency($this->currency);
         $channel->addCurrency($this->currency);
         $channel->addLocale($this->locale);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | no
| License         | MIT

I faced the following issues while running `sylius:install` command on `master`:
- Duplicate entry exception thrown while runnig `sylius:install:setup` when default currency was added before by the fixtures
- Field cannot be null exception when creating channel without default currency

Steps to reproduce:
- Clone the repo
- Follow [quick installation guide](https://github.com/Sylius/Sylius#quick-installation)