### PR TITLE
make PaymentMethodChoiceType to use code as choice option value

### DIFF
--- a/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentMethodChoiceType.php
+++ b/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentMethodChoiceType.php
@@ -110,7 +110,7 @@ class PaymentMethodChoiceType extends AbstractType
                 $resolvedMethods = $this->paymentMethodRepository->findAll();
             }
 
-            return new ObjectChoiceList($resolvedMethods, null, [], null, 'id');
+            return new ObjectChoiceList($resolvedMethods, null, [], null, 'code');
         };
     }
 }

--- a/tests/Controller/CheckoutPaymentApiTest.php
+++ b/tests/Controller/CheckoutPaymentApiTest.php
@@ -138,7 +138,7 @@ EOT;
         $orderId = $checkoutData['order1']->getId();
         $this->addressOrder($orderId);
         $this->selectOrderShippingMethod($orderId, $checkoutData['ups']->getCode());
-        $this->selectOrderPaymentMethod($orderId, $checkoutData['cash_on_delivery']->getId());
+        $this->selectOrderPaymentMethod($orderId, $checkoutData['cash_on_delivery']->getCode());
 
         $data =
 <<<EOT


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |

We are not able to guess the id of a payment method, so I suggest to use code as choice option, we can replace PaymentMethodChoiceType with ours , but it is not a good practice to create a new class whose function is same as the original one.
