### PR TITLE
[Behat] Fix base currency step semantics

### DIFF
--- a/features/account/customer_account/viewing_orders_history/seeing_province_created_manually_in_order_history.feature
+++ b/features/account/customer_account/viewing_orders_history/seeing_province_created_manually_in_order_history.feature
@@ -5,7 +5,7 @@ Feature: Seeing province created manually in order history
     I want to be able to see province in the order history
 
     Background:
-        Given the store operates on a channel named "Web"
+        Given the store operates on a channel named "Web" in currency "USD"
         And the store operates in "United Kingdom"
         And the store has a zone "English" with code "EN"
         And this zone has the "United Kingdom" country member

--- a/features/account/customer_account/viewing_orders_history/seeing_province_created_manually_in_order_history.feature
+++ b/features/account/customer_account/viewing_orders_history/seeing_province_created_manually_in_order_history.feature
@@ -5,7 +5,7 @@ Feature: Seeing province created manually in order history
     I want to be able to see province in the order history
 
     Background:
-        Given the store operates on a channel named "Web" in currency "USD"
+        Given the store operates on a channel named "Web" in "USD" currency
         And the store operates in "United Kingdom"
         And the store has a zone "English" with code "EN"
         And this zone has the "United Kingdom" country member

--- a/features/account/customer_account/viewing_orders_history/viewing_order_recalculated_by_exchange_rate.feature
+++ b/features/account/customer_account/viewing_orders_history/viewing_order_recalculated_by_exchange_rate.feature
@@ -11,7 +11,7 @@ Feature: Viewing details of an order
         And the store operates on a channel named "Web"
         And that channel allows to shop using the "USD" currency
         And that channel allows to shop using the "GBP" currency with exchange rate 3.0
-        And that channel uses the "USD" currency by default
+        And that channel uses the "USD" currency as base
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone
         And the store has a product "Angel T-Shirt" priced at "$20.00"

--- a/features/account/customer_account/viewing_orders_history/viewing_order_recalculated_by_exchange_rate.feature
+++ b/features/account/customer_account/viewing_orders_history/viewing_order_recalculated_by_exchange_rate.feature
@@ -8,10 +8,9 @@ Feature: Viewing details of an order
         Given the store ships to "British Virgin Islands"
         And the store has a zone "English" with code "EN"
         And this zone has the "British Virgin Islands" country member
-        And the store operates on a channel named "Web"
+        And the store operates on a channel named "Web" in currency "USD"
         And that channel allows to shop using the "USD" currency
         And that channel allows to shop using the "GBP" currency with exchange rate 3.0
-        And that channel uses the "USD" currency as base
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone
         And the store has a product "Angel T-Shirt" priced at "$20.00"

--- a/features/account/customer_account/viewing_orders_history/viewing_order_recalculated_by_exchange_rate.feature
+++ b/features/account/customer_account/viewing_orders_history/viewing_order_recalculated_by_exchange_rate.feature
@@ -8,8 +8,7 @@ Feature: Viewing details of an order
         Given the store ships to "British Virgin Islands"
         And the store has a zone "English" with code "EN"
         And this zone has the "British Virgin Islands" country member
-        And the store operates on a channel named "Web" in currency "USD"
-        And that channel allows to shop using the "USD" currency
+        And the store operates on a channel named "Web" in "USD" currency
         And that channel allows to shop using the "GBP" currency with exchange rate 3.0
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone

--- a/features/cart/shopping_cart/adding_product_to_cart_with_prices_dependent_on_channel_and_currency.feature
+++ b/features/cart/shopping_cart/adding_product_to_cart_with_prices_dependent_on_channel_and_currency.feature
@@ -7,9 +7,9 @@ Feature: Adding a product to cart with prices dependent on a channel and a curre
     Background:
         Given the store has currency "EUR"
         And the store has currency "GBP" with exchange rate 0.7
-        And the store operates on a channel named "Web-EU" in currency "EUR"
+        And the store operates on a channel named "Web-EU" in "EUR" currency
         And that channel allows to shop using "EUR" and "GBP" currencies
-        And the store operates on another channel named "Web-GB"
+        And the store operates on another channel named "Web-GB" in "GBP" currency
         And that channel allows to shop using "EUR" and "GBP" currencies
         And the store has a product "Leprechaun's Gold" priced at "€12.54" available in channel "Web-EU" and channel "Web-GB"
         And it has different prices for different channels and currencies

--- a/features/cart/shopping_cart/adding_product_to_cart_with_prices_dependent_on_channel_and_currency.feature
+++ b/features/cart/shopping_cart/adding_product_to_cart_with_prices_dependent_on_channel_and_currency.feature
@@ -9,10 +9,10 @@ Feature: Adding a product to cart with prices dependent on a channel and a curre
         And the store has currency "GBP" with exchange rate 0.7
         And the store operates on a channel named "Web-EU"
         And that channel allows to shop using "EUR" and "GBP" currencies
-        And that channel uses the "EUR" currency by default
+        And that channel uses the "EUR" currency as base
         And the store operates on another channel named "Web-GB"
         And that channel allows to shop using "EUR" and "GBP" currencies
-        And that channel uses the "GBP" currency by default
+        And that channel uses the "GBP" currency as base
         And the store has a product "Leprechaun's Gold" priced at "€12.54" available in channel "Web-EU" and channel "Web-GB"
         And it has different prices for different channels and currencies
         And it has price "€10.00" for "Web-EU" channel and "EUR" currency

--- a/features/cart/shopping_cart/adding_product_to_cart_with_prices_dependent_on_channel_and_currency.feature
+++ b/features/cart/shopping_cart/adding_product_to_cart_with_prices_dependent_on_channel_and_currency.feature
@@ -7,12 +7,10 @@ Feature: Adding a product to cart with prices dependent on a channel and a curre
     Background:
         Given the store has currency "EUR"
         And the store has currency "GBP" with exchange rate 0.7
-        And the store operates on a channel named "Web-EU"
+        And the store operates on a channel named "Web-EU" in currency "EUR"
         And that channel allows to shop using "EUR" and "GBP" currencies
-        And that channel uses the "EUR" currency as base
         And the store operates on another channel named "Web-GB"
         And that channel allows to shop using "EUR" and "GBP" currencies
-        And that channel uses the "GBP" currency as base
         And the store has a product "Leprechaun's Gold" priced at "€12.54" available in channel "Web-EU" and channel "Web-GB"
         And it has different prices for different channels and currencies
         And it has price "€10.00" for "Web-EU" channel and "EUR" currency

--- a/features/cart/shopping_cart/viewing_cart_summary_in_many_channels.feature
+++ b/features/cart/shopping_cart/viewing_cart_summary_in_many_channels.feature
@@ -7,7 +7,7 @@ Feature: Viewing a cart summary in many channels
     Background:
         Given the store operates on another channel named "France"
         And there is product "Banana" available in this channel
-        And the store operates on a channel named "Poland"
+        And the store operates on a channel named "Poland" in currency "PLN"
         And there is product "Onion" available in this channel
 
     @ui

--- a/features/cart/shopping_cart/viewing_cart_summary_in_many_channels.feature
+++ b/features/cart/shopping_cart/viewing_cart_summary_in_many_channels.feature
@@ -7,7 +7,7 @@ Feature: Viewing a cart summary in many channels
     Background:
         Given the store operates on another channel named "France"
         And there is product "Banana" available in this channel
-        And the store operates on a channel named "Poland" in currency "PLN"
+        And the store operates on a channel named "Poland" in "PLN" currency
         And there is product "Onion" available in this channel
 
     @ui

--- a/features/channel/managing_channels/browsing_channels.feature
+++ b/features/channel/managing_channels/browsing_channels.feature
@@ -5,7 +5,7 @@ Feature: Browsing channels
     I want to be able to browse list of them
 
     Background:
-        Given the store operates on a channel named "Web Channel" in currency "USD"
+        Given the store operates on a channel named "Web Channel" in "USD" currency
         And the store operates on another channel named "Mobile Channel"
         And I am logged in as an administrator
 

--- a/features/channel/managing_channels/browsing_channels.feature
+++ b/features/channel/managing_channels/browsing_channels.feature
@@ -5,7 +5,7 @@ Feature: Browsing channels
     I want to be able to browse list of them
 
     Background:
-        Given the store operates on a channel named "Web Channel"
+        Given the store operates on a channel named "Web Channel" in currency "USD"
         And the store operates on another channel named "Mobile Channel"
         And I am logged in as an administrator
 

--- a/features/checkout/seeing_order_summary/seeing_prices_recalculated_by_exchange_rate_on_order_summary.feature
+++ b/features/checkout/seeing_order_summary/seeing_prices_recalculated_by_exchange_rate_on_order_summary.feature
@@ -8,8 +8,7 @@ Feature: Seeing prices recalculated by exchange rate on order summary
         Given the store ships to "British Virgin Islands"
         And the store has a zone "English" with code "EN"
         And this zone has the "British Virgin Islands" country member
-        And the store operates on a channel named "Web" in currency "USD"
-        And that channel allows to shop using the "USD" currency
+        And the store operates on a channel named "Web" in "USD" currency
         And that channel allows to shop using the "GBP" currency with exchange rate 3.0
         And the store has a product "Lannister Coat" priced at "$100.00"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone

--- a/features/checkout/seeing_order_summary/seeing_prices_recalculated_by_exchange_rate_on_order_summary.feature
+++ b/features/checkout/seeing_order_summary/seeing_prices_recalculated_by_exchange_rate_on_order_summary.feature
@@ -8,10 +8,9 @@ Feature: Seeing prices recalculated by exchange rate on order summary
         Given the store ships to "British Virgin Islands"
         And the store has a zone "English" with code "EN"
         And this zone has the "British Virgin Islands" country member
-        And the store operates on a channel named "Web"
+        And the store operates on a channel named "Web" in currency "USD"
         And that channel allows to shop using the "USD" currency
         And that channel allows to shop using the "GBP" currency with exchange rate 3.0
-        And that channel uses the "USD" currency as base
         And the store has a product "Lannister Coat" priced at "$100.00"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone
         And the store allows paying offline

--- a/features/checkout/seeing_order_summary/seeing_prices_recalculated_by_exchange_rate_on_order_summary.feature
+++ b/features/checkout/seeing_order_summary/seeing_prices_recalculated_by_exchange_rate_on_order_summary.feature
@@ -11,7 +11,7 @@ Feature: Seeing prices recalculated by exchange rate on order summary
         And the store operates on a channel named "Web"
         And that channel allows to shop using the "USD" currency
         And that channel allows to shop using the "GBP" currency with exchange rate 3.0
-        And that channel uses the "USD" currency by default
+        And that channel uses the "USD" currency as base
         And the store has a product "Lannister Coat" priced at "$100.00"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone
         And the store allows paying offline

--- a/features/currency/handling_different_currencies_on_multiple_channels.feature
+++ b/features/currency/handling_different_currencies_on_multiple_channels.feature
@@ -5,12 +5,10 @@ Feature: Handling different currencies on multiple channels
     I want to browse channels with a valid currency only
 
     Background:
-        Given the store operates on a channel named "Web"
+        Given the store operates on a channel named "Web" in currency "EUR"
         And that channel allows to shop using "EUR", "USD" and "GBP" currencies
-        And it uses the "EUR" currency as base
-        And the store operates on another channel named "Mobile"
+        And the store operates on another channel named "Mobile" in currency "USD"
         And that channel allows to shop using "USD" and "GBP" currencies
-        And it uses the "USD" currency as base
 
     @ui
     Scenario: Showing currencies only from the current channel

--- a/features/currency/handling_different_currencies_on_multiple_channels.feature
+++ b/features/currency/handling_different_currencies_on_multiple_channels.feature
@@ -7,10 +7,10 @@ Feature: Handling different currencies on multiple channels
     Background:
         Given the store operates on a channel named "Web"
         And that channel allows to shop using "EUR", "USD" and "GBP" currencies
-        And it uses the "EUR" currency by default
+        And it uses the "EUR" currency as base
         And the store operates on another channel named "Mobile"
         And that channel allows to shop using "USD" and "GBP" currencies
-        And it uses the "USD" currency by default
+        And it uses the "USD" currency as base
 
     @ui
     Scenario: Showing currencies only from the current channel

--- a/features/currency/handling_different_currencies_on_multiple_channels.feature
+++ b/features/currency/handling_different_currencies_on_multiple_channels.feature
@@ -5,9 +5,9 @@ Feature: Handling different currencies on multiple channels
     I want to browse channels with a valid currency only
 
     Background:
-        Given the store operates on a channel named "Web" in currency "EUR"
+        Given the store operates on a channel named "Web" in "EUR" currency
         And that channel allows to shop using "EUR", "USD" and "GBP" currencies
-        And the store operates on another channel named "Mobile" in currency "USD"
+        And the store operates on another channel named "Mobile" in "USD" currency
         And that channel allows to shop using "USD" and "GBP" currencies
 
     @ui

--- a/features/currency/handling_disabled_currencies.feature
+++ b/features/currency/handling_disabled_currencies.feature
@@ -7,7 +7,7 @@ Feature: Handling disabled currencies
     Background:
         Given the store operates on a channel named "Web"
         And that channel allows to shop using "EUR", "USD" and "GBP" currencies
-        And it uses the "EUR" currency by default
+        And it uses the "EUR" currency as base
 
     @ui
     Scenario: Not showing the disabled currency

--- a/features/currency/handling_disabled_currencies.feature
+++ b/features/currency/handling_disabled_currencies.feature
@@ -5,7 +5,7 @@ Feature: Handling disabled currencies
     I want to browse channels with a valid currency only
 
     Background:
-        Given the store operates on a channel named "Web" in currency "EUR"
+        Given the store operates on a channel named "Web" in "EUR" currency
         And that channel allows to shop using "EUR", "USD" and "GBP" currencies
 
     @ui

--- a/features/currency/handling_disabled_currencies.feature
+++ b/features/currency/handling_disabled_currencies.feature
@@ -5,9 +5,8 @@ Feature: Handling disabled currencies
     I want to browse channels with a valid currency only
 
     Background:
-        Given the store operates on a channel named "Web"
+        Given the store operates on a channel named "Web" in currency "EUR"
         And that channel allows to shop using "EUR", "USD" and "GBP" currencies
-        And it uses the "EUR" currency as base
 
     @ui
     Scenario: Not showing the disabled currency

--- a/features/currency/managing_currency/inability_of_modifying_base_currency.feature
+++ b/features/currency/managing_currency/inability_of_modifying_base_currency.feature
@@ -10,13 +10,13 @@ Feature: Inability of modifying the base currency
     @ui
     Scenario: Being prevented from disabling base currency
         Given the store operates on a single channel
-        And it uses the "USD" currency by default
+        And it uses the "USD" currency as base
         When I want to edit this currency
         Then I should not be able to disable this currency
 
     @ui
     Scenario: Being prevented from changing base currency exchange rate
         Given the store operates on a single channel
-        And it uses the "USD" currency by default
+        And it uses the "USD" currency as base
         When I want to edit this currency
         Then I should not be able to change exchange rate of this currency

--- a/features/currency/managing_currency/inability_of_modifying_base_currency.feature
+++ b/features/currency/managing_currency/inability_of_modifying_base_currency.feature
@@ -9,14 +9,12 @@ Feature: Inability of modifying the base currency
 
     @ui
     Scenario: Being prevented from disabling base currency
-        Given the store operates on a single channel
-        And it uses the "USD" currency as base
+        Given the store operates on a single channel in currency "USD"
         When I want to edit this currency
         Then I should not be able to disable this currency
 
     @ui
     Scenario: Being prevented from changing base currency exchange rate
-        Given the store operates on a single channel
-        And it uses the "USD" currency as base
+        Given the store operates on a single channel in currency "USD"
         When I want to edit this currency
         Then I should not be able to change exchange rate of this currency

--- a/features/currency/managing_currency/inability_of_modifying_base_currency.feature
+++ b/features/currency/managing_currency/inability_of_modifying_base_currency.feature
@@ -9,12 +9,12 @@ Feature: Inability of modifying the base currency
 
     @ui
     Scenario: Being prevented from disabling base currency
-        Given the store operates on a single channel in currency "USD"
+        Given the store operates on a single channel in "USD" currency
         When I want to edit this currency
         Then I should not be able to disable this currency
 
     @ui
     Scenario: Being prevented from changing base currency exchange rate
-        Given the store operates on a single channel in currency "USD"
+        Given the store operates on a single channel in "USD" currency
         When I want to edit this currency
         Then I should not be able to change exchange rate of this currency

--- a/features/currency/switching_current_currency.feature
+++ b/features/currency/switching_current_currency.feature
@@ -7,7 +7,7 @@ Feature: Switching the current currency
     Background:
         Given the store operates on a channel named "Web"
         And that channel allows to shop using "EUR" and "USD" currencies
-        And it uses the "EUR" currency by default
+        And it uses the "EUR" currency as base
 
     @ui
     Scenario: Showing the current currency

--- a/features/currency/switching_current_currency.feature
+++ b/features/currency/switching_current_currency.feature
@@ -5,9 +5,8 @@ Feature: Switching the current currency
     I want to be able to switch currencies
 
     Background:
-        Given the store operates on a channel named "Web"
+        Given the store operates on a channel named "Web" in currency "EUR"
         And that channel allows to shop using "EUR" and "USD" currencies
-        And it uses the "EUR" currency as base
 
     @ui
     Scenario: Showing the current currency

--- a/features/currency/switching_current_currency.feature
+++ b/features/currency/switching_current_currency.feature
@@ -5,7 +5,7 @@ Feature: Switching the current currency
     I want to be able to switch currencies
 
     Background:
-        Given the store operates on a channel named "Web" in currency "EUR"
+        Given the store operates on a channel named "Web" in "EUR" currency
         And that channel allows to shop using "EUR" and "USD" currencies
 
     @ui

--- a/features/order/managing_orders/modifying_shipping_address/modifying_shipping_address_on_order_with_different_exchange_rate.feature
+++ b/features/order/managing_orders/modifying_shipping_address/modifying_shipping_address_on_order_with_different_exchange_rate.feature
@@ -11,7 +11,7 @@ Feature: Modifying a customer's shipping address of an order with a different cu
         And this zone has the "United States" country member
         And that channel allows to shop using the "USD" currency
         And that channel allows to shop using the "GBP" currency with exchange rate 3.0
-        And that channel uses the "USD" currency by default
+        And that channel uses the "USD" currency as base
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone
         And the store has a product "Suit" priced at "$400.00"

--- a/features/order/managing_orders/modifying_shipping_address/modifying_shipping_address_on_order_with_different_exchange_rate.feature
+++ b/features/order/managing_orders/modifying_shipping_address/modifying_shipping_address_on_order_with_different_exchange_rate.feature
@@ -5,11 +5,10 @@ Feature: Modifying a customer's shipping address of an order with a different cu
     I want to be able to modify a customer's shipping address without changing an order's total
 
     Background:
-        Given the store operates on a channel named "Web" in currency "USD"
+        Given the store operates on a channel named "Web" in "USD" currency
         And the store ships to "United States"
         And the store has a zone "English" with code "EN"
         And this zone has the "United States" country member
-        And that channel allows to shop using the "USD" currency
         And that channel allows to shop using the "GBP" currency with exchange rate 3.0
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone

--- a/features/order/managing_orders/modifying_shipping_address/modifying_shipping_address_on_order_with_different_exchange_rate.feature
+++ b/features/order/managing_orders/modifying_shipping_address/modifying_shipping_address_on_order_with_different_exchange_rate.feature
@@ -5,13 +5,12 @@ Feature: Modifying a customer's shipping address of an order with a different cu
     I want to be able to modify a customer's shipping address without changing an order's total
 
     Background:
-        Given the store operates on a channel named "Web"
+        Given the store operates on a channel named "Web" in currency "USD"
         And the store ships to "United States"
         And the store has a zone "English" with code "EN"
         And this zone has the "United States" country member
         And that channel allows to shop using the "USD" currency
         And that channel allows to shop using the "GBP" currency with exchange rate 3.0
-        And that channel uses the "USD" currency as base
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone
         And the store has a product "Suit" priced at "$400.00"

--- a/features/order/managing_orders/modifying_shipping_address/modifying_shipping_address_validation.feature
+++ b/features/order/managing_orders/modifying_shipping_address/modifying_shipping_address_validation.feature
@@ -6,7 +6,7 @@ Feature: Modifying a customer's shipping address validation
 
     Background:
         Given the store operates on a single channel in the "United States" named "Web"
-        And that channel uses the "USD" currency by default
+        And that channel uses the "USD" currency as base
         And the store ships everywhere for free
         And the store allows paying with "Cash on Delivery"
         And the store has a product "Suit" priced at "$400.00"

--- a/features/order/managing_orders/modifying_shipping_address/modifying_shipping_address_validation.feature
+++ b/features/order/managing_orders/modifying_shipping_address/modifying_shipping_address_validation.feature
@@ -6,7 +6,6 @@ Feature: Modifying a customer's shipping address validation
 
     Background:
         Given the store operates on a single channel in the "United States" named "Web"
-        And that channel uses the "USD" currency as base
         And the store ships everywhere for free
         And the store allows paying with "Cash on Delivery"
         And the store has a product "Suit" priced at "$400.00"

--- a/features/order/managing_orders/seeing_order_currency_on_show.feature
+++ b/features/order/managing_orders/seeing_order_currency_on_show.feature
@@ -8,7 +8,7 @@ Feature: Seeing the currency an order has been placed in on it's details page
         Given the store ships to "British Virgin Islands"
         And the store has a zone "English" with code "EN"
         And this zone has the "British Virgin Islands" country member
-        And the store operates on a channel named "Web" in currency "USD"
+        And the store operates on a channel named "Web" in "USD" currency
         And that channel allows to shop using "USD" and "GBP" currencies
         And the store has "Low VAT" tax rate of 10% for "Lowered EN services" within the "EN" zone
         And the store allows paying with "Cash on Delivery"

--- a/features/order/managing_orders/seeing_order_currency_on_show.feature
+++ b/features/order/managing_orders/seeing_order_currency_on_show.feature
@@ -8,9 +8,8 @@ Feature: Seeing the currency an order has been placed in on it's details page
         Given the store ships to "British Virgin Islands"
         And the store has a zone "English" with code "EN"
         And this zone has the "British Virgin Islands" country member
-        And the store operates on a channel named "Web"
+        And the store operates on a channel named "Web" in currency "USD"
         And that channel allows to shop using "USD" and "GBP" currencies
-        And that channel uses the "USD" currency as base
         And the store has "Low VAT" tax rate of 10% for "Lowered EN services" within the "EN" zone
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone

--- a/features/order/managing_orders/seeing_order_currency_on_show.feature
+++ b/features/order/managing_orders/seeing_order_currency_on_show.feature
@@ -10,7 +10,7 @@ Feature: Seeing the currency an order has been placed in on it's details page
         And this zone has the "British Virgin Islands" country member
         And the store operates on a channel named "Web"
         And that channel allows to shop using "USD" and "GBP" currencies
-        And that channel uses the "USD" currency by default
+        And that channel uses the "USD" currency as base
         And the store has "Low VAT" tax rate of 10% for "Lowered EN services" within the "EN" zone
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone

--- a/features/order/managing_orders/seeing_order_prices_with_its_currencys_exchange_rate_on_show.feature
+++ b/features/order/managing_orders/seeing_order_prices_with_its_currencys_exchange_rate_on_show.feature
@@ -11,7 +11,7 @@ Feature: Seeing all prices calculated accordingly to it's currency's exchange ra
         And the store operates on a channel named "Web"
         And that channel allows to shop using the "USD" currency
         And that channel allows to shop using the "GBP" currency with exchange rate 2.00
-        And that channel uses the "USD" currency by default
+        And that channel uses the "USD" currency as base
         And the store has "Low VAT" tax rate of 10% for "Lowered EN services" within the "EN" zone
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone

--- a/features/order/managing_orders/seeing_order_prices_with_its_currencys_exchange_rate_on_show.feature
+++ b/features/order/managing_orders/seeing_order_prices_with_its_currencys_exchange_rate_on_show.feature
@@ -8,10 +8,9 @@ Feature: Seeing all prices calculated accordingly to it's currency's exchange ra
         Given the store ships to "British Virgin Islands"
         And the store has a zone "English" with code "EN"
         And this zone has the "British Virgin Islands" country member
-        And the store operates on a channel named "Web"
+        And the store operates on a channel named "Web" in currency "USD"
         And that channel allows to shop using the "USD" currency
         And that channel allows to shop using the "GBP" currency with exchange rate 2.00
-        And that channel uses the "USD" currency as base
         And the store has "Low VAT" tax rate of 10% for "Lowered EN services" within the "EN" zone
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone

--- a/features/order/managing_orders/seeing_order_prices_with_its_currencys_exchange_rate_on_show.feature
+++ b/features/order/managing_orders/seeing_order_prices_with_its_currencys_exchange_rate_on_show.feature
@@ -8,8 +8,7 @@ Feature: Seeing all prices calculated accordingly to it's currency's exchange ra
         Given the store ships to "British Virgin Islands"
         And the store has a zone "English" with code "EN"
         And this zone has the "British Virgin Islands" country member
-        And the store operates on a channel named "Web" in currency "USD"
-        And that channel allows to shop using the "USD" currency
+        And the store operates on a channel named "Web" in "USD" currency
         And that channel allows to shop using the "GBP" currency with exchange rate 2.00
         And the store has "Low VAT" tax rate of 10% for "Lowered EN services" within the "EN" zone
         And the store allows paying with "Cash on Delivery"

--- a/features/order/managing_orders/seeing_orders_currency_on_index.feature
+++ b/features/order/managing_orders/seeing_orders_currency_on_index.feature
@@ -8,9 +8,8 @@ Feature: Seeing the currency in which all orders have been placed
         Given the store ships to "British Virgin Islands"
         And the store has a zone "English" with code "EN"
         And this zone has the "British Virgin Islands" country member
-        And the store operates on a channel named "Web"
+        And the store operates on a channel named "Web" in currency "USD"
         And that channel allows to shop using "USD" and "GBP" currencies
-        And that channel uses the "USD" currency as base
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone
         And the store has a product "Angel T-Shirt" priced at "$20.00"

--- a/features/order/managing_orders/seeing_orders_currency_on_index.feature
+++ b/features/order/managing_orders/seeing_orders_currency_on_index.feature
@@ -8,7 +8,7 @@ Feature: Seeing the currency in which all orders have been placed
         Given the store ships to "British Virgin Islands"
         And the store has a zone "English" with code "EN"
         And this zone has the "British Virgin Islands" country member
-        And the store operates on a channel named "Web" in currency "USD"
+        And the store operates on a channel named "Web" in "USD" currency
         And that channel allows to shop using "USD" and "GBP" currencies
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone

--- a/features/order/managing_orders/seeing_orders_currency_on_index.feature
+++ b/features/order/managing_orders/seeing_orders_currency_on_index.feature
@@ -10,7 +10,7 @@ Feature: Seeing the currency in which all orders have been placed
         And this zone has the "British Virgin Islands" country member
         And the store operates on a channel named "Web"
         And that channel allows to shop using "USD" and "GBP" currencies
-        And that channel uses the "USD" currency by default
+        And that channel uses the "USD" currency as base
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone
         And the store has a product "Angel T-Shirt" priced at "$20.00"

--- a/features/order/managing_orders/seeing_orders_currency_with_different_exchange_rates_on_index.feature
+++ b/features/order/managing_orders/seeing_orders_currency_with_different_exchange_rates_on_index.feature
@@ -11,7 +11,7 @@ Feature: Seeing orders' total in their currency and respective exchange rate
         And the store operates on a channel named "Web"
         And that channel allows to shop using the "USD" currency
         And that channel allows to shop using the "GBP" currency with exchange rate 3.0
-        And that channel uses the "USD" currency by default
+        And that channel uses the "USD" currency as base
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone
         And the store has a product "Angel T-Shirt" priced at "$20.00"

--- a/features/order/managing_orders/seeing_orders_currency_with_different_exchange_rates_on_index.feature
+++ b/features/order/managing_orders/seeing_orders_currency_with_different_exchange_rates_on_index.feature
@@ -8,8 +8,7 @@ Feature: Seeing orders' total in their currency and respective exchange rate
         Given the store ships to "British Virgin Islands"
         And the store has a zone "English" with code "EN"
         And this zone has the "British Virgin Islands" country member
-        And the store operates on a channel named "Web" in currency "USD"
-        And that channel allows to shop using the "USD" currency
+        And the store operates on a channel named "Web" in "USD" currency
         And that channel allows to shop using the "GBP" currency with exchange rate 3.0
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone

--- a/features/order/managing_orders/seeing_orders_currency_with_different_exchange_rates_on_index.feature
+++ b/features/order/managing_orders/seeing_orders_currency_with_different_exchange_rates_on_index.feature
@@ -8,10 +8,9 @@ Feature: Seeing orders' total in their currency and respective exchange rate
         Given the store ships to "British Virgin Islands"
         And the store has a zone "English" with code "EN"
         And this zone has the "British Virgin Islands" country member
-        And the store operates on a channel named "Web"
+        And the store operates on a channel named "Web" in currency "USD"
         And that channel allows to shop using the "USD" currency
         And that channel allows to shop using the "GBP" currency with exchange rate 3.0
-        And that channel uses the "USD" currency as base
         And the store allows paying with "Cash on Delivery"
         And the store has "DHL" shipping method with "$20.00" fee within the "EN" zone
         And the store has a product "Angel T-Shirt" priced at "$20.00"

--- a/features/promotion/managing_promotions/adding_promotion_with_action_in_different_currencies.feature
+++ b/features/promotion/managing_promotions/adding_promotion_with_action_in_different_currencies.feature
@@ -9,7 +9,7 @@ Feature: Adding a new promotion with action configured in different currencies
         And the store has currency "GBP" with exchange rate 0.5
         And the store operates on a channel named "Web-US"
         And that channel allows to shop using "USD" and "GBP" currencies
-        And that channel uses the "USD" currency by default
+        And that channel uses the "USD" currency as base
         And I am logged in as an administrator
 
     @ui @javascript

--- a/features/promotion/managing_promotions/adding_promotion_with_action_in_different_currencies.feature
+++ b/features/promotion/managing_promotions/adding_promotion_with_action_in_different_currencies.feature
@@ -7,7 +7,7 @@ Feature: Adding a new promotion with action configured in different currencies
     Background:
         Given the store has currency "USD"
         And the store has currency "GBP" with exchange rate 0.5
-        And the store operates on a channel named "Web-US" in currency "USD"
+        And the store operates on a channel named "Web-US" in "USD" currency
         And that channel allows to shop using "USD" and "GBP" currencies
         And I am logged in as an administrator
 

--- a/features/promotion/managing_promotions/adding_promotion_with_action_in_different_currencies.feature
+++ b/features/promotion/managing_promotions/adding_promotion_with_action_in_different_currencies.feature
@@ -7,9 +7,8 @@ Feature: Adding a new promotion with action configured in different currencies
     Background:
         Given the store has currency "USD"
         And the store has currency "GBP" with exchange rate 0.5
-        And the store operates on a channel named "Web-US"
+        And the store operates on a channel named "Web-US" in currency "USD"
         And that channel allows to shop using "USD" and "GBP" currencies
-        And that channel uses the "USD" currency as base
         And I am logged in as an administrator
 
     @ui @javascript

--- a/features/promotion/receiving_discount/receiving_fixed_discount_dependent_on_currency.feature
+++ b/features/promotion/receiving_discount/receiving_fixed_discount_dependent_on_currency.feature
@@ -9,7 +9,7 @@ Feature: Receiving fixed discount dependent on currency on cart
         And the store has currency "GBP" with exchange rate 0.5
         And the store operates on a channel named "Web-US"
         And that channel allows to shop using "USD" and "GBP" currencies
-        And that channel uses the "USD" currency by default
+        And that channel uses the "USD" currency as base
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And there is a promotion "Holiday promotion"
 

--- a/features/promotion/receiving_discount/receiving_fixed_discount_dependent_on_currency.feature
+++ b/features/promotion/receiving_discount/receiving_fixed_discount_dependent_on_currency.feature
@@ -7,7 +7,7 @@ Feature: Receiving fixed discount dependent on currency on cart
     Background:
         Given the store has currency "USD"
         And the store has currency "GBP" with exchange rate 0.5
-        And the store operates on a channel named "Web-US" in currency "USD"
+        And the store operates on a channel named "Web-US" in "USD" currency
         And that channel allows to shop using "USD" and "GBP" currencies
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And there is a promotion "Holiday promotion"

--- a/features/promotion/receiving_discount/receiving_fixed_discount_dependent_on_currency.feature
+++ b/features/promotion/receiving_discount/receiving_fixed_discount_dependent_on_currency.feature
@@ -7,9 +7,8 @@ Feature: Receiving fixed discount dependent on currency on cart
     Background:
         Given the store has currency "USD"
         And the store has currency "GBP" with exchange rate 0.5
-        And the store operates on a channel named "Web-US"
+        And the store operates on a channel named "Web-US" in currency "USD"
         And that channel allows to shop using "USD" and "GBP" currencies
-        And that channel uses the "USD" currency as base
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And there is a promotion "Holiday promotion"
 

--- a/src/Sylius/Behat/Context/Setup/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Setup/ChannelContext.php
@@ -16,6 +16,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Channel\Factory\ChannelFactoryInterface;
 use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Currency\CurrencyStorageInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Test\Services\DefaultChannelFactoryInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -58,12 +59,18 @@ final class ChannelContext implements Context
     private $channelManager;
 
     /**
+     * @var CurrencyStorageInterface
+     */
+    private $currencyStorage;
+
+    /**
      * @param SharedStorageInterface $sharedStorage
      * @param DefaultChannelFactoryInterface $unitedStatesChannelFactory
      * @param DefaultChannelFactoryInterface $defaultChannelFactory
      * @param ChannelFactoryInterface $channelFactory
      * @param ChannelRepositoryInterface $channelRepository
      * @param ObjectManager $channelManager
+     * @param CurrencyStorageInterface $currencyStorage
      */
     public function __construct(
         SharedStorageInterface $sharedStorage,
@@ -71,7 +78,8 @@ final class ChannelContext implements Context
         DefaultChannelFactoryInterface $defaultChannelFactory,
         ChannelFactoryInterface $channelFactory,
         ChannelRepositoryInterface $channelRepository,
-        ObjectManager $channelManager
+        ObjectManager $channelManager,
+        CurrencyStorageInterface $currencyStorage
     ) {
         $this->sharedStorage = $sharedStorage;
         $this->unitedStatesChannelFactory = $unitedStatesChannelFactory;
@@ -79,6 +87,7 @@ final class ChannelContext implements Context
         $this->channelFactory = $channelFactory;
         $this->channelRepository = $channelRepository;
         $this->channelManager = $channelManager;
+        $this->currencyStorage = $currencyStorage;
     }
 
     /**
@@ -105,7 +114,7 @@ final class ChannelContext implements Context
 
     /**
      * @Given the store operates on a single channel
-     * @Given the store operates on a single channel in currency :currencyCode
+     * @Given the store operates on a single channel in :currencyCode currency
      */
     public function storeOperatesOnASingleChannel($currencyCode = null)
     {
@@ -117,7 +126,7 @@ final class ChannelContext implements Context
 
     /**
      * @Given /^the store operates on (?:a|another) channel named "([^"]+)"$/
-     * @Given /^the store operates on (?:a|another) channel named "([^"]+)" in currency "([^"]+)"$/
+     * @Given /^the store operates on (?:a|another) channel named "([^"]+)" in "([^"]+)" currency$/
      * @Given the store operates on a channel identified by :code code
      */
     public function theStoreOperatesOnAChannelNamed($channelIdentifier, $currencyCode = null)
@@ -126,6 +135,7 @@ final class ChannelContext implements Context
 
         $this->sharedStorage->setClipboard($defaultData);
         $this->sharedStorage->set('channel', $defaultData['channel']);
+        $this->currencyStorage->set($defaultData['channel'], $defaultData['currency']->getCode());
     }
 
     /**

--- a/src/Sylius/Behat/Context/Setup/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Setup/ChannelContext.php
@@ -105,10 +105,11 @@ final class ChannelContext implements Context
 
     /**
      * @Given the store operates on a single channel
+     * @Given the store operates on a single channel in currency :currencyCode
      */
-    public function storeOperatesOnASingleChannel()
+    public function storeOperatesOnASingleChannel($currencyCode = null)
     {
-        $defaultData = $this->defaultChannelFactory->create();
+        $defaultData = $this->defaultChannelFactory->create(null, null, $currencyCode);
 
         $this->sharedStorage->setClipboard($defaultData);
         $this->sharedStorage->set('channel', $defaultData['channel']);
@@ -116,11 +117,12 @@ final class ChannelContext implements Context
 
     /**
      * @Given /^the store operates on (?:a|another) channel named "([^"]+)"$/
+     * @Given /^the store operates on (?:a|another) channel named "([^"]+)" in currency "([^"]+)"$/
      * @Given the store operates on a channel identified by :code code
      */
-    public function theStoreOperatesOnAChannelNamed($channelIdentifier)
+    public function theStoreOperatesOnAChannelNamed($channelIdentifier, $currencyCode = null)
     {
-        $defaultData = $this->defaultChannelFactory->create($channelIdentifier, $channelIdentifier);
+        $defaultData = $this->defaultChannelFactory->create($channelIdentifier, $channelIdentifier, $currencyCode);
 
         $this->sharedStorage->setClipboard($defaultData);
         $this->sharedStorage->set('channel', $defaultData['channel']);

--- a/src/Sylius/Behat/Context/Setup/CurrencyContext.php
+++ b/src/Sylius/Behat/Context/Setup/CurrencyContext.php
@@ -144,10 +144,10 @@ final class CurrencyContext implements Context
     }
 
     /**
-     * @Given /^(that channel) uses the "([^"]+)" currency by default$/
-     * @Given /^(it) uses the "([^"]+)" currency by default$/
+     * @Given /^(that channel) uses the "([^"]+)" currency as base$/
+     * @Given /^(it) uses the "([^"]+)" currency as base$/
      */
-    public function itUsesTheCurrencyByDefault(ChannelInterface $channel, $currencyCode)
+    public function itUsesTheCurrencyAsBase(ChannelInterface $channel, $currencyCode)
     {
         $currency = $this->provideCurrency($currencyCode);
 

--- a/src/Sylius/Behat/Context/Setup/CurrencyContext.php
+++ b/src/Sylius/Behat/Context/Setup/CurrencyContext.php
@@ -144,23 +144,6 @@ final class CurrencyContext implements Context
     }
 
     /**
-     * @Given /^(that channel) uses the "([^"]+)" currency as base$/
-     * @Given /^(it) uses the "([^"]+)" currency as base$/
-     */
-    public function itUsesTheCurrencyAsBase(ChannelInterface $channel, $currencyCode)
-    {
-        $currency = $this->provideCurrency($currencyCode);
-
-        $channel->addCurrency($currency);
-        $channel->setBaseCurrency($currency);
-
-        $this->channelManager->flush();
-
-        $this->sharedStorage->set('currency', $currency);
-        $this->currencyStorage->set($channel, $currency->getCode());
-    }
-
-    /**
      * @Given /^(that channel)(?: also|) allows to shop using the "([^"]+)" currency with exchange rate ([0-9\.]+)$/
      */
     public function thatChannelAllowsToShopUsingCurrency(ChannelInterface $channel, $currencyCode, $exchangeRate = 1.0)

--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -567,10 +567,9 @@ final class OrderContext implements Context
 
         $order->setCustomer($customer);
         $order->setChannel((null !== $channel) ? $channel : $this->sharedStorage->get('channel'));
-        $order->setCurrencyCode((null !== $currencyCode) ? $currencyCode : $this->sharedStorage->get('currency')->getCode());
         $order->setLocaleCode((null !== $localeCode) ? $localeCode : $this->sharedStorage->get('locale')->getCode());
 
-        $currencyCode = $currencyCode ? $currencyCode : $this->sharedStorage->get('currency')->getCode();
+        $currencyCode = $currencyCode ? $currencyCode : $order->getChannel()->getBaseCurrency()->getCode();
         $currency = $this->currencyRepository->findOneBy(['code' => $currencyCode]);
 
         $order->setCurrencyCode($currency->getCode());

--- a/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
@@ -33,6 +33,7 @@
             <argument type="service" id="__symfony__.sylius.factory.channel" />
             <argument type="service" id="__symfony__.sylius.repository.channel" />
             <argument type="service" id="__symfony__.sylius.manager.channel" />
+            <argument type="service" id="__symfony__.sylius.storage.currency" />
             <argument>%__behat__.mink.parameters%</argument>
             <tag name="fob.context_service" />
         </service>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/test_services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/test_services.xml
@@ -40,7 +40,6 @@
             <argument type="service" id="sylius.factory.locale" />
             <argument type="service" id="sylius.factory.zone" />
             <argument type="service" id="sylius.factory.zone_member" />
-            <argument>%currency%</argument>
             <argument>%locale%</argument>
         </service>
         <service id="sylius.behat.factory.default_channel" class="Sylius\Component\Core\Test\Services\DefaultChannelFactory">

--- a/src/Sylius/Component/Core/Test/Services/DefaultChannelFactory.php
+++ b/src/Sylius/Component/Core/Test/Services/DefaultChannelFactory.php
@@ -129,9 +129,7 @@ final class DefaultChannelFactory implements DefaultChannelFactoryInterface
      */
     private function provideCurrency($currencyCode = null)
     {
-        if (null === $currencyCode) {
-            $currencyCode = $this->defaultCurrencyCode;
-        }
+        $currencyCode = $currencyCode ?: $this->defaultCurrencyCode;
 
         /** @var CurrencyInterface $currency */
         $currency = $this->currencyRepository->findOneBy(['code' => $currencyCode]);

--- a/src/Sylius/Component/Core/Test/Services/DefaultChannelFactory.php
+++ b/src/Sylius/Component/Core/Test/Services/DefaultChannelFactory.php
@@ -99,9 +99,9 @@ final class DefaultChannelFactory implements DefaultChannelFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function create($code = null, $name = null)
+    public function create($code = null, $name = null, $currencyCode = null)
     {
-        $currency = $this->provideCurrency();
+        $currency = $this->provideCurrency($currencyCode);
         $locale = $this->provideLocale();
 
         /** @var ChannelInterface $channel */
@@ -127,14 +127,18 @@ final class DefaultChannelFactory implements DefaultChannelFactoryInterface
     /**
      * @return CurrencyInterface
      */
-    private function provideCurrency()
+    private function provideCurrency($currencyCode = null)
     {
+        if (null === $currencyCode) {
+            $currencyCode = $this->defaultCurrencyCode;
+        }
+
         /** @var CurrencyInterface $currency */
-        $currency = $this->currencyRepository->findOneBy(['code' => $this->defaultCurrencyCode]);
+        $currency = $this->currencyRepository->findOneBy(['code' => $currencyCode]);
 
         if (null === $currency) {
             $currency = $this->currencyFactory->createNew();
-            $currency->setCode($this->defaultCurrencyCode);
+            $currency->setCode($currencyCode);
             $currency->setExchangeRate(1.00);
 
             $this->currencyRepository->add($currency);

--- a/src/Sylius/Component/Core/Test/Services/DefaultChannelFactoryInterface.php
+++ b/src/Sylius/Component/Core/Test/Services/DefaultChannelFactoryInterface.php
@@ -19,8 +19,9 @@ interface DefaultChannelFactoryInterface
     /**
      * @param string|null $code
      * @param string|null $name
+     * @param string|null $currencyCode
      *
      * @return array
      */
-    public function create($code = null, $name = null);
+    public function create($code = null, $name = null, $currencyCode = null);
 }

--- a/src/Sylius/Component/Core/Test/Services/DefaultUnitedStatesChannelFactory.php
+++ b/src/Sylius/Component/Core/Test/Services/DefaultUnitedStatesChannelFactory.php
@@ -31,6 +31,7 @@ final class DefaultUnitedStatesChannelFactory implements DefaultChannelFactoryIn
     const DEFAULT_ZONE_CODE = 'US';
     const DEFAULT_ZONE_NAME = 'United States';
     const DEFAULT_CHANNEL_NAME = 'United States';
+    const DEFAULT_CURRENCY_CODE = 'USD';
 
     /**
      * @var RepositoryInterface
@@ -95,11 +96,6 @@ final class DefaultUnitedStatesChannelFactory implements DefaultChannelFactoryIn
     /**
      * @var string
      */
-    private $defaultCurrencyCode;
-
-    /**
-     * @var string
-     */
     private $defaultLocaleCode;
 
     /**
@@ -115,7 +111,6 @@ final class DefaultUnitedStatesChannelFactory implements DefaultChannelFactoryIn
      * @param FactoryInterface $localeFactory
      * @param FactoryInterface $zoneFactory
      * @param FactoryInterface $zoneMemberFactory
-     * @param string $defaultCurrencyCode
      * @param string $defaultLocaleCode
      */
     public function __construct(
@@ -131,7 +126,6 @@ final class DefaultUnitedStatesChannelFactory implements DefaultChannelFactoryIn
         FactoryInterface $localeFactory,
         FactoryInterface $zoneFactory,
         FactoryInterface $zoneMemberFactory,
-        $defaultCurrencyCode,
         $defaultLocaleCode
     ) {
         $this->channelRepository = $channelRepository;
@@ -146,16 +140,15 @@ final class DefaultUnitedStatesChannelFactory implements DefaultChannelFactoryIn
         $this->localeFactory = $localeFactory;
         $this->zoneMemberFactory = $zoneMemberFactory;
         $this->zoneFactory = $zoneFactory;
-        $this->defaultCurrencyCode = $defaultCurrencyCode;
         $this->defaultLocaleCode = $defaultLocaleCode;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function create($code = null, $name = null)
+    public function create($code = null, $name = null, $currencyCode = null)
     {
-        $currency = $this->provideCurrency();
+        $currency = $this->provideCurrency($currencyCode);
         $locale = $this->provideLocale();
 
         $channel = $this->createChannel($code ?: self::DEFAULT_CHANNEL_CODE, $name ?: self::DEFAULT_CHANNEL_NAME);
@@ -206,14 +199,18 @@ final class DefaultUnitedStatesChannelFactory implements DefaultChannelFactoryIn
     /**
      * @return CurrencyInterface
      */
-    private function provideCurrency()
+    private function provideCurrency($currencyCode = null)
     {
+        if (null === $currencyCode) {
+            $currencyCode = self::DEFAULT_CURRENCY_CODE;
+        }
+
         /** @var CurrencyInterface $currency */
-        $currency = $this->currencyRepository->findOneBy(['code' => $this->defaultCurrencyCode]);
+        $currency = $this->currencyRepository->findOneBy(['code' => $currencyCode]);
 
         if (null === $currency) {
             $currency = $this->currencyFactory->createNew();
-            $currency->setCode($this->defaultCurrencyCode);
+            $currency->setCode($currencyCode);
             $currency->setExchangeRate(1.00);
 
             $this->currencyRepository->add($currency);

--- a/src/Sylius/Component/Core/Test/Services/DefaultUnitedStatesChannelFactory.php
+++ b/src/Sylius/Component/Core/Test/Services/DefaultUnitedStatesChannelFactory.php
@@ -201,9 +201,7 @@ final class DefaultUnitedStatesChannelFactory implements DefaultChannelFactoryIn
      */
     private function provideCurrency($currencyCode = null)
     {
-        if (null === $currencyCode) {
-            $currencyCode = self::DEFAULT_CURRENCY_CODE;
-        }
+        $currencyCode = $currencyCode ?: self::DEFAULT_CURRENCY_CODE;
 
         /** @var CurrencyInterface $currency */
         $currency = $this->currencyRepository->findOneBy(['code' => $currencyCode]);

--- a/src/Sylius/Component/Core/spec/Test/Services/DefaultUnitedStatesChannelFactorySpec.php
+++ b/src/Sylius/Component/Core/spec/Test/Services/DefaultUnitedStatesChannelFactorySpec.php
@@ -56,7 +56,6 @@ final class DefaultUnitedStatesChannelFactorySpec extends ObjectBehavior
             $localeFactory,
             $zoneFactory,
             $zoneMemberFactory,
-            'USD',
             'en_US'
         );
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | #6766 |
| License         | MIT |

According to upcoming changes with currencies, it will be more appropriate to have base currency set in channel creation step (``United States`` channel has obviously ``USD`` base currency).