### PR TITLE
[ResourceController] Allow state machine transition from createAction

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -249,6 +249,10 @@ class ResourceController extends Controller
                 return $this->redirectHandler->redirectToIndex($configuration, $newResource);
             }
 
+            if ($configuration->hasStateMachine()) {
+                $this->stateMachine->apply($configuration, $newResource);
+            }
+
             $this->repository->add($newResource);
             $this->eventDispatcher->dispatchPostEvent(ResourceActions::CREATE, $configuration, $newResource);
 

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
@@ -506,6 +506,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         RepositoryInterface $repository,
         ResourceInterface $newResource,
         ResourceFormFactoryInterface $resourceFormFactory,
+        StateMachineInterface $stateMachine,
         Form $form,
         RedirectHandlerInterface $redirectHandler,
         FlashHelperInterface $flashHelper,
@@ -520,6 +521,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
         $configuration->hasPermission()->willReturn(true);
         $configuration->getPermission(ResourceActions::CREATE)->willReturn('sylius.product.create');
+        $configuration->hasStateMachine()->willReturn(true);
 
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
@@ -536,6 +538,8 @@ final class ResourceControllerSpec extends ObjectBehavior
 
         $eventDispatcher->dispatchPreEvent(ResourceActions::CREATE, $configuration, $newResource)->willReturn($event);
         $event->isStopped()->willReturn(false);
+
+        $stateMachine->apply($configuration, $newResource)->shouldBeCalled();
 
         $repository->add($newResource)->shouldBeCalled();
         $eventDispatcher->dispatchPostEvent(ResourceActions::CREATE, $configuration, $newResource)->shouldBeCalled();
@@ -560,6 +564,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         FlashHelperInterface $flashHelper,
         EventDispatcherInterface $eventDispatcher,
         ResourceControllerEvent $event,
+        StateMachineInterface $stateMachine,
         Form $form,
         Request $request,
         Response $response
@@ -570,6 +575,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
         $configuration->hasPermission()->willReturn(true);
         $configuration->getPermission(ResourceActions::CREATE)->willReturn('sylius.product.create');
+        $configuration->hasStateMachine()->willReturn(true);
 
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
@@ -586,6 +592,8 @@ final class ResourceControllerSpec extends ObjectBehavior
 
         $eventDispatcher->dispatchPreEvent(ResourceActions::CREATE, $configuration, $newResource)->willReturn($event);
         $event->isStopped()->willReturn(false);
+
+        $stateMachine->apply($configuration, $newResource)->shouldBeCalled();
 
         $repository->add($newResource)->shouldBeCalled();
         $eventDispatcher->dispatchPostEvent(ResourceActions::CREATE, $configuration, $newResource)->shouldBeCalled();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Related tickets | n/a
| License         | MIT

We have state machine transition possible from `updateAction` but not from `createAction`. Can be pretty useful depending on your model.