### PR TITLE
[Critical][Shop] Revert changes that "fixed" broken cart widget

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Controller/OrderController.php
+++ b/src/Sylius/Bundle/OrderBundle/Controller/OrderController.php
@@ -57,6 +57,28 @@ class OrderController extends ResourceController
 
         return $this->viewHandler->handle($configuration, $view);
     }
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function widgetAction(Request $request)
+    {
+        $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);
+
+        $cart = $this->getCurrentCart();
+
+        if (!$configuration->isHtmlRequest()) {
+            return $this->viewHandler->handle($configuration, View::create($cart));
+        }
+
+        $view = View::create()
+            ->setTemplate($configuration->getTemplate('summary.html'))
+            ->setData(['cart' => $cart])
+        ;
+
+        return $this->viewHandler->handle($configuration, $view);
+    }
 
     /**
      * @param Request $request

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/cart.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/cart.yml
@@ -5,13 +5,9 @@ sylius_shop_partial_cart_summary:
     path: /summary
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:showAction
+        _controller: sylius.controller.order:widgetAction
         _sylius:
             template: $template
-            repository:
-                method: find
-                arguments:
-                    - "expr:service('sylius.context.cart').getCart()"
 
 sylius_shop_partial_cart_add_item:
     path: /add-item

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/_widget.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/_widget.html.twig
@@ -1,7 +1,5 @@
 {% import "@SyliusShop/Common/Macro/money.html.twig" as money %}
 
-{% set cart = order %}
-
 <div id="sylius-cart-button" class="ui circular cart button">
     <i class="cart icon"></i>
     <span id="sylius-cart-total">


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/6961, related to https://github.com/Sylius/Sylius/pull/6958 |
| License         | MIT |

The problem is, in ``showAction`` repository uses newly created cart as argument to ``find`` method - but it does not have an id, and that's why it fails.

Again two questions:
- what was the problem with previous implementation?
- how is it possible it does not break the build on Travis? It fails every single shop scenario on my local machine