### PR TITLE
[Checkout][Core] Fix disappearing email after going back to addressing step

### DIFF
--- a/features/checkout/addressing_order/returning_to_addressing_step_and_changing_address_data.feature
+++ b/features/checkout/addressing_order/returning_to_addressing_step_and_changing_address_data.feature
@@ -1,0 +1,22 @@
+@checkout
+Feature: Returning to the addressing step and changing address data
+    In order to correct my address data
+    As a Visitor
+    I want to be able to return to the addressing step and change previously typed data
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Apollo 11 T-Shirt" priced at "$49.99"
+        And the store ships everywhere for free
+
+    @ui
+    Scenario: Going back to addressing step with and changing email
+        Given I have product "Apollo 11 T-Shirt" in the cart
+        And I am at the checkout addressing step
+        When I specify the email as "jon.snow@example.com"
+        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I complete the addressing step
+        And I decide to change my address
+        And I specify the email as "ned.stark@example.com"
+        And I complete the addressing step
+        Then I should be checking out as "ned.stark@example.com"

--- a/src/Sylius/Behat/Context/Ui/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Ui/CheckoutContext.php
@@ -1398,6 +1398,17 @@ final class CheckoutContext implements Context
     }
 
     /**
+     * @Then I should be checking out as :email
+     */
+    public function iShouldBeCheckingOutAs($email)
+    {
+        Assert::same(
+            'Checking out as '.$email.'.',
+            $this->selectShippingPage->getPurchaserEmail()
+        );
+    }
+
+    /**
      * @return AddressInterface
      */
     private function createDefaultAddress()

--- a/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPage.php
@@ -112,6 +112,14 @@ class SelectShippingPage extends SymfonyPage implements SelectShippingPageInterf
     /**
      * {@inheritdoc}
      */
+    public function getPurchaserEmail()
+    {
+        return $this->getElement('purchaser-email')->getText();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getValidationMessageForShipment()
     {
         $foundElement = $this->getElement('shipment');
@@ -168,6 +176,7 @@ class SelectShippingPage extends SymfonyPage implements SelectShippingPageInterf
             'checkout_subtotal' => '#sylius-checkout-subtotal',
             'next_step' => '#next-step',
             'order_cannot_be_shipped_message' => '#sylius-order-cannot-be-shipped',
+            'purchaser-email' => '#purchaser-email',
             'shipment' => '.items',
             'shipping_method' => '[name="sylius_checkout_select_shipping[shipments][0][method]"]',
             'shipping_method_fee' => '.item:contains("%shipping_method%") .fee',

--- a/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPageInterface.php
@@ -55,6 +55,11 @@ interface SelectShippingPageInterface extends SymfonyPageInterface
     public function changeAddressByStepLabel();
 
     /**
+     * @return mixed string
+     */
+    public function getPurchaserEmail();
+
+    /**
      * @return string
      */
     public function getValidationMessageForShipment();

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
@@ -14,6 +14,7 @@ namespace Sylius\Bundle\CoreBundle\Form\Type\Checkout;
 use Sylius\Bundle\AddressingBundle\Form\Type\AddressType as SyliusAddressType;
 use Sylius\Bundle\CoreBundle\Form\Type\Customer\CustomerGuestType;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
+use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Customer\Model\CustomerAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -52,8 +53,13 @@ final class AddressType extends AbstractResourceType
                 $customer = $options['customer'];
 
                 Assert::isInstanceOf($resource, CustomerAwareInterface::class);
+                /** @var CustomerInterface $resourceCustomer */
+                $resourceCustomer = $resource->getCustomer();
 
-                if (null === $customer && null === $resource->getCustomer()) {
+                if (
+                    (null === $customer && null === $resourceCustomer) ||
+                    (null !== $resourceCustomer && null === $resourceCustomer->getUser())
+                ) {
                     $form->add('customer', CustomerGuestType::class, ['constraints' => [new Valid()]]);
                 }
             })

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_header.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_header.html.twig
@@ -5,7 +5,7 @@
         </div>
         <div class="right menu">
             {% if order.customer.id|default(null) is not null %}
-                <div class="item">{{ 'sylius.ui.checking_out_as'|trans }} {{ order.customer.fullName|default(order.customer.email) }}.</div>
+                <div class="item" id="purchaser-email">{{ 'sylius.ui.checking_out_as'|trans }} {{ order.customer.fullName|default(order.customer.email) }}.</div>
             {% else %}
                 <a href="{{ path('sylius_shop_login') }}" class="item">{{ 'sylius.ui.sign_in'|trans }}</a>
             {% endif %}

--- a/tests/Controller/CheckoutAddressingApiTest.php
+++ b/tests/Controller/CheckoutAddressingApiTest.php
@@ -241,7 +241,10 @@ EOT;
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "differentBillingAddress": false
+            "differentBillingAddress": false,
+            "customer": {
+                "email": "john@doe.com"
+            }
         }
 EOT;
 
@@ -297,7 +300,10 @@ EOT;
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "differentBillingAddress": false
+            "differentBillingAddress": false,
+            "customer": {
+                "email": "john@doe.com"
+            }
         }
 EOT;
 
@@ -354,7 +360,10 @@ EOT;
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "differentBillingAddress": false
+            "differentBillingAddress": false,
+            "customer": {
+                "email": "john@doe.com"
+            }
         }
 EOT;
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | |
| License         | MIT |

Proceeding checkout as guest and then going back to addressing step caused vanishing of email field. That was because we only checked is there `customer` set on cart and if yes, then corresponding field was not added. After this change, we're also checking if there is also `user` on this cart customer - which means is there user logged in or not. Maybe it's not the best solution but imo it would be sufficient for now.