### PR TITLE
[BugFix][Core] Added shipping method eligibility checker to core methods resolver

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -442,6 +442,7 @@
         <service id="sylius.shipping_methods_resolver.zones_and_channel_based" class="%sylius.shipping_methods_resolver.zones_and_channel_based.class%">
             <argument type="service" id="sylius.repository.shipping_method" />
             <argument type="service" id="sylius.zone_matcher" />
+            <argument type="service" id="sylius.shipping_eligibility_checker" />
             <tag name="sylius.shipping_method_resolver" type="zones_and_channel_based" label="sylius.shipping_methods_resolver.zones_and_channel_based" priority="1" />
         </service>
         <service id="sylius.payment_methods_resolver.channel_based" class="%sylius.payment_methods_resolver.channel_based.class%">

--- a/src/Sylius/Component/Core/Resolver/ZoneAndChannelBasedShippingMethodsResolver.php
+++ b/src/Sylius/Component/Core/Resolver/ZoneAndChannelBasedShippingMethodsResolver.php
@@ -14,6 +14,7 @@ namespace Sylius\Component\Core\Resolver;
 use Sylius\Component\Addressing\Matcher\ZoneMatcherInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
+use Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 use Sylius\Component\Core\Repository\ShippingMethodRepositoryInterface;
 use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
@@ -35,15 +36,23 @@ class ZoneAndChannelBasedShippingMethodsResolver implements ShippingMethodsResol
     private $zoneMatcher;
 
     /**
+     * @var ShippingMethodEligibilityCheckerInterface
+     */
+    private $eligibilityChecker;
+
+    /**
      * @param ShippingMethodRepositoryInterface $shippingMethodRepository
      * @param ZoneMatcherInterface $zoneMatcher
+     * @param ShippingMethodEligibilityCheckerInterface $eligibilityChecker
      */
     public function __construct(
         ShippingMethodRepositoryInterface $shippingMethodRepository,
-        ZoneMatcherInterface $zoneMatcher
+        ZoneMatcherInterface $zoneMatcher,
+        ShippingMethodEligibilityCheckerInterface $eligibilityChecker
     ) {
         $this->shippingMethodRepository = $shippingMethodRepository;
         $this->zoneMatcher = $zoneMatcher;
+        $this->eligibilityChecker = $eligibilityChecker;
     }
 
     /**
@@ -61,7 +70,16 @@ class ZoneAndChannelBasedShippingMethodsResolver implements ShippingMethodsResol
             return [];
         }
 
-        return $this->shippingMethodRepository->findEnabledForZonesAndChannel($zones, $order->getChannel());
+        $methods = [];
+
+        $shippingMethods = $this->shippingMethodRepository->findEnabledForZonesAndChannel($zones, $order->getChannel());
+        foreach ($shippingMethods as $shippingMethod) {
+            if ($this->eligibilityChecker->isEligible($subject, $shippingMethod)) {
+                $methods[] = $shippingMethod;
+            }
+        }
+
+        return $methods;
     }
 
     /**

--- a/src/Sylius/Component/Core/spec/Resolver/ZoneAndChannelBasedShippingMethodsResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/Resolver/ZoneAndChannelBasedShippingMethodsResolverSpec.php
@@ -12,6 +12,7 @@
 namespace spec\Sylius\Component\Core\Resolver;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Sylius\Component\Addressing\Matcher\ZoneMatcherInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\AddressInterface;
@@ -20,6 +21,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\Model\ShippingMethodInterface;
 use Sylius\Component\Core\Resolver\ZoneAndChannelBasedShippingMethodsResolver;
+use Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 use Sylius\Component\Core\Repository\ShippingMethodRepositoryInterface;
 use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
@@ -33,9 +35,10 @@ final class ZoneAndChannelBasedShippingMethodsResolverSpec extends ObjectBehavio
 {
     function let(
         ShippingMethodRepositoryInterface $shippingMethodRepository,
-        ZoneMatcherInterface $zoneMatcher
+        ZoneMatcherInterface $zoneMatcher,
+        ShippingMethodEligibilityCheckerInterface $eligibilityChecker
     ) {
-        $this->beConstructedWith($shippingMethodRepository, $zoneMatcher);
+        $this->beConstructedWith($shippingMethodRepository, $zoneMatcher, $eligibilityChecker);
     }
 
     function it_is_initializable()
@@ -49,6 +52,7 @@ final class ZoneAndChannelBasedShippingMethodsResolverSpec extends ObjectBehavio
     }
 
     function it_returns_shipping_methods_matched_for_shipment_order_shipping_address_and_order_channel(
+        $eligibilityChecker,
         AddressInterface $address,
         ChannelInterface $channel,
         OrderInterface $order,
@@ -66,6 +70,8 @@ final class ZoneAndChannelBasedShippingMethodsResolverSpec extends ObjectBehavio
 
         $zoneMatcher->matchAll($address)->willReturn([$firstZone, $secondZone]);
 
+        $eligibilityChecker->isEligible(Argument::any(), Argument::any())->willReturn(true);
+
         $shippingMethodRepository
             ->findEnabledForZonesAndChannel([$firstZone, $secondZone], $channel)
             ->willReturn([$firstShippingMethod, $secondShippingMethod])
@@ -75,6 +81,7 @@ final class ZoneAndChannelBasedShippingMethodsResolverSpec extends ObjectBehavio
     }
 
     function it_returns_empty_array_if_zone_matcher_could_not_match_any_zone(
+        $eligibilityChecker,
         OrderInterface $order,
         AddressInterface $address,
         ChannelInterface $channel,
@@ -87,7 +94,39 @@ final class ZoneAndChannelBasedShippingMethodsResolverSpec extends ObjectBehavio
 
         $zoneMatcher->matchAll($address)->willReturn([]);
 
+        $eligibilityChecker->isEligible(Argument::any(), Argument::any())->willReturn(true);
+
         $this->getSupportedMethods($shipment)->shouldReturn([]);
+    }
+
+    function it_returns_only_shipping_methods_that_are_eligible(
+        $eligibilityChecker,
+        AddressInterface $address,
+        ChannelInterface $channel,
+        OrderInterface $order,
+        ShipmentInterface $shipment,
+        ShippingMethodInterface $firstShippingMethod,
+        ShippingMethodInterface $secondShippingMethod,
+        ShippingMethodRepositoryInterface $shippingMethodRepository,
+        ZoneInterface $firstZone,
+        ZoneInterface $secondZone,
+        ZoneMatcherInterface $zoneMatcher
+    ) {
+        $shipment->getOrder()->willReturn($order);
+        $order->getShippingAddress()->willReturn($address);
+        $order->getChannel()->willReturn($channel);
+
+        $zoneMatcher->matchAll($address)->willReturn([$firstZone, $secondZone]);
+
+        $eligibilityChecker->isEligible(Argument::any(), $firstShippingMethod)->willReturn(false);
+        $eligibilityChecker->isEligible(Argument::any(), $secondShippingMethod)->willReturn(true);
+
+        $shippingMethodRepository
+            ->findEnabledForZonesAndChannel([$firstZone, $secondZone], $channel)
+            ->willReturn([$firstShippingMethod, $secondShippingMethod])
+        ;
+
+        $this->getSupportedMethods($shipment)->shouldReturn([$secondShippingMethod]);
     }
 
     function it_supports_shipments_with_order_and_its_shipping_address_defined(

--- a/src/Sylius/Component/Core/spec/Resolver/ZoneAndChannelBasedShippingMethodsResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/Resolver/ZoneAndChannelBasedShippingMethodsResolverSpec.php
@@ -52,7 +52,7 @@ final class ZoneAndChannelBasedShippingMethodsResolverSpec extends ObjectBehavio
     }
 
     function it_returns_shipping_methods_matched_for_shipment_order_shipping_address_and_order_channel(
-        $eligibilityChecker,
+        ShippingMethodEligibilityCheckerInterface $eligibilityChecker,
         AddressInterface $address,
         ChannelInterface $channel,
         OrderInterface $order,
@@ -70,18 +70,19 @@ final class ZoneAndChannelBasedShippingMethodsResolverSpec extends ObjectBehavio
 
         $zoneMatcher->matchAll($address)->willReturn([$firstZone, $secondZone]);
 
-        $eligibilityChecker->isEligible(Argument::any(), Argument::any())->willReturn(true);
-
         $shippingMethodRepository
             ->findEnabledForZonesAndChannel([$firstZone, $secondZone], $channel)
             ->willReturn([$firstShippingMethod, $secondShippingMethod])
         ;
 
+        $eligibilityChecker->isEligible($shipment, $firstShippingMethod)->willReturn(true);
+        $eligibilityChecker->isEligible($shipment, $secondShippingMethod)->willReturn(true);
+
         $this->getSupportedMethods($shipment)->shouldReturn([$firstShippingMethod, $secondShippingMethod]);
     }
 
     function it_returns_empty_array_if_zone_matcher_could_not_match_any_zone(
-        $eligibilityChecker,
+        ShippingMethodEligibilityCheckerInterface $eligibilityChecker,
         OrderInterface $order,
         AddressInterface $address,
         ChannelInterface $channel,
@@ -94,13 +95,11 @@ final class ZoneAndChannelBasedShippingMethodsResolverSpec extends ObjectBehavio
 
         $zoneMatcher->matchAll($address)->willReturn([]);
 
-        $eligibilityChecker->isEligible(Argument::any(), Argument::any())->willReturn(true);
-
         $this->getSupportedMethods($shipment)->shouldReturn([]);
     }
 
     function it_returns_only_shipping_methods_that_are_eligible(
-        $eligibilityChecker,
+        ShippingMethodEligibilityCheckerInterface $eligibilityChecker,
         AddressInterface $address,
         ChannelInterface $channel,
         OrderInterface $order,
@@ -118,8 +117,8 @@ final class ZoneAndChannelBasedShippingMethodsResolverSpec extends ObjectBehavio
 
         $zoneMatcher->matchAll($address)->willReturn([$firstZone, $secondZone]);
 
-        $eligibilityChecker->isEligible(Argument::any(), $firstShippingMethod)->willReturn(false);
-        $eligibilityChecker->isEligible(Argument::any(), $secondShippingMethod)->willReturn(true);
+        $eligibilityChecker->isEligible($shipment, $firstShippingMethod)->willReturn(false);
+        $eligibilityChecker->isEligible($shipment, $secondShippingMethod)->willReturn(true);
 
         $shippingMethodRepository
             ->findEnabledForZonesAndChannel([$firstZone, $secondZone], $channel)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Related tickets | fixes #5861
| License         | MIT

Check for shipping method eligibility when getting shipping methods based on zone and channel.