### PR TITLE
[BugFix] Do not clear the object manage between fixture loads

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/AbstractResourceFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/AbstractResourceFixture.php
@@ -83,12 +83,10 @@ abstract class AbstractResourceFixture implements FixtureInterface
 
             if (0 === ($i % 10)) {
                 $this->objectManager->flush();
-                $this->objectManager->clear();
             }
         }
 
         $this->objectManager->flush();
-        $this->objectManager->clear();
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Fixture/AbstractResourceFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/AbstractResourceFixture.php
@@ -14,6 +14,7 @@ namespace Sylius\Bundle\CoreBundle\Fixture;
 use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
 use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
+use Sylius\Bundle\FixturesBundle\Suite\SuiteInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\OptionsResolver\Options;
@@ -56,7 +57,7 @@ abstract class AbstractResourceFixture implements FixtureInterface
                 ->setAllowedTypes('prototype', 'array')
                 ->setDefault('custom', [])
                 ->setAllowedTypes('custom', 'array')
-                ->setNormalizer('custom', function (Options $options, array $custom) {
+                ->setNormalizer('custom', function(Options $options, array $custom) {
                     if ($options['random'] <= 0) {
                         return $custom;
                     }
@@ -69,7 +70,7 @@ abstract class AbstractResourceFixture implements FixtureInterface
     /**
      * @param array $options
      */
-    final public function load(array $options)
+    final public function load(array $options, SuiteInterface $suite)
     {
         $options = $this->optionsResolver->resolve($options);
 
@@ -83,10 +84,16 @@ abstract class AbstractResourceFixture implements FixtureInterface
 
             if (0 === ($i % 10)) {
                 $this->objectManager->flush();
+                if ($suite->shouldClearObjectManager()) {
+                    $this->objectManager->clear();
+                }
             }
         }
 
         $this->objectManager->flush();
+        if ($suite->shouldClearObjectManager()) {
+            $this->objectManager->clear();
+        }
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Fixture/BookProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/BookProductFixture.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\CoreBundle\Fixture;
 
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
+use Sylius\Bundle\FixturesBundle\Suite\SuiteInterface;
 use Sylius\Component\Attribute\AttributeType\IntegerAttributeType;
 use Sylius\Component\Attribute\AttributeType\SelectAttributeType;
 use Sylius\Component\Attribute\AttributeType\TextAttributeType;
@@ -81,7 +82,7 @@ class BookProductFixture extends AbstractFixture
     /**
      * {@inheritdoc}
      */
-    public function load(array $options)
+    public function load(array $options, SuiteInterface $suite)
     {
         $options = $this->optionsResolver->resolve($options);
 
@@ -94,7 +95,7 @@ class BookProductFixture extends AbstractFixture
                     'name' => 'Books',
                 ]
             ]
-        ]]]);
+        ]]], $suite);
 
         $bookGenres = ['Fiction', 'Romance', 'Thriller', 'Sports'];
         $this->productAttributeFixture->load(['custom' => [
@@ -110,7 +111,7 @@ class BookProductFixture extends AbstractFixture
                     'choices' => $bookGenres,
                 ]
             ],
-        ]]);
+        ]], $suite);
 
         $products = [];
         $productsNames = $this->getUniqueNames($options['amount']);
@@ -135,7 +136,7 @@ class BookProductFixture extends AbstractFixture
             ];
         }
 
-        $this->productFixture->load(['custom' => $products]);
+        $this->productFixture->load(['custom' => $products], $suite);
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Fixture/CurrencyFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/CurrencyFixture.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\CoreBundle\Fixture;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
+use Sylius\Bundle\FixturesBundle\Suite\SuiteInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -45,7 +46,7 @@ class CurrencyFixture extends AbstractFixture
     /**
      * {@inheritdoc}
      */
-    public function load(array $options)
+    public function load(array $options, SuiteInterface $suite)
     {
         foreach ($options['currencies'] as $currencyCode) {
             /** @var CurrencyInterface $currency */

--- a/src/Sylius/Bundle/CoreBundle/Fixture/GeographicalFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/GeographicalFixture.php
@@ -14,6 +14,7 @@ namespace Sylius\Bundle\CoreBundle\Fixture;
 use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Component\Addressing\Factory\ZoneFactoryInterface;
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
+use Sylius\Bundle\FixturesBundle\Suite\SuiteInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Addressing\Model\ProvinceInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
@@ -83,7 +84,7 @@ class GeographicalFixture extends AbstractFixture
     /**
      * {@inheritdoc}
      */
-    public function load(array $options)
+    public function load(array $options, SuiteInterface $suite)
     {
         $this->loadCountriesWithProvinces($options['countries'], $options['provinces']);
         $this->loadZones($options['zones'], $this->provideZoneValidator($options));

--- a/src/Sylius/Bundle/CoreBundle/Fixture/LocaleFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/LocaleFixture.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\CoreBundle\Fixture;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
+use Sylius\Bundle\FixturesBundle\Suite\SuiteInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -52,7 +53,7 @@ class LocaleFixture extends AbstractFixture
     /**
      * {@inheritdoc}
      */
-    public function load(array $options)
+    public function load(array $options, SuiteInterface $suite)
     {
         $localesCodes = array_merge([$this->baseLocaleCode], $options['locales']);
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/MugProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/MugProductFixture.php
@@ -13,7 +13,7 @@ namespace Sylius\Bundle\CoreBundle\Fixture;
 
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
 use Sylius\Component\Attribute\AttributeType\SelectAttributeType;
-use Sylius\Component\Attribute\AttributeType\TextAttributeType;
+use Sylius\Bundle\FixturesBundle\Suite\SuiteInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -88,7 +88,7 @@ class MugProductFixture extends AbstractFixture
     /**
      * {@inheritdoc}
      */
-    public function load(array $options)
+    public function load(array $options, SuiteInterface $suite)
     {
         $options = $this->optionsResolver->resolve($options);
 
@@ -101,7 +101,7 @@ class MugProductFixture extends AbstractFixture
                     'name' => 'Mugs',
                 ]
             ]
-        ]]]);
+        ]]], $suite);
 
         $mugMaterials = ['Invisible porcelain', 'Banana skin', 'Porcelain', 'Centipede'];
         $this->productAttributeFixture->load(['custom' => [
@@ -114,7 +114,7 @@ class MugProductFixture extends AbstractFixture
                     'choices' => $mugMaterials,
                 ]
             ],
-        ]]);
+        ]], $suite);
 
         $this->productOptionFixture->load(['custom' => [
             [
@@ -126,7 +126,7 @@ class MugProductFixture extends AbstractFixture
                     'mug_type_monster' => 'Monster mug',
                 ],
             ],
-        ]]);
+        ]], $suite);
 
         $products = [];
         $productsNames = $this->getUniqueNames($options['amount']);
@@ -141,13 +141,13 @@ class MugProductFixture extends AbstractFixture
                 ],
                 'product_options' => ['mug_type'],
                 'images' => [
-                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'mugs.jpg'), 'main'],
-                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'mugs.jpg'), 'thumbnail'],
+                    'main' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 'mugs.jpg'),
+                    'thumbnail' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 'mugs.jpg'),
                 ],
             ];
         }
 
-        $this->productFixture->load(['custom' => $products]);
+        $this->productFixture->load(['custom' => $products], $suite);
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Fixture/MugProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/MugProductFixture.php
@@ -141,8 +141,8 @@ class MugProductFixture extends AbstractFixture
                 ],
                 'product_options' => ['mug_type'],
                 'images' => [
-                    'main' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 'mugs.jpg'),
-                    'thumbnail' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 'mugs.jpg'),
+                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'mugs.jpg'), 'main'],
+                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'mugs.jpg'), 'thumbnail'],
                 ],
             ];
         }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
@@ -14,6 +14,7 @@ namespace Sylius\Bundle\CoreBundle\Fixture;
 use Doctrine\Common\Persistence\ObjectManager;
 use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
+use Sylius\Bundle\FixturesBundle\Suite\SuiteInterface;
 use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\OrderCheckoutTransitions;
@@ -142,7 +143,7 @@ class OrderFixture extends AbstractFixture
     /**
      * {@inheritdoc}
      */
-    public function load(array $options)
+    public function load(array $options, SuiteInterface $suite)
     {
         $channels = $this->channelRepository->findAll();
         $customers = $this->customerRepository->findAll();

--- a/src/Sylius/Bundle/CoreBundle/Fixture/SimilarProductAssociationFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/SimilarProductAssociationFixture.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\CoreBundle\Fixture;
 
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
+use Sylius\Bundle\FixturesBundle\Suite\SuiteInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Repository\ProductRepositoryInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -80,14 +81,14 @@ class SimilarProductAssociationFixture extends AbstractFixture
     /**
      * {@inheritdoc}
      */
-    public function load(array $options)
+    public function load(array $options, SuiteInterface $suite)
     {
         $options = $this->optionsResolver->resolve($options);
 
         $this->productAssociationTypeFixture->load(['custom' => [[
             'code' => 'similar_products',
             'name' => 'Similar products',
-        ]]]);
+        ]]], $suite);
 
         $products = $this->productRepository->findAll();
         $products = $this->faker->randomElements($products, $options['amount']);
@@ -102,7 +103,7 @@ class SimilarProductAssociationFixture extends AbstractFixture
             ];
         }
 
-        $this->productAssociationFixture->load(['custom' => $productAssociations]);
+        $this->productAssociationFixture->load(['custom' => $productAssociations], $suite);
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Fixture/StickerProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/StickerProductFixture.php
@@ -136,8 +136,8 @@ class StickerProductFixture extends AbstractFixture
                 ],
                 'product_options' => ['sticker_size'],
                 'images' => [
-                    'main' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 'stickers.jpg'),
-                    'thumbnail' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 'stickers.jpg'),
+                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'stickers.jpg'), 'main'],
+                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'stickers.jpg'), 'thumbnail'],
                 ],
             ];
         }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/StickerProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/StickerProductFixture.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\CoreBundle\Fixture;
 
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
+use Sylius\Bundle\FixturesBundle\Suite\SuiteInterface;
 use Sylius\Component\Attribute\AttributeType\TextAttributeType;
 use Sylius\Component\Core\Model\ProductInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -88,7 +89,7 @@ class StickerProductFixture extends AbstractFixture
     /**
      * {@inheritdoc}
      */
-    public function load(array $options)
+    public function load(array $options, SuiteInterface $suite)
     {
         $options = $this->optionsResolver->resolve($options);
 
@@ -101,12 +102,12 @@ class StickerProductFixture extends AbstractFixture
                     'name' => 'Stickers',
                 ]
             ]
-        ]]]);
+        ]]], $suite);
 
         $this->productAttributeFixture->load(['custom' => [
             ['name' => 'Sticker paper', 'code' => 'sticker_paper', 'type' => TextAttributeType::TYPE],
             ['name' => 'Sticker resolution', 'code' => 'sticker_resolution', 'type' => TextAttributeType::TYPE],
-        ]]);
+        ]], $suite);
 
         $this->productOptionFixture->load(['custom' => [
             [
@@ -118,7 +119,7 @@ class StickerProductFixture extends AbstractFixture
                     'sticker_size_7' => '7"',
                 ],
             ],
-        ]]);
+        ]], $suite);
 
         $products = [];
         $productsNames = $this->getUniqueNames($options['amount']);
@@ -135,13 +136,13 @@ class StickerProductFixture extends AbstractFixture
                 ],
                 'product_options' => ['sticker_size'],
                 'images' => [
-                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'stickers.jpg'), 'main'],
-                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'stickers.jpg'), 'thumbnail'],
+                    'main' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 'stickers.jpg'),
+                    'thumbnail' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 'stickers.jpg'),
                 ],
             ];
         }
 
-        $this->productFixture->load(['custom' => $products]);
+        $this->productFixture->load(['custom' => $products], $suite);
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Fixture/TshirtProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/TshirtProductFixture.php
@@ -162,8 +162,8 @@ class TshirtProductFixture extends AbstractFixture
                 ],
                 'product_options' => ['t_shirt_color', 't_shirt_size'],
                 'images' => [
-                    'main' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 't-shirts.jpg'),
-                    'thumbnail' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 't-shirts.jpg'),
+                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 't-shirts.jpg'), 'main'],
+                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 't-shirts.jpg'), 'thumbnail'],
                 ],
             ];
         }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/TshirtProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/TshirtProductFixture.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\CoreBundle\Fixture;
 
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
+use Sylius\Bundle\FixturesBundle\Suite\SuiteInterface;
 use Sylius\Component\Attribute\AttributeType\TextAttributeType;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -87,7 +88,7 @@ class TshirtProductFixture extends AbstractFixture
     /**
      * {@inheritdoc}
      */
-    public function load(array $options)
+    public function load(array $options, SuiteInterface $suite)
     {
         $options = $this->optionsResolver->resolve($options);
 
@@ -113,13 +114,13 @@ class TshirtProductFixture extends AbstractFixture
                     ],
                 ],
             ],
-        ]]]);
+        ]]], $suite);
 
         $this->productAttributeFixture->load(['custom' => [
             ['name' => 'T-Shirt brand', 'code' => 't_shirt_brand', 'type' => TextAttributeType::TYPE],
             ['name' => 'T-Shirt collection', 'code' => 't_shirt_collection', 'type' => TextAttributeType::TYPE],
             ['name' => 'T-Shirt material', 'code' => 't_shirt_material', 'type' => TextAttributeType::TYPE],
-        ]]);
+        ]], $suite);
 
         $this->productOptionFixture->load(['custom' => [
             [
@@ -142,7 +143,7 @@ class TshirtProductFixture extends AbstractFixture
                     't_shirt_size_xxl' => 'XXL',
                 ],
             ],
-        ]]);
+        ]], $suite);
 
         $products = [];
         $productsNames = $this->getUniqueNames($options['amount']);
@@ -161,13 +162,13 @@ class TshirtProductFixture extends AbstractFixture
                 ],
                 'product_options' => ['t_shirt_color', 't_shirt_size'],
                 'images' => [
-                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 't-shirts.jpg'), 'main'],
-                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 't-shirts.jpg'), 'thumbnail'],
+                    'main' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 't-shirts.jpg'),
+                    'thumbnail' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 't-shirts.jpg'),
                 ],
             ];
         }
 
-        $this->productFixture->load(['custom' => $products]);
+        $this->productFixture->load(['custom' => $products], $suite);
     }
 
     /**

--- a/src/Sylius/Bundle/FixturesBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/FixturesBundle/DependencyInjection/Configuration.php
@@ -64,6 +64,8 @@ final class Configuration implements ConfigurationInterface
                 })
         ;
 
+        $suitesNode->children()->booleanNode('clear_object_manager')->defaultValue(true);
+
         $this->buildFixturesNode($suitesNode);
         $this->buildListenersNode($suitesNode);
     }

--- a/src/Sylius/Bundle/FixturesBundle/Fixture/FixtureInterface.php
+++ b/src/Sylius/Bundle/FixturesBundle/Fixture/FixtureInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\FixturesBundle\Fixture;
 
+use Sylius\Bundle\FixturesBundle\Suite\SuiteInterface;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
@@ -20,8 +21,9 @@ interface FixtureInterface extends ConfigurationInterface
 {
     /**
      * @param array $options
+     * @param SuiteInterface $suite
      */
-    public function load(array $options);
+    public function load(array $options, SuiteInterface $suite);
 
     /**
      * @return string

--- a/src/Sylius/Bundle/FixturesBundle/Loader/FixtureLoader.php
+++ b/src/Sylius/Bundle/FixturesBundle/Loader/FixtureLoader.php
@@ -24,6 +24,6 @@ final class FixtureLoader implements FixtureLoaderInterface
      */
     public function load(SuiteInterface $suite, FixtureInterface $fixture, array $options)
     {
-        $fixture->load($options);
+        $fixture->load($options, $suite);
     }
 }

--- a/src/Sylius/Bundle/FixturesBundle/Suite/Suite.php
+++ b/src/Sylius/Bundle/FixturesBundle/Suite/Suite.php
@@ -36,6 +36,11 @@ final class Suite implements SuiteInterface
     private $listeners;
 
     /**
+     * @var bool
+     */
+    private $clearObjectManager = true;
+
+    /**
      * @param string $name
      */
     public function __construct($name)
@@ -93,5 +98,21 @@ final class Suite implements SuiteInterface
         foreach ($listeners as $listener) {
             yield $listener['listener'] => $listener['options'];
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function shouldClearObjectManager()
+    {
+        return $this->clearObjectManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setClearObjectManager($clear)
+    {
+        $this->clearObjectManager = $clear;
     }
 }

--- a/src/Sylius/Bundle/FixturesBundle/Suite/SuiteFactory.php
+++ b/src/Sylius/Bundle/FixturesBundle/Suite/SuiteFactory.php
@@ -58,8 +58,10 @@ final class SuiteFactory implements SuiteFactoryInterface
     {
         Assert::keyExists($configuration, 'fixtures');
         Assert::keyExists($configuration, 'listeners');
+        Assert::keyExists($configuration, 'clear_object_manager');
 
         $suite = new Suite($name);
+        $suite->setClearObjectManager($configuration['clear_object_manager']);
 
         foreach ($configuration['fixtures'] as $fixtureAlias => $fixtureAttributes) {
             $this->addFixtureToSuite($suite, $fixtureAlias, $fixtureAttributes);

--- a/src/Sylius/Bundle/FixturesBundle/Suite/SuiteInterface.php
+++ b/src/Sylius/Bundle/FixturesBundle/Suite/SuiteInterface.php
@@ -34,4 +34,14 @@ interface SuiteInterface
      * @return \Traversable Listeners as keys, options as values
      */
     public function getListeners();
+
+    /**
+     * @return bool
+     */
+    public function shouldClearObjectManager();
+
+    /**
+     * @param bool $clear
+     */
+    public function setClearObjectManager($clear);
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #6051  |
| License         | MIT |

We should not clear the object manager by default since this can have nasty side effects. I think it should be removed and later made configurable in some way. 