### PR TITLE
[Resource] Upgraded ResourceDeleteSubscriber

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_variant.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_variant.yml
@@ -71,6 +71,7 @@ sylius_admin_product_variant_delete:
     defaults:
         _controller: sylius.controller.product_variant:deleteAction
         _sylius:
+            section: admin
             redirect: referer
             permission: true
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/promotion_coupon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/promotion_coupon.yml
@@ -85,5 +85,6 @@ sylius_admin_promotion_coupon_delete:
     defaults:
         _controller: sylius.controller.promotion_coupon:deleteAction
         _sylius:
+            section: admin
             redirect: referer
             permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shop_user.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shop_user.yml
@@ -4,5 +4,6 @@ sylius_admin_shop_user_delete:
     defaults:
         _controller: sylius.controller.shop_user:deleteAction
         _sylius:
+            section: admin
             redirect: referer
             permission: true


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

Now it'll only handle admin's delete action of sylius resources exclusively.
No more random catching of failed updates, or any other crap like that.