### PR TITLE
[Critical] Payum uses int for amount, not float

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Action/CapturePaymentAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Action/CapturePaymentAction.php
@@ -101,10 +101,10 @@ final class CapturePaymentAction extends GatewayAwareAction
      * @param int $price
      * @param string $currencyCode
      *
-     * @return float
+     * @return int
      */
     private function convertPrice($price, $currencyCode)
     {
-        return round($this->currencyConverter->convertFromBase($price, $currencyCode) / 100, 2);
+        return $this->currencyConverter->convertFromBase($price, $currencyCode);
     }
 }

--- a/src/Sylius/Bundle/PayumBundle/Action/CapturePaymentAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Action/CapturePaymentAction.php
@@ -67,7 +67,8 @@ final class CapturePaymentAction extends GatewayAwareAction
                 $payumPayment->setClientId($order->getCustomer()->getId());
                 $payumPayment->setDescription(sprintf(
                     'Payment contains %d items for a total of %01.2f',
-                    $order->getItems()->count(), $totalAmount
+                    $order->getItems()->count(),
+                    $totalAmount
                 ));
                 $payumPayment->setDetails($payment->getDetails());
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | kinda
| Related tickets | fixes #6599 
| License         | MIT

I don't even know how this could work before. **Payum** uses ints internally to represent total amounts (see https://github.com/Payum/Payum/issues/597#issuecomment-255673769), and the **Payum\Core\Model\Payment** class explicitly declares `$totalAmount` as an int so

I hope I'm not overlooking something important here, but to me this looks like something that should be fixed.