### PR TITLE
Fix Shipping & Billing mapping to order.

### DIFF
--- a/app/migrations/Version20160916113304.php
+++ b/app/migrations/Version20160916113304.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20160916113304 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_order DROP INDEX UNIQ_6196A1F94D4CFF2B, ADD INDEX IDX_6196A1F94D4CFF2B (shipping_address_id)');
+        $this->addSql('ALTER TABLE sylius_order DROP INDEX UNIQ_6196A1F979D0C0E4, ADD INDEX IDX_6196A1F979D0C0E4 (billing_address_id)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_order DROP INDEX IDX_6196A1F94D4CFF2B, ADD UNIQUE INDEX UNIQ_6196A1F94D4CFF2B (shipping_address_id)');
+        $this->addSql('ALTER TABLE sylius_order DROP INDEX IDX_6196A1F979D0C0E4, ADD UNIQUE INDEX UNIQ_6196A1F979D0C0E4 (billing_address_id)');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Order.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Order.orm.xml
@@ -21,21 +21,21 @@
             <join-column name="channel_id" referenced-column-name="id" nullable="true" />
         </many-to-one>
 
-        <one-to-one field="shippingAddress" target-entity="Sylius\Component\Addressing\Model\AddressInterface">
+        <many-to-one field="shippingAddress" target-entity="Sylius\Component\Addressing\Model\AddressInterface">
             <cascade>
                 <cascade-persist/>
                 <cascade-remove/>
             </cascade>
             <join-column name="shipping_address_id" referenced-column-name="id" nullable="true" />
-        </one-to-one>
+        </many-to-one>
 
-        <one-to-one field="billingAddress" target-entity="Sylius\Component\Addressing\Model\AddressInterface">
+        <many-to-one field="billingAddress" target-entity="Sylius\Component\Addressing\Model\AddressInterface">
             <cascade>
                 <cascade-persist/>
                 <cascade-remove/>
             </cascade>
             <join-column name="billing_address_id" referenced-column-name="id" nullable="true" />
-        </one-to-one>
+        </many-to-one>
 
         <many-to-one field="promotionCoupon" target-entity="Sylius\Component\Promotion\Model\CouponInterface">
             <join-column name="promotion_coupon_id" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

When trying to use the same billing address or shipping address for an order, I got an Integrity constraint violation from the unique indexes mapped to billing & shipping address.

Was there a reason for having a one-to-one mapping on order ?

@pamil, @Zales0123  can you check I'm not doing something crazy ?