### PR TITLE
The User component only requires doctrine/collections

### DIFF
--- a/src/Sylius/Bundle/UserBundle/composer.json
+++ b/src/Sylius/Bundle/UserBundle/composer.json
@@ -34,6 +34,7 @@
     "require": {
         "php": "^5.6|^7.0",
 
+        "doctrine/orm": "^2.4.8",
         "sylius/user": "^1.0",
         "sylius/resource-bundle": "^1.0",
         "sylius/mailer-bundle": "^1.0",

--- a/src/Sylius/Component/User/composer.json
+++ b/src/Sylius/Component/User/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php": "^5.6|^7.0",
 
-        "doctrine/orm": "^2.4.8,<2.5",
+        "doctrine/collections": "^1.1",
         "sylius/resource": "^1.0",
         "sylius/storage": "^1.0",
         "symfony/security": "^2.8",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | partially #5999
| License         | MIT

The User component only uses Doctrine's Collections library.  Instead of requiring the full ORM, only that library is required instead using the same version constraint the ORM uses at 2.4.8.