### PR TITLE
Cleanup some state machine callbacks.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine.yml
@@ -40,14 +40,14 @@ winzou_state_machine:
                     on: ["complete"]
                     do: ["@sylius.inventory.on_hold_quantity_updater", "increase"]
                     args: ["object"]
-                sylius_create_payment:
-                    on: ["complete"]
-                    do: ["@sm.callback.cascade_transition", "apply"]
-                    args: ["object.getPayments()", "event", "'create'", "'sylius_payment'"]
                 sylius_request_shipping:
                     on: ["complete"]
                     do: ["@sm.callback.cascade_transition", "apply"]
                     args: ["object", "event", "'request_shipping'", "'sylius_order_shipping'"]
+                sylius_request_payment:
+                    on: ["complete"]
+                    do: ["@sm.callback.cascade_transition", "apply"]
+                    args: ["object", "event", "'request_payment'", "'sylius_order_payment'"]
 
     sylius_order_shipping:
         class: "%sylius.model.order.class%"
@@ -150,10 +150,6 @@ winzou_state_machine:
                     on: ["cancel"]
                     do: ["@sm.callback.cascade_transition", "apply"]
                     args: ["object.getShipments()", "event", "'cancel'", "'sylius_shipment'"]
-                sylius_request_payment:
-                    on: ["create"]
-                    do: ["@sm.callback.cascade_transition", "apply"]
-                    args: ["object", "event", "'request_payment'", "'sylius_order_payment'"]
                 sylius_cancel_order_payment:
                     on: ["cancel"]
                     do: ["@sm.callback.cascade_transition", "apply"]


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

- sylius_create_payment (sylius_order_checkout state machine) is already applyed on sylius_order state machine
- move sylius_request_payment from sylius_order to sylius_order_checkout, to keep consistency with sylius_request_shipping