### PR TITLE
[UnpaidOrdersStateUpdater] Use class constant

### DIFF
--- a/src/Sylius/Component/Core/Updater/UnpaidOrdersStateUpdater.php
+++ b/src/Sylius/Component/Core/Updater/UnpaidOrdersStateUpdater.php
@@ -64,7 +64,7 @@ final class UnpaidOrdersStateUpdater implements UnpaidOrdersStateUpdaterInterfac
      */
     private function cancelOrder(OrderInterface $expiredUnpaidOrder)
     {
-        $stateMachine = $this->stateMachineFactory->get($expiredUnpaidOrder, 'sylius_order');
+        $stateMachine = $this->stateMachineFactory->get($expiredUnpaidOrder, OrderTransitions::GRAPH);
         $stateMachine->apply(OrderTransitions::TRANSITION_CANCEL);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |

Just a small fix — using a defined class constant instead of a string