### PR TITLE
[BugFix][Core] Remove cascade transitions on sylius_shipment_unit

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine.yml
@@ -145,14 +145,6 @@ winzou_state_machine:
                     do: ["@sm.callback.cascade_transition", "apply"]
                     args: ["object", "event", "'cancel'", "'sylius_order_shipping'"]
 
-    sylius_inventory_unit:
-        callbacks:
-            after:
-                sylius_sync_shipping:
-                    excluded_to: [sold]
-                    do: ["@sm.callback.cascade_transition", "apply"]
-                    args: ["object", "event", "null", "'sylius_shipment_unit'"]
-
     sylius_shipment:
         callbacks:
             after:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Related tickets | fixes #5667
| License         | MIT

I looked into issue #5667 and I think the best way to solve it is to remove the whole cascade of the transitions all together. This will prevent some nasty errors that are currently present in core.