### PR TITLE
[ShopBundle] Fix redirect when referer is blank

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Controller/CurrencySwitchController.php
+++ b/src/Sylius/Bundle/ShopBundle/Controller/CurrencySwitchController.php
@@ -91,6 +91,6 @@ final class CurrencySwitchController
 
         $this->currencyChangeHandler->handle($code);
 
-        return new RedirectResponse($request->headers->get('referer', $request->getBaseUrl()));
+        return new RedirectResponse($request->headers->get('referer', $request->getSchemeAndHttpHost()));
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | none |
| License         | MIT |

Currently the currency switch action falls back to `$request->getBaseUrl()`, but unfortunately that is also blank for me. I switched it to use `$request->getSchemeAndHttpHost()`.

By the way, why are controllers final? I was just going to override this controller and change the one action, but can't.