### PR TITLE
[ResourceBundle] Prevent overriding existing association mappings

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/EventListener/ODMMappedSuperClassSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/ODMMappedSuperClassSubscriber.php
@@ -97,7 +97,7 @@ final class ODMMappedSuperClassSubscriber extends AbstractDoctrineSubscriber
 
             if ($parentMetadata->isMappedSuperclass) {
                 foreach ($parentMetadata->associationMappings as $key => $value) {
-                    if ($this->hasRelation($value['association'])) {
+                    if ($this->isRelation($value['association']) && !isset($metadata->associationMappings[$key])) {
                         $metadata->associationMappings[$key] = $value;
                     }
                 }
@@ -115,18 +115,18 @@ final class ODMMappedSuperClassSubscriber extends AbstractDoctrineSubscriber
         }
 
         foreach ($metadata->associationMappings as $key => $value) {
-            if ($this->hasRelation($value['association'])) {
+            if ($this->isRelation($value['association'])) {
                 unset($metadata->associationMappings[$key]);
             }
         }
     }
 
     /**
-     * @param $type
+     * @param string $type
      *
      * @return bool
      */
-    private function hasRelation($type)
+    private function isRelation($type)
     {
         return in_array(
             $type,

--- a/src/Sylius/Bundle/ResourceBundle/EventListener/ORMMappedSuperClassSubscriber.php
+++ b/src/Sylius/Bundle/ResourceBundle/EventListener/ORMMappedSuperClassSubscriber.php
@@ -96,7 +96,7 @@ final class ORMMappedSuperClassSubscriber extends AbstractDoctrineSubscriber
 
             if ($parentMetadata->isMappedSuperclass) {
                 foreach ($parentMetadata->getAssociationMappings() as $key => $value) {
-                    if ($this->hasRelation($value['type'])) {
+                    if ($this->isRelation($value['type']) && !isset($metadata->associationMappings[$key])) {
                         $metadata->associationMappings[$key] = $value;
                     }
                 }
@@ -114,18 +114,18 @@ final class ORMMappedSuperClassSubscriber extends AbstractDoctrineSubscriber
         }
 
         foreach ($metadata->getAssociationMappings() as $key => $value) {
-            if ($this->hasRelation($value['type'])) {
+            if ($this->isRelation($value['type'])) {
                 unset($metadata->associationMappings[$key]);
             }
         }
     }
 
     /**
-     * @param $type
+     * @param string $type
      *
      * @return bool
      */
-    private function hasRelation($type)
+    private function isRelation($type)
     {
         return in_array(
             $type,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |

If the metadata already has existing association mappings for the given field, we won't override anything and leave it as is.

**Example:**
In our bundle, we define our own product entity and want to add an `order-by` to the association mapping of an existing field. So we copy the field definition from `Product.orm.xml` to our own configuration and modify it to our needs.

The current code will always override our custom association mappings for a given field. So the fix is to check if the field has custom association mappings and only apply them if none are configured.

Also renamed the `hasRelation` method since it's really checking if it **is** a relation.