### PR TITLE
Cleanup some state machine callbacks | Reviews

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine.yml
@@ -40,14 +40,6 @@ winzou_state_machine:
                     on: ["complete"]
                     do: ["@sylius.inventory.order_inventory_operator", "hold"]
                     args: ["object"]
-                sylius_request_shipping:
-                    on: ["complete"]
-                    do: ["@sm.callback.cascade_transition", "apply"]
-                    args: ["object", "event", "'request_shipping'", "'sylius_order_shipping'"]
-                sylius_request_payment:
-                    on: ["complete"]
-                    do: ["@sm.callback.cascade_transition", "apply"]
-                    args: ["object", "event", "'request_payment'", "'sylius_order_payment'"]
 
     sylius_order_shipping:
         class: "%sylius.model.order.class%"
@@ -133,18 +125,26 @@ winzou_state_machine:
                     on: ["create"]
                     do: ["@sylius.email_manager.order", "sendConfirmationEmail"]
                     args: ["object"]
+                sylius_request_shipping:
+                    on: ["create"]
+                    do: ["@sm.callback.cascade_transition", "apply"]
+                    args: ["object", "event", "'request_shipping'", "'sylius_order_shipping'"]
+                sylius_request_payment:
+                    on: ["create"]
+                    do: ["@sm.callback.cascade_transition", "apply"]
+                    args: ["object", "event", "'request_payment'", "'sylius_order_payment'"]
                 sylius_create_payment:
                     on: ["create"]
                     do: ["@sm.callback.cascade_transition", "apply"]
                     args: ["object.getPayments()", "event", "'create'", "'sylius_payment'"]
-                sylius_cancel_payment:
-                    on: ["cancel"]
-                    do: ["@sm.callback.cascade_transition", "apply"]
-                    args: ["object.getPayments()", "event", "'cancel'", "'sylius_payment'"]
                 sylius_create_shipment:
                     on: ["create"]
                     do: ["@sm.callback.cascade_transition", "apply"]
                     args: ["object.getShipments()", "event", "'create'", "'sylius_shipment'"]
+                sylius_cancel_payment:
+                    on: ["cancel"]
+                    do: ["@sm.callback.cascade_transition", "apply"]
+                    args: ["object.getPayments()", "event", "'cancel'", "'sylius_payment'"]
                 sylius_cancel_shipment:
                     on: ["cancel"]
                     do: ["@sm.callback.cascade_transition", "apply"]


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| BC breaks?      | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

Move sylius_request_shipping & sylius_request_payment callbacks to sylius_order state machine.
Basically do the same job than before :)