### PR TITLE
Fix #7209: prevent adding unavailable variant

### DIFF
--- a/features/product/viewing_products/viewing_different_price_for_different_product_variants_selected_with_options.feature
+++ b/features/product/viewing_products/viewing_different_price_for_different_product_variants_selected_with_options.feature
@@ -27,3 +27,4 @@ Feature: Viewing different price for different product variants selected with op
         When I view product "Wyborowa Vodka"
         And I set its volume to "1L"
         Then the product price should be "Unavailable"
+        Then I should be unable to add it to the cart

--- a/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
@@ -293,7 +293,7 @@ final class ProductContext implements Context
     {
         Assert::false(
             $this->showPage->hasAddToCartButton(),
-            'Add to cart button should not be visible.'
+            'Add to cart button should be absent or disabled.'
         );
     }
 

--- a/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
+++ b/src/Sylius/Behat/Page/Shop/Product/ShowPage.php
@@ -230,7 +230,8 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
      */
     public function hasAddToCartButton()
     {
-        return $this->getDocument()->hasButton('Add to cart');
+        return $this->getDocument()->hasButton('Add to cart')
+            && false === $this->getDocument()->findButton('Add to cart')->hasAttribute('disabled');
     }
 
     /**

--- a/src/Sylius/Bundle/ProductBundle/Form/DataTransformer/ProductVariantToProductOptionsTransformer.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/DataTransformer/ProductVariantToProductOptionsTransformer.php
@@ -16,6 +16,7 @@ use Sylius\Component\Product\Model\ProductOptionValueInterface;
 use Sylius\Component\Product\Model\ProductVariantInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Exception\TransformationFailedException;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -84,6 +85,10 @@ final class ProductVariantToProductOptionsTransformer implements DataTransformer
             return $variant;
         }
 
-        return null;
+        throw new TransformationFailedException(sprintf(
+            'Variant "%s" not found for product %s',
+            !empty($optionValues[0]) ? $optionValues[0]->getCode() : '',
+            $this->product->getCode()
+        ));
     }
 }

--- a/src/Sylius/Bundle/ProductBundle/spec/Form/DataTransformer/ProductVariantToProductOptionsTransformerSpec.php
+++ b/src/Sylius/Bundle/ProductBundle/spec/Form/DataTransformer/ProductVariantToProductOptionsTransformerSpec.php
@@ -19,6 +19,7 @@ use Sylius\Component\Product\Model\ProductInterface;
 use Sylius\Component\Product\Model\ProductVariantInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Exception\TransformationFailedException;
 
 final class ProductVariantToProductOptionsTransformerSpec extends ObjectBehavior
 {
@@ -73,13 +74,16 @@ final class ProductVariantToProductOptionsTransformerSpec extends ObjectBehavior
         ;
     }
 
-    function it_reverse_transforms_variable_without_variants_into_null(
+    function it_throws_exception_when_trying_to_reverse_transform_variable_without_variants(
         ProductInterface $variable,
         ProductOptionValueInterface $optionValue
     ) {
         $variable->getVariants()->willReturn([]);
+        $variable->getCode()->willReturn('example');
 
-        $this->reverseTransform([$optionValue])->shouldReturn(null);
+        $this
+            ->shouldThrow(TransformationFailedException::class)
+            ->duringReverseTransform([$optionValue]);
     }
 
     function it_reverse_transforms_variable_with_variants_if_options_match(
@@ -94,24 +98,30 @@ final class ProductVariantToProductOptionsTransformerSpec extends ObjectBehavior
         $this->reverseTransform([$optionValue])->shouldReturn($variant);
     }
 
-    function it_does_not_reverse_transform_variable_with_variants_if_options_not_match(
+    function it_throws_exception_when_trying_to_reverse_transform_variable_with_variants_if_options_not_match(
         ProductInterface $variable,
         ProductVariantInterface $variant,
         ProductOptionValueInterface $optionValue
     ) {
         $variable->getVariants()->willReturn([$variant]);
+        $variable->getCode()->willReturn('example');
 
         $variant->hasOptionValue($optionValue)->willReturn(false);
 
-        $this->reverseTransform([$optionValue])->shouldReturn(null);
+        $this
+            ->shouldThrow(TransformationFailedException::class)
+            ->duringReverseTransform([$optionValue]);
     }
 
-    function it_does_not_reverse_transform_variable_with_variants_if_options_are_missing(
+    function it_throws_exception_when_trying_to_reverse_transform_variable_with_variants_if_options_are_missing(
         ProductInterface $variable,
         ProductVariantInterface $variant
     ) {
         $variable->getVariants()->willReturn([$variant]);
+        $variable->getCode()->willReturn('example');
 
-        $this->reverseTransform([null])->shouldReturn(null);
+        $this
+            ->shouldThrow(TransformationFailedException::class)
+            ->duringReverseTransform([null]);
     }
 }

--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-add-to-cart.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-add-to-cart.js
@@ -15,6 +15,12 @@
             $(this).on('submit', function(event) {
                 refresh(this, event);
             });
+        },
+        disable: function() {
+            $('button[type=submit]', this).attr('disabled', 'disabled');
+        },
+        enable: function() {
+            $('button[type=submit]', this).removeAttr('disabled');
         }
     });
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-variants-prices.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-variants-prices.js
@@ -34,8 +34,10 @@ function handleProductOptionsChange() {
 
         if ($price !== undefined) {
             $('#product-price').text($price);
+            $('#sylius-product-adding-to-cart').enable();
         } else {
             $('#product-price').text($('#sylius-variants-pricing').attr('data-unavailable-text'));
+            $('#sylius-product-adding-to-cart').disable();
         }
     });
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #7209  |
| License         | MIT |

For now only the web UI part is done ; I'm not sure where to act on PHP part, because the exception is thrown very deeply in the Symfony Form handling code.