### PR TITLE
[API][Order] Update OrderType to have customer optional

### DIFF
--- a/docs/api/orders.rst
+++ b/docs/api/orders.rst
@@ -352,7 +352,7 @@ Parameters
 
 channel
     The id of channel
-user
+customer *(optional)*
     The id of customer
 currency
     Currency code

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Api/OrderType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Api/OrderType.php
@@ -26,11 +26,7 @@ class OrderType extends BaseOrderType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('user', 'sylius_customer_choice', [
-                'constraints' => [
-                    new NotBlank(),
-                ],
-            ])
+            ->add('customer', 'sylius_customer_choice')
             ->add('currencyCode', 'sylius_currency_code_choice', [
                 'constraints' => [
                     new NotBlank(),


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

The OrderType in ApiBundle has the optional **customer** field instead of the mandatory and deprecated **user** field.