### PR TITLE
[Resource] Add possibility to sort not paginated and not limited resources

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourcesResolver.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourcesResolver.php
@@ -31,7 +31,7 @@ final class ResourcesResolver implements ResourcesResolverInterface
         }
 
         if (!$requestConfiguration->isPaginated() && !$requestConfiguration->isLimited()) {
-            return $repository->findAll();
+            return $repository->findBy([], $requestConfiguration->getSorting());
         }
 
         if (!$requestConfiguration->isPaginated()) {

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourcesResolverSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourcesResolverSpec.php
@@ -45,8 +45,9 @@ final class ResourcesResolverSpec extends ObjectBehavior
 
         $requestConfiguration->isPaginated()->willReturn(false);
         $requestConfiguration->isLimited()->willReturn(false);
+        $requestConfiguration->getSorting()->willReturn([]);
 
-        $repository->findAll()->willReturn([$firstResource, $secondResource]);
+        $repository->findBy([], [])->willReturn([$firstResource, $secondResource]);
 
         $this->getResources($requestConfiguration, $repository)->shouldReturn([$firstResource, $secondResource]);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | yes |
| BC breaks?      | no  |
| Related tickets | partially https://github.com/Sylius/Sylius/issues/4072 |
| License         | MIT |

If routing configuration was
```yml
paginate: false
limit: false
```
listed resources was not sorted, even if ``sorting`` attribute was set correctly.