### PR TITLE
[Behat] Allow to define array of elements

### DIFF
--- a/src/Sylius/Behat/Page/Page.php
+++ b/src/Sylius/Behat/Page/Page.php
@@ -234,7 +234,7 @@ abstract class Page implements PageInterface
             ));
         }
 
-        $elementSelector = strtr($definedElements[$name], $parameters);
+        $elementSelector = $this->resolveParameters($name, $parameters, $definedElements);
 
         return new NodeElement(
             $this->getSelectorAsXpath($elementSelector, $this->session->getSelectorsHandler()),
@@ -254,5 +254,27 @@ abstract class Page implements PageInterface
         $locator = is_array($selector) ? $selector[$selectorType] : $selector;
 
         return $selectorsHandler->selectorToXpath($selectorType, $locator);
+    }
+
+    /**
+     * @param string $name
+     * @param array $parameters
+     * @param array$definedElements
+     *
+     * @return string
+     */
+    private function resolveParameters($name, array $parameters, array $definedElements)
+    {
+        if (!is_array($definedElements[$name])) {
+            return strtr($definedElements[$name], $parameters);
+        }
+
+        array_map(
+            function ($definedElement) use ($parameters) {
+                return strtr($definedElement, $parameters);
+            }, $definedElements[$name]
+        );
+
+        return $definedElements[$name];
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

According to [doc block](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Behat/Page/Page.php#L145-L149), an array can be returned from defined elements as well.