### PR TITLE
[MINOR] Use "same as" instead of deprecated "sameas" in Twig

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_channelSwitch.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_channelSwitch.html.twig
@@ -4,7 +4,7 @@
 {% set code = app.request.query.get('channel') %}
 
 {% for channel in channels %}
-    {% if channel.code is sameas(code) %}
+    {% if channel.code is same as(code) %}
         {% set selected = channel %}
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | deprecation fix |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |
