### PR TITLE
[OrderBundle] Fix Add-to-cart Pre-create event

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Controller/OrderItemController.php
+++ b/src/Sylius/Bundle/OrderBundle/Controller/OrderItemController.php
@@ -72,7 +72,7 @@ class OrderItemController extends ResourceController
         if ($request->isMethod('POST') && $form->submit($request)->isValid()) {
             $newResource = $form->getData();
 
-            $event = $this->eventDispatcher->dispatchPreEvent('sylius.cart_item.pre_create', $configuration, $newResource);
+            $event = $this->eventDispatcher->dispatchPreEvent(ResourceActions::CREATE, $configuration, $newResource);
 
             if ($event->isStopped() && !$configuration->isHtmlRequest()) {
                 throw new HttpException($event->getErrorCode(), $event->getMessage());
@@ -89,6 +89,8 @@ class OrderItemController extends ResourceController
             $cartManager = $this->getCartManager();
             $cartManager->persist($cart);
             $cartManager->flush();
+
+            $this->eventDispatcher->dispatchPostEvent(ResourceActions::CREATE, $configuration, $newResource);
 
             if (!$configuration->isHtmlRequest()) {
                 return $this->viewHandler->handle($configuration, View::create($newResource, Response::HTTP_CREATED));


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #6318
| License         | MIT

Fix `sylius.cart_item.pre_create` not being fired due to incorrect naming. Now, the event we can listen to is `sylius.order_item.pre_create`. A `sylius.order_item.post_create` is now also available.