### PR TITLE
[RFC][BC Break] Rename checkout summary event

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -89,7 +89,7 @@
         <service id="sylius.listener.order_customer_ip" class="Sylius\Bundle\CoreBundle\EventListener\OrderCustomerIpListener">
             <argument type="service" id="sylius.customer_ip_assigner" />
             <argument type="service" id="request_stack" />
-            <tag name="kernel.event_listener" event="sylius.order.pre_summary" method="assignCustomerIpToOrder" />
+            <tag name="kernel.event_listener" event="sylius.order.pre_complete" method="assignCustomerIpToOrder" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/checkout.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/checkout.yml
@@ -76,7 +76,7 @@ sylius_shop_checkout_complete:
     defaults:
         _controller: sylius.controller.order:updateAction
         _sylius:
-            event: summary
+            event: complete
             flash: false
             template: SyliusShopBundle:Checkout:complete.html.twig
             repository:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets |  |
| License         | MIT |

IMO `complete` is more appropriate name for an event dispatched after the checkout summary step.