### PR TITLE
[Critical][Promotion] Fix per customer usage limit

### DIFF
--- a/features/promotion/applying_promotion_coupon/applying_promotion_coupon_with_per_customer_usage_limit.feature
+++ b/features/promotion/applying_promotion_coupon/applying_promotion_coupon_with_per_customer_usage_limit.feature
@@ -7,11 +7,12 @@ Feature: Applying promotion coupon with per customer usage limit
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a product "PHP T-Shirt" priced at "$100.00"
+        And the store has a product "PHP Socks" priced at "$30.00"
         And the store has promotion "Christmas sale" with coupon "SANTA2016"
-        And this coupon can be used once per customer
+        And this coupon can be used twice per customer
         And this promotion gives "$10.00" discount to every order
         And the store ships everywhere for free
-        And the store allows paying offline
+        And the store allows paying "Cash on Delivery"
         And I am a logged in customer
 
     @ui
@@ -22,12 +23,24 @@ Feature: Applying promotion coupon with per customer usage limit
         And my discount should be "-$10.00"
 
     @ui
-    Scenario: Receiving no discount from valid coupon that has reached its per customer usage limit
-        Given I add product "PHP T-Shirt" to the cart
+    Scenario: Receiving discount from valid coupon with a per customer usage limit as a logged in customer
+        Given I placed an order "#00000022"
+        And I bought a "PHP T-Shirt" and a "PHP Socks"
+        And I used "SANTA2016" coupon
+        And I chose "Free" shipping method to "United States" with "Cash on Delivery" payment
+        When I add product "PHP T-Shirt" to the cart
         And I use coupon with code "SANTA2016"
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I proceed with "Free" shipping method and "Offline" payment
-        And I confirm my order
+        Then my cart total should be "$90.00"
+        And my discount should be "-$10.00"
+
+    @ui
+    Scenario: Receiving no discount from valid coupon that has reached its per customer usage limit
+        Given I placed an order "#00000022"
+        And I bought a single "PHP T-Shirt" using "SANTA2016" coupon
+        And I chose "Free" shipping method to "United States" with "Cash on Delivery" payment
+        And I placed an order "#00000023"
+        And I bought a single "PHP Socks" using "SANTA2016" coupon
+        And I chose "Free" shipping method to "United States" with "Cash on Delivery" payment
         When I add product "PHP T-Shirt" to the cart
         And I use coupon with code "SANTA2016"
         Then I should be notified that the coupon is invalid

--- a/features/promotion/applying_promotion_rules/receiving_discount_based_on_nth_order.feature
+++ b/features/promotion/applying_promotion_rules/receiving_discount_based_on_nth_order.feature
@@ -8,21 +8,21 @@ Feature: Receiving discount based on nth order
         Given the store operates on a single channel in "United States"
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And the store ships everywhere for free
-        And the store allows paying offline
+        And the store allows paying "Cash on Delivery"
         And there is a promotion "5th order promotion"
         And it gives "$20.00" off customer's 5th order
         And I am a logged in customer
 
     @ui
     Scenario: Receiving a discount on an order if it's nth order placed
-        Given I have already placed an order 4 times
+        Given I have already placed 4 orders choosing "Free" shipping method to "United States" with "Cash on Delivery" payment
         When I add product "PHP T-Shirt" to the cart
         Then my cart total should be "$80.00"
         And my discount should be "-$20.00"
 
     @ui
     Scenario: Receiving no discount on an order if it's not nth order placed
-        Given I have already placed an order 3 times
+        Given I have already placed 3 orders choosing "Free" shipping method to "United States" with "Cash on Delivery" payment
         When I add product "PHP T-Shirt" to the cart
         Then my cart total should be "$100.00"
         And there should be no discount

--- a/features/promotion/applying_promotion_rules/receiving_discount_based_on_nth_order_for_guest_customer.feature
+++ b/features/promotion/applying_promotion_rules/receiving_discount_based_on_nth_order_for_guest_customer.feature
@@ -8,14 +8,14 @@ Feature: Receiving discount based on nth order
         Given the store operates on a single channel in "United States"
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And the store ships everywhere for free
-        And the store allows paying offline
+        And the store allows paying "Cash on Delivery"
 
     @ui
     Scenario: Receiving a discount on an first order
         Given there is a promotion "1st order promotion"
         And it gives "$20.00" off customer's 1st order
-        And I have product "PHP T-Shirt" in the cart
-        When I complete addressing step with email "john.doe@example.com" and "United States" based shipping address
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john.doe@example.com" and "United States" based shipping address
         Then my cart total should be "$80.00"
         And my discount should be "-$20.00"
 
@@ -24,8 +24,10 @@ Feature: Receiving discount based on nth order
         Given there is a promotion "1st order promotion"
         And it gives "$20.00" off customer's 1st order
         And the customer "john.doe@example.com" has already placed an order "#001"
-        And I have product "PHP T-Shirt" in the cart
-        When I complete addressing step with email "john.doe@example.com" and "United States" based shipping address
+        And the customer bought a single "PHP T-Shirt"
+        And the customer chose "Free" shipping method to "United States" with "Cash on Delivery" payment
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john.doe@example.com" and "United States" based shipping address
         Then my cart total should be "$100.00"
         And there should be no discount
 
@@ -33,7 +35,7 @@ Feature: Receiving discount based on nth order
     Scenario: Receiving no discount on an order if I placed more than one order
         Given there is a promotion "2nd order promotion"
         And it gives "$10.00" off customer's 2nd order
-        And I have product "PHP T-Shirt" in the cart
-        When I complete addressing step with email "john.doe@example.com" and "United States" based shipping address
+        When I add product "PHP T-Shirt" to the cart
+        And I complete addressing step with email "john.doe@example.com" and "United States" based shipping address
         Then my cart total should be "$100.00"
         And there should be no discount

--- a/src/Sylius/Behat/Context/Setup/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/PromotionContext.php
@@ -200,11 +200,11 @@ final class PromotionContext implements Context
     }
 
     /**
-     * @Given /^(this coupon) can be used once per customer$/
+     * @Given /^(this coupon) can be used twice per customer$/
      */
-    public function thisCouponCanBeUsedOncePerCustomer(PromotionCouponInterface $coupon)
+    public function thisCouponCanBeUsedTwicePerCustomer(PromotionCouponInterface $coupon)
     {
-        $coupon->setPerCustomerUsageLimit(1);
+        $coupon->setPerCustomerUsageLimit(2);
 
         $this->objectManager->flush();
     }

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_coupon.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_coupon.yml
@@ -8,12 +8,17 @@ default:
                 - sylius.behat.context.hook.doctrine_orm
 
                 - sylius.behat.context.transform.addressing
+                - sylius.behat.context.transform.coupon
                 - sylius.behat.context.transform.lexical
+                - sylius.behat.context.transform.payment
                 - sylius.behat.context.transform.product
                 - sylius.behat.context.transform.shared_storage
+                - sylius.behat.context.transform.shipping_method
                 - sylius.behat.context.transform.taxon
+                - sylius.behat.context.transform.user
 
                 - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.order
                 - sylius.behat.context.setup.payment
                 - sylius.behat.context.setup.product
                 - sylius.behat.context.setup.promotion

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_rules.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_promotion_rules.yml
@@ -10,8 +10,10 @@ default:
                 - sylius.behat.context.transform.addressing
                 - sylius.behat.context.transform.customer
                 - sylius.behat.context.transform.lexical
+                - sylius.behat.context.transform.payment
                 - sylius.behat.context.transform.product
                 - sylius.behat.context.transform.shared_storage
+                - sylius.behat.context.transform.shipping_method
                 - sylius.behat.context.transform.taxon
                 - sylius.behat.context.transform.user
 

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -42,10 +42,11 @@ class OrderRepository extends BaseOrderRepository implements OrderRepositoryInte
         $queryBuilder = $this->createQueryBuilder('o');
 
         $queryBuilder
-            ->andWhere($queryBuilder->expr()->isNotNull('o.completedAt'))
             ->innerJoin('o.customer', 'customer')
             ->andWhere('customer = :customer')
+            ->andWhere('o.state != :state')
             ->setParameter('customer', $customer)
+            ->setParameter('state', OrderInterface::STATE_CART)
         ;
 
         return $queryBuilder;
@@ -89,13 +90,13 @@ class OrderRepository extends BaseOrderRepository implements OrderRepositoryInte
     {
         $queryBuilder = $this->createQueryBuilder('o')
             ->select('count(o.id)')
-            ->leftJoin('o.items', 'item')
             ->innerJoin('o.promotionCoupon', 'coupon')
             ->andWhere('o.customer = :customer')
-            ->andWhere('o.completedAt IS NOT NULL')
             ->andWhere('coupon = :coupon')
+            ->andWhere('o.state != :state')
             ->setParameter('customer', $customer)
             ->setParameter('coupon', $coupon)
+            ->setParameter('state', OrderInterface::STATE_CART)
         ;
 
         $count = (int) $queryBuilder


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | fixes #5412
| License         | MIT

The `count(o.id)` was counting the same order multiple times (depending on number of items) because of `leftJoin('o.items', 'item')`.

**UPDATE**
Revealed another bug, related to `nth` order scenarios implementation.