### PR TITLE
Fixed incoherent exception when a channel cannot be resolved (Currency not found)

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures.yml
@@ -25,7 +25,7 @@ sylius_fixtures:
                                 currencies:
                                     - "USD"
                                 enabled: true
-                                hostname: "localhost:8000"
+                                hostname: "localhost"
 
                 geographical:
                     options:

--- a/src/Sylius/Component/Currency/Context/CompositeCurrencyContext.php
+++ b/src/Sylius/Component/Currency/Context/CompositeCurrencyContext.php
@@ -41,14 +41,18 @@ final class CompositeCurrencyContext implements CurrencyContextInterface
      */
     public function getCurrencyCode()
     {
+        $lastException = null;
+
         foreach ($this->currencyContexts as $currencyContext) {
             try {
                 return $currencyContext->getCurrencyCode();
             } catch (CurrencyNotFoundException $exception) {
+                $lastException = $exception;
+
                 continue;
             }
         }
 
-        throw new CurrencyNotFoundException();
+        throw new CurrencyNotFoundException(null, $lastException);
     }
 }

--- a/src/Sylius/Component/Locale/Context/CompositeLocaleContext.php
+++ b/src/Sylius/Component/Locale/Context/CompositeLocaleContext.php
@@ -41,14 +41,18 @@ final class CompositeLocaleContext implements LocaleContextInterface
      */
     public function getLocaleCode()
     {
+        $lastException = null;
+
         foreach ($this->localeContexts as $localeContext) {
             try {
                 return $localeContext->getLocaleCode();
             } catch (LocaleNotFoundException $exception) {
+                $lastException = $exception;
+
                 continue;
             }
         }
 
-        throw new LocaleNotFoundException();
+        throw new LocaleNotFoundException(null, $lastException);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #6474, fixes #5812 |
| License         | MIT |

Ensured the last exception caught in `Composite*Context`s gets linked to the one it throws itself.
So now instead of a single `CurrencyNotFound` we'll see every exception which led up to it, giving us the root of the problem (more or less).

Although not a perfect solution, it's probably one of the simplest which won't convolute the logic.