### PR TITLE
[ThemeBundle] make ThemeConfiguration extendable

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Configuration/ThemeConfiguration.php
+++ b/src/Sylius/Bundle/ThemeBundle/Configuration/ThemeConfiguration.php
@@ -18,7 +18,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-final class ThemeConfiguration implements ConfigurationInterface
+class ThemeConfiguration implements ConfigurationInterface
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | none
| License         | MIT

Remove final from class. 

Why? We have Theme system based on ThemeBundle and it's impossible now without duplication whole configuration class (registering it to container and replacing Sylius one with new one in Processor) to add some new properties to theme.json file.