### PR TITLE
[Shipping] ShipmentInterface of subject in the Calculators fix

### DIFF
--- a/src/Sylius/Component/Shipping/Calculator/CalculatorInterface.php
+++ b/src/Sylius/Component/Shipping/Calculator/CalculatorInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Component\Shipping\Calculator;
 
-use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+use Sylius\Component\Shipping\Model\ShipmentInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -19,12 +19,12 @@ use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 interface CalculatorInterface
 {
     /**
-     * @param ShippingSubjectInterface $subject
+     * @param ShipmentInterface $subject
      * @param array                    $configuration
      *
      * @return int
      */
-    public function calculate(ShippingSubjectInterface $subject, array $configuration);
+    public function calculate(ShipmentInterface $subject, array $configuration);
 
     /**
      * @return string

--- a/src/Sylius/Component/Shipping/Calculator/DelegatingCalculator.php
+++ b/src/Sylius/Component/Shipping/Calculator/DelegatingCalculator.php
@@ -12,7 +12,7 @@
 namespace Sylius\Component\Shipping\Calculator;
 
 use Sylius\Component\Registry\ServiceRegistryInterface;
-use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+use Sylius\Component\Shipping\Model\ShipmentInterface;
 
 /**
  * This class delegates the calculation of charge for particular shipping subject
@@ -38,11 +38,10 @@ class DelegatingCalculator implements DelegatingCalculatorInterface
     /**
      * {@inheritdoc}
      */
-    public function calculate(ShippingSubjectInterface $subject)
+    public function calculate(ShipmentInterface $subject)
     {
-        // FIXME: ShippingSubjectInterface does not have any of called methods!
         if (null === $method = $subject->getMethod()) {
-            throw new UndefinedShippingMethodException('Cannot calculate charge for shipping subject without defined shipping method.');
+            throw new UndefinedShippingMethodException('Cannot calculate charge for shipment without a defined shipping method.');
         }
 
         /** @var CalculatorInterface $calculator */

--- a/src/Sylius/Component/Shipping/Calculator/DelegatingCalculatorInterface.php
+++ b/src/Sylius/Component/Shipping/Calculator/DelegatingCalculatorInterface.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Component\Shipping\Calculator;
 
-use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+use Sylius\Component\Shipping\Model\ShipmentInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -19,9 +19,9 @@ use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 interface DelegatingCalculatorInterface
 {
     /**
-     * @param ShippingSubjectInterface $subject
+     * @param ShipmentInterface $subject
      *
      * @return int
      */
-    public function calculate(ShippingSubjectInterface $subject);
+    public function calculate(ShipmentInterface $subject);
 }

--- a/src/Sylius/Component/Shipping/Calculator/FlatRateCalculator.php
+++ b/src/Sylius/Component/Shipping/Calculator/FlatRateCalculator.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Component\Shipping\Calculator;
 
-use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+use Sylius\Component\Shipping\Model\ShipmentInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -21,7 +21,7 @@ class FlatRateCalculator implements CalculatorInterface
     /**
      * {@inheritdoc}
      */
-    public function calculate(ShippingSubjectInterface $subject, array $configuration)
+    public function calculate(ShipmentInterface $subject, array $configuration)
     {
         return (int) $configuration['amount'];
     }

--- a/src/Sylius/Component/Shipping/Calculator/FlexibleRateCalculator.php
+++ b/src/Sylius/Component/Shipping/Calculator/FlexibleRateCalculator.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Component\Shipping\Calculator;
 
-use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+use Sylius\Component\Shipping\Model\ShipmentInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -21,7 +21,7 @@ class FlexibleRateCalculator implements CalculatorInterface
     /**
      * {@inheritdoc}
      */
-    public function calculate(ShippingSubjectInterface $subject, array $configuration)
+    public function calculate(ShipmentInterface $subject, array $configuration)
     {
         $firstUnitCost = $configuration['first_unit_cost'];
         $additionalUnitCost = $configuration['additional_unit_cost'];

--- a/src/Sylius/Component/Shipping/Calculator/PerUnitRateCalculator.php
+++ b/src/Sylius/Component/Shipping/Calculator/PerUnitRateCalculator.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Component\Shipping\Calculator;
 
-use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+use Sylius\Component\Shipping\Model\ShipmentInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -21,7 +21,7 @@ class PerUnitRateCalculator implements CalculatorInterface
     /**
      * {@inheritdoc}
      */
-    public function calculate(ShippingSubjectInterface $subject, array $configuration)
+    public function calculate(ShipmentInterface $subject, array $configuration)
     {
         return (int) ($configuration['amount'] * $subject->getShippingUnitCount());
     }

--- a/src/Sylius/Component/Shipping/Calculator/VolumeRateCalculator.php
+++ b/src/Sylius/Component/Shipping/Calculator/VolumeRateCalculator.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Component\Shipping\Calculator;
 
-use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+use Sylius\Component\Shipping\Model\ShipmentInterface;
 
 /**
  * @author Antonio Peric <antonio@locastic.com>
@@ -21,7 +21,7 @@ class VolumeRateCalculator implements CalculatorInterface
     /**
      * {@inheritdoc}
      */
-    public function calculate(ShippingSubjectInterface $subject, array $configuration)
+    public function calculate(ShipmentInterface $subject, array $configuration)
     {
         return (int) round($configuration['amount'] * ($subject->getShippingVolume() / $configuration['division']));
     }

--- a/src/Sylius/Component/Shipping/Calculator/WeightRateCalculator.php
+++ b/src/Sylius/Component/Shipping/Calculator/WeightRateCalculator.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Component\Shipping\Calculator;
 
-use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+use Sylius\Component\Shipping\Model\ShipmentInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -21,7 +21,7 @@ class WeightRateCalculator implements CalculatorInterface
     /**
      * {@inheritdoc}
      */
-    public function calculate(ShippingSubjectInterface $subject, array $configuration)
+    public function calculate(ShipmentInterface $subject, array $configuration)
     {
         return (int) ($configuration['fixed'] + round($configuration['variable'] * ($subject->getShippingWeight() / $configuration['division'])));
     }

--- a/src/Sylius/Component/Shipping/spec/Calculator/PerUnitRateCalculatorSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Calculator/PerUnitRateCalculatorSpec.php
@@ -13,7 +13,7 @@ namespace spec\Sylius\Component\Shipping\Calculator;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Shipping\Calculator\CalculatorInterface;
-use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+use Sylius\Component\Shipping\Model\ShipmentInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -36,14 +36,14 @@ final class PerUnitRateCalculatorSpec extends ObjectBehavior
     }
 
     function it_should_calculate_the_total_with_the_per_unit_amount_configured_on_the_method(
-        ShippingSubjectInterface $subject
+        ShipmentInterface $subject
     ) {
         $subject->getShippingUnitCount()->willReturn(11);
 
         $this->calculate($subject, ['amount' => 200])->shouldReturn(2200);
     }
 
-    function its_calculated_value_should_be_an_integer(ShippingSubjectInterface $subject)
+    function its_calculated_value_should_be_an_integer(ShipmentInterface $subject)
     {
         $subject->getShippingUnitCount()->willReturn(6);
 

--- a/src/Sylius/Component/Shipping/spec/Calculator/VolumeRateCalculatorSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Calculator/VolumeRateCalculatorSpec.php
@@ -13,7 +13,7 @@ namespace spec\Sylius\Component\Shipping\Calculator;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Shipping\Calculator\CalculatorInterface;
-use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+use Sylius\Component\Shipping\Model\ShipmentInterface;
 
 final class VolumeRateCalculatorSpec extends ObjectBehavior
 {
@@ -32,14 +32,14 @@ final class VolumeRateCalculatorSpec extends ObjectBehavior
         $this->getType()->shouldReturn('volume_rate');
     }
 
-    function it_should_calculate_the_flat_rate_amount_configured_on_the_method(ShippingSubjectInterface $subject)
+    function it_should_calculate_the_flat_rate_amount_configured_on_the_method(ShipmentInterface $subject)
     {
         $subject->getShippingVolume()->willReturn(100);
 
         $this->calculate($subject, ['amount' => 500, 'division' => 2])->shouldReturn(500 * 100 / 2);
     }
 
-    function its_calculated_value_should_be_an_integer(ShippingSubjectInterface $subject)
+    function its_calculated_value_should_be_an_integer(ShipmentInterface $subject)
     {
         $subject->getShippingVolume()->willReturn(100);
 

--- a/src/Sylius/Component/Shipping/spec/Calculator/WeightRateCalculatorSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Calculator/WeightRateCalculatorSpec.php
@@ -13,7 +13,7 @@ namespace spec\Sylius\Component\Shipping\Calculator;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Shipping\Calculator\CalculatorInterface;
-use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+use Sylius\Component\Shipping\Model\ShipmentInterface;
 
 /**
  * @author Alexandre Bacco <alexandre.bacco@gmail.com>
@@ -35,14 +35,14 @@ final class WeightRateCalculatorSpec extends ObjectBehavior
         $this->getType()->shouldReturn('weight_rate');
     }
 
-    function it_should_calculate_the_flat_rate_amount_configured_on_the_method(ShippingSubjectInterface $subject)
+    function it_should_calculate_the_flat_rate_amount_configured_on_the_method(ShipmentInterface $subject)
     {
         $subject->getShippingWeight()->willReturn(10);
 
         $this->calculate($subject, ['fixed' => 200, 'variable' => 500, 'division' => 1])->shouldReturn(200 + 500 * 10);
     }
 
-    function its_calculated_value_should_be_an_integer(ShippingSubjectInterface $subject)
+    function its_calculated_value_should_be_an_integer(ShipmentInterface $subject)
     {
         $subject->getShippingWeight()->willReturn(10);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

Instead of **ShippingSubjectInterface** we should now use the **ShipmentInterface** - corrected in the **CalculatorInterface** and all its implementations. :)