### PR TITLE
[Fixture] Add amount to fulfill name assumptions

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures.yml
@@ -105,14 +105,17 @@ sylius_fixtures:
                                 name: "Clothing Sales Tax 7%"
                                 zone: "US"
                                 category: "clothing"
+                                amount: 0.07
                             books_tax:
                                 name: "Books Sales Tax 2%"
                                 zone: "US"
                                 category: "books"
+                                amount: 0.02
                             default_sales_tax:
                                 name: "Sales Tax 20%"
                                 zone: "US"
                                 category: "other"
+                                amount: 0.2
 
                 mug_product:
                     options:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

It is needed to avoid following situation:
<img width="302" alt="database example" src="https://cloud.githubusercontent.com/assets/6213903/19108179/fe32efa4-8aef-11e6-91aa-4e3f53ed80ce.png">

<img width="1002" alt="ui example" src="https://cloud.githubusercontent.com/assets/6213903/19108207/1ee5aafc-8af0-11e6-8487-57ba5df5f1bb.png">
