### PR TITLE
implement slideshow block for new AdminBundle

### DIFF
--- a/features/cmf/manage_slideshow_block/adding_slideshow_block.feature
+++ b/features/cmf/manage_slideshow_block/adding_slideshow_block.feature
@@ -1,0 +1,18 @@
+@managing_slideshow_blocks
+Feature: Adding a new slideshow block
+    In order to manage slideshow
+    As an Administrator
+    I want to add slideshow block to my site
+
+    Background:
+        Given I am logged in as an administrator
+
+    @ui
+    Scenario: Adding slideshow block
+        Given I want to add a new slideshow block
+        When I set its title to "Slideshow for christmas"
+        And I set its name to "slide-show-for-christmas"
+        And I make it published
+        And I make it available from "21.04.2017" to "21.05.2017"
+        And I add it
+        Then I should be notified that it has been successfully created

--- a/features/cmf/manage_slideshow_block/browsing_slideshow_block.feature
+++ b/features/cmf/manage_slideshow_block/browsing_slideshow_block.feature
@@ -1,0 +1,16 @@
+@managing_slideshow_blocks
+Feature: Browsing slideshow blocks
+    In order to see all slideshow blocks in the store
+    As an Administrator
+    I want to browse slideshow blocks
+
+    Background:
+        Given the store has slideshow "Slideshow for Christmas" with name "slideshow-for-christmas"
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Browsing slideshow blocks in store
+        When I want to browse slideshow blocks of the store
+        Then I should see 1 slideshow blocks in the list
+        And I should see the slideshow block "Slideshow for Christmas" in the list
+

--- a/features/cmf/manage_slideshow_block/deleting_slideshow_block.feature
+++ b/features/cmf/manage_slideshow_block/deleting_slideshow_block.feature
@@ -1,0 +1,15 @@
+@managing_slideshow_blocks
+Feature: Deleting a slideshow
+    In order to remove test, obsolete or incorrect slideshows
+    As an Administrator
+    I want to be able to delete a slideshow
+
+    Background:
+        Given I am logged in as an administrator
+
+    @ui
+    Scenario: Deleted taxon should disappear from the registry
+        Given the store has slideshow "Slideshow for Christmas" with name "slideshow-for-christmas"
+        When I delete slideshow block "Slideshow for Christmas"
+        Then I should be notified that it has been successfully deleted
+        And the slideshow block "Slideshow for Christmas" should no longer exist in the store

--- a/features/cmf/manage_slideshow_block/editing_slideshow_block.feature
+++ b/features/cmf/manage_slideshow_block/editing_slideshow_block.feature
@@ -1,0 +1,17 @@
+@managing_slideshow_blocks
+Feature: Editing a slideshow
+    In order to change slideshow
+    As an Administrator
+    I want to be able to edit a slideshow
+
+    Background:
+        Given I am logged in as an administrator
+
+    @ui @current
+    Scenario: Change title of a slideshow
+        Given the store has slideshow "Slideshow for Christmas" with name "slideshow-for-christmas"
+        And I want to edit this slideshow block
+        When I change its title to "Christmas Slideshow"
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And this slideshow block should have title "Christmas Slideshow"

--- a/src/Sylius/Behat/Context/Setup/SlideshowBlockContext.php
+++ b/src/Sylius/Behat/Context/Setup/SlideshowBlockContext.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Behat\Context\Setup;
+
+use Behat\Behat\Context\Context;
+use Doctrine\Common\Persistence\ObjectManager;
+use Sylius\Bundle\ContentBundle\Document\Slideshow;
+use Sylius\Bundle\ContentBundle\Document\SlideshowBlock;
+use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
+use Sylius\Behat\Service\SharedStorageInterface;
+
+/**
+ * @author Vidy Videni <vidy.videni@gmail.com>
+ */
+final class SlideshowBlockContext implements Context
+{
+    /**
+     * @var SharedStorageInterface
+     */
+    private $sharedStorage;
+
+    /**
+     * @var ExampleFactoryInterface
+     */
+    private $slideshowBlockExampleFactory;
+
+    /**
+     * @var ObjectManager
+     */
+    private $slideshowBlockManager;
+
+    private $imagineBlockExampleFactory;
+
+    /**
+     * @param SharedStorageInterface  $sharedStorage
+     * @param ExampleFactoryInterface $slideshowBlockExampleFactory
+     * @param ObjectManager           $slideshowBlockManager
+     */
+    public function __construct(
+        SharedStorageInterface $sharedStorage,
+        ExampleFactoryInterface $slideshowBlockExampleFactory,
+        ExampleFactoryInterface $imagineBlockExampleFactory,
+        ObjectManager $slideshowBlockManager
+    ) {
+        $this->sharedStorage = $sharedStorage;
+        $this->slideshowBlockExampleFactory = $slideshowBlockExampleFactory;
+        $this->imagineBlockExampleFactory = $imagineBlockExampleFactory;
+        $this->slideshowBlockManager = $slideshowBlockManager;
+    }
+
+    /**
+     * @Given the store has default slideshows
+     */
+    public function theStoreHasDefaultSlideshows()
+    {
+        $slideshowBlock = $this->slideshowBlockExampleFactory->create(['title' => 'test', 'name' => 'test']);
+
+        $imagine = $this->imagineBlockExampleFactory->create(['name' => 'test', 'label' => 'test', 'image' => 'book.jpg']);
+
+        $slideshowBlock->addChildren($imagine);
+
+        $this->slideshowBlockManager->persist($slideshowBlock);
+        $this->slideshowBlockManager->flush();
+
+        $this->sharedStorage->set('slideshow_block', $slideshowBlock);
+    }
+
+    /**
+     * @Given the store has slideshow :title with name :name
+     */
+    public function theStoreHasSlideshowWithName($title, $name)
+    {
+        $slideshowBlock = $this->slideshowBlockExampleFactory->create(['title' => $title, 'name' => $name]);
+
+        $this->slideshowBlockManager->persist($slideshowBlock);
+        $this->slideshowBlockManager->flush();
+
+        $this->sharedStorage->set('slideshow_block', $slideshowBlock);
+    }
+
+    /**
+     * @Given /^(it) is not published yet$/
+     */
+    public function itIsNotPublishedYet(SlideshowBlock $slideshowBlock)
+    {
+        $slideshowBlock->setPublishable(false);
+
+        $this->slideshowBlockManager->flush();
+    }
+}

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingSlideshowBlocksContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingSlideshowBlocksContext.php
@@ -1,0 +1,233 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Behat\Context\Ui\Admin;
+
+use Behat\Behat\Context\Context;
+use Sylius\Behat\Page\Admin\Crud\IndexPageInterface;
+use Sylius\Behat\Page\Admin\SlideshowBlock\CreatePageInterface;
+use Sylius\Behat\Page\Admin\SlideshowBlock\UpdatePageInterface;
+use Sylius\Bundle\ContentBundle\Document\SlideshowBlock;
+use Webmozart\Assert\Assert;
+
+/**
+ * @author Videni Videni <vidy.videni@gmail.com>
+ */
+final class ManagingSlideshowBlocksContext implements Context
+{
+    /**
+     * @var IndexPageInterface
+     */
+    private $indexPage;
+
+    /**
+     * @var CreatePageInterface
+     */
+    private $createPage;
+
+    /**
+     * @var UpdatePageInterface
+     */
+    private $updatePage;
+
+    /**
+     * @param IndexPageInterface $indexPage
+     * @param CreatePageInterface $createPage
+     * @param UpdatePageInterface $updatePage
+     */
+    public function __construct(
+        IndexPageInterface $indexPage,
+        CreatePageInterface $createPage,
+        UpdatePageInterface $updatePage
+    )
+    {
+        $this->indexPage = $indexPage;
+        $this->createPage = $createPage;
+        $this->updatePage = $updatePage;
+    }
+
+    /**
+     * @Given I want to create a new slideshow block
+     * @Given I want to add a new slideshow block
+     */
+    public function iWantToCreateNewSlideShow()
+    {
+        $this->createPage->open();
+    }
+
+    /**
+     * @When I want to browse slideshow blocks of the store
+     */
+    public function iWantToBrowseSlideShowsOfTheStore()
+    {
+        $this->indexPage->open();
+    }
+
+    /**
+     * @When I set its title to :title
+     */
+    public function iSetItsTitleTo($title)
+    {
+        $this->createPage->setTitle($title);
+    }
+
+    /**
+     * @When I set its name to :name
+     */
+    public function iSetItsNameTo($name)
+    {
+        $this->createPage->setName($name);
+    }
+
+    /**
+     * @When I make it published
+     */
+    public function iMakeItPublished()
+    {
+        $this->createPage->setPublished();
+    }
+
+    /**
+     * @When I make it available from :startsDate to :endsDate
+     */
+    public function iMakeItAvailableFromTo(\DateTime $startsDate, \DateTime $endsDate)
+    {
+        $this->createPage->setPublishStartDate($startsDate);
+        $this->createPage->setPublishEndDate($endsDate);
+    }
+
+    /**
+     * @When I add a slide available from :startsDate to :endsDate
+     */
+    public function iAddASlide(\DateTime $startsDate, \DateTime $endsDate)
+    {
+        $this->createPage->addSlide($startsDate, $endsDate);
+    }
+
+    /**
+     * @When I add it
+     * @When I try to add it
+     */
+    public function iAddIt()
+    {
+        $this->createPage->create();
+    }
+
+    /**
+     * @Then /^I should be notified that (name|title) is required$/
+     */
+    public function iShouldBeNotifiedThatElementIsRequired($element)
+    {
+        Assert::same(
+            $this->createPage->getValidationMessage($element),
+            'This value should not be blank.'
+        );
+    }
+
+    /**
+     * @Then the slideshow block :title should appear in the store
+     * @Then I should see the slideshow block :title in the list
+     */
+    public function theSlideShowShouldAppearInTheStore($title)
+    {
+        if (!$this->indexPage->isOpen()) {
+            $this->indexPage->open();
+        }
+
+        Assert::true(
+            $this->indexPage->isSingleResourceOnPage(['title' => $title]),
+            sprintf('Could not find slideshow block with title "%s"!', $title)
+        );
+    }
+
+    /**
+     * @Then I should see :amount slideshow blocks in the list
+     */
+    public function iShouldSeeThatManySlideShowsInTheList($amount)
+    {
+        Assert::same(
+            (int)$amount,
+            $this->indexPage->countItems(),
+            'Amount of slideshow blocks should be equal %s, but was %2$s.'
+        );
+    }
+
+    /**
+     * @Then the slideshow block :title should not be added
+     */
+    public function theSlideShowShouldNotBeAdded($title)
+    {
+        if (!$this->indexPage->isOpen()) {
+            $this->indexPage->open();
+        }
+
+        Assert::false(
+            $this->indexPage->isSingleResourceOnPage(['title' => $title]),
+            sprintf('Slideshow with title %s was created, but it should not.', $title)
+        );
+    }
+
+    /**
+     * @Given /^I want to edit (this slideshow block)$/
+     */
+    public function iWantToEditThisSlideShow(SlideshowBlock $slideshowBlock)
+    {
+        $this->updatePage->open(['id' => $slideshowBlock->getId()]);
+    }
+
+    /**
+     * @When I change its title to :title
+     */
+    public function iChangeItsTitleTo($title)
+    {
+        $this->updatePage->changeTitleTo($title);
+    }
+
+    /**
+     * @When I save my changes
+     * @When I try to save my changes
+     */
+    public function iSaveMyChanges()
+    {
+        $this->updatePage->saveChanges();
+    }
+
+    /**
+     * @When I delete slideshow block :title
+     */
+    public function iDeleteSlideShow($title)
+    {
+        $this->indexPage->open();
+        $this->indexPage->deleteResourceOnPage(['title' => $title]);
+    }
+
+    /**
+     * @Then the slideshow block :title should no longer exist in the store
+     */
+    public function theSlideShowShouldNoLongerExistInTheStore($title)
+    {
+        Assert::false(
+            $this->indexPage->isSingleResourceOnPage(['title' => $title]),
+            sprintf('Slideshow with title %s exists, but should not.', $title)
+        );
+    }
+
+
+    /**
+     * @Then /^(this slideshow block) should have title "([^"]+)"$/
+     */
+    public function thisStaticContentShouldHaveBody(SlideshowBlock $slideshowBlock, $title)
+    {
+        $this->updatePage->open(['id' => $slideshowBlock->getId()]);
+
+        Assert::same($this->updatePage->getTitle(), $title);
+    }
+}

--- a/src/Sylius/Behat/Page/Admin/SlideshowBlock/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/SlideshowBlock/CreatePageInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Behat\Page\Admin\SlideshowBlock;
+
+use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
+
+/**
+ * @author Vidy Videni <vidy.videni@gmail.com>
+ */
+interface CreatePageInterface extends BaseCreatePageInterface
+{
+    /**
+     * @param string $title
+     */
+    public function setTitle($title);
+
+    /**
+     * @param string $name
+     */
+    public function setName($name);
+
+    /**
+     * @return bool
+     */
+    public function setPublished();
+
+    /**
+     * @param \DateTime $dateTime
+     */
+    public function setPublishStartDate(\DateTime $dateTime);
+
+    /**
+     * @param \DateTime $dateTime
+     */
+    public function setPublishEndDate(\DateTime $dateTime);
+
+    /**
+     * @param \DateTime $publishStartDate
+     * @param \DateTime $publishEndDate
+     */
+    public function addSlide(\DateTime $publishStartDate, \DateTime $publishEndDate);
+}

--- a/src/Sylius/Behat/Page/Admin/SlideshowBlock/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/SlideshowBlock/UpdatePage.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Behat\Page\Admin\SlideshowBlock;
+
+use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
+
+/**
+ * @author Vidy Videni <vidy.videni@gmail.com>
+ */
+class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function changeTitleTo($title)
+    {
+        $this->getElement('title')->setValue($title);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTitle()
+    {
+        return $this->getElement('title')->getValue();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDefinedElements()
+    {
+        return array_merge(parent::getDefinedElements(), [
+            'title' => '#sylius_slideshow_block_title',
+        ]);
+    }
+}

--- a/src/Sylius/Behat/Page/Admin/SlideshowBlock/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/SlideshowBlock/UpdatePageInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Behat\Page\Admin\SlideshowBlock;
+
+use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
+
+/**
+ * @author Vidy Videni <vidy.videni@gmail.com>
+ */
+interface UpdatePageInterface extends BaseUpdatePageInterface
+{
+    /**
+     * @param string $title
+     */
+    public function changeTitleTo($title);
+
+    /**
+     * @return string
+     */
+    public function getTitle();
+}

--- a/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
@@ -174,6 +174,14 @@
             <tag name="sylius.behat.context" />
         </service>
 
+        <service id="sylius.behat.context.setup.slideshow_block" class="Sylius\Behat\Context\Setup\SlideshowBlockContext" scope="scenario">
+            <argument type="service" id="sylius.behat.shared_storage" />
+            <argument type="service" id="sylius.fixture.example_factory.slideshow_block" container="symfony" />
+            <argument type="service" id="sylius.fixture.example_factory.imagine_block" container="symfony" />
+            <argument type="service" id="sylius.manager.slideshow_block" container="symfony" />
+            <tag name="sylius.behat.context" />
+        </service>
+
         <service id="sylius.behat.context.setup.taxation" class="Sylius\Behat\Context\Setup\TaxationContext" scope="scenario">
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="sylius.factory.tax_rate" container="symfony" />

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -170,6 +170,13 @@
             <tag name="sylius.behat.context" />
         </service>
 
+        <service id="sylius.behat.context.ui.admin.managing_slideshow_blocks" class="Sylius\Behat\Context\Ui\Admin\ManagingSlideshowBlocksContext" scope="scenario">
+            <argument type="service" id="sylius.behat.page.admin.slideshow_block.index" />
+            <argument type="service" id="sylius.behat.page.admin.slideshow_block.create" />
+            <argument type="service" id="sylius.behat.page.admin.slideshow_block.update" />
+            <tag name="sylius.behat.context" />
+        </service>
+
         <service id="sylius.behat.context.ui.admin.managing_tax_categories" class="Sylius\Behat\Context\Ui\Admin\ManagingTaxCategoriesContext" scope="scenario">
             <argument type="service" id="sylius.behat.page.admin.tax_category.index" />
             <argument type="service" id="sylius.behat.page.admin.tax_category.create" />

--- a/src/Sylius/Behat/Resources/config/services/pages/admin.xml
+++ b/src/Sylius/Behat/Resources/config/services/pages/admin.xml
@@ -32,6 +32,7 @@
         <import resource="admin/route.xml" />
         <import resource="admin/shipping_method.xml" />
         <import resource="admin/static_content.xml" />
+        <import resource="admin/slideshow_block.xml" />
         <import resource="admin/tax_category.xml" />
         <import resource="admin/tax_rate.xml" />
         <import resource="admin/taxon.xml" />

--- a/src/Sylius/Behat/Resources/config/services/pages/admin/slideshow_block.xml
+++ b/src/Sylius/Behat/Resources/config/services/pages/admin/slideshow_block.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="sylius.behat.page.admin.slideshow_block.index.class">%sylius.behat.page.admin.crud.index.class%</parameter>
+        <parameter key="sylius.behat.page.admin.slideshow_block.create.class">Sylius\Behat\Page\Admin\SlideshowBlock\CreatePage</parameter>
+        <parameter key="sylius.behat.page.admin.slideshow_block.update.class">Sylius\Behat\Page\Admin\SlideshowBlock\UpdatePage</parameter>
+    </parameters>
+
+    <services>
+        <service id="sylius.behat.page.admin.slideshow_block.index" class="%sylius.behat.page.admin.slideshow_block.index.class%" parent="sylius.behat.page.admin.crud.index" scope="scenario" public="false">
+            <argument type="string">slideshow_block</argument>
+        </service>
+        <service id="sylius.behat.page.admin.slideshow_block.create" class="%sylius.behat.page.admin.slideshow_block.create.class%" parent="sylius.behat.page.admin.crud.create" scope="scenario" public="false">
+            <argument type="string">slideshow_block</argument>
+        </service>
+        <service id="sylius.behat.page.admin.slideshow_block.update" class="%sylius.behat.page.admin.slideshow_block.update.class%" parent="sylius.behat.page.admin.crud.update" scope="scenario" public="false">
+            <argument type="string">slideshow_block</argument>
+        </service>
+    </services>
+</container>

--- a/src/Sylius/Behat/Resources/config/suites.yml
+++ b/src/Sylius/Behat/Resources/config/suites.yml
@@ -22,6 +22,7 @@ imports:
     - suites/ui/cmf/managing_routes.yml
     - suites/ui/cmf/managing_static_contents.yml
     - suites/ui/cmf/static_content.yml
+    - suites/ui/cmf/managing_slideshow_blocks.yml
     - suites/ui/channel/managing_channels.yml
     - suites/ui/channel/products_accessibility_in_multiple_channels.yml
     - suites/ui/channel/theming.yml

--- a/src/Sylius/Behat/Resources/config/suites/ui/cmf/managing_slideshow_blocks.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/cmf/managing_slideshow_blocks.yml
@@ -1,0 +1,21 @@
+# This file is part of the Sylius package.
+# (c) Paweł Jędrzejewski
+
+default:
+    suites:
+        ui_managing_slideshow_blocks:
+            contexts_as_services:
+                - sylius.behat.context.hook.doctrine_orm
+                - sylius.behat.context.hook.phpcr
+
+                - sylius.behat.context.transform.date_time
+                - sylius.behat.context.transform.shared_storage
+
+                - sylius.behat.context.setup.security
+                - sylius.behat.context.setup.slideshow_block
+
+                - sylius.behat.context.ui.admin.managing_slideshow_blocks
+                - sylius.behat.context.ui.admin.notification
+
+            filters:
+                tags: "@managing_slideshow_blocks && @ui"

--- a/src/Sylius/Bundle/AdminBundle/Menu/MainMenuBuilder.php
+++ b/src/Sylius/Bundle/AdminBundle/Menu/MainMenuBuilder.php
@@ -124,6 +124,11 @@ final class MainMenuBuilder extends AbstractAdminMenuBuilder
             ->setLabel('sylius.menu.admin.main.content.static_contents')
             ->setLabelAttribute('icon', 'file')
         ;
+        $child
+            ->addChild('slideshow_block', ['route' => 'sylius_admin_slideshow_block_index'])
+            ->setLabel('sylius.menu.admin.main.content.slideshow_block')
+            ->setLabelAttribute('icon', 'file')
+        ;
 
         $child
             ->addChild('routes', ['route' => 'sylius_admin_route_index'])

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
@@ -16,6 +16,7 @@ imports:
     - { resource: "@SyliusAdminBundle/Resources/config/grids/route.yml" }
     - { resource: "@SyliusAdminBundle/Resources/config/grids/shipping_method.yml" }
     - { resource: "@SyliusAdminBundle/Resources/config/grids/static_content.yml" }
+    - { resource: "@SyliusAdminBundle/Resources/config/grids/slideshow_block.yml" }
     - { resource: "@SyliusAdminBundle/Resources/config/grids/tax_category.yml" }
     - { resource: "@SyliusAdminBundle/Resources/config/grids/tax_rate.yml" }
     - { resource: "@SyliusAdminBundle/Resources/config/grids/taxon.yml" }

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/slideshow_block.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/slideshow_block.yml
@@ -1,0 +1,30 @@
+sylius_grid:
+    grids:
+        sylius_admin_slideshow_block:
+            driver:
+                name: doctrine/phpcr-odm
+                options:
+                    class: "%sylius.model.slideshow_block.class%"
+            fields:
+                name:
+                    type: string
+                    label: sylius.ui.name
+                title:
+                    type: string
+                    label: sylius.ui.title
+            filters:
+                title:
+                    type: string
+                    label: sylius.ui.title
+                name:
+                    type: string
+                    label: sylius.ui.body
+            actions:
+                main:
+                    create:
+                        type: create
+                item:
+                    update:
+                        type: update
+                    delete:
+                        type: delete

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing.yml
@@ -66,6 +66,9 @@ sylius_admin_shipping_method:
 sylius_admin_static_content:
     resource: "@SyliusAdminBundle/Resources/config/routing/static_content.yml"
 
+sylius_admin_slideshow_block:
+    resource: "@SyliusAdminBundle/Resources/config/routing/slideshow_block.yml"
+
 sylius_admin_taxon:
     resource: "@SyliusAdminBundle/Resources/config/routing/taxon.yml"
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/slideshow_block.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/slideshow_block.yml
@@ -1,0 +1,42 @@
+sylius_admin_slideshow_block:
+    resource: |
+        alias: sylius.slideshow_block
+        section: admin
+        templates: SyliusAdminBundle:Crud
+        except: ['show', 'update', 'delete']
+        redirect: index
+        grid: sylius_admin_slideshow_block
+        permission: true
+        vars:
+            all:
+                templates:
+                    form: SyliusAdminBundle:SlideshowBlock:_form.html.twig
+
+    type: sylius.resource
+
+sylius_admin_slideshow_block_update:
+    path: /slideshow/{id}/edit
+    methods: [GET, PUT]
+    defaults:
+        _controller: sylius.controller.slideshow_block:updateAction
+        _sylius:
+            section: admin
+            permission: true
+            template: SyliusAdminBundle:Crud:update.html.twig
+            vars:
+                templates:
+                    form: SyliusAdminBundle:SlideshowBlock:_form.html.twig
+                    breadcrumb: SyliusAdminBundle:SlideshowBlock/Breadcrumb:_update.html.twig
+    requirements:
+        id: ".+"
+
+sylius_admin_slideshow_block_delete:
+    path: /slideshow/{id}
+    methods: [DELETE]
+    defaults:
+        _controller: sylius.controller.slideshow_block:deleteAction
+        _sylius:
+            section: admin
+            permission: true
+    requirements:
+        id: ".+"

--- a/src/Sylius/Bundle/AdminBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/translations/messages.en.yml
@@ -33,3 +33,4 @@ sylius:
                     header: Content
                     static_contents: Static contents
                     routes: Routes
+                    slideshow_block: Slideshows

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/SlideshowBlock/Breadcrumb/_update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/SlideshowBlock/Breadcrumb/_update.html.twig
@@ -1,0 +1,8 @@
+{% import 'SyliusAdminBundle:Crud/Macro:breadcrumb.html.twig' as breadcrumb %}
+
+{{ breadcrumb.crumble([
+    { label: 'sylius.ui.administration'|trans, url: path('sylius_admin_dashboard') },
+    { label: 'sylius.ui.slideshow'|trans, url: path('sylius_admin_customer_index') },
+    { label: resource.title },
+    { label: 'sylius.ui.edit'|trans }
+]) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/SlideshowBlock/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/SlideshowBlock/_form.html.twig
@@ -1,4 +1,3 @@
-{% import 'SyliusUiBundle:Macro:common.html.twig' as common %}
 
 {{ form_errors(form) }}
 
@@ -9,7 +8,10 @@
         {{ form_row(form.publishable) }}
         {{ form_row(form.publishStartDate) }}
         {{ form_row(form.publishEndDate) }}
-        {{ common.readonly(form.parentDocument,form.parentDocument.vars.value,'/cms/blocks') }}
+
+        <div style="display: none">
+            {{ form_widget(form.parentDocument) }}
+        </div>
     </div>
     <div class="thirteen wide column">
         {{ form_row(form.children) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/SlideshowBlock/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/SlideshowBlock/_form.html.twig
@@ -1,0 +1,18 @@
+{% import 'SyliusUiBundle:Macro:common.html.twig' as common %}
+
+{{ form_errors(form) }}
+
+<div class="ui stackable grid">
+    <div class="three wide column">
+        {{ form_row(form.name) }}
+        {{ form_row(form.title) }}
+        {{ form_row(form.publishable) }}
+        {{ form_row(form.publishStartDate) }}
+        {{ form_row(form.publishEndDate) }}
+        {{ common.readonly(form.parentDocument,form.parentDocument.vars.value,'/cms/blocks') }}
+    </div>
+    <div class="thirteen wide column">
+        {{ form_row(form.children) }}
+    </div>
+</div>
+

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/StaticContent/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/StaticContent/_form.html.twig
@@ -4,6 +4,7 @@
     <div class="three wide column">
         {{ form_row(form.publishable) }}
         {{ form_row(form.name) }}
+
     </div>
     <div class="thirteen wide column">
         {{ form_row(form.title) }}

--- a/src/Sylius/Bundle/ContentBundle/Document/SlideshowBlock.php
+++ b/src/Sylius/Bundle/ContentBundle/Document/SlideshowBlock.php
@@ -11,12 +11,23 @@
 
 namespace Sylius\Bundle\ContentBundle\Document;
 
+use Sonata\BlockBundle\Model\BlockInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Symfony\Cmf\Bundle\BlockBundle\Doctrine\Phpcr\SlideshowBlock as BaseSlideshowBlock;
 
 /**
  * @author Magdalena Banasiak <magdalena.banasiak@lakion.com>
+ * @author Vidy Videni <vidy.videni@gmail.com>
  */
 class SlideshowBlock extends BaseSlideshowBlock implements ResourceInterface
 {
+    /**
+     * @inheritdoc
+     */
+    public function addChild(BlockInterface $child, $key = null)
+    {
+        parent::addChild($child,$key);
+
+        $child->setParent($this);
+    }
 }

--- a/src/Sylius/Bundle/ContentBundle/Factory/SlideshowBlockFactory.php
+++ b/src/Sylius/Bundle/ContentBundle/Factory/SlideshowBlockFactory.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ContentBundle\Factory;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Sylius\Bundle\ContentBundle\Document\SlideshowBlock;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+
+/**
+ * @author Vidy Videni <vidy.videni@gmail.com>
+ */
+final class SlideshowBlockFactory implements FactoryInterface
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $decoratedFactory;
+
+    /**
+     * @var ObjectManager
+     */
+    private $documentManager;
+
+    /**
+     * @var string
+     */
+    private $blockParentPath;
+
+    /**
+     * @param FactoryInterface $decoratedFactory
+     * @param ObjectManager $documentManager
+     * @param string $staticContentParentPath
+     */
+    public function __construct(FactoryInterface $decoratedFactory, ObjectManager $documentManager, $blockParentPath)
+    {
+        $this->decoratedFactory = $decoratedFactory;
+        $this->documentManager = $documentManager;
+        $this->blockParentPath = $blockParentPath;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createNew()
+    {
+        /** @var SlideshowBlock $slideshowBlock */
+        $slideshowBlock = $this->decoratedFactory->createNew();
+
+        $slideshowBlock->setParentDocument($this->documentManager->find(null, $this->blockParentPath));
+
+        return $slideshowBlock;
+    }
+}

--- a/src/Sylius/Bundle/ContentBundle/Form/Type/ImagineBlockType.php
+++ b/src/Sylius/Bundle/ContentBundle/Form/Type/ImagineBlockType.php
@@ -72,15 +72,17 @@ class ImagineBlockType extends AbstractResourceType
             ->add('publishStartDate', 'datetime', [
                 'label' => 'sylius.form.imagine_block.publish_start_date',
                 'empty_value' => /* @Ignore */ ['year' => '-', 'month' => '-', 'day' => '-'],
-                'time_widget' => 'text',
-            ])
+                'date_widget' => 'single_text',
+                'time_widget' => 'single_text',            ])
             ->add('publishEndDate', 'datetime', [
                 'label' => 'sylius.form.imagine_block.publish_end_date',
                 'empty_value' => /* @Ignore */ ['year' => '-', 'month' => '-', 'day' => '-'],
-                'time_widget' => 'text',
+                'date_widget' => 'single_text',
+                'time_widget' => 'single_text',
             ])
             ->add('parentDocument', null, [
                 'label' => 'sylius.form.imagine_block.parent',
+                'required' => false,
             ])
             ->add('name', 'text', [
                 'label' => 'sylius.form.imagine_block.internal_name',

--- a/src/Sylius/Bundle/ContentBundle/Form/Type/ImagineBlockType.php
+++ b/src/Sylius/Bundle/ContentBundle/Form/Type/ImagineBlockType.php
@@ -40,8 +40,8 @@ class ImagineBlockType extends AbstractResourceType
     /**
      * ImagineBlockType constructor.
      *
-     * @param string $dataClass
-     * @param array $validationGroups
+     * @param string              $dataClass
+     * @param array               $validationGroups
      * @param FilterConfiguration $filterConfiguration
      */
     public function __construct(
@@ -61,22 +61,26 @@ class ImagineBlockType extends AbstractResourceType
     {
         $filters = [];
 
-        foreach (array_keys($this->filterConfiguration->all()) as $filter) {
-            $filters[$filter] = sprintf('sylius.form.imagine_block.filter.%s', $filter);
+        foreach ($this->filterConfiguration->all() as $filter => $config) {
+            if (isset($config['data_loader']) && 'cmf_media_doctrine_phpcr' == $config['data_loader']) {
+                $filters[$filter] = sprintf('sylius.form.imagine_block.filter.%s', $filter);
+            }
         }
 
         $builder
             ->add('publishable', null, [
                 'label' => 'sylius.form.imagine_block.publishable',
-                ])
+            ])
             ->add('publishStartDate', 'datetime', [
                 'label' => 'sylius.form.imagine_block.publish_start_date',
-                'empty_value' => /* @Ignore */ ['year' => '-', 'month' => '-', 'day' => '-'],
+                'empty_value' => /* @Ignore */
+                    ['year' => '-', 'month' => '-', 'day' => '-'],
                 'date_widget' => 'single_text',
-                'time_widget' => 'single_text',            ])
+                'time_widget' => 'single_text', ])
             ->add('publishEndDate', 'datetime', [
                 'label' => 'sylius.form.imagine_block.publish_end_date',
-                'empty_value' => /* @Ignore */ ['year' => '-', 'month' => '-', 'day' => '-'],
+                'empty_value' => /* @Ignore */
+                    ['year' => '-', 'month' => '-', 'day' => '-'],
                 'date_widget' => 'single_text',
                 'time_widget' => 'single_text',
             ])
@@ -104,8 +108,7 @@ class ImagineBlockType extends AbstractResourceType
                 'label' => 'sylius.form.imagine_block.image',
                 'attr' => ['class' => 'imagine-thumbnail'],
                 'required' => false,
-            ])
-        ;
+            ]);
     }
 
     /**

--- a/src/Sylius/Bundle/ContentBundle/Form/Type/SlideshowBlockType.php
+++ b/src/Sylius/Bundle/ContentBundle/Form/Type/SlideshowBlockType.php
@@ -52,12 +52,14 @@ class SlideshowBlockType extends AbstractResourceType
             ->add('publishStartDate', 'datetime', [
                 'label' => 'sylius.form.slideshow_block.publish_start_date',
                 'empty_value' => /* @Ignore */ ['year' => '-', 'month' => '-', 'day' => '-'],
-                'time_widget' => 'text',
+                'date_widget' => 'single_text',
+                'time_widget' => 'single_text',
             ])
             ->add('publishEndDate', 'datetime', [
                 'label' => 'sylius.form.slideshow_block.publish_end_date',
                 'empty_value' => /* @Ignore */ ['year' => '-', 'month' => '-', 'day' => '-'],
-                'time_widget' => 'text',
+                'date_widget' => 'single_text',
+                'time_widget' => 'single_text',
             ])
         ;
     }

--- a/src/Sylius/Bundle/ContentBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ContentBundle/Resources/config/services.xml
@@ -19,6 +19,12 @@
             <argument>%cmf_content.persistence.phpcr.content_basepath%</argument>
         </service>
 
+        <service id="sylius.factory.slideshow_block.parent_path" class="Sylius\Bundle\ContentBundle\Factory\SlideshowBlockFactory" decorates="sylius.factory.slideshow_block">
+            <argument type="service" id="sylius.factory.slideshow_block.parent_path.inner" />
+            <argument type="service" id="doctrine_phpcr.odm.document_manager" />
+            <argument>%cmf_block.persistence.phpcr.block_basepath%</argument>
+        </service>
+
         <service id="sylius.factory.route.parent_path" class="Sylius\Bundle\ContentBundle\Factory\RouteFactory" decorates="sylius.factory.route">
             <argument type="service" id="sylius.factory.route.parent_path.inner" />
             <argument type="service" id="doctrine_phpcr.odm.document_manager" />

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ImagineBlockExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ImagineBlockExampleFactory.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Fixture\Factory;
+
+use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
+use Sylius\Bundle\ContentBundle\Document\ImagineBlock;
+use Sylius\Component\Core\Formatter\StringInflector;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Vidy Videni <vidy.videni@gmail.com>
+ */
+final class ImagineBlockExampleFactory implements ExampleFactoryInterface
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $imagineBlockFactory;
+
+    /**
+     * @var \Faker\Generator
+     */
+    private $faker;
+
+    /**
+     * @var OptionsResolver
+     */
+    private $optionsResolver;
+
+    private $filterConfiguration;
+    /**
+     * @param FactoryInterface $imagineBlockFactory
+     */
+    public function __construct(FactoryInterface $imagineBlockFactory,FilterConfiguration $filterConfiguration)
+    {
+        $this->imagineBlockFactory = $imagineBlockFactory;
+        $this->filterConfiguration = $filterConfiguration;
+
+        $this->faker = \Faker\Factory::create();
+        $this->optionsResolver =
+            (new OptionsResolver())
+                ->setDefault('label', function (Options $options) {
+                    return $this->faker->words(3, true);
+                })
+                ->setDefault('name', function (Options $options) {
+                    return StringInflector::nameToCode($options['title']);
+                })
+                ->setDefault('publishable', function (Options $options) {
+                    return $this->faker->boolean(90);
+                })
+                ->setDefault('filter', function (Options $options) {
+                    return $this->faker->randomElement($this->filterConfiguration->all());
+                })
+                ->setDefault('publishStartDate', function (Options $options) {
+                    return $this->faker->dateTimeBetween('-30 days','30 days');
+                }) ->setDefault('publishEndDate', function (Options $options) {
+                    return $this->faker->dateTimeBetween('-30 days','30 days');
+                })
+                ->setRequired('image')
+                ->setAllowedTypes('publishable', 'bool')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(array $options = [])
+    {
+        $options = $this->optionsResolver->resolve($options);
+
+        /** @var ImagineBlock $imagineBlock */
+        $imagineBlock = $this->imagineBlockFactory->createNew();
+        $imagineBlock->setLabel($options['label']);
+        $imagineBlock->setName($options['name']);
+        $imagineBlock->setPublishable($options['publishable']);
+        $imagineBlock->setPublishStartDate($options['publishStartDate']);
+        $imagineBlock->setPublishEndDate($options['publishEndDate']);
+
+
+        return $imagineBlock;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ImagineBlockExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ImagineBlockExampleFactory.php
@@ -15,6 +15,8 @@ use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 use Sylius\Bundle\ContentBundle\Document\ImagineBlock;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Resource\Factory\FactoryInterface;
+use Symfony\Cmf\Bundle\BlockBundle\Model\AbstractBlock;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -42,7 +44,7 @@ final class ImagineBlockExampleFactory implements ExampleFactoryInterface
     /**
      * @param FactoryInterface $imagineBlockFactory
      */
-    public function __construct(FactoryInterface $imagineBlockFactory,FilterConfiguration $filterConfiguration)
+    public function __construct(FactoryInterface $imagineBlockFactory, FilterConfiguration $filterConfiguration)
     {
         $this->imagineBlockFactory = $imagineBlockFactory;
         $this->filterConfiguration = $filterConfiguration;
@@ -63,12 +65,14 @@ final class ImagineBlockExampleFactory implements ExampleFactoryInterface
                     return $this->faker->randomElement($this->filterConfiguration->all());
                 })
                 ->setDefault('publishStartDate', function (Options $options) {
-                    return $this->faker->dateTimeBetween('-30 days','30 days');
-                }) ->setDefault('publishEndDate', function (Options $options) {
-                    return $this->faker->dateTimeBetween('-30 days','30 days');
+                    return $this->faker->dateTimeBetween('-30 days','now');
+                })->setDefault('publishEndDate', function (Options $options) {
+                    return $this->faker->dateTimeBetween('now', '30 days');
                 })
-                ->setRequired('image')
+                ->setRequired(['image', 'parentDocument'])
+                ->setAllowedTypes('parentDocument')
                 ->setAllowedTypes('publishable', 'bool')
+                ->setAllowedTypes('parentDocument', AbstractBlock::class)
         ;
     }
 
@@ -86,7 +90,10 @@ final class ImagineBlockExampleFactory implements ExampleFactoryInterface
         $imagineBlock->setPublishable($options['publishable']);
         $imagineBlock->setPublishStartDate($options['publishStartDate']);
         $imagineBlock->setPublishEndDate($options['publishEndDate']);
+        $imagineBlock->setParentDocument($options['parentDocument']);
 
+        $imagePath = $options['image'];
+        $imagineBlock->setImage(new UploadedFile($imagePath, basename($imagePath)));
 
         return $imagineBlock;
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ImagineBlockExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ImagineBlockExampleFactory.php
@@ -69,6 +69,7 @@ final class ImagineBlockExampleFactory implements ExampleFactoryInterface
                 })->setDefault('publishEndDate', function (Options $options) {
                     return $this->faker->dateTimeBetween('now', '30 days');
                 })
+                ->setDefault('linkUrl','')
                 ->setRequired(['image', 'parentDocument'])
                 ->setAllowedTypes('parentDocument')
                 ->setAllowedTypes('publishable', 'bool')
@@ -91,6 +92,7 @@ final class ImagineBlockExampleFactory implements ExampleFactoryInterface
         $imagineBlock->setPublishStartDate($options['publishStartDate']);
         $imagineBlock->setPublishEndDate($options['publishEndDate']);
         $imagineBlock->setParentDocument($options['parentDocument']);
+        $imagineBlock->setLinkUrl($options['linkUrl']);
 
         $imagePath = $options['image'];
         $imagineBlock->setImage(new UploadedFile($imagePath, basename($imagePath)));

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/SlideShowBlockExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/SlideShowBlockExampleFactory.php
@@ -70,9 +70,9 @@ final class SlideShowBlockExampleFactory implements ExampleFactoryInterface
                     return '/cms/blocks';
                 })
                 ->setDefault('publishStartDate', function (Options $options) {
-                    return $this->faker->dateTimeBetween('-30 days', '30 days');
+                    return $this->faker->dateTimeBetween('-30 days','now');
                 })->setDefault('publishEndDate', function (Options $options) {
-                    return $this->faker->dateTimeBetween('-30 days', '30 days');
+                    return $this->faker->dateTimeBetween('now', '30 days');
                 })
                 ->setAllowedTypes('publishable', 'bool');
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/SlideShowBlockExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/SlideShowBlockExampleFactory.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Fixture\Factory;
+
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Sylius\Bundle\ContentBundle\Document\SlideshowBlock;
+use Sylius\Component\Core\Formatter\StringInflector;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Vidy Videni <vidy.videni@gmail.com>
+ */
+final class SlideShowBlockExampleFactory implements ExampleFactoryInterface
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $slideshowBlockFactory;
+
+    /**
+     * @var \Faker\Generator
+     */
+    private $faker;
+
+    /**
+     * @var OptionsResolver
+     */
+    private $optionsResolver;
+
+    /**
+     * @var DocumentManager
+     */
+    private $documentManager;
+
+    /**
+     * @param FactoryInterface $slideshowBlockFactory
+     */
+    public function __construct(FactoryInterface $slideshowBlockFactory, DocumentManager $documentManager)
+    {
+        $this->slideshowBlockFactory = $slideshowBlockFactory;
+        $this->documentManager = $documentManager;
+
+        $this->faker = \Faker\Factory::create();
+        $this->optionsResolver =
+            (new OptionsResolver())
+                ->setDefault('title', function (Options $options) {
+                    return $this->faker->words(3, true);
+                })
+                ->setDefault('name', function (Options $options) {
+                    return StringInflector::nameToCode($options['title']);
+                })
+                ->setDefault('publishable', function (Options $options) {
+                    return $this->faker->boolean(90);
+                })
+                ->setDefault('enabled', function (Options $options) {
+                    return $this->faker->boolean(90);
+                })
+                ->setDefault('parent', function (Options $options) {
+                    return '/cms/blocks';
+                })
+                ->setDefault('publishStartDate', function (Options $options) {
+                    return $this->faker->dateTimeBetween('-30 days', '30 days');
+                })->setDefault('publishEndDate', function (Options $options) {
+                    return $this->faker->dateTimeBetween('-30 days', '30 days');
+                })
+                ->setAllowedTypes('publishable', 'bool');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create(array $options = [])
+    {
+        $options = $this->optionsResolver->resolve($options);
+
+        /** @var SlideshowBlock $slideshowBlock */
+        $slideshowBlock = $this->slideshowBlockFactory->createNew();
+        $slideshowBlock->setTitle($options['title']);
+        $slideshowBlock->setName($options['name']);
+        $slideshowBlock->setPublishable($options['publishable']);
+        $slideshowBlock->setEnabled($options['enabled']);
+        $slideshowBlock->setPublishStartDate($options['publishStartDate']);
+        $slideshowBlock->setPublishEndDate($options['publishEndDate']);
+
+        $parentDocument = $this->documentManager->find(null, $options['parent']);
+
+        $slideshowBlock->setParentDocument($parentDocument);
+
+        return $slideshowBlock;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Fixture/SlideshowBlockFixtures.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/SlideshowBlockFixtures.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Sylius\Bundle\CoreBundle\Fixture;
+
+use Sylius\Bundle\CoreBundle\Fixture\Factory\ImagineBlockExampleFactory;
+use Sylius\Bundle\CoreBundle\Fixture\Factory\SlideShowBlockExampleFactory;
+use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+/**
+ * @author Vidy Videni<videni@foxmail.com>
+ */
+final class SlideshowBlockFixtures extends AbstractFixture
+{
+    /**
+     * @var SlideShowBlockExampleFactory
+     */
+    private $slideShowBlockExampleFactory;
+
+    /**
+     * @var ImagineBlockExampleFactory
+     */
+    private $imagineBlockExampleFactory;
+
+    /**
+     * @var RepositoryInterface
+     */
+    protected $slideshowBlockRepository;
+
+    public function __construct(SlideShowBlockExampleFactory $slideShowBlockExampleFactory,
+                                ImagineBlockExampleFactory $imagineBlockExampleFactory,
+                                RepositoryInterface $slideshowBlockRepository
+    ) {
+        $this->slideShowBlockExampleFactory = $slideShowBlockExampleFactory;
+        $this->imagineBlockExampleFactory = $imagineBlockExampleFactory;
+        $this->slideshowBlockRepository = $slideshowBlockRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'slideshow_block';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $options)
+    {
+        $slideshowBlock = $this->slideShowBlockExampleFactory->create([
+            'name' => 'slideshow-home',
+            'enabled' => true,
+            'publishable' => true,
+
+        ]);
+
+        foreach (['books.jpg', 'stickers.jpg', 'mugs.jpg'] as $image) {
+            $imagePath = sprintf('%s/../Resources/fixtures/%s', __DIR__, $image);
+
+            $info = pathinfo($imagePath);
+            $fileName = basename($imagePath, '.'.$info['extension']);
+
+            $imagineBlock = $this->imagineBlockExampleFactory->create([
+                'label' => $fileName,
+                'name' => $fileName,
+                'publishable' => true,
+                'image' => $imagePath,
+                'parentDocument' => $slideshowBlock,
+            ]);
+
+            $slideshowBlock->addChild($imagineBlock);
+        }
+
+        $this->slideshowBlockRepository->add($slideshowBlock);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Fixture/SlideshowBlockFixtures.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/SlideshowBlockFixtures.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sylius\Bundle\CoreBundle\Fixture;
 
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ImagineBlockExampleFactory;

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures.yml
@@ -11,6 +11,7 @@ sylius_fixtures:
             fixtures:
                 locale: ~
                 currency: ~
+                slideshow_block: ~
 
                 geographical:
                     options:

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/fixtures.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/fixtures.xml
@@ -174,5 +174,12 @@
             <argument type="service" id="sylius.rbac.initializer" />
             <tag name="sylius_fixtures.fixture" />
         </service>
+
+        <service id="sylius.fixture.slideshow_block" class="Sylius\Bundle\CoreBundle\Fixture\SlideshowBlockFixtures">
+            <argument type="service" id="sylius.fixture.example_factory.slideshow_block"/>
+            <argument type="service" id="sylius.fixture.example_factory.imagine_block"/>
+            <argument type="service" id="sylius.repository.slideshow_block"/>
+            <tag name="sylius_fixtures.fixture"/>
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/fixtures_factories.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/fixtures_factories.xml
@@ -102,6 +102,16 @@
             <argument type="service" id="sylius.factory.static_content" />
         </service>
 
+        <service id="sylius.fixture.example_factory.slideshow_block" class="Sylius\Bundle\CoreBundle\Fixture\Factory\SlideShowBlockExampleFactory">
+            <argument type="service" id="sylius.factory.slideshow_block" />
+            <argument type="service" id="doctrine_phpcr.odm.default_document_manager"/>
+        </service>
+
+        <service id="sylius.fixture.example_factory.imagine_block" class="Sylius\Bundle\CoreBundle\Fixture\Factory\ImagineBlockExampleFactory">
+            <argument type="service" id="sylius.factory.imagine_block" />
+            <argument type="service" id="liip_imagine.filter.configuration"/>
+        </service>
+
         <service id="sylius.fixture.example_factory.route" class="Sylius\Bundle\CoreBundle\Fixture\Factory\RouteExampleFactory">
             <argument type="service" id="sylius.factory.route" />
             <argument type="service" id="sylius.repository.static_content" />

--- a/src/Sylius/Bundle/ResourceBundle/Doctrine/ODM/PHPCR/EventListener/NameResolverListener.php
+++ b/src/Sylius/Bundle/ResourceBundle/Doctrine/ODM/PHPCR/EventListener/NameResolverListener.php
@@ -55,7 +55,7 @@ class NameResolverListener
 
         if ($metadata->idGenerator !== ClassMetadata::GENERATOR_TYPE_PARENT) {
             throw new \RuntimeException(sprintf(
-'Document of class "%s" must be using the GENERATOR_TYPE_PARENT identificatio strategy (value %s), it is current using "%s" (this may be an automatic configuration: be sure to map both the `nodename` and the `parentDocument`).',
+'Document of class "%s" must be using the GENERATOR_TYPE_PARENT identification strategy (value %s), it is current using "%s" (this may be an automatic configuration: be sure to map both the `nodename` and the `parentDocument`).',
                 get_class($document),
                 ClassMetadata::GENERATOR_TYPE_PARENT,
                 $metadata->idGenerator

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -196,3 +196,18 @@
         {% endfor %}
     </div>
 {%- endblock sylius_translations_row %}
+
+{% block sylius_imagine_block_widget %}
+    {{ form_row(form.name) }}
+    {{ form_row(form.label) }}
+    {{ form_row(form.publishable) }}
+    {{ form_row(form.publishStartDate) }}
+    {{ form_row(form.publishEndDate) }}
+    {{ form_row(form.linkUrl) }}
+    {{ form_row(form.filter) }}
+    {{ form_row(form.image) }}
+
+    <div style="display: none">
+        {{ form_row(form.parentDocument) }}
+    </div>
+{% endblock %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Macro/common.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Macro/common.html.twig
@@ -5,3 +5,11 @@
         {%- endif -%}
     {%- endfor -%}
 {% endmacro %}
+
+{% macro readonly(field, value, default_value) %}
+    {% if value == '' %}
+        {{ form_row(field, {'attr': {'class': 'input-lg', 'value': default_value|default(''), 'readonly': 'readonly'}}) }}
+    {% else %}
+        {{ form_row(field, {'label_attr': {'class': 'hidden'},'attr': {'class': 'hidden'}}) }}
+    {% endif %}
+{% endmacro %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Macro/common.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Macro/common.html.twig
@@ -5,11 +5,3 @@
         {%- endif -%}
     {%- endfor -%}
 {% endmacro %}
-
-{% macro readonly(field, value, default_value) %}
-    {% if value == '' %}
-        {{ form_row(field, {'attr': {'class': 'input-lg', 'value': default_value|default(''), 'readonly': 'readonly'}}) }}
-    {% else %}
-        {{ form_row(field, {'label_attr': {'class': 'hidden'},'attr': {'class': 'hidden'}}) }}
-    {% endif %}
-{% endmacro %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | Yes |
| BC breaks? | no |
| License | MIT |

Todo:
- [x] When saving SlideshowBlock and ImagineBlock , automatically set the SlideshowBlock as the parent of ImagineBlock
- [x] Hide parentDocument form field for cmf block
- [x]  Only display filters whose data_loader is cmf_media_doctrine_phpcr for ImagineBlockType
- [ ] Correct Behat feature to test image upload for slideshow block 
