### PR TITLE
Product attribute creation must be typed

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/product_attribute.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/product_attribute.yml
@@ -20,6 +20,10 @@ sylius_api_product_attribute_create:
         _controller: sylius.controller.product_attribute:createAction
         _sylius:
             serialization_version: $version
+            factory:
+                method: createTyped
+                arguments:
+                    type: $type
 
 sylius_api_product_attribute_update:
     path: /{id}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets | #6117 |
| License         | MIT |

This PR aims to fix product attribute creation via api as the configured factory does not allows creating untyped attributes (https://github.com/Sylius/Sylius/blob/master/src/Sylius/Component/Attribute/Factory/AttributeFactory.php#L48-L53).