### PR TITLE
Deleted unused private methods in OrderController

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Controller/OrderController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/OrderController.php
@@ -229,20 +229,4 @@ class OrderController extends ResourceController
     {
         return $this->container->get('event_dispatcher');
     }
-
-    /**
-     * @return EntityManager
-     */
-    private function getOrderManager()
-    {
-        return $this->get('sylius.manager.order');
-    }
-
-    /**
-     * @return RegistryInterface
-     */
-    private function getPayum()
-    {
-        return $this->get('payum');
-    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| License         | MIT

These two private methods are not called from any other method in that class, so i guess they can be removed. 

