### PR TITLE
[Github] Fix default PR description template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 | Q               | A
 | --------------- | ---
-| Bug fix?        | no|yes
-| New feature?    | no|yes
-| BC breaks?      | no|yes
+| Bug fix?        | no/yes
+| New feature?    | no/yes
+| BC breaks?      | no/yes
 | Related tickets | fixes #X, partially #Y, mentioned in #Z
 | License         | MIT


### PR DESCRIPTION
There were problems with ``|`` signs in few rows.

Previous:
![zrzut ekranu 2016-11-04 o 10 09 49](https://cloud.githubusercontent.com/assets/6212718/20000314/31b5ba52-a277-11e6-8cfb-f3bd8bb860e7.png)

Now:
![zrzut ekranu 2016-11-04 o 10 45 53](https://cloud.githubusercontent.com/assets/6212718/20001329/f6ff34ba-a27b-11e6-9fbd-6dce8ce8509c.png)
