### PR TITLE
[Ui] Fixed yes/no translations

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
@@ -459,7 +459,7 @@ sylius:
         new_zone: 'New zone'
         newest_products: 'Newest products'
         next: Next
-        no: No
+        "no": No
         no_account: 'No account yet'
         no_account: no account
         no_association_types_to_display: 'There are no association types defined'
@@ -774,7 +774,7 @@ sylius:
         welcome: Welcome
         welcome_to_our_store: 'Welcome to our store'
         welcome_to_your_space: 'Welcome to your space'
-        yes: Yes
+        "yes": Yes
         you_are_customer_since: 'You are customer since'
         you_have_no_addresses_defined: 'You have no addresses defined'
         you_have_no_new_orders: 'You have no new orders'


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | - 
| License         | MIT

Should fix the 1/empty label rendering in admin's customer index. No way to test it without SyliusBot push crowdin and getting translations back. 😞 