### PR TITLE
[Admin] Relocated ResourceDeleteSubscriber

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
+++ b/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\ResourceBundle\EventListener;
+namespace Sylius\Bundle\AdminBundle\EventListener;
 
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use FOS\RestBundle\View\View;

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -21,8 +21,6 @@
         <service id="sylius.event_subscriber.resource_delete" class="Sylius\Bundle\AdminBundle\EventListener\ResourceDeleteSubscriber">
             <argument type="service" id="router" />
             <argument type="service" id="session" />
-            <argument type="service" id="translator" />
-            <argument type="service" id="fos_rest.view_handler" />
             <tag name="kernel.event_subscriber" event="kernel.exception" />
         </service>
     </services>

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -16,4 +16,14 @@
         <import resource="services/controller.xml" />
         <import resource="services/menu.xml" />
     </imports>
+
+    <services>
+        <service id="sylius.event_subscriber.resource_delete" class="Sylius\Bundle\AdminBundle\EventListener\ResourceDeleteSubscriber">
+            <argument type="service" id="router" />
+            <argument type="service" id="session" />
+            <argument type="service" id="translator" />
+            <argument type="service" id="fos_rest.view_handler" />
+            <tag name="kernel.event_subscriber" event="kernel.exception" />
+        </service>
+    </services>
 </container>

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
@@ -32,14 +32,6 @@
 
         <service id="sylius.expression_language" class="Symfony\Component\DependencyInjection\ExpressionLanguage" public="false" />
 
-        <service id="sylius.event_subscriber.resource_delete" class="Sylius\Bundle\ResourceBundle\EventListener\ResourceDeleteSubscriber">
-            <argument type="service" id="router" />
-            <argument type="service" id="session" />
-            <argument type="service" id="translator" />
-            <argument type="service" id="fos_rest.view_handler" />
-            <tag name="kernel.event_subscriber" event="kernel.exception" />
-        </service>
-
         <service id="sylius.form.extension.type.collection" class="Sylius\Bundle\ResourceBundle\Form\Extension\CollectionTypeExtension">
             <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\CollectionType" />
         </service>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets | mentioned in #7335 |
| License         | MIT |

Plus a slight trim, the addition of `section` check invalidates all its API related logic, because we don't use sections in API's routing.