### PR TITLE
[DOCS] Proposed a maintained fork of OAuth2 plugin for API authorization

### DIFF
--- a/docs/api/authorization.rst
+++ b/docs/api/authorization.rst
@@ -40,7 +40,7 @@ Example Result
 
     If you use Guzzle check out `OAuth2 plugin`__ and use Password Credentials.
 
-__ https://github.com/commerceguys/guzzle-oauth2-plugin
+__ https://github.com/Sainsburys/guzzle-oauth2-plugin
 
 Obtain access token
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
OAuth2 plugin from commerceguys is abandoned. In addition it hasn't support Guzzle in version 6 (last supported is 5), which is a current one for Sylius. Proposed a fork, which is maintained. 

| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |
