### PR TITLE
[Admin][Images] Fix displaying images on product and taxon pages

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/_form.html.twig
@@ -24,7 +24,4 @@
         </div>
     {% endfor %}
 </div>
-<div class="ui segment">
-    <h3 class="ui dividing header">{{ 'sylius.ui.media'|trans }}</h3>
-    {{ form_row(form.images, {'label': false}) }}
-</div>
+{% include '@SyliusAdmin/Taxon/_media.html.twig' %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/_media.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/_media.html.twig
@@ -1,6 +1,6 @@
 {% form_theme form 'SyliusUiBundle:Form:imagesTheme.html.twig' %}
 
-<div class="ui tab" data-tab="media">
+<div class="ui segment">
     <h3 class="ui dividing header">{{ 'sylius.ui.media'|trans }}</h3>
     {{ form_row(form.images, {'label': false}) }}
 </div>

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/imagesTheme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/imagesTheme.html.twig
@@ -1,0 +1,87 @@
+{% extends 'SyliusUiBundle:Form:theme.html.twig' %}
+
+{% block collection_widget -%}
+    {% from 'SyliusResourceBundle:Macros:notification.html.twig' import error %}
+    {% set attr = attr|merge({'class': attr.class|default ~ ' controls collection-widget'}) %}
+
+    {% spaceless %}
+        <div data-form-type="collection" {{ block('widget_container_attributes') }}
+                {% if prototype is defined and allow_add %}
+                    data-prototype='{{ _self.collection_item(prototype, allow_delete, button_delete_label, '__name__')|e }}'
+                {%- endif -%}
+        >
+            {{ error(form.vars.errors) }}
+
+            {% if prototypes|default is iterable %}
+                {% for key, subPrototype in prototypes %}
+                    <input type="hidden" data-form-prototype="{{ key }}" value="{{ _self.collection_item(subPrototype, allow_delete, button_delete_label, '__name__')|e }}" />
+                {% endfor %}
+            {% endif %}
+
+            <div data-form-collection="list" class="ui three column stackable grid">
+                {% for child in form %}
+                    {{ _self.collection_item(child, allow_delete, button_delete_label, loop.index0) }}
+                {% endfor %}
+            </div>
+
+            {% if prototype is defined and allow_add %}
+                <a href="#" class="ui labeled icon button" data-form-collection="add">
+                    <i class="plus square outline icon"></i>
+                    {{ button_add_label|trans }}
+                </a>
+            {% endif %}
+        </div>
+    {% endspaceless %}
+{%- endblock collection_widget %}
+
+{% macro collection_item(form, allow_delete, button_delete_label, index) %}
+    {% spaceless %}
+        <div class="column">
+            <div data-form-collection="item" data-form-collection-index="{{ index }}">
+                {{ form_widget(form) }}
+                {% if allow_delete %}
+                    <a href="#" data-form-collection="delete" class="ui red labeled icon button" style="margin-bottom: 1em;">
+                        <i class="trash icon"></i>
+                        {{ button_delete_label|trans }}
+                    </a>
+                {% endif %}
+            </div>
+        </div>
+    {% endspaceless %}
+{% endmacro %}
+
+{% block sylius_product_image_widget %}
+    <div class="ui upload box segment">
+        {{ form_row(form.code) }}
+        {% if form.vars.value.path|default(null) is null %}
+            <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.choose_file'|trans }}</label>
+        {% else %}
+            <img class="ui small bordered image" src="{{ form.vars.value.path|imagine_filter('sylius_small') }}" alt="{{ form.vars.value.code }}" />
+            <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.change_file'|trans }}</label>
+        {% endif %}
+        <div class="ui hidden element">
+            {{ form_widget(form.file) }}
+        </div>
+        <div class="ui element">
+            {{- form_errors(form.file) -}}
+        </div>
+    </div>
+{% endblock %}
+
+{% block sylius_taxon_image_widget %}
+    <div class="ui upload box segment">
+        {{ form_row(form.code) }}
+        {% if form.vars.value.path|default(null) is null %}
+            <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.choose_file'|trans }}</label>
+        {% else %}
+            <img class="ui small bordered image" src="{{ form.vars.value.path|imagine_filter('sylius_small') }}" alt="{{ form.vars.value.code }}" />
+            <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.change_file'|trans }}</label>
+        {% endif %}
+        <div class="ui hidden element">
+            {{ form_widget(form.file) }}
+        </div>
+        <div class="ui element">
+            {{- form_errors(form.file) -}}
+        </div>
+    </div>
+{% endblock %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -177,42 +177,6 @@
     </div>
 {% endblock %}
 
-{% block sylius_product_image_widget %}
-    <div class="ui upload box segment">
-        {{ form_row(form.code) }}
-        {% if form.vars.value.path|default(null) is null %}
-            <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.choose_file'|trans }}</label>
-        {% else %}
-            <img class="ui small bordered image" src="{{ form.vars.value.path|imagine_filter('sylius_small') }}" alt="{{ form.vars.value.code }}" />
-            <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.change_file'|trans }}</label>
-        {% endif %}
-        <div class="ui hidden element">
-            {{ form_widget(form.file) }}
-        </div>
-        <div class="ui element">
-            {{- form_errors(form.file) -}}
-        </div>
-    </div>
-{% endblock %}
-
-{% block sylius_taxon_image_widget %}
-    <div class="ui upload box segment">
-        {{ form_row(form.code) }}
-        {% if form.vars.value.path|default(null) is null %}
-            <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.choose_file'|trans }}</label>
-        {% else %}
-            <img class="ui small bordered image" src="{{ form.vars.value.path|imagine_filter('sylius_small') }}" alt="{{ form.vars.value.code }}" />
-            <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.change_file'|trans }}</label>
-        {% endif %}
-        <div class="ui hidden element">
-            {{ form_widget(form.file) }}
-        </div>
-        <div class="ui element">
-            {{- form_errors(form.file) -}}
-        </div>
-    </div>
-{% endblock %}
-
 {% block sylius_translations_row -%}
     <h4 class="ui dividing header">{{ form_label(form) }}</h4>
     <div class="ui grid">


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | |
| License         | MIT |

After this change, images are displayed in three columns, as below:
![image](https://cloud.githubusercontent.com/assets/6140884/20804581/b9bcaa64-b7f3-11e6-9588-9a3ec2251f7d.png)
