### PR TITLE
[Installer] Fix getCode on null exception

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
@@ -60,16 +60,10 @@ EOT
             return 1;
         }
 
-        $doctrineConfiguration = $this->get('doctrine.orm.entity_manager')->getConnection()->getConfiguration();
-        $logger = $doctrineConfiguration->getSQLLogger();
-        $doctrineConfiguration->setSQLLogger(null);
-
         $commands = [
             'sylius:fixtures:load' => ['--no-interaction' => true],
         ];
 
         $this->runCommands($commands, $input, $output);
-
-        $doctrineConfiguration->setSQLLogger($logger);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #5762 
| License         | MIT

I don't remember, why did we do this magic with unsetting logger, but at least it is the fastest working solution. 