### PR TITLE
[Shop] Made lang attribute W3C standard compliant

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="{{ app.request.locale }}">
+<html lang="{{ app.request.locale|slice(0, 2) }}">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

The language specified in the lang attribute has to follow the ISO 639-1 standard (http://www.w3schools.com/tags/ref_language_codes.asp), i.e. let's use the first two characters of our lang attribute which may be up to five characters long (ISO 639-1 + '_' + ISO 3166-1 alpha-2, e.g. sv_SE)