### PR TITLE
[Promotion] Use one autocomplete type to rule them all

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
@@ -50,5 +50,11 @@
 
         $(document).productSlugGenerator();
         $(document).taxonSlugGenerator();
+
+        $(document).on('collection-form-update', function (event, choice) {
+            $.each($('.sylius-autocomplete'), function (index, element) {
+                $(element).autoComplete();
+            });
+        });
     });
 })(jQuery);

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Filter/ProductFilterConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Filter/ProductFilterConfigurationType.php
@@ -11,8 +11,7 @@
 
 namespace Sylius\Bundle\CoreBundle\Form\Type\Promotion\Filter;
 
-use Sylius\Bundle\ProductBundle\Form\Type\ProductChoiceType;
-use Sylius\Component\Core\Repository\ProductRepositoryInterface;
+use Sylius\Bundle\ResourceBundle\Form\Type\ResourceAutocompleteChoiceType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -41,14 +40,18 @@ final class ProductFilterConfigurationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('products', ProductChoiceType::class, [
+            ->add('products', ResourceAutocompleteChoiceType::class, [
                 'label' => 'sylius.form.promotion_filter.products',
                 'multiple' => true,
                 'required' => false,
+                'remote_route' => 'sylius_admin_ajax_product_index',
+                'remote_criteria_type' => 'contains',
+                'remote_criteria_name' => 'search',
+                'choice_value' => 'id',
+                'choice_name' => 'name',
+                'resource' => 'sylius.product',
             ])
         ;
-
-        $builder->get('products')->addModelTransformer($this->productsToCodesTransformer);
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Filter/TaxonFilterConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Filter/TaxonFilterConfigurationType.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\CoreBundle\Form\Type\Promotion\Filter;
 
-use Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonChoiceType;
+use Sylius\Bundle\ResourceBundle\Form\Type\ResourceAutocompleteChoiceType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -41,14 +41,18 @@ final class TaxonFilterConfigurationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('taxons', TaxonChoiceType::class, [
+            ->add('taxons', ResourceAutocompleteChoiceType::class, [
                 'label' => 'sylius.form.promotion_filter.taxons',
-                'multiple' => true,
+                'multiple' => false,
                 'required' => false,
+                'remote_route' => 'sylius_admin_ajax_taxon_index',
+                'remote_criteria_type' => 'contains',
+                'remote_criteria_name' => 'name',
+                'resource' => 'sylius.taxon',
+                'choice_name' => 'name',
+                'choice_value' => 'code',
             ])
         ;
-
-        $builder->get('taxons')->addModelTransformer($this->taxonsToCodesTransformer);
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ContainsProductConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ContainsProductConfigurationType.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule;
 
-use Sylius\Bundle\ProductBundle\Form\Type\ProductCodeChoiceType;
+use Sylius\Bundle\ResourceBundle\Form\Type\ResourceAutocompleteChoiceType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -29,7 +29,13 @@ final class ContainsProductConfigurationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('product_code', ProductCodeChoiceType::class, [
+            ->add('product_code', ResourceAutocompleteChoiceType::class, [
+                'remote_route' => 'sylius_admin_ajax_product_index',
+                'remote_criteria_type' => 'contains',
+                'remote_criteria_name' => 'search',
+                'choice_value' => 'id',
+                'choice_name' => 'name',
+                'resource' => 'sylius.product',
                 'label' => 'sylius.form.promotion_action.add_product_configuration.product',
                 'constraints' => [
                     new NotBlank(['groups' => ['sylius']]),

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/HasTaxonConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/HasTaxonConfigurationType.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule;
 
-use Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonChoiceType;
+use Sylius\Bundle\ResourceBundle\Form\Type\ResourceAutocompleteChoiceType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -40,13 +40,17 @@ final class HasTaxonConfigurationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('taxons', TaxonChoiceType::class, [
+            ->add('taxons', ResourceAutocompleteChoiceType::class, [
+                'remote_route' => 'sylius_admin_ajax_taxon_index',
+                'remote_criteria_type' => 'contains',
+                'remote_criteria_name' => 'name',
+                'resource' => 'sylius.taxon',
+                'choice_name' => 'name',
+                'choice_value' => 'code',
                 'label' => 'sylius.form.promotion_rule.has_taxon.taxons',
                 'multiple' => true,
             ])
         ;
-
-        $builder->get('taxons')->addModelTransformer($this->taxonsToCodesTransformer);
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/Form/DataTransformer/RecursiveTransformer.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/DataTransformer/RecursiveTransformer.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\ResourceBundle\Form\DataTransformer;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
@@ -38,6 +39,10 @@ final class RecursiveTransformer implements DataTransformerInterface
      */
     public function transform($values)
     {
+        if (null === $values) {
+            $values = new ArrayCollection();
+        }
+
         $this->assertTransformationValueType($values, Collection::class);
 
         return $values->map(function ($value) {

--- a/src/Sylius/Bundle/ResourceBundle/Form/Type/ResourceAutocompleteChoiceType.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/Type/ResourceAutocompleteChoiceType.php
@@ -79,6 +79,10 @@ class ResourceAutocompleteChoiceType extends AbstractType
         $view->vars['choice_name'] = $options['choice_name'];
         $view->vars['choice_value'] = $options['choice_value'];
         $view->vars['placeholder'] = $options['placeholder'];
+        $view->vars['remote_criteria_type'] = $options['remote_criteria_type'];
+        $view->vars['remote_criteria_name'] = $options['remote_criteria_name'];
+        $view->vars['remote_route'] = $options['remote_route'];
+        $view->vars['remote_route_parameters'] = $options['remote_route_parameters'];
     }
 
     /**
@@ -98,12 +102,17 @@ class ResourceAutocompleteChoiceType extends AbstractType
                 'repository' => function (Options $options) {
                     return $this->resourceRepositoryRegistry->get($options['resource']);
                 },
+                'remote_criteria_type' => 'contains',
+                'remote_criteria_name' => 'name',
+                'remote_route' => null,
+                'remote_route_parameters' => []
             ])
             ->setAllowedTypes('resource', ['string'])
             ->setAllowedTypes('multiple', ['bool'])
             ->setAllowedTypes('choice_name', ['string'])
             ->setAllowedTypes('choice_value', ['string'])
             ->setAllowedTypes('placeholder', ['string'])
+            ->setAllowedTypes('remote_route_parameters', ['array'])
         ;
     }
 

--- a/src/Sylius/Bundle/ResourceBundle/spec/Form/DataTransformer/RecursiveTransformerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Form/DataTransformer/RecursiveTransformerSpec.php
@@ -60,4 +60,9 @@ final class RecursiveTransformerSpec extends ObjectBehavior
         $this->shouldThrow(TransformationFailedException::class)->during('transform', [new \stdClass()]);
         $this->shouldThrow(TransformationFailedException::class)->during('reverseTransform', [new \stdClass()]);
     }
+
+    function it_transforms_null_into_empty_array_collection()
+    {
+        $this->transform(null)->shouldBeLike(new ArrayCollection());
+    }
 }

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -196,7 +196,11 @@
     {{- form_label(form) -}}
     <div
             class="sylius-autocomplete ui fluid search selection dropdown {% if multiple %}multiple{% endif %}"
-            data-url="{{ remote_url }}"
+            {% if remote_url is defined %}
+                data-url="{{ remote_url }}"
+            {% elseif remote_route is defined %}
+                data-url="{{ path(remote_route, remote_route_parameters) }}"
+            {% endif %}
             data-choice-name="{{ choice_name }}"
             data-choice-value="{{ choice_value }}"
             data-criteria-type="{{ remote_criteria_type }}"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| License         | MIT |

Resource auto complete configuration reference:
```php
->add('products', ResourceAutocompleteChoiceType::class, [
                'label' => 'sylius.form.promotion_filter.products',
                'multiple' => true,
                'required' => false,
                'choice_value' => 'id',
                'choice_name' => 'name',
                'resource' => 'sylius.product',
])
```
```twig
{{form(form, { 'remote_url': path('sylius_admin_ajax_product_index'), 'remote_criteria_type': 'contains', 'remote_criteria_name': 'search' })}}
```
And that is it generic javascript will catch this and do the rest
Blocked by #6936 