### PR TITLE
Doctrine caching in test_cached environment

### DIFF
--- a/app/config/config_test_cached.yml
+++ b/app/config/config_test_cached.yml
@@ -8,6 +8,14 @@ doctrine:
     orm:
         entity_managers:
             default:
+                result_cache_driver:
+                    type: memcached
+                    host: localhost
+                    port: 11211
+                query_cache_driver:
+                    type: memcached
+                    host: localhost
+                    port: 11211
                 metadata_cache_driver:
                     type: memcached
                     host: localhost


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

Before:
![screen shot 2017-01-24 at 13 57 40](https://cloud.githubusercontent.com/assets/1897953/22248107/5c33331c-e23d-11e6-9810-050f4b946313.png)

After:
![screen shot 2017-01-24 at 13 57 25](https://cloud.githubusercontent.com/assets/1897953/22248114/637f77ca-e23d-11e6-88da-762c4a2a857b.png)

Result cache not even used yet! 🎉 