### PR TITLE
Show name field in product variant form so it wont get lost on updating

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_details.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_details.html.twig
@@ -3,6 +3,9 @@
 
     <div class="ui segments">
         <div class="ui segment">
+            {{ form_row(form.name) }}
+        </div>
+        <div class="ui segment">
             {{ form_row(form.code) }}
             <div class="two fields">
                 {{ form_row(form.price) }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #6786 |
| License         | MIT |

Just adds the name field in the product variant edit form. 

