### PR TITLE
[Core] [DX] Extract payment target transition resolver

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/state_resolvers.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/state_resolvers.xml
@@ -18,9 +18,11 @@
         </service>
         <service id="sylius.state_resolver.order_payment" class="Sylius\Component\Core\StateResolver\OrderPaymentStateResolver">
             <argument type="service" id="sm.factory" />
+            <argument type="service" id="sylius.target_transition_resolver.payment" />
         </service>
         <service id="sylius.state_resolver.order_shipping" class="Sylius\Component\Core\StateResolver\OrderShippingStateResolver">
             <argument type="service" id="sm.factory" />
         </service>
+        <service id="sylius.target_transition_resolver.payment" class="Sylius\Component\Core\StateResolver\PaymentTargetTransitionResolver" />
     </services>
 </container>

--- a/src/Sylius/Component/Core/StateResolver/OrderPaymentStateResolver.php
+++ b/src/Sylius/Component/Core/StateResolver/OrderPaymentStateResolver.php
@@ -15,8 +15,8 @@ use SM\Factory\FactoryInterface;
 use SM\StateMachine\StateMachineInterface;
 use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Order\StateResolver\StateResolverInterface;
-use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\OrderPaymentTransitions;
+use Sylius\Component\Order\StateResolver\TargetTransitionResolverInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -31,11 +31,18 @@ class OrderPaymentStateResolver implements StateResolverInterface
     private $stateMachineFactory;
 
     /**
-     * @param FactoryInterface $stateMachineFactory
+     * @var TargetTransitionResolverInterface
      */
-    public function __construct(FactoryInterface $stateMachineFactory)
+    private $transitionResolver;
+
+    /**
+     * @param FactoryInterface $stateMachineFactory
+     * @param TargetTransitionResolverInterface $transitionResolver
+     */
+    public function __construct(FactoryInterface $stateMachineFactory, TargetTransitionResolverInterface $transitionResolver)
     {
         $this->stateMachineFactory = $stateMachineFactory;
+        $this->transitionResolver = $transitionResolver;
     }
 
     /**
@@ -44,7 +51,7 @@ class OrderPaymentStateResolver implements StateResolverInterface
     public function resolve(OrderInterface $order)
     {
         $stateMachine = $this->stateMachineFactory->get($order, OrderPaymentTransitions::GRAPH);
-        $targetTransition = $this->getTargetTransition($order);
+        $targetTransition = $this->transitionResolver->resolve($order);
 
         if (null !== $targetTransition) {
             $this->applyTransition($stateMachine, $targetTransition);
@@ -60,58 +67,5 @@ class OrderPaymentStateResolver implements StateResolverInterface
         if ($stateMachine->can($transition)) {
             $stateMachine->apply($transition);
         }
-    }
-
-    /**
-     * @param OrderInterface $order
-     *
-     * @return string|null
-     */
-    private function getTargetTransition(OrderInterface $order)
-    {
-        $refundedPaymentTotal = 0;
-        $refundedPayments = $this->getPaymentsWithState($order, PaymentInterface::STATE_REFUNDED);
-
-        foreach ($refundedPayments as $payment) {
-            $refundedPaymentTotal += $payment->getAmount();
-        }
-
-        if (0 < $refundedPayments->count() && $refundedPaymentTotal >= $order->getTotal()) {
-            return OrderPaymentTransitions::TRANSITION_REFUND;
-        }
-
-        if ($refundedPaymentTotal < $order->getTotal() && 0 < $refundedPaymentTotal) {
-            return OrderPaymentTransitions::TRANSITION_PARTIALLY_REFUND;
-        }
-
-        $completedPaymentTotal = 0;
-        $completedPayments = $this->getPaymentsWithState($order, PaymentInterface::STATE_COMPLETED);
-
-        foreach ($completedPayments as $payment) {
-            $completedPaymentTotal += $payment->getAmount();
-        }
-
-        if (0 < $completedPayments->count() && $completedPaymentTotal >= $order->getTotal()) {
-            return OrderPaymentTransitions::TRANSITION_PAY;
-        }
-
-        if ($completedPaymentTotal < $order->getTotal() && 0 < $completedPaymentTotal) {
-            return OrderPaymentTransitions::TRANSITION_PARTIALLY_PAY;
-        }
-
-        return null;
-    }
-
-    /**
-     * @param OrderInterface $order
-     * @param string $state
-     *
-     * @return PaymentInterface[]
-     */
-    private function getPaymentsWithState(OrderInterface $order, $state)
-    {
-        return $order->getPayments()->filter(function (PaymentInterface $payment) use ($state) {
-            return $state === $payment->getState();
-        });
     }
 }

--- a/src/Sylius/Component/Core/StateResolver/PaymentTargetTransitionResolver.php
+++ b/src/Sylius/Component/Core/StateResolver/PaymentTargetTransitionResolver.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\StateResolver;
+
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\OrderPaymentTransitions;
+use Sylius\Component\Order\StateResolver\TargetTransitionResolverInterface;
+
+/**
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Arkadiusz Krakowiak <arkadiusz.krakowiak@lakion.com>
+ * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ */
+final class PaymentTargetTransitionResolver implements TargetTransitionResolverInterface
+{
+    /**
+     * @param OrderInterface $order
+     *
+     * @return string|null
+     */
+    public function resolve(OrderInterface $order)
+    {
+        $refundedPaymentTotal = 0;
+        $refundedPayments = $this->getPaymentsWithState($order, PaymentInterface::STATE_REFUNDED);
+
+        foreach ($refundedPayments as $payment) {
+            $refundedPaymentTotal += $payment->getAmount();
+        }
+
+        if (0 < $refundedPayments->count() && $refundedPaymentTotal >= $order->getTotal()) {
+            return OrderPaymentTransitions::TRANSITION_REFUND;
+        }
+
+        if ($refundedPaymentTotal < $order->getTotal() && 0 < $refundedPaymentTotal) {
+            return OrderPaymentTransitions::TRANSITION_PARTIALLY_REFUND;
+        }
+
+        $completedPaymentTotal = 0;
+        $completedPayments = $this->getPaymentsWithState($order, PaymentInterface::STATE_COMPLETED);
+
+        foreach ($completedPayments as $payment) {
+            $completedPaymentTotal += $payment->getAmount();
+        }
+
+        if (0 < $completedPayments->count() && $completedPaymentTotal >= $order->getTotal()) {
+            return OrderPaymentTransitions::TRANSITION_PAY;
+        }
+
+        if ($completedPaymentTotal < $order->getTotal() && 0 < $completedPaymentTotal) {
+            return OrderPaymentTransitions::TRANSITION_PARTIALLY_PAY;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param OrderInterface $order
+     * @param string $state
+     *
+     * @return PaymentInterface[]
+     */
+    private function getPaymentsWithState(OrderInterface $order, $state)
+    {
+        return $order->getPayments()->filter(function (PaymentInterface $payment) use ($state) {
+            return $state === $payment->getState();
+        });
+    }
+}

--- a/src/Sylius/Component/Core/spec/StateResolver/PaymentTargetTransitionResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/StateResolver/PaymentTargetTransitionResolverSpec.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Core\StateResolver;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\OrderPaymentTransitions;
+use Sylius\Component\Core\StateResolver\PaymentTargetTransitionResolver;
+use Sylius\Component\Order\StateResolver\TargetTransitionResolverInterface;
+
+/**
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
+ */
+final class PaymentTargetTransitionResolverSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PaymentTargetTransitionResolver::class);
+    }
+
+    function it_implements_an_order_state_resolver_interface()
+    {
+        $this->shouldImplement(TargetTransitionResolverInterface::class);
+    }
+
+    function it_resolves_refunded_if_all_its_payments_are_refunded(
+        OrderInterface $order,
+        PaymentInterface $firstPayment,
+        PaymentInterface $secondPayment
+    ) {
+        $firstPayment->getAmount()->willReturn(6000);
+        $firstPayment->getState()->willReturn(PaymentInterface::STATE_REFUNDED);
+        $secondPayment->getAmount()->willReturn(4000);
+        $secondPayment->getState()->willReturn(PaymentInterface::STATE_REFUNDED);
+
+        $order
+            ->getPayments()
+            ->willReturn(new ArrayCollection([$firstPayment->getWrappedObject(), $secondPayment->getWrappedObject()]))
+        ;
+        $order->getTotal()->willReturn(10000);
+
+        $this->resolve($order)->shouldReturn(OrderPaymentTransitions::TRANSITION_REFUND);
+    }
+
+    function it_resolves_refunded_if_its_payments_are_refunded_or_failed_but_at_least_one_is_refunded(
+        OrderInterface $order,
+        PaymentInterface $firstPayment,
+        PaymentInterface $secondPayment
+    ) {
+        $firstPayment->getAmount()->willReturn(10000);
+        $firstPayment->getState()->willReturn(PaymentInterface::STATE_FAILED);
+        $secondPayment->getAmount()->willReturn(10000);
+        $secondPayment->getState()->willReturn(PaymentInterface::STATE_REFUNDED);
+
+        $order
+            ->getPayments()
+            ->willReturn(new ArrayCollection([$firstPayment->getWrappedObject(), $secondPayment->getWrappedObject()]))
+        ;
+
+        $order->getTotal()->willReturn(10000);
+
+        $this->resolve($order)->shouldReturn(OrderPaymentTransitions::TRANSITION_REFUND);
+    }
+
+    function it_resolves_paid_if_fully_paid(
+        OrderInterface $order,
+        PaymentInterface $payment
+    ) {
+        $payment->getAmount()->willReturn(10000);
+        $payment->getState()->willReturn(PaymentInterface::STATE_COMPLETED);
+
+        $payments = new ArrayCollection([$payment->getWrappedObject()]);
+
+        $order->getPayments()->willReturn($payments);
+        $order->getTotal()->willReturn(10000);
+
+        $this->resolve($order)->shouldReturn(OrderPaymentTransitions::TRANSITION_PAY);
+    }
+
+    function it_resolves_paid_if_fully_paid_even_if_previous_payment_was_failed(
+        OrderInterface $order,
+        PaymentInterface $firstPayment,
+        PaymentInterface $secondPayment
+    ) {
+        $firstPayment->getAmount()->willReturn(10000);
+        $firstPayment->getState()->willReturn(PaymentInterface::STATE_FAILED);
+        $secondPayment->getAmount()->willReturn(10000);
+        $secondPayment->getState()->willReturn(PaymentInterface::STATE_COMPLETED);
+
+        $payments = new ArrayCollection([$firstPayment->getWrappedObject(), $secondPayment->getWrappedObject()]);
+
+        $order->getPayments()->willReturn($payments);
+        $order->getTotal()->willReturn(10000);
+
+        $this->resolve($order)->shouldReturn(OrderPaymentTransitions::TRANSITION_PAY);
+    }
+
+    function it_resolves_partially_refunded_if_one_of_the_payment_is_completed(
+        OrderInterface $order,
+        PaymentInterface $firstPayment,
+        PaymentInterface $secondPayment
+    ) {
+        $firstPayment->getAmount()->willReturn(6000);
+        $firstPayment->getState()->willReturn(PaymentInterface::STATE_COMPLETED);
+        $secondPayment->getAmount()->willReturn(4000);
+        $secondPayment->getState()->willReturn(PaymentInterface::STATE_REFUNDED);
+
+        $order
+            ->getPayments()
+            ->willReturn(new ArrayCollection([$firstPayment->getWrappedObject(), $secondPayment->getWrappedObject()]))
+        ;
+        $order->getTotal()->willReturn(10000);
+
+        $this->resolve($order)->shouldReturn(OrderPaymentTransitions::TRANSITION_PARTIALLY_REFUND);
+    }
+
+    function it_resolves_completed_if_fully_paid_multiple_payments(
+        OrderInterface $order,
+        PaymentInterface $firstPayment,
+        PaymentInterface $secondPayment
+    ) {
+        $firstPayment->getAmount()->willReturn(6000);
+        $firstPayment->getState()->willReturn(PaymentInterface::STATE_COMPLETED);
+        $secondPayment->getAmount()->willReturn(4000);
+        $secondPayment->getState()->willReturn(PaymentInterface::STATE_COMPLETED);
+
+        $order
+            ->getPayments()
+            ->willReturn(new ArrayCollection([$firstPayment->getWrappedObject(), $secondPayment->getWrappedObject()]))
+        ;
+        $order->getTotal()->willReturn(10000);
+
+        $this->resolve($order)->shouldReturn(OrderPaymentTransitions::TRANSITION_PAY);
+    }
+
+    function it_resolves_partially_paid_if_one_of_the_payment_is_processing(
+        OrderInterface $order,
+        PaymentInterface $firstPayment,
+        PaymentInterface $secondPayment
+    ) {
+        $firstPayment->getAmount()->willReturn(6000);
+        $firstPayment->getState()->willReturn(PaymentInterface::STATE_PROCESSING);
+        $secondPayment->getAmount()->willReturn(4000);
+        $secondPayment->getState()->willReturn(PaymentInterface::STATE_COMPLETED);
+
+        $order
+            ->getPayments()
+            ->willReturn(new ArrayCollection([$firstPayment->getWrappedObject(), $secondPayment->getWrappedObject()]))
+        ;
+        $order->getTotal()->willReturn(10000);
+
+        $this->resolve($order)->shouldReturn(OrderPaymentTransitions::TRANSITION_PARTIALLY_PAY);
+    }
+}

--- a/src/Sylius/Component/Order/StateResolver/TargetTransitionResolverInterface.php
+++ b/src/Sylius/Component/Order/StateResolver/TargetTransitionResolverInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Order\StateResolver;
+
+use Sylius\Component\Order\Model\OrderInterface;
+
+/**
+ * @author Paweł Jędrzejewski <pawel@sylius.org>
+ */
+interface TargetTransitionResolverInterface
+{
+    /**
+     * @param OrderInterface $order
+     */
+    public function resolve(OrderInterface $order);
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #7137  |
| License         | MIT |

The only question is should we introduce same concept for [shipping](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Component/Core/StateResolver/OrderShippingStateResolver.php#L53-L59) and [order](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Component/Core/StateResolver/OrderStateResolver.php#L56-L62) state resolvers? 