### PR TITLE
[Core] Use dbname from doctrine connection to allow custom values

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Command/InstallDatabaseCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallDatabaseCommand.php
@@ -117,13 +117,7 @@ EOT
      */
     protected function getDatabaseName()
     {
-        $databaseName = $this->getContainer()->getParameter('database_name');
-
-        if ('prod' !== $this->getEnvironment()) {
-            $databaseName = sprintf('%s_%s', $databaseName, $this->getEnvironment());
-        }
-
-        return $databaseName;
+        return $this->get('doctrine')->getManager()->getConnection()->getDatabase();
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |

This change makes it possible to use the same database name in every environment. Currently, the `InstallDatabaseCommand` will always prepend `_%env%` to the database name, even if I specified `sylius` (no `_%env%`) in my dev config, which won't match the expectations made here.

It will return `NULL` for SQLite and eventually explode since `listDatabases` is not supported anyway.