### PR TITLE
[Promotion] Inject correct registry in subscriber

### DIFF
--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services/forms.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services/forms.xml
@@ -69,12 +69,12 @@
         </service>
 
         <service id="sylius.form.event_subscriber.build_promotion_action" class="Sylius\Bundle\PromotionBundle\Form\EventListener\BuildPromotionActionFormSubscriber">
-            <argument type="service" id="sylius.registry_promotion_rule_checker" />
+            <argument type="service" id="sylius.registry_promotion_action" />
             <argument type="service" id="form.factory" />
         </service>
 
         <service id="sylius.form.event_subscriber.build_promotion_rule" class="Sylius\Bundle\PromotionBundle\Form\EventListener\BuildPromotionRuleFormSubscriber">
-            <argument type="service" id="sylius.registry_promotion_action" />
+            <argument type="service" id="sylius.registry_promotion_rule_checker" />
             <argument type="service" id="form.factory" />
         </service>
     </services>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | see https://github.com/Sylius/Sylius/pull/5946#issuecomment-266992768 |
| License         | MIT |

During our upgrade process to `beta.1` the forms were not able to render, as the `action` registry was injected in the `rule` subscriber (and the other way around).