### PR TITLE
Don't mandate configuring the InventoryBundle resources section

### DIFF
--- a/src/Sylius/Bundle/InventoryBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/InventoryBundle/DependencyInjection/Configuration.php
@@ -55,7 +55,6 @@ final class Configuration implements ConfigurationInterface
         $node
             ->children()
                 ->arrayNode('resources')
-                    ->isRequired()
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->arrayNode('inventory_unit')


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

The `InventoryBundle` specifies that its `resources` section is required to be configured but each of the nodes provides sensible and usable configuration values.  This removes the configuration directive specifying that it must be declared in the configuration.