### PR TITLE
[Documentation]  SyliusResourceBundle » Forms current config ends up with an error

### DIFF
--- a/docs/bundles/SyliusResourceBundle/forms.rst
+++ b/docs/bundles/SyliusResourceBundle/forms.rst
@@ -42,7 +42,6 @@ Now, configure it under ``sylius_resource``:
             app.book:
                 classes:
                     model: AppBundle\Entity\Book
-                    form:
-                        default: AppBundle\Form\Type\BookType
+                    form: AppBundle\Form\Type\BookType
 
 That's it. Your new class will be used for all forms!


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |


The error is this one : Invalid type for path "sylius_resource.resources.app.book.classes.form". Expected scalar, but got array.
