### PR TITLE
[Promotion] Fix promotion edit page

### DIFF
--- a/features/promotion/managing_promotions/editing_promotion.feature
+++ b/features/promotion/managing_promotions/editing_promotion.feature
@@ -53,3 +53,9 @@ Feature: Editing promotion
         And I save my changes
         Then I should be notified that it has been successfully edited
         And the "Christmas sale" promotion should be available from "12.12.2017" to "24.12.2017"
+
+    @ui
+    Scenario: Editing promotion after adding a new channel
+        Given this promotion gives "$10.00" discount to every order
+        When the store also operates on another channel named "EU-WEB"
+        Then I should be able to modify a "Christmas sale" promotion

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -426,6 +426,7 @@ final class ManagingPromotionsContext implements Context
     /**
      * @Given I want to modify a :promotion promotion
      * @Given /^I want to modify (this promotion)$/
+     * @Then I should be able to modify a :promotion promotion
      */
     public function iWantToModifyAPromotion(PromotionInterface $promotion)
     {

--- a/src/Sylius/Bundle/CoreBundle/Form/EventSubscriber/BuildChannelBasedPromotionActionFormSubscriber.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/EventSubscriber/BuildChannelBasedPromotionActionFormSubscriber.php
@@ -109,7 +109,7 @@ final class BuildChannelBasedPromotionActionFormSubscriber extends AbstractConfi
             'currency' => $channel->getBaseCurrency()->getCode(),
         ];
 
-        $data = empty($data) ? $data : $data[$channel->getCode()];
+        $data = array_key_exists($channel->getCode(), $data) ? $data[$channel->getCode()] : [];
 
         return $this->factory->createNamed($channel->getCode(), $configuration, $data, $config);
     }

--- a/src/Sylius/Bundle/CoreBundle/Form/EventSubscriber/BuildChannelBasedPromotionRuleFormSubscriber.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/EventSubscriber/BuildChannelBasedPromotionRuleFormSubscriber.php
@@ -110,7 +110,7 @@ final class BuildChannelBasedPromotionRuleFormSubscriber extends AbstractConfigu
             'currency' => $channel->getBaseCurrency()->getCode(),
         ];
 
-        $data = empty($data) ? $data : $data[$channel->getCode()];
+        $data = array_key_exists($channel->getCode(), $data) ? $data[$channel->getCode()] : [];
 
         return $this->factory->createNamed($channel->getCode(), $configuration, $data, $config);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

Fix for following issue:
```gherkin
Given this promotion gives "$10.00" discount to every order
When the store also operates on another channel named "EU-WEB"
Then I should be able to modify a "Christmas sale" promotion
```

resulted in: 
<img width="893" alt="zrzut ekranu 2017-01-05 o 15 57 59" src="https://cloud.githubusercontent.com/assets/6213903/21684895/c0e9443c-d35f-11e6-927e-980643c3710d.png">
