### PR TITLE
[Gulp] Clean up Sylius gulp files

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,155 +1,16 @@
 var gulp = require('gulp');
-var gulpif = require('gulp-if');
-var uglify = require('gulp-uglify');
-var uglifycss = require('gulp-uglifycss');
-var concat = require('gulp-concat');
-var sass = require('gulp-sass');
-var sourcemaps = require('gulp-sourcemaps');
-var debug = require('gulp-debug');
-var livereload = require('gulp-livereload');
-var order = require('gulp-order');
-var merge = require('merge-stream');
-var env = process.env.GULP_ENV;
+var chug = require('gulp-chug');
 
-var rootPath = 'web/assets/';
-
-var adminRootPath = rootPath + 'admin/';
-var shopRootPath = rootPath + 'shop/';
-
-var paths = {
-    admin: {
-        js: [
-            'node_modules/jquery/dist/jquery.min.js',
-            'node_modules/semantic-ui-css/semantic.min.js',
-            'src/Sylius/Bundle/AdminBundle/Resources/private/js/**',
-            'src/Sylius/Bundle/UiBundle/Resources/private/js/**',
-            'src/Sylius/Bundle/ShippingBundle/Resources/public/js/**',
-            'src/Sylius/Bundle/PromotionBundle/Resources/public/js/sylius-promotion.js',
-            'src/Sylius/Bundle/UserBundle/Resources/public/js/sylius-user.js'
-        ],
-        sass: [
-            'src/Sylius/Bundle/UiBundle/Resources/private/sass/**',
-        ],
-        css: [
-            'node_modules/semantic-ui-css/semantic.min.css',
-        ],
-        img: [
-            'src/Sylius/Bundle/UiBundle/Resources/private/img/**',
-        ]
-    },
-    shop: {
-        js: [
-            'node_modules/jquery/dist/jquery.min.js',
-            'node_modules/semantic-ui-css/semantic.min.js',
-            'src/Sylius/Bundle/UiBundle/Resources/private/js/**',
-            'src/Sylius/Bundle/ShopBundle/Resources/private/js/**'
-        ],
-        sass: [
-            'src/Sylius/Bundle/UiBundle/Resources/private/sass/**',
-            'src/Sylius/Bundle/ShopBundle/Resources/private/scss/**',
-        ],
-        css: [
-            'node_modules/semantic-ui-css/semantic.min.css',
-        ],
-        img: [
-            'src/Sylius/Bundle/UiBundle/Resources/private/img/**',
-        ]
-    }
-};
-
-gulp.task('admin-js', function () {
-    return gulp.src(paths.admin.js)
-        .pipe(concat('app.js'))
-        .pipe(gulpif(env === 'prod', uglify))
-        .pipe(sourcemaps.write('./'))
-        .pipe(gulp.dest(adminRootPath + 'js/'))
+gulp.task('admin', function() {
+    gulp.src('src/Sylius/Bundle/AdminBundle/Gulpfile.js', { read: false })
+        .pipe(chug())
     ;
 });
 
-gulp.task('admin-css', function() {
-    gulp.src(['node_modules/semantic-ui-css/themes/**/*']).pipe(gulp.dest(adminRootPath + 'css/themes/'));
-
-    var cssStream = gulp.src(paths.admin.css)
-        .pipe(concat('css-files.css'))
-    ;
-
-    var sassStream = gulp.src(paths.admin.sass)
-        .pipe(sass())
-        .pipe(concat('sass-files.scss'))
-    ;
-
-    return merge(cssStream, sassStream)
-        .pipe(order(['css-files.css', 'sass-files.scss']))
-        .pipe(concat('style.css'))
-        .pipe(gulpif(env === 'prod', uglifycss))
-        .pipe(sourcemaps.write('./'))
-        .pipe(gulp.dest(adminRootPath + 'css/'))
-        .pipe(livereload())
+gulp.task('shop', function() {
+    gulp.src('src/Sylius/Bundle/ShopBundle/Gulpfile.js', { read: false })
+        .pipe(chug())
     ;
 });
 
-gulp.task('admin-img', function() {
-    return gulp.src(paths.admin.img)
-        .pipe(sourcemaps.write('./'))
-        .pipe(gulp.dest(adminRootPath + 'img/'))
-    ;
-});
-
-gulp.task('admin-watch', function() {
-    livereload.listen();
-
-    gulp.watch(paths.admin.js, ['admin-js']);
-    gulp.watch(paths.admin.sass, ['admin-css']);
-    gulp.watch(paths.admin.css, ['admin-css']);
-    gulp.watch(paths.admin.img, ['admin-img']);
-});
-
-gulp.task('shop-js', function () {
-    return gulp.src(paths.shop.js)
-        .pipe(concat('app.js'))
-        .pipe(gulpif(env === 'prod', uglify))
-        .pipe(sourcemaps.write('./'))
-        .pipe(gulp.dest(shopRootPath + 'js/'))
-    ;
-});
-
-gulp.task('shop-css', function() {
-    gulp.src(['node_modules/semantic-ui-css/themes/**/*']).pipe(gulp.dest(shopRootPath + 'css/themes/'));
-
-    var cssStream = gulp.src(paths.shop.css)
-        .pipe(concat('css-files.css'))
-    ;
-
-    var sassStream = gulp.src(paths.shop.sass)
-        .pipe(sass())
-        .pipe(concat('sass-files.scss'))
-    ;
-
-    return merge(cssStream, sassStream)
-        .pipe(order(['css-files.css', 'sass-files.scss']))
-        .pipe(concat('style.css'))
-        .pipe(gulpif(env === 'prod', uglifycss))
-        .pipe(sourcemaps.write('./'))
-        .pipe(gulp.dest(shopRootPath + 'css/'))
-        .pipe(livereload())
-    ;
-});
-
-gulp.task('shop-img', function() {
-    return gulp.src(paths.shop.img)
-        .pipe(sourcemaps.write('./'))
-        .pipe(gulp.dest(shopRootPath + 'img/'))
-    ;
-});
-
-gulp.task('shop-watch', function() {
-    livereload.listen();
-
-    gulp.watch(paths.shop.js, ['shop-js']);
-    gulp.watch(paths.shop.sass, ['shop-css']);
-    gulp.watch(paths.shop.css, ['shop-css']);
-    gulp.watch(paths.shop.img, ['shop-img']);
-});
-
-gulp.task('default', ['admin-js', 'admin-css', 'admin-img', 'shop-js', 'shop-css', 'shop-img']);
-gulp.task('watch', ['default', 'admin-watch', 'shop-watch']);
+gulp.task('default', ['admin', 'shop']);

--- a/src/Sylius/Bundle/AdminBundle/Gulpfile.js
+++ b/src/Sylius/Bundle/AdminBundle/Gulpfile.js
@@ -1,0 +1,87 @@
+var concat = require('gulp-concat');
+var env = process.env.GULP_ENV;
+var gulp = require('gulp');
+var gulpif = require('gulp-if');
+var livereload = require('gulp-livereload');
+var merge = require('merge-stream');
+var order = require('gulp-order');
+var sass = require('gulp-sass');
+var sourcemaps = require('gulp-sourcemaps');
+var uglify = require('gulp-uglify');
+var uglifycss = require('gulp-uglifycss');
+
+var rootPath = '../../../../web/assets/';
+var adminRootPath = rootPath + 'admin/';
+
+var paths = {
+    admin: {
+        js: [
+            '../../../../node_modules/jquery/dist/jquery.min.js',
+            '../../../../node_modules/semantic-ui-css/semantic.min.js',
+            '../PromotionBundle/Resources/public/js/sylius-promotion.js',
+            '../ShippingBundle/Resources/public/js/**',
+            '../UiBundle/Resources/private/js/**',
+            '../UserBundle/Resources/public/js/sylius-user.js',
+            'Resources/private/js/**'
+        ],
+        sass: [
+            '../UiBundle/Resources/private/sass/**'
+        ],
+        css: [
+            '../../../../node_modules/semantic-ui-css/semantic.min.css'
+        ],
+        img: [
+            '../UiBundle/Resources/private/img/**'
+        ]
+    }
+};
+
+gulp.task('admin-js', function () {
+    return gulp.src(paths.admin.js)
+        .pipe(concat('app.js'))
+        .pipe(gulpif(env === 'prod', uglify))
+        .pipe(sourcemaps.write('./'))
+        .pipe(gulp.dest(adminRootPath + 'js/'))
+    ;
+});
+
+gulp.task('admin-css', function() {
+    gulp.src(['node_modules/semantic-ui-css/themes/**/*']).pipe(gulp.dest(adminRootPath + 'css/themes/'));
+
+    var cssStream = gulp.src(paths.admin.css)
+        .pipe(concat('css-files.css'))
+    ;
+
+    var sassStream = gulp.src(paths.admin.sass)
+        .pipe(sass())
+        .pipe(concat('sass-files.scss'))
+    ;
+
+    return merge(cssStream, sassStream)
+        .pipe(order(['css-files.css', 'sass-files.scss']))
+        .pipe(concat('style.css'))
+        .pipe(gulpif(env === 'prod', uglifycss))
+        .pipe(sourcemaps.write('./'))
+        .pipe(gulp.dest(adminRootPath + 'css/'))
+        .pipe(livereload())
+    ;
+});
+
+gulp.task('admin-img', function() {
+    return gulp.src(paths.admin.img)
+        .pipe(sourcemaps.write('./'))
+        .pipe(gulp.dest(adminRootPath + 'img/'))
+    ;
+});
+
+gulp.task('admin-watch', function() {
+    livereload.listen();
+
+    gulp.watch(paths.admin.js, ['admin-js']);
+    gulp.watch(paths.admin.sass, ['admin-css']);
+    gulp.watch(paths.admin.css, ['admin-css']);
+    gulp.watch(paths.admin.img, ['admin-img']);
+});
+
+gulp.task('default', ['admin-js', 'admin-css', 'admin-img']);
+gulp.task('watch', ['default', 'admin-watch']);

--- a/src/Sylius/Bundle/AdminBundle/package.json
+++ b/src/Sylius/Bundle/AdminBundle/package.json
@@ -5,9 +5,7 @@
   },
   "devDependencies": {
     "gulp": "^3.9.0",
-    "gulp-chug": "^0.5",
     "gulp-concat": "^2.6.0",
-    "gulp-debug": "^2.1.2",
     "gulp-if": "^2.0.0",
     "gulp-livereload": "^3.8.1",
     "gulp-order": "^1.1.1",
@@ -22,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Sylius/Sylius.git"
+    "url": "git+https://github.com/Sylius/SyliusAdminBundle.git"
   },
   "author": "Paweł Jędrzejewski",
   "license": "MIT"

--- a/src/Sylius/Bundle/ShopBundle/Gulpfile.js
+++ b/src/Sylius/Bundle/ShopBundle/Gulpfile.js
@@ -1,0 +1,85 @@
+var concat = require('gulp-concat');
+var env = process.env.GULP_ENV;
+var gulp = require('gulp');
+var gulpif = require('gulp-if');
+var livereload = require('gulp-livereload');
+var merge = require('merge-stream');
+var order = require('gulp-order');
+var sass = require('gulp-sass');
+var sourcemaps = require('gulp-sourcemaps');
+var uglify = require('gulp-uglify');
+var uglifycss = require('gulp-uglifycss');
+
+var rootPath = '../../../../web/assets/';
+var shopRootPath = rootPath + 'shop/';
+
+var paths = {
+    shop: {
+        js: [
+            '../../../../node_modules/jquery/dist/jquery.min.js',
+            '../../../../node_modules/semantic-ui-css/semantic.min.js',
+            '../UiBundle/Resources/private/js/**',
+            'Resources/private/js/**'
+        ],
+        sass: [
+            '../UiBundle/Resources/private/sass/**',
+            'ShopBundle/Resources/private/scss/**'
+        ],
+        css: [
+            '../../../../node_modules/semantic-ui-css/semantic.min.css'
+        ],
+        img: [
+            '../UiBundle/Resources/private/img/**'
+        ]
+    }
+};
+
+gulp.task('shop-js', function () {
+    return gulp.src(paths.shop.js)
+        .pipe(concat('app.js'))
+        .pipe(gulpif(env === 'prod', uglify))
+        .pipe(sourcemaps.write('./'))
+        .pipe(gulp.dest(shopRootPath + 'js/'))
+    ;
+});
+
+gulp.task('shop-css', function() {
+    gulp.src(['node_modules/semantic-ui-css/themes/**/*']).pipe(gulp.dest(shopRootPath + 'css/themes/'));
+
+    var cssStream = gulp.src(paths.shop.css)
+            .pipe(concat('css-files.css'))
+        ;
+
+    var sassStream = gulp.src(paths.shop.sass)
+            .pipe(sass())
+            .pipe(concat('sass-files.scss'))
+        ;
+
+    return merge(cssStream, sassStream)
+        .pipe(order(['css-files.css', 'sass-files.scss']))
+        .pipe(concat('style.css'))
+        .pipe(gulpif(env === 'prod', uglifycss))
+        .pipe(sourcemaps.write('./'))
+        .pipe(gulp.dest(shopRootPath + 'css/'))
+        .pipe(livereload())
+    ;
+});
+
+gulp.task('shop-img', function() {
+    return gulp.src(paths.shop.img)
+        .pipe(sourcemaps.write('./'))
+        .pipe(gulp.dest(shopRootPath + 'img/'))
+    ;
+});
+
+gulp.task('shop-watch', function() {
+    livereload.listen();
+
+    gulp.watch(paths.shop.js, ['shop-js']);
+    gulp.watch(paths.shop.sass, ['shop-css']);
+    gulp.watch(paths.shop.css, ['shop-css']);
+    gulp.watch(paths.shop.img, ['shop-img']);
+});
+
+gulp.task('default', ['shop-js', 'shop-css', 'shop-img']);
+gulp.task('watch', ['default', 'shop-watch']);

--- a/src/Sylius/Bundle/ShopBundle/package.json
+++ b/src/Sylius/Bundle/ShopBundle/package.json
@@ -5,7 +5,6 @@
   },
   "devDependencies": {
     "gulp": "^3.9.0",
-    "gulp-chug": "^0.5",
     "gulp-concat": "^2.6.0",
     "gulp-debug": "^2.1.2",
     "gulp-if": "^2.0.0",
@@ -18,7 +17,7 @@
     "merge-stream": "^1.0.0"
   },
   "scripts": {
-    "gulp": "gulp"
+      "gulp": "gulp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets |
| License         | MIT

We should deeply consider gulp files structure in *Sylius*. First step could be splitting ``Gulpfile.js`` into *ShopBundle* and *AdminBundle*, that would allow us to easily install only needed assets (again - superuseful for *Sylius-Standard*).