### PR TITLE
[TaxonomyBundle] rename the taxon table on TaxonomyBundle

### DIFF
--- a/src/Sylius/Bundle/TaxonomyBundle/Resources/config/doctrine/model/Taxon.orm.xml
+++ b/src/Sylius/Bundle/TaxonomyBundle/Resources/config/doctrine/model/Taxon.orm.xml
@@ -17,7 +17,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <mapped-superclass name="Sylius\Component\Taxonomy\Model\Taxon">
+    <mapped-superclass name="Sylius\Component\Taxonomy\Model\Taxon" table="sylius_taxon">
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | 
| License         | MIT

This pull request rename the taxon table from "taxon" to "sylius_taxon"

