### PR TITLE
Trim whitespaces from money macro

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Common/Macro/money.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Common/Macro/money.html.twig
@@ -1,3 +1,3 @@
-{% macro format(amount, currency) %}
+{%- macro format(amount, currency) -%}
     {{ amount|sylius_format_money(currency, app.user.localeCode) }}
-{% endmacro %}
+{%- endmacro -%}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Macro/money.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Macro/money.html.twig
@@ -1,15 +1,15 @@
-{% macro format(amount, currency_code) %}
+{%- macro format(amount, currency_code) -%}
     {{ amount|sylius_format_money(currency_code, sylius.localeCode) }}
-{% endmacro %}
+{%- endmacro -%}
 
-{% macro convertAndFormat(amount) %}
+{%- macro convertAndFormat(amount) -%}
     {% from _self import format %}
 
-    {{ format(amount|sylius_convert_money(sylius.channel.baseCurrency.code, sylius.currencyCode), sylius.currencyCode) }}
-{% endmacro %}
+    {{- format(amount|sylius_convert_money(sylius.channel.baseCurrency.code, sylius.currencyCode), sylius.currencyCode) }}
+{%- endmacro -%}
 
-{% macro calculatePrice(variant) %}
+{%- macro calculatePrice(variant) -%}
     {% from _self import convertAndFormat %}
 
-    {{ convertAndFormat(variant|sylius_calculate_price({'channel': sylius.channel})) }}
-{% endmacro %}
+    {{- convertAndFormat(variant|sylius_calculate_price({'channel': sylius.channel})) }}
+{%- endmacro -%}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | maybe |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | no |
| License         | MIT |

Before:
```
<span>

        €75.00


</span>
```

After:
`<span>€75.00</span>`