### PR TITLE
Stubs for pricing bundle docs

### DIFF
--- a/docs/bundles/SyliusPricingBundle/index.rst
+++ b/docs/bundles/SyliusPricingBundle/index.rst
@@ -1,4 +1,4 @@
 SyliusPricingBundle
-================
+===================
 
 A generic solution for a pricing system inside a Symfony application.

--- a/docs/bundles/SyliusPricingBundle/index.rst
+++ b/docs/bundles/SyliusPricingBundle/index.rst
@@ -2,3 +2,8 @@ SyliusPricingBundle
 ===================
 
 A generic solution for a pricing system inside a Symfony application.
+
+.. toctree::
+   :numbered:
+
+   installation

--- a/docs/bundles/SyliusPricingBundle/index.rst
+++ b/docs/bundles/SyliusPricingBundle/index.rst
@@ -1,0 +1,4 @@
+SyliusPricingBundle
+================
+
+A generic solution for a pricing system inside a Symfony application.

--- a/docs/bundles/SyliusPricingBundle/installation.rst
+++ b/docs/bundles/SyliusPricingBundle/installation.rst
@@ -1,0 +1,53 @@
+Installation
+============
+
+We assume you're familiar with `Composer <http://packagist.org>`_, a dependency manager for PHP.
+Use the following command to add the bundle to your `composer.json` and download the package.
+
+If you have `Composer installed globally <http://getcomposer.org/doc/00-intro.md#globally>`_.
+
+.. code-block:: bash
+
+    $ composer require sylius/pricing-bundle
+
+Otherwise you have to download .phar file.
+
+.. code-block:: bash
+
+    $ curl -sS https://getcomposer.org/installer | php
+    $ php composer.phar require sylius/pricing-bundle
+
+Adding required bundles to the kernel
+-------------------------------------
+
+You need to enable the bundle inside the kernel.
+
+If you're not using any other Sylius bundles, you will also need to add `SyliusResourceBundle` and its dependencies to kernel.
+Don't worry, everything was automatically installed via Composer.
+
+.. code-block:: php
+
+    <?php
+
+    // app/AppKernel.php
+
+    public function registerBundles()
+    {
+        $bundles = array(
+            new FOS\RestBundle\FOSRestBundle(),
+            new JMS\SerializerBundle\JMSSerializerBundle($this),
+            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
+            new WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
+            new Sylius\Bundle\ResourceBundle\SyliusResourceBundle(),
+            new Sylius\Bundle\PricingBundle\SyliusPricingBundle(),
+
+            // Other bundles...
+            new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+        );
+    }
+
+.. note::
+
+    Please register the bundle before *DoctrineBundle*. This is important as we use listeners which have to be processed first.
+
+Congratulations! The bundle is now installed and ready to use.

--- a/docs/bundles/index.rst
+++ b/docs/bundles/index.rst
@@ -17,6 +17,7 @@ Symfony Bundles
     SyliusMailerBundle/index
     SyliusOmnipayBundle/index
     SyliusOrderBundle/index
+    SyliusPricingBundle/index
     SyliusProductBundle/index
     SyliusPromotionBundle/index
     SyliusRbacBundle/index

--- a/docs/bundles/map.rst.inc
+++ b/docs/bundles/map.rst.inc
@@ -11,6 +11,7 @@
 * :doc:`/bundles/SyliusMailerBundle/index`
 * :doc:`/bundles/SyliusOmnipayBundle/index`
 * :doc:`/bundles/SyliusOrderBundle/index`
+* :doc:`/bundles/SyliusPricingBundle/index`
 * :doc:`/bundles/SyliusProductBundle/index`
 * :doc:`/bundles/SyliusPromotionBundle/index`
 * :doc:`/bundles/SyliusRbacBundle/index`


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | N/A
| License         | MIT

There is no documentation for the pricing bundle and clicking the docs link in the bundle's README results in a 404 page.  This creates stubs so there's at least a usable (even if minimal) page to be found.