### PR TITLE
[Critical][Order] Fix order cancelling issue

### DIFF
--- a/features/order/managing_orders/cancelling_order_with_promotion.feature
+++ b/features/order/managing_orders/cancelling_order_with_promotion.feature
@@ -1,0 +1,27 @@
+@managing_orders
+Feature: Cancelling order with promotion applied
+    In order to maintain correct order history
+    As an Administrator
+    I want to have a promotion still applied after cancelling order even if the promotion is no longer valid
+
+    Background:
+        Given the store operates on a single channel in the "United States" named "Web"
+        And the store ships everywhere for free
+        And the store allows paying with "Cash on Delivery"
+        And the store has a product "Suit" priced at "$400.00"
+        And there is a promotion "Holiday promotion"
+        And the promotion gives "$50" discount to every order
+        And there is a customer "mike@ross.com" that placed an order "#00000001"
+        And the customer bought a single "Suit"
+        And the customer "Mike Ross" addressed it to "350 5th Ave", "10118" "New York" in the "United States" with identical billing address
+        And the customer chose "Free" shipping method with "Cash on Delivery" payment
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Cancelling order when the applied promotion is no longer valid
+        Given the promotion was disabled for the channel "Web"
+        When I view the summary of the order "#00000001"
+        And I cancel this order
+        Then this order should have state "Cancelled"
+        And the order's total should still be "$350.00"
+        And the order's promotion total should still be "-$50.00"

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -547,6 +547,7 @@ final class ManagingOrdersContext implements Context
     }
 
     /**
+     * @Then this order should have state :state
      * @Then its state should be :state
      */
     public function itsStateShouldBe($state)

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_payment.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_payment.yml
@@ -4,7 +4,7 @@ winzou_state_machine:
             after:
                 process_order:
                     on: ["fail", "cancel"]
-                    do: ["@sylius.order_processing.order_processor", "process"]
+                    do: ["@sylius.order_processing.order_payment_processor", "process"]
                     args: ["object.getOrder()"]
                 update_order_payment_state:
                     on: ["complete"]

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/promotion.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/promotion.xml
@@ -17,6 +17,12 @@
             <argument type="service" id="sylius.repository.promotion" />
         </service>
 
+        <service id="sylius.promotion_processor" class="Sylius\Component\Promotion\Processor\PromotionProcessor">
+            <argument type="service" id="sylius.active_promotions_by_channel_provider" />
+            <argument type="service" id="sylius.promotion_eligibility_checker" />
+            <argument type="service" id="sylius.promotion_applicator" />
+        </service>
+
         <service id="sylius.promotion_rule_checker.nth_order" class="Sylius\Component\Core\Promotion\Checker\Rule\NthOrderRuleChecker">
             <argument type="service" id="sylius.repository.order" />
             <tag name="sylius.promotion_rule_checker" type="nth_order" label="Nth order" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/promotion.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/promotion.xml
@@ -17,12 +17,6 @@
             <argument type="service" id="sylius.repository.promotion" />
         </service>
 
-        <service id="sylius.promotion_processor" class="Sylius\Component\Promotion\Processor\PromotionProcessor">
-            <argument type="service" id="sylius.active_promotions_by_channel_provider" />
-            <argument type="service" id="sylius.promotion_eligibility_checker" />
-            <argument type="service" id="sylius.promotion_applicator" />
-        </service>
-
         <service id="sylius.promotion_rule_checker.nth_order" class="Sylius\Component\Core\Promotion\Checker\Rule\NthOrderRuleChecker">
             <argument type="service" id="sylius.repository.order" />
             <tag name="sylius.promotion_rule_checker" type="nth_order" label="Nth order" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

`OrderPaymentProcessor` should be called instead of `OrderProcessor` on payment fail/cancel to avoid whole order recalculation.

Based on #6437.