### PR TITLE
[ShopBundle] Fix dependency issue with AdminBundle in _addresses.html.twig

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Order/_addresses.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Order/_addresses.html.twig
@@ -2,11 +2,11 @@
     <div class="ui two column divided stackable grid">
         <div class="column" id="shipping-address">
             <div class="ui small dividing header">{{ 'sylius.ui.shipping_address'|trans }}</div>
-            {% include '@SyliusAdmin/Common/_address.html.twig' with {'address': order.shippingAddress} %}
+            {% include '@SyliusShop/Common/_address.html.twig' with {'address': order.shippingAddress} %}
         </div>
         <div class="column" id="billing-address">
             <div class="ui small dividing header">{{ 'sylius.ui.billing_address'|trans }}</div>
-            {% include '@SyliusAdmin/Common/_address.html.twig' with {'address': order.billingAddress} %}
+            {% include '@SyliusShop/Common/_address.html.twig' with {'address': order.billingAddress} %}
         </div>
     </div>
 </div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Related tickets | fixes #6098 
| License         | MIT

Use the `_address.html.twig` partial template from the ShopBundle instead of the AdminBundle.