### PR TITLE
[Core][Product] Fix query with true value instead of 1

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -218,7 +218,7 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
             ->andWhere('taxon.code = :code')
             ->innerJoin('o.channels', 'channel')
             ->andWhere('channel = :channel')
-            ->andWhere('o.enabled = 1')
+            ->andWhere('o.enabled = true')
             ->setParameter('code', $code)
             ->setParameter('channel', $channel)
             ->getQuery()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | -
| License         | MIT

Fix findEnabledByTaxonCodeAndChannel in ProductRepository with true value instead of 1, for PostgreSQL compatibility.
