### PR TITLE
[RFC] [Doctrine] Default output walkers turn off

### DIFF
--- a/src/Sylius/Bundle/GridBundle/Doctrine/ORM/DataSource.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/ORM/DataSource.php
@@ -71,7 +71,7 @@ final class DataSource implements DataSourceInterface
     public function getData(Parameters $parameters)
     {
         // Use output walkers option in DoctrineORMAdapter should be false as it affects performance greatly. (see #3775)
-        $paginator = new Pagerfanta(new DoctrineORMAdapter($this->queryBuilder, true, false));
+        $paginator = new Pagerfanta(new DoctrineORMAdapter($this->queryBuilder, true, null));
         $paginator->setNormalizeOutOfRangePages(true);
         $paginator->setCurrentPage($parameters->get('page', 1));
 

--- a/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/EntityRepository.php
+++ b/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/EntityRepository.php
@@ -65,7 +65,7 @@ class EntityRepository extends BaseEntityRepository implements RepositoryInterfa
     protected function getPaginator(QueryBuilder $queryBuilder)
     {
         // Use output walkers option in DoctrineORMAdapter should be false as it affects performance greatly (see #3775)
-        return new Pagerfanta(new DoctrineORMAdapter($queryBuilder, true, false));
+        return new Pagerfanta(new DoctrineORMAdapter($queryBuilder, true, null));
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Related tickets | |
| License         | MIT
 
During my work with #6674 I have noticed, that we slightly might missed a proper turn off. The default option for third parameter of constructor [is null](https://github.com/whiteoctober/Pagerfanta/blob/master/src/Pagerfanta/Adapter/DoctrineORMAdapter.php#L35). And the place where it changes the behaviour of doctrine paginator is [here](https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Tools/Pagination/Paginator.php#L210:L212).

It has been fixed previously by #3185.