### PR TITLE
Fixed some Product model methods requirements

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -84,6 +84,7 @@ After:
 
 * `ProductVariant::$name` property (and corresponding getter and setter) was removed to make it translatable. Therefore, `ProductVariantTranslation` was introduced with one `$name` property. All product variants names are migrated to new concept with migration `Version2016121415313`. Look at [this PR](https://github.com/Sylius/Sylius/pull/7091) if you have any problems with upgrade.
 * `ProductAssociationType::$name` property (and corresponding getter and setter) was removed to make it translatable. Therefore, `ProductAssociationTypeTranslation` was introduced with one `$name` property. All product association types names are migrated to new concept with migration `Version20161219160441`. Look at [this PR](https://github.com/Sylius/Sylius/pull/7134) if you have any problems with upgrade.
+* `Product::addAttribute()`, `Product::removeAttribute()`, `Product::hasAttribute()` now require `Sylius\Component\Product\Model\ProductAttributeValueInterface` instead of `Sylius\Component\Attribute\Model\AttributeValueInterface`. Nothing changed on the ORM point of view as its config was already using the right interface. Look at [this PR](https://github.com/Sylius/Sylius/pull/7196) for details.
 
 ### Promotion / PromotionBundle
 

--- a/src/Sylius/Component/Product/Model/Product.php
+++ b/src/Sylius/Component/Product/Model/Product.php
@@ -13,7 +13,6 @@ namespace Sylius\Component\Product\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Sylius\Component\Attribute\Model\AttributeValueInterface;
 use Sylius\Component\Resource\Model\TimestampableTrait;
 use Sylius\Component\Resource\Model\ToggleableTrait;
 use Sylius\Component\Resource\Model\TranslatableTrait;
@@ -51,7 +50,7 @@ class Product implements ProductInterface
     protected $availableUntil;
 
     /**
-     * @var Collection|AttributeValueInterface[]
+     * @var Collection|ProductAttributeValueInterface[]
      */
     protected $attributes;
 
@@ -245,7 +244,7 @@ class Product implements ProductInterface
     /**
      * {@inheritdoc}
      */
-    public function addAttribute(AttributeValueInterface $attribute)
+    public function addAttribute(ProductAttributeValueInterface $attribute)
     {
         if (!$this->hasAttribute($attribute)) {
             $attribute->setProduct($this);
@@ -256,7 +255,7 @@ class Product implements ProductInterface
     /**
      * {@inheritdoc}
      */
-    public function removeAttribute(AttributeValueInterface $attribute)
+    public function removeAttribute(ProductAttributeValueInterface $attribute)
     {
         if ($this->hasAttribute($attribute)) {
             $this->attributes->removeElement($attribute);
@@ -267,7 +266,7 @@ class Product implements ProductInterface
     /**
      * {@inheritdoc}
      */
-    public function hasAttribute(AttributeValueInterface $attribute)
+    public function hasAttribute(ProductAttributeValueInterface $attribute)
     {
         return $this->attributes->contains($attribute);
     }


### PR DESCRIPTION
In Product model, methods interacting with Attributes require Sylius\Component\Attribute\Model\AttributeValueInterface, instead of Sylius\Component\Product\Model\ProductAttributeValueInterface, which exists just for that and is the one used [by the ORM config](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Product.orm.xml#L27) and [by the tests](https://github.com/Sylius/Sylius/blob/570d66b1b064fc92d6dd115486077f13b3a14195/src/Sylius/Component/Product/spec/Model/ProductSpec.php#L123-L142).


| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #7189 |
| License         | MIT |
