### PR TITLE
Fix #7093 #7094

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Command/DemoteUserCommand.php
+++ b/src/Sylius/Bundle/UserBundle/Command/DemoteUserCommand.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\UserBundle\Command;
 
 use Sylius\Component\User\Model\UserInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -33,6 +34,7 @@ class DemoteUserCommand extends AbstractRoleCommand
                 new InputArgument('email', InputArgument::REQUIRED, 'Email'),
                 new InputArgument('roles', InputArgument::IS_ARRAY, 'Security roles'),
                 new InputOption('super-admin', null, InputOption::VALUE_NONE, 'Unset the user as super admin'),
+                new InputOption('user-type', null, InputOption::VALUE_NONE, 'Use shop or admin user type'),
             ))
             ->setHelp(<<<EOT
 The <info>sylius:user:demote</info> command demotes a user by removing security roles
@@ -45,7 +47,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function executeRoleCommand(OutputInterface $output, UserInterface $user, array $securityRoles)
+    protected function executeRoleCommand(InputInterface $input, OutputInterface $output, UserInterface $user, array $securityRoles)
     {
         $error = false;
 
@@ -61,7 +63,7 @@ EOT
         }
 
         if (!$error) {
-            $this->getEntityManager()->flush();
+            $this->getEntityManager($input->getOption('user-type'))->flush();
         }
     }
 }

--- a/src/Sylius/Bundle/UserBundle/Command/PromoteUserCommand.php
+++ b/src/Sylius/Bundle/UserBundle/Command/PromoteUserCommand.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\UserBundle\Command;
 
 use Sylius\Component\User\Model\UserInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -33,6 +34,7 @@ class PromoteUserCommand extends AbstractRoleCommand
                 new InputArgument('email', InputArgument::REQUIRED, 'Email'),
                 new InputArgument('roles', InputArgument::IS_ARRAY, 'Security roles'),
                 new InputOption('super-admin', null, InputOption::VALUE_NONE, 'Set the user as a super admin'),
+                new InputOption('user-type', null, InputOption::VALUE_NONE, 'Use shop or admin user type'),
             ))
             ->setHelp(<<<EOT
 The <info>sylius:user:promote</info> command promotes a user by adding security roles
@@ -45,7 +47,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function executeRoleCommand(OutputInterface $output, UserInterface $user, array $securityRoles)
+    protected function executeRoleCommand(InputInterface $input, OutputInterface $output, UserInterface $user, array $securityRoles)
     {
         $error = false;
 
@@ -61,7 +63,7 @@ EOT
         }
 
         if (!$error) {
-            $this->getEntityManager()->flush();
+            $this->getEntityManager($input->getOption('user-type'))->flush();
         }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | yes |
| BC breaks?      | maybe* |
| Related tickets | fixes #7093 #7094  |
| License         | MIT |

## Promoting / Demoting user roles
[SyliusUserBundle] Refactored question helper - fixes #7093 
[SyliusUserBundle] Added a new interaction to specify the user type (shop / admin) - fixes #7094 

## * BC breaks 
* I don't know if this can be called a "BC break" since the code was already broken since Symfony 3.0, and the patch should work on Symfony 2.5+.
* The protected function `Sylius\Bundle\UserBundle\Command\AbstractRoleCommand::executeRoleCommand` has a new 1st argument: `InputInterface`. This indeed leads to a BC break to possible custom inheritances of `Sylius\Bundle\UserBundle\Command\AbstractRoleCommand`, but the probability to drink a beer with an alien on the Eiffel Tower one day is more important than facing that kind of issue, IMHO.