### PR TITLE
[RFC] [API] Snake cased fields

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Controller/TokenController.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/TokenController.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ApiBundle\Controller;
+
+use FOS\RestBundle\Decoder\DecoderProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use OAuth2\OAuth2;
+use OAuth2\OAuth2ServerException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * @see \FOS\OAuthServerBundle\Controller\TokenController
+ * @see \FOS\RestBundle\EventListener\BodyListener
+ *
+ * @author Łukasz Chruściel <lchrusciel@gmail.com>
+ */
+final class TokenController
+{
+    /**
+     * @var OAuth2
+     */
+    private $server;
+
+    /**
+     * @var DecoderProviderInterface
+     */
+    private $decoderProvider;
+
+    /**
+     * @param OAuth2 $server
+     * @param DecoderProviderInterface $decoderProvider
+     */
+    public function __construct(OAuth2 $server, DecoderProviderInterface $decoderProvider)
+    {
+        $this->server = $server;
+        $this->decoderProvider = $decoderProvider;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function tokenAction(Request $request)
+    {
+        $this->convertContentToRequestParameters($request);
+
+        try {
+            return $this->server->grantAccessToken($request);
+        } catch (OAuth2ServerException $e) {
+            return $e->getHttpResponse();
+        }
+    }
+
+    /**
+     * Additional action to keep default behaviour of FosRestBundle. Main aim is to turn off data normalization.
+     *
+     * @param Request $request
+     */
+    private function convertContentToRequestParameters(Request $request)
+    {
+        $format = $request->getFormat($request->headers->get('Content-Type', '')) ?: $request->getRequestFormat();
+        $content = $request->getContent();
+
+        if (empty($content)) {
+            return;
+        }
+
+        if (!$this->decoderProvider->supports($format)) {
+            return;
+        }
+
+        $decoder = $this->decoderProvider->getDecoder($format);
+        $data = $decoder->decode($content);
+
+        if (!is_array($data)) {
+            throw new BadRequestHttpException(sprintf('Invalid %s message received', $format));
+        }
+
+        $request->request = new ParameterBag($data);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/DependencyInjection/SyliusApiExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/DependencyInjection/SyliusApiExtension.php
@@ -11,12 +11,15 @@
 
 namespace Sylius\Bundle\ApiBundle\DependencyInjection;
 
+use Sylius\Bundle\ApiBundle\Controller\TokenController;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractResourceExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -34,6 +37,11 @@ class SyliusApiExtension extends AbstractResourceExtension implements PrependExt
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);
 
         $loader->load('services.xml');
+
+        $container->setDefinition('fos_oauth_server.controller.token', new Definition(TokenController::class, [
+            new Reference('fos_oauth_server.server'),
+            new Reference('fos_rest.decoder_provider'),
+        ]));
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -108,3 +108,7 @@ twig:
     exception_controller: "FOS\\RestBundle\\Controller\\ExceptionController::showAction"
     globals:
         sylius: "@sylius.context.shopper"
+
+fos_rest:
+    body_listener:
+        array_normalizer: fos_rest.normalizer.camel_keys

--- a/tests/Controller/CheckoutAddressingApiTest.php
+++ b/tests/Controller/CheckoutAddressingApiTest.php
@@ -68,7 +68,7 @@ final class CheckoutAddressingApiTest extends CheckoutApiTestCase
         $data =
 <<<EOT
         {
-            "differentBillingAddress": false,
+            "different_billing_address": false,
             "customer": {
                 "email": "john@doe.com"
             }
@@ -94,15 +94,15 @@ EOT;
         $data =
 <<<EOT
         {
-            "shippingAddress": {
-                "firstName": "Hieronim",
-                "lastName": "Bosch",
+            "shipping_address": {
+                "first_name": "Hieronim",
+                "last_name": "Bosch",
                 "street": "Surrealism St.",
-                "countryCode": "NL",
+                "country_code": "NL",
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "differentBillingAddress": false,
+            "different_billing_address": false,
             "customer": {
                 "email": "john@doe.com"
             }
@@ -129,15 +129,15 @@ EOT;
         $data =
 <<<EOT
         {
-            "shippingAddress": {
-                "firstName": "Hieronim",
-                "lastName": "Bosch",
+            "shipping_address": {
+                "first_name": "Hieronim",
+                "last_name": "Bosch",
                 "street": "Surrealism St.",
-                "countryCode": "NL",
+                "country_code": "NL",
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "differentBillingAddress": true,
+            "different_billing_address": true,
             "customer": {
                 "email": "john@doe.com"
             }
@@ -163,23 +163,23 @@ EOT;
         $data =
 <<<EOT
         {
-            "shippingAddress": {
-                "firstName": "Hieronim",
-                "lastName": "Bosch",
+            "shipping_address": {
+                "first_name": "Hieronim",
+                "last_name": "Bosch",
                 "street": "Surrealism St.",
-                "countryCode": "NL",
+                "country_code": "NL",
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "billingAddress": {
-                "firstName": "Vincent",
-                "lastName": "van Gogh",
+            "billing_address": {
+                "first_name": "Vincent",
+                "last_name": "van Gogh",
                 "street": "Post-Impressionism St.",
-                "countryCode": "NL",
+                "country_code": "NL",
                 "city": "Groot Zundert",
                 "postcode": "88-888"
             },
-            "differentBillingAddress": true,
+            "different_billing_address": true,
             "customer": {
                 "email": "john@doe.com"
             }
@@ -210,15 +210,15 @@ EOT;
         $data =
 <<<EOT
         {
-            "shippingAddress": {
-                "firstName": "Vincent",
-                "lastName": "van Gogh",
+            "shipping_address": {
+                "first_name": "Vincent",
+                "last_name": "van Gogh",
                 "street": "Post-Impressionism St.",
-                "countryCode": "NL",
+                "country_code": "NL",
                 "city": "Groot Zundert",
                 "postcode": "88-888"
             },
-            "differentBillingAddress": false,
+            "different_billing_address": false,
             "customer": {
                 "email": "john@doe.com"
             }
@@ -233,15 +233,15 @@ EOT;
         $newData =
 <<<EOT
         {
-            "shippingAddress": {
-                "firstName": "Hieronim",
-                "lastName": "Bosch",
+            "shipping_address": {
+                "first_name": "Hieronim",
+                "last_name": "Bosch",
                 "street": "Surrealism St.",
-                "countryCode": "NL",
+                "country_code": "NL",
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "differentBillingAddress": false,
+            "different_billing_address": false,
             "customer": {
                 "email": "john@doe.com"
             }
@@ -267,15 +267,15 @@ EOT;
         $addressData =
 <<<EOT
         {
-            "shippingAddress": {
-                "firstName": "Vincent",
-                "lastName": "van Gogh",
+            "shipping_address": {
+                "first_name": "Vincent",
+                "last_name": "van Gogh",
                 "street": "Post-Impressionism St.",
-                "countryCode": "NL",
+                "country_code": "NL",
                 "city": "Groot Zundert",
                 "postcode": "88-888"
             },
-            "differentBillingAddress": false,
+            "different_billing_address": false,
             "customer": {
                 "email": "john@doe.com"
             }
@@ -292,15 +292,15 @@ EOT;
         $newAddressData =
 <<<EOT
         {
-            "shippingAddress": {
-                "firstName": "Hieronim",
-                "lastName": "Bosch",
+            "shipping_address": {
+                "first_name": "Hieronim",
+                "last_name": "Bosch",
                 "street": "Surrealism St.",
-                "countryCode": "NL",
+                "country_code": "NL",
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "differentBillingAddress": false,
+            "different_billing_address": false,
             "customer": {
                 "email": "john@doe.com"
             }
@@ -326,15 +326,15 @@ EOT;
         $addressData =
 <<<EOT
         {
-            "shippingAddress": {
-                "firstName": "Vincent",
-                "lastName": "van Gogh",
+            "shipping_address": {
+                "first_name": "Vincent",
+                "last_name": "van Gogh",
                 "street": "Post-Impressionism St.",
-                "countryCode": "NL",
+                "country_code": "NL",
                 "city": "Groot Zundert",
                 "postcode": "88-888"
             },
-            "differentBillingAddress": false,
+            "different_billing_address": false,
             "customer": {
                 "email": "john@doe.com"
             }
@@ -352,15 +352,15 @@ EOT;
         $newAddressData =
 <<<EOT
         {
-            "shippingAddress": {
-                "firstName": "Hieronim",
-                "lastName": "Bosch",
+            "shipping_address": {
+                "first_name": "Hieronim",
+                "last_name": "Bosch",
                 "street": "Surrealism St.",
-                "countryCode": "NL",
+                "country_code": "NL",
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "differentBillingAddress": false,
+            "different_billing_address": false,
             "customer": {
                 "email": "john@doe.com"
             }

--- a/tests/Controller/CheckoutApiTestCase.php
+++ b/tests/Controller/CheckoutApiTestCase.php
@@ -44,23 +44,23 @@ class CheckoutApiTestCase extends JsonApiTestCase
         $data =
 <<<EOT
         {
-            "shippingAddress": {
-                "firstName": "Hieronim",
-                "lastName": "Bosch",
+            "shipping_address": {
+                "first_name": "Hieronim",
+                "last_name": "Bosch",
                 "street": "Surrealism St.",
-                "countryCode": "NL",
+                "country_code": "NL",
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "billingAddress": {
-                "firstName": "Vincent",
-                "lastName": "van Gogh",
+            "billing_address": {
+                "first_name": "Vincent",
+                "last_name": "van Gogh",
                 "street": "Post-Impressionism St.",
-                "countryCode": "NL",
+                "country_code": "NL",
                 "city": "Groot Zundert",
                 "postcode": "88-888"
             },
-            "differentBillingAddress": true,
+            "different_billing_address": true,
             "customer": {
                 "email": "john@doe.com"
             }

--- a/tests/Controller/CountryApiTest.php
+++ b/tests/Controller/CountryApiTest.php
@@ -67,7 +67,7 @@ class CountryApiTest extends JsonApiTestCase
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
 
         $data =
-            <<<EOT
+<<<EOT
         {
             "code": "BE"
         }

--- a/tests/Controller/CustomerApiTest.php
+++ b/tests/Controller/CustomerApiTest.php
@@ -91,8 +91,8 @@ EOT;
         $data =
 <<<EOT
         {
-            "firstName": "John",
-            "lastName": "Diggle",
+            "first_name": "John",
+            "last_name": "Diggle",
             "email": "john.diggle@yahoo.com",
             "gender": "m"
         }
@@ -114,8 +114,8 @@ EOT;
         $data =
 <<<EOT
         {
-            "firstName": "John",
-            "lastName": "Diggle",
+            "first_name": "John",
+            "last_name": "Diggle",
             "email": "john.diggle@yahoo.com",
             "gender": "m",
             "user": {
@@ -256,8 +256,8 @@ EOT;
         $data =
 <<<EOT
         {
-            "firstName": "John",
-            "lastName": "Diggle",
+            "first_name": "John",
+            "last_name": "Diggle",
             "email": "john.diggle@example.com",
             "gender": "m"
         }
@@ -298,8 +298,8 @@ EOT;
         $data =
 <<<EOT
         {
-            "firstName": "John",
-            "lastName": "Doe"
+            "first_name": "John",
+            "last_name": "Doe"
         }
 EOT;
 

--- a/tests/Controller/OrderApiTest.php
+++ b/tests/Controller/OrderApiTest.php
@@ -102,7 +102,7 @@ final class OrderApiTest extends JsonApiTestCase
         {
             "customer": "oliver.queen@star-city.com",
             "channel": "WEB",
-            "localeCode": "en_US"
+            "locale_code": "en_US"
         }
 EOT;
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets |  |
| License         | MIT |

One of a milestones for beta2 are finishing and polishing our API. One of it drawback is incoherence in field notation. JMSSerializer returns a snaked_cased fields by default, when our forms expects a camelCased notation. The simplest solution for that is to turn on camel cased normalizer. The problem with this solution is that FOSOauthServer requires snaked_cased parameters, because token generation is not done with forms...

How can we avoid this? Create custom TokenController which has some logic from FOSRest and FOSOAuthServer. 

Please, share your thought about my proposal :)