### PR TITLE
Fix #7093 #7094 #7096

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Command/AbstractRoleCommand.php
+++ b/src/Sylius/Bundle/UserBundle/Command/AbstractRoleCommand.php
@@ -17,6 +17,8 @@ use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\Question;
 
 /**
  * @author Loïc Frémont <loic@mobizel.com>
@@ -28,27 +30,47 @@ abstract class AbstractRoleCommand extends ContainerAwareCommand
      */
     protected function interact(InputInterface $input, OutputInterface $output)
     {
+
+        // User types configured in the Bundle
+        $availableUserTypes = $this->getAvailableUserTypes();
+        if (empty($availableUserTypes)) {
+            throw new \Exception(sprintf('At least one user type should implement %s', UserInterface::class));
+        }
+
+        if (!$input->getOption('user-type')) {
+
+            // Do not ask if there's only 1 user type configured
+            if (count($availableUserTypes) === 1) {
+                $input->setOption('user-type', $availableUserTypes[0]);
+            } else {
+                $question = new ChoiceQuestion('Please enter the user type:', $availableUserTypes, 1);
+                $question->setErrorMessage('Choice %s is invalid.');
+                $userType = $this->getHelper('question')->ask($input, $output, $question);
+                $input->setOption('user-type', $userType);
+            }
+        }
+
         if (!$input->getArgument('email')) {
-            $email = $this->getHelper('dialog')->askAndValidate(
-                $output,
-                'Please enter an email:',
-                function ($email) {
-                    if (empty($email)) {
-                        throw new \Exception('Email can not be empty');
-                    }
-
-                    return $email;
+            $question = new Question('Please enter an email:');
+            $question->setValidator(function ($email) {
+                if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                    throw new \RuntimeException("The email you entered is invalid.");
                 }
-            );
-
+                return $email;
+            });
+            $email = $this->getHelper('question')->ask($input, $output, $question);
             $input->setArgument('email', $email);
         }
 
         if (!$input->getArgument('roles')) {
-            $roles = $this->getHelper('dialog')->ask(
-                $output,
-                'Please enter user\'s roles (separated by space):'
-            );
+            $question = new Question('Please enter user\'s roles (separated by space):');
+            $question->setValidator(function ($roles) {
+                if (strlen($roles) < 1) {
+                    throw new \RuntimeException("The value cannot be blank.");
+                }
+                return $roles;
+            });
+            $roles = $this->getHelper('question')->ask($input, $output, $question);
 
             if (!empty($roles)) {
                 $input->setArgument('roles', explode(' ', $roles));
@@ -64,26 +86,29 @@ abstract class AbstractRoleCommand extends ContainerAwareCommand
         $email = $input->getArgument('email');
         $securityRoles = $input->getArgument('roles');
         $superAdmin = $input->getOption('super-admin');
+        $userType = $input->getOption('user-type');
 
         if ($superAdmin) {
             $securityRoles[] = 'ROLE_ADMINISTRATION_ACCESS';
         }
 
         /** @var UserInterface $user */
-        $user = $this->findUserByEmail($email);
+        $user = $this->findUserByEmail($email, $userType);
 
-        $this->executeRoleCommand($output, $user, $securityRoles);
+        $this->executeRoleCommand($input, $output, $user, $securityRoles);
     }
 
     /**
      * @param string $email
+     * @param        $userType
      *
      * @return UserInterface
+     * @throws \InvalidArgumentException
      */
-    protected function findUserByEmail($email)
+    protected function findUserByEmail($email, $userType)
     {
         /** @var UserInterface $user */
-        $user = $this->getUserRepository()->findOneByEmail($email);
+        $user = $this->getUserRepository($userType)->findOneByEmail($email);
 
         if (null === $user) {
             throw new \InvalidArgumentException(sprintf('Could not find user identified by email "%s"', $email));
@@ -93,19 +118,52 @@ abstract class AbstractRoleCommand extends ContainerAwareCommand
     }
 
     /**
+     * @param $userType
      * @return ObjectManager
      */
-    protected function getEntityManager()
+    protected function getEntityManager($userType)
     {
-        return $this->getContainer()->get('sylius.manager.shop_user');
+        $class = $this->getUserModelClass($userType);
+        return $this->getContainer()->get('doctrine')->getManagerForClass($class);
     }
 
     /**
+     * @param $userType
      * @return UserRepositoryInterface
      */
-    protected function getUserRepository()
+    protected function getUserRepository($userType)
     {
-        return $this->getContainer()->get('sylius.repository.shop_user');
+        $class = $this->getUserModelClass($userType);
+        return $this->getEntityManager($userType)->getRepository($class);
+    }
+
+    /**
+     * @return array
+     */
+    protected function getAvailableUserTypes()
+    {
+        $config = $this->getContainer()->getParameter('sylius.user.users');
+
+        // Keep only users types which implement \Sylius\Component\User\Model\UserInterface
+        $userTypes = array_filter($config, function ($userTypeConfig) {
+            return isset($userTypeConfig['user']['classes']['model']) && is_a($userTypeConfig['user']['classes']['model'], UserInterface::class, true);
+        });
+
+        return array_keys($userTypes);
+    }
+
+    /**
+     * @param $userType
+     * @return string
+     * @throws \InvalidArgumentException
+     */
+    protected function getUserModelClass($userType)
+    {
+        $config = $this->getContainer()->getParameter('sylius.user.users');
+        if (empty($config[$userType]['user']['classes']['model'])) {
+            throw new \InvalidArgumentException(sprintf('User type %s misconfigured.', $userType));
+        }
+        return $config[$userType]['user']['classes']['model'];
     }
 
     /**
@@ -113,5 +171,5 @@ abstract class AbstractRoleCommand extends ContainerAwareCommand
      * @param UserInterface $user
      * @param array $securityRoles
      */
-    abstract protected function executeRoleCommand(OutputInterface $output, UserInterface $user, array $securityRoles);
+    abstract protected function executeRoleCommand(InputInterface $input, OutputInterface $output, UserInterface $user, array $securityRoles);
 }

--- a/src/Sylius/Bundle/UserBundle/Command/DemoteUserCommand.php
+++ b/src/Sylius/Bundle/UserBundle/Command/DemoteUserCommand.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\UserBundle\Command;
 
 use Sylius\Component\User\Model\UserInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -33,6 +34,7 @@ class DemoteUserCommand extends AbstractRoleCommand
                 new InputArgument('email', InputArgument::REQUIRED, 'Email'),
                 new InputArgument('roles', InputArgument::IS_ARRAY, 'Security roles'),
                 new InputOption('super-admin', null, InputOption::VALUE_NONE, 'Unset the user as super admin'),
+                new InputOption('user-type', null, InputOption::VALUE_REQUIRED, 'Use shop or admin user type'),
             ))
             ->setHelp(<<<EOT
 The <info>sylius:user:demote</info> command demotes a user by removing security roles
@@ -45,7 +47,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function executeRoleCommand(OutputInterface $output, UserInterface $user, array $securityRoles)
+    protected function executeRoleCommand(InputInterface $input, OutputInterface $output, UserInterface $user, array $securityRoles)
     {
         $error = false;
 
@@ -61,7 +63,7 @@ EOT
         }
 
         if (!$error) {
-            $this->getEntityManager()->flush();
+            $this->getEntityManager($input->getOption('user-type'))->flush();
         }
     }
 }

--- a/src/Sylius/Bundle/UserBundle/Command/PromoteUserCommand.php
+++ b/src/Sylius/Bundle/UserBundle/Command/PromoteUserCommand.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\UserBundle\Command;
 
 use Sylius\Component\User\Model\UserInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -33,6 +34,7 @@ class PromoteUserCommand extends AbstractRoleCommand
                 new InputArgument('email', InputArgument::REQUIRED, 'Email'),
                 new InputArgument('roles', InputArgument::IS_ARRAY, 'Security roles'),
                 new InputOption('super-admin', null, InputOption::VALUE_NONE, 'Set the user as a super admin'),
+                new InputOption('user-type', null, InputOption::VALUE_REQUIRED, 'User type'),
             ))
             ->setHelp(<<<EOT
 The <info>sylius:user:promote</info> command promotes a user by adding security roles
@@ -45,7 +47,7 @@ EOT
     /**
      * {@inheritdoc}
      */
-    protected function executeRoleCommand(OutputInterface $output, UserInterface $user, array $securityRoles)
+    protected function executeRoleCommand(InputInterface $input, OutputInterface $output, UserInterface $user, array $securityRoles)
     {
         $error = false;
 
@@ -61,7 +63,7 @@ EOT
         }
 
         if (!$error) {
-            $this->getEntityManager()->flush();
+            $this->getEntityManager($input->getOption('user-type'))->flush();
         }
     }
 }


### PR DESCRIPTION
New PR from #7096.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | yes |
| BC breaks?      | maybe* |
| Related tickets | fixes #7093 #7094  |
| License         | MIT |

## Promoting / Demoting user roles
[SyliusUserBundle] Refactored question helper - fixes #7093 
[SyliusUserBundle] Added a new interaction to specify the user type - fixes #7094 

## * BC breaks 
* I don't know if this can be called a "BC break" since the code was already broken since Symfony 3.0, and the patch should work on Symfony 2.5+.
* The protected function `Sylius\Bundle\UserBundle\Command\AbstractRoleCommand::executeRoleCommand` has a new 1st argument: `InputInterface`. This indeed leads to a BC break to possible custom inheritances of `Sylius\Bundle\UserBundle\Command\AbstractRoleCommand`, but the probability to drink a beer with an alien on the Eiffel Tower one day is more important than facing that kind of issue, IMHO.