### PR TITLE
[Admin][UI] Small fixes in slug generation UI

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-product-slug.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-product-slug.js
@@ -17,14 +17,14 @@ $(document).ready(function() {
 });
 
 function updateSlug($element) {
-    $form = $element.parents('form');
     $slugInput = $element.parents('.content').find('[name*="[slug]"]');
+    $loadableParent = $slugInput.parents('.field.loadable');
 
     if ('readonly' == $slugInput.attr('readonly')) {
         return;
     }
 
-    $form.addClass('loading');
+    $loadableParent.addClass('loading');
 
     $.ajax({
         type: "GET",
@@ -38,7 +38,7 @@ function updateSlug($element) {
                 $slugInput.parents('.field').removeClass('error');
                 $slugInput.parents('.field').find('.sylius-validation-error').remove();
             }
-            $form.removeClass('loading');
+            $loadableParent.removeClass('loading');
         }
     });
 }
@@ -46,9 +46,9 @@ function updateSlug($element) {
 function toggleSlugModification($button, $slugInput) {
     if ($slugInput.attr('readonly')) {
         $slugInput.removeAttr('readonly');
-        $button.html('<i class="lock icon"></i>');
+        $button.html('<i class="unlock icon"></i>');
     } else {
         $slugInput.attr('readonly', 'readonly');
-        $button.html('<i class="unlock icon"></i>');
+        $button.html('<i class="lock icon"></i>');
     }
 }

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_details.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_details.html.twig
@@ -33,7 +33,7 @@
                 <i class="dropdown icon"></i>
                 <i class="{{ locale|slice(3, 2)|lower }} flag"></i> {{ locale|sylius_locale_name }}
             </div>
-            <div class="content{% if 0 == loop.index0 %} active{% endif %}">
+            <div class="ui content{% if 0 == loop.index0 %} active{% endif %}">
                 {{ form_row(translationForm.name) }}
                 {% include '@SyliusAdmin/Product/_slugField.html.twig' with { 'slugField': translationForm.slug } %}
                 {{ form_row(translationForm.shortDescription, {'attr': {'rows': 3}}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_slugField.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_slugField.html.twig
@@ -1,4 +1,4 @@
-<div class="{% if slugField.vars.required %}required {% endif %}field{% if slugField.vars.errors|length > 0 %} error{% endif %}">
+<div class="{% if slugField.vars.required %}required {% endif %}field{% if slugField.vars.errors|length > 0 %} error{% endif %} ui loadable form">
     {{ form_label(slugField) }}
     {% if product.slug == null %}
         {{ form_widget(slugField, {'attr': {'data-url': path('sylius_admin_api_generate_product_slug')}}) }}
@@ -6,7 +6,7 @@
     <div class="ui action input">
         {{ form_widget(slugField, {'attr': {'readonly': 'readonly', 'data-url': path('sylius_admin_api_generate_product_slug')}}) }}
         <span id="toggle-slug-modification" class="ui icon button">
-            <i class="unlock icon"></i>
+            <i class="lock icon"></i>
         </span>
     </div>
     {% endif %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | |
| License         | MIT

* Loader on slug field, not on whole form
![zrzut ekranu 2016-11-08 o 11 38 07](https://cloud.githubusercontent.com/assets/6212718/20096431/2a34f49c-a5aa-11e6-9bf7-b5063e76cc0e.png)

* Toggle slug button now shows current state, not target state (more natural, I suppose)
![zrzut ekranu 2016-11-08 o 11 47 37](https://cloud.githubusercontent.com/assets/6212718/20096448/3fa4a9da-a5aa-11e6-8e50-7f3c10f0c909.png)
![zrzut ekranu 2016-11-08 o 11 48 09](https://cloud.githubusercontent.com/assets/6212718/20096449/3fa4cd52-a5aa-11e6-9b47-87a2598ccb74.png)
