### PR TITLE
[Product] Add groupBy missing parameters for Postgresql/Mysql

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -68,7 +68,7 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
             ->andWhere('channel = :channel')
             ->andWhere('o.enabled = true')
             ->andWhere('channelPricing.channel = :channel')
-            ->groupBy('o.id')
+            ->groupBy('o.id, translation.id, productTaxon.position, channelPricing.price')
             ->setParameter('locale', $locale)
             ->setParameter('taxonSlug', $taxonSlug)
             ->setParameter('channel', $channel)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

I have an issue with groupBy queries with PostgreSQL

In fact, PostgreSQL requires all columns selected in groupBy clause, or at least, when it's about join selected columns, the id of joined entity.

Maybe there are more in code, i will fix them as i spot them.
