### PR TITLE
Added raw keyword on User Confirmation Email

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/views/Email/userConfirmation.html.twig
+++ b/src/Sylius/Bundle/CoreBundle/Resources/views/Email/userConfirmation.html.twig
@@ -3,5 +3,5 @@
 {% endblock %}
 
 {% block body %}
-    {{ 'sylius.email.user_confirmation.content'|trans({'%username%': user.username}) }}
+    {{ 'sylius.email.user_confirmation.content'|trans({'%username%': user.username})|raw }}
 {% endblock %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Related tickets |  |
| License | MIT |

Found the user confirmation email was outputting <br/> in the email content and raw wasn't used
