### PR TITLE
[Resource] Fix default form type

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/Form/Builder/DefaultFormBuilder.php
+++ b/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/Form/Builder/DefaultFormBuilder.php
@@ -69,7 +69,7 @@ class DefaultFormBuilder implements DefaultFormBuilderInterface
 
         foreach ($classMetadata->getAssociationMappings() as $fieldName => $associationMapping) {
             if (ClassMetadataInfo::ONE_TO_MANY !== $associationMapping['type']) {
-                $formBuilder->add($fieldName, null, ['property' => 'id']);
+                $formBuilder->add($fieldName, null, ['choice_label' => 'id']);
             }
         }
     }


### PR DESCRIPTION
Update the automatic form creation when a mapping is present in the entity in order to be compatible with Symfony 3.

Source : http://symfony.com/doc/2.8/reference/forms/types/entity.html#choice-label

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |   |
| License         | MIT |


