### PR TITLE
[UI][JS] Make attribute choice listener generic

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-product-attributes.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-product-attributes.js
@@ -66,14 +66,16 @@
     }
 
     function setAttributeChoiceListener() {
-        $('#attributeChoice button').on('click', function(event) {
+        var $attributeChoice = $('#attributeChoice');
+        $attributeChoice.find('button').on('click', function(event) {
             var $attributesContainer = $('#attributesContainer');
             event.preventDefault();
 
+            var $attributeChoiceSelect = $attributeChoice.find('select');
             var data = '';
-            $('#sylius_product_attribute_choice').val().forEach(function(item) {
+            $attributeChoiceSelect.val().forEach(function(item) {
                 if (!isInTheAttributesContainer(item)) {
-                    data += 'sylius_product_attribute_choice[]=' + item + "&";
+                    data += $attributeChoiceSelect.prop('name') + '=' + item + "&";
                 }
             });
             data += "count=" + getNextIndex();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | n/a |
| License         | MIT |

So that it now also works on other attributes than product attribute. Such as when enabling attributes for product variants.

Without this PR, no attributes will be returned by the 
`$attributes = $form->getData();`
in the "renderAttributeValueFormsAction" function of an attribute enabled model.