### PR TITLE
[Core] [Addressing] [Currency] [Order] [Product] [Review] Repositories cleanup

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/AddressingBundle/DependencyInjection/Configuration.php
@@ -18,7 +18,6 @@ use Sylius\Bundle\AddressingBundle\Form\Type\ProvinceType;
 use Sylius\Bundle\AddressingBundle\Form\Type\ZoneMemberType;
 use Sylius\Bundle\AddressingBundle\Form\Type\ZoneType;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
-use Sylius\Bundle\ResourceBundle\Doctrine\ORM\ResourceLogEntryRepository;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Sylius\Component\Addressing\Model\Address;
 use Sylius\Component\Addressing\Model\AddressInterface;
@@ -101,7 +100,7 @@ final class Configuration implements ConfigurationInterface
                                     ->children()
                                         ->scalarNode('model')->defaultValue(AddressLogEntry::class)->cannotBeEmpty()->end()
                                         ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
-                                        ->scalarNode('repository')->defaultValue(ResourceLogEntryRepository::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('repository')->cannotBeEmpty()->end()
                                         ->scalarNode('factory')->defaultValue(Factory::class)->end()
                                     ->end()
                                 ->end()

--- a/src/Sylius/Bundle/AddressingBundle/DependencyInjection/SyliusAddressingExtension.php
+++ b/src/Sylius/Bundle/AddressingBundle/DependencyInjection/SyliusAddressingExtension.php
@@ -32,6 +32,8 @@ final class SyliusAddressingExtension extends AbstractResourceExtension
         $config = $this->processConfiguration($this->getConfiguration([], $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
+        $loader->load(sprintf('services/integrations/%s.xml', $config['driver']));
+
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);
 
         $loader->load('services.xml');

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/services/integrations/doctrine/orm.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/services/integrations/doctrine/orm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="sylius.repository.address_log_entry.class">Sylius\Bundle\ResourceBundle\Doctrine\ORM\ResourceLogEntryRepository</parameter>
+    </parameters>
+</container>

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Configuration.php
@@ -113,7 +113,7 @@ final class Configuration implements ConfigurationInterface
                                         ->scalarNode('model')->defaultValue(ChannelPricing::class)->cannotBeEmpty()->end()
                                         ->scalarNode('interface')->defaultValue(ChannelPricingInterface::class)->cannotBeEmpty()->end()
                                         ->scalarNode('factory')->defaultValue(Factory::class)->end()
-                                        ->scalarNode('repository')->defaultValue(EntityRepository::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('repository')->cannotBeEmpty()->end()
                                         ->scalarNode('form')->defaultValue(ChannelPricingType::class)->cannotBeEmpty()->end()
                                     ->end()
                                 ->end()

--- a/src/Sylius/Bundle/CurrencyBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/CurrencyBundle/DependencyInjection/Configuration.php
@@ -87,7 +87,7 @@ final class Configuration implements ConfigurationInterface
                                         ->scalarNode('model')->defaultValue(ExchangeRate::class)->cannotBeEmpty()->end()
                                         ->scalarNode('interface')->defaultValue(ExchangeRateInterface::class)->cannotBeEmpty()->end()
                                         ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
-                                        ->scalarNode('repository')->defaultValue(ExchangeRateRepository::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('repository')->cannotBeEmpty()->end()
                                         ->scalarNode('factory')->defaultValue(Factory::class)->cannotBeEmpty()->end()
                                         ->scalarNode('form')->defaultValue(ExchangeRateType::class)->cannotBeEmpty()->end()
                                     ->end()

--- a/src/Sylius/Bundle/CurrencyBundle/DependencyInjection/SyliusCurrencyExtension.php
+++ b/src/Sylius/Bundle/CurrencyBundle/DependencyInjection/SyliusCurrencyExtension.php
@@ -29,6 +29,8 @@ final class SyliusCurrencyExtension extends AbstractResourceExtension
         $config = $this->processConfiguration($this->getConfiguration([], $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
+        $loader->load(sprintf('services/integrations/%s.xml', $config['driver']));
+
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);
 
         $loader->load('services.xml');

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/services/integrations/doctrine/orm.xml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/services/integrations/doctrine/orm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="sylius.repository.exchange_rate.class">Sylius\Bundle\CurrencyBundle\Doctrine\ORM\ExchangeRateRepository</parameter>
+    </parameters>
+</container>

--- a/src/Sylius/Bundle/GridBundle/Doctrine/ORM/Driver.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/ORM/Driver.php
@@ -11,9 +11,10 @@
 
 namespace Sylius\Bundle\GridBundle\Doctrine\ORM;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Sylius\Component\Grid\Data\DriverInterface;
 use Sylius\Component\Grid\Parameters;
+use Sylius\Component\Registry\ServiceRegistryInterface;
+use Sylius\Component\Resource\Metadata\RegistryInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -23,16 +24,23 @@ final class Driver implements DriverInterface
     const NAME = 'doctrine/orm';
 
     /**
-     * @var ManagerRegistry
+     * @var RegistryInterface
      */
-    private $managerRegistry;
+    private $metadataRegistry;
 
     /**
-     * @param ManagerRegistry $managerRegistry
+     * @var ServiceRegistryInterface
      */
-    public function __construct(ManagerRegistry $managerRegistry)
+    private $repositoryRegistry;
+
+    /**
+     * @param RegistryInterface $metadataRegistry
+     * @param ServiceRegistryInterface $repositoryRegistry
+     */
+    public function __construct(RegistryInterface $metadataRegistry, ServiceRegistryInterface $repositoryRegistry)
     {
-        $this->managerRegistry = $managerRegistry;
+        $this->metadataRegistry = $metadataRegistry;
+        $this->repositoryRegistry = $repositoryRegistry;
     }
 
     /**
@@ -44,9 +52,8 @@ final class Driver implements DriverInterface
             throw new \InvalidArgumentException('"class" must be configured.');
         }
 
-        $repository = $this->managerRegistry
-            ->getManagerForClass($configuration['class'])
-            ->getRepository($configuration['class']);
+        $metadata = $this->metadataRegistry->getByClass($configuration['class']);
+        $repository = $this->repositoryRegistry->get($metadata->getAlias());
 
         if (isset($configuration['repository']['method'])) {
             $method = $configuration['repository']['method'];

--- a/src/Sylius/Bundle/GridBundle/Resources/config/services/integrations/doctrine/orm.xml
+++ b/src/Sylius/Bundle/GridBundle/Resources/config/services/integrations/doctrine/orm.xml
@@ -14,7 +14,8 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sylius.grid_driver.doctrine.orm" class="Sylius\Bundle\GridBundle\Doctrine\ORM\Driver">
-            <argument type="service" id="doctrine" />
+            <argument type="service" id="sylius.resource_registry" />
+            <argument type="service" id="sylius.registry.resource_repository" />
             <tag name="sylius.grid_driver" alias="doctrine/orm" />
         </service>
         <service id="sylius.grid_driver.doctrine.dbal" class="Sylius\Bundle\GridBundle\Doctrine\DBAL\Driver">

--- a/src/Sylius/Bundle/GridBundle/spec/Doctrine/ORM/DriverSpec.php
+++ b/src/Sylius/Bundle/GridBundle/spec/Doctrine/ORM/DriverSpec.php
@@ -11,7 +11,6 @@
 
 namespace spec\Sylius\Bundle\GridBundle\Doctrine\ORM;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
@@ -20,15 +19,17 @@ use Sylius\Bundle\GridBundle\Doctrine\ORM\DataSource;
 use Sylius\Bundle\GridBundle\Doctrine\ORM\Driver;
 use Sylius\Component\Grid\Data\DriverInterface;
 use Sylius\Component\Grid\Parameters;
+use Sylius\Component\Registry\ServiceRegistryInterface;
+use Sylius\Component\Resource\Metadata\RegistryInterface;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
 final class DriverSpec extends ObjectBehavior
 {
-    function let(ManagerRegistry $managerRegistry)
+    function let(RegistryInterface $metadataRegistry, ServiceRegistryInterface $repositoryRegistry)
     {
-        $this->beConstructedWith($managerRegistry);
+        $this->beConstructedWith($metadataRegistry, $repositoryRegistry);
     }
 
     function it_is_initializable()
@@ -49,13 +50,14 @@ final class DriverSpec extends ObjectBehavior
     }
 
     function it_creates_data_source_via_doctrine_orm_query_builder(
-        ManagerRegistry $managerRegistry,
+        RegistryInterface $metadataRegistry,
+        ServiceRegistryInterface $repositoryRegistry,
         EntityManagerInterface $entityManager,
         EntityRepository $entityRepository,
         QueryBuilder $queryBuilder
     ) {
-        $managerRegistry->getManagerForClass('App:Book')->willReturn($entityManager);
-        $entityManager->getRepository('App:Book')->willReturn($entityRepository);
+        $metadataRegistry->getByClass('App:Book')->willReturn('app.book');
+        $repositoryRegistry->get('app.book')->willReturn($entityRepository);
         $entityRepository->createQueryBuilder('o')->willReturn($queryBuilder);
 
         $this->getDataSource(['class' => 'App:Book'], new Parameters())->shouldHaveType(DataSource::class);

--- a/src/Sylius/Bundle/OrderBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/OrderBundle/DependencyInjection/Configuration.php
@@ -12,7 +12,6 @@
 namespace Sylius\Bundle\OrderBundle\DependencyInjection;
 
 use Sylius\Bundle\OrderBundle\Controller\OrderItemController;
-use Sylius\Bundle\OrderBundle\Doctrine\ORM\OrderRepository;
 use Sylius\Bundle\OrderBundle\Form\Type\OrderItemType;
 use Sylius\Bundle\OrderBundle\Form\Type\OrderType;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
@@ -79,7 +78,7 @@ final class Configuration implements ConfigurationInterface
                                         ->scalarNode('model')->defaultValue(Order::class)->cannotBeEmpty()->end()
                                         ->scalarNode('interface')->defaultValue(OrderInterface::class)->cannotBeEmpty()->end()
                                         ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
-                                        ->scalarNode('repository')->defaultValue(OrderRepository::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('repository')->cannotBeEmpty()->end()
                                         ->scalarNode('factory')->defaultValue(Factory::class)->end()
                                         ->scalarNode('form')->defaultValue(OrderType::class)->cannotBeEmpty()->end()
                                     ->end()

--- a/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
+++ b/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
@@ -30,10 +30,11 @@ final class SyliusOrderExtension extends AbstractResourceExtension
         $config = $this->processConfiguration($this->getConfiguration([], $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
+        $loader->load(sprintf('services/integrations/%s.xml', $config['driver']));
+
         $this->registerResources('sylius', $config['driver'], $config['resources'], $container);
 
         $loader->load('services.xml');
-        $loader->load(sprintf('services/integrations/%s.xml', $config['driver']));
 
         $container->setParameter('sylius_order.cart_expiration_period', $config['expiration']['cart']);
         $container->setParameter('sylius_order.order_expiration_period', $config['expiration']['order']);

--- a/src/Sylius/Bundle/ProductBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/ProductBundle/DependencyInjection/Configuration.php
@@ -11,8 +11,6 @@
 
 namespace Sylius\Bundle\ProductBundle\DependencyInjection;
 
-use Sylius\Bundle\ProductBundle\Doctrine\ORM\ProductRepository;
-use Sylius\Bundle\ProductBundle\Doctrine\ORM\ProductVariantRepository;
 use Sylius\Bundle\ProductBundle\Form\Type\ProductAssociationType;
 use Sylius\Bundle\ProductBundle\Form\Type\ProductAssociationTypeTranslationType;
 use Sylius\Bundle\ProductBundle\Form\Type\ProductAssociationTypeType;
@@ -100,7 +98,7 @@ final class Configuration implements ConfigurationInterface
                                         ->scalarNode('model')->defaultValue(Product::class)->cannotBeEmpty()->end()
                                         ->scalarNode('interface')->defaultValue(ProductInterface::class)->cannotBeEmpty()->end()
                                         ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
-                                        ->scalarNode('repository')->defaultValue(ProductRepository::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('repository')->cannotBeEmpty()->end()
                                         ->scalarNode('factory')->defaultValue(TranslatableFactory::class)->end()
                                         ->scalarNode('form')->defaultValue(ProductType::class)->cannotBeEmpty()->end()
                                     ->end()
@@ -134,7 +132,7 @@ final class Configuration implements ConfigurationInterface
                                         ->scalarNode('model')->defaultValue(ProductVariant::class)->cannotBeEmpty()->end()
                                         ->scalarNode('interface')->defaultValue(ProductVariantInterface::class)->cannotBeEmpty()->end()
                                         ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
-                                        ->scalarNode('repository')->defaultValue(ProductVariantRepository::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('repository')->cannotBeEmpty()->end()
                                         ->scalarNode('factory')->defaultValue(TranslatableFactory::class)->end()
                                         ->scalarNode('form')->defaultValue(ProductVariantType::class)->cannotBeEmpty()->end()
                                     ->end()

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/services/integrations/doctrine/orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/services/integrations/doctrine/orm.xml
@@ -13,6 +13,8 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
+        <parameter key="sylius.repository.product.class">Sylius\Bundle\ProductBundle\Doctrine\ORM\ProductRepository</parameter>
+        <parameter key="sylius.repository.product_variant.class">Sylius\Bundle\ProductBundle\Doctrine\ORM\ProductVariantRepository</parameter>
         <parameter key="sylius.repository.product_attribute.class">Sylius\Bundle\AttributeBundle\Doctrine\ORM\AttributeRepository</parameter>
         <parameter key="sylius.repository.product_option.class">Sylius\Bundle\ProductBundle\Doctrine\ORM\ProductOptionRepository</parameter>
     </parameters>

--- a/src/Sylius/Bundle/ReviewBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/ReviewBundle/DependencyInjection/Configuration.php
@@ -71,7 +71,7 @@ final class Configuration implements ConfigurationInterface
                                         ->scalarNode('model')->isRequired()->end()
                                         ->scalarNode('interface')->defaultValue(ReviewInterface::class)->cannotBeEmpty()->end()
                                         ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
-                                        ->scalarNode('repository')->defaultValue(EntityRepository::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('repository')->cannotBeEmpty()->end()
                                         ->scalarNode('factory')->defaultValue(Factory::class)->cannotBeEmpty()->end()
                                         ->scalarNode('form')->defaultValue(ReviewType::class)->cannotBeEmpty()->end()
                                     ->end()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes(new ORMDriver dependencies) |
| Related tickets |  |
| License         | MIT |

I have removed a repository definition from configuration tree to decouple bundles from ORM. Unfortunately, the ORM Driver didn't resolved properly repository classes. 

My proposal is to gather repository from repository registry, but we need an alias for that, which can be taken from Metadata registry based on class name. The drawback of this solution is that it will couple GridBundle with ResourceBundle...

Other possible solutions would be refactoring of repository registry to use models FQCN  as a key, or specify or specify resource alias instead of class in grid configuration.

I have chosen this solution, as it affects the smallest part of our code base, but if you think that there is a better one, I'm open for proposals. 