### PR TITLE
[Behat][Repositories] Refactory find by name repository methods

### DIFF
--- a/src/Sylius/Behat/Context/Setup/TaxationContext.php
+++ b/src/Sylius/Behat/Context/Setup/TaxationContext.php
@@ -176,7 +176,7 @@ final class TaxationContext implements Context
     {
         $taxCategories = $this->taxCategoryRepository->findByName($taxCategoryName);
         if (empty($taxCategories)) {
-            $taxCategories = [$this->createTaxCategory($taxCategoryName)];
+            return $this->createTaxCategory($taxCategoryName);
         }
 
         Assert::eq(

--- a/src/Sylius/Behat/Context/Setup/TaxationContext.php
+++ b/src/Sylius/Behat/Context/Setup/TaxationContext.php
@@ -22,6 +22,7 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Taxation\Model\TaxCategoryInterface;
 use Sylius\Component\Taxation\Repository\TaxCategoryRepositoryInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -173,12 +174,18 @@ final class TaxationContext implements Context
      */
     private function getOrCreateTaxCategory($taxCategoryName)
     {
-        $taxCategory = $this->taxCategoryRepository->findOneByName($taxCategoryName);
-        if (null === $taxCategory) {
-            $taxCategory = $this->createTaxCategory($taxCategoryName);
+        $taxCategories = $this->taxCategoryRepository->findByName($taxCategoryName);
+        if (empty($taxCategories)) {
+            $taxCategories = [$this->createTaxCategory($taxCategoryName)];
         }
 
-        return $taxCategory;
+        Assert::eq(
+            1,
+            count($taxCategories),
+            sprintf('%d tax categories has been found with name "%s".', count($taxCategories), $taxCategoryName)
+        );
+
+        return $taxCategories[0];
     }
 
     /**

--- a/src/Sylius/Behat/Context/Transform/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Transform/ChannelContext.php
@@ -41,13 +41,14 @@ final class ChannelContext implements Context
      */
     public function getChannelByName($channelName)
     {
-        $channel = $this->channelRepository->findOneByName($channelName);
+        $channels = $this->channelRepository->findByName($channelName);
 
-        Assert::notNull(
-            $channel,
-            sprintf('Channel with name "%s" does not exist', $channelName)
+        Assert::eq(
+            1,
+            count($channels),
+            sprintf('%d channels has been found with name "%s".', count($channels), $channelName)
         );
 
-        return $channel;
+        return $channels[0];
     }
 }

--- a/src/Sylius/Behat/Context/Transform/PaymentMethodContext.php
+++ b/src/Sylius/Behat/Context/Transform/PaymentMethodContext.php
@@ -40,13 +40,14 @@ final class PaymentMethodContext implements Context
      */
     public function getPaymentMethodByName($paymentMethodName)
     {
-        $paymentMethod = $this->paymentMethodRepository->findOneByName($paymentMethodName);
+        $paymentMethods = $this->paymentMethodRepository->findByName($paymentMethodName);
 
-        Assert::notNull(
-            $paymentMethod,
-            sprintf('Payment method with name "%s" does not exist', $paymentMethodName)
+        Assert::eq(
+            1,
+            count($paymentMethods),
+            sprintf('%d payment methods has been found with name "%s".', count($paymentMethods), $paymentMethodName)
         );
 
-        return $paymentMethod;
+        return $paymentMethods[0];
     }
 }

--- a/src/Sylius/Behat/Context/Transform/PaymentMethodContext.php
+++ b/src/Sylius/Behat/Context/Transform/PaymentMethodContext.php
@@ -40,7 +40,7 @@ final class PaymentMethodContext implements Context
      */
     public function getPaymentMethodByName($paymentMethodName)
     {
-        $paymentMethods = $this->paymentMethodRepository->findByName($paymentMethodName);
+        $paymentMethods = $this->paymentMethodRepository->findByName($paymentMethodName, 'en_US');
 
         Assert::eq(
             1,

--- a/src/Sylius/Behat/Context/Transform/ProductContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductContext.php
@@ -41,7 +41,7 @@ final class ProductContext implements Context
      */
     public function getProductByName($productName)
     {
-        $products = $this->productRepository->findByName($productName);
+        $products = $this->productRepository->findByName($productName, 'en_US');
 
         Assert::eq(
             1,

--- a/src/Sylius/Behat/Context/Transform/ProductContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductContext.php
@@ -41,14 +41,15 @@ final class ProductContext implements Context
      */
     public function getProductByName($productName)
     {
-        $product = $this->productRepository->findOneByName($productName);
+        $products = $this->productRepository->findByName($productName);
 
-        Assert::notNull(
-            $product,
-            sprintf('Product with name "%s" does not exist', $productName)
+        Assert::eq(
+            1,
+            count($products),
+            sprintf('%d products has been found with name "%s".', count($products), $productName)
         );
 
-        return $product;
+        return $products[0];
     }
 
     /**

--- a/src/Sylius/Behat/Context/Transform/ProductOptionContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductOptionContext.php
@@ -40,7 +40,7 @@ final class ProductOptionContext implements Context
      */
     public function getProductOptionByName($productOptionName)
     {
-        $productOptions = $this->productOptionRepository->findByName($productOptionName);
+        $productOptions = $this->productOptionRepository->findByName($productOptionName, 'en_US');
 
         Assert::eq(
             1,

--- a/src/Sylius/Behat/Context/Transform/ProductOptionContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductOptionContext.php
@@ -40,12 +40,14 @@ final class ProductOptionContext implements Context
      */
     public function getProductOptionByName($productOptionName)
     {
-        $productOption = $this->productOptionRepository->findOneByName($productOptionName);
-        Assert::notNull(
-            $productOption,
-            sprintf('Product option with name "%s" does not exist in the product option repository.', $productOptionName)
+        $productOptions = $this->productOptionRepository->findByName($productOptionName);
+
+        Assert::eq(
+            1,
+            count($productOptions),
+            sprintf('%d product options has been found with name "%s".', count($productOptions), $productOptionName)
         );
 
-        return $productOption;
+        return $productOptions[0];
     }
 }

--- a/src/Sylius/Behat/Context/Transform/ProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductVariantContext.php
@@ -46,12 +46,15 @@ final class ProductVariantContext implements Context
      */
     public function getProductVariantByNameAndProduct($variantName, $productName)
     {
-        $product = $this->productRepository->findOneByName($productName);
-        if (null === $product) {
-            throw new \InvalidArgumentException(sprintf('Product with name "%s" does not exist', $productName));
-        }
+        $products = $this->productRepository->findByName($productName);
 
-        $productVariant = $this->productVariantRepository->findOneBy(['name' => $variantName, 'object' => $product]);
+        Assert::eq(
+            1,
+            count($products),
+            sprintf('%d products has been found with name "%s".', count($products), $productName)
+        );
+
+        $productVariant = $this->productVariantRepository->findOneBy(['name' => $variantName, 'object' => $products[0]]);
         if (null === $productVariant) {
             throw new \InvalidArgumentException(sprintf('Product variant with name "%s" of product "%s" does not exist', $variantName, $productName));
         }
@@ -65,9 +68,14 @@ final class ProductVariantContext implements Context
      */
     public function getProductVariantByName($name)
     {
-        $productVariant = $this->productVariantRepository->findOneBy(['name' => $name]);
-        Assert::notNull($productVariant, sprintf('There is no product variant for "%s" name', $name));
+        $productVariants = $this->productVariantRepository->findByName($name);
 
-        return $productVariant;
+        Assert::eq(
+            1,
+            count($productVariants),
+            sprintf('%d product variants has been found with name "%s".', count($productVariants), $name)
+        );
+
+        return $productVariants[0];
     }
 }

--- a/src/Sylius/Behat/Context/Transform/ProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductVariantContext.php
@@ -46,7 +46,7 @@ final class ProductVariantContext implements Context
      */
     public function getProductVariantByNameAndProduct($variantName, $productName)
     {
-        $products = $this->productRepository->findByName($productName);
+        $products = $this->productRepository->findByName($productName, 'en_US');
 
         Assert::eq(
             1,

--- a/src/Sylius/Behat/Context/Transform/ShippingMethodContext.php
+++ b/src/Sylius/Behat/Context/Transform/ShippingMethodContext.php
@@ -40,13 +40,14 @@ final class ShippingMethodContext implements Context
      */
     public function getShippingMethodByName($shippingMethodName)
     {
-        $shippingMethod = $this->shippingMethodRepository->findOneByName($shippingMethodName);
+        $shippingMethods = $this->shippingMethodRepository->findByName($shippingMethodName);
 
-        Assert::notNull(
-            $shippingMethod,
-            sprintf('Shipping method with name "%s" does not exist', $shippingMethodName)
+        Assert::eq(
+            1,
+            count($shippingMethods),
+            sprintf('%d shippinf methods has been found with name "%s".', count($shippingMethods), $shippingMethodName)
         );
 
-        return $shippingMethod;
+        return $shippingMethods[0];
     }
 }

--- a/src/Sylius/Behat/Context/Transform/ShippingMethodContext.php
+++ b/src/Sylius/Behat/Context/Transform/ShippingMethodContext.php
@@ -40,7 +40,7 @@ final class ShippingMethodContext implements Context
      */
     public function getShippingMethodByName($shippingMethodName)
     {
-        $shippingMethods = $this->shippingMethodRepository->findByName($shippingMethodName);
+        $shippingMethods = $this->shippingMethodRepository->findByName($shippingMethodName, 'en_US');
 
         Assert::eq(
             1,

--- a/src/Sylius/Behat/Context/Transform/TaxCategoryContext.php
+++ b/src/Sylius/Behat/Context/Transform/TaxCategoryContext.php
@@ -40,13 +40,14 @@ final class TaxCategoryContext implements Context
      */
     public function getTaxCategoryByName($taxCategoryName)
     {
-        $taxCategory = $this->taxCategoryRepository->findOneByName($taxCategoryName);
+        $taxCategories = $this->taxCategoryRepository->findByName($taxCategoryName);
 
-        Assert::notNull(
-            $taxCategory,
-            sprintf('Tax category with name "%s" does not exist', $taxCategoryName)
+        Assert::eq(
+            1,
+            count($taxCategories),
+            sprintf('%d tax categories has been found with name "%s".', count($taxCategories), $taxCategoryName)
         );
 
-        return $taxCategory;
+        return $taxCategories[0];
     }
 }

--- a/src/Sylius/Behat/Context/Transform/TaxonContext.php
+++ b/src/Sylius/Behat/Context/Transform/TaxonContext.php
@@ -45,7 +45,7 @@ final class TaxonContext implements Context
      */
     public function getTaxonByName($name)
     {
-        $taxons = $this->taxonRepository->findByName($name);
+        $taxons = $this->taxonRepository->findByName($name, 'en_US');
 
         Assert::eq(
             1,

--- a/src/Sylius/Behat/Context/Transform/TaxonContext.php
+++ b/src/Sylius/Behat/Context/Transform/TaxonContext.php
@@ -45,10 +45,15 @@ final class TaxonContext implements Context
      */
     public function getTaxonByName($name)
     {
-        $taxon = $this->taxonRepository->findOneByName($name);
-        Assert::notNull($taxon, sprintf('Taxon with name "%s" does not exist.', $name));
+        $taxons = $this->taxonRepository->findByName($name);
 
-        return $taxon;
+        Assert::eq(
+            1,
+            count($taxons),
+            sprintf('%d taxons has been found with name "%s".', count($taxons), $name)
+        );
+
+        return $taxons[0];
     }
 
     /**

--- a/src/Sylius/Bundle/AddressingBundle/Doctrine/ORM/ZoneRepository.php
+++ b/src/Sylius/Bundle/AddressingBundle/Doctrine/ORM/ZoneRepository.php
@@ -22,7 +22,7 @@ class ZoneRepository extends EntityRepository implements ZoneRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function findOneByName($name)
+    public function findByName($name)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('members')
@@ -30,7 +30,7 @@ class ZoneRepository extends EntityRepository implements ZoneRepositoryInterface
             ->where('o.name = :name')
             ->setParameter('name', $name)
             ->getQuery()
-            ->getOneOrNullResult()
+            ->getResult()
         ;
     }
 }

--- a/src/Sylius/Bundle/AttributeBundle/Doctrine/ORM/AttributeRepository.php
+++ b/src/Sylius/Bundle/AttributeBundle/Doctrine/ORM/AttributeRepository.php
@@ -23,13 +23,15 @@ class AttributeRepository extends EntityRepository implements AttributeRepositor
     /**
      * {@inheritdoc}
      */
-    public function findByName($name)
+    public function findByName($name, $locale)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
             ->leftJoin('o.translations', 'translation')
             ->where('translation.name = :name')
+            ->andWhere('translation.locale = :locale')
             ->setParameter('name', $name)
+            ->setParameter('locale', $locale)
             ->getQuery()
             ->getResult()
         ;

--- a/src/Sylius/Bundle/AttributeBundle/Doctrine/ORM/AttributeRepository.php
+++ b/src/Sylius/Bundle/AttributeBundle/Doctrine/ORM/AttributeRepository.php
@@ -23,7 +23,7 @@ class AttributeRepository extends EntityRepository implements AttributeRepositor
     /**
      * {@inheritdoc}
      */
-    public function findOneByName($name)
+    public function findByName($name)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
@@ -31,7 +31,7 @@ class AttributeRepository extends EntityRepository implements AttributeRepositor
             ->where('translation.name = :name')
             ->setParameter('name', $name)
             ->getQuery()
-            ->getOneOrNullResult()
+            ->getResult()
         ;
     }
 

--- a/src/Sylius/Bundle/ChannelBundle/Doctrine/ORM/ChannelRepository.php
+++ b/src/Sylius/Bundle/ChannelBundle/Doctrine/ORM/ChannelRepository.php
@@ -38,8 +38,8 @@ class ChannelRepository extends EntityRepository implements ChannelRepositoryInt
     /**
      * {@inheritdoc}
      */
-    public function findOneByName($name)
+    public function findByName($name)
     {
-        return $this->findOneBy(['name' => $name]);
+        return $this->findBy(['name' => $name]);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ShipmentRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ShipmentRepository.php
@@ -36,13 +36,15 @@ class ShipmentRepository extends EntityRepository implements ShipmentRepositoryI
     /**
      * {@inheritdoc}
      */
-    public function findByName($name)
+    public function findByName($name, $locale)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
             ->leftJoin('o.translations', 'translation')
             ->where('translation.name = :name')
+            ->andWhere('translation.locale = :locale')
             ->setParameter('name', $name)
+            ->setParameter('locale', $locale)
             ->getQuery()
             ->getResult()
         ;

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ShipmentRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ShipmentRepository.php
@@ -36,7 +36,7 @@ class ShipmentRepository extends EntityRepository implements ShipmentRepositoryI
     /**
      * {@inheritdoc}
      */
-    public function findOneByName($name)
+    public function findByName($name)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
@@ -44,7 +44,7 @@ class ShipmentRepository extends EntityRepository implements ShipmentRepositoryI
             ->where('translation.name = :name')
             ->setParameter('name', $name)
             ->getQuery()
-            ->getOneOrNullResult()
+            ->getResult()
         ;
     }
 

--- a/src/Sylius/Bundle/PaymentBundle/Doctrine/ORM/PaymentMethodRepository.php
+++ b/src/Sylius/Bundle/PaymentBundle/Doctrine/ORM/PaymentMethodRepository.php
@@ -22,7 +22,7 @@ class PaymentMethodRepository extends EntityRepository implements PaymentMethodR
     /**
      * {@inheritdoc}
      */
-    public function findByName(array $names)
+    public function findByName($name)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
@@ -31,7 +31,7 @@ class PaymentMethodRepository extends EntityRepository implements PaymentMethodR
             ->setParameter('name', $name)
             ->getQuery()
             ->getResult()
-            ;
+        ;
     }
 
     /**

--- a/src/Sylius/Bundle/PaymentBundle/Doctrine/ORM/PaymentMethodRepository.php
+++ b/src/Sylius/Bundle/PaymentBundle/Doctrine/ORM/PaymentMethodRepository.php
@@ -28,25 +28,10 @@ class PaymentMethodRepository extends EntityRepository implements PaymentMethodR
             ->addSelect('translation')
             ->leftJoin('o.translations', 'translation')
             ->where('translation.name = :name')
-            ->setParameter('name', $names)
-            ->getQuery()
-            ->getResult()
-        ;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function findOneByName($name)
-    {
-        return $this->createQueryBuilder('o')
-            ->addSelect('translation')
-            ->leftJoin('o.translations', 'translation')
-            ->where('translation.name = :name')
             ->setParameter('name', $name)
             ->getQuery()
-            ->getOneOrNullResult()
-        ;
+            ->getResult()
+            ;
     }
 
     /**

--- a/src/Sylius/Bundle/PaymentBundle/Doctrine/ORM/PaymentMethodRepository.php
+++ b/src/Sylius/Bundle/PaymentBundle/Doctrine/ORM/PaymentMethodRepository.php
@@ -22,13 +22,15 @@ class PaymentMethodRepository extends EntityRepository implements PaymentMethodR
     /**
      * {@inheritdoc}
      */
-    public function findByName($name)
+    public function findByName($name, $locale)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
             ->leftJoin('o.translations', 'translation')
             ->where('translation.name = :name')
+            ->andWhere('translation.locale = :locale')
             ->setParameter('name', $name)
+            ->setParameter('locale', $locale)
             ->getQuery()
             ->getResult()
         ;

--- a/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductRepository.php
@@ -23,13 +23,15 @@ class ProductRepository extends EntityRepository implements ProductRepositoryInt
     /**
      * {@inheritdoc}
      */
-    public function findByName($name)
+    public function findByName($name, $locale)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
             ->leftJoin('o.translations', 'translation')
             ->where('translation.name = :name')
+            ->andWhere('translation.locale = :locale')
             ->setParameter('name', $name)
+            ->setParameter('locale', $locale)
             ->getQuery()
             ->getResult()
         ;

--- a/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductRepository.php
@@ -23,7 +23,7 @@ class ProductRepository extends EntityRepository implements ProductRepositoryInt
     /**
      * {@inheritdoc}
      */
-    public function findOneByName($name)
+    public function findByName($name)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
@@ -31,7 +31,7 @@ class ProductRepository extends EntityRepository implements ProductRepositoryInt
             ->where('translation.name = :name')
             ->setParameter('name', $name)
             ->getQuery()
-            ->getOneOrNullResult()
+            ->getResult()
         ;
     }
 

--- a/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/VariantRepository.php
+++ b/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/VariantRepository.php
@@ -24,14 +24,7 @@ class VariantRepository extends EntityRepository implements VariantRepositoryInt
      */
     public function findByName($name)
     {
-        return $this->createQueryBuilder('o')
-            ->addSelect('translation')
-            ->leftJoin('o.translations', 'translation')
-            ->where('translation.name = :name')
-            ->setParameter('name', $name)
-            ->getQuery()
-            ->getResult()
-        ;
+        return $this->findBy(['name' => $name]);
     }
 
     /**

--- a/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/VariantRepository.php
+++ b/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/VariantRepository.php
@@ -22,7 +22,7 @@ class VariantRepository extends EntityRepository implements VariantRepositoryInt
     /**
      * {@inheritdoc}
      */
-    public function findOneByName($name)
+    public function findByName($name)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
@@ -30,7 +30,7 @@ class VariantRepository extends EntityRepository implements VariantRepositoryInt
             ->where('translation.name = :name')
             ->setParameter('name', $name)
             ->getQuery()
-            ->getOneOrNullResult()
+            ->getResult()
         ;
     }
 

--- a/src/Sylius/Bundle/PromotionBundle/Doctrine/ORM/PromotionRepository.php
+++ b/src/Sylius/Bundle/PromotionBundle/Doctrine/ORM/PromotionRepository.php
@@ -45,14 +45,9 @@ class PromotionRepository extends EntityRepository implements PromotionRepositor
     /**
      * {@inheritdoc}
      */
-    public function findOneByName($name)
+    public function findByName($name)
     {
-        return $this->createQueryBuilder('o')
-            ->where('o.name = :name')
-            ->setParameter('name', $name)
-            ->getQuery()
-            ->getOneOrNullResult()
-        ;
+        return $this->findBy(['name' => $name]);
     }
 
     /**

--- a/src/Sylius/Bundle/ShippingBundle/Doctrine/ORM/ShippingMethodRepository.php
+++ b/src/Sylius/Bundle/ShippingBundle/Doctrine/ORM/ShippingMethodRepository.php
@@ -22,13 +22,15 @@ class ShippingMethodRepository extends EntityRepository implements ShippingMetho
     /**
      * {@inheritdoc}
      */
-    public function findByName($name)
+    public function findByName($name, $locale)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
             ->leftJoin('o.translations', 'translation')
             ->where('translation.name = :name')
+            ->andWhere('translation.locale = :locale')
             ->setParameter('name', $name)
+            ->setParameter('locale', $locale)
             ->getQuery()
             ->getResult()
         ;

--- a/src/Sylius/Bundle/ShippingBundle/Doctrine/ORM/ShippingMethodRepository.php
+++ b/src/Sylius/Bundle/ShippingBundle/Doctrine/ORM/ShippingMethodRepository.php
@@ -22,7 +22,7 @@ class ShippingMethodRepository extends EntityRepository implements ShippingMetho
     /**
      * {@inheritdoc}
      */
-    public function findOneByName($name)
+    public function findByName($name)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
@@ -30,7 +30,7 @@ class ShippingMethodRepository extends EntityRepository implements ShippingMetho
             ->where('translation.name = :name')
             ->setParameter('name', $name)
             ->getQuery()
-            ->getOneOrNullResult()
+            ->getResult()
         ;
     }
 }

--- a/src/Sylius/Bundle/TaxationBundle/Doctrine/ORM/TaxCategoryRepository.php
+++ b/src/Sylius/Bundle/TaxationBundle/Doctrine/ORM/TaxCategoryRepository.php
@@ -22,8 +22,8 @@ class TaxCategoryRepository extends EntityRepository implements TaxCategoryRepos
     /**
      * {@inheritdoc}
      */
-    public function findOneByName($name)
+    public function findByName($name)
     {
-        return $this->findOneBy(['name' => $name]);
+        return $this->findBy(['name' => $name]);
     }
 }

--- a/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
@@ -109,7 +109,7 @@ class TaxonRepository extends EntityRepository implements TaxonRepositoryInterfa
     /**
      * {@inheritdoc}
      */
-    public function findOneByName($name)
+    public function findByName($name)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
@@ -117,7 +117,7 @@ class TaxonRepository extends EntityRepository implements TaxonRepositoryInterfa
             ->where('translation.name = :name')
             ->setParameter('name', $name)
             ->getQuery()
-            ->getOneOrNullResult()
+            ->getResult()
         ;
     }
 

--- a/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
@@ -109,13 +109,15 @@ class TaxonRepository extends EntityRepository implements TaxonRepositoryInterfa
     /**
      * {@inheritdoc}
      */
-    public function findByName($name)
+    public function findByName($name, $locale)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
             ->leftJoin('o.translations', 'translation')
             ->where('translation.name = :name')
+            ->andWhere('translation.locale = :locale')
             ->setParameter('name', $name)
+            ->setParameter('locale', $locale)
             ->getQuery()
             ->getResult()
         ;

--- a/src/Sylius/Bundle/VariationBundle/Doctrine/ORM/OptionRepository.php
+++ b/src/Sylius/Bundle/VariationBundle/Doctrine/ORM/OptionRepository.php
@@ -22,13 +22,15 @@ class OptionRepository extends EntityRepository implements OptionRepositoryInter
     /**
      * {@inheritdoc}
      */
-    public function findByName($name)
+    public function findByName($name, $locale)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
             ->leftJoin('o.translations', 'translation')
             ->where('translation.name = :name')
+            ->andWhere('translation.locale = :locale')
             ->setParameter('name', $name)
+            ->setParameter('locale', $locale)
             ->getQuery()
             ->getResult()
         ;

--- a/src/Sylius/Bundle/VariationBundle/Doctrine/ORM/OptionRepository.php
+++ b/src/Sylius/Bundle/VariationBundle/Doctrine/ORM/OptionRepository.php
@@ -22,7 +22,7 @@ class OptionRepository extends EntityRepository implements OptionRepositoryInter
     /**
      * {@inheritdoc}
      */
-    public function findOneByName($name)
+    public function findByName($name)
     {
         return $this->createQueryBuilder('o')
             ->addSelect('translation')
@@ -30,7 +30,7 @@ class OptionRepository extends EntityRepository implements OptionRepositoryInter
             ->where('translation.name = :name')
             ->setParameter('name', $name)
             ->getQuery()
-            ->getOneOrNullResult()
+            ->getResult()
         ;
     }
 }

--- a/src/Sylius/Component/Addressing/Repository/ZoneRepositoryInterface.php
+++ b/src/Sylius/Component/Addressing/Repository/ZoneRepositoryInterface.php
@@ -22,7 +22,7 @@ interface ZoneRepositoryInterface extends RepositoryInterface
     /**
      * @param string $name
      *
-     * @return ZoneInterface|null
+     * @return ZoneInterface[]
      */
-    public function findOneByName($name);
+    public function findByName($name);
 }

--- a/src/Sylius/Component/Attribute/Repository/AttributeRepositoryInterface.php
+++ b/src/Sylius/Component/Attribute/Repository/AttributeRepositoryInterface.php
@@ -22,10 +22,11 @@ interface AttributeRepositoryInterface extends RepositoryInterface
 {
     /**
      * @param string $name
+     * @param string $locale
      *
      * @return AttributeInterface[]
      */
-    public function findByName($name);
+    public function findByName($name, $locale);
 
     /**
      * @param array $criteria

--- a/src/Sylius/Component/Attribute/Repository/AttributeRepositoryInterface.php
+++ b/src/Sylius/Component/Attribute/Repository/AttributeRepositoryInterface.php
@@ -23,9 +23,9 @@ interface AttributeRepositoryInterface extends RepositoryInterface
     /**
      * @param string $name
      *
-     * @return AttributeInterface|null
+     * @return AttributeInterface[]
      */
-    public function findOneByName($name);
+    public function findByName($name);
 
     /**
      * @param array $criteria

--- a/src/Sylius/Component/Channel/Repository/ChannelRepositoryInterface.php
+++ b/src/Sylius/Component/Channel/Repository/ChannelRepositoryInterface.php
@@ -36,7 +36,7 @@ interface ChannelRepositoryInterface extends RepositoryInterface
     /**
      * @param string $name
      *
-     * @return ChannelInterface|null
+     * @return ChannelInterface[]
      */
-    public function findOneByName($name);
+    public function findByName($name);
 }

--- a/src/Sylius/Component/Core/Repository/ShipmentRepositoryInterface.php
+++ b/src/Sylius/Component/Core/Repository/ShipmentRepositoryInterface.php
@@ -31,9 +31,9 @@ interface ShipmentRepositoryInterface extends RepositoryInterface
     /**
      * @param string $name
      *
-     * @return ShipmentInterface|null
+     * @return ShipmentInterface[]
      */
-    public function findOneByName($name);
+    public function findByName($name);
 
     /**
      * @param array $criteria

--- a/src/Sylius/Component/Core/Repository/ShipmentRepositoryInterface.php
+++ b/src/Sylius/Component/Core/Repository/ShipmentRepositoryInterface.php
@@ -30,10 +30,11 @@ interface ShipmentRepositoryInterface extends RepositoryInterface
 
     /**
      * @param string $name
+     * @param string $locale
      *
      * @return ShipmentInterface[]
      */
-    public function findByName($name);
+    public function findByName($name, $locale);
 
     /**
      * @param array $criteria

--- a/src/Sylius/Component/Payment/Repository/PaymentMethodRepositoryInterface.php
+++ b/src/Sylius/Component/Payment/Repository/PaymentMethodRepositoryInterface.php
@@ -21,10 +21,11 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 interface PaymentMethodRepositoryInterface extends RepositoryInterface
 {
     /**
-     * @param string $names
+     * @param string $name
+     * @param string $locale
      *
      * @return PaymentMethodInterface[]
      */
-    public function findByName($name);
+    public function findByName($name, $locale);
 }
 

--- a/src/Sylius/Component/Payment/Repository/PaymentMethodRepositoryInterface.php
+++ b/src/Sylius/Component/Payment/Repository/PaymentMethodRepositoryInterface.php
@@ -26,12 +26,5 @@ interface PaymentMethodRepositoryInterface extends RepositoryInterface
      * @return PaymentMethodInterface[]
      */
     public function findByName(array $names);
-
-    /**
-     * @param string $name
-     *
-     * @return PaymentMethodInterface|null
-     */
-    public function findOneByName($name);
 }
 

--- a/src/Sylius/Component/Payment/Repository/PaymentMethodRepositoryInterface.php
+++ b/src/Sylius/Component/Payment/Repository/PaymentMethodRepositoryInterface.php
@@ -21,10 +21,10 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 interface PaymentMethodRepositoryInterface extends RepositoryInterface
 {
     /**
-     * @param array $names
+     * @param string $names
      *
      * @return PaymentMethodInterface[]
      */
-    public function findByName(array $names);
+    public function findByName($name);
 }
 

--- a/src/Sylius/Component/Product/Repository/ProductRepositoryInterface.php
+++ b/src/Sylius/Component/Product/Repository/ProductRepositoryInterface.php
@@ -22,9 +22,9 @@ interface ProductRepositoryInterface extends RepositoryInterface
     /**
      * @param string $name
      *
-     * @return ProductInterface|null
+     * @return ProductInterface[]
      */
-    public function findOneByName($name);
+    public function findByName($name);
 
     /**
      * @param string $slug

--- a/src/Sylius/Component/Product/Repository/ProductRepositoryInterface.php
+++ b/src/Sylius/Component/Product/Repository/ProductRepositoryInterface.php
@@ -21,10 +21,11 @@ interface ProductRepositoryInterface extends RepositoryInterface
 {
     /**
      * @param string $name
+     * @param string $locale
      *
      * @return ProductInterface[]
      */
-    public function findByName($name);
+    public function findByName($name, $locale);
 
     /**
      * @param string $slug

--- a/src/Sylius/Component/Product/Repository/VariantRepositoryInterface.php
+++ b/src/Sylius/Component/Product/Repository/VariantRepositoryInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Product\Repository;
 
+use Doctrine\ORM\QueryBuilder;
 use Sylius\Component\Product\Model\VariantInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 
@@ -22,9 +23,9 @@ interface VariantRepositoryInterface extends RepositoryInterface
     /**
      * @param string $name
      *
-     * @return VariantInterface|null
+     * @return VariantInterface[]
      */
-    public function findOneByName($name);
+    public function findByName($name);
 
     /**
      * @param mixed $productId

--- a/src/Sylius/Component/Promotion/Repository/PromotionRepositoryInterface.php
+++ b/src/Sylius/Component/Promotion/Repository/PromotionRepositoryInterface.php
@@ -28,7 +28,7 @@ interface PromotionRepositoryInterface extends RepositoryInterface
     /**
      * @param string $name
      *
-     * @return PromotionInterface|null
+     * @return PromotionInterface[]
      */
-    public function findOneByName($name);
+    public function findByName($name);
 }

--- a/src/Sylius/Component/Shipping/Repository/ShippingMethodRepositoryInterface.php
+++ b/src/Sylius/Component/Shipping/Repository/ShippingMethodRepositoryInterface.php
@@ -21,8 +21,9 @@ interface ShippingMethodRepositoryInterface extends RepositoryInterface
 {
     /**
      * @param string $name
+     * @param string $locale
      *
      * @return ShippingMethodInterface[]
      */
-    public function findByName($name);
+    public function findByName($name, $locale);
 }

--- a/src/Sylius/Component/Shipping/Repository/ShippingMethodRepositoryInterface.php
+++ b/src/Sylius/Component/Shipping/Repository/ShippingMethodRepositoryInterface.php
@@ -22,7 +22,7 @@ interface ShippingMethodRepositoryInterface extends RepositoryInterface
     /**
      * @param string $name
      *
-     * @return ShippingMethodInterface|null
+     * @return ShippingMethodInterface[]
      */
-    public function findOneByName($name);
+    public function findByName($name);
 }

--- a/src/Sylius/Component/Taxation/Repository/TaxCategoryRepositoryInterface.php
+++ b/src/Sylius/Component/Taxation/Repository/TaxCategoryRepositoryInterface.php
@@ -22,7 +22,7 @@ interface TaxCategoryRepositoryInterface extends RepositoryInterface
     /**
      * @param string $name
      *
-     * @return TaxCategoryInterface|null
+     * @return TaxCategoryInterface[]
      */
-    public function findOneByName($name);
+    public function findByName($name);
 }

--- a/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
+++ b/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
@@ -71,9 +71,9 @@ interface TaxonRepositoryInterface extends RepositoryInterface
     /**
      * @param string $name
      *
-     * @return TaxonInterface|null
+     * @return TaxonInterface[]
      */
-    public function findOneByName($name);
+    public function findByName($name);
 
     /**
      * @return QueryBuilder

--- a/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
+++ b/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
@@ -70,10 +70,11 @@ interface TaxonRepositoryInterface extends RepositoryInterface
 
     /**
      * @param string $name
+     * @param string $locale
      *
      * @return TaxonInterface[]
      */
-    public function findByName($name);
+    public function findByName($name, $locale);
 
     /**
      * @return QueryBuilder

--- a/src/Sylius/Component/Variation/Repository/OptionRepositoryInterface.php
+++ b/src/Sylius/Component/Variation/Repository/OptionRepositoryInterface.php
@@ -22,7 +22,7 @@ interface OptionRepositoryInterface extends RepositoryInterface
     /**
      * @param string $name
      *
-     * @return OptionInterface|null
+     * @return OptionInterface[]
      */
-    public function findOneByName($name);
+    public function findByName($name);
 }

--- a/src/Sylius/Component/Variation/Repository/OptionRepositoryInterface.php
+++ b/src/Sylius/Component/Variation/Repository/OptionRepositoryInterface.php
@@ -21,8 +21,9 @@ interface OptionRepositoryInterface extends RepositoryInterface
 {
     /**
      * @param string $name
+     * @param string $locale
      *
      * @return OptionInterface[]
      */
-    public function findByName($name);
+    public function findByName($name, $locale);
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Related tickets | https://github.com/Sylius/Sylius/pull/6137, https://github.com/Sylius/Sylius/issues/5374
| License         | MIT

As entities names are not unique, whole concept of ``findOneByName`` repository methods is incorrect and leads to some potential errors. I've changed each ``findOneByName`` to ``findByName``, therefore giving possibility to return zero or multiple entities.
Moreover, currently these methods are used only in Behat contexts. Instead of asserting ``notNull`` in them (basically in transformer's methods), now we assets ``eq(1,...)``, to be sure we operate on **one** and only **one** object.