### PR TITLE
[Resource] Allow to inject IdentityTranslator to flash helper

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/FlashHelper.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/FlashHelper.php
@@ -15,6 +15,7 @@ use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -28,7 +29,7 @@ final class FlashHelper implements FlashHelperInterface
     private $session;
 
     /**
-     * @var TranslatorBagInterface
+     * @var TranslatorInterface
      */
     private $translator;
 
@@ -39,10 +40,10 @@ final class FlashHelper implements FlashHelperInterface
 
     /**
      * @param SessionInterface $session
-     * @param TranslatorBagInterface $translator
+     * @param TranslatorInterface $translator
      * @param string $defaultLocale
      */
-    public function __construct(SessionInterface $session, TranslatorBagInterface $translator, $defaultLocale)
+    public function __construct(SessionInterface $session, TranslatorInterface $translator, $defaultLocale)
     {
         $this->session = $session;
         $this->translator = $translator;
@@ -129,8 +130,12 @@ final class FlashHelper implements FlashHelperInterface
      */
     private function isTranslationDefined($message, $locale)
     {
-        $defaultCatalogue = $this->translator->getCatalogue($locale);
+        if ($this->translator instanceof TranslatorBagInterface) {
+            $defaultCatalogue = $this->translator->getCatalogue($locale);
 
-        return $defaultCatalogue->has($message, 'flashes');
+            return $defaultCatalogue->has($message, 'flashes');
+        }
+
+        return false;
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/FlashHelperSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/FlashHelperSpec.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -30,7 +31,7 @@ use Symfony\Component\Translation\TranslatorBagInterface;
  */
 final class FlashHelperSpec extends ObjectBehavior
 {
-    function let(SessionInterface $session, TranslatorBagInterface $translator)
+    function let(SessionInterface $session, TranslatorInterface $translator)
     {
         $this->beConstructedWith($session, $translator, 'en');
     }
@@ -62,6 +63,37 @@ final class FlashHelperSpec extends ObjectBehavior
 
         $translator->getCatalogue('en')->willReturn($messageCatalogue);
 
+        $session->getBag('flashes')->willReturn($flashBag);
+        $flashBag->add(
+            'success',
+            [
+                'message' => 'sylius.resource.create',
+                'parameters' => ['%resource%' => 'Product'],
+            ]
+        )->shouldBeCalled();
+
+        $this->addSuccessFlash($requestConfiguration, ResourceActions::CREATE, $resource);
+    }
+
+    function it_adds_resource_message_flash_bag_is_not_available(
+        SessionInterface $session,
+        TranslatorBagInterface $translator,
+        MessageCatalogueInterface $messageCatalogue,
+        FlashBagInterface $flashBag,
+        MetadataInterface $metadata,
+        RequestConfiguration $requestConfiguration,
+        ResourceInterface $resource
+    ) {
+        $this->beConstructedWith($session, $translator, 'en');
+
+        $metadata->getApplicationName()->willReturn('sylius');
+        $metadata->getHumanizedName()->willReturn('product');
+
+        $requestConfiguration->getMetadata()->willReturn($metadata);
+        $requestConfiguration->getFlashMessage(ResourceActions::CREATE)->willReturn('sylius.product.create');
+
+        $translator->getCatalogue('en')->willReturn($messageCatalogue);
+
         $messageCatalogue->has('sylius.product.create', 'flashes')->willReturn(false);
 
         $session->getBag('flashes')->willReturn($flashBag);
@@ -85,6 +117,8 @@ final class FlashHelperSpec extends ObjectBehavior
         RequestConfiguration $requestConfiguration,
         ResourceInterface $resource
     ) {
+        $this->beConstructedWith($session, $translator, 'en');
+
         $metadata->getApplicationName()->willReturn('sylius');
         $metadata->getHumanizedName()->willReturn('product');
 
@@ -110,6 +144,8 @@ final class FlashHelperSpec extends ObjectBehavior
         RequestConfiguration $requestConfiguration,
         ResourceInterface $resource
     ) {
+        $this->beConstructedWith($session, $translator, 'en');
+
         $metadata->getApplicationName()->willReturn('app');
         $metadata->getHumanizedName()->willReturn('book');
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | |
| License         | MIT |

A default [symfony translator](https://github.com/symfony/translation/blob/master/IdentityTranslator.php#L19) implementation doesn't implement *TranslatorBagInterface* but it is require by FlashHelper. This fix will allow to handle all symfony translator classes 