### PR TITLE
[Ui] Perfect admin menu display

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/sass/main.scss
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/sass/main.scss
@@ -10,6 +10,7 @@
 
 #sidebar {
   font-size: 1.1em;
+  padding-bottom: 30px;
 }
 
 #logo {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | |
| License         | MIT |

It was really annoying in `dev` environment (last menu item covered with debug bar) and also just looks better (more space, more air, more freedom 🐃 ).

Before:
![before](https://cloud.githubusercontent.com/assets/6212718/21430368/4519fb5a-c863-11e6-8446-9a60fc79e64d.png)

After:
![after](https://cloud.githubusercontent.com/assets/6212718/21430375/4c43918e-c863-11e6-9ad3-b85a2d3b23a3.png)
