### PR TITLE
Make Twig runtime services for Twig extension integrations

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/services.xml
@@ -24,6 +24,7 @@
 
         <service id="sylius.province_naming_provider" class="Sylius\Component\Addressing\Provider\ProvinceNamingProvider" lazy="true">
             <argument type="service" id="sylius.repository.province" />
+            <tag name="twig.runtime" />
         </service>
         <service id="sylius.zone_matcher" class="Sylius\Component\Addressing\Matcher\ZoneMatcher">
             <argument type="service" id="sylius.repository.zone" />
@@ -37,8 +38,6 @@
             <tag name="twig.extension"/>
         </service>
         <service id="sylius.twig.extension.province_naming" class="Sylius\Bundle\AddressingBundle\Twig\ProvinceNamingExtension">
-            <argument type="service" id="sylius.province_naming_provider" />
-            <argument type="string" id="provinceCode" />
             <tag name="twig.extension" />
         </service>
 

--- a/src/Sylius/Bundle/AddressingBundle/Twig/ProvinceNamingExtension.php
+++ b/src/Sylius/Bundle/AddressingBundle/Twig/ProvinceNamingExtension.php
@@ -11,8 +11,7 @@
 
 namespace Sylius\Bundle\AddressingBundle\Twig;
 
-use Sylius\Component\Addressing\Model\AddressInterface;
-use Sylius\Component\Addressing\Provider\ProvinceNamingProviderInterface;
+use Sylius\Component\Addressing\Provider\ProvinceNamingProvider;
 
 /**
  * @author Jan Góralski <jan.goralski@lakion.com>
@@ -20,47 +19,14 @@ use Sylius\Component\Addressing\Provider\ProvinceNamingProviderInterface;
 class ProvinceNamingExtension extends \Twig_Extension
 {
     /**
-     * @var ProvinceNamingProviderInterface
-     */
-    private $provinceNamingProvider;
-
-    /**
-     * @param ProvinceNamingProviderInterface $provinceNamingProvider
-     */
-    public function __construct(ProvinceNamingProviderInterface $provinceNamingProvider)
-    {
-        $this->provinceNamingProvider = $provinceNamingProvider;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('sylius_province_name', [$this, 'getProvinceName']),
-            new \Twig_SimpleFilter('sylius_province_abbreviation', [$this, 'getProvinceAbbreviation']),
+            new \Twig_SimpleFilter('sylius_province_name', [ProvinceNamingProvider::class, 'getProvinceName']),
+            new \Twig_SimpleFilter('sylius_province_abbreviation', [ProvinceNamingProvider::class, 'getProvinceAbbreviation']),
         ];
-    }
-
-    /**
-     * @param AddressInterface $address
-     *
-     * @return string
-     */
-    public function getProvinceName(AddressInterface $address)
-    {
-        return $this->provinceNamingProvider->getName($address);
-    }
-
-    /**
-     * @param AddressInterface $address
-     *
-     * @return string
-     */
-    public function getProvinceAbbreviation(AddressInterface $address)
-    {
-        return $this->provinceNamingProvider->getAbbreviation($address);
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -90,11 +90,6 @@
             <argument type="service" id="sylius.calculator.product_variant_price" />
         </service>
 
-        <service id="sylius.twig.extension.product_variants_prices" class="Sylius\Bundle\CoreBundle\Twig\ProductVariantsPricesExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.product_variants_prices" />
-            <tag name="twig.extension" />
-        </service>
-
         <service id="sylius.unique_id_based_order_token_assigner" class="Sylius\Component\Core\TokenAssigner\UniqueIdBasedOrderTokenAssigner" />
 
         <service id="sylius.customer_unique_address_adder" class="Sylius\Component\Core\Customer\CustomerUniqueAddressAdder">

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
@@ -16,25 +16,30 @@
         <service id="sylius.templating.helper.product_variants_prices" class="Sylius\Bundle\CoreBundle\Templating\Helper\ProductVariantsPricesHelper">
             <argument type="service" id="sylius.provider.product_variants_prices" />
             <tag name="templating.helper" alias="sylius_product_variants_prices" />
+            <tag name="twig.runtime" />
+        </service>
+
+        <service id="sylius.twig.extension.product_variants_prices" class="Sylius\Bundle\CoreBundle\Twig\ProductVariantsPricesExtension" public="false">
+            <tag name="twig.extension" />
         </service>
 
         <service id="sylius.templating.helper.price" class="Sylius\Bundle\CoreBundle\Templating\Helper\PriceHelper" lazy="true">
             <argument type="service" id="sylius.calculator.product_variant_price" />
             <tag name="templating.helper" alias="sylius_calculate_price" />
+            <tag name="twig.runtime" />
         </service>
 
         <service id="sylius.twig.extension.price" class="Sylius\Bundle\CoreBundle\Twig\PriceExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.price" />
             <tag name="twig.extension" />
         </service>
 
         <service id="sylius.templating.helper.variant_resolver" class="Sylius\Bundle\CoreBundle\Templating\Helper\VariantResolverHelper">
             <argument type="service" id="sylius.product_variant_resolver.default" />
             <tag name="templating.helper" alias="sylius_resolve_variant" />
+            <tag name="twig.runtime" />
         </service>
 
         <service id="sylius.twig.extension.variant_resolver" class="Sylius\Bundle\CoreBundle\Twig\VariantResolverExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.variant_resolver" />
             <tag name="twig.extension" />
         </service>
     </services>

--- a/src/Sylius/Bundle/CoreBundle/Twig/PriceExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/PriceExtension.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\CoreBundle\Twig;
 
-use Symfony\Component\Templating\Helper\Helper;
+use Sylius\Bundle\CoreBundle\Templating\Helper\PriceHelper;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -19,25 +19,12 @@ use Symfony\Component\Templating\Helper\Helper;
 final class PriceExtension extends \Twig_Extension
 {
     /**
-     * @var Helper
-     */
-    private $helper;
-
-    /**
-     * @param Helper $helper
-     */
-    public function __construct(Helper $helper)
-    {
-        $this->helper = $helper;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('sylius_calculate_price', [$this->helper, 'getPrice']),
+            new \Twig_SimpleFilter('sylius_calculate_price', [PriceHelper::class, 'getPrice']),
         ];
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Twig/ProductVariantsPricesExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/ProductVariantsPricesExtension.php
@@ -19,25 +19,12 @@ use Sylius\Bundle\CoreBundle\Templating\Helper\ProductVariantsPricesHelper;
 final class ProductVariantsPricesExtension extends \Twig_Extension
 {
     /**
-     * @var ProductVariantsPricesHelper
-     */
-    private $productVariantsPricesHelper;
-
-    /**
-     * @param ProductVariantsPricesHelper $productVariantsPricesHelper
-     */
-    public function __construct(ProductVariantsPricesHelper $productVariantsPricesHelper)
-    {
-        $this->productVariantsPricesHelper = $productVariantsPricesHelper;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sylius_product_variant_prices', [$this->productVariantsPricesHelper, 'getPrices']),
+            new \Twig_SimpleFunction('sylius_product_variant_prices', [ProductVariantsPricesHelper::class, 'getPrices']),
         ];
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Twig/VariantResolverExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/VariantResolverExtension.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\CoreBundle\Twig;
 
-use Symfony\Component\Templating\Helper\Helper;
+use Sylius\Bundle\CoreBundle\Templating\Helper\VariantResolverHelper;
 
 /**
  * @author Jan Góralski <jan.goralski@lakion.com>
@@ -19,25 +19,12 @@ use Symfony\Component\Templating\Helper\Helper;
 final class VariantResolverExtension extends \Twig_Extension
 {
     /**
-     * @var Helper
-     */
-    private $helper;
-
-    /**
-     * @param Helper $helper
-     */
-    public function __construct(Helper $helper)
-    {
-        $this->helper = $helper;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('sylius_resolve_variant', [$this->helper, 'resolveVariant']),
+            new \Twig_SimpleFilter('sylius_resolve_variant', [VariantResolverHelper::class, 'resolveVariant']),
         ];
     }
 

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/services.xml
@@ -32,10 +32,10 @@
 
         <service id="sylius.templating.helper.currency" class="Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelper" lazy="true">
             <tag name="templating.helper" alias="sylius_currency" />
+            <tag name="twig.runtime" />
         </service>
 
         <service id="sylius.twig.extension.currency" class="Sylius\Bundle\CurrencyBundle\Twig\CurrencyExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.currency" />
             <tag name="twig.extension" />
         </service>
 

--- a/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\CurrencyBundle\Twig;
 
-use Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelperInterface;
+use Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelper;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -19,25 +19,12 @@ use Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelperInterface;
 final class CurrencyExtension extends \Twig_Extension
 {
     /**
-     * @var CurrencyHelperInterface
-     */
-    private $helper;
-
-    /**
-     * @param CurrencyHelperInterface $helper
-     */
-    public function __construct(CurrencyHelperInterface $helper)
-    {
-        $this->helper = $helper;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('sylius_currency_symbol', [$this->helper, 'convertCurrencyCodeToSymbol']),
+            new \Twig_SimpleFilter('sylius_currency_symbol', [CurrencyHelper::class, 'convertCurrencyCodeToSymbol']),
         ];
     }
 

--- a/src/Sylius/Bundle/GridBundle/Resources/config/services/templating.xml
+++ b/src/Sylius/Bundle/GridBundle/Resources/config/services/templating.xml
@@ -16,6 +16,7 @@
         <service id="sylius.templating.helper.grid" class="Sylius\Bundle\GridBundle\Templating\Helper\GridHelper" lazy="true">
             <argument type="service" id="sylius.grid.renderer" />
             <tag name="templating.helper" alias="sylius_grid" />
+            <tag name="twig.runtime" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/GridBundle/Resources/config/services/twig.xml
+++ b/src/Sylius/Bundle/GridBundle/Resources/config/services/twig.xml
@@ -23,7 +23,6 @@
             <argument>%sylius.grid.templates.filter%</argument>
         </service>
         <service id="sylius.twig.extension.grid" class="Sylius\Bundle\GridBundle\Twig\GridExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.grid" />
             <tag name="twig.extension" />
         </service>
     </services>

--- a/src/Sylius/Bundle/GridBundle/Twig/GridExtension.php
+++ b/src/Sylius/Bundle/GridBundle/Twig/GridExtension.php
@@ -19,28 +19,15 @@ use Sylius\Bundle\GridBundle\Templating\Helper\GridHelper;
 final class GridExtension extends \Twig_Extension
 {
     /**
-     * @var GridHelper
-     */
-    private $gridHelper;
-
-    /**
-     * @param GridHelper $gridHelper
-     */
-    public function __construct(GridHelper $gridHelper)
-    {
-        $this->gridHelper = $gridHelper;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sylius_grid_render', [$this->gridHelper, 'renderGrid'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFunction('sylius_grid_render_field', [$this->gridHelper, 'renderField'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFunction('sylius_grid_render_action', [$this->gridHelper, 'renderAction'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFunction('sylius_grid_render_filter', [$this->gridHelper, 'renderFilter'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFunction('sylius_grid_render', [GridHelper::class, 'renderGrid'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFunction('sylius_grid_render_field', [GridHelper::class, 'renderField'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFunction('sylius_grid_render_action', [GridHelper::class, 'renderAction'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFunction('sylius_grid_render_filter', [GridHelper::class, 'renderFilter'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/InventoryBundle/Resources/config/services.xml
@@ -23,10 +23,10 @@
         <service id="sylius.templating.helper.inventory" class="Sylius\Bundle\InventoryBundle\Templating\Helper\InventoryHelper">
             <argument type="service" id="sylius.availability_checker" />
             <tag name="templating.helper" alias="sylius_inventory" />
+            <tag name="twig.runtime" />
         </service>
 
         <service id="sylius.twig.extension.inventory" class="Sylius\Bundle\InventoryBundle\Twig\InventoryExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.inventory" />
             <tag name="twig.extension" />
         </service>
     </services>

--- a/src/Sylius/Bundle/InventoryBundle/Twig/InventoryExtension.php
+++ b/src/Sylius/Bundle/InventoryBundle/Twig/InventoryExtension.php
@@ -19,26 +19,13 @@ use Sylius\Bundle\InventoryBundle\Templating\Helper\InventoryHelper;
 final class InventoryExtension extends \Twig_Extension
 {
     /**
-     * @var InventoryHelper
-     */
-    private $helper;
-
-    /**
-     * @param InventoryHelper $helper
-     */
-    public function __construct(InventoryHelper $helper)
-    {
-        $this->helper = $helper;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getFunctions()
     {
         return [
-             new \Twig_SimpleFunction('sylius_inventory_is_available', [$this->helper, 'isStockAvailable']),
-             new \Twig_SimpleFunction('sylius_inventory_is_sufficient', [$this->helper, 'isStockSufficient']),
+             new \Twig_SimpleFunction('sylius_inventory_is_available', [InventoryHelper::class, 'isStockAvailable']),
+             new \Twig_SimpleFunction('sylius_inventory_is_sufficient', [InventoryHelper::class, 'isStockSufficient']),
         ];
     }
 

--- a/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
@@ -46,10 +46,10 @@
         <service id="sylius.templating.helper.locale" class="Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelper">
             <argument type="service" id="sylius.locale_converter" />
             <tag name="templating.helper" alias="sylius_locale" />
+            <tag name="twig.runtime" />
         </service>
 
         <service id="sylius.twig.extension.locale" class="Sylius\Bundle\LocaleBundle\Twig\LocaleExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.locale" />
             <tag name="twig.extension" />
         </service>
     </services>

--- a/src/Sylius/Bundle/LocaleBundle/Twig/LocaleExtension.php
+++ b/src/Sylius/Bundle/LocaleBundle/Twig/LocaleExtension.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\LocaleBundle\Twig;
 
-use Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelperInterface;
+use Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelper;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -20,25 +20,12 @@ use Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelperInterface;
 final class LocaleExtension extends \Twig_Extension
 {
     /**
-     * @var LocaleHelperInterface
-     */
-    private $localeHelper;
-
-    /**
-     * @param LocaleHelperInterface $localeHelper
-     */
-    public function __construct(LocaleHelperInterface $localeHelper)
-    {
-        $this->localeHelper = $localeHelper;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('sylius_locale_name', [$this->localeHelper, 'convertCodeToName']),
+            new \Twig_SimpleFilter('sylius_locale_name', [LocaleHelper::class, 'convertCodeToName']),
         ];
     }
 

--- a/src/Sylius/Bundle/MoneyBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/MoneyBundle/Resources/config/services.xml
@@ -22,10 +22,10 @@
         <service id="sylius.templating.helper.format_money" class="Sylius\Bundle\MoneyBundle\Templating\Helper\FormatMoneyHelper" lazy="true">
             <argument type="service" id="sylius.money_formatter" />
             <tag name="templating.helper" alias="sylius_format_money" />
+            <tag name="twig.runtime" />
         </service>
 
         <service id="sylius.twig.extension.money" class="Sylius\Bundle\MoneyBundle\Twig\FormatMoneyExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.format_money" />
             <tag name="twig.extension" />
         </service>
     </services>

--- a/src/Sylius/Bundle/MoneyBundle/Resources/config/services/integrations/currency.xml
+++ b/src/Sylius/Bundle/MoneyBundle/Resources/config/services/integrations/currency.xml
@@ -16,10 +16,10 @@
         <service id="sylius.templating.helper.convert_money" class="Sylius\Bundle\MoneyBundle\Templating\Helper\ConvertMoneyHelper" lazy="true">
             <argument type="service" id="sylius.currency_converter" />
             <tag name="templating.helper" alias="sylius_convert_money" />
+            <tag name="twig.runtime" />
         </service>
 
         <service id="sylius.twig.extension.convert_amount" class="Sylius\Bundle\MoneyBundle\Twig\ConvertMoneyExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.convert_money" />
             <tag name="twig.extension" />
         </service>
     </services>

--- a/src/Sylius/Bundle/MoneyBundle/Twig/ConvertMoneyExtension.php
+++ b/src/Sylius/Bundle/MoneyBundle/Twig/ConvertMoneyExtension.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\MoneyBundle\Twig;
 
-use Sylius\Bundle\MoneyBundle\Templating\Helper\ConvertMoneyHelperInterface;
+use Sylius\Bundle\MoneyBundle\Templating\Helper\ConvertMoneyHelper;
 
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
@@ -19,25 +19,12 @@ use Sylius\Bundle\MoneyBundle\Templating\Helper\ConvertMoneyHelperInterface;
 final class ConvertMoneyExtension extends \Twig_Extension
 {
     /**
-     * @var ConvertMoneyHelperInterface
-     */
-    private $helper;
-
-    /**
-     * @param ConvertMoneyHelperInterface $helper
-     */
-    public function __construct(ConvertMoneyHelperInterface $helper)
-    {
-        $this->helper = $helper;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('sylius_convert_money', [$this->helper, 'convertAmount']),
+            new \Twig_SimpleFilter('sylius_convert_money', [ConvertMoneyHelper::class, 'convertAmount']),
         ];
     }
 

--- a/src/Sylius/Bundle/MoneyBundle/Twig/FormatMoneyExtension.php
+++ b/src/Sylius/Bundle/MoneyBundle/Twig/FormatMoneyExtension.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\MoneyBundle\Twig;
 
-use Sylius\Bundle\MoneyBundle\Templating\Helper\FormatMoneyHelperInterface;
+use Sylius\Bundle\MoneyBundle\Templating\Helper\FormatMoneyHelper;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -19,25 +19,12 @@ use Sylius\Bundle\MoneyBundle\Templating\Helper\FormatMoneyHelperInterface;
 final class FormatMoneyExtension extends \Twig_Extension
 {
     /**
-     * @var FormatMoneyHelperInterface
-     */
-    private $helper;
-
-    /**
-     * @param FormatMoneyHelperInterface $helper
-     */
-    public function __construct(FormatMoneyHelperInterface $helper)
-    {
-        $this->helper = $helper;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('sylius_format_money', [$this->helper, 'formatAmount']),
+            new \Twig_SimpleFilter('sylius_format_money', [FormatMoneyHelper::class, 'formatAmount']),
         ];
     }
 

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services/templating.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services/templating.xml
@@ -16,6 +16,7 @@
         <service id="sylius.templating.helper.adjustment" class="Sylius\Bundle\OrderBundle\Templating\Helper\AdjustmentsHelper">
             <argument type="service" id="sylius.adjustments_aggregator" />
             <tag name="templating.helper" alias="sylius_adjustments" />
+            <tag name="twig.runtime" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services/twig.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services/twig.xml
@@ -14,7 +14,6 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sylius.twig.extension.aggregate_adjustments" class="Sylius\Bundle\OrderBundle\Twig\AggregateAdjustmentsExtension" public="false">
-            <argument type="service" id="sylius.templating.helper.adjustment" />
             <tag name="twig.extension" />
         </service>
     </services>

--- a/src/Sylius/Bundle/OrderBundle/Twig/AggregateAdjustmentsExtension.php
+++ b/src/Sylius/Bundle/OrderBundle/Twig/AggregateAdjustmentsExtension.php
@@ -19,36 +19,13 @@ use Sylius\Bundle\OrderBundle\Templating\Helper\AdjustmentsHelper;
 final class AggregateAdjustmentsExtension extends \Twig_Extension
 {
     /**
-     * @var AdjustmentsHelper
-     */
-    private $adjustmentsHelper;
-
-    /**
-     * @param AdjustmentsHelper $adjustmentsHelper
-     */
-    public function __construct(AdjustmentsHelper $adjustmentsHelper)
-    {
-        $this->adjustmentsHelper = $adjustmentsHelper;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('sylius_aggregate_adjustments', [$this, 'aggregateAdjustments']),
+            new \Twig_SimpleFunction('sylius_aggregate_adjustments', [AdjustmentsHelper::class, 'aggregateAdjustments']),
         ];
-    }
-
-    /**
-     * @param array $adjustments
-     *
-     * @return array
-     */
-    public function aggregateAdjustments(array $adjustments)
-    {
-        return $this->adjustmentsHelper->getAggregatedAdjustments($adjustments);
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

Note: This would depend on #7165 being merged first to define the correct minimum Twig dependency

Twig 1.26 and Symfony 3.2 introduced support for a "Twig runtime", essentially creating an ability to split up the code defining Twig integrations (functions, filters, etc.) from the runtime code executed by calling those items in Twig layouts.  This PR does that here.

Admittedly, this could be hit or miss.  On the one hand, it seems like the main thing this does is to defer when the integrations are needed to when they are actually needed (so a cache warmup wouldn't need the services a Twig extension depends on to simply compile the cached templates, those won't be called/loaded until a template is rendered calling a filter/function/etc. using those services).  On the other hand, it more closely couples a Twig extension with the services it provides, though it could also be argued that Twig extensions really start getting into implementation details and are less designed for an inheritable structure (the fact most of the extension classes here are final supports that, though one could still use Symfony compiler passes to change a service's class).