### PR TITLE
[BUG] Added Correct Currency Code to Checkout Payments

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Order/_payments.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Order/_payments.html.twig
@@ -6,7 +6,7 @@
             {{ payment.method }}
             ({{ payment.state }})
         </div>
-        <p>{{ payment.amount|sylius_price(payment.currencyCode, payment.order.exchangeRate) }}</p>
+        <p>{{ payment.amount|sylius_price(payment.order.currencyCode, payment.order.exchangeRate) }}</p>
     </div>
 </div>
 {% endfor %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

When viewing the checkout complete page, it shows the correct value but the wrong currency code.