### PR TITLE
[Core] Ensure writable web/ directories with absolute paths in the installer

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Command/AbstractInstallCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/AbstractInstallCommand.php
@@ -37,11 +37,7 @@ abstract class AbstractInstallCommand extends ContainerAwareCommand
         $application = $this->getApplication();
         $application->setCatchExceptions(false);
 
-        $this->commandExecutor = new CommandExecutor(
-            $input,
-            $output,
-            $application
-        );
+        $this->commandExecutor = new CommandExecutor($input, $output, $application);
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallAssetsCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallAssetsCommand.php
@@ -39,8 +39,9 @@ EOT
         $output->writeln(sprintf('Installing Sylius assets for environment <info>%s</info>.', $this->getEnvironment()));
 
         try {
-            $this->ensureDirectoryExistsAndIsWritable(self::WEB_ASSETS_DIRECTORY, $output);
-            $this->ensureDirectoryExistsAndIsWritable(self::WEB_BUNDLES_DIRECTORY, $output);
+            $rootDir = $this->getContainer()->getParameter('kernel.root_dir') . '/../';
+            $this->ensureDirectoryExistsAndIsWritable($rootDir . self::WEB_ASSETS_DIRECTORY, $output);
+            $this->ensureDirectoryExistsAndIsWritable($rootDir . self::WEB_BUNDLES_DIRECTORY, $output);
         } catch (\RuntimeException $exception) {
             return 1;
         }

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
@@ -42,6 +42,8 @@ EOT
         $output->writeln(sprintf('<error>Warning! This will erase your database.</error> Your current environment is <info>%s</info>.', $this->getEnvironment()));
 
         if (!$this->getHelperSet()->get('dialog')->askConfirmation($output, '<question>Load sample data? (y/N)</question> ', false)) {
+            $output->writeln('Cancelled loading sample data.');
+
             return 0;
         }
 

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
@@ -52,8 +52,9 @@ EOT
         $output->writeln('Loading sample data...');
 
         try {
-            $this->ensureDirectoryExistsAndIsWritable(self::WEB_MEDIA_DIRECTORY, $output);
-            $this->ensureDirectoryExistsAndIsWritable(self::WEB_MEDIA_IMAGE_DIRECTORY, $output);
+            $rootDir = $this->getContainer()->getParameter('kernel.root_dir') . '/../';
+            $this->ensureDirectoryExistsAndIsWritable($rootDir . self::WEB_MEDIA_DIRECTORY, $output);
+            $this->ensureDirectoryExistsAndIsWritable($rootDir . self::WEB_MEDIA_IMAGE_DIRECTORY, $output);
         } catch (\RuntimeException $exception) {
             $output->writeln($exception->getMessage());
 

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
@@ -41,10 +41,6 @@ EOT
     {
         $output->writeln(sprintf('<error>Warning! This will erase your database.</error> Your current environment is <info>%s</info>.', $this->getEnvironment()));
 
-        if ($input->getOption('no-interaction')) {
-            return 0;
-        }
-
         if (!$this->getHelperSet()->get('dialog')->askConfirmation($output, '<question>Load sample data? (y/N)</question> ', false)) {
             return 0;
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |

This fixes a problem when the install command is not called from the Symfony root directory. Since the web paths are relative, the directories will be created wherever I call the installer from.

Additionally, I removed a `no-interaction` check since Symfony's `askConfirmation` method will do this automatically for us in the next step.