### PR TITLE
[Rbac] Remove RBAC-related packages from composer "replace" list

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -137,8 +137,6 @@
         "sylius/product-bundle": "self.version",
         "sylius/promotion": "self.version",
         "sylius/promotion-bundle": "self.version",
-        "sylius/rbac": "self.version",
-        "sylius/rbac-bundle": "self.version",
         "sylius/registry": "self.version",
         "sylius/report": "self.version",
         "sylius/report-bundle": "self.version",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d147d7b0ebd8a2dc839c47e451ee75c7",
-    "content-hash": "c97a448890e36f39f4d9fc01dd7e1019",
+    "hash": "bbaed3288a55b40f6fce95b441401dc5",
+    "content-hash": "d3f702c14741c255e99e493cebaaf361",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -2997,7 +2997,7 @@
                     "email": "stof@notk.org"
                 },
                 {
-                    "name": "Knplabs",
+                    "name": "KnpLabs",
                     "homepage": "http://knplabs.com"
                 },
                 {
@@ -8443,7 +8443,7 @@
                     "email": "adrien.brault@gmail.com"
                 },
                 {
-                    "name": "William Durand",
+                    "name": "William DURAND",
                     "email": "william.durand1@gmail.com"
                 }
             ],
@@ -8493,7 +8493,7 @@
             ],
             "authors": [
                 {
-                    "name": "William Durand",
+                    "name": "William DURAND",
                     "email": "william.durand1@gmail.com"
                 }
             ],
@@ -8536,7 +8536,7 @@
             ],
             "authors": [
                 {
-                    "name": "William DURAND",
+                    "name": "William Durand",
                     "email": "william.durand1@gmail.com",
                     "homepage": "http://www.willdurand.fr"
                 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | #5869
| License         | MIT

Now that RBAC is out of core, it should be possible to require `sylius/rbac` and/or `sylius/rbac-bundle` in a project where `sylius/sylius` is already a dependency.

These two lines are preventing it and should be removed.

I don't think `composer.lock` requires an update, please let me know if I'm wrong.