### PR TITLE
Remove the remaining resolver references

### DIFF
--- a/docs/bundles/SyliusCartBundle/services.rst
+++ b/docs/bundles/SyliusCartBundle/services.rst
@@ -39,10 +39,10 @@ You're interacting with them like you usually do with own entities in your proje
         $item = $this->get('sylius.repository.cart')->createNew();
     }
 
-Provider and Resolver
----------------------
+Provider
+--------
 
-There are also 3 more services for you.
+There is also 1 more service for you.
 
 You use the provider to obtain the current user cart, if there is none, a new one is created and saved.
 The ``->setCart()`` method also allows you to replace the current cart.
@@ -62,20 +62,3 @@ This is useful, for example, when after completing an order you want to start wi
         $provider->setCart($customCart);
         $provider->abandonCart();
     }
-
-The resolver is used to create a new item based on the user request.
-
-.. code-block:: php
-
-    <?php
-
-    // ...
-    public function addItemAction(Request $request)
-    {
-        $resolver = $this->get('sylius.cart_resolver');
-        $item = $resolver->resolve($this->createNew(), $request);
-    }
-
-.. note::
-
-    A more advanced example of a resolver implementation is available `in Sylius Sandbox application on GitHub <https://github.com/Sylius/Sylius-Sandbox/blob/master/src/Sylius/Bundle/SandboxBundle/Resolver/ItemResolver.php>`_.

--- a/src/Sylius/Bundle/CartBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/CartBundle/DependencyInjection/Configuration.php
@@ -48,7 +48,6 @@ class Configuration implements ConfigurationInterface
             ->addDefaultsIfNotSet()
             ->children()
                 ->scalarNode('driver')->defaultValue(SyliusResourceBundle::DRIVER_DOCTRINE_ORM)->cannotBeEmpty()->end()
-                ->scalarNode('resolver')->isRequired()->cannotBeEmpty()->end()
             ->end()
         ;
 

--- a/src/Sylius/Bundle/CartBundle/DependencyInjection/SyliusCartExtension.php
+++ b/src/Sylius/Bundle/CartBundle/DependencyInjection/SyliusCartExtension.php
@@ -49,8 +49,6 @@ class SyliusCartExtension extends AbstractResourceExtension implements PrependEx
             $loader->load($configFile);
         }
 
-        $container->setAlias('sylius.cart_resolver', $config['resolver']);
-
         $definition = $container->getDefinition('sylius.form.type.cart_item');
         $definition->addArgument(new Reference('sylius.form.data_mapper.order_item_quantity'));
     }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius.yml
@@ -27,7 +27,6 @@ sylius_association:
                     interface: Sylius\Component\Product\Model\ProductAssociationInterface
 
 sylius_cart:
-    resolver: sylius.cart_item_resolver.default
     resources:
         cart:
             classes:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | continuation from #5862
| License         | MIT

The `Sylius\Component\Cart\Resolver\ItemResolverInterface` was removed and its uses in the CartBundle pulled out as well.  However it is still required to configure a resolver in the CartBundle's configuration.  Removed this configuration requirement and the remaining documentation for the service.