### PR TITLE
[Core] Refactor default payment method resolver

### DIFF
--- a/src/Sylius/Component/Core/Resolver/DefaultPaymentMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/DefaultPaymentMethodResolver.php
@@ -12,15 +12,12 @@
 namespace Sylius\Component\Core\Resolver;
 
 use Sylius\Component\Core\Model\ChannelInterface;
-use Sylius\Component\Core\Model\PaymentInterface as CorePaymentInterface;
 use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
 use Sylius\Component\Payment\Exception\UnresolvedDefaultPaymentMethodException;
-use Sylius\Component\Payment\Model\PaymentInterface;
-use Sylius\Component\Payment\Resolver\DefaultPaymentMethodResolverInterface;
-use Webmozart\Assert\Assert;
 
 /**
  * @author Anna Walasek <anna.walasek@lakion.com>
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
 class DefaultPaymentMethodResolver implements DefaultPaymentMethodResolverInterface
 {
@@ -40,14 +37,8 @@ class DefaultPaymentMethodResolver implements DefaultPaymentMethodResolverInterf
     /**
      * {@inheritdoc}
      */
-    public function getDefaultPaymentMethod(PaymentInterface $subject)
+    public function getDefaultPaymentMethodByChannel(ChannelInterface $channel)
     {
-        /** @var CorePaymentInterface $subject */
-        Assert::isInstanceOf($subject, CorePaymentInterface::class);
-
-        /** @var ChannelInterface $channel */
-        $channel = $subject->getOrder()->getChannel();
-        
         $paymentMethods = $this->paymentMethodRepository->findEnabledForChannel($channel);
         if (empty($paymentMethods)) {
             throw new UnresolvedDefaultPaymentMethodException();

--- a/src/Sylius/Component/Core/Resolver/DefaultPaymentMethodResolverInterface.php
+++ b/src/Sylius/Component/Core/Resolver/DefaultPaymentMethodResolverInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Resolver;
+
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+interface DefaultPaymentMethodResolverInterface
+{
+    /**
+     * @param ChannelInterface $channel
+     *
+     * @return PaymentMethodInterface
+     */
+    public function getDefaultPaymentMethodByChannel(ChannelInterface $channel);
+}

--- a/src/Sylius/Component/Core/spec/Resolver/DefaultPaymentMethodResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/Resolver/DefaultPaymentMethodResolverSpec.php
@@ -13,14 +13,11 @@ namespace spec\Sylius\Component\Core\Resolver;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ChannelInterface;
-use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\Model\PaymentInterface as CorePaymentInterface;
 use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
 use Sylius\Component\Core\Resolver\DefaultPaymentMethodResolver;
+use Sylius\Component\Core\Resolver\DefaultPaymentMethodResolverInterface;
 use Sylius\Component\Payment\Exception\UnresolvedDefaultPaymentMethodException;
-use Sylius\Component\Payment\Model\PaymentInterface;
 use Sylius\Component\Payment\Model\PaymentMethodInterface;
-use Sylius\Component\Payment\Resolver\DefaultPaymentMethodResolverInterface;
 
 /**
  * @author Anna Walasek <anna.walasek@lakion.com>
@@ -42,43 +39,29 @@ final class DefaultPaymentMethodResolverSpec extends ObjectBehavior
         $this->shouldImplement(DefaultPaymentMethodResolverInterface::class);
     }
 
-    function it_throws_an_invalid_argument_exception_if_subject_not_implements_core_payment_interface(
-        PaymentInterface $payment
-    ) {
-        $this->shouldThrow(\InvalidArgumentException::class)->during('getDefaultPaymentMethod', [$payment]);
-    }
-
     function it_throws_an_unresolved_default_payment_method_exception_if_there_is_no_enabled_payment_methods_in_database(
-        CorePaymentInterface $payment,
-        PaymentMethodRepositoryInterface $paymentMethodRepository,
         ChannelInterface $channel,
-        OrderInterface $order
+        PaymentMethodRepositoryInterface $paymentMethodRepository
     ) {
-        $payment->getOrder()->willReturn($order);
-        $order->getChannel()->willReturn($channel);
         $paymentMethodRepository->findEnabledForChannel($channel)->willReturn([]);
 
         $this
             ->shouldThrow(UnresolvedDefaultPaymentMethodException::class)
-            ->during('getDefaultPaymentMethod', [$payment])
+            ->during('getDefaultPaymentMethodByChannel', [$channel])
         ;
     }
 
     function it_returns_first_payment_method_from_availables_which_is_enclosed_in_channel(
-        CorePaymentInterface $payment,
-        PaymentMethodRepositoryInterface $paymentMethodRepository,
+        ChannelInterface $channel,
         PaymentMethodInterface $firstPaymentMethod,
         PaymentMethodInterface $secondPaymentMethod,
-        ChannelInterface $channel,
-        OrderInterface $order
+        PaymentMethodRepositoryInterface $paymentMethodRepository
     ) {
-        $payment->getOrder()->willReturn($order);
-        $order->getChannel()->willReturn($channel);
         $paymentMethodRepository
             ->findEnabledForChannel($channel)
             ->willReturn([$firstPaymentMethod, $secondPaymentMethod])
         ;
 
-        $this->getDefaultPaymentMethod($payment)->shouldReturn($firstPaymentMethod);
+        $this->getDefaultPaymentMethodByChannel($channel)->shouldReturn($firstPaymentMethod);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets | |
| License         | MIT |

`DefaultPaymentMethodResolver` from *Payment* component is not used in *Sylius*, better - it's not even registered. Is there any reason to share interface between this class and `DefaultPaymentMethodResolver` from *Core*? It only forces us to do some weird stuff like passing `Payment` to resolver, necessarily with set `Order` to get channel from it rather than just passing an `Order` object.