### PR TITLE
make sylius.average_rating_updater service use sylius.manager.product…

### DIFF
--- a/src/Sylius/Bundle/ReviewBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ReviewBundle/Resources/config/services.xml
@@ -27,7 +27,7 @@
         <service id="sylius.average_rating_calculator" class="Sylius\Component\Review\Calculator\AverageRatingCalculator" />
         <service id="sylius.average_rating_updater" class="Sylius\Bundle\ReviewBundle\Updater\AverageRatingUpdater">
             <argument type="service" id="sylius.average_rating_calculator" />
-            <argument type="service" id="doctrine.orm.default_entity_manager" />
+            <argument type="service" id="sylius.manager.product_review" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |

the `sylius.average_rating_updater ` should use ` sylius.manager.product_review` instead of the default entity manager service. 