### PR TITLE
[DOC] Added string filter option.type configuration

### DIFF
--- a/docs/bundles/SyliusGridBundle/filters.rst
+++ b/docs/bundles/SyliusGridBundle/filters.rst
@@ -35,6 +35,19 @@ The filter allows the user to select following search options:
 * in
 * not in
 
+If you don't want display to user matching possibilites, you can choose one in a configuration. Then only the value input will display. You can achieve it adding options.type parameter:
+
+.. code-block:: yaml
+
+    sylius_grid:
+        grids:
+            app_user:
+                filters:
+                    username:
+                        type: string
+                        options:
+                            type: contains
+
 Boolean
 -------
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |


I added info about string filter configuration not mentioned in a docs. I want to write my own filter without choosing matching possibilities but I saw, that this is already implemented but anything in docs about it.