### PR TITLE
Loosen Promotion component's coupling to Doctrine

### DIFF
--- a/src/Sylius/Component/Promotion/Repository/PromotionCouponRepositoryInterface.php
+++ b/src/Sylius/Component/Promotion/Repository/PromotionCouponRepositoryInterface.php
@@ -12,7 +12,6 @@
 namespace Sylius\Component\Promotion\Repository;
 
 use Doctrine\ORM\QueryBuilder;
-use Sylius\Component\Promotion\Model\PromotionCouponInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 /**

--- a/src/Sylius/Component/Promotion/composer.json
+++ b/src/Sylius/Component/Promotion/composer.json
@@ -22,12 +22,17 @@
     "require": {
         "php": "^5.6|^7.0",
 
-        "doctrine/orm": "^2.4.8",
+        "doctrine/collections": "^1.1",
+        "doctrine/common": "^2.4",
         "sylius/registry": "^1.0",
         "sylius/resource": "^1.0"
     },
     "require-dev": {
+        "doctrine/orm": "^2.4.8",
         "phpspec/phpspec": "^3.0"
+    },
+    "suggest": {
+        "doctrine/orm": "Required if implementing Sylius\\Component\\Promotion\\Repository\\CouponRepositoryInterface"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Related tickets | partially #5999 |
| License | MIT |

The Promotion component only requires Doctrine's Collections and Common libraries.  It has one reference to the ORM but that is only in a typehint in the `CouponRepositoryInterface`.  Loosen up the dependencies to only pull in Collections and Common with a require-dev dependency to ORM and suggest its use if implementing `CouponRepositoryInterface`.
