### PR TITLE
[Core] Maintain previous cart after logging in

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -61,6 +61,7 @@ security:
                 path: sylius_shop_logout
                 target: sylius_shop_login
                 invalidate_session: false
+                success_handler: sylius.handler.shop_user_logout
             anonymous: true
 
         dev:

--- a/features/cart/shopping_cart/clearing_cart_after_logging_out.feature
+++ b/features/cart/shopping_cart/clearing_cart_after_logging_out.feature
@@ -1,0 +1,17 @@
+@shopping_cart
+Feature: Clearing cart after logging out
+    In order to not allow to use my cart by anybody
+    As a Customer
+    I want to be able to have my cart cleared after logging out
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Stark T-shirt" priced at "$12.00"
+        And I am a logged in customer
+        And I have product "Stark T-Shirt" in the cart
+
+    @ui
+    Scenario: Clearing cart after logging out
+        When I log out
+        And I see the summary of my cart
+        Then my cart should be empty

--- a/features/cart/shopping_cart/maintaining_previous_cart_after_authorization.feature
+++ b/features/cart/shopping_cart/maintaining_previous_cart_after_authorization.feature
@@ -1,0 +1,20 @@
+@shopping_cart
+Feature: Maintaining previous cart after authorization
+    In order to retrieve my previous unfinished order
+    As a Visitor
+    I want to be able to have my cart previous maintained
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Stark T-shirt" priced at "$12.00"
+        And there is a user "robb@stark.com" identified by "KingInTheNorth"
+        And I log in as "robb@stark.com" with "KingInTheNorth" password
+
+    @ui @todo
+    Scenario: Having cart maintained after logging out and next in
+        Given I have product "Stark T-Shirt" in the cart
+        When I log out
+        And I log in as "robb@stark.com" with "KingInTheNorth" password
+        And I see the summary of my cart
+        Then there should be one item in my cart
+        And this item should have name "Stark T-shirt"

--- a/features/cart/shopping_cart/maintaining_previous_cart_after_authorization.feature
+++ b/features/cart/shopping_cart/maintaining_previous_cart_after_authorization.feature
@@ -10,8 +10,8 @@ Feature: Maintaining previous cart after authorization
         And there is a user "robb@stark.com" identified by "KingInTheNorth"
         And I log in as "robb@stark.com" with "KingInTheNorth" password
 
-    @ui @todo
-    Scenario: Having cart maintained after logging out and next in
+    @ui
+    Scenario: Having cart maintained after logging out and then logging in
         Given I have product "Stark T-Shirt" in the cart
         When I log out
         And I log in as "robb@stark.com" with "KingInTheNorth" password

--- a/src/Sylius/Behat/Context/Ui/UserContext.php
+++ b/src/Sylius/Behat/Context/Ui/UserContext.php
@@ -15,6 +15,7 @@ use Behat\Behat\Context\Context;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Sylius\Behat\Page\Admin\Customer\ShowPageInterface;
 use Sylius\Behat\Page\Shop\Account\LoginPageInterface;
+use Sylius\Behat\Page\Shop\HomePageInterface;
 use Sylius\Behat\Page\Shop\User\RegisterPageInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
@@ -42,18 +43,53 @@ final class UserContext implements Context
     private $customerShowPage;
 
     /**
+     * @var LoginPageInterface
+     */
+    private $loginPage;
+
+    /**
+     * @var HomePageInterface
+     */
+    private $homePage;
+
+    /**
      * @param SharedStorageInterface $sharedStorage
      * @param UserRepositoryInterface $userRepository
      * @param ShowPageInterface $customerShowPage
+     * @param LoginPageInterface $loginPage
+     * @param HomePageInterface $homePage
      */
     public function __construct(
         SharedStorageInterface $sharedStorage,
         UserRepositoryInterface $userRepository,
-        ShowPageInterface $customerShowPage
+        ShowPageInterface $customerShowPage,
+        LoginPageInterface $loginPage,
+        HomePageInterface $homePage
     ) {
         $this->sharedStorage = $sharedStorage;
         $this->userRepository = $userRepository;
         $this->customerShowPage = $customerShowPage;
+        $this->loginPage = $loginPage;
+        $this->homePage = $homePage;
+    }
+
+    /**
+     * @Given I log in as :email with :password password
+     */
+    public function iLogInAsWithPassword($email, $password)
+    {
+        $this->loginPage->open();
+        $this->loginPage->specifyUsername($email);
+        $this->loginPage->specifyPassword($password);
+        $this->loginPage->logIn();
+    }
+
+    /**
+     * @When I log out
+     */
+    public function iLogOut()
+    {
+        $this->homePage->logOut();
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/UserContext.php
+++ b/src/Sylius/Behat/Context/Ui/UserContext.php
@@ -43,11 +43,6 @@ final class UserContext implements Context
     private $customerShowPage;
 
     /**
-     * @var LoginPageInterface
-     */
-    private $loginPage;
-
-    /**
      * @var HomePageInterface
      */
     private $homePage;
@@ -56,32 +51,18 @@ final class UserContext implements Context
      * @param SharedStorageInterface $sharedStorage
      * @param UserRepositoryInterface $userRepository
      * @param ShowPageInterface $customerShowPage
-     * @param LoginPageInterface $loginPage
      * @param HomePageInterface $homePage
      */
     public function __construct(
         SharedStorageInterface $sharedStorage,
         UserRepositoryInterface $userRepository,
         ShowPageInterface $customerShowPage,
-        LoginPageInterface $loginPage,
         HomePageInterface $homePage
     ) {
         $this->sharedStorage = $sharedStorage;
         $this->userRepository = $userRepository;
         $this->customerShowPage = $customerShowPage;
-        $this->loginPage = $loginPage;
         $this->homePage = $homePage;
-    }
-
-    /**
-     * @Given I log in as :email with :password password
-     */
-    public function iLogInAsWithPassword($email, $password)
-    {
-        $this->loginPage->open();
-        $this->loginPage->specifyUsername($email);
-        $this->loginPage->specifyPassword($password);
-        $this->loginPage->logIn();
     }
 
     /**

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -312,6 +312,8 @@
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="__symfony__.sylius.repository.shop_user" />
             <argument type="service" id="sylius.behat.page.admin.customer.show" />
+            <argument type="service" id="sylius.behat.page.shop.account.login" />
+            <argument type="service" id="sylius.behat.page.shop.home" />
             <tag name="fob.context_service" />
         </service>
 

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -312,7 +312,6 @@
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="__symfony__.sylius.repository.shop_user" />
             <argument type="service" id="sylius.behat.page.admin.customer.show" />
-            <argument type="service" id="sylius.behat.page.shop.account.login" />
             <argument type="service" id="sylius.behat.page.shop.home" />
             <tag name="fob.context_service" />
         </service>

--- a/src/Sylius/Bundle/CoreBundle/Context/CustomerAndChannelBasedCartContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Context/CustomerAndChannelBasedCartContext.php
@@ -62,7 +62,7 @@ final class CustomerAndChannelBasedCartContext implements CartContextInterface
         try {
             $channel = $this->channelContext->getChannel();
         } catch (ChannelNotFoundException $exception) {
-            return;
+            throw new CartNotFoundException('Sylius was not able to find the cart, as there is no current channel.');
         }
 
         $customer = $this->customerContext->getCustomer();
@@ -70,7 +70,7 @@ final class CustomerAndChannelBasedCartContext implements CartContextInterface
             throw new CartNotFoundException('Sylius was not able to find the cart, as there is no logged in user.');
         }
 
-        $cart = $this->orderRepository->findCartByChannelAndCustomer($channel, $customer);
+        $cart = $this->orderRepository->findLatestCartByChannelAndCustomer($channel, $customer);
         if (null === $cart) {
             throw new CartNotFoundException('Sylius was not able to find the cart for currently logged in user.');
         }

--- a/src/Sylius/Bundle/CoreBundle/Context/CustomerAndChannelBasedCartContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Context/CustomerAndChannelBasedCartContext.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Context;
+
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Customer\Context\CustomerContextInterface;
+use Sylius\Component\Order\Context\CartContextInterface;
+use Sylius\Component\Order\Context\CartNotFoundException;
+use Sylius\Component\Order\Model\OrderInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class CustomerAndChannelBasedCartContext implements CartContextInterface
+{
+    /**
+     * @var CustomerContextInterface
+     */
+    private $customerContext;
+
+    /**
+     * @var ChannelContextInterface
+     */
+    private $channelContext;
+
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @param CustomerContextInterface $customerContext
+     * @param ChannelContextInterface $channelContext
+     * @param OrderRepositoryInterface $orderRepository
+     */
+    public function __construct(
+        CustomerContextInterface $customerContext,
+        ChannelContextInterface $channelContext,
+        OrderRepositoryInterface $orderRepository
+    ) {
+        $this->customerContext = $customerContext;
+        $this->channelContext = $channelContext;
+        $this->orderRepository = $orderRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCart()
+    {
+        try {
+            $channel = $this->channelContext->getChannel();
+        } catch (ChannelNotFoundException $exception) {
+            return;
+        }
+
+        $customer = $this->customerContext->getCustomer();
+        if (null === $customer) {
+            throw new CartNotFoundException('Sylius was not able to find the cart, as there is no logged in user.');
+        }
+
+        $cart = $this->orderRepository->findCartByChannelAndCustomer($channel, $customer);
+        if (null === $cart) {
+            throw new CartNotFoundException('Sylius was not able to find the cart for currently logged in user.');
+        }
+
+        return $cart;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -154,7 +154,7 @@ class OrderRepository extends BaseOrderRepository implements OrderRepositoryInte
     /**
      * {@inheritdoc}
      */
-    public function findCartByChannelAndCustomer(ChannelInterface $channel, CustomerInterface $customer)
+    public function findLatestCartByChannelAndCustomer(ChannelInterface $channel, CustomerInterface $customer)
     {
         return $this->createQueryBuilder('o')
             ->where('o.state = :state')
@@ -163,6 +163,8 @@ class OrderRepository extends BaseOrderRepository implements OrderRepositoryInte
             ->setParameter('state', OrderInterface::STATE_CART)
             ->setParameter('channel', $channel)
             ->setParameter('customer', $customer)
+            ->orderBy('o.createdAt', 'desc')
+            ->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult()
         ;

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -152,6 +152,23 @@ class OrderRepository extends BaseOrderRepository implements OrderRepositoryInte
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function findCartByChannelAndCustomer(ChannelInterface $channel, CustomerInterface $customer)
+    {
+        return $this->createQueryBuilder('o')
+            ->where('o.state = :state')
+            ->andWhere('o.channel = :channel')
+            ->andWhere('o.customer = :customer')
+            ->setParameter('state', OrderInterface::STATE_CART)
+            ->setParameter('channel', $channel)
+            ->setParameter('customer', $customer)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getTotalSalesForChannel(ChannelInterface $channel)

--- a/src/Sylius/Bundle/CoreBundle/EventListener/ShopUserLogoutHandler.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/ShopUserLogoutHandler.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\EventListener;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class ShopUserLogoutHandler implements LogoutSuccessHandlerInterface
+{
+    /**
+     * @var SessionInterface
+     */
+    private $session;
+
+    /**
+     * @param SessionInterface $session
+     */
+    public function __construct(SessionInterface $session)
+    {
+        $this->session = $session;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function onLogoutSuccess(Request $request)
+    {
+        $this->session->clear();
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/context.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/context.xml
@@ -40,6 +40,12 @@
             <argument type="service" id="sylius.context.channel.cached" />
             <argument type="service" id="sylius.repository.order" />
         </service>
+        <service id="sylius.context.cart.customer_and_channel_based" class="Sylius\Bundle\CoreBundle\Context\CustomerAndChannelBasedCartContext">
+            <argument type="service" id="sylius.context.customer" />
+            <argument type="service" id="sylius.context.channel" />
+            <argument type="service" id="sylius.repository.order" />
+            <tag name="sylius.context.cart" priority="-555" />
+        </service>
 
         <service id="sylius.currency_provider.channel_based" class="Sylius\Component\Core\Provider\ChannelBasedCurrencyProvider" decorates="sylius.currency_provider">
             <argument type="service" id="sylius.context.channel" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/handlers.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/handlers.xml
@@ -37,7 +37,10 @@
         </service>
 
         <service id="sylius.handler.shop_user_logout" class="Sylius\Bundle\CoreBundle\EventListener\ShopUserLogoutHandler">
+            <argument type="service" id="security.http_utils" />
+            <argument>/</argument>
             <argument type="service" id="session" />
+            <argument type="service" id="sylius.context.channel" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/handlers.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/handlers.xml
@@ -35,5 +35,9 @@
             <argument type="service" id="event_dispatcher" />
             <tag name="sylius.currency.change_handler" />
         </service>
+
+        <service id="sylius.handler.shop_user_logout" class="Sylius\Bundle\CoreBundle\EventListener\ShopUserLogoutHandler">
+            <argument type="service" id="session" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/spec/Context/CustomerAndChannelBasedCartContextSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Context/CustomerAndChannelBasedCartContextSpec.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\CoreBundle\Context;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\CoreBundle\Context\CustomerAndChannelBasedCartContext;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Customer\Context\CustomerContextInterface;
+use Sylius\Component\Order\Context\CartContextInterface;
+use Sylius\Component\Order\Context\CartNotFoundException;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class CustomerAndChannelBasedCartContextSpec extends ObjectBehavior
+{
+    function let(
+        CustomerContextInterface $customerContext,
+        ChannelContextInterface $channelContext,
+        OrderRepositoryInterface $orderRepository
+    ) {
+        $this->beConstructedWith($customerContext, $channelContext, $orderRepository);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(CustomerAndChannelBasedCartContext::class);
+    }
+
+    function it_implements_cart_context_interface()
+    {
+        $this->shouldImplement(CartContextInterface::class);
+    }
+
+    function it_returns_uncompleted_cart_for_currently_logged_user(
+        ChannelInterface $channel,
+        ChannelContextInterface $channelContext,
+        CustomerContextInterface $customerContext,
+        CustomerInterface $customer,
+        OrderInterface $order,
+        OrderRepositoryInterface $orderRepository
+    ) {
+        $channelContext->getChannel()->willReturn($channel);
+        $customerContext->getCustomer()->willReturn($customer);
+
+        $orderRepository->findCartByChannelAndCustomer($channel, $customer)->willReturn($order);
+
+        $this->getCart()->shouldReturn($order);
+    }
+
+    function it_throws_exception_if_no_cart_can_be_provided(
+        ChannelInterface $channel,
+        ChannelContextInterface $channelContext,
+        CustomerContextInterface $customerContext,
+        CustomerInterface $customer,
+        OrderRepositoryInterface $orderRepository
+    ) {
+        $channelContext->getChannel()->willReturn($channel);
+        $customerContext->getCustomer()->willReturn($customer);
+
+        $orderRepository->findCartByChannelAndCustomer($channel, $customer)->willReturn(null);
+
+        $this
+            ->shouldThrow(new CartNotFoundException('Sylius was not able to find the cart for currently logged in user.'))
+            ->during('getCart', [])
+        ;
+    }
+
+    function it_throws_exception_if_there_is_no_logged_in_customer(CustomerContextInterface $customerContext)
+    {
+        $customerContext->getCustomer()->willReturn(null);
+
+        $this
+            ->shouldThrow(new CartNotFoundException('Sylius was not able to find the cart, as there is no logged in user.'))
+            ->during('getCart', [])
+        ;
+    }
+
+    function it_does_nothing_if_channel_could_not_be_found(
+        ChannelContextInterface $channelContext,
+        CustomerContextInterface $customerContext
+    ) {
+        $channelContext->getChannel()->willThrow(new ChannelNotFoundException());
+
+        $customerContext->getCustomer()->shouldNotBeCalled();
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/spec/Context/CustomerAndChannelBasedCartContextSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Context/CustomerAndChannelBasedCartContextSpec.php
@@ -57,7 +57,7 @@ final class CustomerAndChannelBasedCartContextSpec extends ObjectBehavior
         $channelContext->getChannel()->willReturn($channel);
         $customerContext->getCustomer()->willReturn($customer);
 
-        $orderRepository->findCartByChannelAndCustomer($channel, $customer)->willReturn($order);
+        $orderRepository->findLatestCartByChannelAndCustomer($channel, $customer)->willReturn($order);
 
         $this->getCart()->shouldReturn($order);
     }
@@ -72,7 +72,7 @@ final class CustomerAndChannelBasedCartContextSpec extends ObjectBehavior
         $channelContext->getChannel()->willReturn($channel);
         $customerContext->getCustomer()->willReturn($customer);
 
-        $orderRepository->findCartByChannelAndCustomer($channel, $customer)->willReturn(null);
+        $orderRepository->findLatestCartByChannelAndCustomer($channel, $customer)->willReturn(null);
 
         $this
             ->shouldThrow(new CartNotFoundException('Sylius was not able to find the cart for currently logged in user.'))
@@ -90,12 +90,13 @@ final class CustomerAndChannelBasedCartContextSpec extends ObjectBehavior
         ;
     }
 
-    function it_does_nothing_if_channel_could_not_be_found(
-        ChannelContextInterface $channelContext,
-        CustomerContextInterface $customerContext
-    ) {
+    function it_does_nothing_if_channel_could_not_be_found(ChannelContextInterface $channelContext)
+    {
         $channelContext->getChannel()->willThrow(new ChannelNotFoundException());
 
-        $customerContext->getCustomer()->shouldNotBeCalled();
+        $this
+            ->shouldThrow(new CartNotFoundException('Sylius was not able to find the cart, as there is no current channel.'))
+            ->during('getCart', [])
+        ;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/ShopUserLogoutHandlerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/ShopUserLogoutHandlerSpec.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\CoreBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\CoreBundle\EventListener\ShopUserLogoutHandler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class ShopUserLogoutHandlerSpec extends ObjectBehavior
+{
+    function let(SessionInterface $session)
+    {
+        $this->beConstructedWith($session);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ShopUserLogoutHandler::class);
+    }
+
+    function it_implements_logout_success_handler_interface()
+    {
+        $this->shouldImplement(LogoutSuccessHandlerInterface::class);
+    }
+
+    function it_clears_cart_session_after_logging_out(Request $request, SessionInterface $session)
+    {
+        $session->clear()->shouldBeCalled();
+
+        $this->onLogoutSuccess($request);
+    }
+}

--- a/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
+++ b/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
@@ -83,7 +83,7 @@ interface OrderRepositoryInterface extends BaseOrderRepositoryInterface
      *
      * @return OrderInterface|null
      */
-    public function findCartByChannelAndCustomer(ChannelInterface $channel, CustomerInterface $customer);
+    public function findLatestCartByChannelAndCustomer(ChannelInterface $channel, CustomerInterface $customer);
 
     /**
      * @param ChannelInterface $channel

--- a/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
+++ b/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
@@ -12,11 +12,10 @@
 namespace Sylius\Component\Core\Repository;
 
 use Doctrine\ORM\QueryBuilder;
-use Pagerfanta\PagerfantaInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
-use Sylius\Component\Core\Model\PromotionCouponInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PromotionCouponInterface;
 use Sylius\Component\Order\Repository\OrderRepositoryInterface as BaseOrderRepositoryInterface;
 
 interface OrderRepositoryInterface extends BaseOrderRepositoryInterface
@@ -77,6 +76,14 @@ interface OrderRepositoryInterface extends BaseOrderRepositoryInterface
      * @return OrderInterface|null
      */
     public function findCartByChannel($id, ChannelInterface $channel);
+
+    /**
+     * @param ChannelInterface $channel
+     * @param CustomerInterface $customer
+     *
+     * @return OrderInterface|null
+     */
+    public function findCartByChannelAndCustomer(ChannelInterface $channel, CustomerInterface $customer);
 
     /**
      * @param ChannelInterface $channel


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | |
| License         | MIT |

This PR solves two issues:
- when we had some products in the cart (or even some checkout steps already passed) and logged out, cart was still available for the not logged in user
- after logging out with unfinished order, it was impossible to continue shopping after session expired/on different browser etc.