### PR TITLE
[Behat] Fix exception msg for Toggles checkbox assertion

### DIFF
--- a/src/Sylius/Behat/Behaviour/Toggles.php
+++ b/src/Sylius/Behat/Behaviour/Toggles.php
@@ -54,7 +54,11 @@ trait Toggles
     private function assertCheckboxState(NodeElement $toggleableElement, $expectedState)
     {
         if ($toggleableElement->isChecked() !== $expectedState) {
-            throw new \RuntimeException('Toggleable element state %s but expected %s.', $toggleableElement->isChecked(), $expectedState);
+            throw new \RuntimeException(sprintf(
+                "Toggleable element state is '%s' but expected '%s'.",
+                $toggleableElement->isChecked() ? 'true' : 'false',
+                $expectedState ? 'true' : 'false'
+            ));
         }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |

**Before:**
```
Behat\Testwork\Call\Exception\FatalThrowableError: Fatal error: Wrong parameters for RuntimeException([string $message [, long $code [, Throwable $previous = NULL]]]) in vendor/sylius/sylius/src/Sylius/Behat/Behaviour/Toggles.php:57
```

**After:**
```
RuntimeException: Toggleable element state is 'false' but expected 'true'. in vendor/sylius/sylius/src/Sylius/Behat/Behaviour/Toggles.php:57
```