### PR TITLE
Remove unused "sylius_admin_dashboard_redirect" route

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -167,6 +167,8 @@ These services will be generated automatically based on subject name.
 
 ## Application:
 
+* `sylius_admin_dashboard_redirect` route was removed, use `sylius_admin_dashboard` instead.
+
 ### Configuration
 
 ### Security

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,14 +1,6 @@
 # This file is part of the Sylius package.
 # (c) Paweł Jędrzejewski
 
-sylius_admin_dashboard_redirect:
-    path: /admin
-    methods: [GET]
-    defaults:
-        _controller: FrameworkBundle:Redirect:redirect
-        route: sylius_admin_dashboard
-        permanent: true
-
 sylius_shop:
     resource: "@SyliusShopBundle/Resources/config/routing.yml"
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets | - |
| License         | MIT |

It automatically redirect from `/admin` to `/admin/`, both when logged in or not.