### PR TITLE
Don't double translate messages

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_customers.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_customers.html.twig
@@ -36,6 +36,6 @@
             </tbody>
         </table>
     {% else %}
-        {{ messages.info('sylius.ui.no_results_to_display'|trans) }}
+        {{ messages.info('sylius.ui.no_results_to_display') }}
     {% endif %}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_orders.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_orders.html.twig
@@ -36,7 +36,7 @@
             </tbody>
         </table>
     {% else %}
-        {{ messages.info('sylius.ui.no_results_to_display'|trans) }}
+        {{ messages.info('sylius.ui.no_results_to_display') }}
     {% endif %}
 </div>
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/AddressBook/index.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/AddressBook/index.html.twig
@@ -27,6 +27,6 @@
         {% endfor %}
     </div>
     {% else %}
-        {{ messages.info('sylius.ui.you_have_no_addresses_defined'|trans) }}
+        {{ messages.info('sylius.ui.you_have_no_addresses_defined') }}
     {% endif %}
 {% endblock %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/summary.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/summary.html.twig
@@ -24,6 +24,6 @@
 
         {% include '@SyliusShop/Cart/Summary/_suggestions.html.twig' %}
     {% else %}
-        {{ messages.info('sylius.ui.your_cart_is_empty'|trans) }}
+        {{ messages.info('sylius.ui.your_cart_is_empty') }}
     {% endif %}
 {% endblock %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Order/show.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Order/show.html.twig
@@ -19,7 +19,7 @@
             {{ form_row(form._token) }}
             {{ form_end(form, {'render_rest': false}) }}
         {% else %}
-            {{ messages.info('sylius.ui.you_can_no_longer_change_payment_method_of_this_order'|trans) }}
+            {{ messages.info('sylius.ui.you_can_no_longer_change_payment_method_of_this_order') }}
         {% endif %}
     </div>
 {% endblock %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_main.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_main.html.twig
@@ -15,5 +15,5 @@
     <div class="ui hidden divider"></div>
     {{ pagination.simple(resources.data) }}
 {% else %}
-    {{ messages.info('sylius.ui.no_results_to_display'|trans) }}
+    {{ messages.info('sylius.ui.no_results_to_display') }}
 {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/ProductReview/_list.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/ProductReview/_list.html.twig
@@ -7,5 +7,5 @@
         {% endfor %}
     </div>
 {% else %}
-    {{ messages.info('sylius.ui.there_are_no_reviews'|trans) }}
+    {{ messages.info('sylius.ui.there_are_no_reviews') }}
 {% endif %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
@@ -43,7 +43,7 @@
             </tbody>
         </table>
     {% else %}
-        {{ messages.info('sylius.ui.no_results_to_display'|trans) }}
+        {{ messages.info('sylius.ui.no_results_to_display') }}
     {% endif %}
     {{ pagination.simple(data) }}
 </div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

The messages macro in `@SyliusUi/Macro/messages.html.twig` will attempt to translate the message it is given when rendering, so there isn't a need to also translate the message in the calling layout.  This results in the message trying to be translated twice and Symfony's profiler will tell you there are missing translations for the second attempt.