### PR TITLE
add a way to make object manager name consistent

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/AbstractResourceBundle.php
+++ b/src/Sylius/Bundle/ResourceBundle/AbstractResourceBundle.php
@@ -54,7 +54,7 @@ abstract class AbstractResourceBundle extends Bundle implements ResourceBundleIn
                         case ResourceBundleInterface::MAPPING_YAML:
                             $container->addCompilerPass($compilerPassClassName::$compilerPassMethod(
                                 [$this->getConfigFilesPath() => $this->getModelNamespace()],
-                                [sprintf('%s.object_manager', $this->getBundlePrefix())],
+                                [$this->getObjectManagerParameter()],
                                 sprintf('%s.driver.%s', $this->getBundlePrefix(), $driver)
                             ));
                             break;
@@ -146,5 +146,13 @@ abstract class AbstractResourceBundle extends Bundle implements ResourceBundleIn
             $this->getPath(),
             strtolower($this->getDoctrineMappingDirectory())
         );
+    }
+
+    /**
+     * @return string
+     */
+    protected function getObjectManagerParameter()
+    {
+        return sprintf('%s.object_manager', $this->getBundlePrefix());
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| License         | MIT |

the object manager name created in AbstractResourceBundle is not consistent with the one created in AbstractResourceExtension, which makes us to add extra code to register model namespace. 