### PR TITLE
Remove dependency on pamil/phpspec-generator-extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,7 +85,6 @@
         "matthiasnoback/symfony-config-test": "^2.0",
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "mikey179/vfsStream": "^1.6",
-        "pamil/phpspec-generator-extension": "^0.4",
         "pamil/prophecy-common": "^0.1",
         "phpspec/phpspec": "^3.2",
         "phpunit/phpunit": "^5.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6d99b3b08f07d0a35a3cb76cfdf62eb0",
-    "content-hash": "af835214d229ed3a288cd7dcde952214",
+    "hash": "24314752a0ee06aaa6c9b6d1b098156e",
+    "content-hash": "0b80a29ea39ca7e77c54686c0df8a854",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -6883,53 +6883,6 @@
                 "xml conversion"
             ],
             "time": "2015-09-16 18:59:23"
-        },
-        {
-            "name": "pamil/phpspec-generator-extension",
-            "version": "v0.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pamil/phpspec-generator-extension.git",
-                "reference": "e64e7c6a83a6f45f0cd8cd09e1a366d950f41e89"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pamil/phpspec-generator-extension/zipball/e64e7c6a83a6f45f0cd8cd09e1a366d950f41e89",
-                "reference": "e64e7c6a83a6f45f0cd8cd09e1a366d950f41e89",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6|^7.0",
-                "phpspec/phpspec": "^3.0"
-            },
-            "require-dev": {
-                "behat/behat": "^3.1"
-            },
-            "type": "phpspec-extension",
-            "autoload": {
-                "psr-4": {
-                    "Pamil\\PhpSpecGeneratorExtension\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kamil Kokot",
-                    "email": "kamil@kokot.me",
-                    "homepage": "http://kamil.kokot.me"
-                }
-            ],
-            "description": "Provides matchers useful for specifying generators",
-            "keywords": [
-                "extension",
-                "generator",
-                "matcher",
-                "phpspec"
-            ],
-            "time": "2016-07-21 12:23:15"
         },
         {
             "name": "pamil/prophecy-common",

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -54,4 +54,3 @@ suites:
 
 extensions:
     Akeneo\SkipExampleExtension: ~
-    Pamil\PhpSpecGeneratorExtension\Extension: ~

--- a/src/Sylius/Bundle/FixturesBundle/composer.json
+++ b/src/Sylius/Bundle/FixturesBundle/composer.json
@@ -34,7 +34,6 @@
         "doctrine/doctrine-bundle": "~1.3",
         "matthiasnoback/symfony-config-test": "^2.0",
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
-        "pamil/phpspec-generator-extension": "^0.4",
         "phpspec/phpspec": "^3.2",
         "phpunit/phpunit": "^5.6",
         "twig/twig": "~1.11",

--- a/src/Sylius/Bundle/FixturesBundle/phpspec.yml.dist
+++ b/src/Sylius/Bundle/FixturesBundle/phpspec.yml.dist
@@ -3,6 +3,3 @@ suites:
         namespace: Sylius\Bundle\FixturesBundle
         psr4_prefix: Sylius\Bundle\FixturesBundle
         src_path: .
-
-extensions:
-    Pamil\PhpSpecGeneratorExtension\Extension: ~

--- a/src/Sylius/Bundle/FixturesBundle/spec/Suite/SuiteFactorySpec.php
+++ b/src/Sylius/Bundle/FixturesBundle/spec/Suite/SuiteFactorySpec.php
@@ -12,6 +12,7 @@
 namespace spec\Sylius\Bundle\FixturesBundle\Suite;
 
 use PhpSpec\ObjectBehavior;
+use PhpSpec\Wrapper\Collaborator;
 use Prophecy\Argument;
 use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
 use Sylius\Bundle\FixturesBundle\Fixture\FixtureRegistryInterface;
@@ -33,7 +34,7 @@ final class SuiteFactorySpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Bundle\FixturesBundle\Suite\SuiteFactory');
+        $this->shouldHaveType(SuiteFactory::class);
     }
 
     function it_implements_suite_factory_interface()
@@ -46,7 +47,7 @@ final class SuiteFactorySpec extends ObjectBehavior
         $suite = $this->createSuite('suite_name', ['listeners' => [], 'fixtures' => []]);
 
         $suite->getName()->shouldReturn('suite_name');
-        $suite->getFixtures()->shouldGenerate();
+        $suite->getFixtures()->shouldIterateAs([]);
     }
 
     function it_creates_a_new_suite_with_fixtures(
@@ -67,7 +68,7 @@ final class SuiteFactorySpec extends ObjectBehavior
         ]]);
 
         $suite->getName()->shouldReturn('suite_name');
-        $suite->getFixtures()->shouldGenerateKeys($firstFixture, $secondFixture);
+        $suite->getFixtures()->shouldIterateAs($this->createGenerator($firstFixture, $secondFixture));
     }
 
     function it_creates_a_new_suite_with_fixtures_based_on_its_name_rather_than_alias(
@@ -85,7 +86,7 @@ final class SuiteFactorySpec extends ObjectBehavior
         ]]);
 
         $suite->getName()->shouldReturn('suite_name');
-        $suite->getFixtures()->shouldGenerateKeys($fixture);
+        $suite->getFixtures()->shouldIterateAs($this->createGenerator($fixture));
     }
 
     function it_creates_a_new_suite_with_prioritized_fixtures(
@@ -106,7 +107,7 @@ final class SuiteFactorySpec extends ObjectBehavior
         ]]);
 
         $suite->getName()->shouldReturn('suite_name');
-        $suite->getFixtures()->shouldGenerateKeys($higherPriorityFixture, $fixture);
+        $suite->getFixtures()->shouldIterateAs($this->createGenerator($higherPriorityFixture, $fixture));
     }
 
     function it_creates_a_new_suite_with_customized_fixture(
@@ -123,7 +124,7 @@ final class SuiteFactorySpec extends ObjectBehavior
         ]]);
 
         $suite->getName()->shouldReturn('suite_name');
-        $suite->getFixtures()->shouldGenerate([$fixture, ['fixture_option' => 'fixture_value']]);
+        $suite->getFixtures()->shouldHaveKeyWithValue($fixture, ['fixture_option' => 'fixture_value']);
     }
 
     function it_creates_a_new_suite_with_listeners(
@@ -144,7 +145,7 @@ final class SuiteFactorySpec extends ObjectBehavior
         ]]);
 
         $suite->getName()->shouldReturn('suite_name');
-        $suite->getListeners()->shouldGenerateKeys($firstListener, $secondListener);
+        $suite->getListeners()->shouldIterateAs($this->createGenerator($firstListener, $secondListener));
     }
 
     function it_creates_a_new_suite_with_prioritized_listeners(
@@ -165,7 +166,7 @@ final class SuiteFactorySpec extends ObjectBehavior
         ]]);
 
         $suite->getName()->shouldReturn('suite_name');
-        $suite->getListeners()->shouldGenerateKeys($higherPriorityListener, $listener);
+        $suite->getListeners()->shouldIterateAs($this->createGenerator($higherPriorityListener, $listener));
     }
 
     function it_creates_a_new_suite_with_customized_listener(
@@ -182,7 +183,7 @@ final class SuiteFactorySpec extends ObjectBehavior
         ]]);
 
         $suite->getName()->shouldReturn('suite_name');
-        $suite->getListeners()->shouldGenerate([$listener, ['listener_option' => 'listener_value']]);
+        $suite->getListeners()->shouldHaveKeyWithValue($listener, ['listener_option' => 'listener_value']);
     }
 
     function it_throws_an_exception_if_suite_options_does_not_have_fixtures()
@@ -214,5 +215,16 @@ final class SuiteFactorySpec extends ObjectBehavior
         $this->shouldThrow(\InvalidArgumentException::class)->during('createSuite', ['suite_name', ['fixtures' => [], 'listeners' => [
             'listener' => [],
         ]]]);
+    }
+
+    /**
+     * @param Collaborator[] ...$collaborators
+     *
+     * @return \Generator
+     */
+    private function createGenerator(Collaborator ...$collaborators) {
+        foreach ($collaborators as $collaborator) {
+            yield $collaborator->getWrappedObject() => [];
+        }
     }
 }

--- a/src/Sylius/Bundle/FixturesBundle/spec/Suite/SuiteSpec.php
+++ b/src/Sylius/Bundle/FixturesBundle/spec/Suite/SuiteSpec.php
@@ -12,6 +12,7 @@
 namespace spec\Sylius\Bundle\FixturesBundle\Suite;
 
 use PhpSpec\ObjectBehavior;
+use PhpSpec\Wrapper\Collaborator;
 use Prophecy\Argument;
 use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
 use Sylius\Bundle\FixturesBundle\Suite\Suite;
@@ -29,7 +30,7 @@ final class SuiteSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType('Sylius\Bundle\FixturesBundle\Suite\Suite');
+        $this->shouldHaveType(Suite::class);
     }
 
     function it_implements_suite_interface()
@@ -44,21 +45,21 @@ final class SuiteSpec extends ObjectBehavior
 
     function it_has_no_fixtures_by_default()
     {
-        $this->getFixtures()->shouldGenerate();
+        $this->getFixtures()->shouldIterateAs([]);
     }
 
     function it_allows_for_adding_a_fixture(FixtureInterface $fixture)
     {
         $this->addFixture($fixture, []);
 
-        $this->getFixtures()->shouldGenerateKeys($fixture);
+        $this->getFixtures()->shouldHaveKey($fixture);
     }
 
     function it_stores_a_fixture_with_its_options(FixtureInterface $fixture)
     {
         $this->addFixture($fixture, ['fixture_option' => 'fixture_name']);
 
-        $this->getFixtures()->shouldGenerate([$fixture, ['fixture_option' => 'fixture_name']]);
+        $this->getFixtures()->shouldHaveKeyWithValue($fixture, ['fixture_option' => 'fixture_name']);
     }
 
     function it_stores_multiple_fixtures_as_queue(FixtureInterface $firstFixture, FixtureInterface $secondFixture)
@@ -66,7 +67,7 @@ final class SuiteSpec extends ObjectBehavior
         $this->addFixture($firstFixture, []);
         $this->addFixture($secondFixture, []);
 
-        $this->getFixtures()->shouldGenerateKeys($firstFixture, $secondFixture);
+        $this->getFixtures()->shouldIterateAs($this->createGenerator($firstFixture, $secondFixture));
     }
 
     function it_keeps_the_priority_of_fixtures(
@@ -78,6 +79,17 @@ final class SuiteSpec extends ObjectBehavior
         $this->addFixture($higherPriorityFixture, [], 10);
         $this->addFixture($lowerPriorityFixture, [], -10);
 
-        $this->getFixtures()->shouldGenerateKeys($higherPriorityFixture, $regularFixture, $lowerPriorityFixture);
+        $this->getFixtures()->shouldIterateAs($this->createGenerator($higherPriorityFixture, $regularFixture, $lowerPriorityFixture));
+    }
+
+    /**
+     * @param Collaborator[] ...$collaborators
+     *
+     * @return \Generator
+     */
+    private function createGenerator(Collaborator ...$collaborators) {
+        foreach ($collaborators as $collaborator) {
+            yield $collaborator->getWrappedObject() => [];
+        }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

PhpSpec 3.2 has it out of the box - https://github.com/phpspec/phpspec/pull/1016.