### PR TITLE
Allow null or string on default currency and locale in ChannelExampleFactory

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -81,7 +81,7 @@ final class ChannelExampleFactory implements ExampleFactoryInterface
                 ->setDefault('default_locale', function (Options $options) {
                     return $this->faker->randomElement($options['locales']);
                 })
-                ->setAllowedTypes('default_locale', ['null', 'string', LocaleInterface::class])
+                ->setAllowedTypes('default_locale', ['string', LocaleInterface::class])
                 ->setNormalizer('default_locale', LazyOption::findOneBy($localeRepository, 'code'))
                 ->setDefault('locales', LazyOption::all($localeRepository))
                 ->setAllowedTypes('locales', 'array')
@@ -89,7 +89,7 @@ final class ChannelExampleFactory implements ExampleFactoryInterface
                 ->setDefault('default_currency', function (Options $options) {
                     return $this->faker->randomElement($options['currencies']);
                 })
-                ->setAllowedTypes('default_currency', ['null', 'string', CurrencyInterface::class])
+                ->setAllowedTypes('default_currency', ['string', CurrencyInterface::class])
                 ->setNormalizer('default_currency', LazyOption::findOneBy($currencyRepository, 'code'))
                 ->setDefault('currencies', LazyOption::all($currencyRepository))
                 ->setAllowedTypes('currencies', 'array')

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -81,7 +81,7 @@ final class ChannelExampleFactory implements ExampleFactoryInterface
                 ->setDefault('default_locale', function (Options $options) {
                     return $this->faker->randomElement($options['locales']);
                 })
-                ->setAllowedTypes('default_locale', LocaleInterface::class)
+                ->setAllowedTypes('default_locale', ['null', 'string', LocaleInterface::class])
                 ->setNormalizer('default_locale', LazyOption::findOneBy($localeRepository, 'code'))
                 ->setDefault('locales', LazyOption::all($localeRepository))
                 ->setAllowedTypes('locales', 'array')
@@ -89,7 +89,7 @@ final class ChannelExampleFactory implements ExampleFactoryInterface
                 ->setDefault('default_currency', function (Options $options) {
                     return $this->faker->randomElement($options['currencies']);
                 })
-                ->setAllowedTypes('default_currency', CurrencyInterface::class)
+                ->setAllowedTypes('default_currency', ['null', 'string', CurrencyInterface::class])
                 ->setNormalizer('default_currency', LazyOption::findOneBy($currencyRepository, 'code'))
                 ->setDefault('currencies', LazyOption::all($currencyRepository))
                 ->setAllowedTypes('currencies', 'array')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Related tickets | no |
| License | MIT |

Channel fixtures don't support defining default currency or locale. It throws the following exception when you try to define a current locale for example:

`The option "default_locale" with value "es_ES" is expected to be of type "Sylius\Component\Locale\Model\LocaleInterface", but is of type "string".`

**Steps to reproduce**
- Clone the master branch of sylius/sylius
- Copy [this gist](https://gist.github.com/gorkalaucirica/b50edfbf767123cb370ed05f4af3eddc) and include it in `app/config/config.yml`. The config is the same as found in [Core Bundle fixtures.yml](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures.yml) but adding `default_locale` in [line 51](https://gist.github.com/gorkalaucirica/b50edfbf767123cb370ed05f4af3eddc#file-fixtures-yml-L51). 
- Run the following:

``` bash
$ php app/console sylius:install:database
$ php app/console sylius:fixtures:load this_fails
```
