### PR TITLE
Add github templates

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,16 @@
+### Steps to reproduce [](URLS / Actions)
+
+1.
+2.
+
+### Expected Behavior [](ex.: )
+
+### Actual behavior [](ex.: steps and urls to be tested )
+
+### What are the relevant tickets?[](ex.: JIRA tickets, by ID, )
+
+Closes [#IDJIRA](https://urbanara.atlassian.net/browse/#IDJIRA)
+
+### Screenshots (if appropriate)
+
+### Questions:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+<!-- 
+	PR Table Template 	
+--> 
+| Q             | A
+| ------------- | ---
+| Bug fix?      | [](no|yes)
+| New feature?  | [](no|yes)
+| BC breaks?    | [](no|yes)
+| Deprecations? | [](no|yes)
+| Fixed tickets | #X
+| License       | MIT
+| Doc PR        | Sylius/Sylius-Docs#X


### PR DESCRIPTION
<!-- 
	PR Table Template 	
--> 
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | none
| License       | MIT
| Doc PR        | none


Just adding the [PR and Issue templates](https://github.com/blog/2111-issue-and-pull-request-templates) as files inside `/.github` folders