### PR TITLE
Revert "Fix root option on TaxonChoiceType"

### DIFF
--- a/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
@@ -12,6 +12,7 @@
 namespace Sylius\Bundle\TaxonomyBundle\Doctrine\ORM;
 
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+use Sylius\Component\Taxonomy\Model\TaxonInterface;
 use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
 
 /**
@@ -86,7 +87,7 @@ class TaxonRepository extends EntityRepository implements TaxonRepositoryInterfa
     /**
      * {@inheritdoc}
      */
-    public function findNodesTreeSorted($rootCode = null)
+    public function findNodesTreeSorted()
     {
         return $this->createQueryBuilder('o')
             ->addOrderBy('o.root')
@@ -95,16 +96,6 @@ class TaxonRepository extends EntityRepository implements TaxonRepositoryInterfa
             ->getQuery()
             ->getResult()
         ;
-
-        if (null !== $rootCode) {
-            $queryBuilder
-                ->join('o.root', 'root')
-                ->andWhere('root.code = :rootCode')
-                ->setParameter('rootCode', $rootCode)
-            ;
-        }
-
-        return $queryBuilder->getQuery()->getResult();
     }
 
     /**

--- a/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonChoiceType.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonChoiceType.php
@@ -16,6 +16,7 @@ use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
 use Symfony\Bridge\Doctrine\Form\DataTransformer\CollectionToArrayTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
+use Symfony\Component\Form\Extension\Core\ChoiceList\ObjectChoiceList;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -80,15 +81,21 @@ final class TaxonChoiceType extends AbstractType
         $resolver
             ->setDefaults([
                 'choices' => function (Options $options) {
-                    return $this->getTaxons($options['root_code'], $options['filter']);
+                    $taxons = $this->taxonRepository->findNodesTreeSorted();
+
+                    if (null !== $options['filter']) {
+                        $taxons = array_filter($taxons, $options['filter']);
+                    }
+
+                    return $taxons;
                 },
                 'choice_value' => 'id',
                 'choice_label' => 'name',
                 'choice_translation_domain' => false,
-                'root_code' => null,
+                'root' => null,
                 'filter' => null,
             ])
-            ->setAllowedTypes('root_code', ['string', 'null'])
+            ->setAllowedTypes('root', [TaxonInterface::class, 'string', 'null'])
             ->setAllowedTypes('filter', ['callable', 'null'])
         ;
     }
@@ -99,22 +106,5 @@ final class TaxonChoiceType extends AbstractType
     public function getBlockPrefix()
     {
         return 'sylius_taxon_choice';
-    }
-
-    /**
-     * @param string|null $rootCode
-     * @param callable|null $filter
-     *
-     * @return TaxonInterface[]
-     */
-    private function getTaxons($rootCode = null, $filter = null)
-    {
-        $taxons = $this->taxonRepository->findNodesTreeSorted($rootCode);
-
-        if (null !== $filter) {
-            $taxons = array_filter($taxons, $filter);
-        }
-
-        return $taxons;
     }
 }

--- a/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonChoiceType.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonChoiceType.php
@@ -92,10 +92,8 @@ final class TaxonChoiceType extends AbstractType
                 'choice_value' => 'id',
                 'choice_label' => 'name',
                 'choice_translation_domain' => false,
-                'root' => null,
                 'filter' => null,
             ])
-            ->setAllowedTypes('root', [TaxonInterface::class, 'string', 'null'])
             ->setAllowedTypes('filter', ['callable', 'null'])
         ;
     }

--- a/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
+++ b/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
@@ -36,12 +36,10 @@ interface TaxonRepositoryInterface extends RepositoryInterface
     public function findRootNodes();
 
     /**
-     * @param string|null $rootCode
-     *
      * @return TaxonInterface[]
      */
-    public function findNodesTreeSorted($rootCode = null);
-
+    public function findNodesTreeSorted();
+    
     /**
      * @param string $slug
      *


### PR DESCRIPTION
Doubled `return` in repository method, that PR hasn't changed anything in fact.

Reverts #7254, fixes #7390.

Also removes not used "root" option from `TaxonChoiceType`.