### PR TITLE
[ResourceBundle] Allow array to form config.

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Routing/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Routing/Configuration.php
@@ -31,7 +31,7 @@ final class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('alias')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('path')->cannotBeEmpty()->end()
-                ->scalarNode('form')->cannotBeEmpty()->end()
+                ->variableNode('form')->cannotBeEmpty()->end()
                 ->scalarNode('section')->cannotBeEmpty()->end()
                 ->scalarNode('redirect')->cannotBeEmpty()->end()
                 ->scalarNode('templates')->cannotBeEmpty()->end()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | ~
| License         | MIT

Before:

```yaml
rout_name:
    resource: |
        form: form_type_name
```

After

```yaml
rout_name:
    resource: |
        form: form_type_name
        # or
        form:
            type: form_type_name
            options:
                foo: bar
```