### PR TITLE
Channels should be protected

### DIFF
--- a/src/Sylius/Component/Core/Model/ShippingMethod.php
+++ b/src/Sylius/Component/Core/Model/ShippingMethod.php
@@ -38,7 +38,7 @@ class ShippingMethod extends BaseShippingMethod implements ShippingMethodInterfa
     /**
      * @var Collection
      */
-    private $channels;
+    protected $channels;
 
     public function __construct()
     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |

If extended and the extended class is configured to be used, there is an doctrine error thrown that the property doesnt exist.