### PR TITLE
Allow POST on sylius_shop_order_after_pay route

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/order.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/order.yml
@@ -20,7 +20,7 @@ sylius_shop_order_pay:
 
 sylius_shop_order_after_pay:
     path: /after-pay
-    methods: [GET]
+    methods: [GET, POST]
     defaults:
         _controller: sylius.controller.payum:afterCaptureAction
 


### PR DESCRIPTION
There are payment providers that do a POST based redirect back to the store instead of the GET.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | none |
| License         | MIT |
