### PR TITLE
[Documentation]  SyliusResourceBundle » Forms precision

### DIFF
--- a/docs/bundles/SyliusResourceBundle/forms.rst
+++ b/docs/bundles/SyliusResourceBundle/forms.rst
@@ -41,7 +41,7 @@ Create the form's service :
         class: AppBundle\Form\Type\BookType
         tags:
             - { name: form.type }
-        arguments: ['%sylius.model.order.class%']
+        arguments: ['%app.model.book.class%']
 
 Now, configure it under ``sylius_resource``:
 

--- a/docs/bundles/SyliusResourceBundle/forms.rst
+++ b/docs/bundles/SyliusResourceBundle/forms.rst
@@ -33,6 +33,16 @@ You need to create a simple class:
         }
     }
 
+Create the form's service :
+
+.. code-block:: yaml
+
+    app.book.form.type:
+        class: AppBundle\Form\Type\BookType
+        tags:
+            - { name: form.type }
+        arguments: ['%sylius.model.order.class%']
+
 Now, configure it under ``sylius_resource``:
 
 .. code-block:: yaml


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |


The service definition of the form wasn't given, it could be a good idea to describe it.


If you don't specify the service the forms construct is not filled and end up with an error.