### PR TITLE
Correct spelling

### DIFF
--- a/docs/book/checkout.rst
+++ b/docs/book/checkout.rst
@@ -210,7 +210,7 @@ and apply a proper transition and flush the order via the manager.
 
 **What happens during the transition?**
 
-The method ``process($order)`` of the `CompositeOrderProcessor <https://github.com/Sylius/Sylius/blob/master/src/Sylius/Component/Core/OrderProcessing/CompositeOrderProcessor.php>`_ is run and checks all the adjustments ont the order.
+The method ``process($order)`` of the `CompositeOrderProcessor <https://github.com/Sylius/Sylius/blob/master/src/Sylius/Component/Core/OrderProcessing/CompositeOrderProcessor.php>`_ is run and checks all the adjustments on the order.
 The method ``update($order)`` of the `OrderExchangeRateAndCurrencyUpdater <https://github.com/Sylius/Sylius/blob/master/src/Sylius/Component/Core/OrderProcessing/OrderExchangeRateAndCurrencyUpdater.php>`_ is run.
 Here this method is responsible for controlling the **exchangeRate** of the order's currency.
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | none
| License         | MIT

There was a misspelled on. I have change it from `ont` to `on`.

The whole sentence was

```
is run and checks all the adjustments ont the order.
```

and not it is

is run and checks all the adjustments on the order.