### PR TITLE
Let us to create a custom checkout flow

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Checkout/CheckoutResolver.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/CheckoutResolver.php
@@ -14,7 +14,6 @@ namespace Sylius\Bundle\CoreBundle\Checkout;
 use SM\Factory\FactoryInterface;
 use Sylius\Component\Cart\Context\CartContextInterface;
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\OrderCheckoutTransitions;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -71,6 +70,7 @@ final class CheckoutResolver implements EventSubscriberInterface
      */
     public function onKernelRequest(GetResponseEvent $event)
     {
+
         if (!$event->isMasterRequest()) {
             return;
         }
@@ -83,7 +83,7 @@ final class CheckoutResolver implements EventSubscriberInterface
 
         /** @var OrderInterface $order */
         $order = $this->cartContext->getCart();
-        $stateMachine = $this->stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH);
+        $stateMachine = $this->stateMachineFactory->get($order, $this->getRequestedGraph($request));
 
         if ($stateMachine->can($this->getRequestedTransition($request))) {
             return;
@@ -116,6 +116,16 @@ final class CheckoutResolver implements EventSubscriberInterface
     private function getRequestedTransition(Request $request)
     {
         return $request->attributes->get('_sylius')['state_machine']['transition'];
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return string
+     */
+    private function getRequestedGraph(Request $request)
+    {
+        return $request->attributes->get('_sylius')['state_machine']['graph'];
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| License | MIT |

Because OrderCheckoutTransitions class is final , we have no way to add custom translation , and also  CheckoutResolver is bound to OrderCheckoutTransitions,  we can't create a custom checkout flow.  making CheckoutResolver to get translation graph from request , probably this is the simplest way to let us create a custom checkout flow。
