### PR TITLE
Move SessionCartSubscriber to CoreBundle

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/SessionCartSubscriber.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/SessionCartSubscriber.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\OrderBundle\EventListener;
+namespace Sylius\Bundle\CoreBundle\EventListener;
 
 use Sylius\Component\Order\Context\CartContextInterface;
 use Sylius\Component\Order\Context\CartNotFoundException;

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -81,5 +81,10 @@
             <argument type="service" id="request_stack" />
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="2" />
         </service>
+        <service id="sylius.listener.session_cart" class="Sylius\Bundle\CoreBundle\EventListener\SessionCartSubscriber">
+            <argument type="service" id="sylius.context.cart" />
+            <argument>_sylius.cart</argument>
+            <tag name="kernel.event_subscriber" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
@@ -49,12 +49,6 @@
 
         <service id="sylius.order_processing.order_processor" class="Sylius\Component\Order\Processor\CompositeOrderProcessor" />
 
-        <service id="sylius.listener.session_cart" class="Sylius\Bundle\OrderBundle\EventListener\SessionCartSubscriber">
-            <argument type="service" id="sylius.context.cart" />
-            <argument>_sylius.cart</argument>
-            <tag name="kernel.event_subscriber" />
-        </service>
-
         <service id="sylius.cart.order_modifier" class="Sylius\Component\Order\Modifier\OrderModifier">
             <argument type="service" id="sylius.order_processing.order_processor" />
             <argument type="service" id="sylius.order_item_quantity_modifier" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Related tickets | partially #6279 
| License         | MIT

Partially fixes #6279, perhaps the OrderBundle might want to provide a default implementation of this that doesn't call `getChannel()`