### PR TITLE
[Promotion] Fix per channel promotions availability

### DIFF
--- a/features/promotion/receiving_discount/applying_only_promotions_enabled_for_given_channel.feature
+++ b/features/promotion/receiving_discount/applying_only_promotions_enabled_for_given_channel.feature
@@ -1,0 +1,24 @@
+@receiving_discount
+Feature: Applying only promotions enabled for given channel
+    In order to place a valid order
+    As a Visitor
+    I want to have only available promotions applied to my cart
+
+    Background:
+        Given the store operates on a single channel in the "United States" named "Web"
+        And the store has a product "PHP T-Shirt" priced at "$100.00"
+        And there is a promotion "Holiday promotion"
+        And it gives "$10.00" discount to every order
+
+    @ui
+    Scenario: Receiving fixed discount for my cart
+        When I add product "PHP T-Shirt" to the cart
+        Then my cart total should be "$90.00"
+        And my discount should be "-$10.00"
+
+    @ui
+    Scenario: Not receiving discount when promotion is disabled for current channel
+        Given the promotion was disabled for the channel "Web"
+        When I add product "PHP T-Shirt" to the cart
+        Then my cart total should be "$100.00"
+        And there should be no discount

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/receiving_discount.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/receiving_discount.yml
@@ -7,6 +7,7 @@ default:
             contexts_as_services:
                 - sylius.behat.context.hook.doctrine_orm
 
+                - sylius.behat.context.transform.channel
                 - sylius.behat.context.transform.lexical
                 - sylius.behat.context.transform.product
                 - sylius.behat.context.transform.shared_storage

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/promotion.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/promotion.xml
@@ -13,7 +13,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylius.active_promotions_by_channel_provider" class="Sylius\Component\Core\Provider\ActivePromotionsByChannelProvider">
+        <service id="sylius.active_promotions_provider" class="Sylius\Component\Core\Provider\ActivePromotionsByChannelProvider">
             <argument type="service" id="sylius.repository.promotion" />
         </service>
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

`ActivePromotionsByChannelProvider` was not used in `Core`