### PR TITLE
Use variadic instead of call_user_func_array

### DIFF
--- a/src/Sylius/Bundle/GridBundle/Doctrine/ORM/Driver.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/ORM/Driver.php
@@ -47,10 +47,10 @@ class Driver implements DriverInterface
         $repository = $this->entityManager->getRepository($configuration['class']);
 
         if (isset($configuration['repository']['method'])) {
-            $callable = [$repository, $configuration['repository']['method']];
-            $arguments = isset($configuration['repository']['arguments']) ? $configuration['repository']['arguments'] : [];
+            $method = $configuration['repository']['method'];
+            $arguments = isset($configuration['repository']['arguments']) ? array_values($configuration['repository']['arguments']) : [];
 
-            $queryBuilder = call_user_func_array($callable, $arguments);
+            $queryBuilder = $repository->$method(...$arguments);
         } else {
             $queryBuilder = $repository->createQueryBuilder('o');
         }

--- a/src/Sylius/Bundle/ResourceBundle/Controller/NewResourceFactory.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/NewResourceFactory.php
@@ -16,7 +16,7 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class NewResourceFactory implements NewResourceFactoryInterface
+final class NewResourceFactory implements NewResourceFactoryInterface
 {
     /**
      * {@inheritdoc}
@@ -27,9 +27,8 @@ class NewResourceFactory implements NewResourceFactoryInterface
             return $factory->createNew();
         }
 
-        $callable = [$factory, $method];
-        $arguments = $requestConfiguration->getFactoryArguments();
+        $arguments = array_values($requestConfiguration->getFactoryArguments());
 
-        return call_user_func_array($callable, $arguments);
+        return $factory->$method(...$arguments);
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourcesResolver.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourcesResolver.php
@@ -23,11 +23,11 @@ class ResourcesResolver implements ResourcesResolverInterface
      */
     public function getResources(RequestConfiguration $requestConfiguration, RepositoryInterface $repository)
     {
-        if (null !== $repositoryMethod = $requestConfiguration->getRepositoryMethod()) {
-            $callable = [$repository, $repositoryMethod];
-            $resources = call_user_func_array($callable, $requestConfiguration->getRepositoryArguments());
+        $repositoryMethod = $requestConfiguration->getRepositoryMethod();
+        if (null !== $repositoryMethod) {
+            $arguments = array_values($requestConfiguration->getRepositoryArguments());
 
-            return $resources;
+            return $repository->$repositoryMethod(...$arguments);
         }
 
         if (!$requestConfiguration->isPaginated() && !$requestConfiguration->isLimited()) {

--- a/src/Sylius/Bundle/ResourceBundle/Controller/SingleResourceProvider.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/SingleResourceProvider.php
@@ -23,10 +23,11 @@ class SingleResourceProvider implements SingleResourceProviderInterface
      */
     public function get(RequestConfiguration $requestConfiguration, RepositoryInterface $repository)
     {
-        if (null !== $repositoryMethod = $requestConfiguration->getRepositoryMethod()) {
-            $callable = [$repository, $repositoryMethod];
+        $repositoryMethod = $requestConfiguration->getRepositoryMethod();
+        if (null !== $repositoryMethod) {
+            $arguments = array_values($requestConfiguration->getRepositoryArguments());
 
-            return call_user_func_array($callable, $requestConfiguration->getRepositoryArguments());
+            return $repository->$repositoryMethod(...$arguments);
         }
 
         $criteria = [];

--- a/src/Sylius/Bundle/ThemeBundle/Translation/ThemeAwareTranslator.php
+++ b/src/Sylius/Bundle/ThemeBundle/Translation/ThemeAwareTranslator.php
@@ -57,7 +57,10 @@ final class ThemeAwareTranslator implements TranslatorInterface, TranslatorBagIn
      */
     public function __call($method, array $arguments)
     {
-        return call_user_func_array([$this->translator, $method], $arguments);
+        $translator = $this->translator;
+        $arguments = array_values($arguments);
+
+        return $translator->$method(...$arguments);
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | -
| License         | MIT

Using variadic arguments instead of `call_user_func_array` is faster (it's the reason of [PerformanceExtension](https://github.com/FriendsOfBehat/PerformanceExtension) too).