### PR TITLE
[Core] Use cache_dir parameter to ensure writable cache dir in InstallCommand

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Command/AbstractInstallCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/AbstractInstallCommand.php
@@ -19,7 +19,6 @@ use Symfony\Component\Validator\ConstraintViolationList;
 
 abstract class AbstractInstallCommand extends ContainerAwareCommand
 {
-    const APP_CACHE = 'app/cache/';
     const WEB_ASSETS_DIRECTORY = 'web/assets/';
     const WEB_BUNDLES_DIRECTORY = 'web/bundles/';
     const WEB_MEDIA_DIRECTORY = 'web/media/';

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallCommand.php
@@ -67,7 +67,7 @@ EOT
         $output->writeln('<info>Installing Sylius...</info>');
         $output->writeln('');
 
-        $this->ensureDirectoryExistsAndIsWritable(self::APP_CACHE, $output);
+        $this->ensureDirectoryExistsAndIsWritable($this->getContainer()->getParameter('kernel.cache_dir'), $output);
 
         foreach ($this->commands as $step => $command) {
             try {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes? |
| License         | MIT |

This fixes a potential problem if the `cache_dir` is not configured to be the default `app/cache` (e.g. Vagrantfile).

I'm not sure about the BC of this in commands, the `APP_CACHE` constant was exposed.

Unrelated question: [Here](http://docs.sylius.org/en/latest/contributing/code/patches.html#make-a-pull-request) it's described that each BC Break PR must contain an entry in the CHANGELOG/UPGRADE file. I've checked the last BC breaking PRs and none of them had any changes like that. Is this still relevant?