### PR TITLE
[Fixture] Change prototype for locales

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/LocaleFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/LocaleFixture.php
@@ -86,7 +86,7 @@ final class LocaleFixture extends AbstractFixture
             ->children()
                 ->arrayNode('locales')
                     ->useAttributeAsKey('code')
-                    ->prototype('scalar')
+                    ->prototype('boolean')
                         ->defaultTrue()
         ;
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

According to [this line](https://github.com/lchrusciel/Sylius/blob/09b8f6afaf630a09b293320392677080488a5255/src/Sylius/Bundle/CoreBundle/Fixture/CurrencyFixture.php#L95) this will be more appropriate prototype. The definition should looks like this:
```yml
locale:
    options:
        locales:
            de-DE: true

```