### PR TITLE
Remove duplicate “flash” config entry

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/checkout.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/checkout.yml
@@ -20,7 +20,6 @@ sylius_shop_checkout_address:
                 type: sylius_checkout_address
                 options:
                     customer: expr:service('sylius.context.customer').getCustomer()
-            flash: false
             repository:
                 method: find
                 arguments: [expr:service('sylius.context.cart').getCart()]


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | -
| License         | MIT

Just a very minor cleanup for a duplicate config entry that was introduced in 0b555349.