### PR TITLE
Add price and taxons filters UI for promotions

### DIFF
--- a/features/promotion/managing_promotions/adding_promotion_with_filter.feature
+++ b/features/promotion/managing_promotions/adding_promotion_with_filter.feature
@@ -1,0 +1,48 @@
+@managing_promotions
+Feature: Adding promotion with filter
+    In order to give possibility to pay less for some goods based on specific configuration
+    As an Administrator
+    I want to add a new promotion with filtered action to the registry
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And I am logged in as an administrator
+
+    @ui @javascript
+    Scenario: Adding a promotion with item fixed discount only for products over 100
+        Given I want to create a new promotion
+        When I specify its code as "10_for_all_products_over_100"
+        And I name it "$10 discount for all products over 100!"
+        And I add the "Item fixed discount" action configured with amount of "$10"
+        And I add a price filter with minimum value of "$10"
+        And I add it
+        Then I should be notified that it has been successfully created
+        And the "$10 discount for all products over 100!" promotion should appear in the registry
+
+    @ui @javascript @skip
+    Scenario: Adding a promotion with item fixed discount only for products between 10 and 100
+
+    @ui @javascript @skip
+    Scenario: Adding a promotion with item fixed discount only for products from a certain taxon
+
+    @ui @javascript @skip
+    Scenario: Adding a promotion with item percentage discount only for products over 100
+
+    @ui @javascript @skip
+    Scenario: Adding a promotion with item percentage discount only for products between 10 and 100
+
+    @ui @javascript @skip
+    Scenario: Adding a promotion with item percentage discount only for products from a certain taxon
+
+    @ui @javascript @skip
+    Scenario: Adding a promotion with item percentage discount only for products over 100 and from a certain taxon
+
+    @ui @javascript @skip
+    Scenario: Adding a promotion with item percentage discount only for products between 10 and 100 and from a certain taxon
+
+    @ui @javascript @skip
+    Scenario: Adding a promotion with fixed discount does not show filters
+
+    @ui @javascript @skip
+    Scenario: Adding a promotion with percentage discount does not show filters
+

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -58,10 +58,10 @@ final class ManagingPromotionsContext implements Context
     private $notificationChecker;
 
     /**
-     * @param SharedStorageInterface $sharedStorage
-     * @param IndexPageInterface $indexPage
-     * @param CreatePageInterface $createPage
-     * @param UpdatePageInterface $updatePage
+     * @param SharedStorageInterface       $sharedStorage
+     * @param IndexPageInterface           $indexPage
+     * @param CreatePageInterface          $createPage
+     * @param UpdatePageInterface          $updatePage
      * @param CurrentPageResolverInterface $currentPageResolver
      * @param NotificationCheckerInterface $notificationChecker
      */
@@ -186,9 +186,21 @@ final class ManagingPromotionsContext implements Context
     }
 
     /**
+     * @Given /^I add a price filter with minimum value of ("(?:€|£|\$)[^"]+")$/
+     * @Given /^I add a price filter with minimum value of ("(?:€|£|\$)[^"]+") and maximum of ("(?:€|£|\$)[^"]+") $/
+     */
+    public function iAddAPriceFilterRange($minimum, $maximum = null)
+    {
+        $this->createPage->fillActionOption('Min', $minimum);
+
+        if ($maximum) {
+            $this->createPage->fillActionOption('Max', $maximum);
+        }
+    }
+
+    /**
      * @Given I add the :actionType action configured with a percentage value of :percentage%
      * @Given I add the :actionType action configured without a percentage value
-     *
      */
     public function iAddTheActionConfiguredWithAPercentageValue($actionType, $percentage = null)
     {
@@ -414,7 +426,7 @@ final class ManagingPromotionsContext implements Context
     public function iShouldBeNotifiedOfFailure()
     {
         $this->notificationChecker->checkNotification(
-            "Cannot delete, the promotion is in use.",
+            'Cannot delete, the promotion is in use.',
             NotificationType::failure()
         );
     }
@@ -518,7 +530,7 @@ final class ManagingPromotionsContext implements Context
 
     /**
      * @param PromotionInterface $promotion
-     * @param string $field
+     * @param string             $field
      */
     private function assertIfFieldIsTrue(PromotionInterface $promotion, $field)
     {

--- a/src/Sylius/Bundle/CoreBundle/spec/Form/DataTransformer/TaxonsToCodesTransformerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Form/DataTransformer/TaxonsToCodesTransformerSpec.php
@@ -27,22 +27,22 @@ use Symfony\Component\Form\DataTransformerInterface;
  */
 final class TaxonsToCodesTransformerSpec extends ObjectBehavior
 {
-    function let(TaxonRepositoryInterface $taxonRepository)
+    public function let(TaxonRepositoryInterface $taxonRepository)
     {
         $this->beConstructedWith($taxonRepository);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType(TaxonsToCodesTransformer::class);
     }
 
-    function it_implements_data_transformer_interface()
+    public function it_implements_data_transformer_interface()
     {
         $this->shouldImplement(DataTransformerInterface::class);
     }
 
-    function it_transforms_array_of_taxons_codes_to_taxons_collection(
+    public function it_transforms_array_of_taxons_codes_to_taxons_collection(
         TaxonRepositoryInterface $taxonRepository,
         TaxonInterface $bows,
         TaxonInterface $swords
@@ -51,10 +51,10 @@ final class TaxonsToCodesTransformerSpec extends ObjectBehavior
 
         $taxons = new ArrayCollection([$bows->getWrappedObject(), $swords->getWrappedObject()]);
 
-        $this->transform(['taxons' => ['bows', 'swords']])->shouldBeCollection($taxons);
+        $this->transform(['bows', 'swords'])->shouldBeCollection($taxons);
     }
 
-    function it_transforms_only_existing_taxons(
+    public function it_transforms_only_existing_taxons(
         TaxonRepositoryInterface $taxonRepository,
         TaxonInterface $bows
     ) {
@@ -62,15 +62,15 @@ final class TaxonsToCodesTransformerSpec extends ObjectBehavior
 
         $taxons = new ArrayCollection([$bows->getWrappedObject()]);
 
-        $this->transform(['taxons' => ['bows', 'swords']])->shouldBeCollection($taxons);
+        $this->transform(['bows', 'swords'])->shouldBeCollection($taxons);
     }
 
-    function it_transforms_empty_array_into_empty_collection()
+    public function it_transforms_empty_array_into_empty_collection()
     {
         $this->transform([])->shouldBeCollection(new ArrayCollection([]));
     }
 
-    function it_throws_exception_if_value_to_transform_is_not_array()
+    public function it_throws_exception_if_value_to_transform_is_not_array()
     {
         $this
             ->shouldThrow(new UnexpectedTypeException('badObject', 'array'))
@@ -78,7 +78,7 @@ final class TaxonsToCodesTransformerSpec extends ObjectBehavior
         ;
     }
 
-    function it_reverse_transforms_into_array_of_taxons_codes(
+    public function it_reverse_transforms_into_array_of_taxons_codes(
         TaxonInterface $axes,
         TaxonInterface $shields
     ) {
@@ -86,12 +86,12 @@ final class TaxonsToCodesTransformerSpec extends ObjectBehavior
         $shields->getCode()->willReturn('shields');
 
         $this
-            ->reverseTransform(new ArrayCollection(['taxons' => [$axes->getWrappedObject(), $shields->getWrappedObject()]]))
-            ->shouldReturn(['taxons' => ['axes', 'shields']])
+            ->reverseTransform(new ArrayCollection([$axes->getWrappedObject(), $shields->getWrappedObject()]))
+            ->shouldReturn(['axes', 'shields'])
         ;
     }
 
-    function it_throws_exception_if_reverse_transformed_object_is_not_collection()
+    public function it_throws_exception_if_reverse_transformed_object_is_not_collection()
     {
         $this
             ->shouldThrow(new UnexpectedTypeException('badObject', Collection::class))
@@ -99,22 +99,9 @@ final class TaxonsToCodesTransformerSpec extends ObjectBehavior
         ;
     }
 
-    function it_returns_empty_array_if_passed_collection_is_empty()
+    public function it_returns_empty_array_if_passed_collection_is_empty()
     {
         $this->reverseTransform(new ArrayCollection())->shouldReturn([]);
-    }
-
-    function it_returns_empty_array_if_passed_collection_has_no_taxon_element()
-    {
-        $this->reverseTransform(new ArrayCollection(['test' => ['test']]))->shouldReturn([]);
-    }
-
-    function it_throws_exception_while_reverse_transform_if_taxons_element_is_not_an_array(TaxonInterface $axes)
-    {
-        $this
-            ->shouldThrow(new \InvalidArgumentException('"taxons" element of collection should be Traversable'))
-            ->during('reverseTransform', [new ArrayCollection(['taxons' => $axes->getWrappedObject()])])
-        ;
     }
 
     /**

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/PercentageDiscountConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/PercentageDiscountConfigurationType.php
@@ -16,7 +16,6 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Type;
-use Sylius\Bundle\PromotionBundle\Form\Type\Filter\ActionFiltersType;
 
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
@@ -43,7 +42,6 @@ class PercentageDiscountConfigurationType extends AbstractType
                     ]),
                 ],
             ])
-            ->add('filters', ActionFiltersType::class)
         ;
     }
 

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/PercentageDiscountConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/PercentageDiscountConfigurationType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Type;
+use Sylius\Bundle\PromotionBundle\Form\Type\Filter\ActionFiltersType;
 
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
@@ -42,6 +43,7 @@ class PercentageDiscountConfigurationType extends AbstractType
                     ]),
                 ],
             ])
+            ->add('filters', ActionFiltersType::class)
         ;
     }
 

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/UnitFixedDiscountConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/UnitFixedDiscountConfigurationType.php
@@ -9,18 +9,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\PromotionBundle\Form\Type\Filter;
+namespace Sylius\Bundle\PromotionBundle\Form\Type\Action;
 
-use Symfony\Component\Form\AbstractType;
-use Sylius\Bundle\MoneyBundle\Form\Type\MoneyType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints\Type;
+use Sylius\Bundle\PromotionBundle\Form\Type\Filter\ActionFiltersType;
 
 /**
  * @author Viorel Craescu <viorel@craescu.com>
  * @author Gabi Udrescu <gabriel.udr@gmail.com>
  */
-class PriceRangeType extends AbstractType
+class UnitFixedDiscountConfigurationType extends FixedDiscountConfigurationType
 {
     /**
      * @param FormBuilderInterface $builder
@@ -28,15 +26,18 @@ class PriceRangeType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('min', MoneyType::class, [
-            'constraints' => [
-                new Type(['type' => 'numeric']),
-            ],
+        parent::buildForm($builder, $options);
+
+        $builder->add('filters', ActionFiltersType::class, [
+            'empty_data' => [],
         ]);
-        $builder->add('max', MoneyType::class, [
-            'constraints' => [
-                new Type(['type' => 'numeric']),
-            ],
-        ]);
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'sylius_promotion_action_unit_fixed_discount_configuration';
     }
 }

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/UnitPercentageDiscountConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/UnitPercentageDiscountConfigurationType.php
@@ -9,18 +9,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\PromotionBundle\Form\Type\Filter;
+namespace Sylius\Bundle\PromotionBundle\Form\Type\Action;
 
-use Symfony\Component\Form\AbstractType;
-use Sylius\Bundle\MoneyBundle\Form\Type\MoneyType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints\Type;
+use Sylius\Bundle\PromotionBundle\Form\Type\Filter\ActionFiltersType;
 
 /**
  * @author Viorel Craescu <viorel@craescu.com>
  * @author Gabi Udrescu <gabriel.udr@gmail.com>
  */
-class PriceRangeType extends AbstractType
+class UnitPercentageDiscountConfigurationType extends PercentageDiscountConfigurationType
 {
     /**
      * @param FormBuilderInterface $builder
@@ -28,15 +26,15 @@ class PriceRangeType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('min', MoneyType::class, [
-            'constraints' => [
-                new Type(['type' => 'numeric']),
-            ],
+        parent::buildForm($builder, $options);
+
+        $builder->add('filters', ActionFiltersType::class, [
+            'empty_data' => [],
         ]);
-        $builder->add('max', MoneyType::class, [
-            'constraints' => [
-                new Type(['type' => 'numeric']),
-            ],
-        ]);
+    }
+
+    public function getName()
+    {
+        return 'sylius_promotion_action_unit_percentage_discount_configuration';
     }
 }

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Filter/ActionFiltersType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Filter/ActionFiltersType.php
@@ -1,0 +1,29 @@
+<?php
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\PromotionBundle\Form\Type\Filter;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * The form type used to filter the promotion subjects when applying an action to them
+ *
+ * @author Viorel Craescu <viorel.craescu@trisoft.ro>
+ * @author Gabi Udrescu <gabriel.udr@gmail.com>
+ */
+
+class ActionFiltersType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('price_range', PriceRangeType::class);
+    }
+}

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Filter/ActionFiltersType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Filter/ActionFiltersType.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Sylius package.
  *
@@ -10,20 +11,46 @@
 
 namespace Sylius\Bundle\PromotionBundle\Form\Type\Filter;
 
+use Sylius\Bundle\CoreBundle\Form\DataTransformer\TaxonsToCodesTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonChoiceType;
 
 /**
- * The form type used to filter the promotion subjects when applying an action to them
- *
- * @author Viorel Craescu <viorel.craescu@trisoft.ro>
+ * @author Viorel Craescu <viorel@craescu.com>
  * @author Gabi Udrescu <gabriel.udr@gmail.com>
  */
-
 class ActionFiltersType extends AbstractType
 {
+    /**
+     * @var TaxonsToCodesTransformer
+     */
+    private $transformer;
+
+    /**
+     * @param TaxonsToCodesTransformer $transformer
+     */
+    public function __construct(TaxonsToCodesTransformer $transformer)
+    {
+        $this->transformer = $transformer;
+    }
+
+    /**
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('price_range', PriceRangeType::class);
+        $builder
+            ->add(
+                'taxons',
+                TaxonChoiceType::class,
+                [
+                    'multiple' => true,
+                ]
+            )
+            ->add('price_range', PriceRangeType::class);
+
+        $builder->get('taxons')->addModelTransformer($this->transformer);
     }
 }

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Filter/PriceRangeType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Filter/PriceRangeType.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\PromotionBundle\Form\Type\Filter;
+
+use Symfony\Component\Form\AbstractType;
+use Sylius\Bundle\MoneyBundle\Form\Type\MoneyType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Type;
+
+/**
+ * The form type used to filter the promotion subjects using a price range
+ *
+ * @author Viorel Craescu <viorel.craescu@trisoft.ro>
+ * @author Gabi Udrescu <gabriel.udr@gmail.com>
+ */
+class PriceRangeType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('min', MoneyType::class, [
+            'constraints' => [
+                new Type(['type' => 'numeric']),
+            ]
+        ]);
+        $builder->add('max', MoneyType::class, [
+            'constraints' => [
+                new Type(['type' => 'numeric']),
+            ]
+        ]);
+    }
+}

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
@@ -69,5 +69,15 @@
             <argument type="service" id="sylius.promotion_coupon_generator.percentage_policy" />
             <tag name="validator.constraint_validator" alias="sylius_coupon_generation_amount_validator" />
         </service>
+
+
+        <service id="sylius.form.type.promotion_action.filter" class="Sylius\Bundle\PromotionBundle\Form\Type\Filter\ActionFiltersType">
+            <tag name="form.type" alias="sylius_promotion_action_filter" />
+        </service>
+
+        <service id="sylius.form.type.promotion_action.filter.price_range" class="Sylius\Bundle\PromotionBundle\Form\Type\Filter\PriceRangeType">
+            <tag name="form.type" alias="sylius_promotion_action_filter_price_range" />
+        </service>
+
     </services>
 </container>

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
@@ -70,14 +70,13 @@
             <tag name="validator.constraint_validator" alias="sylius_coupon_generation_amount_validator" />
         </service>
 
-
         <service id="sylius.form.type.promotion_action.filter" class="Sylius\Bundle\PromotionBundle\Form\Type\Filter\ActionFiltersType">
+            <argument type="service" id="sylius.form.type.data_transformer.taxons_to_codes" />
             <tag name="form.type" alias="sylius_promotion_action_filter" />
         </service>
 
         <service id="sylius.form.type.promotion_action.filter.price_range" class="Sylius\Bundle\PromotionBundle\Form\Type\Filter\PriceRangeType">
             <tag name="form.type" alias="sylius_promotion_action_filter_price_range" />
         </service>
-
     </services>
 </container>

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services/forms.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services/forms.xml
@@ -34,8 +34,14 @@
         <service id="sylius.form.type.promotion_action.fixed_discount_configuration" class="Sylius\Bundle\PromotionBundle\Form\Type\Action\FixedDiscountConfigurationType">
             <tag name="form.type" alias="sylius_promotion_action_fixed_discount_configuration" />
         </service>
+        <service id="sylius.form.type.promotion_action.unit_fixed_discount_configuration" class="Sylius\Bundle\PromotionBundle\Form\Type\Action\UnitFixedDiscountConfigurationType">
+            <tag name="form.type" alias="sylius_promotion_action_unit_fixed_discount_configuration" />
+        </service>
         <service id="sylius.form.type.promotion_action.percentage_discount_configuration" class="Sylius\Bundle\PromotionBundle\Form\Type\Action\PercentageDiscountConfigurationType">
             <tag name="form.type" alias="sylius_promotion_action_percentage_discount_configuration" />
+        </service>
+        <service id="sylius.form.type.promotion_action.unit_percentage_discount_configuration" class="Sylius\Bundle\PromotionBundle\Form\Type\Action\UnitPercentageDiscountConfigurationType">
+            <tag name="form.type" alias="sylius_promotion_action_unit_percentage_discount_configuration" />
         </service>
         <service id="sylius.form.type.promotion_rule.item_total_configuration" class="Sylius\Bundle\PromotionBundle\Form\Type\Rule\ItemTotalConfigurationType">
             <tag name="form.type" alias="sylius_promotion_rule_item_total_configuration" />

--- a/src/Sylius/Bundle/PromotionBundle/composer.json
+++ b/src/Sylius/Bundle/PromotionBundle/composer.json
@@ -27,7 +27,8 @@
         "sylius/registry": "^1.0",
         "sylius/money-bundle": "^1.0",
         "sylius/resource-bundle": "^1.0",
-        "symfony/framework-bundle": "^2.8"
+        "symfony/framework-bundle": "^2.8",
+        "sylius/taxonomy-bundle": "^1.0"
     },
     "require-dev": {
         "doctrine/orm": "^2.4.8",

--- a/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Action/UnitFixedDiscountConfigurationTypeSpec.php
+++ b/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Action/UnitFixedDiscountConfigurationTypeSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace spec\Sylius\Bundle\PromotionBundle\Form\Type\Action;
+
+use Sylius\Bundle\PromotionBundle\Form\Type\Action\UnitFixedDiscountConfigurationType;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\PromotionBundle\Form\Type\Action\FixedDiscountConfigurationType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Sylius\Bundle\PromotionBundle\Form\Type\Filter\ActionFiltersType;
+
+class UnitFixedDiscountConfigurationTypeSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(UnitFixedDiscountConfigurationType::class);
+    }
+
+    public function it_should_be_an_fixed_discount_configuration_type()
+    {
+        $this->shouldHaveType(FixedDiscountConfigurationType::class);
+    }
+
+    public function it_should_have_filters(FormBuilderInterface $builder)
+    {
+        $builder
+            ->add('amount', 'sylius_money', Argument::any())
+            ->willReturn($builder);
+
+        $builder
+            ->add('filters', ActionFiltersType::class, Argument::withKey('empty_data'))
+            ->willReturn($builder);
+
+        $this->buildForm($builder, []);
+    }
+}

--- a/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Action/UnitPercentageDiscountConfigurationTypeSpec.php
+++ b/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Action/UnitPercentageDiscountConfigurationTypeSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\PromotionBundle\Form\Type\Action;
+
+use Sylius\Bundle\PromotionBundle\Form\Type\Action\UnitPercentageDiscountConfigurationType;
+use Sylius\Bundle\PromotionBundle\Form\Type\Action\PercentageDiscountConfigurationType;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Form\FormBuilderInterface;
+use Sylius\Bundle\PromotionBundle\Form\Type\Filter\ActionFiltersType;
+
+/**
+ * @author Viorel Craescu <viorel@craescu.com>
+ * @author Gabi Udrescu <gabriel.udr@gmail.com>
+ */
+class UnitPercentageDiscountConfigurationTypeSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(UnitPercentageDiscountConfigurationType::class);
+    }
+
+    public function it_is_a_percentage_discount_configuration_form_type()
+    {
+        $this->shouldHaveType(PercentageDiscountConfigurationType::class);
+    }
+
+    public function it_should_have_filters(FormBuilderInterface $builder)
+    {
+        $builder
+            ->add('percentage', 'percent', Argument::any())
+            ->willReturn($builder);
+
+        $builder
+            ->add('filters', ActionFiltersType::class, Argument::withKey('empty_data'))
+            ->willReturn($builder);
+
+        $this->buildForm($builder, []);
+    }
+
+    public function it_should_have_a_name()
+    {
+        $this->getName()->shouldReturn('sylius_promotion_action_unit_percentage_discount_configuration');
+    }
+}

--- a/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Filter/ActionFiltersTypeSpec.php
+++ b/src/Sylius/Bundle/PromotionBundle/spec/Form/Type/Filter/ActionFiltersTypeSpec.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace spec\Sylius\Bundle\PromotionBundle\Form\Type\Filter;
+
+use Sylius\Bundle\PromotionBundle\Form\Type\Filter\ActionFiltersType;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Sylius\Bundle\PromotionBundle\Form\Type\Filter\PriceRangeType;
+use Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonChoiceType;
+use Sylius\Bundle\CoreBundle\Form\DataTransformer\TaxonsToCodesTransformer;
+
+class ActionFiltersTypeSpec extends ObjectBehavior
+{
+    public function let(TaxonsToCodesTransformer $transformer)
+    {
+        $this->beConstructedWith($transformer);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(ActionFiltersType::class);
+    }
+
+    public function it_is_an_abstract_form()
+    {
+        $this->shouldHaveType(AbstractType::class);
+    }
+
+    public function it_should_have_price_range_and_taxon_filters(FormBuilderInterface $builder, FormBuilderInterface $taxons, TaxonsToCodesTransformer $transformer)
+    {
+        $builder
+            ->add('price_range', PriceRangeType::class)
+            ->willReturn($builder)
+            ->shouldBeCalled()
+        ;
+
+        $builder
+            ->add('taxons', TaxonChoiceType::class, Argument::exact([
+                'multiple' => true,
+            ]))
+            ->willReturn($builder)
+            ->shouldBeCalled()
+        ;
+
+        $builder->get('taxons')->willReturn($taxons);
+
+        $taxons->addModelTransformer($transformer)->shouldBeCalled();
+
+        $this->buildForm($builder, []);
+    }
+}

--- a/src/Sylius/Component/Core/Promotion/Action/UnitFixedDiscountPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/UnitFixedDiscountPromotionActionCommand.php
@@ -38,8 +38,8 @@ class UnitFixedDiscountPromotionActionCommand extends UnitDiscountPromotionActio
 
     /**
      * @param FactoryInterface $adjustmentFactory
-     * @param FilterInterface $priceRangeFilter
-     * @param FilterInterface $taxonFilter
+     * @param FilterInterface  $priceRangeFilter
+     * @param FilterInterface  $taxonFilter
      */
     public function __construct(
         FactoryInterface $adjustmentFactory,
@@ -78,12 +78,12 @@ class UnitFixedDiscountPromotionActionCommand extends UnitDiscountPromotionActio
      */
     public function getConfigurationFormType()
     {
-        return 'sylius_promotion_action_fixed_discount_configuration';
+        return 'sylius_promotion_action_unit_fixed_discount_configuration';
     }
 
     /**
      * @param OrderItemInterface $item
-     * @param int $amount
+     * @param int                $amount
      * @param PromotionInterface $promotion
      */
     private function setUnitsAdjustments(OrderItemInterface $item, $amount, PromotionInterface $promotion)

--- a/src/Sylius/Component/Core/Promotion/Action/UnitPercentageDiscountPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/UnitPercentageDiscountPromotionActionCommand.php
@@ -38,8 +38,8 @@ class UnitPercentageDiscountPromotionActionCommand extends UnitDiscountPromotion
 
     /**
      * @param FactoryInterface $adjustmentFactory
-     * @param FilterInterface $priceRangeFilter
-     * @param FilterInterface $taxonFilter
+     * @param FilterInterface  $priceRangeFilter
+     * @param FilterInterface  $taxonFilter
      */
     public function __construct(
         FactoryInterface $adjustmentFactory,
@@ -75,12 +75,12 @@ class UnitPercentageDiscountPromotionActionCommand extends UnitDiscountPromotion
      */
     public function getConfigurationFormType()
     {
-        return 'sylius_promotion_action_percentage_discount_configuration';
+        return 'sylius_promotion_action_unit_percentage_discount_configuration';
     }
 
     /**
      * @param OrderItemInterface $item
-     * @param int $promotionAmount
+     * @param int                $promotionAmount
      * @param PromotionInterface $promotion
      */
     private function setUnitsAdjustments(OrderItemInterface $item, $promotionAmount, PromotionInterface $promotion)

--- a/src/Sylius/Component/Core/spec/Promotion/Action/UnitFixedDiscountPromotionActionCommandSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/UnitFixedDiscountPromotionActionCommandSpec.php
@@ -33,7 +33,7 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
  */
 final class UnitFixedDiscountPromotionActionCommandSpec extends ObjectBehavior
 {
-    function let(
+    public function let(
         FactoryInterface $adjustmentFactory,
         FilterInterface $priceRangeFilter,
         FilterInterface $taxonFilter
@@ -41,7 +41,7 @@ final class UnitFixedDiscountPromotionActionCommandSpec extends ObjectBehavior
         $this->beConstructedWith($adjustmentFactory, $priceRangeFilter, $taxonFilter);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType(UnitFixedDiscountPromotionActionCommand::class);
     }
@@ -234,8 +234,8 @@ final class UnitFixedDiscountPromotionActionCommandSpec extends ObjectBehavior
         ;
     }
 
-    function it_has_a_configuration_form_type()
+    public function it_has_configuration_form_type()
     {
-        $this->getConfigurationFormType()->shouldReturn('sylius_promotion_action_fixed_discount_configuration');
+        $this->getConfigurationFormType()->shouldReturn('sylius_promotion_action_unit_fixed_discount_configuration');
     }
 }

--- a/src/Sylius/Component/Core/spec/Promotion/Action/UnitPercentageDiscountPromotionActionCommandSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Action/UnitPercentageDiscountPromotionActionCommandSpec.php
@@ -32,7 +32,7 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
  */
 final class UnitPercentageDiscountPromotionActionCommandSpec extends ObjectBehavior
 {
-    function let(
+    public function let(
         FactoryInterface $adjustmentFactory,
         FilterInterface $priceRangeFilter,
         FilterInterface $taxonFilter
@@ -40,20 +40,31 @@ final class UnitPercentageDiscountPromotionActionCommandSpec extends ObjectBehav
         $this->beConstructedWith($adjustmentFactory, $priceRangeFilter, $taxonFilter);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType(UnitPercentageDiscountPromotionActionCommand::class);
     }
 
+<<<<<<< 79e1ae723f64dd234dbbb0a1b0829f58988422ab
     function it_is_an_item_discount_action()
+=======
+    public function it_is_item_discount_action()
+>>>>>>> added taxons filters
     {
         $this->shouldHaveType(UnitDiscountPromotionActionCommand::class);
     }
 
+<<<<<<< 79e1ae723f64dd234dbbb0a1b0829f58988422ab
     function it_applies_percentage_discount_on_every_unit_in_order(
         FactoryInterface $adjustmentFactory,
         FilterInterface $priceRangeFilter,
         FilterInterface $taxonFilter,
+=======
+    public function it_applies_percentage_discount_on_every_unit_in_order(
+        $adjustmentFactory,
+        $priceRangeFilter,
+        $taxonFilter,
+>>>>>>> added taxons filters
         AdjustmentInterface $promotionAdjustment1,
         AdjustmentInterface $promotionAdjustment2,
         Collection $originalItems,
@@ -107,7 +118,11 @@ final class UnitPercentageDiscountPromotionActionCommandSpec extends ObjectBehav
         $this->execute($order, ['percentage' => 0.2, 'filters' => ['taxons' => ['testTaxon']]], $promotion);
     }
 
+<<<<<<< 79e1ae723f64dd234dbbb0a1b0829f58988422ab
     function it_throws_an_exception_if_passed_subject_is_not_order(
+=======
+    public function it_throws_exception_if_passed_subject_is_not_order(
+>>>>>>> added taxons filters
         PromotionSubjectInterface $subject,
         PromotionInterface $promotion
     ) {
@@ -117,7 +132,11 @@ final class UnitPercentageDiscountPromotionActionCommandSpec extends ObjectBehav
         ;
     }
 
+<<<<<<< 79e1ae723f64dd234dbbb0a1b0829f58988422ab
     function it_reverts_a_proper_promotion_adjustment_from_all_units(
+=======
+    public function it_reverts_proper_promotion_adjustment_from_all_units(
+>>>>>>> added taxons filters
         AdjustmentInterface $promotionAdjustment1,
         AdjustmentInterface $promotionAdjustment2,
         Collection $items,
@@ -151,7 +170,11 @@ final class UnitPercentageDiscountPromotionActionCommandSpec extends ObjectBehav
         $this->revert($order, ['percentage' => 0.2], $promotion);
     }
 
+<<<<<<< 79e1ae723f64dd234dbbb0a1b0829f58988422ab
     function it_throws_an_exception_if_passed_subject_to_revert_is_not_order(
+=======
+    public function it_throws_exception_if_passed_subject_to_revert_is_not_order(
+>>>>>>> added taxons filters
         PromotionSubjectInterface $subject,
         PromotionInterface $promotion
     ) {
@@ -161,8 +184,12 @@ final class UnitPercentageDiscountPromotionActionCommandSpec extends ObjectBehav
         ;
     }
 
+<<<<<<< 79e1ae723f64dd234dbbb0a1b0829f58988422ab
     function it_has_a_configuration_form_type()
+=======
+    public function it_has_configuration_form_type()
+>>>>>>> added taxons filters
     {
-        $this->getConfigurationFormType()->shouldReturn('sylius_promotion_action_percentage_discount_configuration');
+        $this->getConfigurationFormType()->shouldReturn('sylius_promotion_action_unit_percentage_discount_configuration');
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Related tickets | partially #3368
| License         | MIT

with this new addition, you can create campaigns like this:
 - give 10% off for all products that cost more than 100$

if this is well received, the next step is to do another PR with a taxon filter, that will solve the riddle I've posted here: #5772

I couldn't have managed to pull this off without the help of @vcraescu, so much of the kudos goes to him :beers: 

![image](https://cloud.githubusercontent.com/assets/5156054/18411193/847d6b1c-777b-11e6-8eb9-2a82edefff45.png)

![image](https://cloud.githubusercontent.com/assets/5156054/18411194/8f0aaa4a-777b-11e6-8a60-4257edc25417.png)
