### PR TITLE
[Free Order] Add missing constant state for checkout

### DIFF
--- a/src/Sylius/Component/Core/OrderCheckoutStates.php
+++ b/src/Sylius/Component/Core/OrderCheckoutStates.php
@@ -20,6 +20,7 @@ final class OrderCheckoutStates
     const STATE_CART = 'cart';
     const STATE_COMPLETED = 'completed';
     const STATE_PAYMENT_SELECTED = 'payment_selected';
+    const STATE_PAYMENT_SKIPPED = 'payment_skipped';
     const STATE_SHIPPING_SELECTED = 'shipping_selected';
 
     private function __construct()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | kindof |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | mentioned in #7031 |
| License         | MIT |

OrderCheckoutStates' constants should reflect the state machine — one constant was missing after the mentioned PR, this adds it back in.