### PR TITLE
[RFC] Hide root taxon from UI

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/Show/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/Show/_breadcrumb.html.twig
@@ -4,8 +4,12 @@
     <a href="{{ path('sylius_shop_homepage') }}" class="section">{{ 'sylius.ui.home'|trans }}</a>
     <div class="divider"> / </div>
     {% for parent in parents %}
-    <a href="{{ path('sylius_shop_taxon_show', {'slug': parent.slug}) }}" class="section">{{ parent.name }}</a>
-    <div class="divider"> / </div>
+        {% if  parent.isRoot %}
+            {{ parent.name }}
+        {% else %}
+            <a href="{{ path('sylius_shop_taxon_show', {'slug': parent.slug}) }}" class="section">{{ parent.name }}</a>
+        {% endif %}
+        <div class="divider"> / </div>
     {% endfor %}
     <div class="active section">{{ taxon.name }}</div>
 </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/Show/_children.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/Show/_children.html.twig
@@ -1,6 +1,6 @@
 <div class="ui fluid vertical menu">
     <div class="header item">{{ taxon.name }}</div>
-    {% if taxon.parent is not empty %}
+    {% if taxon.parent is not empty and not taxon.parent.isRoot %}
         <a href="{{ path('sylius_shop_taxon_show', {'slug': taxon.parent.slug}) }}" class="item">
             <i class="up arrow icon"></i> {{ 'sylius.ui.go_level_up'|trans }}
         </a>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

Do not allow to navigate to a root taxon in the default UI.