### PR TITLE
POC - Use trans choice instead of multiple message keys

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/_widget.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/_widget.html.twig
@@ -2,7 +2,11 @@
 {% set cart = sylius_cart_get() %}
 
 <div id="sylius-cart-button" class="ui circular cart button">
-    <i class="cart icon"></i><span id="sylius-cart-total">{{ money.convertAndFormat(cart.itemsTotal) }}</span>{% if not cart.empty %}, {{ cart.items|length }} {{ 'sylius.ui.items'|trans|lower }}{% endif %}
+    <i class="cart icon"></i>
+    <span id="sylius-cart-total">
+        {{ money.convertAndFormat(cart.itemsTotal) }}
+    </span>
+    {% transchoice cart.items|length %}sylius.ui.item.choice{% endtranschoice %}
 </div>
 <div class="ui large flowing cart hidden popup">
     {% if cart.empty %}

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
@@ -369,6 +369,7 @@ sylius:
         it_seems_you_have_an_account_already: 'It seems you have an account already'
         item: 'Item'
         items: 'Items'
+        item.choice: "{0} |{1}, 1 item|]1,Inf], %count% items"
         items_total: 'Items total'
         jump_to_page: 'Jump to page'
         label: 'Label'


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | n/a |
| License         | MIT |

currently, adding a product to cart will render "1 items". instead of using ifs, why not using transchoice?

it looks like this:
![image](https://cloud.githubusercontent.com/assets/5156054/20730097/6aeee4e0-b68d-11e6-93a1-4b5d3019a7b3.png)

![image](https://cloud.githubusercontent.com/assets/5156054/20730116/7c836686-b68d-11e6-9e2a-557bb1904974.png)

![image](https://cloud.githubusercontent.com/assets/5156054/20730128/8909474a-b68d-11e6-93c2-206825954111.png)
