### PR TITLE
[Shop][Product] Sort product options by position

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Product.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Product.orm.xml
@@ -40,6 +40,9 @@
             <cascade>
                 <cascade-persist />
             </cascade>
+            <order-by>
+                <order-by-field name="position" direction="ASC" />
+            </order-by>
             <join-table name="sylius_product_options">
                 <join-columns>
                     <join-column name="product_id" referenced-column-name="id" nullable="false" unique="false" on-delete="CASCADE" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | Complementary to PR #7147  |
| License         | MIT |

Products options aren't sorted by position when displayed on product page. The PR #7147 fixed their order in the admin, but it seems logical that they should be displayed in the same order in the shop.

It seems to me like adding a "order-by" in the product mapping fixes this and doesn't have any other implications.