### PR TITLE
Implement Twig_SourceContextLoaderInterface

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Twig/ThemeFilesystemLoader.php
+++ b/src/Sylius/Bundle/ThemeBundle/Twig/ThemeFilesystemLoader.php
@@ -18,7 +18,7 @@ use Symfony\Component\Templating\TemplateReferenceInterface;
 /**
  * @author Kamil Kokot <kamil.kokot@lakion.com>
  */
-final class ThemeFilesystemLoader implements \Twig_LoaderInterface, \Twig_ExistsLoaderInterface
+final class ThemeFilesystemLoader implements \Twig_LoaderInterface, \Twig_ExistsLoaderInterface, \Twig_SourceContextLoaderInterface
 {
     /**
      * @var \Twig_LoaderInterface
@@ -57,6 +57,8 @@ final class ThemeFilesystemLoader implements \Twig_LoaderInterface, \Twig_Exists
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated To be removed when Twig 1.x compatibility is dropped
      */
     public function getSource($name)
     {
@@ -64,6 +66,24 @@ final class ThemeFilesystemLoader implements \Twig_LoaderInterface, \Twig_Exists
             return file_get_contents($this->findTemplate($name));
         } catch (\Exception $exception) {
             return $this->decoratedLoader->getSource($name);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSourceContext($name)
+    {
+        try {
+            $path = $this->findTemplate($name);
+
+            return new \Twig_Source(file_get_contents($path), $name, $path);
+        } catch (\Exception $exception) {
+            if ($this->decoratedLoader instanceof \Twig_SourceContextLoaderInterface) {
+                return $this->decoratedLoader->getSourceContext($name);
+            }
+
+            throw new \Twig_Error_Loader($exception->getMessage(), -1, null, $exception);
         }
     }
 

--- a/src/Sylius/Bundle/ThemeBundle/Twig/ThemeFilesystemLoader.php
+++ b/src/Sylius/Bundle/ThemeBundle/Twig/ThemeFilesystemLoader.php
@@ -79,7 +79,8 @@ final class ThemeFilesystemLoader implements \Twig_LoaderInterface, \Twig_Exists
 
             return new \Twig_Source(file_get_contents($path), $name, $path);
         } catch (\Exception $exception) {
-            if ($this->decoratedLoader instanceof \Twig_SourceContextLoaderInterface) {
+            // In Twig 2.0, getSourceContext is part of \Twig_LoaderInterface
+            if ($this->decoratedLoader instanceof \Twig_SourceContextLoaderInterface || method_exists('\\Twig_LoaderInterface', 'getSourceContext')) {
                 return $this->decoratedLoader->getSourceContext($name);
             }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

Since Twig 1.27, a `Twig_LoaderInterface` implementation should also implement `Twig_SourceContextLoaderInterface` as the `getSource()` method is deprecated.  This PR implements the new interface and method.

This also introduces forward compatibility with Twig 2.0.  The `getSourceContext()` method is moved to `Twig_LoaderInterface` and `Twig_SourceContextLoaderInterface` deprecated.  So appropriate checks are made in the Exception handling block of the new method before throwing a `Twig_Error_Loader` as defined by the interface in an error state.