### PR TITLE
[BugFix][Core] Order::isInvoiceAvailable, remove `STATE_RETURNED` constant.

### DIFF
--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -491,7 +491,7 @@ class Order extends Cart implements OrderInterface
     public function isInvoiceAvailable()
     {
         if (false !== $lastShipment = $this->getLastShipment()) {
-            return in_array($lastShipment->getState(), [ShipmentInterface::STATE_RETURNED, ShipmentInterface::STATE_SHIPPED]);
+            return in_array($lastShipment->getState(), [ShipmentInterface::STATE_SHIPPED]);
         }
 
         return false;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Related tickets | fixes #6139
| License         | MIT

