### PR TITLE
[AdminBundle] Fixed consistency issue with Product and ProductVariant

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_details.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_details.html.twig
@@ -1,4 +1,6 @@
 <div class="ui active tab" data-tab="details">
+    <h3 class="ui dividing header">{{ 'sylius.ui.details'|trans }}</h3>
+
     <div class="ui segments">
         <div class="ui segment">
             {{ form_row(form.code) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/_form.html.twig
@@ -5,6 +5,8 @@
         {% include '@SyliusAdmin/ProductVariant/_menu.html.twig' %}
     </div>
     <div class="thirteen wide column">
-        {% include '@SyliusAdmin/ProductVariant/_tabs.html.twig' %}
+        <div class="ui segment">
+            {% include '@SyliusAdmin/ProductVariant/_tabs.html.twig' %}
+        </div>
     </div>
 </div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | -
| License         | MIT

This pull request fixes a minor inconsistency between Product and Product Variant forms in Admin Bundle, more specifically, the Variant form when used in the context of a simple product and that of a configurable product.

| -       | Product | Variant (before) | Variant (after)
| ------- | ------- | --------------| ---------------
| **Details** | [![Product details](http://i.imgur.com/Hyytdrb.png)](http://i.imgur.com/Hyytdrb.png) | [![Variant details (before)](http://i.imgur.com/uN7dtyc.png)](http://i.imgur.com/uN7dtyc.png) | [![Variant details (after)](http://i.imgur.com/OsF9cyP.png)](http://i.imgur.com/OsF9cyP.png)
| **Taxes**   | [![Product taxes](http://i.imgur.com/Aq99wis.png)](http://i.imgur.com/Aq99wis.png) | [![Variant taxes (before)](http://i.imgur.com/5ajAYUk.png)](http://i.imgur.com/5ajAYUk.png) | [![Variant taxes (after)](http://i.imgur.com/d7XAWb5.png)](http://i.imgur.com/d7XAWb5.png)