### PR TITLE
[WIP] [RFC] Semantic ui calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "jquery": "^2.2.0",
     "semantic-ui-css": "^2.2.0",
+    "semantic-ui-calendar": "^0.0.3",
     "sortablejs": "^1.4.2"
   },
   "devDependencies": {

--- a/src/Sylius/Bundle/AdminBundle/Gulpfile.js
+++ b/src/Sylius/Bundle/AdminBundle/Gulpfile.js
@@ -20,6 +20,7 @@ var paths = {
             '../../../../node_modules/sortablejs/Sortable.js',
             '../../../../node_modules/sortablejs/jquery.binding.js',
             '../../../../node_modules/semantic-ui-css/semantic.min.js',
+            '../../../../node_modules/semantic-ui-calendar/dist/calendar.js',
             '../PromotionBundle/Resources/public/js/sylius-promotion.js',
             '../ShippingBundle/Resources/public/js/**',
             '../UiBundle/Resources/private/js/**',
@@ -33,7 +34,8 @@ var paths = {
             '../UiBundle/Resources/private/sass/**'
         ],
         css: [
-            '../../../../node_modules/semantic-ui-css/semantic.min.css'
+            '../../../../node_modules/semantic-ui-css/semantic.min.css',
+            '../../../../node_modules/semantic-ui-calendar/dist/calendar.css'
         ],
         img: [
             '../UiBundle/Resources/private/img/**'

--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/semantic-ui-calendar.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/semantic-ui-calendar.js
@@ -1,0 +1,11 @@
+(function($) {
+    $(document).ready(function() {
+        $('.calendar').calendar();
+        $('#rangestart').calendar({
+            endCalendar: $('#rangeend')
+        });
+        $('#rangeend').calendar({
+            startCalendar: $('#rangestart')
+        });
+    });
+})(jQuery);

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Promotion/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Promotion/_form.html.twig
@@ -23,8 +23,8 @@
         <h4 class="ui dividing header">{{ 'sylius.ui.start_date'|trans }} & {{ 'sylius.ui.end_date'|trans }}</h4>
 
         <div class="two fields">
-            {{ form_row(form.startsAt) }}
-            {{ form_row(form.endsAt) }}
+            {{ form_row(form.startsAt, { 'id': 'rangestart'}) }}
+            {{ form_row(form.endsAt, { 'id': 'rangeend'}) }}
         </div>
     </div>
 </div>

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionType.php
@@ -42,14 +42,12 @@ class PromotionType extends AbstractResourceType
             ])
             ->add('startsAt', 'datetime', [
                 'label' => 'sylius.form.promotion.starts_at',
-                'date_widget' => 'single_text',
-                'time_widget' => 'single_text',
+                'widget' => 'single_text',
                 'required' => false,
             ])
             ->add('endsAt', 'datetime', [
                 'label' => 'sylius.form.promotion.ends_at',
-                'date_widget' => 'single_text',
-                'time_widget' => 'single_text',
+                'widget' => 'single_text',
                 'required' => false,
             ])
             ->add('couponBased', 'checkbox', [

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -154,6 +154,12 @@
     </div>
 {% endblock %}
 
+{% block datetime_widget %}
+    <div class="ui input calendar" {% if id is not empty %}id="{{ id }}" {% endif %}>
+        {{ form_widget(form) }}
+    </div>
+{% endblock %}
+
 {% block sylius_product_option_value_widget %}
     <div class="ui segment">
         {{ form_row(form.code) }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | yes (because of changes in promotion form type) |
| Related tickets |  |
| License         | MIT |

I have recently notice, that semantic ui calendar has been publish as a [third party library](https://github.com/mdehoog/Semantic-UI-Calendar). I have needed it during some work with promotion so I tried to implement it to Sylius. It looks much better, but probably it will be hard to make it translatable. I'm the really last person to touch js, so if anybody is willing to finish it feel free to take my work. 

With semantic calendar:
![with semantic calendar](https://cloud.githubusercontent.com/assets/6213903/20246122/a2d070ac-a9b0-11e6-8d57-ab7c4e79e09c.png)


Without semantic calendar:
![without semantic calendar](https://cloud.githubusercontent.com/assets/6213903/20246115/77138fc6-a9b0-11e6-9755-0e8e4f18165f.png)
