### PR TITLE
Bump bundle Twig dependencies to match Symfony's TwigBundle and TwigBridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "symfony/swiftmailer-bundle": "^2.4",
         "symfony/symfony": "^3.2",
         "twig/extensions": "^1.4",
-        "twig/twig": "^1.27",
+        "twig/twig": "^1.28",
         "webmozart/assert": "^1.1",
         "white-october/pagerfanta-bundle": "^1.0",
         "willdurand/hateoas-bundle": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b80a29ea39ca7e77c54686c0df8a854",
+    "content-hash": "3b250064e9bf0ea099faf65a3015769c",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -2371,7 +2371,7 @@
                     "email": "stof@notk.org"
                 },
                 {
-                    "name": "Knplabs",
+                    "name": "KnpLabs",
                     "homepage": "http://knplabs.com"
                 },
                 {
@@ -4647,16 +4647,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.28.2",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "b22ce0eb070e41f7cba65d78fe216de29726459c"
+                "reference": "c6ff71094fde15d12398eaba029434b013dc5e59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/b22ce0eb070e41f7cba65d78fe216de29726459c",
-                "reference": "b22ce0eb070e41f7cba65d78fe216de29726459c",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/c6ff71094fde15d12398eaba029434b013dc5e59",
+                "reference": "c6ff71094fde15d12398eaba029434b013dc5e59",
                 "shasum": ""
             },
             "require": {
@@ -4669,7 +4669,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.28-dev"
+                    "dev-master": "1.30-dev"
                 }
             },
             "autoload": {
@@ -4704,7 +4704,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-11-23T18:41:40+00:00"
+            "time": "2016-12-23T11:06:22+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -32,7 +32,7 @@
         "doctrine/orm": "^2.5",
         "phpspec/phpspec": "^3.2",
         "phpunit/phpunit": "^5.6",
-        "twig/twig": "^1.0"
+        "twig/twig": "^1.28"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Sylius/Bundle/ChannelBundle/composer.json
+++ b/src/Sylius/Bundle/ChannelBundle/composer.json
@@ -30,7 +30,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "phpspec/phpspec": "^3.2",
         "phpunit/phpunit": "^5.6",
-        "twig/twig": "^1.0",
+        "twig/twig": "^1.28",
         "doctrine/orm": "^2.5",
         "symfony/form": "^3.2",
         "symfony/browser-kit": "^3.2",

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -31,7 +31,7 @@
         "doctrine/orm": "^2.5",
         "phpspec/phpspec": "^3.2",
         "phpunit/phpunit": "^5.6",
-        "twig/twig": "^1.0",
+        "twig/twig": "^1.28",
         "symfony/form": "^3.2",
         "symfony/browser-kit": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",

--- a/src/Sylius/Bundle/FixturesBundle/composer.json
+++ b/src/Sylius/Bundle/FixturesBundle/composer.json
@@ -36,7 +36,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "phpspec/phpspec": "^3.2",
         "phpunit/phpunit": "^5.6",
-        "twig/twig": "~1.11",
+        "twig/twig": "^1.28",
         "symfony/browser-kit": "^3.2",
         "symfony/templating": "^3.2",
         "symfony/translation": "^3.2",

--- a/src/Sylius/Bundle/GridBundle/composer.json
+++ b/src/Sylius/Bundle/GridBundle/composer.json
@@ -38,7 +38,7 @@
         "pagerfanta/pagerfanta": "^1.0",
         "phpspec/phpspec": "^3.2",
         "phpunit/phpunit": "^5.6",
-        "twig/twig": "^1.11",
+        "twig/twig": "^1.28",
         "symfony/browser-kit": "^3.2",
         "symfony/twig-bundle": "^3.2",
         "symfony/validator": "^3.2",

--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -32,7 +32,7 @@
         "doctrine/orm": "^2.5",
         "phpspec/phpspec": "^3.2",
         "phpunit/phpunit": "^5.6",
-        "twig/twig": "^1.0",
+        "twig/twig": "^1.28",
         "symfony/browser-kit": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0"

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -31,7 +31,7 @@
         "doctrine/orm": "^2.5",
         "phpspec/phpspec": "^3.2",
         "phpunit/phpunit": "^5.6",
-        "twig/twig": "^1.0",
+        "twig/twig": "^1.28",
         "ocramius/proxy-manager": "^2.0",
         "symfony/browser-kit": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",

--- a/src/Sylius/Bundle/MailerBundle/composer.json
+++ b/src/Sylius/Bundle/MailerBundle/composer.json
@@ -38,7 +38,7 @@
         "symfony/translation": "^3.2",
         "symfony/twig-bundle": "^3.2",
         "swiftmailer/swiftmailer": "^5.4",
-        "twig/twig": "^1.0",
+        "twig/twig": "^1.28",
         "incenteev/composer-parameter-handler": "~2.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0"
     },

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -32,7 +32,7 @@
         "doctrine/orm": "^2.5",
         "phpspec/phpspec": "^3.2",
         "phpunit/phpunit": "^5.6",
-        "twig/twig": "^1.0",
+        "twig/twig": "^1.28",
         "sylius/currency-bundle": "^1.0",
         "symfony/form": "^3.2",
         "symfony/browser-kit": "^3.2",

--- a/src/Sylius/Bundle/ResourceBundle/composer.json
+++ b/src/Sylius/Bundle/ResourceBundle/composer.json
@@ -55,7 +55,7 @@
         "sensio/generator-bundle": "^3.1",
         "sylius/grid-bundle": "^1.0",
         "sylius/locale": "^1.0",
-        "twig/twig": "^1.11"
+        "twig/twig": "^1.28"
     },
     "suggest": {
         "doctrine/orm": "^2.5",

--- a/src/Sylius/Bundle/ThemeBundle/composer.json
+++ b/src/Sylius/Bundle/ThemeBundle/composer.json
@@ -34,7 +34,7 @@
         "sylius/registry": "^1.0",
         "doctrine/orm": "^2.5",
         "doctrine/doctrine-bundle": "~1.3",
-        "twig/twig": "~1.11",
+        "twig/twig": "^1.28",
         "symfony/browser-kit": "^3.2",
         "symfony/twig-bundle": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",

--- a/src/Sylius/Bundle/UiBundle/composer.json
+++ b/src/Sylius/Bundle/UiBundle/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "phpspec/phpspec": "^3.2",
         "symfony/form": "^3.2",
-        "twig/twig": "^1.11"
+        "twig/twig": "^1.28"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

Symfony's TwigBundle and TwigBridge require `"twig/twig": "~1.28|~2.0"` as of Symfony 3.2.  This PR updates the Twig dependency for the main app and all bundles to match the 1.x branch requirement.