### PR TITLE
[BugFix] Enable translations at default

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Configuration.php
@@ -137,7 +137,7 @@ final class Configuration implements ConfigurationInterface
         $node
             ->children()
                 ->arrayNode('translation')
-                    ->canBeEnabled()
+                    ->canBeDisabled()
                     ->children()
                         ->scalarNode('locale_provider')->defaultValue('sylius.translation_locale_provider.immutable')->cannotBeEmpty()->end()
                 ->end()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

With this change the translation services will be loaded always, unless intentionally disabled.