### PR TITLE
[Behat] Cleanup ProductContext

### DIFF
--- a/features/cart/shopping_cart/adding_products_with_quantity_to_cart.feature
+++ b/features/cart/shopping_cart/adding_products_with_quantity_to_cart.feature
@@ -10,7 +10,7 @@ Feature: Adding a simple product of given quantity to the cart
 
     @ui
     Scenario: Adding a product with stated quantity to the cart
-        Given there are 10 items of product "T-shirt banana" available in the inventory
+        Given there are 10 units of product "T-shirt banana" available in the inventory
         When I add 5 of them to my cart
         Then I should be on my cart summary page
         And I should be notified that the product has been successfully added

--- a/features/inventory/cart_inventory/prevent_buying_more_products_than_available_in_a_stock.feature
+++ b/features/inventory/cart_inventory/prevent_buying_more_products_than_available_in_a_stock.feature
@@ -8,7 +8,7 @@ Feature: Prevent buying more products than available in a stock
         Given the store operates on a single channel in "United States"
         And the store has a product "T-shirt Mononoke" priced at "$12.54"
         And "T-shirt Mononoke" product is tracked by the inventory
-        And there are 5 items of product "T-Shirt Mononoke" available in the inventory
+        And there are 5 units of product "T-Shirt Mononoke" available in the inventory
 
     @ui @javascript
     Scenario: Preventing from adding more items to the cart than it's available in stock

--- a/features/inventory/cart_inventory/verify_inventory_quantity_when_updating_carty_summary.feature
+++ b/features/inventory/cart_inventory/verify_inventory_quantity_when_updating_carty_summary.feature
@@ -8,7 +8,7 @@ Feature: Verifying inventory quantity on cart summary
         Given the store operates on a single channel in "United States"
         And the store has a product "Iron Maiden T-Shirt" priced at "€12.54"
         And this product is tracked by the inventory
-        And there are 5 items of product "Iron Maiden T-Shirt" available in the inventory
+        And there are 5 units of product "Iron Maiden T-Shirt" available in the inventory
 
     @ui
     Scenario: Being unable to save a cart with product that is out of stock

--- a/features/inventory/verify_reserved_inventory_is_back_in_stock_on_order_cancelling.feature
+++ b/features/inventory/verify_reserved_inventory_is_back_in_stock_on_order_cancelling.feature
@@ -9,11 +9,11 @@ Feature: Inventory releasing on order cancellation
         And the store has a product "T-Shirt banana"
         And the product "T-shirt banana" has "Green" variant priced at "€5.54"
         And the product "T-shirt banana" has "Red" variant priced at "€5.54"
-        And there are 5 items of "Green" variant of product "T-shirt banana" available in the inventory
-        And there are 5 items of "Red" variant of product "T-shirt banana" available in the inventory
+        And there are 5 units of "Green" variant of product "T-shirt banana" available in the inventory
+        And there are 5 units of "Red" variant of product "T-shirt banana" available in the inventory
         And the store has a product "Skirt watermelon"
         And the product "Skirt watermelon" has "Yellow" variant priced at "€500.43"
-        And there are 5 items of "Yellow" variant of product "Skirt watermelon" available in the inventory
+        And there are 5 units of "Yellow" variant of product "Skirt watermelon" available in the inventory
         And the store ships everywhere for free
         And the store allows paying with "Cash on Delivery"
         And I am logged in as an administrator
@@ -21,7 +21,7 @@ Feature: Inventory releasing on order cancellation
     @ui
     Scenario: Verify the reserved inventory is back in stock after cancellation of a new order
         Given there is a customer "john.doe@gmail.com" that placed an order "#00000022"
-        And the customer bought 3 items of "Green" variant of product "T-shirt banana"
+        And the customer bought 3 units of "Green" variant of product "T-shirt banana"
         And the customer chose "Free" shipping method to "United States" with "Cash on Delivery" payment
         And the order "#00000022" was cancelled
         When I view all variants of the product "T-shirt banana"
@@ -31,7 +31,7 @@ Feature: Inventory releasing on order cancellation
     @ui
     Scenario: Verify the reserved inventory and quantity of product's items is back in stock after cancellation of paid order
         Given there is a customer "john.doe@gmail.com" that placed an order "#00000022"
-        And the customer bought 3 items of "Green" variant of product "T-shirt banana"
+        And the customer bought 3 units of "Green" variant of product "T-shirt banana"
         And the customer chose "Free" shipping method to "United States" with "Cash on Delivery" payment
         And the order "#00000022" is already paid
         And the order "#00000022" was cancelled
@@ -42,8 +42,8 @@ Feature: Inventory releasing on order cancellation
     @ui
     Scenario: Verify the reserved inventory is back in stock after cancellation of a new order with two variants of product
         Given there is a customer "john.doe@gmail.com" that placed an order "#00000023"
-        And the customer bought 3 items of "Green" variant of product "T-shirt banana"
-        And the customer bought 2 items of "Red" variant of product "T-shirt banana"
+        And the customer bought 3 units of "Green" variant of product "T-shirt banana"
+        And the customer bought 2 units of "Red" variant of product "T-shirt banana"
         And the customer chose "Free" shipping method to "United States" with "Cash on Delivery" payment
         And the order "#00000023" was cancelled
         When I view all variants of the product "T-shirt banana"
@@ -55,8 +55,8 @@ Feature: Inventory releasing on order cancellation
     @ui
     Scenario: Verify the reserved inventory and quantity of product's items is back in stock after cancellation of paid order with two variants of product
         Given there is a customer "john.doe@gmail.com" that placed an order "#00000023"
-        And the customer bought 3 items of "Green" variant of product "T-shirt banana"
-        And the customer bought 2 items of "Red" variant of product "T-shirt banana"
+        And the customer bought 3 units of "Green" variant of product "T-shirt banana"
+        And the customer bought 2 units of "Red" variant of product "T-shirt banana"
         And the customer chose "Free" shipping method to "United States" with "Cash on Delivery" payment
         And the order "#00000023" is already paid
         And the order "#00000023" was cancelled
@@ -69,8 +69,8 @@ Feature: Inventory releasing on order cancellation
     @ui
     Scenario: Verify the reserved inventory is back in stock after cancellation of a new order with two variants of differents products
         Given there is a customer "john.doe@gmail.com" that placed an order "#00000024"
-        And the customer bought 3 items of "Green" variant of product "T-shirt banana"
-        And the customer bought 2 items of "Yellow" variant of product "Skirt watermelon"
+        And the customer bought 3 units of "Green" variant of product "T-shirt banana"
+        And the customer bought 2 units of "Yellow" variant of product "Skirt watermelon"
         And the customer chose "Free" shipping method to "United States" with "Cash on Delivery" payment
         And the order "#00000024" was cancelled
         Then the "Green" variant of "T-shirt banana" product should have 5 items on hand
@@ -81,8 +81,8 @@ Feature: Inventory releasing on order cancellation
     @ui
     Scenario: Verify the reserved inventory and quantity of product's items is back in stock after cancellation of paid order with two variants of differents products
         Given there is a customer "john.doe@gmail.com" that placed an order "#00000024"
-        And the customer bought 3 items of "Green" variant of product "T-shirt banana"
-        And the customer bought 2 items of "Yellow" variant of product "Skirt watermelon"
+        And the customer bought 3 units of "Green" variant of product "T-shirt banana"
+        And the customer bought 2 units of "Yellow" variant of product "Skirt watermelon"
         And the customer chose "Free" shipping method to "United States" with "Cash on Delivery" payment
         And the order "#00000024" is already paid
         And the order "#00000024" was cancelled

--- a/features/inventory/viewing_product_variant_with_specify_quantity_of_items_on_hand.feature
+++ b/features/inventory/viewing_product_variant_with_specify_quantity_of_items_on_hand.feature
@@ -9,8 +9,8 @@ Feature: Seeing product's variant with specify quantity of items on hand
         And the store has a "T-shirt banana" configurable product
         And the product "T-shirt banana" has "Yellow" variant priced at "€20.54"
         And the product "T-shirt banana" has "Green" variant priced at "€5.54"
-        And there are 5 items of "Yellow" variant of product "T-shirt banana" available in the inventory
-        And there are 5 items of "Green" variant of product "T-shirt banana" available in the inventory
+        And there are 5 units of "Yellow" variant of product "T-shirt banana" available in the inventory
+        And there are 5 units of "Green" variant of product "T-shirt banana" available in the inventory
         And the store ships everywhere for free
         And the store allows paying with "Cash on Delivery"
         And I am logged in as an administrator
@@ -18,7 +18,7 @@ Feature: Seeing product's variant with specify quantity of items on hand
     @ui
     Scenario: Seeing decreased quantity of product's items in selected variant after order payment
         Given there is a customer "lucy@teamlucifer.com" that placed an order "#00000666"
-        And the customer bought 3 items of "Green" variant of product "T-shirt banana"
+        And the customer bought 3 units of "Green" variant of product "T-shirt banana"
         And the customer "Lucifer Morningstar" addressed it to "Seaside Fwy", "90802" "Los Angeles" in the "United States" with identical billing address
         And the customer chose "Free" shipping method with "Cash on Delivery" payment
         And this order is already paid
@@ -28,8 +28,8 @@ Feature: Seeing product's variant with specify quantity of items on hand
     @ui
     Scenario: Seeing decreased quantity of product's items from different variants after order payment
         Given there is a customer "lucy@teamlucifer.com" that placed an order "#00000666"
-        And the customer bought 3 items of "Yellow" variant of product "T-shirt banana"
-        And the customer bought 2 items of "Green" variant of product "T-shirt banana"
+        And the customer bought 3 units of "Yellow" variant of product "T-shirt banana"
+        And the customer bought 2 units of "Green" variant of product "T-shirt banana"
         And the customer "Lucifer Morningstar" addressed it to "Seaside Fwy", "90802" "Los Angeles" in the "United States" with identical billing address
         And the customer chose "Free" shipping method with "Cash on Delivery" payment
         And this order is already paid

--- a/features/order/managing_orders/seeing_order_item_detailed_data.feature
+++ b/features/order/managing_orders/seeing_order_item_detailed_data.feature
@@ -19,7 +19,7 @@ Feature: Seeing order item detailed data
         And there is a promotion "T-Shirts promotion"
         And it gives "$2.00" off on every product with minimum price at "$20.00"
         And there is a customer "tony@stark.com" that placed an order "#00000666"
-        And the customer bought 4 items of "Iron Man T-Shirt" variant of product "Marvel T-Shirt"
+        And the customer bought 4 units of "Iron Man T-Shirt" variant of product "Marvel T-Shirt"
         And the customer chose "Free" shipping method to "United States" with "Cash on Delivery" payment
         And I am logged in as an administrator
 

--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -336,7 +336,7 @@ final class OrderContext implements Context
     }
 
     /**
-     * @Given /^the customer bought ([^"]+) items of ("[^"]+" variant of product "[^"]+")$/
+     * @Given /^the customer bought ([^"]+) units of ("[^"]+" variant of product "[^"]+")$/
      */
     public function theCustomerBoughtSeveralVariantsOfProduct($quantity, ProductVariantInterface $variant)
     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #5934
| License         | MIT

- Rename `items` to `units` when talking about inventory (#5934)
- Use `DefaultVariantResolver` instead of `getFirstVariant`