### PR TITLE
Remove reference to translation bundle

### DIFF
--- a/docs/bundles/SyliusProductBundle/installation.rst
+++ b/docs/bundles/SyliusProductBundle/installation.rst
@@ -42,7 +42,6 @@ Don't worry, everything was automatically installed via Composer.
             new Sylius\Bundle\ResourceBundle\SyliusResourceBundle(),
             new Sylius\Bundle\AttributeBundle\SyliusAttributeBundle(),
             new Sylius\Bundle\VariationBundle\SyliusVariationBundle(),
-            new Sylius\Bundle\TranslationBundle\SyliusTranslationBundle(),
 
             // Other bundles...
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | N/A
| License         | MIT

Translation bundle doesn't exist anymore, can't enable a bundle that doesn't exist.