### PR TITLE
[RFC] [Shop] [Twig] All metatags in matatags block

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
@@ -2,14 +2,13 @@
 
 <html lang="{{ app.request.locale }}">
 <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-
     <title>{% block title %}Sylius{% endblock %}</title>
 
-    <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
-
     {% block metatags %}
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+        <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
     {% endblock %}
 
     {% block stylesheets %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | maybe |
| New feature? | no |
| BC breaks? | no |
| Related tickets |  |
| License | MIT |

Just an idea. Is there any reason why some of metatags shouldn't be place in matatags block? If no, I think it would be better to keep them there. 
