### PR TITLE
[Promotion] Better coverage of percentage promotion distribution

### DIFF
--- a/features/promotion/receiving_discount/receiving_percentage_discount_promotion_on_order.feature
+++ b/features/promotion/receiving_discount/receiving_percentage_discount_promotion_on_order.feature
@@ -27,9 +27,17 @@ Feature: Receiving percentage discount promotion on order
         And my discount should be "-$20.00"
 
     @ui
-    Scenario: Receiving percentage discount is proportional to items values
+    Scenario: Receiving percentage discount is correct for two items with different price
         Given the store has a product "Vintage Watch" priced at "$1000.00"
         When I add product "PHP T-Shirt" to the cart
         And I add product "Vintage Watch" to the cart
         Then my cart total should be "$880.00"
         And my discount should be "-$220.00"
+
+    @ui
+    Scenario: Receiving percentage discount is proportional to items values
+        Given the store has a product "Symfony T-Shirt" priced at "$100.00"
+        When I add 11 products "PHP T-Shirt" to the cart
+        And I add product "Symfony T-Shirt" to the cart
+        Then my cart total should be "$960.00"
+        And my discount should be "-$240.00"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | mentioned in #6190
| License         | MIT

To make sure that the promotion is applied correctly even if the discount is bigger than the item total.