### PR TITLE
[Core] Ensure customer exists before checking for eligibility

### DIFF
--- a/src/Sylius/Component/Core/Promotion/Checker/Eligibility/PromotionCouponPerCustomerUsageLimitEligibilityChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Eligibility/PromotionCouponPerCustomerUsageLimitEligibilityChecker.php
@@ -55,7 +55,7 @@ final class PromotionCouponPerCustomerUsageLimitEligibilityChecker implements Pr
         }
 
         $customer = $promotionSubject->getCustomer();
-        if ($customer === null) {
+        if ($customer === null || $customer->getId() === null) {
             return true;
         }
 

--- a/src/Sylius/Component/Core/spec/Promotion/Checker/Eligibility/PromotionCouponPerCustomerUsageLimitEligibilityCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Checker/Eligibility/PromotionCouponPerCustomerUsageLimitEligibilityCheckerSpec.php
@@ -47,6 +47,7 @@ final class PromotionCouponPerCustomerUsageLimitEligibilityCheckerSpec extends O
         CorePromotionCouponInterface $promotionCoupon,
         CustomerInterface $customer
     ) {
+        $customer->getId()->willReturn(1);
         $promotionSubject->getCustomer()->willReturn($customer);
         $promotionCoupon->getPerCustomerUsageLimit()->willReturn(42);
 
@@ -61,6 +62,7 @@ final class PromotionCouponPerCustomerUsageLimitEligibilityCheckerSpec extends O
         CorePromotionCouponInterface $promotionCoupon,
         CustomerInterface $customer
     ) {
+        $customer->getId()->willReturn(1);
         $promotionSubject->getCustomer()->willReturn($customer);
         $promotionCoupon->getPerCustomerUsageLimit()->willReturn(42);
 

--- a/src/Sylius/Component/Core/spec/Promotion/Checker/Eligibility/PromotionCouponPerCustomerUsageLimitEligibilityCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Promotion/Checker/Eligibility/PromotionCouponPerCustomerUsageLimitEligibilityCheckerSpec.php
@@ -71,6 +71,18 @@ final class PromotionCouponPerCustomerUsageLimitEligibilityCheckerSpec extends O
         $this->isEligible($promotionSubject, $promotionCoupon)->shouldReturn(true);
     }
 
+    function it_returns_true_if_promotion_subject_has_customer_that_is_not_persisted(
+        OrderInterface $promotionSubject,
+        CorePromotionCouponInterface $promotionCoupon,
+        CustomerInterface $customer
+    ) {
+        $customer->getId()->willReturn(null);
+        $promotionSubject->getCustomer()->willReturn($customer);
+        $promotionCoupon->getPerCustomerUsageLimit()->willReturn(42);
+
+        $this->isEligible($promotionSubject, $promotionCoupon)->shouldReturn(true);
+    }
+
     function it_returns_true_if_promotion_subject_has_no_customer(
         OrderInterface $promotionSubject,
         CorePromotionCouponInterface $promotionCoupon


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/7112 |
| License         | MIT |

I hope this is good enough. The better way to do this would be to actually check if this entity is managed by the entity manager to infer existence, but this seemed simpler.