### PR TITLE
[Taxation] Remove useless argument type property

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/taxation.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/taxation.xml
@@ -31,7 +31,7 @@
         </service>
 
         <service id="sylius.taxation.order_items_based_strategy" class="Sylius\Bundle\CoreBundle\Taxation\Strategy\TaxCalculationStrategy">
-            <argument key="type">order_items_based</argument>
+            <argument>order_items_based</argument>
             <argument type="collection">
                 <argument type="service" id="sylius.taxation.order_items_taxes_applicator" />
                 <argument type="service" id="sylius.taxation.order_shipment_taxes_applicator" />
@@ -40,7 +40,7 @@
         </service>
 
         <service id="sylius.taxation.order_item_units_based_strategy" class="Sylius\Bundle\CoreBundle\Taxation\Strategy\TaxCalculationStrategy">
-            <argument key="type">order_item_units_based</argument>
+            <argument>order_item_units_based</argument>
             <argument type="collection">
                 <argument type="service" id="sylius.taxation.order_item_units_taxes_applicator" />
                 <argument type="service" id="sylius.taxation.order_shipment_taxes_applicator" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |

This fixes a 'non-numeric value encountered' warning when running
PHP7.1. PR in Symfony to handle these: https://github.com/symfony/symfony/pull/20539