### PR TITLE
[RFC] Identifable User abstaction

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.IdentifiableUser.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.IdentifiableUser.yml
@@ -1,0 +1,2 @@
+Sylius\Component\Core\Model\IdentifiableUser:
+    exclusion_policy: ALL

--- a/src/Sylius/Component/Core/Model/AdminUser.php
+++ b/src/Sylius/Component/Core/Model/AdminUser.php
@@ -11,74 +11,9 @@
 
 namespace Sylius\Component\Core\Model;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Sylius\Component\Rbac\Model\RoleInterface;
-use Sylius\Component\User\Model\User;
-
 /**
  * @author Arkadiusz Krakowiak <arkadiusz.krakowiak@lakion.com>
  */
-class AdminUser extends User implements AdminUserInterface
+class AdminUser extends IdentifiableUser implements AdminUserInterface
 {
-    /**
-     * @var ArrayCollection
-     */
-    protected $authorizationRoles;
-
-    public function __construct()
-    {
-        parent::__construct();
-
-        $this->authorizationRoles = new ArrayCollection();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getAuthorizationRoles()
-    {
-        return $this->authorizationRoles;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function addAuthorizationRole(RoleInterface $role)
-    {
-        if (!$this->hasAuthorizationRole($role)) {
-            $this->authorizationRoles->add($role);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function removeAuthorizationRole(RoleInterface $role)
-    {
-        if ($this->hasAuthorizationRole($role)) {
-            $this->authorizationRoles->removeElement($role);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasAuthorizationRole(RoleInterface $role)
-    {
-        return $this->authorizationRoles->contains($role);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getRoles()
-    {
-        $roles = parent::getRoles();
-
-        foreach ($this->getAuthorizationRoles() as $role) {
-            $roles = array_merge($roles, $role->getSecurityRoles());
-        }
-
-        return $roles;
-    }
 }

--- a/src/Sylius/Component/Core/Model/AdminUserInterface.php
+++ b/src/Sylius/Component/Core/Model/AdminUserInterface.php
@@ -11,29 +11,9 @@
 
 namespace Sylius\Component\Core\Model;
 
-use Sylius\Component\Rbac\Model\IdentityInterface;
-use Sylius\Component\Rbac\Model\RoleInterface;
-use Sylius\Component\User\Model\UserInterface as BaseUserInterface;
-
 /**
  * @author Arkadiusz Krakowiak <arkadiusz.krakowiak@lakion.com>
  */
-interface AdminUserInterface extends BaseUserInterface, IdentityInterface
+interface AdminUserInterface extends IdentifiableUserInterface
 {
-    /**
-     * @param RoleInterface $role
-     */
-    public function addAuthorizationRole(RoleInterface $role);
-
-    /**
-     * @param RoleInterface $role
-     */
-    public function removeAuthorizationRole(RoleInterface $role);
-
-    /**
-     * @param RoleInterface $role
-     *
-     * @return bool
-     */
-    public function hasAuthorizationRole(RoleInterface $role);
 }

--- a/src/Sylius/Component/Core/Model/IdentifiableUser.php
+++ b/src/Sylius/Component/Core/Model/IdentifiableUser.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Model;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Sylius\Component\Rbac\Model\RoleInterface;
+use Sylius\Component\User\Model\User;
+
+/**
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ */
+abstract class IdentifiableUser extends User implements IdentifiableUserInterface
+{
+    /**
+     * @var ArrayCollection
+     */
+    protected $authorizationRoles;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->authorizationRoles = new ArrayCollection();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAuthorizationRoles()
+    {
+        return $this->authorizationRoles;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAuthorizationRole(RoleInterface $role)
+    {
+        if (!$this->hasAuthorizationRole($role)) {
+            $this->authorizationRoles->add($role);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeAuthorizationRole(RoleInterface $role)
+    {
+        if ($this->hasAuthorizationRole($role)) {
+            $this->authorizationRoles->removeElement($role);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasAuthorizationRole(RoleInterface $role)
+    {
+        return $this->authorizationRoles->contains($role);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRoles()
+    {
+        $roles = parent::getRoles();
+
+        foreach ($this->getAuthorizationRoles() as $role) {
+            $roles = array_merge($roles, $role->getSecurityRoles());
+        }
+
+        return $roles;
+    }
+}

--- a/src/Sylius/Component/Core/Model/IdentifiableUserInterface.php
+++ b/src/Sylius/Component/Core/Model/IdentifiableUserInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Model;
+
+use Sylius\Component\Rbac\Model\IdentityInterface;
+use Sylius\Component\Rbac\Model\RoleInterface;
+use Sylius\Component\User\Model\UserInterface;
+
+/**
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ */
+interface IdentifiableUserInterface extends UserInterface, IdentityInterface
+{
+    /**
+     * @param RoleInterface $role
+     */
+    public function addAuthorizationRole(RoleInterface $role);
+
+    /**
+     * @param RoleInterface $role
+     */
+    public function removeAuthorizationRole(RoleInterface $role);
+
+    /**
+     * @param RoleInterface $role
+     *
+     * @return bool
+     */
+    public function hasAuthorizationRole(RoleInterface $role);
+}

--- a/src/Sylius/Component/Core/Model/ShopUser.php
+++ b/src/Sylius/Component/Core/Model/ShopUser.php
@@ -13,20 +13,14 @@ namespace Sylius\Component\Core\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Sylius\Component\Customer\Model\CustomerInterface as BaseCustomerInterface;
-use Sylius\Component\Rbac\Model\RoleInterface;
-use Sylius\Component\User\Model\User as BaseUser;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class ShopUser extends BaseUser implements ShopUserInterface
+class ShopUser extends IdentifiableUser implements ShopUserInterface
 {
-    /**
-     * @var ArrayCollection
-     */
-    protected $authorizationRoles;
-
     /**
      * @var CustomerInterface
      */
@@ -44,48 +38,6 @@ class ShopUser extends BaseUser implements ShopUserInterface
     public function getAuthorizationRoles()
     {
         return $this->authorizationRoles;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function addAuthorizationRole(RoleInterface $role)
-    {
-        if (!$this->hasAuthorizationRole($role)) {
-            $this->authorizationRoles->add($role);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function removeAuthorizationRole(RoleInterface $role)
-    {
-        if ($this->hasAuthorizationRole($role)) {
-            $this->authorizationRoles->removeElement($role);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasAuthorizationRole(RoleInterface $role)
-    {
-        return $this->authorizationRoles->contains($role);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getRoles()
-    {
-        $roles = parent::getRoles();
-
-        foreach ($this->getAuthorizationRoles() as $role) {
-            $roles = array_merge($roles, $role->getSecurityRoles());
-        }
-
-        return $roles;
     }
 
     /**

--- a/src/Sylius/Component/Core/Model/ShopUserInterface.php
+++ b/src/Sylius/Component/Core/Model/ShopUserInterface.php
@@ -12,29 +12,10 @@
 namespace Sylius\Component\Core\Model;
 
 use Sylius\Component\Customer\Model\CustomerAwareInterface;
-use Sylius\Component\Rbac\Model\IdentityInterface;
-use Sylius\Component\Rbac\Model\RoleInterface;
-use Sylius\Component\User\Model\UserInterface as BaseUserInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface ShopUserInterface extends BaseUserInterface, IdentityInterface, CustomerAwareInterface
+interface ShopUserInterface extends IdentifiableUserInterface, CustomerAwareInterface
 {
-    /**
-     * @param RoleInterface $role
-     */
-    public function addAuthorizationRole(RoleInterface $role);
-
-    /**
-     * @param RoleInterface $role
-     */
-    public function removeAuthorizationRole(RoleInterface $role);
-
-    /**
-     * @param RoleInterface $role
-     *
-     * @return bool
-     */
-    public function hasAuthorizationRole(RoleInterface $role);
 }

--- a/src/Sylius/Component/Core/spec/Model/AdminUserSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/AdminUserSpec.php
@@ -14,6 +14,7 @@ namespace spec\Sylius\Component\Core\Model;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\AdminUser;
 use Sylius\Component\Core\Model\AdminUserInterface;
+use Sylius\Component\Core\Model\IdentifiableUserInterface;
 use Sylius\Component\Rbac\Model\RoleInterface;
 use Sylius\Component\User\Model\User;
 use Sylius\Component\User\Model\UserInterface;
@@ -23,7 +24,7 @@ use Sylius\Component\User\Model\UserInterface;
  *
  * @author Arkadiusz Krakowiak <arkadiusz.krakowiak@lakion.com>
  */
-class AdminUserSpec extends ObjectBehavior
+final class AdminUserSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
@@ -43,6 +44,11 @@ class AdminUserSpec extends ObjectBehavior
     function it_implements_user_interface()
     {
         $this->shouldImplement(UserInterface::class);
+    }
+
+    function it_implements_identifiable_user_interface()
+    {
+        $this->shouldImplement(IdentifiableUserInterface::class);
     }
 
     function its_authorization_roles_are_mutable(RoleInterface $role)

--- a/src/Sylius/Component/Core/spec/Model/ShopUserSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ShopUserSpec.php
@@ -12,9 +12,12 @@
 namespace spec\Sylius\Component\Core\Model;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\IdentifiableUserInterface;
 use Sylius\Component\Core\Model\ShopUser;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\Rbac\Model\RoleInterface;
+use Sylius\Component\User\Model\User;
+use Sylius\Component\User\Model\UserInterface;
 
 /**
  * @author Alexandre Bacco <alexandre.bacco@gmail.com>
@@ -30,6 +33,21 @@ final class ShopUserSpec extends ObjectBehavior
     function it_implements_user_component_interface()
     {
         $this->shouldImplement(ShopUserInterface::class);
+    }
+
+    function it_extends_base_user_model()
+    {
+        $this->shouldHaveType(User::class);
+    }
+
+    function it_implements_user_interface()
+    {
+        $this->shouldImplement(UserInterface::class);
+    }
+
+    function it_implements_identifiable_user_interface()
+    {
+        $this->shouldImplement(IdentifiableUserInterface::class);
     }
 
     function its_authorization_roles_are_mutable(RoleInterface $role)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Related tickets | 
| License         | MIT

Both ShopUserInterface and AdminUserInterface had same methods. Our logic force to also override one of the user methods too. Because we have missed this override in admin class I had to made #5789. This PR extracts common logic to one abstract class, just to keep SSoT. Both AdminUserInterface and ShopUserInterface have been left as a markers. 