### PR TITLE
Remove deprecated usage of FormInterface::submit(Request $request)

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Controller/OrderController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/OrderController.php
@@ -72,7 +72,7 @@ class OrderController extends ResourceController
 
         $form = $this->resourceFormFactory->create($configuration, $resource);
 
-        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && $form->submit($request, !$request->isMethod('PATCH'))->isValid()) {
+        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && $form->handleRequest($request)->isValid()) {
             $resource = $form->getData();
 
             $event = $this->eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource);

--- a/src/Sylius/Bundle/CoreBundle/Controller/ProductTaxonController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/ProductTaxonController.php
@@ -37,7 +37,7 @@ class ProductTaxonController extends ResourceController
         $this->isGrantedOr403($configuration, ResourceActions::UPDATE);
         $productTaxons = $request->get('productTaxons');
 
-        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH']) && null !== $productTaxons) {
+        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && null !== $productTaxons) {
             foreach($productTaxons as $productTaxon) {
 
                 if(!is_numeric($productTaxon['position'])) {

--- a/src/Sylius/Bundle/OrderBundle/Controller/OrderItemController.php
+++ b/src/Sylius/Bundle/OrderBundle/Controller/OrderItemController.php
@@ -53,7 +53,7 @@ class OrderItemController extends ResourceController
             $configuration->getFormOptions()
         );
 
-        if ($request->isMethod('POST') && $form->submit($request)->isValid()) {
+        if ($request->isMethod('POST') && $form->handleRequest($request)->isValid()) {
             /** @var AddToCartCommandInterface $addCartItemCommand */
             $addToCartCommand = $form->getData();
 

--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -235,7 +235,7 @@ class ResourceController extends Controller
 
         $form = $this->resourceFormFactory->create($configuration, $newResource);
 
-        if ($request->isMethod('POST') && $form->submit($request)->isValid()) {
+        if ($request->isMethod('POST') && $form->handleRequest($request)->isValid()) {
             $newResource = $form->getData();
 
             $event = $this->eventDispatcher->dispatchPreEvent(ResourceActions::CREATE, $configuration, $newResource);
@@ -297,7 +297,7 @@ class ResourceController extends Controller
 
         $form = $this->resourceFormFactory->create($configuration, $resource);
 
-        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH']) && $form->submit($request, !$request->isMethod('PATCH'))->isValid()) {
+        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && $form->handleRequest($request)->isValid()) {
             $resource = $form->getData();
 
             $event = $this->eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource);

--- a/src/Sylius/Bundle/ResourceBundle/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\Form\Extension\HttpFoundation;
+
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\RequestHandlerInterface;
+use Symfony\Component\Form\Util\ServerParams;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Does not compare the form's method with the request's method.
+ * Always submits the form, even if there are no fields sent.
+ *
+ * @internal
+ *
+ * @see \Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler
+ */
+final class HttpFoundationRequestHandler implements RequestHandlerInterface
+{
+    /**
+     * @var ServerParams
+     */
+    private $serverParams;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(ServerParams $serverParams = null)
+    {
+        $this->serverParams = $serverParams ?: new ServerParams();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(FormInterface $form, $request = null)
+    {
+        if (!$request instanceof Request) {
+            throw new UnexpectedTypeException($request, 'Symfony\Component\HttpFoundation\Request');
+        }
+
+        $name = $form->getName();
+        $method = $request->getMethod();
+
+        // For request methods that must not have a request body we fetch data
+        // from the query string. Otherwise we look for data in the request body.
+        if ('GET' === $method || 'HEAD' === $method || 'TRACE' === $method) {
+            if ('' === $name) {
+                $data = $request->query->all();
+            } else {
+                // Don't submit GET requests if the form's name does not exist
+                // in the request
+                if (!$request->query->has($name)) {
+                    return;
+                }
+
+                $data = $request->query->get($name);
+            }
+        } else {
+            // Mark the form with an error if the uploaded size was too large
+            // This is done here and not in FormValidator because $_POST is
+            // empty when that error occurs. Hence the form is never submitted.
+            if ($this->serverParams->hasPostMaxSizeBeenExceeded()) {
+                // Submit the form, but don't clear the default values
+                $form->submit(null, false);
+
+                $form->addError(new FormError(
+                    call_user_func($form->getConfig()->getOption('upload_max_size_message')),
+                    null,
+                    array('{{ max }}' => $this->serverParams->getNormalizedIniPostMaxSize())
+                ));
+
+                return;
+            }
+
+            if ('' === $name) {
+                $params = $request->request->all();
+                $files = $request->files->all();
+            } elseif ($request->request->has($name) || $request->files->has($name)) {
+                $default = $form->getConfig()->getCompound() ? array() : null;
+                $params = $request->request->get($name, $default);
+                $files = $request->files->get($name, $default);
+            } else {
+                // Don't submit the form if it is not present in the request
+                return;
+            }
+
+            if (is_array($params) && is_array($files)) {
+                $data = array_replace_recursive($params, $files);
+            } else {
+                $data = $params ?: $files;
+            }
+        }
+
+        $form->submit($data, 'PATCH' !== $method);
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
@@ -23,6 +23,10 @@
     </parameters>
 
     <services>
+        <service id="sylius.form.type_extension.form.request_handler"
+                 class="Sylius\Bundle\ResourceBundle\Form\Extension\HttpFoundation\HttpFoundationRequestHandler"
+                 decorates="form.type_extension.form.request_handler" public="false" />
+
         <service id="sylius.resource_registry" class="Sylius\Component\Resource\Metadata\Registry" public="false" />
 
         <service id="sylius.expression_language" class="Symfony\Component\DependencyInjection\ExpressionLanguage" public="false" />

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
@@ -382,7 +382,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
 
         $request->isMethod('POST')->willReturn(true);
-        $form->submit($request)->willReturn($form);
+        $form->handleRequest($request)->willReturn($form);
         $form->isValid()->willReturn(false);
         $form->createView()->willReturn($formView);
 
@@ -432,7 +432,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
 
         $request->isMethod('POST')->willReturn(true);
-        $form->submit($request)->willReturn($form);
+        $form->handleRequest($request)->willReturn($form);
         $form->isValid()->willReturn(false);
 
         $expectedView = View::create($form, 400);
@@ -477,7 +477,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
 
         $request->isMethod('POST')->willReturn(true);
-        $form->submit($request)->willReturn($form);
+        $form->handleRequest($request)->willReturn($form);
         $form->isValid()->willReturn(true);
         $form->getData()->willReturn($newResource);
 
@@ -532,7 +532,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
 
         $request->isMethod('POST')->willReturn(true);
-        $form->submit($request)->willReturn($form);
+        $form->handleRequest($request)->willReturn($form);
         $form->isValid()->willReturn(true);
         $form->getData()->willReturn($newResource);
 
@@ -586,7 +586,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
 
         $request->isMethod('POST')->willReturn(true);
-        $form->submit($request)->willReturn($form);
+        $form->handleRequest($request)->willReturn($form);
         $form->isValid()->willReturn(true);
         $form->getData()->willReturn($newResource);
 
@@ -639,7 +639,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
 
         $request->isMethod('POST')->willReturn(true);
-        $form->submit($request)->willReturn($form);
+        $form->handleRequest($request)->willReturn($form);
         $form->isValid()->willReturn(true);
         $form->getData()->willReturn($newResource);
 
@@ -733,7 +733,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $request->isMethod('PATCH')->willReturn(false);
         $request->getMethod()->willReturn('GET');
 
-        $form->submit($request, true)->willReturn($form);
+        $form->handleRequest($request)->willReturn($form);
         $form->createView()->willReturn($formView);
 
         $expectedView = View::create()
@@ -785,7 +785,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $request->isMethod('PATCH')->willReturn(false);
         $request->getMethod()->willReturn('PUT');
 
-        $form->submit($request, true)->willReturn($form);
+        $form->handleRequest($request)->willReturn($form);
 
         $form->isValid()->willReturn(false);
         $form->createView()->willReturn($formView);
@@ -836,7 +836,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $request->isMethod('PATCH')->willReturn(true);
         $request->getMethod()->willReturn('PATCH');
 
-        $form->submit($request, false)->willReturn($form);
+        $form->handleRequest($request)->willReturn($form);
         $form->isValid()->willReturn(false);
 
         $expectedView = View::create($form, 400);
@@ -880,7 +880,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $request->isMethod('PATCH')->willReturn(false);
         $request->getMethod()->willReturn('PUT');
 
-        $form->submit($request, true)->willReturn($form);
+        $form->handleRequest($request)->willReturn($form);
 
         $form->isSubmitted()->willReturn(true);
         $form->isValid()->willReturn(true);
@@ -936,7 +936,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $request->isMethod('PATCH')->willReturn(false);
         $request->getMethod()->willReturn('PUT');
 
-        $form->submit($request, true)->willReturn($form);
+        $form->handleRequest($request)->willReturn($form);
 
         $form->isSubmitted()->willReturn(true);
         $form->isValid()->willReturn(true);
@@ -988,7 +988,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $request->isMethod('PATCH')->willReturn(false);
         $request->getMethod()->willReturn('PUT');
 
-        $form->submit($request, true)->willReturn($form);
+        $form->handleRequest($request)->willReturn($form);
         $form->isValid()->willReturn(true);
         $form->getData()->willReturn($resource);
 
@@ -1036,7 +1036,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $request->isMethod('PATCH')->willReturn(false);
         $request->getMethod()->willReturn('PUT');
 
-        $form->submit($request, true)->willReturn($form);
+        $form->handleRequest($request)->willReturn($form);
         $form->isValid()->willReturn(true);
         $form->getData()->willReturn($resource);
 
@@ -1092,7 +1092,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $request->isMethod('PATCH')->willReturn(false);
         $request->getMethod()->willReturn('PUT');
 
-        $form->submit($request, true)->willReturn($form);
+        $form->handleRequest($request)->willReturn($form);
 
         $form->isSubmitted()->willReturn(true);
         $form->isValid()->willReturn(true);

--- a/src/Sylius/Bundle/UserBundle/Controller/UserController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/UserController.php
@@ -54,7 +54,7 @@ class UserController extends ResourceController
         $formType = $request->attributes->get('_sylius[form]', 'sylius_user_change_password', true);
         $form = $this->createResourceForm($configuration, $formType, $changePassword);
 
-        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH']) && $form->submit($request, !$request->isMethod('PATCH'))->isValid()) {
+        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && $form->handleRequest($request)->isValid()) {
             return $this->handleChangePassword($request, $configuration, $user, $changePassword->getNewPassword());
         }
 
@@ -119,7 +119,7 @@ class UserController extends ResourceController
         $formType = $request->attributes->get('_sylius[form]', 'sylius_user_reset_password', true);
         $form = $this->createResourceForm($configuration, $formType, $passwordReset);
 
-        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH']) && $form->submit($request, !$request->isMethod('PATCH'))->isValid()) {
+        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && $form->handleRequest($request)->isValid()) {
             return $this->handleResetPassword($request, $configuration, $user, $passwordReset->getPassword());
         }
 
@@ -237,7 +237,7 @@ class UserController extends ResourceController
         $template = $request->attributes->get('_sylius[template]', null, true);
         Assert::notNull($template, 'Template is not configured.');
 
-        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH']) && $form->submit($request, !$request->isMethod('PATCH'))->isValid()) {
+        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && $form->handleRequest($request)->isValid()) {
             $user = $this->repository->findOneByEmail($passwordReset->getEmail());
             if (null !== $user) {
                 $this->handleResetPasswordRequest($generator, $user, $senderEvent);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | extracted from #6738 |
| License         | MIT |

