### PR TITLE
[AdminBundle] Create checkbox based on form instead of attribute

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
@@ -40,7 +40,7 @@
 {% macro collection_item(form, allow_delete, button_delete_label, index) %}
     <div class="attribute" data-id="{{ form.vars.data.attribute.id }}">
         {% set id = form.vars.id %}
-        {% if 'checkbox' in form.vars.value.type %}
+        {% if 'checkbox' in form.children.value.vars.block_prefixes %}
             <div class="ui toggle checkbox" style="margin-top: 15px; margin-bottom: 15px;">
                 {{ form_widget(form.value) }}
                 <label>{{ form.vars.value.attribute.name }}</label>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

By checking the form type instead of the attribute type it is possible to use the CheckboxAttributeType of Sylius as form type parent and thereby get its looks in the product's attributes view. This is more in line with how using form type parents work in Symfony.