### PR TITLE
[BugFix] Remove final keyword from some Behat pages

### DIFF
--- a/src/Sylius/Behat/Page/Shop/Account/AddressBook/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/AddressBook/UpdatePage.php
@@ -16,7 +16,7 @@ use Sylius\Behat\Page\SymfonyPage;
 /**
  * @author Jan Góralski <jan.goralski@lakion.com>
  */
-final class UpdatePage extends SymfonyPage implements UpdatePageInterface
+class UpdatePage extends SymfonyPage implements UpdatePageInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Sylius/Behat/Page/Shop/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Shop/Order/ShowPage.php
@@ -17,7 +17,7 @@ use Sylius\Behat\Page\SymfonyPage;
 /**
  * @author Arkadiusz Krakowiak <arkadiusz.krakowiak@lakion.com>
  */
-final class ShowPage extends SymfonyPage implements ShowPageInterface
+class ShowPage extends SymfonyPage implements ShowPageInterface
 {
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | none |
| License         | MIT |

This should not be final, since you should be able to extend these pages. These are the only behat pages that are final, probably by accident.
