### PR TITLE
[RFC] Add PhpSpec templates

### DIFF
--- a/.phpspec/class.tpl
+++ b/.phpspec/class.tpl
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */%namespace_block%
+
+final class %name%
+{
+}

--- a/.phpspec/interface.tpl
+++ b/.phpspec/interface.tpl
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */%namespace_block%
+
+interface %name%
+{
+}

--- a/.phpspec/specification.tpl
+++ b/.phpspec/specification.tpl
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace %namespace%;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+final class %name% extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(\%subject%::class);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | -
| License         | MIT

By adding these templates, PhpSpec will generate classes / interfaces / specifications with license block automatically added.