### PR TITLE
[Sylius] Changed remember_me key to secret

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -52,7 +52,7 @@ security:
                 use_forward: false
                 use_referer: true
             remember_me:
-                key: %secret%
+                secret: %secret%
                 name: APP_REMEMBER_ME
                 lifetime: 31536000
                 always_remember_me: true


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | partially #3564 
| License         | MIT

Quote from Symfony Profiler: "remember_me.key is deprecated since version 2.8 and will be removed in 3.0. Use remember_me.secret instead."