### PR TITLE
Allow setting theme name in Channel fixtures

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/ChannelFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ChannelFixture.php
@@ -45,6 +45,7 @@ final class ChannelFixture extends AbstractResourceFixture
                 ->arrayNode('currencies')->prototype('scalar')->end()->end()
                 ->arrayNode('payment_methods')->prototype('scalar')->end()->end()
                 ->arrayNode('shipping_methods')->prototype('scalar')->end()->end()
+                ->scalarNode('theme_name')->end()
         ;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -100,6 +100,7 @@ final class ChannelExampleFactory implements ExampleFactoryInterface
                 ->setDefault('shipping_methods', LazyOption::all($shippingMethodRepository))
                 ->setAllowedTypes('shipping_methods', 'array')
                 ->setNormalizer('shipping_methods', LazyOption::findBy($shippingMethodRepository, 'code'))
+                ->setDefault('theme_name', null)
         ;
     }
 
@@ -117,6 +118,7 @@ final class ChannelExampleFactory implements ExampleFactoryInterface
         $channel->setEnabled($options['enabled']);
         $channel->setColor($options['color']);
         $channel->setTaxCalculationStrategy($options['tax_calculation_strategy']);
+        $channel->setThemeName($options['theme_name']);
 
         $channel->setDefaultLocale($options['default_locale']);
         foreach ($options['locales'] as $locale) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | no
| License         | MIT

This PR enables the possibility to set the theme name in the fixtures as follows:

```yml
sylius_fixtures:
    suites:
        default:
            listeners:
                orm_purger: ~
                logger: ~

            fixtures:
                channel:
                    options:
                        custom:
                            us_web_store:
                                name: US Web Store
                                locales:
                                    - "%locale%"
                                currencies:
                                    - "%currency%"
                                shipping_methods:
                                    - ups
                                    - dhl_express
                                    - fedex
                                payment_methods:
                                    - cash_on_delivery
                                    - bank_transfer
                                theme_name: vendor/theme-name
```

