### PR TITLE
[Documentation][API] Fix API authorization doc

### DIFF
--- a/docs/api/authorization.rst
+++ b/docs/api/authorization.rst
@@ -18,13 +18,13 @@ Sylius has configured OAuth2 authorization. The authorization process is standar
 Create OAuth client
 ~~~~~~~~~~~~~~~~~~~
 
-Use sylius command:
+Use Sylius command:
 
 .. code-block:: bash
 
-    php app/console sylius:oauth-server:create-client
-        --grant-type="password"
-        --grant-type="refresh_token"
+    php app/console sylius:oauth-server:create-client \
+        --grant-type="password" \
+        --grant-type="refresh_token" \
         --grant-type="token"
 
 You will receive client public id and client secret
@@ -77,11 +77,11 @@ Example
 
 .. code-block:: bash
 
-    curl http://sylius.dev/api/oauth/v2/token
-        -d "client_id"=demo_client
-        -d "client_secret"=secret_demo_client
-        -d "grant_type"=password
-        -d "username"=api@example.com
+    curl http://sylius.dev/api/oauth/v2/token \
+        -d "client_id"=demo_client \
+        -d "client_secret"=secret_demo_client \
+        -d "grant_type"=password \
+        -d "username"=api@example.com \
         -d "password"=sylius-api
 
 .. tip::
@@ -154,10 +154,10 @@ Example
 
 .. code-block:: bash
 
-    curl http://sylius.dev/api/oauth/v2/token
-        -d "client_id"=demo_client
-        -d "client_secret"=secret_demo_client
-        -d "grant_type"=refresh_token
+    curl http://sylius.dev/api/oauth/v2/token \
+        -d "client_id"=demo_client \
+        -d "client_secret"=secret_demo_client \
+        -d "grant_type"=refresh_token \
         -d "refresh_token"=MDk2ZmIwODBkYmE3YjNjZWQ4ZTk2NTk2N2JmNjkyZDQ4NzA3YzhiZDQzMjJjODI5MmQ4ZmYxZjlkZmU1ZDNkMQ
 
 Example Response


### PR DESCRIPTION
Hello there :hand: 
It has been a while :)

This PR allows to copy/paste the API commands. Without the `\`, the next lines are not taken into consideration. It can lead to misunderstandings, as the command does not fail, even if the other arguments are not applied.

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | -
| License         | MIT

