### PR TITLE
[Core][Installer] Rework installer commands

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Command/AbstractInstallCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/AbstractInstallCommand.php
@@ -11,14 +11,12 @@
 
 namespace Sylius\Bundle\CoreBundle\Command;
 
+use Sylius\Bundle\CoreBundle\Installer\Executor\CommandExecutor;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Validator\ConstraintViolationList;
 
 abstract class AbstractInstallCommand extends ContainerAwareCommand
 {

--- a/src/Sylius/Bundle/CoreBundle/Command/AbstractInstallCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/AbstractInstallCommand.php
@@ -44,7 +44,7 @@ abstract class AbstractInstallCommand extends ContainerAwareCommand
     }
 
     /**
-     * @param $id
+     * @param string $id
      *
      * @return object
      */
@@ -81,7 +81,8 @@ abstract class AbstractInstallCommand extends ContainerAwareCommand
         $table
             ->setHeaders($headers)
             ->setRows($rows)
-            ->render();
+            ->render()
+        ;
     }
 
     /**
@@ -104,11 +105,10 @@ abstract class AbstractInstallCommand extends ContainerAwareCommand
 
     /**
      * @param array $commands
-     * @param InputInterface $input
      * @param OutputInterface $output
      * @param bool $displayProgress
      */
-    protected function runCommands(array $commands, InputInterface $input, OutputInterface $output, $displayProgress = true)
+    protected function runCommands(array $commands, OutputInterface $output, $displayProgress = true)
     {
         if ($displayProgress) {
             $progress = $this->createProgressBar($output, count($commands));

--- a/src/Sylius/Bundle/CoreBundle/Command/CheckRequirementsCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/CheckRequirementsCommand.php
@@ -39,7 +39,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $fulfilled = $this->get('sylius.installer.checker.requirements')->check($input, $output);
+        $fulfilled = $this->get('sylius.installer.checker.sylius_requirements')->check($input, $output);
 
         if (!$fulfilled) {
             throw new RuntimeException('Some system requirements are not fulfilled. Please check output messages and fix them.');

--- a/src/Sylius/Bundle/CoreBundle/Command/CommandExecutor.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/CommandExecutor.php
@@ -40,9 +40,9 @@ final class CommandExecutor
     protected $application;
 
     /**
-     * @param InputInterface  $input
+     * @param InputInterface $input
      * @param OutputInterface $output
-     * @param Application     $application
+     * @param Application $application
      */
     public function __construct(InputInterface $input, OutputInterface $output, Application $application)
     {
@@ -52,7 +52,7 @@ final class CommandExecutor
     }
 
     /**
-     * @param $command
+     * @param string $command
      * @param array $parameters
      * @param OutputInterface $output
      *
@@ -80,17 +80,14 @@ final class CommandExecutor
 
             $errorMessage = sprintf('The command terminated with an error code: %u.', $exitCode);
             $this->output->writeln("<error>$errorMessage</error>");
-            $exception = new \Exception($errorMessage, $exitCode);
 
-            throw $exception;
+            throw new \Exception($errorMessage, $exitCode);
         }
 
         return $this;
     }
 
     /**
-     * Get default parameters.
-     *
      * @return array
      */
     protected function getDefaultParameters()

--- a/src/Sylius/Bundle/CoreBundle/Command/CommandExecutor.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/CommandExecutor.php
@@ -72,7 +72,7 @@ final class CommandExecutor
         $exitCode = $this->application->run(new ArrayInput($parameters), $output ?: new NullOutput());
 
         if (1 === $exitCode) {
-            throw new RuntimeException('This command terminated with a permission error');
+            throw new RuntimeException('This command terminated with a permission error.');
         }
 
         if (0 !== $exitCode) {

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallAssetsCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallAssetsCommand.php
@@ -50,6 +50,6 @@ EOT
             'assets:install',
         ];
 
-        $this->runCommands($commands, $input, $output);
+        $this->runCommands($commands, $output);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallAssetsCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallAssetsCommand.php
@@ -43,6 +43,8 @@ EOT
             $this->ensureDirectoryExistsAndIsWritable($rootDir . self::WEB_ASSETS_DIRECTORY, $output);
             $this->ensureDirectoryExistsAndIsWritable($rootDir . self::WEB_BUNDLES_DIRECTORY, $output);
         } catch (\RuntimeException $exception) {
+            $output->writeln($exception->getMessage());
+
             return 1;
         }
 

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallCommand.php
@@ -40,11 +40,6 @@ final class InstallCommand extends AbstractInstallCommand
     ];
 
     /**
-     * @var bool
-     */
-    private $isErrored = false;
-
-    /**
      * {@inheritdoc}
      */
     protected function configure()
@@ -69,30 +64,31 @@ EOT
 
         $this->ensureDirectoryExistsAndIsWritable($this->getContainer()->getParameter('kernel.cache_dir'), $output);
 
+        $errored = false;
         foreach ($this->commands as $step => $command) {
             try {
                 $output->writeln(sprintf('<comment>Step %d of %d.</comment> <info>%s</info>', $step + 1, count($this->commands), $command['message']));
                 $this->commandExecutor->runCommand('sylius:install:'.$command['command'], [], $output);
                 $output->writeln('');
             } catch (RuntimeException $exception) {
-                $this->isErrored = true;
-
-                continue;
+                $errored = true;
             }
         }
 
         $frontControllerPath = 'prod' === $this->getEnvironment() ? '/' : sprintf('/app_%s.php', $this->getEnvironment());
 
-        $output->writeln($this->getProperFinalMessage());
+        $output->writeln($this->getProperFinalMessage($errored));
         $output->writeln(sprintf('You can now open your store at the following path under the website root: <info>%s.</info>', $frontControllerPath));
     }
 
     /**
+     * @param bool $errored
+     *
      * @return string
      */
-    private function getProperFinalMessage()
+    private function getProperFinalMessage($errored)
     {
-        if ($this->isErrored) {
+        if ($errored) {
             return '<info>Sylius has been installed, but some error occurred.</info>';
         }
 

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallDatabaseCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallDatabaseCommand.php
@@ -11,13 +11,12 @@
 
 namespace Sylius\Bundle\CoreBundle\Command;
 
-use Doctrine\DBAL\Schema\AbstractSchemaManager;
-use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
-use Symfony\Component\Console\Question\Question;
 
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
 final class InstallDatabaseCommand extends AbstractInstallCommand
 {
     /**
@@ -42,137 +41,11 @@ EOT
     {
         $output->writeln(sprintf('Creating Sylius database for environment <info>%s</info>.', $this->getEnvironment()));
 
-        if (!$this->isDatabasePresent()) {
-            return $this->createAndFillDatabase($output);
-        }
-
-        $commands = [];
-
-        if ($input->getOption('no-interaction')) {
-            $commands['doctrine:schema:update'] = ['--force' => true];
-        } else {
-            $commands = array_merge($commands, $this->setupDatabase($input, $output));
-        }
-
-        $commands = array_merge($commands, [
-            'cache:clear',
-            'doctrine:migrations:version' => [
-                '--add' => true,
-                '--all' => true,
-                '--no-interaction' => true,
-            ],
-        ]);
+        $commands = $this->get('sylius.commands_provider.database_setup')->getCommands($input, $output, $this->getHelper('question'));
 
         $this->runCommands($commands, $output);
         $output->writeln('');
 
         $this->commandExecutor->runCommand('sylius:install:sample-data', [], $output);
-    }
-
-    /**
-     * @return bool
-     *
-     * @throws \Exception
-     */
-    protected function isDatabasePresent()
-    {
-        $databaseName = $this->getDatabaseName();
-
-        try {
-            $schemaManager = $this->getSchemaManager();
-        } catch (\Exception $exception) {
-            $message = $exception->getMessage();
-
-            $mysqlDatabaseError = false !== strpos($message, sprintf("Unknown database '%s'", $databaseName));
-            $postgresDatabaseError = false !== strpos($message, sprintf('database "%s" does not exist', $databaseName));
-
-            if ($mysqlDatabaseError || $postgresDatabaseError) {
-                return false;
-            }
-
-            throw $exception;
-        }
-
-        return in_array($databaseName, $schemaManager->listDatabases());
-    }
-
-    /**
-     * @return bool
-     */
-    protected function isSchemaPresent()
-    {
-        return 0 !== count($this->getSchemaManager()->listTableNames());
-    }
-
-    /**
-     * @return string
-     */
-    protected function getDatabaseName()
-    {
-        return $this->get('doctrine')->getManager()->getConnection()->getDatabase();
-    }
-
-    /**
-     * @return AbstractSchemaManager
-     */
-    protected function getSchemaManager()
-    {
-        return $this->get('doctrine')->getManager()->getConnection()->getSchemaManager();
-    }
-
-    /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     *
-     * @return array
-     */
-    protected function setupDatabase(InputInterface $input, OutputInterface $output)
-    {
-        /** @var QuestionHelper $questionHelper */
-        $questionHelper = $this->getHelper('question');
-
-        $question = new ConfirmationQuestion('It appears that your database already exists. Would you like to reset it? (y/N)', false);
-        if ($questionHelper->ask($input, $output, $question)) {
-            return [
-                'doctrine:database:drop' => ['--force' => true],
-                'doctrine:database:create',
-                'doctrine:schema:create',
-            ];
-        }
-
-        if (!$this->isSchemaPresent()) {
-            return [
-                'doctrine:schema:create',
-            ];
-        }
-
-        $question = new ConfirmationQuestion('Seems like your database contains schema. Do you want to reset it? (y/N)', false);
-        if ($questionHelper->ask($input, $output, $question)) {
-            return [
-                'doctrine:schema:drop' => ['--force' => true],
-                'doctrine:schema:create',
-            ];
-        }
-
-        return [];
-    }
-
-    /**
-     * @param OutputInterface $output
-     *
-     * @return CommandExecutor
-     */
-    private function createAndFillDatabase(OutputInterface $output)
-    {
-        $commands = [
-            'doctrine:database:create',
-            'doctrine:schema:create',
-            'cache:clear',
-        ];
-
-        $this->runCommands($commands, $output);
-        $output->writeln('');
-
-        return $this->commandExecutor->runCommand('sylius:install:sample-data', [], $output);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
@@ -49,7 +49,7 @@ EOT
             $this->getEnvironment()
         ));
 
-        if (!$questionHelper->ask($input, $output, new Question('Load sample data? (y/N)', false))) {
+        if (!$questionHelper->ask($input, $output, new Question('Load sample data? (y/N) ', false))) {
             $output->writeln('Cancelled loading sample data.');
 
             return 0;

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
@@ -44,7 +44,10 @@ EOT
         /** @var QuestionHelper $questionHelper */
         $questionHelper = $this->getHelper('question');
 
-        $output->writeln(sprintf('<error>Warning! This will erase your database.</error> Your current environment is <info>%s</info>.', $this->getEnvironment()));
+        $output->writeln(sprintf(
+            '<error>Warning! This will erase your database.</error> Your current environment is <info>%s</info>.',
+            $this->getEnvironment()
+        ));
 
         if (!$questionHelper->ask($input, $output, new Question('Load sample data? (y/N)', false))) {
             $output->writeln('Cancelled loading sample data.');
@@ -68,6 +71,6 @@ EOT
             'sylius:fixtures:load' => ['--no-interaction' => true],
         ];
 
-        $this->runCommands($commands, $input, $output);
+        $this->runCommands($commands, $output);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
@@ -14,6 +14,7 @@ namespace Sylius\Bundle\CoreBundle\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 
 /**
@@ -49,7 +50,7 @@ EOT
             $this->getEnvironment()
         ));
 
-        if (!$questionHelper->ask($input, $output, new Question('Load sample data? (y/N) ', false))) {
+        if (!$questionHelper->ask($input, $output, new ConfirmationQuestion('Load sample data? (y/N) ', false))) {
             $output->writeln('Cancelled loading sample data.');
 
             return 0;

--- a/src/Sylius/Bundle/CoreBundle/Command/SetupCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/SetupCommand.php
@@ -61,8 +61,8 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->setupCurrency($input, $output);
-        $this->setupLocale($output);
+        $this->currency = $this->get('sylius.setup.currency')->setup($input, $output, $this->getHelper('question'));
+        $this->locale = $this->get('sylius.setup.locale')->setup($input, $output);
         $this->setupChannel();
         $this->setupAdministratorUser($input, $output);
     }
@@ -93,65 +93,6 @@ EOT
         $userManager->flush();
 
         $output->writeln('Administrator account successfully registered.');
-    }
-
-    /**
-     * @param OutputInterface $output
-     */
-    protected function setupLocale(OutputInterface $output)
-    {
-        $localeRepository = $this->get('sylius.repository.locale');
-        $localeFactory = $this->get('sylius.factory.locale');
-
-        $code = trim($this->getContainer()->getParameter('locale'));
-        $name = Intl::getLanguageBundle()->getLanguageName($code);
-        $output->writeln(sprintf('Adding <info>%s</info> locale.', $name));
-
-        $existingLocale = $localeRepository->findOneBy(['code' => $code]);
-        if (null !== $existingLocale) {
-            $this->locale = $existingLocale;
-
-            return;
-        }
-
-        $locale = $localeFactory->createNew();
-        $locale->setCode($code);
-
-        $localeRepository->add($locale);
-
-        $this->locale = $locale;
-    }
-
-    /**
-     * @param InputInterface  $input
-     * @param OutputInterface $output
-     */
-    protected function setupCurrency(InputInterface $input, OutputInterface $output)
-    {
-        /** @var QuestionHelper $questionHelper */
-        $questionHelper = $this->getHelper('question');
-        $question = new Question('Currency (press enter to use USD): ', 'USD');
-
-        $currencyRepository = $this->get('sylius.repository.currency');
-        $currencyFactory = $this->get('sylius.factory.currency');
-
-        $code = trim($questionHelper->ask($input, $output, $question));
-
-        $name = Intl::getCurrencyBundle()->getCurrencyName($code);
-        $output->writeln(sprintf('Adding <info>%s</info> currency.', $name));
-
-        $existingCurrency = $currencyRepository->findOneBy(['code' => $code]);
-        if (null !== $existingCurrency) {
-            $this->currency = $existingCurrency;
-
-            return;
-        }
-
-        $currency = $currencyFactory->createNew();
-        $currency->setCode($code);
-        $currencyRepository->add($currency);
-
-        $this->currency = $currency;
     }
 
     protected function setupChannel()

--- a/src/Sylius/Bundle/CoreBundle/Installer/Checker/RequirementsChecker.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Checker/RequirementsChecker.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Installer\Checker;
+
+use Sylius\Bundle\CoreBundle\Installer\Renderer\TableRenderer;
+use Sylius\Bundle\CoreBundle\Installer\Requirement\Requirement;
+use Sylius\Bundle\CoreBundle\Installer\Requirement\RequirementCollection;
+use Sylius\Bundle\CoreBundle\Installer\Requirement\SyliusRequirements;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class RequirementsChecker
+{
+    /**
+     * @var SyliusRequirements
+     */
+    private $syliusRequirements;
+
+    /**
+     * @var bool
+     */
+    private $fulfilled = true;
+
+    /**
+     * @param SyliusRequirements $syliusRequirements
+     */
+    public function __construct(SyliusRequirements $syliusRequirements)
+    {
+        $this->syliusRequirements = $syliusRequirements;
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return bool
+     */
+    public function check(InputInterface $input, OutputInterface $output)
+    {
+        $notFulfilledTable = new TableRenderer($output);
+        $notFulfilledTable->setHeaders(['Requirement', 'Status']);
+
+        $helpTable = new TableRenderer($output);
+        $helpTable->setHeaders(['Issue', 'Recommendation']);
+
+        foreach ($this->syliusRequirements as $collection) {
+            $this->checkRequirementsInCollection($collection, $notFulfilledTable, $helpTable, $input->getOption('verbose'));
+        }
+
+        if (!$helpTable->isEmpty()) {
+            $helpTable->render();
+        }
+
+        return $this->fulfilled;
+    }
+
+    /**
+     * @param RequirementCollection $collection
+     * @param TableRenderer $notFulfilledTable
+     * @param TableRenderer $helpTable
+     * @param mixed $verbose
+     */
+    private function checkRequirementsInCollection(
+        RequirementCollection $collection,
+        TableRenderer $notFulfilledTable,
+        TableRenderer $helpTable,
+        $verbose
+    ) {
+        /** @var Requirement $requirement */
+        foreach ($collection as $requirement) {
+            $label = $requirement->getLabel();
+
+            if ($requirement->isFulfilled()) {
+                $notFulfilledTable->addRow([$label, '<info>OK!</info>']);
+
+                continue;
+            }
+
+            $notFulfilledTable->addRow([$label, $this->getRequirementRequiredMessage($requirement)]);
+            $helpTable->addRow([$label, sprintf('<comment>%s</comment>', $requirement->getHelp())]);
+        }
+
+        if ($verbose || !$this->fulfilled) {
+            $notFulfilledTable->setLabel($collection->getLabel());
+            $notFulfilledTable->render();
+        }
+    }
+
+    /**
+     * @param Requirement $requirement
+     *
+     * @return string
+     */
+    private function getRequirementRequiredMessage(Requirement $requirement)
+    {
+        if ($requirement->isRequired()) {
+            $this->fulfilled = false;
+
+            return '<error>ERROR!</error>';
+        }
+
+        return '<comment>WARNING!</comment>';
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Installer/Checker/RequirementsCheckerInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Checker/RequirementsCheckerInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Installer\Checker;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+interface RequirementsCheckerInterface
+{
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return bool
+     */
+    public function check(InputInterface $input, OutputInterface $output);
+}

--- a/src/Sylius/Bundle/CoreBundle/Installer/Checker/SyliusRequirementsChecker.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Checker/SyliusRequirementsChecker.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-final class RequirementsChecker
+final class SyliusRequirementsChecker implements RequirementsCheckerInterface
 {
     /**
      * @var SyliusRequirements
@@ -42,10 +42,7 @@ final class RequirementsChecker
     }
 
     /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function check(InputInterface $input, OutputInterface $output)
     {

--- a/src/Sylius/Bundle/CoreBundle/Installer/Executor/CommandExecutor.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Executor/CommandExecutor.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\Command;
+namespace Sylius\Bundle\CoreBundle\Installer\Executor;
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;

--- a/src/Sylius/Bundle/CoreBundle/Installer/Provider/DatabaseSetupCommandsProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Provider/DatabaseSetupCommandsProvider.php
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Installer\Provider;
+
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class DatabaseSetupCommandsProvider implements DatabaseSetupCommandsProviderInterface
+{
+    /**
+     * @var Registry
+     */
+    private $doctrineRegistry;
+
+    /**
+     * @param Registry $doctrineRegistry
+     */
+    public function __construct(Registry $doctrineRegistry)
+    {
+        $this->doctrineRegistry = $doctrineRegistry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCommands(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper)
+    {
+        if (!$this->isDatabasePresent()) {
+            return [
+                'doctrine:database:create',
+                'doctrine:schema:create',
+                'cache:clear',
+            ];
+        }
+
+        return array_merge($this->getRequiredCommands($input, $output, $questionHelper), [
+            'cache:clear',
+            'doctrine:migrations:version' => [
+                '--add' => true,
+                '--all' => true,
+                '--no-interaction' => true,
+            ],
+        ]);
+    }
+
+    /**
+     * @return bool
+     *
+     * @throws \Exception
+     */
+    private function isDatabasePresent()
+    {
+        $databaseName = $this->getDatabaseName();
+
+        try {
+            $schemaManager = $this->getSchemaManager();
+        } catch (\Exception $exception) {
+            $message = $exception->getMessage();
+
+            $mysqlDatabaseError = false !== strpos($message, sprintf("Unknown database '%s'", $databaseName));
+            $postgresDatabaseError = false !== strpos($message, sprintf('database "%s" does not exist', $databaseName));
+
+            if ($mysqlDatabaseError || $postgresDatabaseError) {
+                return false;
+            }
+
+            throw $exception;
+        }
+
+        return in_array($databaseName, $schemaManager->listDatabases());
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param QuestionHelper $questionHelper
+     *
+     * @return array
+     */
+    private function getRequiredCommands(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper)
+    {
+        if ($input->getOption('no-interaction')) {
+            $commands['doctrine:schema:update'] = ['--force' => true];
+        }
+
+        return $this->setupDatabase($input, $output, $questionHelper);
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param QuestionHelper $questionHelper
+     *
+     * @return array
+     */
+    private function setupDatabase(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper)
+    {
+        $question = new ConfirmationQuestion('It appears that your database already exists. Would you like to reset it? (y/N) ', false);
+        if ($questionHelper->ask($input, $output, $question)) {
+            return [
+                'doctrine:database:drop' => ['--force' => true],
+                'doctrine:database:create',
+                'doctrine:schema:create',
+            ];
+        }
+
+        if (!$this->isSchemaPresent()) {
+            return ['doctrine:schema:create'];
+        }
+
+        $question = new ConfirmationQuestion('Seems like your database contains schema. Do you want to reset it? (y/N) ', false);
+        if ($questionHelper->ask($input, $output, $question)) {
+            return [
+                'doctrine:schema:drop' => ['--force' => true],
+                'doctrine:schema:create',
+            ];
+        }
+
+        return [];
+    }
+
+    /**
+     * @return bool
+     */
+    private function isSchemaPresent()
+    {
+        return 0 !== count($this->getSchemaManager()->listTableNames());
+    }
+
+    /**
+     * @return string
+     */
+    private function getDatabaseName()
+    {
+        return $this->doctrineRegistry->getManager()->getConnection()->getDatabase();
+    }
+
+    /**
+     * @return AbstractSchemaManager
+     */
+    private function getSchemaManager()
+    {
+        return $this->doctrineRegistry->getManager()->getConnection()->getSchemaManager();
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Installer/Provider/DatabaseSetupCommandsProviderInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Provider/DatabaseSetupCommandsProviderInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Installer\Provider;
+
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+interface DatabaseSetupCommandsProviderInterface
+{
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param QuestionHelper $questionHelper
+     *
+     * @return array
+     */
+    public function getCommands(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper);
+}

--- a/src/Sylius/Bundle/CoreBundle/Installer/Renderer/TableRenderer.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Renderer/TableRenderer.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Installer\Renderer;
+
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class TableRenderer
+{
+    /**
+     * @var Table
+     */
+    private $table;
+
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var array
+     */
+    private $headers;
+
+    /**
+     * @var array
+     */
+    private $rows = [];
+
+    /**
+     * @var string
+     */
+    private $label;
+
+    /**
+     * @param OutputInterface $output
+     */
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+        $this->table = new Table($output);
+    }
+
+    /**
+     * @param array $headers
+     */
+    public function setHeaders(array $headers)
+    {
+        $this->headers = $headers;
+    }
+
+    /**
+     * @param array $row
+     */
+    public function addRow(array $row)
+    {
+        $this->rows[] = $row;
+    }
+
+    /**
+     * @param $label
+     */
+    public function setLabel($label)
+    {
+        $this->label = $label;
+    }
+
+    public function render()
+    {
+        if (null !== $this->label) {
+            $this->output->writeln(sprintf('<comment>%s</comment>', $this->label));
+        }
+
+        $this->table
+            ->setHeaders($this->headers)
+            ->setRows($this->rows)
+            ->render()
+        ;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return empty($this->rows);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelSetup.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelSetup.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Installer\Setup;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Currency\Model\CurrencyInterface;
+use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class ChannelSetup implements ChannelSetupInterface
+{
+    /**
+     * @var RepositoryInterface
+     */
+    private $channelRepository;
+
+    /**
+     * @var FactoryInterface
+     */
+    private $channelFactory;
+
+    /**
+     * @var ObjectManager
+     */
+    private $channelManager;
+
+    /**
+     * @param RepositoryInterface $channelRepository
+     * @param FactoryInterface $channelFactory
+     * @param ObjectManager $channelManager
+     */
+    public function __construct(
+        RepositoryInterface $channelRepository,
+        FactoryInterface $channelFactory,
+        ObjectManager $channelManager
+    ) {
+        $this->channelRepository = $channelRepository;
+        $this->channelFactory = $channelFactory;
+        $this->channelManager = $channelManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setup(LocaleInterface $locale, CurrencyInterface $currency)
+    {
+        /** @var ChannelInterface $channel */
+        $channel = $this->channelRepository->findOneBy([]);
+
+        if (null === $channel) {
+            $channel = $this->channelFactory->createNew();
+            $channel->setCode('default');
+            $channel->setName('Default');
+            $channel->setTaxCalculationStrategy('order_items_based');
+
+            $this->channelManager->persist($channel);
+        }
+
+        $channel->addCurrency($currency);
+        $channel->setBaseCurrency($currency);
+        $channel->addLocale($locale);
+        $channel->setDefaultLocale($locale);
+
+        $this->channelManager->flush();
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelSetupInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelSetupInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Installer\Setup;
+
+use Sylius\Component\Currency\Model\CurrencyInterface;
+use Sylius\Component\Locale\Model\LocaleInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+interface ChannelSetupInterface
+{
+    /**
+     * @param LocaleInterface $locale
+     * @param CurrencyInterface $currency
+     */
+    public function setup(LocaleInterface $locale, CurrencyInterface $currency);
+}

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/CurrencySetup.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/CurrencySetup.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Installer\Setup;
+
+use Sylius\Component\Currency\Model\CurrencyInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Intl\Intl;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class CurrencySetup implements CurrencySetupInterface
+{
+    /**
+     * @var RepositoryInterface
+     */
+    private $currencyRepository;
+
+    /**
+     * @var FactoryInterface
+     */
+    private $currencyFactory;
+
+    /**
+     * @param RepositoryInterface $currencyRepository
+     * @param FactoryInterface $currencyFactory
+     */
+    public function __construct(RepositoryInterface $currencyRepository, FactoryInterface $currencyFactory)
+    {
+        $this->currencyRepository = $currencyRepository;
+        $this->currencyFactory = $currencyFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setup(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper)
+    {
+        $code = $this->getCurrencyCodeFromUser($input, $output, $questionHelper);
+
+        $existingCurrency = $this->currencyRepository->findOneBy(['code' => $code]);
+        if (null !== $existingCurrency) {
+            return $existingCurrency;
+        }
+
+        /** @var CurrencyInterface $currency */
+        $currency = $this->currencyFactory->createNew();
+        $currency->setCode($code);
+
+        $this->currencyRepository->add($currency);
+
+        return $currency;
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param QuestionHelper $questionHelper
+     *
+     * @return string
+     */
+    private function getCurrencyCodeFromUser(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper)
+    {
+        $code = $this->getNewCurrencyCode($input, $output, $questionHelper);
+        $name = $this->getCurrencyName($code);
+
+        while (null === $name) {
+            $output->writeln(
+                sprintf('<comment>Currency with code <info>%s</info> could not be resolved.</comment>', $code)
+            );
+
+            $code = $this->getNewCurrencyCode($input, $output, $questionHelper);
+            $name = $this->getCurrencyName($code);
+        }
+
+        $output->writeln(sprintf('Adding <info>%s</info> currency.', $name));
+
+        return $code;
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param QuestionHelper $questionHelper
+     *
+     * @return string
+     */
+    private function getNewCurrencyCode(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper)
+    {
+        $question = new Question('Currency (press enter to use USD): ', 'USD');
+
+        return trim($questionHelper->ask($input, $output, $question));
+    }
+
+    /**
+     * @param string $code
+     *
+     * @return string|null
+     */
+    private function getCurrencyName($code)
+    {
+        return Intl::getCurrencyBundle()->getCurrencyName($code);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/CurrencySetupInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/CurrencySetupInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Installer\Setup;
+
+use Sylius\Component\Currency\Model\CurrencyInterface;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+interface CurrencySetupInterface
+{
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param QuestionHelper $questionHelper
+     *
+     * @return CurrencyInterface
+     */
+    public function setup(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper);
+}

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/LocaleSetup.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/LocaleSetup.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Installer\Setup;
+
+use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Intl\Intl;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class LocaleSetup implements LocaleSetupInterface
+{
+    /**
+     * @var RepositoryInterface
+     */
+    private $localeRepository;
+
+    /**
+     * @var FactoryInterface
+     */
+    private $localeFactory;
+
+    /**
+     * @var string
+     */
+    private $locale;
+
+    /**
+     * @param RepositoryInterface $localeRepository
+     * @param FactoryInterface $localeFactory
+     * @param string $locale
+     */
+    public function __construct(RepositoryInterface $localeRepository, FactoryInterface $localeFactory, $locale)
+    {
+        $this->localeRepository = $localeRepository;
+        $this->localeFactory = $localeFactory;
+        $this->locale = trim($locale);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setup(InputInterface $input, OutputInterface $output)
+    {
+        $name = $this->getLanguageName($this->locale);
+
+        $output->writeln(sprintf('Adding <info>%s</info> locale.', $name));
+
+        $existingLocale = $this->localeRepository->findOneBy(['code' => $this->locale]);
+        if (null !== $existingLocale) {
+            return $existingLocale;
+        }
+
+        /** @var LocaleInterface $locale */
+        $locale = $this->localeFactory->createNew();
+        $locale->setCode($this->locale);
+
+        $this->localeRepository->add($locale);
+
+        return $locale;
+    }
+
+    /**
+     * @param string $code
+     *
+     * @return string|null
+     */
+    private function getLanguageName($code)
+    {
+        return Intl::getLanguageBundle()->getLanguageName($code);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/LocaleSetupInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/LocaleSetupInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Installer\Setup;
+
+use Sylius\Component\Locale\Model\LocaleInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+interface LocaleSetupInterface
+{
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return LocaleInterface
+     */
+    public function setup(InputInterface $input, OutputInterface $output);
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
@@ -23,5 +23,15 @@
         <service id="sylius.commands_provider.database_setup" class="Sylius\Bundle\CoreBundle\Installer\Provider\DatabaseSetupCommandsProvider">
             <argument type="service" id="doctrine" />
         </service>
+
+        <service id="sylius.setup.currency" class="Sylius\Bundle\CoreBundle\Installer\Setup\CurrencySetup">
+            <argument type="service" id="sylius.repository.currency" />
+            <argument type="service" id="sylius.factory.currency" />
+        </service>
+        <service id="sylius.setup.locale" class="Sylius\Bundle\CoreBundle\Installer\Setup\LocaleSetup">
+            <argument type="service" id="sylius.repository.locale" />
+            <argument type="service" id="sylius.factory.locale" />
+            <argument>%locale%%</argument>
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
@@ -16,8 +16,12 @@
         <service id="sylius.installer.checker.command_directory" class="Sylius\Bundle\CoreBundle\Installer\Checker\CommandDirectoryChecker">
             <argument type="service" id="filesystem" />
         </service>
-        <service id="sylius.installer.checker.requirements" class="Sylius\Bundle\CoreBundle\Installer\Checker\RequirementsChecker">
+        <service id="sylius.installer.checker.sylius_requirements" class="Sylius\Bundle\CoreBundle\Installer\Checker\SyliusRequirementsChecker">
             <argument type="service" id="sylius.requirements" />
+        </service>
+
+        <service id="sylius.commands_provider.database_setup" class="Sylius\Bundle\CoreBundle\Installer\Provider\DatabaseSetupCommandsProvider">
+            <argument type="service" id="doctrine" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
@@ -16,5 +16,8 @@
         <service id="sylius.installer.checker.command_directory" class="Sylius\Bundle\CoreBundle\Installer\Checker\CommandDirectoryChecker">
             <argument type="service" id="filesystem" />
         </service>
+        <service id="sylius.installer.checker.requirements" class="Sylius\Bundle\CoreBundle\Installer\Checker\RequirementsChecker">
+            <argument type="service" id="sylius.requirements" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
@@ -33,5 +33,10 @@
             <argument type="service" id="sylius.factory.locale" />
             <argument>%locale%%</argument>
         </service>
+        <service id="sylius.setup.channel" class="Sylius\Bundle\CoreBundle\Installer\Setup\ChannelSetup">
+            <argument type="service" id="sylius.repository.channel" />
+            <argument type="service" id="sylius.factory.channel" />
+            <argument type="service" id="sylius.manager.channel" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/spec/Installer/Executor/CommandExecutorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Installer/Executor/CommandExecutorSpec.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace spec\Sylius\Bundle\CoreBundle\Command;
+namespace spec\Sylius\Bundle\CoreBundle\Installer\Executor;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Bundle\CoreBundle\Command\CommandExecutor;
+use Sylius\Bundle\CoreBundle\Installer\Executor\CommandExecutor;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | |
| License         | MIT |

*Sylius* installer is a powerful tool, but since last few years it became a little bit messy. This PR is the first step to make it usable.

- [x] read all commands and make sure they work properly (especially checking and setting permissions)
- [x] take care about coding standards
- [x] make output as minimal as it can be
- [x] extract commands logic to services to make them cleaner and more readable - the goal is to make command run service, optionally display start and end message, maybe run another command

To-do:
- [x] clean up ``SetupCommand``

I hope we will be able to test this commands properly in the nearest future, as current test doesn't really test anything ;)