### PR TITLE
[Attribute] Add Json storage type for custom attributes

### DIFF
--- a/app/migrations/Version20170103120334.php
+++ b/app/migrations/Version20170103120334.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170103120334 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_product_attribute_value ADD json_value LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:json_array)\'');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_product_attribute_value DROP json_value');
+    }
+}

--- a/src/Sylius/Bundle/AttributeBundle/Resources/config/doctrine/model/AttributeValue.orm.xml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/config/doctrine/model/AttributeValue.orm.xml
@@ -27,6 +27,7 @@
         <field name="float" column="float_value" type="float" nullable="true" />
         <field name="datetime" column="datetime_value" type="datetime" nullable="true" />
         <field name="date" column="date_value" type="date" nullable="true" />
+        <field name="json" column="json_value" type="json_array" nullable="true" />
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Component/Attribute/Model/AttributeValue.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeValue.php
@@ -63,6 +63,11 @@ class AttributeValue implements AttributeValueInterface
     private $date;
 
     /**
+     * @var array
+     */
+    private $json;
+
+    /**
      * {@inheritdoc}
      */
     public function getId()
@@ -252,6 +257,22 @@ class AttributeValue implements AttributeValueInterface
     protected function setDate(\DateTime $date)
     {
         $this->date = $date;
+    }
+
+    /**
+     * @return array
+     */
+    public function getJson()
+    {
+        return $this->json;
+    }
+
+    /**
+     * @param array $json
+     */
+    public function setJson(array $json)
+    {
+        $this->json = $json;
     }
 
     /**

--- a/src/Sylius/Component/Attribute/Model/AttributeValueInterface.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeValueInterface.php
@@ -18,12 +18,13 @@ use Sylius\Component\Resource\Model\ResourceInterface;
  */
 interface AttributeValueInterface extends ResourceInterface
 {
-    const STORAGE_TEXT = 'text';
     const STORAGE_BOOLEAN = 'boolean';
     const STORAGE_DATE = 'date';
     const STORAGE_DATETIME = 'datetime';
-    const STORAGE_INTEGER = 'integer';
     const STORAGE_FLOAT = 'float';
+    const STORAGE_INTEGER = 'integer';
+    const STORAGE_JSON = 'json';
+    const STORAGE_TEXT = 'text';
 
     /**
      * @return AttributeSubjectInterface


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | |
| License         | MIT |

As **json** storage type is not currently used by any existing attribute, it could be immensely useful for more sophisticated custom attributes.