### PR TITLE
Latest translatable issue

### DIFF
--- a/features/homepage/viewing_latest_products.feature
+++ b/features/homepage/viewing_latest_products.feature
@@ -1,4 +1,4 @@
-@viewing_products
+@homepage
 Feature: Viewing a latest product list
     In order to be up-to-date with the newest products
     As a Visitor
@@ -6,7 +6,7 @@ Feature: Viewing a latest product list
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store has "Belvedere Vodka", "Coconaut Liqeur", "Chopin Chocolate Liquer" and "Capitan Morgan White Rum" products
+        And this channel has "Belvedere Vodka", "Coconaut Liqeur", "Chopin Chocolate Liquer" and "Capitan Morgan White Rum" products
 
     @ui
     Scenario: Viewing latest products

--- a/features/product/viewing_products/viewing_latest_product.feature
+++ b/features/product/viewing_products/viewing_latest_product.feature
@@ -1,0 +1,23 @@
+@viewing_products
+Feature: Viewing a latest product list
+    In order to be up-to-date with the newest products
+    As a Visitor
+    I want to be able to view a latest product list
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has "Belvedere Vodka", "Coconaut Liqeur", "Chopin Chocolate Liquer" and "Capitan Morgan White Rum" products
+
+    @ui
+    Scenario: Viewing latest products
+        When I check latest products
+        Then I should see 4 products in the list
+
+    @ui
+    Scenario: Viewing latest products with translation
+        Given the product "Belvedere Vodka" is named "Wódka Belveder" in the "Polish (Poland)" locale
+        And the product "Coconaut Liqeur" is named "Likier kokosowy" in the "Polish (Poland)" locale
+        And the product "Chopin Chocolate Liquer" is named "Chopin Likier Czekoladowy" in the "Polish (Poland)" locale
+        And the product "Capitan Morgan White Rum" is named "Capitan Morgan Biały Rum" in the "Polish (Poland)" locale
+        When I check latest products
+        Then I should see 4 products in the list

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -224,6 +224,7 @@ final class ProductContext implements Context
 
     /**
      * @Given /^(this product) is named "([^"]+)" (in the "([^"]+)" locale)$/
+     * @Given /^the (product "[^"]+") is named "([^"]+)" (in the "([^"]+)" locale)$/
      */
     public function thisProductIsNamedIn(ProductInterface $product, $name, $locale)
     {
@@ -269,6 +270,19 @@ final class ProductContext implements Context
     {
         foreach ($productsNames as $productName) {
             $this->saveProduct($this->createProduct($productName));
+        }
+    }
+
+    /**
+     * @Given /^(this channel) has "([^"]+)", "([^"]+)", "([^"]+)" and "([^"]+)" products$/
+     */
+    public function thisChannelHasProducts(ChannelInterface $channel, ...$productsNames)
+    {
+        foreach ($productsNames as $productName) {
+            $product = $this->createProduct($productName);
+            $product->addChannel($channel);
+
+            $this->saveProduct($product);
         }
     }
 

--- a/src/Sylius/Behat/Context/Ui/Shop/HomepageContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/HomepageContext.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Behat\Context\Ui\Shop;
+
+use Behat\Behat\Context\Context;
+use Sylius\Behat\Page\Shop\HomePageInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ */
+final class HomepageContext implements Context
+{
+    /**
+     * @var HomePageInterface
+     */
+    private $homePage;
+
+    /**
+     * @param HomePageInterface $homepage
+     */
+    public function __construct(HomePageInterface $homepage)
+    {
+        $this->homePage = $homepage;
+    }
+
+    /**
+     * @When I check latest products
+     */
+    public function iCheckLatestProducts()
+    {
+        $this->homePage->open();
+    }
+
+    /**
+     * @Then I should see :numberOfProducts products in the list
+     */
+    public function iShouldSeeProductsInTheList($numberOfProducts)
+    {
+        $foundProductsNames = $this->homePage->getLatestProductsNames();
+
+        Assert::same(
+            (int) $numberOfProducts,
+            count($foundProductsNames),
+            '%d rows with products should appear on page, %d rows has been found'
+        );
+    }
+}

--- a/src/Sylius/Behat/Page/Shop/HomePage.php
+++ b/src/Sylius/Behat/Page/Shop/HomePage.php
@@ -105,6 +105,17 @@ class HomePage extends SymfonyPage implements HomePageInterface
     /**
      * {@inheritdoc}
      */
+    public function getLatestProductsNames()
+    {;
+        return array_map(
+            function (NodeElement $element) { return $element->getText(); },
+            $this->getDocument()->findAll('css', '.sylius-product-name')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function getDefinedElements()
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Shop/HomePageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/HomePageInterface.php
@@ -57,4 +57,9 @@ interface HomePageInterface extends SymfonyPageInterface
      * @param string $localeCode
      */
     public function switchLocale($localeCode);
+
+    /**
+     * @return array
+     */
+    public function getLatestProductsNames();
 }

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -333,6 +333,11 @@
             <tag name="fob.context_service" />
         </service>
 
+        <service id="sylius.behat.context.ui.shop.homepage" class="Sylius\Behat\Context\Ui\Shop\HomepageContext">
+            <argument type="service" id="sylius.behat.page.shop.home" />
+            <tag name="fob.context_service" />
+        </service>
+
         <service id="sylius.behat.context.ui.shop.locale" class="Sylius\Behat\Context\Ui\Shop\LocaleContext">
             <argument type="service" id="sylius.behat.page.shop.home" />
             <tag name="fob.context_service" />

--- a/src/Sylius/Behat/Resources/config/suites.yml
+++ b/src/Sylius/Behat/Resources/config/suites.yml
@@ -29,6 +29,7 @@ imports:
     - suites/ui/checkout/paying_for_order.yml
     - suites/ui/currency/currencies.yml
     - suites/ui/currency/managing_currencies.yml
+    - suites/ui/homepage/viewing_products.yml
     - suites/ui/inventory/cart_inventory.yml
     - suites/ui/inventory/checkout_inventory.yml
     - suites/ui/inventory/managing_inventory.yml

--- a/src/Sylius/Behat/Resources/config/suites/ui/homepage/viewing_products.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/homepage/viewing_products.yml
@@ -1,0 +1,20 @@
+# This file is part of the Sylius package.
+# (c) Paweł Jędrzejewski
+
+default:
+    suites:
+        ui_homepage:
+            contexts_services:
+                - sylius.behat.context.hook.doctrine_orm
+
+                - sylius.behat.context.transform.lexical
+                - sylius.behat.context.transform.product
+                - sylius.behat.context.transform.shared_storage
+
+                - sylius.behat.context.setup.channel
+                - sylius.behat.context.setup.product
+                - sylius.behat.context.setup.shop_security
+
+                - sylius.behat.context.ui.shop.homepage
+            filters:
+                tags: "@homepage && @ui"

--- a/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
@@ -60,8 +60,6 @@ class OrderRepository extends EntityRepository implements OrderRepositoryInterfa
     public function findLatest($count)
     {
         return $this->createQueryBuilder('o')
-            ->addSelect('item')
-            ->leftJoin('o.items', 'item')
             ->andWhere('o.state != :state')
             ->setMaxResults($count)
             ->orderBy('o.checkoutCompletedAt', 'desc')


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #3513 |
| License         | MIT |

The issue #3513 does not exist at the moment. This scenarios would protect us from regression. 

The base problem of an issue is to add select with translation. With the current [function](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php#L74-L86) we do not add any select. If we would add any to-many association, then this query would be broken. Of course, we can consider to have translation fetched from database directly in the query instead of lazy loaded, but before we won't measure its impact on performance it is just a blind shot.

Anyway, if we decide to add some any to-many association there are at least two solutions:
 * Build two separated queries as it is explained [here](http://stackoverflow.com/questions/8554119/set-limit-with-doctrine-2)
 * Make this to-many association to-one, i.e. we can add some where constraint 
 
**Edit**: Last commit fixes admin dashboard with little overhead of number of queries, but not with the time. But to confirm that I would have to do better profiling, what is not a case at the moment.
before: 
<img width="967" alt="before" src="https://cloud.githubusercontent.com/assets/6213903/20352717/9668f068-ac18-11e6-83e9-51d9653ab67b.png">

after:
<img width="925" alt="after" src="https://cloud.githubusercontent.com/assets/6213903/20352725/9e77ae20-ac18-11e6-9373-4d7343596cc8.png">

FYI: xdebug was turned on