### PR TITLE
[RFC][Resource] Make Resource actions easier to overwrite

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -182,7 +182,7 @@ class ResourceController extends Controller
             $view
                 ->setTemplate($configuration->getTemplate(ResourceActions::SHOW . '.html'))
                 ->setTemplateVar($this->metadata->getName())
-                ->setData($this->getShowTemplateData($configuration, $resource))
+                ->setData($this->provideShowTemplateData($configuration, $resource))
             ;
         }
 
@@ -207,7 +207,7 @@ class ResourceController extends Controller
             $view
                 ->setTemplate($configuration->getTemplate(ResourceActions::INDEX . '.html'))
                 ->setTemplateVar($this->metadata->getPluralName())
-                ->setData($this->getIndexTemplateData($configuration, $resources))
+                ->setData($this->provideIndexTemplateData($configuration, $resources))
             ;
         }
 
@@ -259,7 +259,7 @@ class ResourceController extends Controller
         }
 
         $view = View::create()
-            ->setData($this->getCreateTemplateData($configuration, $newResource, $form))
+            ->setData($this->provideFormTemplateData($configuration, $newResource, $form))
             ->setTemplate($configuration->getTemplate(ResourceActions::CREATE . '.html'))
         ;
 
@@ -315,7 +315,7 @@ class ResourceController extends Controller
         }
 
         $view = View::create()
-            ->setData($this->getUpdateTemplateData($configuration, $resource, $form))
+            ->setData($this->provideFormTemplateData($configuration, $resource, $form))
             ->setTemplate($configuration->getTemplate(ResourceActions::UPDATE . '.html'))
         ;
 
@@ -519,7 +519,7 @@ class ResourceController extends Controller
     /**
      * @param RequestConfiguration $configuration
      *
-     * @return \Sylius\Component\Resource\Model\ResourceInterface
+     * @return ResourceInterface
      *
      * @throws NotFoundHttpException
      */
@@ -538,7 +538,7 @@ class ResourceController extends Controller
      *
      * @return array
      */
-    protected function getShowTemplateData(RequestConfiguration $configuration, ResourceInterface $resource)
+    protected function provideShowTemplateData(RequestConfiguration $configuration, ResourceInterface $resource)
     {
         return [
             'configuration' => $configuration,
@@ -554,7 +554,7 @@ class ResourceController extends Controller
      *
      * @return array
      */
-    protected function getIndexTemplateData(RequestConfiguration $configuration, $resources)
+    protected function provideIndexTemplateData(RequestConfiguration $configuration, $resources)
     {
         return [
             'configuration' => $configuration,
@@ -566,42 +566,12 @@ class ResourceController extends Controller
 
     /**
      * @param RequestConfiguration $configuration
-     * @param ResourceInterface $newResource
-     * @param FormInterface $form
-     *
-     * @return array
-     */
-    protected function getCreateTemplateData(
-        RequestConfiguration $configuration,
-        ResourceInterface $newResource,
-        FormInterface $form
-    ) {
-        return $this->getFormTemplateData($configuration, $newResource, $form);
-    }
-
-    /**
-     * @param RequestConfiguration $configuration
      * @param ResourceInterface $resource
      * @param FormInterface $form
      *
      * @return array
      */
-    protected function getUpdateTemplateData(
-        RequestConfiguration $configuration,
-        ResourceInterface $resource,
-        FormInterface $form
-    ) {
-        return $this->getFormTemplateData($configuration, $resource, $form);
-    }
-
-    /**
-     * @param RequestConfiguration $configuration
-     * @param ResourceInterface $resource
-     * @param FormInterface $form
-     *
-     * @return array
-     */
-    protected function getFormTemplateData(
+    protected function provideFormTemplateData(
         RequestConfiguration $configuration,
         ResourceInterface $resource,
         FormInterface $form

--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -13,11 +13,14 @@ namespace Sylius\Bundle\ResourceBundle\Controller;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use FOS\RestBundle\View\View;
+use Sylius\Bundle\ResourceBundle\Grid\View\ResourceGridView;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Resource\Metadata\MetadataInterface;
+use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Resource\ResourceActions;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -179,12 +182,7 @@ class ResourceController extends Controller
             $view
                 ->setTemplate($configuration->getTemplate(ResourceActions::SHOW . '.html'))
                 ->setTemplateVar($this->metadata->getName())
-                ->setData([
-                    'configuration' => $configuration,
-                    'metadata' => $this->metadata,
-                    'resource' => $resource,
-                    $this->metadata->getName() => $resource,
-                ])
+                ->setData($this->getShowTemplateData($configuration, $resource))
             ;
         }
 
@@ -209,12 +207,7 @@ class ResourceController extends Controller
             $view
                 ->setTemplate($configuration->getTemplate(ResourceActions::INDEX . '.html'))
                 ->setTemplateVar($this->metadata->getPluralName())
-                ->setData([
-                    'configuration' => $configuration,
-                    'metadata' => $this->metadata,
-                    'resources' => $resources,
-                    $this->metadata->getPluralName() => $resources,
-                ])
+                ->setData($this->getIndexTemplateData($configuration, $resources))
             ;
         }
 
@@ -266,13 +259,7 @@ class ResourceController extends Controller
         }
 
         $view = View::create()
-            ->setData([
-                'configuration' => $configuration,
-                'metadata' => $this->metadata,
-                'resource' => $newResource,
-                $this->metadata->getName() => $newResource,
-                'form' => $form->createView(),
-            ])
+            ->setData($this->getCreateTemplateData($configuration, $newResource, $form))
             ->setTemplate($configuration->getTemplate(ResourceActions::CREATE . '.html'))
         ;
 
@@ -328,13 +315,7 @@ class ResourceController extends Controller
         }
 
         $view = View::create()
-            ->setData([
-                'configuration' => $configuration,
-                'metadata' => $this->metadata,
-                'resource' => $resource,
-                $this->metadata->getName() => $resource,
-                'form' => $form->createView(),
-            ])
+            ->setData($this->getUpdateTemplateData($configuration, $resource, $form))
             ->setTemplate($configuration->getTemplate(ResourceActions::UPDATE . '.html'))
         ;
 
@@ -549,5 +530,88 @@ class ResourceController extends Controller
         }
 
         return $resource;
+    }
+
+    /**
+     * @param RequestConfiguration $configuration
+     * @param ResourceInterface $resource
+     *
+     * @return array
+     */
+    protected function getShowTemplateData(RequestConfiguration $configuration, ResourceInterface $resource)
+    {
+        return [
+            'configuration' => $configuration,
+            'metadata' => $this->metadata,
+            'resource' => $resource,
+            $this->metadata->getName() => $resource,
+        ];
+    }
+
+    /**
+     * @param RequestConfiguration $configuration
+     * @param mixed $resources
+     *
+     * @return array
+     */
+    protected function getIndexTemplateData(RequestConfiguration $configuration, $resources)
+    {
+        return [
+            'configuration' => $configuration,
+            'metadata' => $this->metadata,
+            'resources' => $resources,
+            $this->metadata->getPluralName() => $resources,
+        ];
+    }
+
+    /**
+     * @param RequestConfiguration $configuration
+     * @param ResourceInterface $newResource
+     * @param FormInterface $form
+     *
+     * @return array
+     */
+    protected function getCreateTemplateData(
+        RequestConfiguration $configuration,
+        ResourceInterface $newResource,
+        FormInterface $form
+    ) {
+        return $this->getFormTemplateData($configuration, $newResource, $form);
+    }
+
+    /**
+     * @param RequestConfiguration $configuration
+     * @param ResourceInterface $resource
+     * @param FormInterface $form
+     *
+     * @return array
+     */
+    protected function getUpdateTemplateData(
+        RequestConfiguration $configuration,
+        ResourceInterface $resource,
+        FormInterface $form
+    ) {
+        return $this->getFormTemplateData($configuration, $resource, $form);
+    }
+
+    /**
+     * @param RequestConfiguration $configuration
+     * @param ResourceInterface $resource
+     * @param FormInterface $form
+     *
+     * @return array
+     */
+    protected function getFormTemplateData(
+        RequestConfiguration $configuration,
+        ResourceInterface $resource,
+        FormInterface $form
+    ) {
+        return [
+            'configuration' => $configuration,
+            'metadata' => $this->metadata,
+            'resource' => $resource,
+            $this->metadata->getName() => $resource,
+            'form' => $form->createView(),
+        ];
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets |
| License         | MIT

As we know, ``ResourceController`` gives us a lot, starting from duplication reduction, on sense of security ending 😄  However, it's pretty hard to use its methods with some extra data or logic - it usually ends up with copying whole action. It's ridiculous, especially when we just want to add some extra data to template (which was my use case in https://github.com/Sylius/Sylius/pull/6161 - I ended up with overwriting the whole damn action).
I suggest to introduce some protected methods returning templates data, that can be overwrote instead of actions. I know it's not the most clean way (we still have some parameters passed to these functions which looks awful for method, that should just return required data), but could be a first step for making ``ResourceController`` easier to use.
I would appreciate any feedback about this, is it the path we want to follow or not. 🐫 