### PR TITLE
[RFC] [OrderComponent] OrderProcessorInterface moved to order component.

### DIFF
--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -17,7 +17,7 @@ use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\CouponInterface;
 use Sylius\Component\Core\OrderCheckoutTransitions;
-use Sylius\Component\Core\OrderProcessing\OrderProcessorInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Order\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\OrderInterface;

--- a/src/Sylius/Bundle/CoreBundle/EventListener/OrderRecalculationListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/OrderRecalculationListener.php
@@ -12,7 +12,7 @@
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\OrderProcessing\OrderProcessorInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 

--- a/src/Sylius/Bundle/CoreBundle/EventListener/UserCartRecalculationListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/UserCartRecalculationListener.php
@@ -14,7 +14,7 @@ namespace Sylius\Bundle\CoreBundle\EventListener;
 use Sylius\Component\Cart\Context\CartContextInterface;
 use Sylius\Component\Cart\Context\CartNotFoundException;
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\OrderProcessing\OrderProcessorInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\Event;
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/order_processor.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/order_processor.xml
@@ -23,7 +23,7 @@
             <argument type="service" id="sm.factory" />
         </service>
 
-        <service id="sylius.order_processing.order_processor" class="Sylius\Component\Core\OrderProcessing\CompositeOrderProcessor">
+        <service id="sylius.order_processing.order_processor" class="Sylius\Component\Order\Processor\CompositeOrderProcessor">
             <call method="addProcessor">
                 <argument type="service">
                     <service class="Sylius\Component\Core\OrderProcessing\OrderExchangeRateProcessor">

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/OrderRecalculationListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/OrderRecalculationListenerSpec.php
@@ -14,7 +14,7 @@ namespace spec\Sylius\Bundle\CoreBundle\EventListener;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\CoreBundle\EventListener\OrderRecalculationListener;
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\OrderProcessing\OrderProcessorInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/UserCartRecalculationListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/UserCartRecalculationListenerSpec.php
@@ -18,7 +18,7 @@ use Sylius\Component\Cart\Context\CartContextInterface;
 use Sylius\Component\Cart\Context\CartNotFoundException;
 use Sylius\Component\Cart\Model\CartInterface;
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\OrderProcessing\OrderProcessorInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\Event;
 

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
@@ -59,5 +59,7 @@
         <service id="sylius.order_number_assigner" class="%sylius.order_number_assigner.class%">
             <argument type="service" id="sylius.sequential_order_number_generator" />
         </service>
+
+        <service id="sylius.order_processing.order_processor" class="Sylius\Component\Order\Processor\CompositeOrderProcessor" />
     </services>
 </container>

--- a/src/Sylius/Component/Core/OrderProcessing/OrderAdjustmentsClearer.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderAdjustmentsClearer.php
@@ -12,7 +12,8 @@
 namespace Sylius\Component\Core\OrderProcessing;
 
 use Sylius\Component\Core\Model\AdjustmentInterface;
-use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>

--- a/src/Sylius/Component/Core/OrderProcessing/OrderExchangeRateProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderExchangeRateProcessor.php
@@ -11,8 +11,9 @@
 
 namespace Sylius\Component\Core\OrderProcessing;
 
-use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Updater\OrderUpdaterInterface;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 
 /**
  * @author Jan Góralski <jan.goralski@lakion.com>

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
@@ -11,8 +11,9 @@
 
 namespace Sylius\Component\Core\OrderProcessing;
 
-use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Payment\Factory\PaymentFactoryInterface;
 
 /**

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPricesRecalculator.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPricesRecalculator.php
@@ -11,7 +11,8 @@
 
 namespace Sylius\Component\Core\OrderProcessing;
 
-use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Pricing\Calculator\DelegatingCalculatorInterface;
 
 /**

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPromotionProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPromotionProcessor.php
@@ -11,7 +11,8 @@
 
 namespace Sylius\Component\Core\OrderProcessing;
 
-use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Promotion\Processor\PromotionProcessorInterface;
 
 /**

--- a/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
@@ -11,8 +11,9 @@
 
 namespace Sylius\Component\Core\OrderProcessing;
 
-use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Shipping\Exception\UnresolvedDefaultShippingMethodException;
 use Sylius\Component\Shipping\Resolver\DefaultShippingMethodResolverInterface;

--- a/src/Sylius/Component/Core/OrderProcessing/OrderTaxesProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderTaxesProcessor.php
@@ -14,10 +14,11 @@ namespace Sylius\Component\Core\OrderProcessing;
 use Sylius\Component\Addressing\Matcher\ZoneMatcherInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\AdjustmentInterface;
-use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Provider\ZoneProviderInterface;
 use Sylius\Component\Core\Taxation\Exception\UnsupportedTaxCalculationStrategyException;
 use Sylius\Component\Core\Taxation\Strategy\TaxCalculationStrategyInterface;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Registry\PrioritizedServiceRegistryInterface;
 
 /**

--- a/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php
@@ -12,7 +12,8 @@
 namespace Sylius\Component\Core\OrderProcessing;
 
 use Sylius\Component\Core\Model\AdjustmentInterface;
-use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Shipping\Calculator\DelegatingCalculatorInterface;
 use Sylius\Component\Shipping\Calculator\UndefinedShippingMethodException;

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderAdjustmentsClearerSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderAdjustmentsClearerSpec.php
@@ -15,7 +15,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\OrderProcessing\OrderAdjustmentsClearer;
-use Sylius\Component\Core\OrderProcessing\OrderProcessorInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 
 /**
  * @mixin OrderAdjustmentsClearer

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderExchangeRateProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderExchangeRateProcessorSpec.php
@@ -15,7 +15,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\OrderProcessing\OrderExchangeRateProcessor;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Sylius\Component\Core\OrderProcessing\OrderProcessorInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Core\Updater\OrderUpdaterInterface;
 
 /**

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderPaymentProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderPaymentProcessorSpec.php
@@ -16,7 +16,7 @@ use Prophecy\Argument;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\OrderProcessing\OrderPaymentProcessor;
-use Sylius\Component\Core\OrderProcessing\OrderProcessorInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Payment\Factory\PaymentFactoryInterface;
 use Sylius\Component\Payment\Model\PaymentMethodInterface;
 

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderPricesRecalculatorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderPricesRecalculatorSpec.php
@@ -17,7 +17,7 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\OrderProcessing\OrderPricesRecalculator;
-use Sylius\Component\Core\OrderProcessing\OrderProcessorInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Customer\Model\GroupableInterface;
 use Sylius\Component\Pricing\Calculator\DelegatingCalculatorInterface;
 use Sylius\Component\Pricing\Model\PriceableInterface;

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentProcessorSpec.php
@@ -16,7 +16,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
-use Sylius\Component\Core\OrderProcessing\OrderProcessorInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Core\OrderProcessing\OrderShipmentProcessor;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderTaxesProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderTaxesProcessorSpec.php
@@ -18,7 +18,7 @@ use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
-use Sylius\Component\Core\OrderProcessing\OrderProcessorInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Core\OrderProcessing\OrderTaxesProcessor;
 use Sylius\Component\Core\Provider\ZoneProviderInterface;
 use Sylius\Component\Core\Taxation\Exception\UnsupportedTaxCalculationStrategyException;

--- a/src/Sylius/Component/Core/spec/OrderProcessing/ShippingChargesProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/ShippingChargesProcessorSpec.php
@@ -15,7 +15,7 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\OrderProcessing\OrderProcessorInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Core\OrderProcessing\ShippingChargesProcessor;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Shipping\Calculator\DelegatingCalculatorInterface;

--- a/src/Sylius/Component/Order/Processor/CompositeOrderProcessor.php
+++ b/src/Sylius/Component/Order/Processor/CompositeOrderProcessor.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Component\Core\OrderProcessing;
+namespace Sylius\Component\Order\Processor;
 
-use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Order\Model\OrderInterface;
 use Zend\Stdlib\PriorityQueue;
 
 /**

--- a/src/Sylius/Component/Order/Processor/OrderProcessorInterface.php
+++ b/src/Sylius/Component/Order/Processor/OrderProcessorInterface.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Component\Core\OrderProcessing;
+namespace Sylius\Component\Order\Processor;
 
-use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Order\Model\OrderInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Related tickets | 
| License         | MIT

`CompositeOrderProcessor` doesn't have any external dependencies, so it could be useful to keep it inside an `Order` component instead of core. Same with `OrderProcessorInterface`. 

When it'll be merged, `CartModifier` from #5970 could be moved to `CartBundle` from the Core also.