### PR TITLE
Remove PR template from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,21 +7,6 @@ You can learn [how to contribute the patches](http://docs.sylius.org/en/latest/c
 and [how we use Behat & PHPSpec](http://docs.sylius.org/en/latest/contributing/code/bdd.html)
 in two separate parts of our [Contributing Guide](http://docs.sylius.org/en/latest/contributing/index.html).
 
-PR Table Template
------------------
-
-```
-| Q             | A
-| ------------- | ---
-| Bug fix?      | no|yes
-| New feature?  | no|yes
-| BC breaks?    | no|yes
-| Deprecations? | no|yes
-| Fixed tickets | #X
-| License       | MIT
-| Doc PR        | Sylius/Sylius-Docs#X
-```
-
 Security Issues
 ---------------
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | -
| License         | MIT

We currently have PR template in `PULL_REQUEST_TEMPLATE.md` so the one in `CONTRIBUTING.md` is not needed (and is outdated).
