### PR TITLE
Let the ThemeFilesystemLoader check if a template exists in the decorated loader

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Twig/ThemeFilesystemLoader.php
+++ b/src/Sylius/Bundle/ThemeBundle/Twig/ThemeFilesystemLoader.php
@@ -120,6 +120,11 @@ final class ThemeFilesystemLoader implements \Twig_LoaderInterface, \Twig_Exists
         try {
             return stat($this->findTemplate($name)) !== false;
         } catch (\Exception $exception) {
+            // In Twig 2.0, exists is part of \Twig_LoaderInterface
+            if ($this->decoratedLoader instanceof \Twig_ExistsLoaderInterface || method_exists('\\Twig_LoaderInterface', 'exists')) {
+                return $this->decoratedLoader->exists($name);
+            }
+
             return false;
         }
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

Instead of failing immediately in the `ThemeFilesystemLoader` if a template doesn't exist, try to check the decorated loader if it supports checking for existence for the template as well.

The check here is similar to the one used for `getSourceContext` since the method is not implemented on the base loader interface in Twig 1.x and loaders may not implement the deprecated `Twig_ExistsLoaderInterface` if supporting Twig 2.0+ only.