### PR TITLE
[API] Keep resource name coherent

### DIFF
--- a/tests/Controller/ChannelApiTest.php
+++ b/tests/Controller/ChannelApiTest.php
@@ -46,7 +46,7 @@ final class ChannelApiTest extends JsonApiTestCase
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $channelData = $this->loadFixturesFromFile('resources/channels.yml');
 
-        $this->client->request('GET', '/api/v1/channels/'.$channelData['channel-web']->getId(), [], [], static::$authorizedHeaderWithContentType);
+        $this->client->request('GET', '/api/v1/channels/'.$channelData['channel_web']->getId(), [], [], static::$authorizedHeaderWithContentType);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'channel/show_response', Response::HTTP_OK);

--- a/tests/DataFixtures/ORM/resources/channels.yml
+++ b/tests/DataFixtures/ORM/resources/channels.yml
@@ -1,5 +1,5 @@
 Sylius\Component\Core\Model\Channel:
-    channel-web:
+    channel_web:
         code: "WEB"
         name: "Web Channel"
         hostname: "localhost"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets |  |
| License         | MIT |

In every other fixture file we are using a snake case notation. 