### PR TITLE
stop UserLastLoginSubscriber from executing several times when there …

### DIFF
--- a/src/Sylius/Bundle/UserBundle/EventListener/UserLastLoginSubscriber.php
+++ b/src/Sylius/Bundle/UserBundle/EventListener/UserLastLoginSubscriber.php
@@ -27,11 +27,18 @@ class UserLastLoginSubscriber implements EventSubscriberInterface
     protected $userManager;
 
     /**
-     * @param ObjectManager $userManager
+     * @var string
      */
-    public function __construct(ObjectManager $userManager)
+    private $userClass;
+
+    /**
+     * @param ObjectManager $userManager
+     * @param string $userClass
+     */
+    public function __construct(ObjectManager $userManager, $userClass)
     {
         $this->userManager = $userManager;
+        $this->userClass = $userClass;
     }
 
     /**
@@ -51,10 +58,7 @@ class UserLastLoginSubscriber implements EventSubscriberInterface
     public function onSecurityInteractiveLogin(InteractiveLoginEvent $event)
     {
         $user = $event->getAuthenticationToken()->getUser();
-
-        if ($user instanceof UserInterface) {
-            $this->updateUserLastLogin($user);
-        }
+        $this->updateUserLastLogin($user);
     }
 
     /**
@@ -70,8 +74,10 @@ class UserLastLoginSubscriber implements EventSubscriberInterface
      */
     protected function updateUserLastLogin(UserInterface $user)
     {
-        $user->setLastLogin(new \DateTime());
-        $this->userManager->persist($user);
-        $this->userManager->flush();
+        if ($user instanceof $this->userClass) {
+            $user->setLastLogin(new \DateTime());
+            $this->userManager->persist($user);
+            $this->userManager->flush();
+        }
     }
 }

--- a/src/Sylius/Bundle/UserBundle/spec/EventListener/UserLastLoginSubscriberSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/EventListener/UserLastLoginSubscriberSpec.php
@@ -17,17 +17,17 @@ use Prophecy\Argument;
 use Sylius\Bundle\UserBundle\Event\UserEvent;
 use Sylius\Bundle\UserBundle\EventListener\UserLastLoginSubscriber;
 use Sylius\Bundle\UserBundle\UserEvents;
-use Sylius\Component\User\Model\UserInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
+use Sylius\Component\User\Model\UserInterface;
 
 final class UserLastLoginSubscriberSpec extends ObjectBehavior
 {
     function let(ObjectManager $userManager)
     {
-        $this->beConstructedWith($userManager);
+        $this->beConstructedWith($userManager, 'Sylius\Component\User\Model\UserInterface');
     }
 
     function it_is_initializable()


### PR DESCRIPTION
…are multiple user entities

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |

UserLastLoginSubscriber will execute as many time as the number of user resources, it's not  a problem if we use SyliusUserBundle in one database connection, but when we use it in two database connection, it would throw an error, because the orm mapping  of the two entity manager is different. 