### PR TITLE
Make forms & related stuff final again

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/AddressType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/AddressType.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class AddressType extends AbstractResourceType
+final class AddressType extends AbstractResourceType
 {
     /**
      * @var EventSubscriberInterface

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
@@ -20,7 +20,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-class CountryChoiceType extends AbstractType
+final class CountryChoiceType extends AbstractType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryCodeChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryCodeChoiceType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\ReversedTransformer;
 /**
  * @author Jan Góralski <jan.goralski@lakion.com>
  */
-class CountryCodeChoiceType extends AbstractType
+final class CountryCodeChoiceType extends AbstractType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  * @author Gustavo Perdomo <gperdomor@gmail.com>
  */
-class CountryType extends AbstractResourceType
+final class CountryType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceChoiceType.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ProvinceChoiceType extends AbstractType
+final class ProvinceChoiceType extends AbstractType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceCodeChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceCodeChoiceType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\ReversedTransformer;
 /**
  * @author Jan Góralski <jan.goralski@lakion.com>
  */
-class ProvinceCodeChoiceType extends AbstractType
+final class ProvinceCodeChoiceType extends AbstractType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ProvinceType extends AbstractResourceType
+final class ProvinceType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneChoiceType.php
@@ -20,7 +20,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ZoneChoiceType extends AbstractType
+final class ZoneChoiceType extends AbstractType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneCodeChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneCodeChoiceType.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Jan Góralski <jan.goralski@lakion.com>
  */
-class ZoneCodeChoiceType extends AbstractType
+final class ZoneCodeChoiceType extends AbstractType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneMemberType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneMemberType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Jan Góralski <jan.goralski@lakion.com>
  */
-class ZoneMemberType extends AbstractResourceType
+final class ZoneMemberType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
@@ -26,7 +26,7 @@ use Symfony\Component\Form\FormEvents;
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  * @author Jan Góralski <jan.goralski@lakion.com>
  */
-class ZoneType extends AbstractResourceType
+final class ZoneType extends AbstractResourceType
 {
     /**
      * @var array

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneTypeChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneTypeChoiceType.php
@@ -19,7 +19,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Joseph Bielawski <stloyd@gmail.com>
  */
-class ZoneTypeChoiceType extends AbstractType
+final class ZoneTypeChoiceType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ApiBundle/Form/Type/ClientType.php
+++ b/src/Sylius/Bundle/ApiBundle/Form/Type/ClientType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ClientType extends AbstractResourceType
+final class ClientType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ApiBundle/Form/Type/OrderType.php
+++ b/src/Sylius/Bundle/ApiBundle/Form/Type/OrderType.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class OrderType extends AbstractType
+final class OrderType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/CheckboxAttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/CheckboxAttributeType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class CheckboxAttributeType extends AbstractType
+final class CheckboxAttributeType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/DateAttributeConfigurationType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/DateAttributeConfigurationType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class DateAttributeConfigurationType extends AbstractType
+final class DateAttributeConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/DatetimeAttributeConfigurationType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/DatetimeAttributeConfigurationType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class DatetimeAttributeConfigurationType extends AbstractType
+final class DatetimeAttributeConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/TextAttributeConfigurationType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/TextAttributeConfigurationType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class TextAttributeConfigurationType extends AbstractType
+final class TextAttributeConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/DateAttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/DateAttributeType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class DateAttributeType extends AbstractType
+final class DateAttributeType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/DatetimeAttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/DatetimeAttributeType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class DatetimeAttributeType extends AbstractType
+final class DatetimeAttributeType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/IntegerAttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/IntegerAttributeType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class IntegerAttributeType extends AbstractType
+final class IntegerAttributeType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/PercentAttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/PercentAttributeType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class PercentAttributeType extends AbstractType
+final class PercentAttributeType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/TextAttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/TextAttributeType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class TextAttributeType extends AbstractType
+final class TextAttributeType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/TextareaAttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/TextareaAttributeType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class TextareaAttributeType extends AbstractType
+final class TextareaAttributeType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeTypeChoiceType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeTypeChoiceType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class AttributeTypeChoiceType extends AbstractType
+final class AttributeTypeChoiceType extends AbstractType
 {
     /**
      * @var array

--- a/src/Sylius/Bundle/ChannelBundle/Form/Type/ChannelChoiceType.php
+++ b/src/Sylius/Bundle/ChannelBundle/Form/Type/ChannelChoiceType.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-class ChannelChoiceType extends AbstractType
+final class ChannelChoiceType extends AbstractType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/ChannelBundle/Form/Type/ChannelType.php
+++ b/src/Sylius/Bundle/ChannelBundle/Form/Type/ChannelType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ChannelType extends AbstractResourceType
+final class ChannelType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/DataTransformer/ProductTaxonCollectionToTaxonCollectionTransformer.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/DataTransformer/ProductTaxonCollectionToTaxonCollectionTransformer.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\DataTransformerInterface;
 /**
  * @author Anna Walasek <anna.walasek@lakion.com>
  */
-class ProductTaxonCollectionToTaxonCollectionTransformer implements DataTransformerInterface
+final class ProductTaxonCollectionToTaxonCollectionTransformer implements DataTransformerInterface
 {
     /**
      * @var FactoryInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/EventSubscriber/AddBaseCurrencySubscriber.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/EventSubscriber/AddBaseCurrencySubscriber.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormEvents;
 /**
  * @author Anna Walasek <anna.walasek@lakion.com>
  */
-class AddBaseCurrencySubscriber implements EventSubscriberInterface
+final class AddBaseCurrencySubscriber implements EventSubscriberInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
@@ -24,7 +24,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ChannelTypeExtension extends AbstractTypeExtension
+final class ChannelTypeExtension extends AbstractTypeExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/LocaleTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/LocaleTypeExtension.php
@@ -24,7 +24,7 @@ use Symfony\Component\Intl\Intl;
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-class LocaleTypeExtension extends AbstractTypeExtension
+final class LocaleTypeExtension extends AbstractTypeExtension
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/OrderTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/OrderTypeExtension.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class OrderTypeExtension extends AbstractTypeExtension
+final class OrderTypeExtension extends AbstractTypeExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/PaymentMethodTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/PaymentMethodTypeExtension.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class PaymentMethodTypeExtension extends AbstractTypeExtension
+final class PaymentMethodTypeExtension extends AbstractTypeExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductTranslationTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductTranslationTypeExtension.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-class ProductTranslationTypeExtension extends AbstractTypeExtension
+final class ProductTranslationTypeExtension extends AbstractTypeExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductTypeExtension.php
@@ -27,7 +27,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  * @author Anna Walasek <anna.walasek@lakion.com>
  */
-class ProductTypeExtension extends AbstractTypeExtension
+final class ProductTypeExtension extends AbstractTypeExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantGenerationTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantGenerationTypeExtension.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class ProductVariantGenerationTypeExtension extends AbstractTypeExtension
+final class ProductVariantGenerationTypeExtension extends AbstractTypeExtension
 {
     /**
      * @var EventSubscriberInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantTypeExtension.php
@@ -26,7 +26,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ProductVariantTypeExtension extends AbstractTypeExtension
+final class ProductVariantTypeExtension extends AbstractTypeExtension
 {
     /**
      * @var EventSubscriberInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionActionTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionActionTypeExtension.php
@@ -22,7 +22,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class PromotionActionTypeExtension extends AbstractTypeExtension
+final class PromotionActionTypeExtension extends AbstractTypeExtension
 {
     /**
      * @var ServiceRegistryInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionCouponTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionCouponTypeExtension.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Myke Hines <myke@webhines.com>
  */
-class PromotionCouponTypeExtension extends AbstractTypeExtension
+final class PromotionCouponTypeExtension extends AbstractTypeExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionFilterCollectionTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionFilterCollectionTypeExtension.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class PromotionFilterCollectionTypeExtension extends AbstractTypeExtension
+final class PromotionFilterCollectionTypeExtension extends AbstractTypeExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionRuleTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionRuleTypeExtension.php
@@ -23,7 +23,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class PromotionRuleTypeExtension extends AbstractTypeExtension
+final class PromotionRuleTypeExtension extends AbstractTypeExtension
 {
     /**
      * @var ServiceRegistryInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionTypeExtension.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Kristian Loevstroem <kristian@loevstroem.dk>
  */
-class PromotionTypeExtension extends AbstractTypeExtension
+final class PromotionTypeExtension extends AbstractTypeExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ShippingMethodTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ShippingMethodTypeExtension.php
@@ -23,7 +23,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ShippingMethodTypeExtension extends AbstractTypeExtension
+final class ShippingMethodTypeExtension extends AbstractTypeExtension
 {
     /**
      * @var ServiceRegistryInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/AddressChoiceType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/AddressChoiceType.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Jan Góralski <jan.goralski@lakion.com>
  */
-class AddressChoiceType extends AbstractType
+final class AddressChoiceType extends AbstractType
 {
     /**
      * @var AddressRepositoryInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
@@ -28,7 +28,7 @@ use Webmozart\Assert\Assert;
 /**
  * @author Arkadiusz Krakowiak <arkadiusz.krakowiak@lakion.com>
  */
-class AddressType extends AbstractResourceType
+final class AddressType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/CompleteType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/CompleteType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Arkadiusz Krakowiak <arkadiusz.krakowiak@lakion.com>
  */
-class CompleteType extends AbstractResourceType
+final class CompleteType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/PaymentType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/PaymentType.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Anna Walasek <anna.walasek@lakion.com>
  */
-class PaymentType extends AbstractType
+final class PaymentType extends AbstractType
 {
     /**
      * @var string

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/SelectPaymentType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/SelectPaymentType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Anna Walasek <anna.walasek@lakion.com>
  */
-class SelectPaymentType extends AbstractResourceType
+final class SelectPaymentType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/SelectShippingType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/SelectShippingType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class SelectShippingType extends AbstractResourceType
+final class SelectShippingType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/ShipmentType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/ShipmentType.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ShipmentType extends AbstractType
+final class ShipmentType extends AbstractType
 {
     /**
      * @var string

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerDefaultAddressType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerDefaultAddressType.php
@@ -19,7 +19,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Jan Góralski <jan.goralski@lakion.com>
  */
-class CustomerDefaultAddressType extends AbstractType
+final class CustomerDefaultAddressType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerGuestType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerGuestType.php
@@ -24,7 +24,7 @@ use Symfony\Component\Form\FormEvents;
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  * @author Anna Walasek <anna.walasek@lakion.com>
  */
-class CustomerGuestType extends AbstractResourceType
+final class CustomerGuestType extends AbstractResourceType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerRegistrationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerRegistrationType.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\CoreBundle\Form\Type\Customer;
 
+use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -18,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
  */
-class CustomerRegistrationType extends CustomerSimpleRegistrationType
+final class CustomerRegistrationType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}
@@ -43,6 +44,14 @@ class CustomerRegistrationType extends CustomerSimpleRegistrationType
                 'label' => 'sylius.form.customer.subscribed_to_newsletter',
             ])
         ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return CustomerSimpleRegistrationType::class;
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerSimpleRegistrationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Customer/CustomerSimpleRegistrationType.php
@@ -23,7 +23,7 @@ use Symfony\Component\Validator\Constraints\Valid;
 /**
  * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
  */
-class CustomerSimpleRegistrationType extends AbstractResourceType
+final class CustomerSimpleRegistrationType extends AbstractResourceType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/ImageType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/ImageType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
  */
-class ImageType extends AbstractResourceType
+abstract class ImageType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Order/CartItemType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Order/CartItemType.php
@@ -29,7 +29,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class CartItemType extends AbstractType
+final class CartItemType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Product/ProductImageType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Product/ProductImageType.php
@@ -16,7 +16,7 @@ use Sylius\Bundle\CoreBundle\Form\Type\ImageType;
 /**
  * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
  */
-class ProductImageType extends ImageType
+final class ProductImageType extends ImageType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/ProductTaxonChoiceType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/ProductTaxonChoiceType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Anna Walasek <anna.walasek@lakion.com>
  */
-class ProductTaxonChoiceType extends AbstractType
+final class ProductTaxonChoiceType extends AbstractType
 {
     /**
      * @var FactoryInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Filter/ProductFilterConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Filter/ProductFilterConfigurationType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class ProductFilterConfigurationType extends AbstractType
+final class ProductFilterConfigurationType extends AbstractType
 {
     /**
      * @var ProductRepositoryInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Filter/TaxonFilterConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Filter/TaxonFilterConfigurationType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  * @author Gabi Udrescu <gabriel.udr@gmail.com>
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class TaxonFilterConfigurationType extends AbstractType
+final class TaxonFilterConfigurationType extends AbstractType
 {
     /**
      * @var DataTransformerInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ContainsProductConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ContainsProductConfigurationType.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints\Type;
  * @author Alexandre Bacco <alexandre.bacco@gmail.com>
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class ContainsProductConfigurationType extends AbstractType
+final class ContainsProductConfigurationType extends AbstractType
 {
     /**
      * @var ProductRepositoryInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/CustomerGroupType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/CustomerGroupType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @author Antonio Perić <antonio@locastic.com>
  */
-class CustomerGroupType extends AbstractType
+final class CustomerGroupType extends AbstractType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/HasTaxonConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/HasTaxonConfigurationType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class HasTaxonConfigurationType extends AbstractType
+final class HasTaxonConfigurationType extends AbstractType
 {
     /**
      * @var DataTransformerInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/NthOrderConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/NthOrderConfigurationType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class NthOrderConfigurationType extends AbstractType
+final class NthOrderConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ShippingCountryConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ShippingCountryConfigurationType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class ShippingCountryConfigurationType extends AbstractType
+final class ShippingCountryConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/TotalOfItemsFromTaxonConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/TotalOfItemsFromTaxonConfigurationType.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-class TotalOfItemsFromTaxonConfigurationType extends AbstractType
+final class TotalOfItemsFromTaxonConfigurationType extends AbstractType
 {
     /**
      * @var TaxonRepositoryInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Shipping/Calculator/ChannelBasedFlatRateConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Shipping/Calculator/ChannelBasedFlatRateConfigurationType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
  */
-class ChannelBasedFlatRateConfigurationType extends AbstractType
+final class ChannelBasedFlatRateConfigurationType extends AbstractType
 {
     /**
      * @var ChannelRepositoryInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Shipping/Calculator/ChannelBasedPerUnitRateConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Shipping/Calculator/ChannelBasedPerUnitRateConfigurationType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
  */
-class ChannelBasedPerUnitRateConfigurationType extends AbstractType
+final class ChannelBasedPerUnitRateConfigurationType extends AbstractType
 {
     /**
      * @var ChannelRepositoryInterface

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/TaxCalculationStrategyChoiceType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/TaxCalculationStrategyChoiceType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Mark McKelvie <mark.mckelvie@reiss.com>
  */
-class TaxCalculationStrategyChoiceType extends AbstractType
+final class TaxCalculationStrategyChoiceType extends AbstractType
 {
     /**
      * @var array

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Taxon/TaxonImageType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Taxon/TaxonImageType.php
@@ -16,7 +16,7 @@ use Sylius\Bundle\CoreBundle\Form\Type\ImageType;
 /**
  * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
  */
-class TaxonImageType extends ImageType
+final class TaxonImageType extends ImageType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/User/ShopUserRegistrationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/User/ShopUserRegistrationType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class ShopUserRegistrationType extends AbstractResourceType
+final class ShopUserRegistrationType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CurrencyBundle/Form/Type/CurrencyType.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Form/Type/CurrencyType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\Extension\Core\Type\CurrencyType as SymfonyCurrencyTy
  * @author Saša Stamenković <umpirsky@gmail.com>
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class CurrencyType extends AbstractResourceType
+final class CurrencyType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CurrencyBundle/Form/Type/ExchangeRateType.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Form/Type/ExchangeRateType.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Jan Góralski <jan.goralski@lakion.com>
  */
-class ExchangeRateType extends AbstractResourceType
+final class ExchangeRateType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CustomerBundle/Form/Type/CustomerGroupType.php
+++ b/src/Sylius/Bundle/CustomerBundle/Form/Type/CustomerGroupType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
  */
-class CustomerGroupType extends AbstractResourceType
+final class CustomerGroupType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CustomerBundle/Form/Type/CustomerProfileType.php
+++ b/src/Sylius/Bundle/CustomerBundle/Form/Type/CustomerProfileType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
  */
-class CustomerProfileType extends AbstractResourceType
+final class CustomerProfileType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CustomerBundle/Form/Type/CustomerType.php
+++ b/src/Sylius/Bundle/CustomerBundle/Form/Type/CustomerType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
  */
-class CustomerType extends AbstractResourceType
+final class CustomerType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CustomerBundle/Form/Type/GenderType.php
+++ b/src/Sylius/Bundle/CustomerBundle/Form/Type/GenderType.php
@@ -19,7 +19,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
  */
-class GenderType extends AbstractType
+final class GenderType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/GridBundle/Form/Type/Filter/BooleanFilterType.php
+++ b/src/Sylius/Bundle/GridBundle/Form/Type/Filter/BooleanFilterType.php
@@ -19,7 +19,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class BooleanFilterType extends AbstractType
+final class BooleanFilterType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/GridBundle/Form/Type/Filter/StringFilterType.php
+++ b/src/Sylius/Bundle/GridBundle/Form/Type/Filter/StringFilterType.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class StringFilterType extends AbstractType
+final class StringFilterType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/LocaleBundle/Form/Type/LocaleChoiceType.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/Type/LocaleChoiceType.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-class LocaleChoiceType extends AbstractType
+final class LocaleChoiceType extends AbstractType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/LocaleBundle/Form/Type/LocaleType.php
+++ b/src/Sylius/Bundle/LocaleBundle/Form/Type/LocaleType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class LocaleType extends AbstractResourceType
+final class LocaleType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/MoneyBundle/Form/DataTransformer/SyliusMoneyTransformer.php
+++ b/src/Sylius/Bundle/MoneyBundle/Form/DataTransformer/SyliusMoneyTransformer.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\MoneyToLocalizedString
 /**
  * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
  */
-class SyliusMoneyTransformer extends MoneyToLocalizedStringTransformer
+final class SyliusMoneyTransformer extends MoneyToLocalizedStringTransformer
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/MoneyBundle/Form/Type/MoneyType.php
+++ b/src/Sylius/Bundle/MoneyBundle/Form/Type/MoneyType.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>
  */
-class MoneyType extends AbstractType
+final class MoneyType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/OrderBundle/Form/Type/OrderItemType.php
+++ b/src/Sylius/Bundle/OrderBundle/Form/Type/OrderItemType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class OrderItemType extends AbstractResourceType
+final class OrderItemType extends AbstractResourceType
 {
     /**
      * @var DataMapperInterface

--- a/src/Sylius/Bundle/OrderBundle/Form/Type/OrderType.php
+++ b/src/Sylius/Bundle/OrderBundle/Form/Type/OrderType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class OrderType extends AbstractResourceType
+final class OrderType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PaymentBundle/Form/Type/CreditCardType.php
+++ b/src/Sylius/Bundle/PaymentBundle/Form/Type/CreditCardType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Dylan Johnson <eponymi.dev@gmail.com>
  */
-class CreditCardType extends AbstractResourceType
+final class CreditCardType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentGatewayChoiceType.php
+++ b/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentGatewayChoiceType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class PaymentGatewayChoiceType extends AbstractType
+final class PaymentGatewayChoiceType extends AbstractType
 {
     /**
      * @var array

--- a/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentMethodChoiceType.php
+++ b/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentMethodChoiceType.php
@@ -28,7 +28,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  * @author Anna Walasek <anna.walasek@lakion.com>
  */
-class PaymentMethodChoiceType extends AbstractType
+final class PaymentMethodChoiceType extends AbstractType
 {
     /**
      * @var PaymentMethodsResolverInterface

--- a/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentMethodTranslationType.php
+++ b/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentMethodTranslationType.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class PaymentMethodTranslationType extends AbstractResourceType
+final class PaymentMethodTranslationType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentMethodType.php
+++ b/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentMethodType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class PaymentMethodType extends AbstractResourceType
+final class PaymentMethodType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentType.php
+++ b/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class PaymentType extends AbstractResourceType
+final class PaymentType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAssociationType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAssociationType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class ProductAssociationType extends AbstractResourceType
+final class ProductAssociationType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAssociationTypeChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAssociationTypeChoiceType.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-class ProductAssociationTypeChoiceType extends AbstractType
+final class ProductAssociationTypeChoiceType extends AbstractType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAssociationTypeType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAssociationTypeType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Leszek Prabucki <leszek.prabucki@gmail.com>
  */
-class ProductAssociationTypeType extends AbstractResourceType
+final class ProductAssociationTypeType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAssociationsType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAssociationsType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
  */
-class ProductAssociationsType extends AbstractType
+final class ProductAssociationsType extends AbstractType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAttributeChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAttributeChoiceType.php
@@ -16,7 +16,7 @@ use Sylius\Bundle\AttributeBundle\Form\Type\AttributeChoiceType;
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-class ProductAttributeChoiceType extends AttributeChoiceType
+final class ProductAttributeChoiceType extends AttributeChoiceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAttributeTranslationType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAttributeTranslationType.php
@@ -16,7 +16,7 @@ use Sylius\Bundle\AttributeBundle\Form\Type\AttributeTranslationType;
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-class ProductAttributeTranslationType extends AttributeTranslationType
+final class ProductAttributeTranslationType extends AttributeTranslationType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAttributeType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAttributeType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Jan Góralski <jan.goralski@lakion.com>
  */
-class ProductAttributeType extends AttributeType
+final class ProductAttributeType extends AttributeType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAttributeValueType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAttributeValueType.php
@@ -16,7 +16,7 @@ use Sylius\Bundle\AttributeBundle\Form\Type\AttributeValueType;
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-class ProductAttributeValueType extends AttributeValueType
+final class ProductAttributeValueType extends AttributeValueType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductChoiceType.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-class ProductChoiceType extends AbstractType
+final class ProductChoiceType extends AbstractType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductGenerateVariantsType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductGenerateVariantsType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class ProductGenerateVariantsType extends AbstractResourceType
+final class ProductGenerateVariantsType extends AbstractResourceType
 {
     /**
      * @var EventSubscriberInterface

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionChoiceType.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-class ProductOptionChoiceType extends AbstractType
+final class ProductOptionChoiceType extends AbstractType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionTranslationType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionTranslationType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-class ProductOptionTranslationType extends AbstractResourceType
+final class ProductOptionTranslationType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-class ProductOptionType extends AbstractResourceType
+final class ProductOptionType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueChoiceType.php
@@ -22,7 +22,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ProductOptionValueChoiceType extends AbstractType
+final class ProductOptionValueChoiceType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueCollectionType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueCollectionType.php
@@ -25,7 +25,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ProductOptionValueCollectionType extends AbstractType
+final class ProductOptionValueCollectionType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueTranslationType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueTranslationType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Vincenzo Provenza <vincenzo.provenza89@gmail.com>
  */
-class ProductOptionValueTranslationType extends AbstractResourceType
+final class ProductOptionValueTranslationType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductOptionValueType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ProductOptionValueType extends AbstractResourceType
+final class ProductOptionValueType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductTranslationType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductTranslationType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-class ProductTranslationType extends AbstractResourceType
+final class ProductTranslationType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductType.php
@@ -25,7 +25,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-class ProductType extends AbstractResourceType
+final class ProductType extends AbstractResourceType
 {
     /**
      * @var ProductVariantResolverInterface

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductVariantChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductVariantChoiceType.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ProductVariantChoiceType extends AbstractType
+final class ProductVariantChoiceType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductVariantGenerationType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductVariantGenerationType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class ProductVariantGenerationType extends AbstractResourceType
+final class ProductVariantGenerationType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductVariantMatchType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductVariantMatchType.php
@@ -20,7 +20,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ProductVariantMatchType extends AbstractType
+final class ProductVariantMatchType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductVariantType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductVariantType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ProductVariantType extends AbstractResourceType
+final class ProductVariantType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/FixedDiscountConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/FixedDiscountConfigurationType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class FixedDiscountConfigurationType extends AbstractType
+final class FixedDiscountConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/PercentageDiscountConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/PercentageDiscountConfigurationType.php
@@ -23,7 +23,7 @@ use Symfony\Component\Validator\Constraints\Type;
  * @author Saša Stamenković <umpirsky@gmail.com>
  * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
  */
-class PercentageDiscountConfigurationType extends AbstractType
+final class PercentageDiscountConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/UnitFixedDiscountConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/UnitFixedDiscountConfigurationType.php
@@ -24,7 +24,7 @@ use Symfony\Component\Validator\Constraints\Type;
  * @author Gabi Udrescu <gabriel.udr@gmail.com>
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class UnitFixedDiscountConfigurationType extends AbstractType
+final class UnitFixedDiscountConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/UnitPercentageDiscountConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Action/UnitPercentageDiscountConfigurationType.php
@@ -25,7 +25,7 @@ use Symfony\Component\Validator\Constraints\Type;
  * @author Gabi Udrescu <gabriel.udr@gmail.com>
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class UnitPercentageDiscountConfigurationType extends AbstractType
+final class UnitPercentageDiscountConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Filter/PriceRangeFilterConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Filter/PriceRangeFilterConfigurationType.php
@@ -22,7 +22,7 @@ use Symfony\Component\Validator\Constraints\Type;
  * @author Gabi Udrescu <gabriel.udr@gmail.com>
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class PriceRangeFilterConfigurationType extends AbstractType
+final class PriceRangeFilterConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionActionChoiceType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionActionChoiceType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class PromotionActionChoiceType extends AbstractType
+final class PromotionActionChoiceType extends AbstractType
 {
     /**
      * @var array

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionActionCollectionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionActionCollectionType.php
@@ -16,7 +16,7 @@ use Sylius\Bundle\PromotionBundle\Form\Type\Core\AbstractConfigurationCollection
 /**
  * @author Arnaud Langlade <arn0d.dev@gmail.com>
  */
-class PromotionActionCollectionType extends AbstractConfigurationCollectionType
+final class PromotionActionCollectionType extends AbstractConfigurationCollectionType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionActionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionActionType.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @author Saša Stamenković <umpirsky@gmail.com>
  * @author Arnaud Langlade <arn0d.dev@gmail.com>
  */
-class PromotionActionType extends AbstractResourceType
+final class PromotionActionType extends AbstractResourceType
 {
     /**
      * @var ServiceRegistryInterface

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionCouponGeneratorInstructionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionCouponGeneratorInstructionType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class PromotionCouponGeneratorInstructionType extends AbstractResourceType
+final class PromotionCouponGeneratorInstructionType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionCouponType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionCouponType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class PromotionCouponType extends AbstractResourceType
+final class PromotionCouponType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionFilterCollectionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionFilterCollectionType.php
@@ -19,7 +19,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class PromotionFilterCollectionType extends AbstractType
+final class PromotionFilterCollectionType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionRuleChoiceType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionRuleChoiceType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class PromotionRuleChoiceType extends AbstractType
+final class PromotionRuleChoiceType extends AbstractType
 {
     protected $rules;
 

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionRuleCollectionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionRuleCollectionType.php
@@ -16,7 +16,7 @@ use Sylius\Bundle\PromotionBundle\Form\Type\Core\AbstractConfigurationCollection
 /**
  * @author Arnaud Langlade <arn0d.dev@gmail.com>
  */
-class PromotionRuleCollectionType extends AbstractConfigurationCollectionType
+final class PromotionRuleCollectionType extends AbstractConfigurationCollectionType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionRuleType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionRuleType.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @author Saša Stamenković <umpirsky@gmail.com>
  * @author Arnaud Langlade <arn0d.dev@gmail.com>
  */
-class PromotionRuleType extends AbstractResourceType
+final class PromotionRuleType extends AbstractResourceType
 {
     /**
      * @var ServiceRegistryInterface

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/PromotionType.php
@@ -23,7 +23,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class PromotionType extends AbstractResourceType
+final class PromotionType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Rule/CartQuantityConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Rule/CartQuantityConfigurationType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class CartQuantityConfigurationType extends AbstractType
+final class CartQuantityConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/Rule/ItemTotalConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/Rule/ItemTotalConfigurationType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @author Saša Stamenković <umpirsky@gmail.com>
  */
-class ItemTotalConfigurationType extends AbstractType
+final class ItemTotalConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ResourceBundle/Form/Type/ResourceChoiceType.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/Type/ResourceChoiceType.php
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @author Aleksey Bannov <a.s.bannov@gmail.com>
  * @author Anna Walasek <anna.walasek@gmail.com>
  */
-class ResourceChoiceType extends AbstractType
+final class ResourceChoiceType extends AbstractType
 {
     /**
      * @var MetadataInterface

--- a/src/Sylius/Bundle/ResourceBundle/Form/Type/ResourceToIdentifierType.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/Type/ResourceToIdentifierType.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @author Alexandre Bacco <alexandre.bacco@gmail.com>
  * @author Anna Walasek <anna.walasek@lakion.com>
  */
-class ResourceToIdentifierType extends AbstractType
+final class ResourceToIdentifierType extends AbstractType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Form/Type/BookTranslationType.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Form/Type/BookTranslationType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Anna Walasek <anna.walasek@lakion.com>
  */
-class BookTranslationType extends AbstractResourceType
+final class BookTranslationType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Form/Type/BookType.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Form/Type/BookType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Anna Walasek <anna.walasek@lakion.com>
  */
-class BookType extends AbstractResourceType
+final class BookType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ShippingBundle/Form/EventSubscriber/BuildShippingMethodFormSubscriber.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/EventSubscriber/BuildShippingMethodFormSubscriber.php
@@ -25,7 +25,7 @@ use Symfony\Component\Form\FormInterface;
  *
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class BuildShippingMethodFormSubscriber implements EventSubscriberInterface
+final class BuildShippingMethodFormSubscriber implements EventSubscriberInterface
 {
     /**
      * @var ServiceRegistryInterface

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/Calculator/FlatRateConfigurationType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/Calculator/FlatRateConfigurationType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class FlatRateConfigurationType extends AbstractType
+final class FlatRateConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/Calculator/PerUnitRateConfigurationType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/Calculator/PerUnitRateConfigurationType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Constraints\Type;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class PerUnitRateConfigurationType extends AbstractType
+final class PerUnitRateConfigurationType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/CalculatorChoiceType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/CalculatorChoiceType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class CalculatorChoiceType extends AbstractType
+final class CalculatorChoiceType extends AbstractType
 {
     /**
      * @var array

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShipmentShipType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShipmentShipType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Arkadiusz Krakowiak <arkadiusz.krakowiak@lakion.com>
  */
-class ShipmentShipType extends AbstractResourceType
+final class ShipmentShipType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShipmentType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShipmentType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class ShipmentType extends AbstractResourceType
+final class ShipmentType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingCategoryChoiceType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingCategoryChoiceType.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-class ShippingCategoryChoiceType extends AbstractType
+final class ShippingCategoryChoiceType extends AbstractType
 {
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingCategoryType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingCategoryType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ShippingCategoryType extends AbstractResourceType
+final class ShippingCategoryType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodChoiceType.php
@@ -29,7 +29,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class ShippingMethodChoiceType extends AbstractType
+final class ShippingMethodChoiceType extends AbstractType
 {
     /**
      * @var ShippingMethodsResolverInterface

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodTranslationType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodTranslationType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-class ShippingMethodTranslationType extends AbstractResourceType
+final class ShippingMethodTranslationType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodType.php
@@ -32,7 +32,7 @@ use Symfony\Component\Form\FormView;
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  * @author Anna Walasek <anna.walasek@lakion.com>
  */
-class ShippingMethodType extends AbstractResourceType
+final class ShippingMethodType extends AbstractResourceType
 {
     /**
      * @var string

--- a/src/Sylius/Bundle/TaxationBundle/Form/Type/TaxCalculatorChoiceType.php
+++ b/src/Sylius/Bundle/TaxationBundle/Form/Type/TaxCalculatorChoiceType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class TaxCalculatorChoiceType extends AbstractType
+final class TaxCalculatorChoiceType extends AbstractType
 {
     /**
      * @var array

--- a/src/Sylius/Bundle/TaxationBundle/Form/Type/TaxCategoryType.php
+++ b/src/Sylius/Bundle/TaxationBundle/Form/Type/TaxCategoryType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class TaxCategoryType extends AbstractResourceType
+final class TaxCategoryType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/TaxationBundle/Form/Type/TaxRateType.php
+++ b/src/Sylius/Bundle/TaxationBundle/Form/Type/TaxRateType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class TaxRateType extends AbstractResourceType
+final class TaxRateType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonChoiceType.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonChoiceType.php
@@ -29,7 +29,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @author Saša Stamenković <umpirsky@gmail.com>
  * @author Anna Walasek <anna.walasek@lakion.com>
  */
-class TaxonChoiceType extends AbstractType
+final class TaxonChoiceType extends AbstractType
 {
     /**
      * @var TaxonRepositoryInterface

--- a/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonTranslationType.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonTranslationType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-class TaxonTranslationType extends AbstractResourceType
+final class TaxonTranslationType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonType.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Form\FormBuilderInterface;
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  */
-class TaxonType extends AbstractResourceType
+final class TaxonType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/UiBundle/Form/Type/SecurityLoginType.php
+++ b/src/Sylius/Bundle/UiBundle/Form/Type/SecurityLoginType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-class SecurityLoginType extends AbstractType
+final class SecurityLoginType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/UserBundle/Form/EventSubscriber/AddUserFormSubscriber.php
+++ b/src/Sylius/Bundle/UserBundle/Form/EventSubscriber/AddUserFormSubscriber.php
@@ -21,7 +21,7 @@ use Webmozart\Assert\Assert;
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class AddUserFormSubscriber implements EventSubscriberInterface
+final class AddUserFormSubscriber implements EventSubscriberInterface
 {
     /**
      * @var string

--- a/src/Sylius/Bundle/UserBundle/Form/Type/UserChangePasswordType.php
+++ b/src/Sylius/Bundle/UserBundle/Form/Type/UserChangePasswordType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class UserChangePasswordType extends AbstractResourceType
+final class UserChangePasswordType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/UserBundle/Form/Type/UserLoginType.php
+++ b/src/Sylius/Bundle/UserBundle/Form/Type/UserLoginType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class UserLoginType extends AbstractType
+final class UserLoginType extends AbstractType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/UserBundle/Form/Type/UserRequestPasswordResetType.php
+++ b/src/Sylius/Bundle/UserBundle/Form/Type/UserRequestPasswordResetType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class UserRequestPasswordResetType extends AbstractResourceType
+final class UserRequestPasswordResetType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/UserBundle/Form/Type/UserResetPasswordType.php
+++ b/src/Sylius/Bundle/UserBundle/Form/Type/UserResetPasswordType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
  */
-class UserResetPasswordType extends AbstractResourceType
+final class UserResetPasswordType extends AbstractResourceType
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets | - |
| License         | MIT |

If you need to extend a form type - [create a form type extension](https://github.com/Sylius/Sylius/tree/master/src/Sylius/Bundle/CoreBundle/Form/Extension).
If you need to create a new form type on top of an existing one - [create it and define `getParent()`](http://symfony.com/doc/current/form/create_custom_field_type.html).

And data transformers / event listeners shouldn't be extended anyway.