### PR TITLE
[Behat] Improve assertions usage in contexts

### DIFF
--- a/src/Sylius/Behat/Context/Domain/CartContext.php
+++ b/src/Sylius/Behat/Context/Domain/CartContext.php
@@ -60,10 +60,7 @@ final class CartContext implements Context
     {
         $this->expiredCartsRemover->remove();
 
-        Assert::null(
-            $cart->getId(),
-            'This cart should not exist in registry but it does.'
-        );
+        Assert::null($cart->getId());
     }
 
     /**
@@ -73,9 +70,6 @@ final class CartContext implements Context
     {
         $this->expiredCartsRemover->remove();
 
-        Assert::notNull(
-            $cart->getId(),
-            'This cart should be in registry but it is not.'
-        );
+        Assert::notNull($cart->getId());
     }
 }

--- a/src/Sylius/Behat/Context/Domain/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Domain/ManagingOrdersContext.php
@@ -178,11 +178,7 @@ final class ManagingOrdersContext implements Context
      */
     public function thisOrderShouldBeAutomaticallyCancelled(OrderInterface $order)
     {
-        Assert::same(
-            OrderInterface::STATE_CANCELLED,
-            $order->getState(),
-            'Order should be cancelled, but its not.'
-        );
+        Assert::same($order->getState(), OrderInterface::STATE_CANCELLED);
     }
 
     /**
@@ -190,10 +186,6 @@ final class ManagingOrdersContext implements Context
      */
     public function thisOrderShouldNotBeCancelled(OrderInterface $order)
     {
-        Assert::notSame(
-            OrderInterface::STATE_CANCELLED,
-            $order->getState(),
-            'Order should not be cancelled, but its is.'
-        );
+        Assert::notSame($order->getState(), OrderInterface::STATE_CANCELLED);
     }
 }

--- a/src/Sylius/Behat/Context/Domain/ManagingPromotionCouponsContext.php
+++ b/src/Sylius/Behat/Context/Domain/ManagingPromotionCouponsContext.php
@@ -71,10 +71,7 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function couponShouldNotExistInTheRegistry(PromotionCouponInterface $coupon)
     {
-        Assert::null(
-            $this->couponRepository->findOneBy(['code' => $coupon->getCode()]),
-            sprintf('The coupon with code %s should not exist', $coupon->getCode())
-        );
+        Assert::null($this->couponRepository->findOneBy(['code' => $coupon->getCode()]));
     }
 
     /**
@@ -90,9 +87,6 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function couponShouldStillExistInTheRegistry(PromotionCouponInterface $coupon)
     {
-        Assert::notNull(
-            $this->couponRepository->find($coupon->getId()),
-            sprintf('The coupon with id %s should exist', $coupon->getId())
-        );
+        Assert::notNull($this->couponRepository->find($coupon->getId()));
     }
 }

--- a/src/Sylius/Behat/Context/Setup/CustomerGroupContext.php
+++ b/src/Sylius/Behat/Context/Setup/CustomerGroupContext.php
@@ -71,7 +71,7 @@ final class CustomerGroupContext implements Context
         /** @var CustomerGroupInterface $customerGroup */
         $customerGroup = $this->customerGroupFactory->createNew();
 
-        $customerGroup->setCode($code ? $code : $this->generateCodeFromName($name));
+        $customerGroup->setCode($code ?: $this->generateCodeFromName($name));
         $customerGroup->setName(ucfirst($name));
 
         $this->sharedStorage->set('customer_group', $customerGroup);

--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -27,7 +27,6 @@ use Sylius\Component\Core\Model\ShippingMethodInterface;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\OrderPaymentTransitions;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Sylius\Component\Currency\Model\CurrencyInterface;
 use Sylius\Component\Customer\Model\CustomerInterface;
 use Sylius\Component\Order\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Component\Order\OrderTransitions;
@@ -71,11 +70,6 @@ final class OrderContext implements Context
     private $itemQuantityModifier;
 
     /**
-     * @var RepositoryInterface
-     */
-    private $currencyRepository;
-
-    /**
      * @var FactoryInterface
      */
     private $customerFactory;
@@ -106,7 +100,6 @@ final class OrderContext implements Context
      * @param FactoryInterface $orderFactory
      * @param FactoryInterface $orderItemFactory
      * @param OrderItemQuantityModifierInterface $itemQuantityModifier
-     * @param RepositoryInterface $currencyRepository
      * @param FactoryInterface $customerFactory
      * @param RepositoryInterface $customerRepository
      * @param ObjectManager $objectManager
@@ -119,7 +112,6 @@ final class OrderContext implements Context
         FactoryInterface $orderFactory,
         FactoryInterface $orderItemFactory,
         OrderItemQuantityModifierInterface $itemQuantityModifier,
-        RepositoryInterface $currencyRepository,
         FactoryInterface $customerFactory,
         RepositoryInterface $customerRepository,
         ObjectManager $objectManager,
@@ -131,7 +123,6 @@ final class OrderContext implements Context
         $this->orderFactory = $orderFactory;
         $this->orderItemFactory = $orderItemFactory;
         $this->itemQuantityModifier = $itemQuantityModifier;
-        $this->currencyRepository = $currencyRepository;
         $this->customerFactory = $customerFactory;
         $this->customerRepository = $customerRepository;
         $this->objectManager = $objectManager;

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -58,11 +58,6 @@ final class ProductContext implements Context
     private $productRepository;
 
     /**
-     * @var RepositoryInterface
-     */
-    private $productAttributeRepository;
-
-    /**
      * @var ProductFactoryInterface
      */
     private $productFactory;
@@ -71,11 +66,6 @@ final class ProductContext implements Context
      * @var FactoryInterface
      */
     private $productTranslationFactory;
-
-    /**
-     * @var AttributeFactoryInterface
-     */
-    private $productAttributeFactory;
 
     /**
      * @var FactoryInterface
@@ -135,10 +125,8 @@ final class ProductContext implements Context
     /**
      * @param SharedStorageInterface $sharedStorage
      * @param ProductRepositoryInterface $productRepository
-     * @param RepositoryInterface $productAttributeRepository
      * @param ProductFactoryInterface $productFactory
      * @param FactoryInterface $productTranslationFactory
-     * @param AttributeFactoryInterface $productAttributeFactory
      * @param FactoryInterface $productVariantFactory
      * @param FactoryInterface $productVariantTranslationFactory
      * @param FactoryInterface $channelPricingFactory
@@ -154,10 +142,8 @@ final class ProductContext implements Context
     public function __construct(
         SharedStorageInterface $sharedStorage,
         ProductRepositoryInterface $productRepository,
-        RepositoryInterface $productAttributeRepository,
         ProductFactoryInterface $productFactory,
         FactoryInterface $productTranslationFactory,
-        AttributeFactoryInterface $productAttributeFactory,
         FactoryInterface $productVariantFactory,
         FactoryInterface $productVariantTranslationFactory,
         FactoryInterface $channelPricingFactory,
@@ -172,10 +158,8 @@ final class ProductContext implements Context
     ) {
         $this->sharedStorage = $sharedStorage;
         $this->productRepository = $productRepository;
-        $this->productAttributeRepository = $productAttributeRepository;
         $this->productFactory = $productFactory;
         $this->productTranslationFactory = $productTranslationFactory;
-        $this->productAttributeFactory = $productAttributeFactory;
         $this->productVariantFactory = $productVariantFactory;
         $this->productVariantTranslationFactory = $productVariantTranslationFactory;
         $this->channelPricingFactory = $channelPricingFactory;

--- a/src/Sylius/Behat/Context/Setup/ProductOptionContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductOptionContext.php
@@ -114,7 +114,7 @@ final class ProductOptionContext implements Context
         /** @var ProductOptionInterface $productOption */
         $productOption = $this->productOptionFactory->createNew();
         $productOption->setName($name);
-        $productOption->setCode($code ? $code : StringInflector::nameToCode($name));
+        $productOption->setCode($code ?: StringInflector::nameToCode($name));
         $productOption->setPosition($position);
 
         $this->sharedStorage->set('product_option', $productOption);

--- a/src/Sylius/Behat/Context/Setup/TaxationContext.php
+++ b/src/Sylius/Behat/Context/Setup/TaxationContext.php
@@ -171,8 +171,8 @@ final class TaxationContext implements Context
         }
 
         Assert::eq(
-            1,
             count($taxCategories),
+            1,
             sprintf('%d tax categories has been found with name "%s".', count($taxCategories), $taxCategoryName)
         );
 

--- a/src/Sylius/Behat/Context/Transform/AddressContext.php
+++ b/src/Sylius/Behat/Context/Transform/AddressContext.php
@@ -12,15 +12,10 @@
 namespace Sylius\Behat\Context\Transform;
 
 use Behat\Behat\Context\Context;
-use Sylius\Bundle\CoreBundle\Fixture\Factory\AddressExampleFactory;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
 use Sylius\Component\Addressing\Converter\CountryNameConverterInterface;
-use Sylius\Component\Addressing\Model\CountryInterface;
-use Sylius\Component\Addressing\Model\ProvinceInterface;
-use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Repository\AddressRepositoryInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
-use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Webmozart\Assert\Assert;
 
 /**

--- a/src/Sylius/Behat/Context/Transform/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Transform/ChannelContext.php
@@ -44,8 +44,8 @@ final class ChannelContext implements Context
         $channels = $this->channelRepository->findByName($channelName);
 
         Assert::eq(
-            1,
             count($channels),
+            1,
             sprintf('%d channels has been found with name "%s".', count($channels), $channelName)
         );
 

--- a/src/Sylius/Behat/Context/Transform/PaymentMethodContext.php
+++ b/src/Sylius/Behat/Context/Transform/PaymentMethodContext.php
@@ -43,8 +43,8 @@ final class PaymentMethodContext implements Context
         $paymentMethods = $this->paymentMethodRepository->findByName($paymentMethodName, 'en_US');
 
         Assert::eq(
-            1,
             count($paymentMethods),
+            1,
             sprintf('%d payment methods has been found with name "%s".', count($paymentMethods), $paymentMethodName)
         );
 

--- a/src/Sylius/Behat/Context/Transform/ProductAssociationTypeContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductAssociationTypeContext.php
@@ -45,8 +45,8 @@ final class ProductAssociationTypeContext implements Context
         );
 
         Assert::eq(
-            1,
             count($productAssociationTypes),
+            1,
             sprintf(
                 '%d product association types has been found with name "%s".',
                 count($productAssociationTypes),

--- a/src/Sylius/Behat/Context/Transform/ProductContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductContext.php
@@ -44,8 +44,8 @@ final class ProductContext implements Context
         $products = $this->productRepository->findByName($productName, 'en_US');
 
         Assert::eq(
-            1,
             count($products),
+            1,
             sprintf('%d products has been found with name "%s".', count($products), $productName)
         );
 

--- a/src/Sylius/Behat/Context/Transform/ProductOptionContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductOptionContext.php
@@ -43,8 +43,8 @@ final class ProductOptionContext implements Context
         $productOptions = $this->productOptionRepository->findByName($productOptionName, 'en_US');
 
         Assert::eq(
-            1,
             count($productOptions),
+            1,
             sprintf('%d product options has been found with name "%s".', count($productOptions), $productOptionName)
         );
 

--- a/src/Sylius/Behat/Context/Transform/ProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Transform/ProductVariantContext.php
@@ -51,8 +51,8 @@ final class ProductVariantContext implements Context
         $products = $this->productRepository->findByName($productName, 'en_US');
 
         Assert::eq(
-            1,
             count($products),
+            1,
             sprintf('%d products has been found with name "%s".', count($products), $productName)
         );
 
@@ -75,8 +75,8 @@ final class ProductVariantContext implements Context
         $productVariants = $this->productVariantRepository->findByName($name, 'en_US');
 
         Assert::eq(
-            1,
             count($productVariants),
+            1,
             sprintf('%d product variants has been found with name "%s".', count($productVariants), $name)
         );
 

--- a/src/Sylius/Behat/Context/Transform/ShippingCategoryContext.php
+++ b/src/Sylius/Behat/Context/Transform/ShippingCategoryContext.php
@@ -44,8 +44,8 @@ class ShippingCategoryContext implements Context
         $shippingCategories = $this->shippingCategoryRepository->findBy(['name' => $shippingCategoryName]);
 
         Assert::eq(
-            1,
             count($shippingCategories),
+            1,
             sprintf('%d shipping category has been found with name "%s".', count($shippingCategories), $shippingCategoryName)
         );
 

--- a/src/Sylius/Behat/Context/Transform/ShippingMethodContext.php
+++ b/src/Sylius/Behat/Context/Transform/ShippingMethodContext.php
@@ -43,8 +43,8 @@ final class ShippingMethodContext implements Context
         $shippingMethods = $this->shippingMethodRepository->findByName($shippingMethodName, 'en_US');
 
         Assert::eq(
-            1,
             count($shippingMethods),
+            1,
             sprintf('%d shipping methods have been found with name "%s".', count($shippingMethods), $shippingMethodName)
         );
 

--- a/src/Sylius/Behat/Context/Transform/TaxCategoryContext.php
+++ b/src/Sylius/Behat/Context/Transform/TaxCategoryContext.php
@@ -43,8 +43,8 @@ final class TaxCategoryContext implements Context
         $taxCategories = $this->taxCategoryRepository->findByName($taxCategoryName);
 
         Assert::eq(
-            1,
             count($taxCategories),
+            1,
             sprintf('%d tax categories has been found with name "%s".', count($taxCategories), $taxCategoryName)
         );
 

--- a/src/Sylius/Behat/Context/Transform/TaxonContext.php
+++ b/src/Sylius/Behat/Context/Transform/TaxonContext.php
@@ -49,8 +49,8 @@ final class TaxonContext implements Context
         $taxons = $this->taxonRepository->findByName($name, 'en_US');
 
         Assert::eq(
-            1,
             count($taxons),
+            1,
             sprintf('%d taxons has been found with name "%s".', count($taxons), $name)
         );
 

--- a/src/Sylius/Behat/Context/Ui/Admin/ImpersonatingCustomersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ImpersonatingCustomersContext.php
@@ -101,10 +101,7 @@ final class ImpersonatingCustomersContext implements Context
      */
     public function iShouldBeUnableToImpersonateThem()
     {
-        Assert::false(
-            $this->customerShowPage->hasImpersonateButton(),
-            'I should not be able to impersonate this user.'
-        );
+        Assert::false($this->customerShowPage->hasImpersonateButton());
     }
 
     /**
@@ -120,15 +117,8 @@ final class ImpersonatingCustomersContext implements Context
      */
     public function iShouldBeLoggedInAs($fullName)
     {
-        Assert::true(
-            $this->homePage->hasLogoutButton(),
-            'I should be able to sign out.'
-        );
-        Assert::contains(
-            $this->homePage->getFullName(),
-            $fullName,
-            'The full name should be "%2$s", but is "%s" instead.'
-        );
+        Assert::true($this->homePage->hasLogoutButton());
+        Assert::contains($this->homePage->getFullName(), $fullName);
     }
 
     /**
@@ -138,14 +128,8 @@ final class ImpersonatingCustomersContext implements Context
     {
         $this->homePage->open();
 
-        Assert::false(
-            $this->homePage->hasLogoutButton(),
-            'I should not be logged in.'
-        );
-        Assert::false(
-            strpos($this->homePage->getFullName(), $fullName),
-            sprintf('I should not be logged in as %s.', $fullName)
-        );
+        Assert::false($this->homePage->hasLogoutButton());
+        Assert::false(strpos($this->homePage->getFullName(), $fullName));
     }
 
     /**
@@ -153,9 +137,6 @@ final class ImpersonatingCustomersContext implements Context
      */
     public function iShouldSeeThatImpersonatingWasSuccessful($email)
     {
-        Assert::contains(
-            $this->customerShowPage->getSuccessFlashMessage(),
-            $email
-        );
+        Assert::contains($this->customerShowPage->getSuccessFlashMessage(), $email);
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/LocaleContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/LocaleContext.php
@@ -50,14 +50,7 @@ final class LocaleContext implements Context
     {
         $this->dashboardPage->open();
 
-        $expectedSubHeader = $this->translate('sylius.ui.overview_of_your_store', $localeCode);
-        $actualSubHeader = $this->dashboardPage->getSubHeader();
-
-        Assert::same(
-            $actualSubHeader,
-            $expectedSubHeader,
-            sprintf('Dashboard header should say "%s", but says "%s" instead.', $expectedSubHeader, $actualSubHeader)
-        );
+        Assert::same($this->dashboardPage->getSubHeader(), $this->translate('sylius.ui.overview_of_your_store', $localeCode));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/LoginContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/LoginContext.php
@@ -80,10 +80,7 @@ final class LoginContext implements Context
      */
     public function iShouldBeLoggedIn()
     {
-        Assert::true(
-            $this->dashboardPage->isOpen(),
-            'I should be on administration dashboard page.'
-        );
+        Assert::true($this->dashboardPage->isOpen());
     }
 
     /**
@@ -91,10 +88,7 @@ final class LoginContext implements Context
      */
     public function iShouldNotBeLoggedIn()
     {
-        Assert::false(
-            $this->dashboardPage->isOpen(),
-            'I should not have access to administration dashboard page.'
-        );
+        Assert::false($this->dashboardPage->isOpen());
     }
 
     /**
@@ -102,10 +96,7 @@ final class LoginContext implements Context
      */
     public function iShouldBeNotifiedAboutBadCredentials()
     {
-        Assert::true(
-            $this->loginPage->hasValidationErrorWith('Error Bad credentials.'),
-            'I should see validation error.'
-        );
+        Assert::true($this->loginPage->hasValidationErrorWith('Error Bad credentials.'));
     }
 
     /**
@@ -115,10 +106,7 @@ final class LoginContext implements Context
     {
         $this->logInAgain($username, $password);
 
-        Assert::true(
-            $this->dashboardPage->isOpen(),
-            'I should be able to log in.'
-        );
+        Assert::true($this->dashboardPage->isOpen());
     }
 
     /**
@@ -136,15 +124,8 @@ final class LoginContext implements Context
     {
         $this->logInAgain($username, $password);
 
-        Assert::true(
-            $this->loginPage->hasValidationErrorWith('Error Bad credentials.'),
-            'I should see validation error.'
-        );
-
-        Assert::false(
-            $this->dashboardPage->isOpen(),
-            'I should not be able to log in.'
-        );
+        Assert::true($this->loginPage->hasValidationErrorWith('Error Bad credentials.'));
+        Assert::false($this->dashboardPage->isOpen());
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingAdministratorsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingAdministratorsContext.php
@@ -198,10 +198,7 @@ final class ManagingAdministratorsContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['email' => $email]),
-            sprintf('Administrator %s does not exist', $email)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['email' => $email]));
     }
 
     /**
@@ -212,10 +209,7 @@ final class ManagingAdministratorsContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['username' => $username]),
-            sprintf('Administrator with %s username does not exist', $username)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['username' => $username]));
     }
 
     /**
@@ -223,11 +217,7 @@ final class ManagingAdministratorsContext implements Context
      */
     public function iShouldSeeAdministratorsInTheList($number)
     {
-        Assert::same(
-            $this->indexPage->countItems(),
-            (int) $number,
-            sprintf('There should be %s administrators, but got %s', $number, $this->indexPage->countItems())
-        );
+        Assert::same($this->indexPage->countItems(), (int) $number);
     }
 
     /**
@@ -269,11 +259,7 @@ final class ManagingAdministratorsContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::same(
-            1,
-            $this->indexPage->countItems(),
-            'There should not be any new administrators'
-        );
+        Assert::same($this->indexPage->countItems(), 1);
     }
 
     /**
@@ -281,10 +267,7 @@ final class ManagingAdministratorsContext implements Context
      */
     public function thereShouldBeNoAnymore($email)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['email' => $email]),
-            sprintf('Administrator with %s email should be deleted', $email)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['email' => $email]));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
@@ -136,10 +136,7 @@ final class ManagingChannelsContext implements Context
     {
         $this->iWantToBrowseChannels();
 
-        Assert::true($this->indexPage->isSingleResourceOnPage(
-            ['nameAndDescription' => $channelName]),
-            sprintf('Channel with name %s has not been found.', $channelName)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['nameAndDescription' => $channelName]));
     }
 
     /**
@@ -218,10 +215,7 @@ final class ManagingChannelsContext implements Context
     {
         $this->iWantToBrowseChannels();
 
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage([$element => $value]),
-            sprintf('Channel with %s "%s" was created, but it should not.', $element, $value)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
     /**
@@ -255,15 +249,10 @@ final class ManagingChannelsContext implements Context
     {
         $this->iWantToBrowseChannels();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(
-                [
-                    'code' => $channel->getCode(),
-                    'nameAndDescription' => $channelName,
-                ]
-            ),
-            sprintf('Channel name %s has not been assigned properly.', $channelName)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([
+            'code' => $channel->getCode(),
+            'nameAndDescription' => $channelName,
+        ]));
     }
 
     /**
@@ -290,10 +279,7 @@ final class ManagingChannelsContext implements Context
     {
         $this->iWantToBrowseChannels();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage([$element => $value]),
-            sprintf('Channel with %s %s cannot be found.', $element, $value)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
     /**
@@ -309,13 +295,7 @@ final class ManagingChannelsContext implements Context
      */
     public function iShouldSeeChannelsInTheList($numberOfChannels)
     {
-        $foundRows = $this->indexPage->countItems();
-
-        Assert::eq(
-            (int) $numberOfChannels,
-            $foundRows,
-            sprintf('%s rows with channels should appear on page, %s rows has been found', $numberOfChannels, $foundRows)
-        );
+        Assert::same($this->indexPage->countItems(), (int) $numberOfChannels);
     }
 
     /**
@@ -323,10 +303,7 @@ final class ManagingChannelsContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeDisabled(),
-            'Code should be immutable, but it does not.'
-        );
+        Assert::true($this->updatePage->isCodeDisabled());
     }
 
     /**
@@ -360,10 +337,7 @@ final class ManagingChannelsContext implements Context
      */
     public function thisChannelShouldNoLongerExistInTheRegistry($channelName)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['nameAndDescription' => $channelName]),
-            sprintf('Channel with name %s exists but should not.', $channelName)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['nameAndDescription' => $channelName]));
     }
 
     /**
@@ -394,10 +368,7 @@ final class ManagingChannelsContext implements Context
     {
         $this->updatePage->open(['id' => $channel->getId()]);
 
-        Assert::true(
-            $this->updatePage->isLocaleChosen($locale),
-            sprintf('Language %s should be selected but it is not', $locale)
-        );
+        Assert::true($this->updatePage->isLocaleChosen($locale));
     }
 
     /**
@@ -417,10 +388,7 @@ final class ManagingChannelsContext implements Context
     {
         $this->updatePage->open(['id' => $channel->getId()]);
 
-        Assert::true(
-            $this->updatePage->isCurrencyChosen($currencyCode),
-            sprintf('Currency %s should be selected but it is not', $currencyCode)
-        );
+        Assert::true($this->updatePage->isCurrencyChosen($currencyCode));
     }
 
     /**
@@ -458,10 +426,7 @@ final class ManagingChannelsContext implements Context
     {
         $this->updatePage->open(['id' => $channel->getId()]);
 
-        Assert::true(
-            $this->updatePage->isDefaultTaxZoneChosen($taxZone),
-            sprintf('Default tax zone %s should be selected, but it is not', $taxZone)
-        );
+        Assert::true($this->updatePage->isDefaultTaxZoneChosen($taxZone));
     }
 
     /**
@@ -471,10 +436,7 @@ final class ManagingChannelsContext implements Context
     {
         $this->updatePage->open(['id' => $channel->getId()]);
 
-        Assert::false(
-            $this->updatePage->isAnyDefaultTaxZoneChosen(),
-            'Channel should not have default tax zone, but it has.'
-        );
+        Assert::false($this->updatePage->isAnyDefaultTaxZoneChosen());
     }
 
     /**
@@ -484,10 +446,7 @@ final class ManagingChannelsContext implements Context
     {
         $this->updatePage->open(['id' => $channel->getId()]);
 
-        Assert::true(
-            $this->updatePage->isTaxCalculationStrategyChosen($taxCalculationStrategy),
-            sprintf('Tax calculation strategy %s should be selected, but it is not', $taxCalculationStrategy)
-        );
+        Assert::true($this->updatePage->isTaxCalculationStrategyChosen($taxCalculationStrategy));
     }
 
     /**
@@ -495,10 +454,7 @@ final class ManagingChannelsContext implements Context
      */
     public function theBaseCurrencyFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isBaseCurrencyDisabled(),
-            'Base currency should be immutable, but it is not.'
-        );
+        Assert::true($this->updatePage->isBaseCurrencyDisabled());
     }
 
     /**
@@ -509,13 +465,9 @@ final class ManagingChannelsContext implements Context
     {
         $this->iWantToBrowseChannels();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(
-                [
-                    'nameAndDescription' => $channel->getName(),
-                    'enabled' => $state,
-                ]
-            ), sprintf('Channel with name %s and state %s has not been found.', $channel->getName(), $state)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([
+            'nameAndDescription' => $channel->getName(),
+            'enabled' => $state,
+        ]));
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCountriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCountriesContext.php
@@ -138,10 +138,7 @@ final class ManagingCountriesContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['code' => $country->getCode()]),
-            sprintf('Country %s should exist but it does not', $country->getCode())
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $country->getCode()]));
     }
 
     /**
@@ -151,10 +148,7 @@ final class ManagingCountriesContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isCountryEnabled($country),
-            sprintf('Country %s should be enabled but it is not', $country->getCode())
-        );
+        Assert::true($this->indexPage->isCountryEnabled($country));
     }
 
     /**
@@ -164,10 +158,7 @@ final class ManagingCountriesContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isCountryDisabled($country),
-            sprintf('Country %s should be disabled but it is not', $country->getCode())
-        );
+        Assert::true($this->indexPage->isCountryDisabled($country));
     }
 
     /**
@@ -189,10 +180,7 @@ final class ManagingCountriesContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeFieldDisabled(),
-            'Code field should be disabled but is not'
-        );
+        Assert::true($this->updatePage->isCodeFieldDisabled());
     }
 
     /**
@@ -203,10 +191,7 @@ final class ManagingCountriesContext implements Context
     {
         $this->iWantToEditThisCountry($country);
 
-        Assert::true(
-            $this->updatePage->isThereProvince($provinceName),
-            sprintf('%s is not a province of this country.', $provinceName)
-        );
+        Assert::true($this->updatePage->isThereProvince($provinceName));
     }
 
     /**
@@ -216,10 +201,7 @@ final class ManagingCountriesContext implements Context
     {
         $this->iWantToEditThisCountry($country);
 
-        Assert::false(
-            $this->updatePage->isThereProvince($provinceName),
-            sprintf('%s is a province of this country.', $provinceName)
-        );
+        Assert::false($this->updatePage->isThereProvince($provinceName));
     }
 
     /**
@@ -229,10 +211,7 @@ final class ManagingCountriesContext implements Context
     {
         $this->updatePage->open(['id' => $country->getId()]);
 
-        Assert::true(
-            $this->updatePage->isThereProvince($provinceName),
-            sprintf('%s is not a province of this country.', $provinceName)
-        );
+        Assert::true($this->updatePage->isThereProvince($provinceName));
     }
 
     /**
@@ -242,10 +221,7 @@ final class ManagingCountriesContext implements Context
     {
         $this->updatePage->open(['id' => $country->getId()]);
 
-        Assert::false(
-            $this->updatePage->isThereProvince($provinceName),
-            sprintf('%s is a province of this country.', $provinceName)
-        );
+        Assert::false($this->updatePage->isThereProvince($provinceName));
     }
 
     /**
@@ -255,10 +231,7 @@ final class ManagingCountriesContext implements Context
     {
         $this->updatePage->open(['id' => $country->getId()]);
 
-        Assert::false(
-            $this->updatePage->isThereProvinceWithCode($provinceCode),
-            sprintf('%s is a province of this country.', $provinceCode)
-        );
+        Assert::false($this->updatePage->isThereProvinceWithCode($provinceCode));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCurrenciesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCurrenciesContext.php
@@ -86,10 +86,7 @@ final class ManagingCurrenciesContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['code' => $currency->getCode()]),
-            sprintf('Currency %s should exist but it does not.', $currency->getCode())
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $currency->getCode()]));
     }
 
     /**
@@ -130,11 +127,7 @@ final class ManagingCurrenciesContext implements Context
      */
     public function theCodeFiledShouldBeDisabled()
     {
-        Assert::eq(
-            'disabled',
-            $this->updatePage->getCodeDisabledAttribute(),
-            'Code field should be disabled but is not.'
-        );
+        Assert::same($this->updatePage->getCodeDisabledAttribute(), 'disabled');
     }
 
     /**
@@ -152,10 +145,7 @@ final class ManagingCurrenciesContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage([$element => $codeValue]),
-            sprintf('Currency with %s %s cannot be found.', $element, $codeValue)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([$element => $codeValue]));
     }
 
     /**
@@ -171,14 +161,6 @@ final class ManagingCurrenciesContext implements Context
      */
     public function iShouldSeeCurrenciesInTheList($amountOfCurrencies)
     {
-        Assert::same(
-            (int) $amountOfCurrencies,
-            $this->indexPage->countItems(),
-            sprintf(
-                'Amount of currencies should be equal %d, but was %d.',
-                $amountOfCurrencies,
-                $this->indexPage->countItems()
-            )
-        );
+        Assert::same($this->indexPage->countItems(), (int) $amountOfCurrencies);
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomerGroupsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomerGroupsContext.php
@@ -95,10 +95,7 @@ final class ManagingCustomerGroupsContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['name' => $customerGroup->getName()]),
-            sprintf('Customer group with name %s should exist but it does not.', $customerGroup->getName())
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $customerGroup->getName()]));
     }
 
     /**
@@ -127,10 +124,7 @@ final class ManagingCustomerGroupsContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['name' => $name]),
-            sprintf('The customer group with a name %s should exist, but it does not.', $name)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $name]));
     }
 
     /**
@@ -148,15 +142,7 @@ final class ManagingCustomerGroupsContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::same(
-            (int) $amountOfCustomerGroups,
-            $this->indexPage->countItems(),
-            sprintf(
-                'Amount of customer groups should be equal %s, but is %s.',
-                $amountOfCustomerGroups,
-                $this->indexPage->countItems()
-            )
-        );
+        Assert::same($this->indexPage->countItems(), (int) $amountOfCustomerGroups);
     }
 
     /**
@@ -166,10 +152,7 @@ final class ManagingCustomerGroupsContext implements Context
     {
         $this->iWantToBrowseCustomerGroups();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['name' => $customerGroup->getName()]),
-            sprintf('Customer group name %s has not been assigned properly.', $customerGroupName)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $customerGroupName]));
     }
 
     /**
@@ -196,10 +179,7 @@ final class ManagingCustomerGroupsContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeDisabled(),
-            'Code field should be disabled but it is not.'
-        );
+        Assert::true($this->updatePage->isCodeDisabled());
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomersContext.php
@@ -130,10 +130,7 @@ final class ManagingCustomersContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['email' => $customer->getEmail()]),
-            sprintf('Customer with email %s should exist but it does not.', $customer->getEmail())
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['email' => $customer->getEmail()]));
     }
 
     /**
@@ -184,11 +181,7 @@ final class ManagingCustomersContext implements Context
     {
         $this->updatePage->open(['id' => $customer->getId()]);
 
-        Assert::eq(
-            $name,
-            $this->updatePage->getFullName(),
-            sprintf('Customer should have name %s, but they have %s.', $name, $this->updatePage->getFullName())
-        );
+        Assert::same($this->updatePage->getFullName(), $name);
     }
 
     /**
@@ -204,11 +197,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldSeeCustomersInTheList($amountOfCustomers)
     {
-        Assert::same(
-            (int) $amountOfCustomers,
-            $this->indexPage->countItems(),
-            sprintf('Amount of customers should be equal %s, but is not.', $amountOfCustomers)
-        );
+        Assert::same($this->indexPage->countItems(), (int) $amountOfCustomers);
     }
 
     /**
@@ -216,10 +205,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldSeeTheCustomerInTheList($email)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['email' => $email]),
-            sprintf('Customer with email %s should exist but it does not.', $email)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['email' => $email]));
     }
 
     /**
@@ -251,10 +237,7 @@ final class ManagingCustomersContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['email' => $email]),
-            sprintf('Customer with email %s was created, but it should not.', $email)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['email' => $email]));
     }
 
     /**
@@ -273,11 +256,7 @@ final class ManagingCustomersContext implements Context
     {
         $this->updatePage->open(['id' => $customer->getId()]);
 
-        Assert::eq(
-            '',
-            $this->updatePage->getFirstName(),
-            'Customer should have an empty first name, but it does not.'
-        );
+        Assert::eq($this->updatePage->getFirstName(), '');
     }
 
     /**
@@ -296,11 +275,7 @@ final class ManagingCustomersContext implements Context
     {
         $this->updatePage->open(['id' => $customer->getId()]);
 
-        Assert::eq(
-            '',
-            $this->updatePage->getLastName(),
-            'Customer should have an empty last name, but it does not.'
-        );
+        Assert::eq($this->updatePage->getLastName(), '');
     }
 
     /**
@@ -334,10 +309,7 @@ final class ManagingCustomersContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['email' => $email]),
-            sprintf('Customer with email %s cannot be found.', $email)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['email' => $email]));
     }
 
     /**
@@ -372,11 +344,7 @@ final class ManagingCustomersContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::eq(
-            'Enabled',
-            $this->indexPage->getCustomerAccountStatus($customer),
-            'Customer account should be enabled, but it does not.'
-        );
+        Assert::eq($this->indexPage->getCustomerAccountStatus($customer), 'Enabled');
     }
 
     /**
@@ -386,11 +354,7 @@ final class ManagingCustomersContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::eq(
-            'Disabled',
-            $this->indexPage->getCustomerAccountStatus($customer),
-            'Customer account should be disabled, but it does not.'
-        );
+        Assert::eq($this->indexPage->getCustomerAccountStatus($customer), 'Disabled');
     }
 
     /**
@@ -443,11 +407,7 @@ final class ManagingCustomersContext implements Context
      */
     public function hisNameShouldBe($name)
     {
-        Assert::same(
-            $name,
-            $this->showPage->getCustomerName(),
-            'Customer name should be "%s", but it is not.'
-        );
+        Assert::same($this->showPage->getCustomerName(), $name);
     }
 
     /**
@@ -455,11 +415,7 @@ final class ManagingCustomersContext implements Context
      */
     public function hisRegistrationDateShouldBe($registrationDate)
     {
-        Assert::eq(
-            new \DateTime($registrationDate),
-            $this->showPage->getRegistrationDate(),
-            'Customer registration date should be "%s", but it is not.'
-        );
+        Assert::eq($this->showPage->getRegistrationDate(), new \DateTime($registrationDate));
     }
 
     /**
@@ -467,11 +423,7 @@ final class ManagingCustomersContext implements Context
      */
     public function hisEmailShouldBe($email)
     {
-        Assert::same(
-            $email,
-            $this->showPage->getCustomerEmail(),
-            'Customer email should be "%s", but it is not'
-        );
+        Assert::same($this->showPage->getCustomerEmail(), $email);
     }
 
     /**
@@ -479,11 +431,7 @@ final class ManagingCustomersContext implements Context
      */
     public function hisShippingAddressShouldBe($defaultAddress)
     {
-        Assert::same(
-            str_replace(',', '', $defaultAddress),
-            $this->showPage->getDefaultAddress(),
-            'Customer\'s default address should be "%s", but it is not.'
-        );
+        Assert::same($this->showPage->getDefaultAddress(), str_replace(',', '', $defaultAddress));
     }
 
     /**
@@ -491,10 +439,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldSeeInformationAboutNoExistingAccountForThisCustomer()
     {
-        Assert::true(
-            $this->showPage->hasAccount(),
-            'There should be information about no account, but there is none.'
-        );
+        Assert::true($this->showPage->hasAccount());
     }
 
     /**
@@ -502,10 +447,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldSeeThatThisCustomerIsSubscribedToTheNewsletter()
     {
-        Assert::true(
-            $this->showPage->isSubscribedToNewsletter(),
-            'There should be information that this customer is subscribed to the newsletter.'
-        );
+        Assert::true($this->showPage->isSubscribedToNewsletter());
     }
 
     /**
@@ -513,10 +455,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldSeeInformationAboutEmailVerification()
     {
-        Assert::true(
-            $this->showPage->hasEmailVerificationInformation(),
-            'There should be no information about email verification.'
-        );
+        Assert::true($this->showPage->hasEmailVerificationInformation());
     }
 
     /**
@@ -542,10 +481,7 @@ final class ManagingCustomersContext implements Context
      */
     public function thisCustomerShouldBeSubscribedToTheNewsletter()
     {
-        Assert::true(
-            $this->updatePage->isSubscribedToTheNewsletter(),
-            'This customer should subscribe to the newsletter.'
-        );
+        Assert::true($this->updatePage->isSubscribedToTheNewsletter());
     }
 
     /**
@@ -553,10 +489,7 @@ final class ManagingCustomersContext implements Context
      */
     public function theProvinceInTheDefaultAddressShouldBe($provinceName)
     {
-        Assert::true(
-            $this->showPage->hasDefaultAddressProvinceName($provinceName),
-            sprintf('Cannot find shipping address with province %s', $provinceName)
-        );
+        Assert::true($this->showPage->hasDefaultAddressProvinceName($provinceName));
     }
 
     /**
@@ -567,11 +500,7 @@ final class ManagingCustomersContext implements Context
         /** @var UpdatePageInterface|ShowPageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->updatePage, $this->showPage]);
 
-        Assert::same(
-            $groupName,
-            $currentPage->getGroupName(),
-            sprintf('Customer should have %s as group, but it does not.', $groupName)
-        );
+        Assert::same($currentPage->getGroupName(), $groupName);
     }
 
     /**
@@ -579,10 +508,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldSeeThatThisCustomerHasVerifiedTheEmail()
     {
-        Assert::true(
-            $this->showPage->hasVerifiedEmail(),
-            'There should be information that this customer has verified the email.'
-        );
+        Assert::true($this->showPage->hasVerifiedEmail());
     }
 
     /**
@@ -590,11 +516,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldSeeASingleOrderInTheList()
     {
-        Assert::same(
-            1,
-            $this->ordersIndexPage->countItems(),
-            'Cannot find order in the list.'
-        );
+        Assert::same($this->ordersIndexPage->countItems(), 1);
     }
 
     /**
@@ -602,10 +524,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldSeeASingleOrderFromCustomer($orderNumber)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['number' => $orderNumber]),
-            sprintf('Cannot find order with number "%s" in the list.', $orderNumber)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['number' => $orderNumber]));
     }
 
     /**
@@ -613,10 +532,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldNotSeeASingleOrderFromCustomer($orderNumber)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['number' => $orderNumber]),
-            sprintf('Cannot find order with number "%s" in the list.', $orderNumber)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['number' => $orderNumber]));
     }
 
     /**
@@ -632,10 +548,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldNotBeAbleToSpecifyItPassword()
     {
-        Assert::true(
-            $this->createPage->isUserFormHidden(),
-            'There should not be password field, but it is.'
-         );
+        Assert::true($this->createPage->isUserFormHidden());
     }
 
     /**
@@ -643,10 +556,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldBeOnTheCustomerCreationPage()
     {
-        Assert::true(
-            $this->createPage->isOpen(),
-            'The customer creation page should be open, but it is not.'
-        );
+        Assert::true($this->createPage->isOpen());
     }
 
     /**
@@ -654,10 +564,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldBeAbleToSelectCreateAccountOption()
     {
-        Assert::false(
-            $this->createPage->hasCheckedCreateOption(),
-            'The create account option should not be selected, but it is.'
-        );
+        Assert::false($this->createPage->hasCheckedCreateOption());
     }
 
     /**
@@ -665,10 +572,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldBeAbleToSpecifyItPassword()
     {
-        Assert::true(
-            $this->createPage->hasPasswordField(),
-            'There should be password field, but it is not.'
-        );
+        Assert::true($this->createPage->hasPasswordField());
     }
 
     /**
@@ -676,10 +580,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldNotBeAbleToSelectCreateAccountOption()
     {
-        Assert::true(
-            $this->createPage->hasCheckedCreateOption(),
-            'The create account option should be selected, but it is not.'
-        );
+        Assert::true($this->createPage->hasCheckedCreateOption());
     }
 
     /**
@@ -695,10 +596,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldNotSeeCreateAccountOption()
     {
-        Assert::false(
-            $this->createPage->hasCreateOption(),
-            'The create account option should not be on customer creation page, but it is.'
-        );
+        Assert::false($this->createPage->hasCreateOption());
     }
 
     /**
@@ -717,7 +615,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldSeeTheCustomerHasNotYetPlacedAnyOrders()
     {
-        Assert::false($this->showPage->hasCustomerPlacedAnyOrders(), 'The customer should not have any orders');
+        Assert::false($this->showPage->hasCustomerPlacedAnyOrders());
     }
 
     /**
@@ -725,13 +623,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldSeeThatTheyHavePlacedOrdersAcrossAllChannels($orderCount)
     {
-        $actualOrdersCount = $this->showPage->getOverallOrdersCount();
-
-        Assert::same(
-            $actualOrdersCount,
-            (int) $orderCount,
-            'Expected orders count to be %2$d, but is %d instead.'
-        );
+        Assert::same($this->showPage->getOverallOrdersCount(), (int) $orderCount);
     }
 
     /**
@@ -739,13 +631,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldSeeThatTheyHavePlacedOrdersInTheChannel($ordersCount, $channelName)
     {
-        $actualOrdersCount = $this->showPage->getOrdersCountInChannel($channelName);
-
-        Assert::same(
-            $actualOrdersCount,
-            (int) $ordersCount,
-            'Expected orders count to be %2$d, but is %d instead.'
-        );
+        Assert::same($this->showPage->getOrdersCountInChannel($channelName), (int) $ordersCount);
     }
 
     /**
@@ -753,13 +639,7 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldSeeThatTheOverallTotalValueOfAllTheirOrdersInTheChannelIs($channelName, $ordersValue)
     {
-        $actualOrdersValue = $this->showPage->getOrdersTotalInChannel($channelName);
-
-        Assert::same(
-            $actualOrdersValue,
-            $ordersValue,
-            'Expected orders total value to be %2$s, but is %s instead.'
-        );
+        Assert::same($this->showPage->getOrdersTotalInChannel($channelName), $ordersValue);
     }
 
     /**
@@ -767,12 +647,6 @@ final class ManagingCustomersContext implements Context
      */
     public function iShouldSeeThatTheAverageTotalValueOfTheirOrderInTheChannelIs($channelName, $ordersValue)
     {
-        $actualOrdersValue = $this->showPage->getOrdersTotalInChannel($channelName);
-
-        Assert::same(
-            $actualOrdersValue,
-            $ordersValue,
-            'Expected order average total value to be %2$s, but is %s instead.'
-        );
+        Assert::same($this->showPage->getOrdersTotalInChannel($channelName), $ordersValue);
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingExchangeRatesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingExchangeRatesContext.php
@@ -190,7 +190,10 @@ final class ManagingExchangeRatesContext implements Context
      */
     public function iShouldSeeAnExchangeRateBetweenAndOnTheList($sourceCurrencyName, $targetCurrencyName)
     {
-        $this->assertExchangeRateIsOnList($sourceCurrencyName, $targetCurrencyName);
+        Assert::true($this->indexPage->isSingleResourceOnPage([
+            'sourceCurrency' => $sourceCurrencyName,
+            'targetCurrency' => $targetCurrencyName,
+        ]));
     }
 
     /**
@@ -198,11 +201,7 @@ final class ManagingExchangeRatesContext implements Context
      */
     public function thisExchangeRateShouldHaveRatioOf($ratio)
     {
-        Assert::eq(
-            $ratio,
-            $this->updatePage->getRatio(),
-            'Exchange rate\'s ratio should be %s, but is %s instead.'
-        );
+        Assert::eq($this->updatePage->getRatio(), $ratio);
     }
 
     /**
@@ -242,10 +241,7 @@ final class ManagingExchangeRatesContext implements Context
      */
     public function iShouldSeeThatTheSourceCurrencyIsDisabled()
     {
-        Assert::true(
-            $this->updatePage->isSourceCurrencyDisabled(),
-            'The source currency is not disabled.'
-        );
+        Assert::true($this->updatePage->isSourceCurrencyDisabled());
     }
 
     /**
@@ -253,10 +249,7 @@ final class ManagingExchangeRatesContext implements Context
      */
     public function iShouldSeeThatTheTargetCurrencyIsDisabled()
     {
-        Assert::true(
-            $this->updatePage->isTargetCurrencyDisabled(),
-            'The target currency is not disabled.'
-        );
+        Assert::true($this->updatePage->isTargetCurrencyDisabled());
     }
 
     /**
@@ -283,9 +276,7 @@ final class ManagingExchangeRatesContext implements Context
      */
     public function iShouldBeNotifiedThatSourceAndTargetCurrenciesMustDiffer()
     {
-        $expectedMessage = 'The source and target currencies must differ.';
-
-        $this->assertFormHasValidationMessage($expectedMessage);
+        $this->assertFormHasValidationMessage('The source and target currencies must differ.');
     }
 
     /**
@@ -293,30 +284,7 @@ final class ManagingExchangeRatesContext implements Context
      */
     public function iShouldBeNotifiedThatTheCurrencyPairMustBeUnique()
     {
-        $expectedMessage = 'The currency pair must be unique.';
-
-        $this->assertFormHasValidationMessage($expectedMessage);
-    }
-
-    /**
-     * @param string $sourceCurrencyName
-     * @param string $targetCurrencyName
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function assertExchangeRateIsOnList($sourceCurrencyName, $targetCurrencyName)
-    {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage([
-                'sourceCurrency' => $sourceCurrencyName,
-                'targetCurrency' => $targetCurrencyName,
-            ]),
-            sprintf(
-                'An exchange rate with source currency %s and target currency %s was not found on the list.',
-                $sourceCurrencyName,
-                $targetCurrencyName
-            )
-        );
+        $this->assertFormHasValidationMessage('The currency pair must be unique.');
     }
 
     /**
@@ -371,10 +339,8 @@ final class ManagingExchangeRatesContext implements Context
      */
     private function assertCountOfExchangeRatesOnTheList($count)
     {
-        $actualCount = $this->indexPage->countItems();
-
         Assert::same(
-            $actualCount,
+            $this->indexPage->countItems(),
             (int) $count,
             'Expected %2$d exchange rates to be on the list, but found %d instead.'
         );

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingInventoryContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingInventoryContext.php
@@ -57,13 +57,7 @@ final class ManagingInventoryContext implements Context
      */
     public function iShouldSeeOnlyOneTrackedVariantInTheList()
     {
-        $foundRows = $this->indexPage->countItems();
-
-        Assert::same(
-            1,
-            $foundRows,
-            '%s rows with tracked product variants should appear on page, %s rows has been found.'
-        );
+        Assert::same($this->indexPage->countItems(), 1);
     }
 
     /**
@@ -71,16 +65,9 @@ final class ManagingInventoryContext implements Context
      */
     public function iShouldSeeThatTheProductVariantHasQuantityOnHand($productVariantName, $quantity)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage([
-                'name' => $productVariantName,
-                'inventory' => sprintf('%s Available on hand', $quantity)
-            ]),
-            sprintf(
-                'This "%s" variant should have %s on hand quantity, but it does not.',
-                $productVariantName,
-                $quantity
-            )
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([
+            'name' => $productVariantName,
+            'inventory' => sprintf('%s Available on hand', $quantity),
+        ]));
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingLocalesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingLocalesContext.php
@@ -72,6 +72,7 @@ final class ManagingLocalesContext implements Context
     public function storeShouldBeAvailableInLanguage($name)
     {
         $doesLocaleExist = $this->indexPage->isSingleResourceOnPage(['name' => $name]);
+
         Assert::true($doesLocaleExist);
     }
 

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -222,10 +222,7 @@ final class ManagingOrdersContext implements Context
      */
     public function iShouldSeeASingleOrderFromCustomer(CustomerInterface $customer)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['customer' => $customer->getEmail()]),
-            sprintf('Cannot find order for customer "%s" in the list.', $customer->getEmail())
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['customer' => $customer->getEmail()]));
     }
 
     /**
@@ -233,10 +230,7 @@ final class ManagingOrdersContext implements Context
      */
     public function itShouldBePlacedByCustomer($customerEmail)
     {
-        Assert::true(
-            $this->showPage->hasCustomer($customerEmail),
-            sprintf('Cannot find customer "%s".', $customerEmail)
-        );
+        Assert::true($this->showPage->hasCustomer($customerEmail));
     }
 
     /**
@@ -255,10 +249,7 @@ final class ManagingOrdersContext implements Context
             $this->iSeeTheOrder($order);
         }
 
-        Assert::true(
-            $this->showPage->hasShippingAddress($customerName, $street, $postcode, $city, $countryName),
-            sprintf('Cannot find shipping address "%s, %s %s, %s".', $street, $postcode, $city, $countryName)
-        );
+        Assert::true($this->showPage->hasShippingAddress($customerName, $street, $postcode, $city, $countryName));
     }
 
     /**
@@ -278,10 +269,7 @@ final class ManagingOrdersContext implements Context
             $this->iSeeTheOrder($order);
         }
 
-        Assert::true(
-            $this->showPage->hasBillingAddress($customerName, $street, $postcode, $city, $countryName),
-            sprintf('Cannot find shipping address "%s, %s %s, %s".', $street, $postcode, $city, $countryName)
-        );
+        Assert::true($this->showPage->hasBillingAddress($customerName, $street, $postcode, $city, $countryName));
     }
 
     /**
@@ -289,10 +277,7 @@ final class ManagingOrdersContext implements Context
      */
     public function itShouldBeShippedViaShippingMethod($shippingMethodName)
     {
-        Assert::true(
-            $this->showPage->hasShipment($shippingMethodName),
-            sprintf('Cannot find shipment "%s".', $shippingMethodName)
-        );
+        Assert::true($this->showPage->hasShipment($shippingMethodName));
     }
 
     /**
@@ -300,10 +285,7 @@ final class ManagingOrdersContext implements Context
      */
     public function itShouldBePaidWith($paymentMethodName)
     {
-        Assert::true(
-            $this->showPage->hasPayment($paymentMethodName),
-            sprintf('Cannot find payment "%s".', $paymentMethodName)
-        );
+        Assert::true($this->showPage->hasPayment($paymentMethodName));
     }
 
     /**
@@ -313,13 +295,7 @@ final class ManagingOrdersContext implements Context
      */
     public function itShouldHaveAmountOfItems($amount = 1)
     {
-        $itemsCount = $this->showPage->countItems();
-
-        Assert::same(
-            (int)$amount,
-            $itemsCount,
-            sprintf('There should be %d items, but get %d.', $amount, $itemsCount)
-        );
+        Assert::same($this->showPage->countItems(), (int) $amount);
     }
 
     /**
@@ -327,10 +303,7 @@ final class ManagingOrdersContext implements Context
      */
     public function theProductShouldBeInTheItemsList($productName)
     {
-        Assert::true(
-            $this->showPage->isProductInTheList($productName),
-            sprintf('Product %s is not in the item list.', $productName)
-        );
+        Assert::true($this->showPage->isProductInTheList($productName));
     }
 
     /**
@@ -338,13 +311,7 @@ final class ManagingOrdersContext implements Context
      */
     public function theOrdersItemsTotalShouldBe($itemsTotal)
     {
-        $itemsTotalOnPage = $this->showPage->getItemsTotal();
-
-        Assert::eq(
-            $itemsTotalOnPage,
-            $itemsTotal,
-            'Items total is %s, but should be %s.'
-        );
+        Assert::eq($this->showPage->getItemsTotal(), $itemsTotal);
     }
 
     /**
@@ -352,13 +319,7 @@ final class ManagingOrdersContext implements Context
      */
     public function theOrdersTotalShouldBe($total)
     {
-        $totalOnPage = $this->showPage->getTotal();
-
-        Assert::eq(
-            $totalOnPage,
-            $total,
-            'Total is %s, but should be %s.'
-        );
+        Assert::eq($this->showPage->getTotal(), $total);
     }
 
     /**
@@ -366,10 +327,7 @@ final class ManagingOrdersContext implements Context
      */
     public function theOrdersShippingChargesShouldBe($shippingCharge)
     {
-        Assert::true(
-            $this->showPage->hasShippingCharge($shippingCharge),
-            sprintf('Shipping charges is not "%s".', $shippingCharge)
-        );
+        Assert::true($this->showPage->hasShippingCharge($shippingCharge));
     }
 
     /**
@@ -377,13 +335,7 @@ final class ManagingOrdersContext implements Context
      */
     public function theOrdersShippingTotalShouldBe($shippingTotal)
     {
-        $shippingTotalOnPage = $this->showPage->getShippingTotal();
-
-        Assert::eq(
-            $shippingTotal,
-            $shippingTotalOnPage,
-            sprintf('Shipping total is "%s", but should be "%s".', $shippingTotalOnPage, $shippingTotal)
-        );
+        Assert::eq($this->showPage->getShippingTotal(), $shippingTotal);
     }
 
     /**
@@ -391,9 +343,7 @@ final class ManagingOrdersContext implements Context
      */
     public function theOrdersPaymentShouldBe($paymentAmount)
     {
-        $actualPaymentAmount = $this->showPage->getPaymentAmount();
-
-        Assert::eq($paymentAmount, $actualPaymentAmount);
+        Assert::eq($this->showPage->getPaymentAmount(), $paymentAmount);
     }
 
     /**
@@ -401,10 +351,7 @@ final class ManagingOrdersContext implements Context
      */
     public function theOrderShouldHaveTax($tax)
     {
-        Assert::true(
-            $this->showPage->hasTax($tax),
-            sprintf('Order should have tax "%s", but it does not.', $tax)
-        );
+        Assert::true($this->showPage->hasTax($tax));
     }
 
     /**
@@ -412,13 +359,7 @@ final class ManagingOrdersContext implements Context
      */
     public function theOrdersTaxTotalShouldBe($taxTotal)
     {
-        $taxTotalOnPage = $this->showPage->getTaxTotal();
-
-        Assert::eq(
-            $taxTotal,
-            $taxTotalOnPage,
-            sprintf('Tax total is "%s", but should be "%s".', $taxTotalOnPage, $taxTotal)
-        );
+        Assert::eq($this->showPage->getTaxTotal(), $taxTotal);
     }
 
     /**
@@ -426,10 +367,7 @@ final class ManagingOrdersContext implements Context
      */
     public function theOrdersPromotionDiscountShouldBe($promotionDiscount)
     {
-        Assert::true(
-            $this->showPage->hasPromotionDiscount($promotionDiscount),
-            sprintf('Promotion discount is not "%s".', $promotionDiscount)
-        );
+        Assert::true($this->showPage->hasPromotionDiscount($promotionDiscount));
     }
 
     /**
@@ -445,13 +383,7 @@ final class ManagingOrdersContext implements Context
      */
     public function theOrdersPromotionTotalShouldBe($promotionTotal)
     {
-        $promotionTotalOnPage = $this->showPage->getPromotionTotal();
-
-        Assert::eq(
-            $promotionTotalOnPage,
-            $promotionTotal,
-            'Promotion total is %s, but should be %s.'
-        );
+        Assert::eq($this->showPage->getPromotionTotal(), $promotionTotal);
     }
 
     /**
@@ -467,13 +399,7 @@ final class ManagingOrdersContext implements Context
      */
     public function itemCodeShouldBe($itemName, $code)
     {
-        $itemCodeOnPage = $this->showPage->getItemCode($itemName);
-
-        Assert::same(
-            $itemCodeOnPage,
-            $code,
-            'Item code is %s, but should be %s.'
-        );
+        Assert::same($this->showPage->getItemCode($itemName), $code);
     }
 
     /**
@@ -481,13 +407,7 @@ final class ManagingOrdersContext implements Context
      */
     public function itemUnitPriceShouldBe($itemName, $unitPrice)
     {
-        $itemUnitPriceOnPage = $this->showPage->getItemUnitPrice($itemName);
-
-        Assert::eq(
-            $itemUnitPriceOnPage,
-            $unitPrice,
-            'Item unit price is %s, but should be %s.'
-        );
+        Assert::eq($this->showPage->getItemUnitPrice($itemName), $unitPrice);
     }
 
     /**
@@ -495,13 +415,7 @@ final class ManagingOrdersContext implements Context
      */
     public function itemDiscountedUnitPriceShouldBe($itemName, $discountedUnitPrice)
     {
-        $itemUnitPriceOnPage = $this->showPage->getItemDiscountedUnitPrice($itemName);
-
-        Assert::eq(
-            $itemUnitPriceOnPage,
-            $discountedUnitPrice,
-            'Item discounted unit price is %s, but should be %s.'
-        );
+        Assert::eq($this->showPage->getItemDiscountedUnitPrice($itemName), $discountedUnitPrice);
     }
 
     /**
@@ -509,13 +423,7 @@ final class ManagingOrdersContext implements Context
      */
     public function itemQuantityShouldBe($itemName, $quantity)
     {
-        $itemQuantityOnPage = $this->showPage->getItemQuantity($itemName);
-
-        Assert::eq(
-            $itemQuantityOnPage,
-            $quantity,
-            'Item quantity is %s, but should be %s.'
-        );
+        Assert::eq($this->showPage->getItemQuantity($itemName), $quantity);
     }
 
     /**
@@ -523,13 +431,7 @@ final class ManagingOrdersContext implements Context
      */
     public function itemSubtotalShouldBe($itemName, $subtotal)
     {
-        $itemSubtotalOnPage = $this->showPage->getItemSubtotal($itemName);
-
-        Assert::eq(
-            $itemSubtotalOnPage,
-            $subtotal,
-            'Item subtotal is %s, but should be %s.'
-        );
+        Assert::eq($this->showPage->getItemSubtotal($itemName), $subtotal);
     }
 
     /**
@@ -537,13 +439,7 @@ final class ManagingOrdersContext implements Context
      */
     public function theItemShouldHaveDiscount($itemName, $discount)
     {
-        $itemDiscountOnPage = $this->showPage->getItemDiscount($itemName);
-
-        Assert::eq(
-            $itemDiscountOnPage,
-            $discount,
-            'Item discount is %s, but should be %s.'
-        );
+        Assert::eq($this->showPage->getItemDiscount($itemName), $discount);
     }
 
     /**
@@ -551,13 +447,7 @@ final class ManagingOrdersContext implements Context
      */
     public function itemTaxShouldBe($itemName, $tax)
     {
-        $itemTaxOnPage = $this->showPage->getItemTax($itemName);
-
-        Assert::eq(
-            $itemTaxOnPage,
-            $tax,
-            'Item tax is %s, but should be %s.'
-        );
+        Assert::eq($this->showPage->getItemTax($itemName), $tax);
     }
 
     /**
@@ -565,13 +455,7 @@ final class ManagingOrdersContext implements Context
      */
     public function itemTotalShouldBe($itemName, $total)
     {
-        $itemTotalOnPage = $this->showPage->getItemTotal($itemName);
-
-        Assert::eq(
-            $itemTotalOnPage,
-            $total,
-            'Item total is %s, but should be %s.'
-        );
+        Assert::eq($this->showPage->getItemTotal($itemName), $total);
     }
 
     /**
@@ -579,9 +463,10 @@ final class ManagingOrdersContext implements Context
      */
     public function iShouldBeNotifiedThatTheOrderSPaymentHasBeenSuccessfullyCompleted()
     {
-        $this
-            ->notificationChecker
-            ->checkNotification('Payment has been successfully updated.', NotificationType::success());
+        $this->notificationChecker->checkNotification(
+            'Payment has been successfully updated.',
+            NotificationType::success()
+        );
     }
 
     /**
@@ -589,9 +474,10 @@ final class ManagingOrdersContext implements Context
      */
     public function iShouldBeNotifiedThatTheOrderSPaymentHasBeenSuccessfullyRefunded()
     {
-        $this
-            ->notificationChecker
-            ->checkNotification('Payment has been successfully refunded.', NotificationType::success());
+        $this->notificationChecker->checkNotification(
+            'Payment has been successfully refunded.',
+            NotificationType::success()
+        );
     }
 
     /**
@@ -600,10 +486,7 @@ final class ManagingOrdersContext implements Context
      */
     public function itShouldHavePaymentState($paymentState)
     {
-        Assert::true(
-            $this->showPage->hasPayment($paymentState),
-            sprintf('It should have payment with %s state', $paymentState)
-        );
+        Assert::true($this->showPage->hasPayment($paymentState));
     }
 
     /**
@@ -611,23 +494,15 @@ final class ManagingOrdersContext implements Context
      */
     public function itShouldHaveOrderPaymentState($orderPaymentState)
     {
-        Assert::same(
-            $this->showPage->getPaymentState(),
-            $orderPaymentState,
-            'Order payment state should be %2$s, but it is %s.'
-        );
+        Assert::same($this->showPage->getPaymentState(), $orderPaymentState);
     }
-    
+
     /**
      * @Then it's payment state should be refunded
      */
     public function orderPaymentStateShouldBeRefunded()
     {
-        Assert::same(
-            $this->showPage->getPaymentState(),
-            'Refunded',
-            'Order payment state should be refunded, but it is not.'
-        );
+        Assert::same($this->showPage->getPaymentState(), 'Refunded');
     }
 
     /**
@@ -635,10 +510,7 @@ final class ManagingOrdersContext implements Context
      */
     public function iShouldNotBeAbleToFinalizeItsPayment(OrderInterface $order)
     {
-        Assert::false(
-            $this->showPage->canCompleteOrderLastPayment($order),
-            'It should not have complete payment button.'
-        );
+        Assert::false($this->showPage->canCompleteOrderLastPayment($order));
     }
 
     /**
@@ -657,10 +529,7 @@ final class ManagingOrdersContext implements Context
      */
     public function iShouldNotBeAbleToShipThisOrder(OrderInterface $order)
     {
-        Assert::false(
-            $this->showPage->canShipOrder($order),
-            'It should not have ship shipment button.'
-        );
+        Assert::false($this->showPage->canShipOrder($order));
     }
 
     /**
@@ -687,10 +556,7 @@ final class ManagingOrdersContext implements Context
      */
     public function iShouldNotBeAbleToCancelThisOrder()
     {
-        Assert::false(
-            $this->showPage->hasCancelButton(),
-            'There should not be a cancel button, but it is.'
-        );
+        Assert::false($this->showPage->hasCancelButton());
     }
 
     /**
@@ -699,11 +565,7 @@ final class ManagingOrdersContext implements Context
      */
     public function itsStateShouldBe($state)
     {
-        Assert::same(
-            $this->showPage->getOrderState(),
-            $state,
-            'The order state should be %2$s, but it is %s.'
-        );
+        Assert::same($this->showPage->getOrderState(), $state);
     }
 
     /**
@@ -711,10 +573,7 @@ final class ManagingOrdersContext implements Context
      */
     public function itShouldHaveState($state)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['state' => $state]),
-            sprintf('Cannot find order with "%s" state in the list.', $state)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['state' => $state]));
     }
 
     /**
@@ -729,7 +588,8 @@ final class ManagingOrdersContext implements Context
             $user,
             function () use ($note, $order) {
                 $this->showPage->open(['id' => $order->getId()]);
-                Assert::true($this->showPage->hasNote($note), sprintf('I should see %s note, but I do not see', $note));
+
+                Assert::true($this->showPage->hasNote($note));
             }
         );
     }
@@ -739,10 +599,7 @@ final class ManagingOrdersContext implements Context
      */
     public function iShouldSeeOrderWithNumber($orderNumber)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['number' => $orderNumber]),
-            sprintf('Cannot find order with "%s" number in the list.', $orderNumber)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['number' => $orderNumber]));
     }
 
     /**
@@ -750,10 +607,7 @@ final class ManagingOrdersContext implements Context
      */
     public function iShouldNotSeeOrderWithNumber($orderNumber)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['number' => $orderNumber]),
-            sprintf('Order with "%s" number should not be in the list.', $orderNumber)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['number' => $orderNumber]));
     }
 
     /**
@@ -761,10 +615,7 @@ final class ManagingOrdersContext implements Context
      */
     public function iShouldNotSeeAnyOrderWithCurrency($currencyCode)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['currencyCode' => $currencyCode]),
-            sprintf('Order with currency "%s" should not be on the list.', $currencyCode)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['currencyCode' => $currencyCode]));
     }
 
     /**
@@ -772,13 +623,7 @@ final class ManagingOrdersContext implements Context
      */
     public function theFirstOrderShouldHaveNumber($number)
     {
-        $actualNumber = $this->indexPage->getColumnFields('number')[0];
-
-        Assert::eq(
-            $actualNumber,
-            $number,
-            sprintf('Expected first order\'s number to be %s, but it is %s.', $number, $actualNumber)
-        );
+        Assert::eq($this->indexPage->getColumnFields('number')[0], $number);
     }
 
     /**
@@ -786,10 +631,7 @@ final class ManagingOrdersContext implements Context
      */
     public function itShouldHaveShipmentState($shipmentState)
     {
-        Assert::true(
-            $this->showPage->hasShipment($shipmentState),
-            sprintf('It should have shipment with %s state', $shipmentState)
-        );
+        Assert::true($this->showPage->hasShipment($shipmentState));
     }
 
     /**
@@ -797,10 +639,7 @@ final class ManagingOrdersContext implements Context
      */
     public function thisOrderShipmentStateShouldBe($shippingState)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['shippingState' => $shippingState]),
-            sprintf('Order should have %s shipping state', $shippingState)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['shippingState' => $shippingState]));
     }
 
     /**
@@ -809,10 +648,7 @@ final class ManagingOrdersContext implements Context
      */
     public function theOrderShouldHavePaymentState(OrderInterface $order, $orderPaymentState)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['paymentState' => $orderPaymentState]),
-            sprintf('Cannot find order with "%s" order payment state in the list.', $orderPaymentState)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['paymentState' => $orderPaymentState]));
     }
 
     /**
@@ -820,10 +656,7 @@ final class ManagingOrdersContext implements Context
      */
     public function theOrderShouldHaveShipmentState(OrderInterface $order, $orderShipmentState)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['shippingState' => $orderShipmentState]),
-            sprintf('Cannot find order with "%s" order shipping state on the list.', $orderShipmentState)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['shippingState' => $orderShipmentState]));
     }
 
     /**
@@ -831,9 +664,7 @@ final class ManagingOrdersContext implements Context
      */
     public function theOrderShouldHaveNumberOfPayments($number)
     {
-        $actualNumberOfPayments = $this->showPage->getPaymentsCount();
-
-        Assert::same((int)$number, $actualNumberOfPayments);
+        Assert::same($this->showPage->getPaymentsCount(), (int) $number);
     }
 
     /**
@@ -841,10 +672,7 @@ final class ManagingOrdersContext implements Context
      */
     public function iShouldSeeTheOrderWithTotal($orderNumber, $total)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['total' => $total]),
-            sprintf('The total of order "%s" is not "%s".', $orderNumber, $total)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['total' => $total]));
     }
 
     /**
@@ -896,10 +724,7 @@ final class ManagingOrdersContext implements Context
      */
     public function iShouldSeeAsProvinceInTheShippingAddress($provinceName)
     {
-        Assert::true(
-            $this->showPage->hasShippingProvinceName($provinceName),
-            sprintf('Cannot find shipping address with province %s', $provinceName)
-        );
+        Assert::true($this->showPage->hasShippingProvinceName($provinceName));
     }
 
     /**
@@ -907,10 +732,7 @@ final class ManagingOrdersContext implements Context
      */
     public function iShouldSeeAdProvinceInTheBillingAddress($provinceName)
     {
-        Assert::true(
-            $this->showPage->hasBillingProvinceName($provinceName),
-            sprintf('Cannot find shipping address with province %s', $provinceName)
-        );
+        Assert::true($this->showPage->hasBillingProvinceName($provinceName));
     }
 
     /**
@@ -925,11 +747,7 @@ final class ManagingOrdersContext implements Context
             function () use ($order) {
                 $this->showPage->open(['id' => $order->getId()]);
 
-                Assert::notSame(
-                    $this->showPage->getIpAddressAssigned(),
-                    '',
-                    'There should be IP address assigned to order, but there is not.'
-                );
+                Assert::notSame($this->showPage->getIpAddressAssigned(), '');
             }
         );
     }
@@ -965,11 +783,8 @@ final class ManagingOrdersContext implements Context
     {
         $this->sharedSecurityService->performActionAsAdminUser($user, function () use ($order, $currency) {
             $this->showPage->open(['id' => $order->getId()]);
-            Assert::same(
-                $this->showPage->getOrderCurrency(),
-                $currency,
-                'The order has been placed in %s, but it was expected to be placed in %s'
-            );
+
+            Assert::same($this->showPage->getOrderCurrency(), $currency);
         });
     }
 
@@ -981,10 +796,7 @@ final class ManagingOrdersContext implements Context
         $this->sharedSecurityService->performActionAsAdminUser($user, function () use ($total) {
             $this->indexPage->open();
 
-            Assert::true(
-                $this->indexPage->isSingleResourceOnPage(['total' => $total]),
-                sprintf('The order with total "%s" has not been found.', $total)
-            );
+            Assert::true($this->indexPage->isSingleResourceOnPage(['total' => $total]));
         });
     }
 
@@ -993,10 +805,7 @@ final class ManagingOrdersContext implements Context
      */
     public function thereShouldBeCountChangesInTheRegistry($count)
     {
-        Assert::same(
-            $this->historyPage->countShippingAddressChanges(),
-            (int) $count
-        );
+        Assert::same($this->historyPage->countShippingAddressChanges(), (int) $count);
     }
 
     /**
@@ -1012,11 +821,7 @@ final class ManagingOrdersContext implements Context
      */
     public function iShouldNotSeeInformationAboutPayments()
     {
-        Assert::same(
-            0,
-            $this->showPage->getPaymentsCount(),
-            'There should be no payments, but they are.'
-        );
+        Assert::same($this->showPage->getPaymentsCount(), 0);
     }
 
     /**
@@ -1029,9 +834,6 @@ final class ManagingOrdersContext implements Context
     private function assertElementValidationMessage($type, $element, $expectedMessage)
     {
         $element = sprintf('%s_%s', $type, implode('_', explode(' ', $element)));
-        Assert::true(
-            $this->updatePage->checkValidationMessageFor($element, $expectedMessage),
-            sprintf('The %s should be required.', $element)
-        );
+        Assert::true($this->updatePage->checkValidationMessageFor($element, $expectedMessage));
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentMethodsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentMethodsContext.php
@@ -158,10 +158,7 @@ final class ManagingPaymentMethodsContext implements Context
      */
     public function thisPaymentMethodElementShouldBe($element, $value)
     {
-        Assert::true(
-            $this->updatePage->hasResourceValues([$element => $value]),
-            sprintf('Payment method %s should be %s', $element, $value)
-        );
+        Assert::true($this->updatePage->hasResourceValues([$element => $value]));
     }
 
     /**
@@ -222,10 +219,7 @@ final class ManagingPaymentMethodsContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['name' => $paymentMethodName]),
-            sprintf('Payment method with name %s has not been found.', $paymentMethodName)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $paymentMethodName]));
     }
 
     /**
@@ -250,13 +244,7 @@ final class ManagingPaymentMethodsContext implements Context
      */
     public function theFirstPaymentMethodOnTheListShouldHave($field, $value)
     {
-        $actualValue = $this->indexPage->getColumnFields($field)[0];
-
-        Assert::same(
-            $actualValue,
-            $value,
-            sprintf('Expected first payment method\'s %s to be "%s", but it is "%s".', $field, $value, $actualValue)
-        );
+        Assert::same($this->indexPage->getColumnFields($field)[0], $value);
     }
 
     /**
@@ -264,14 +252,9 @@ final class ManagingPaymentMethodsContext implements Context
      */
     public function theLastPaymentMethodOnTheListShouldHave($field, $value)
     {
-        $fields = $this->indexPage->getColumnFields($field);
-        $actualValue = end($fields);
+        $values = $this->indexPage->getColumnFields($field);
 
-        Assert::same(
-            $actualValue,
-            $value,
-            sprintf('Expected last payment method\'s %s to be "%s", but it is "%s".', $field, $value, $actualValue)
-        );
+        Assert::same(end($values), $value);
     }
 
     /**
@@ -289,13 +272,7 @@ final class ManagingPaymentMethodsContext implements Context
      */
     public function iShouldSeePaymentMethodsInTheList($amount)
     {
-        $foundRows = $this->indexPage->countItems();
-
-        Assert::same(
-            (int) $amount,
-            $foundRows,
-            '%2$s rows with payment methods should appear on page, %s rows has been found'
-        );
+        Assert::same($this->indexPage->countItems(), (int) $amount);
     }
 
     /**
@@ -313,10 +290,7 @@ final class ManagingPaymentMethodsContext implements Context
     {
         $this->iBrowsePaymentMethods();
 
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage([$element => $value]),
-            sprintf('Payment method with %s %s was created, but it should not.', $element, $value)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
     /**
@@ -326,13 +300,10 @@ final class ManagingPaymentMethodsContext implements Context
     {
         $this->iBrowsePaymentMethods();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage([
-                'code' => $paymentMethod->getCode(),
-                'name' => $paymentMethodName,
-            ]),
-            sprintf('Payment method name %s has not been assigned properly.', $paymentMethodName)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([
+            'code' => $paymentMethod->getCode(),
+            'name' => $paymentMethodName,
+        ]));
     }
 
     /**
@@ -352,10 +323,7 @@ final class ManagingPaymentMethodsContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeDisabled(),
-            'Code field should be disabled'
-        );
+        Assert::true($this->updatePage->isCodeDisabled());
     }
 
     /**
@@ -363,10 +331,7 @@ final class ManagingPaymentMethodsContext implements Context
      */
     public function thisPaymentMethodShouldBeEnabled()
     {
-        Assert::true(
-            $this->updatePage->isPaymentMethodEnabled(),
-            'Payment method should be enabled'
-        );
+        Assert::true($this->updatePage->isPaymentMethodEnabled());
     }
 
     /**
@@ -374,10 +339,7 @@ final class ManagingPaymentMethodsContext implements Context
      */
     public function thisPaymentMethodShouldBeDisabled()
     {
-        Assert::false(
-            $this->updatePage->isPaymentMethodEnabled(),
-            'Payment method should be disabled'
-        );
+        Assert::false($this->updatePage->isPaymentMethodEnabled());
     }
 
     /**
@@ -390,10 +352,7 @@ final class ManagingPaymentMethodsContext implements Context
     ) {
         $this->iWantToModifyAPaymentMethod($paymentMethod);
 
-        Assert::same(
-            $this->updatePage->getPaymentMethodInstructions($language),
-            $instructions
-        );
+        Assert::same($this->updatePage->getPaymentMethodInstructions($language), $instructions);
     }
 
     /**
@@ -405,10 +364,7 @@ final class ManagingPaymentMethodsContext implements Context
     ) {
         $this->iWantToModifyAPaymentMethod($paymentMethod);
 
-        Assert::true(
-            $this->updatePage->isAvailableInChannel($channelName),
-            sprintf('Payment method should be available in channel "%s" but it does not.', $channelName)
-        );
+        Assert::true($this->updatePage->isAvailableInChannel($channelName));
     }
 
     /**
@@ -416,10 +372,10 @@ final class ManagingPaymentMethodsContext implements Context
      */
     public function thisPaymentMethodShouldNoLongerExistInTheRegistry(PaymentMethodInterface $paymentMethod)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['code' => $paymentMethod->getCode(), 'name' => $paymentMethod->getName()]),
-            sprintf('Payment method %s should no longer exist in the registry', $paymentMethod->getName())
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage([
+            'code' => $paymentMethod->getCode(),
+            'name' => $paymentMethod->getName(),
+        ]));
     }
 
     /**
@@ -437,9 +393,6 @@ final class ManagingPaymentMethodsContext implements Context
     {
         $this->iBrowsePaymentMethods();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage([$element => $code]),
-            sprintf('Payment method with %s %s cannot be found.', $element, $code)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([$element => $code]));
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAssociationTypesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAssociationTypesContext.php
@@ -168,11 +168,7 @@ final class ManagingProductAssociationTypesContext implements Context
      */
     public function iShouldSeeProductAssociationTypesInTheList($amount = 1)
     {
-        Assert::same(
-            (int) $amount,
-            $this->indexPage->countItems(),
-            sprintf('Amount of product association types should be equal %s, but is not.', $amount)
-        );
+        Assert::same($this->indexPage->countItems(), (int) $amount);
     }
 
     /**
@@ -183,10 +179,7 @@ final class ManagingProductAssociationTypesContext implements Context
     {
         $this->iWantToBrowseProductAssociationTypes();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['name' => $name]),
-            sprintf('The product association type with a name %s should exist, but it does not.', $name)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $name]));
     }
 
     /**
@@ -196,13 +189,7 @@ final class ManagingProductAssociationTypesContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['name' => $productAssociationType->getName()]),
-            sprintf(
-                'Product association type with name %s should exist but it does not.',
-                $productAssociationType->getName()
-            )
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $productAssociationType->getName()]));
     }
 
     /**
@@ -215,15 +202,10 @@ final class ManagingProductAssociationTypesContext implements Context
     ) {
         $this->iWantToBrowseProductAssociationTypes();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(
-                [
-                    'code' => $productAssociationType->getCode(),
-                    'name' => $productAssociationTypeName,
-                ]
-            ),
-            sprintf('Product association type name %s has not been assigned properly.', $productAssociationTypeName)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([
+            'code' => $productAssociationType->getCode(),
+            'name' => $productAssociationTypeName,
+        ]));
     }
 
     /**
@@ -231,10 +213,7 @@ final class ManagingProductAssociationTypesContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeDisabled(),
-            'Code field should be disabled'
-        );
+        Assert::true($this->updatePage->isCodeDisabled());
     }
 
     /**
@@ -243,16 +222,10 @@ final class ManagingProductAssociationTypesContext implements Context
     public function thisProductAssociationTypeShouldNoLongerExistInTheRegistry(
         ProductAssociationTypeInterface $productAssociationType
     ) {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage([
-                'code' => $productAssociationType->getCode(),
-                'name' => $productAssociationType->getName()]
-            ),
-            sprintf(
-                'Product association type %s should no longer exist in the registry',
-                $productAssociationType->getName()
-            )
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage([
+            'code' => $productAssociationType->getCode(),
+            'name' => $productAssociationType->getName(),
+        ]));
     }
 
     /**
@@ -273,10 +246,7 @@ final class ManagingProductAssociationTypesContext implements Context
     {
         $this->iWantToBrowseProductAssociationTypes();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage([$element => $code]),
-            sprintf('Association type with %s %s cannot be found.', $element, $code)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([$element => $code]));
     }
 
     /**
@@ -284,10 +254,7 @@ final class ManagingProductAssociationTypesContext implements Context
      */
     public function iShouldBeNotifiedThatIsRequired($element)
     {
-        $this->assertFieldValidationMessage(
-            $element,
-            sprintf('Please enter association type %s.', $element)
-        );
+        $this->assertFieldValidationMessage($element, sprintf('Please enter association type %s.', $element));
     }
 
     /**
@@ -297,10 +264,7 @@ final class ManagingProductAssociationTypesContext implements Context
     {
         $this->iWantToBrowseProductAssociationTypes();
 
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage([$element => $value]),
-            sprintf('Product association type with %s %s was created, but it should not.', $element, $value)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
@@ -103,10 +103,7 @@ final class ManagingProductAttributesContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['name' => $name]),
-            sprintf('The product attribute with name %s should appear on page, but it does not.', $name)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $name]));
     }
 
     /**
@@ -116,13 +113,10 @@ final class ManagingProductAttributesContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceWithSpecificElementOnPage(
-                ['name' => $name],
-                sprintf('td span.ui.label:contains("%s")', $type)
-            ),
-            sprintf('The product attribute with name %s and type %s should appear on page, but it does not.', $name, $type)
-        );
+        Assert::true($this->indexPage->isSingleResourceWithSpecificElementOnPage(
+            ['name' => $name],
+            sprintf('td span.ui.label:contains("%s")', $type)
+        ));
     }
 
     /**
@@ -155,10 +149,7 @@ final class ManagingProductAttributesContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeDisabled(),
-            'Code field should be disabled, but it does not.'
-        );
+        Assert::true($this->updatePage->isCodeDisabled());
     }
 
     /**
@@ -168,10 +159,7 @@ final class ManagingProductAttributesContext implements Context
     {
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        Assert::true(
-            $currentPage->isTypeDisabled(),
-            'Type field should be disabled, but it does not.'
-        );
+        Assert::true($currentPage->isTypeDisabled());
     }
 
     /**
@@ -189,10 +177,7 @@ final class ManagingProductAttributesContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['code' => $code]),
-            sprintf('There should be only one product attribute with code %s, but it does not.', $code)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $code]));
     }
 
     /**
@@ -218,10 +203,7 @@ final class ManagingProductAttributesContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage([$elementName => $elementValue]),
-            sprintf('There should not be product attribute with %s %s, but it is.', $elementName, $elementValue)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage([$elementName => $elementValue]));
     }
 
     /**
@@ -245,11 +227,7 @@ final class ManagingProductAttributesContext implements Context
      */
     public function iShouldSeeCustomersInTheList($amountOfProductAttributes)
     {
-        Assert::same(
-            (int) $amountOfProductAttributes,
-            $this->indexPage->countItems(),
-            sprintf('Amount of product attributes should be equal %s, but is not.', $amountOfProductAttributes)
-        );
+        Assert::same($this->indexPage->countItems(), (int) $amountOfProductAttributes);
     }
 
     /**
@@ -266,10 +244,7 @@ final class ManagingProductAttributesContext implements Context
      */
     public function thisProductAttributeShouldNoLongerExistInTheRegistry(ProductAttributeInterface $productAttribute)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['code' => $productAttribute->getCode()]),
-            sprintf('Product attribute %s should no exist in the registry, but it does.', $productAttribute->getName())
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $productAttribute->getCode()]));
     }
 
     /**
@@ -277,14 +252,9 @@ final class ManagingProductAttributesContext implements Context
      */
     public function theFirstProductAttributeOnTheListShouldHave($name)
     {
-        $fields = $this->indexPage->getColumnFields('name');
-        $actualName = reset($fields);
+        $names = $this->indexPage->getColumnFields('name');
 
-        Assert::same(
-            $actualName,
-            $name,
-            sprintf('Expected first product attribute\'s name to be "%s", but it is "%s".', $name, $actualName)
-        );
+        Assert::same(reset($names), $name);
     }
 
     /**
@@ -292,14 +262,9 @@ final class ManagingProductAttributesContext implements Context
      */
     public function theLastProductAttributeOnTheListShouldHave($name)
     {
-        $fields = $this->indexPage->getColumnFields('name');
-        $actualName = end($fields);
+        $names = $this->indexPage->getColumnFields('name');
 
-        Assert::same(
-            $actualName,
-            $name,
-            sprintf('Expected last product attribute\'s name to be "%s", but it is "%s".', $name, $actualName)
-        );
+        Assert::same(end($names), $name);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductOptionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductOptionsContext.php
@@ -156,10 +156,7 @@ final class ManagingProductOptionsContext implements Context
     {
         $this->iBrowseProductOptions();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['name' => $productOptionName]),
-            sprintf('The product option with name %s has not been found.', $productOptionName)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $productOptionName]));
     }
 
     /**
@@ -177,10 +174,7 @@ final class ManagingProductOptionsContext implements Context
     {
         $this->iBrowseProductOptions();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage([$element => $value]),
-            sprintf('Product option with %s %s cannot be found.', $element, $value)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
     /**
@@ -198,10 +192,7 @@ final class ManagingProductOptionsContext implements Context
     {
         $this->iBrowseProductOptions();
 
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage([$element => $value]),
-            sprintf('Product option with %s %s was created, but it should not.', $element, $value)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
     /**
@@ -212,13 +203,10 @@ final class ManagingProductOptionsContext implements Context
     {
         $this->iBrowseProductOptions();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage([
-                'code' => $productOption->getCode(),
-                'name' => $productOptionName,
-            ]),
-            sprintf('Product option name %s has not been assigned properly.', $productOptionName)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([
+            'code' => $productOption->getCode(),
+            'name' => $productOptionName,
+        ]));
     }
 
     /**
@@ -226,10 +214,7 @@ final class ManagingProductOptionsContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeDisabled(),
-            'Code field should be disabled but it is not'
-        );
+        Assert::true($this->updatePage->isCodeDisabled());
     }
 
     /**
@@ -245,10 +230,7 @@ final class ManagingProductOptionsContext implements Context
      */
     public function iShouldBeNotifiedThatAtLeastTwoOptionValuesAreRequired()
     {
-        Assert::true(
-            $this->createPage->checkValidationMessageForOptionValues('Please add at least 2 option values.'),
-            'I should be notified that product option needs at least two option values.'
-        );
+        Assert::true($this->createPage->checkValidationMessageForOptionValues('Please add at least 2 option values.'));
     }
 
     /**
@@ -256,13 +238,7 @@ final class ManagingProductOptionsContext implements Context
      */
     public function iShouldSeeProductOptionsInTheList($amount)
     {
-        $foundRows = $this->indexPage->countItems();
-
-        Assert::same(
-            (int) $amount,
-            $foundRows,
-            '%2$s rows with product options should appear on page, %s rows has been found'
-        );
+        Assert::same($this->indexPage->countItems(), (int) $amount);
     }
 
     /**
@@ -272,10 +248,7 @@ final class ManagingProductOptionsContext implements Context
     {
         $this->iWantToModifyAProductOption($productOption);
 
-        Assert::true(
-            $this->updatePage->isThereOptionValue($optionValue),
-            sprintf('%s is not a value of this product option.', $optionValue)
-        );
+        Assert::true($this->updatePage->isThereOptionValue($optionValue));
     }
 
     /**
@@ -283,13 +256,7 @@ final class ManagingProductOptionsContext implements Context
      */
     public function theFirstProductOptionInTheListShouldHave($field, $value)
     {
-        $actualValue = $this->indexPage->getColumnFields($field)[0];
-
-        Assert::same(
-            $actualValue,
-            $value,
-            sprintf('Expected first product option\'s %s to be "%s", but it is "%s".', $field, $value, $actualValue)
-        );
+        Assert::same($this->indexPage->getColumnFields($field)[0], $value);
     }
 
     /**
@@ -297,13 +264,8 @@ final class ManagingProductOptionsContext implements Context
      */
     public function theLastProductOptionInTheListShouldHave($field, $value)
     {
-        $fields = $this->indexPage->getColumnFields($field);
-        $actualValue = end($fields);
+        $values = $this->indexPage->getColumnFields($field);
 
-        Assert::same(
-            $actualValue,
-            $value,
-            sprintf('Expected last product option\'s %s to be "%s", but it is "%s".', $field, $value, $actualValue)
-        );
+        Assert::same(end($values), $value);
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductReviewsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductReviewsContext.php
@@ -67,10 +67,7 @@ final class ManagingProductReviewsContext implements Context
      */
     public function iShouldSeeTheProductReviewTitleInTheList($title)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['title' => $title]),
-            sprintf('Product review with a title %s should exist but it does not.', $title)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['title' => $title]));
     }
 
     /**
@@ -78,11 +75,7 @@ final class ManagingProductReviewsContext implements Context
      */
     public function iShouldSeeReviewsInTheList($amount)
     {
-        Assert::same(
-            (int) $amount,
-            $this->indexPage->countItems(),
-            '%2$s rows with product reviews should appear on page, %s rows has been found'
-        );
+        Assert::same($this->indexPage->countItems(), (int) $amount);
     }
 
     /**
@@ -133,11 +126,7 @@ final class ManagingProductReviewsContext implements Context
      */
     public function thisProductReviewRatingShouldBe($rating)
     {
-        Assert::same(
-            $rating,
-            $this->updatePage->getRating(),
-            'Product review should have rating %s, but it has %s'
-        );
+        Assert::same($this->updatePage->getRating(), $rating);
     }
 
     /**
@@ -153,11 +142,7 @@ final class ManagingProductReviewsContext implements Context
      */
     public function iShouldBeEditingReviewOfProduct($productName)
     {
-        Assert::same(
-            $productName,
-            $this->updatePage->getProductName(),
-            'Product should have name %s, but it has %s'
-        );
+        Assert::same($this->updatePage->getProductName(), $productName);
     }
 
     /**
@@ -165,11 +150,7 @@ final class ManagingProductReviewsContext implements Context
      */
     public function iShouldSeeTheCustomerSName($customerName)
     {
-        Assert::same(
-            $customerName,
-            $this->updatePage->getCustomerName(),
-            'Customer should have name %s, but they have %s'
-        );
+        Assert::same($this->updatePage->getCustomerName(), $customerName);
     }
 
     /**
@@ -193,14 +174,10 @@ final class ManagingProductReviewsContext implements Context
      */
     public function thisProductReviewStatusShouldBe(ReviewInterface $productReview, $status)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['title' => $productReview->getTitle(), 'status' => $status]),
-            sprintf(
-                'Product review with title "%s" and status "%s" is not in the list.',
-                $productReview->getTitle(),
-                $status
-            )
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([
+            'title' => $productReview->getTitle(),
+            'status' => $status,
+        ]));
     }
 
     /**
@@ -209,7 +186,8 @@ final class ManagingProductReviewsContext implements Context
     public function iShouldBeNotifiedThatItHasBeenSuccessfullyUpdated($action)
     {
         $this->notificationChecker->checkNotification(
-            sprintf('Review has been successfully %s.', $action), NotificationType::success()
+            sprintf('Review has been successfully %s.', $action),
+            NotificationType::success()
         );
     }
 
@@ -227,10 +205,7 @@ final class ManagingProductReviewsContext implements Context
      */
     public function thisProductReviewShouldNoLongerExistInTheRegistry(ReviewInterface $productReview)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['title' => $productReview->getTitle()]),
-            sprintf('Product review with title "%s" should no longer exist in the registry.', $productReview->getTitle())
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['title' => $productReview->getTitle()]));
     }
 
     /**
@@ -248,10 +223,7 @@ final class ManagingProductReviewsContext implements Context
     {
         $this->iWantToBrowseProductReviews();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['title' => $productReviewTitle]),
-            sprintf('Product review title %s has not been assigned properly.', $productReviewTitle)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['title' => $productReviewTitle]));
     }
 
     /**
@@ -270,10 +242,7 @@ final class ManagingProductReviewsContext implements Context
      */
     private function assertElementValue($element, $value)
     {
-        Assert::true(
-            $this->updatePage->hasResourceValues([$element => $value]),
-            sprintf('Product review should have %s with %s value.', $element, $value)
-        );
+        Assert::true($this->updatePage->hasResourceValues([$element => $value]));
     }
 
     /**
@@ -282,9 +251,6 @@ final class ManagingProductReviewsContext implements Context
      */
     private function assertFieldValidationMessage($element, $expectedMessage)
     {
-        Assert::same(
-            $this->updatePage->getValidationMessage($element),
-            $expectedMessage
-        );
+        Assert::same($this->updatePage->getValidationMessage($element), $expectedMessage);
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsContext.php
@@ -230,10 +230,7 @@ final class ManagingProductVariantsContext implements Context
     {
         $this->iWantToViewAllVariantsOfThisProduct($product);
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['code' => $productVariantCode]),
-            sprintf('The product variant with code %s has not been found.', $productVariantCode)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $productVariantCode]));
     }
 
     /**
@@ -243,10 +240,7 @@ final class ManagingProductVariantsContext implements Context
     {
         $this->iWantToViewAllVariantsOfThisProduct($product);
 
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['code' => $productVariantCode]),
-            sprintf('The product variant with code %s has not been found.', $productVariantCode)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $productVariantCode]));
     }
 
     /**
@@ -272,10 +266,7 @@ final class ManagingProductVariantsContext implements Context
     {
         $this->updatePage->open(['id' => $productVariant->getId(), 'productId' => $productVariant->getProduct()->getId()]);
 
-        Assert::same(
-            $this->updatePage->getPriceForChannel($channelName),
-            $price
-        );
+        Assert::same($this->updatePage->getPriceForChannel($channelName), $price);
     }
 
     /**
@@ -285,7 +276,7 @@ final class ManagingProductVariantsContext implements Context
     {
         $this->updatePage->open(['id' => $productVariant->getId(), 'productId' => $productVariant->getProduct()->getId()]);
 
-        Assert::same($name, $this->updatePage->getNameInLanguage($language));
+        Assert::same($this->updatePage->getNameInLanguage($language), $name);
     }
 
     /**
@@ -304,13 +295,7 @@ final class ManagingProductVariantsContext implements Context
      */
     public function iShouldSeeProductVariantsInTheList($numberOfProductVariants = 0)
     {
-        $foundRows = $this->indexPage->countItems();
-
-        Assert::same(
-            (int) $numberOfProductVariants,
-            $foundRows,
-            '%s rows with product variants should appear on page, %s rows has been found'
-        );
+        Assert::same($this->indexPage->countItems(), (int) $numberOfProductVariants);
     }
 
     /**
@@ -331,10 +316,7 @@ final class ManagingProductVariantsContext implements Context
     {
         $this->iWantToViewAllVariantsOfThisProduct($productVariant->getProduct());
 
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['name' => $productVariant->getName()]),
-            sprintf('Product variant with code %s exists but should not.', $productVariant->getName())
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['name' => $productVariant->getName()]));
     }
 
     /**
@@ -369,10 +351,7 @@ final class ManagingProductVariantsContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeDisabled(),
-            'Code should be immutable, but it does not.'
-        );
+        Assert::true($this->updatePage->isCodeDisabled());
     }
 
     /**
@@ -498,10 +477,10 @@ final class ManagingProductVariantsContext implements Context
      */
     public function thisVariantShouldHaveItemsOnHand($productVariantName, $quantity)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceWithSpecificElementOnPage(['name' => $productVariantName], sprintf('td > div.ui.label:contains("%s")', $quantity)),
-            sprintf('The product variant %s should have %s items on hand, but it does not.', $productVariantName, $quantity)
-        );
+        Assert::true($this->indexPage->isSingleResourceWithSpecificElementOnPage(
+            ['name' => $productVariantName],
+            sprintf('td > div.ui.label:contains("%s")', $quantity)
+        ));
     }
 
     /**
@@ -511,10 +490,10 @@ final class ManagingProductVariantsContext implements Context
     {
         $this->indexPage->open(['productId' => $product->getId()]);
 
-        Assert::true(
-            $this->indexPage->isSingleResourceWithSpecificElementOnPage(['name' => $productVariantName], sprintf('td > div.ui.label:contains("%s")', $quantity)),
-            sprintf('The product variant %s should have %s items on hand, but it does not.', $productVariantName, $quantity)
-        );
+        Assert::true($this->indexPage->isSingleResourceWithSpecificElementOnPage(
+            ['name' => $productVariantName],
+            sprintf('td > div.ui.label:contains("%s")', $quantity)
+        ));
     }
 
     /**
@@ -524,10 +503,7 @@ final class ManagingProductVariantsContext implements Context
     {
         $this->iWantToModifyAProduct($productVariant);
 
-        Assert::false(
-            $this->updatePage->isTracked(),
-            'This variant should not be tracked, but it is.'
-        );
+        Assert::false($this->updatePage->isTracked());
     }
 
     /**
@@ -537,10 +513,7 @@ final class ManagingProductVariantsContext implements Context
     {
         $this->iWantToModifyAProduct($productVariant);
 
-        Assert::true(
-            $this->updatePage->isTracked(),
-            'This variant should be tracked, but it is not.'
-        );
+        Assert::true($this->updatePage->isTracked());
     }
 
     /**
@@ -548,10 +521,10 @@ final class ManagingProductVariantsContext implements Context
      */
     public function iShouldSeeThatIsNotTracked(ProductVariantInterface $productVariant)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['name' => $productVariant->getName(), 'inventory' => 'Not tracked']),
-            sprintf('This "%s" variant should have label not tracked, but it does not have', $productVariant->getName())
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([
+            'name' => $productVariant->getName(),
+            'inventory' => 'Not tracked',
+        ]));
     }
 
     /**
@@ -559,10 +532,10 @@ final class ManagingProductVariantsContext implements Context
      */
     public function iShouldSeeThatTheVariantHasZeroOnHandQuantity(ProductVariantInterface $productVariant)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['name' => $productVariant->getName(), 'inventory' => '0 Available on hand']),
-            sprintf('This "%s" variant should have 0 on hand quantity, but it does not.', $productVariant->getName())
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([
+            'name' => $productVariant->getName(),
+            'inventory' => '0 Available on hand',
+        ]));
     }
 
     /**
@@ -583,18 +556,8 @@ final class ManagingProductVariantsContext implements Context
     {
         /** @var ProductVariantInterface $variant */
         $variant = $this->defaultProductVariantResolver->getVariant($product);
-        $actualQuantity = $this->indexPage->getOnHandQuantityFor($variant);
 
-        Assert::same(
-            (int) $quantity,
-            $actualQuantity,
-            sprintf(
-                'Unexpected on hand quantity for "%s" variant. It should be "%s" but is "%s"',
-                $variant->getName(),
-                $quantity,
-                $actualQuantity
-            )
-        );
+        Assert::same($this->indexPage->getOnHandQuantityFor($variant), (int) $quantity);
     }
 
     /**
@@ -631,13 +594,7 @@ final class ManagingProductVariantsContext implements Context
      */
     public function theFirstVariantInTheListShouldHave($field, $value)
     {
-        $actualValue = $this->indexPage->getColumnFields($field)[0];
-
-        Assert::same(
-            $actualValue,
-            $value,
-            sprintf('Expected first variant\'s %s to be "%s", but it is "%s".', $field, $value, $actualValue)
-        );
+        Assert::same($this->indexPage->getColumnFields($field)[0], $value);
     }
 
     /**
@@ -645,14 +602,9 @@ final class ManagingProductVariantsContext implements Context
      */
     public function theLastVariantInTheListShouldHave($field, $value)
     {
-        $fields = $this->indexPage->getColumnFields($field);
-        $actualValue = end($fields);
+        $values = $this->indexPage->getColumnFields($field);
 
-        Assert::same(
-            $actualValue,
-            $value,
-            sprintf('Expected last variant\'s %s to be "%s", but it is "%s".', $field, $value, $actualValue)
-        );
+        Assert::same(end($values), $value);
     }
 
     /**
@@ -728,7 +680,7 @@ final class ManagingProductVariantsContext implements Context
     {
         // Intentionally left blank to fulfill context expectation
     }
-    
+
     /**
      * @When I change its quantity of inventory to :amount
      */
@@ -744,10 +696,7 @@ final class ManagingProductVariantsContext implements Context
     {
         $this->indexPage->open(['productId' => $productVariant->getProduct()->getId()]);
 
-        Assert::same(
-            $this->indexPage->getOnHandQuantityFor($productVariant),
-            (int) $amountInStock
-        );
+        Assert::same($this->indexPage->getOnHandQuantityFor($productVariant), (int) $amountInStock);
     }
 
     /**
@@ -784,8 +733,8 @@ final class ManagingProductVariantsContext implements Context
         $actualAmount = $this->indexPage->getOnHoldQuantityFor($variant);
 
         Assert::same(
-            (int) $expectedAmount,
             $actualAmount,
+            (int) $expectedAmount,
             sprintf(
                 'Unexpected on hold quantity for "%s" variant. It should be "%s" but is "%s"',
                 $variant->getName(),

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -23,7 +23,6 @@ use Sylius\Behat\Page\Admin\Product\IndexPerTaxonPageInterface;
 use Sylius\Behat\Page\Admin\Product\UpdateConfigurableProductPageInterface;
 use Sylius\Behat\Page\Admin\Product\UpdateSimpleProductPageInterface;
 use Sylius\Behat\Page\Admin\ProductReview\IndexPageInterface as ProductReviewIndexPageInterface;
-use Sylius\Behat\Page\SymfonyPageInterface;
 use Sylius\Behat\Service\NotificationCheckerInterface;
 use Sylius\Behat\Service\Resolver\CurrentPageResolverInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
@@ -253,10 +252,7 @@ final class ManagingProductsContext implements Context
     {
         $this->iWantToBrowseProducts();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['name' => $productName]),
-            sprintf('The product with name %s has not been found.', $productName)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $productName]));
     }
 
     /**
@@ -289,10 +285,7 @@ final class ManagingProductsContext implements Context
      */
     public function iShouldSeeProductWith($field, $value)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage([$field => $value]),
-            sprintf('The product with %s "%s" has not been found.', $field, $value)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([$field => $value]));
     }
 
     /**
@@ -300,10 +293,7 @@ final class ManagingProductsContext implements Context
      */
     public function iShouldNotSeeAnyProductWith($field, $value)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage([$field => $value]),
-            sprintf('The product with %s "%s" has been found.', $field, $value)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage([$field => $value]));
     }
 
     /**
@@ -313,13 +303,7 @@ final class ManagingProductsContext implements Context
     {
         $currentPage = $this->resolveCurrentPage();
 
-        $actualValue = $currentPage->getColumnFields($field)[0];
-
-        Assert::same(
-            $actualValue,
-            $value,
-            sprintf('Expected first product\'s %s to be "%s", but it is "%s".', $field, $value, $actualValue)
-        );
+        Assert::same($currentPage->getColumnFields($field)[0], $value);
     }
 
     /**
@@ -327,14 +311,9 @@ final class ManagingProductsContext implements Context
      */
     public function theLastProductOnTheListShouldHave($field, $value)
     {
-        $columnFields = $this->indexPerTaxonPage->getColumnFields($field);
-        $actualValue = end($columnFields);
+        $values = $this->indexPerTaxonPage->getColumnFields($field);
 
-        Assert::same(
-            $actualValue,
-            $value,
-            sprintf('Expected last product\'s %s to be "%s", but it is "%s".', $field, $value, $actualValue)
-        );
+        Assert::same(end($values), $value);
     }
 
     /**
@@ -352,13 +331,7 @@ final class ManagingProductsContext implements Context
      */
     public function iShouldSeeProductsInTheList($numberOfProducts)
     {
-        $foundRows = $this->indexPage->countItems();
-
-        Assert::same(
-            (int) $numberOfProducts,
-            $foundRows,
-            '%s rows with products should appear on page, %s rows has been found'
-        );
+        Assert::same($this->indexPage->countItems(), (int) $numberOfProducts);
     }
 
     /**
@@ -380,10 +353,7 @@ final class ManagingProductsContext implements Context
     {
         $this->iWantToBrowseProducts();
 
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['code' => $product->getCode()]),
-            sprintf('Product with code %s exists but should not.', $product->getCode())
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $product->getCode()]));
     }
 
     /**
@@ -428,10 +398,7 @@ final class ManagingProductsContext implements Context
     {
         $currentPage = $this->resolveCurrentPage();
 
-        Assert::true(
-            $currentPage->isCodeDisabled(),
-            'Code should be immutable, but it does not.'
-        );
+        Assert::true($currentPage->isCodeDisabled());
     }
 
     /**
@@ -440,10 +407,7 @@ final class ManagingProductsContext implements Context
      */
     public function theSlugFieldShouldNotBeEditable($localeCode = 'en_US')
     {
-        Assert::true(
-            $this->updateSimpleProductPage->isSlugReadOnlyIn($localeCode),
-            'Slug should be immutable, but it does not.'
-        );
+        Assert::true($this->updateSimpleProductPage->isSlugReadOnlyIn($localeCode));
     }
 
     /**
@@ -524,19 +488,7 @@ final class ManagingProductsContext implements Context
     {
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
 
-        $valueOnPage = $this->updateSimpleProductPage->getAttributeValue($attributeName, $language);
-
-        Assert::same(
-            $value,
-            $valueOnPage,
-            sprintf(
-                'Product attribute "%s" should have value "%s" in language "%s" but it has "%s".',
-                $attributeName,
-                $value,
-                $language,
-                $valueOnPage
-            )
-        );
+        Assert::same($this->updateSimpleProductPage->getAttributeValue($attributeName, $language), $value);
     }
 
     /**
@@ -546,10 +498,7 @@ final class ManagingProductsContext implements Context
     {
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
 
-        Assert::false(
-            $this->updateSimpleProductPage->hasAttribute($attribute),
-            sprintf('Product "%s" should not have attribute "%s" but it does.', $product->getName(), $attribute)
-        );
+        Assert::false($this->updateSimpleProductPage->hasAttribute($attribute));
     }
 
     /**
@@ -558,13 +507,7 @@ final class ManagingProductsContext implements Context
      */
     public function productShouldNotHaveAnyAttributes(ProductInterface $product, $count = 0)
     {
-        $numberOfAttributes = $this->updateSimpleProductPage->getNumberOfAttributes();
-
-        Assert::same(
-            (int) $count,
-            $numberOfAttributes,
-            sprintf('Product "%s" should have %d attributes, but it has %d.', $product->getName(), $count, $numberOfAttributes)
-        );
+        Assert::same($this->updateSimpleProductPage->getNumberOfAttributes(), (int) $count);
     }
 
     /**
@@ -574,10 +517,7 @@ final class ManagingProductsContext implements Context
     {
         $this->iWantToBrowseProducts();
 
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage([$element => $value]),
-            sprintf('Product with %s %s was created, but it should not.', $element, $value)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
     /**
@@ -603,10 +543,7 @@ final class ManagingProductsContext implements Context
      */
     public function theOptionFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updateConfigurableProductPage->isProductOptionsDisabled(),
-            'Options field should be immutable, but it does not.'
-        );
+        Assert::true($this->updateConfigurableProductPage->isProductOptionsDisabled());
     }
 
     /**
@@ -627,11 +564,7 @@ final class ManagingProductsContext implements Context
     {
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
 
-        Assert::same(
-            $this->updateSimpleProductPage->getSlug($locale),
-            $slug,
-            'Expected slug %2$s, but found %s.'
-        );
+        Assert::same($this->updateSimpleProductPage->getSlug($locale), $slug);
     }
 
     /**
@@ -639,15 +572,10 @@ final class ManagingProductsContext implements Context
      */
     public function thisProductMainTaxonShouldBe(ProductInterface $product, $taxonName)
     {
-        /** @var UpdatePageInterface $currentPage */
         $currentPage = $this->resolveCurrentPage();
-
         $currentPage->open(['id' => $product->getId()]);
 
-        Assert::true(
-            $this->updateConfigurableProductPage->isMainTaxonChosen($taxonName),
-            sprintf('The main taxon %s should be chosen, but it does not.', $taxonName)
-        );
+        Assert::true($currentPage->isMainTaxonChosen($taxonName));
     }
 
     /**
@@ -657,10 +585,7 @@ final class ManagingProductsContext implements Context
     {
         $this->iWantToModifyAProduct($product);
 
-        Assert::false(
-            $this->updateSimpleProductPage->isTracked(),
-            '"%s" should not be tracked, but it is.'
-        );
+        Assert::false($this->updateSimpleProductPage->isTracked());
     }
 
     /**
@@ -670,10 +595,7 @@ final class ManagingProductsContext implements Context
     {
         $this->iWantToModifyAProduct($product);
 
-        Assert::true(
-            $this->updateSimpleProductPage->isTracked(),
-            '"%s" should be tracked, but it is not.'
-        );
+        Assert::true($this->updateSimpleProductPage->isTracked());
     }
 
     /**
@@ -736,10 +658,7 @@ final class ManagingProductsContext implements Context
         /** @var UpdateSimpleProductPageInterface|UpdateConfigurableProductPageInterface $currentPage */
         $currentPage = $this->resolveCurrentPage();
 
-        Assert::true(
-            $currentPage->isImageWithCodeDisplayed($code),
-            sprintf('Image with a code %s should have been displayed.', $code)
-        );
+        Assert::true($currentPage->isImageWithCodeDisplayed($code));
     }
 
     /**
@@ -750,10 +669,7 @@ final class ManagingProductsContext implements Context
         /** @var UpdateSimpleProductPageInterface|UpdateConfigurableProductPageInterface $currentPage */
         $currentPage = $this->resolveCurrentPage();
 
-        Assert::false(
-            $currentPage->isImageWithCodeDisplayed($code),
-            sprintf('Image with a code %s should not have been displayed.', $code)
-        );
+        Assert::false($currentPage->isImageWithCodeDisplayed($code));
     }
 
     /**
@@ -796,14 +712,9 @@ final class ManagingProductsContext implements Context
     {
         $this->iWantToModifyAProduct($product);
 
-        /** @var UpdateSimpleProductPageInterface|UpdateConfigurableProductPageInterface $currentPage */
         $currentPage = $this->resolveCurrentPage();
 
-        Assert::same(
-            0,
-            $currentPage->countImages(),
-            'This product has %2$s, but it should not have.'
-        );
+        Assert::same($currentPage->countImages(), 0);
     }
 
     /**
@@ -814,10 +725,7 @@ final class ManagingProductsContext implements Context
         /** @var UpdateSimpleProductPageInterface|UpdateConfigurableProductPageInterface $currentPage */
         $currentPage = $this->resolveCurrentPage();
 
-        Assert::true(
-            $currentPage->isImageCodeDisabled(),
-            'Image code field should be disabled but it is not.'
-        );
+        Assert::true($currentPage->isImageCodeDisabled());
     }
 
     /**
@@ -825,7 +733,7 @@ final class ManagingProductsContext implements Context
      */
     public function iShouldBeNotifiedThatTheImageWithThisCodeAlreadyExists()
     {
-        Assert::same($this->updateSimpleProductPage->getValidationMessageForImage('code'), 'Image code must be unique within this product.');
+        Assert::same($this->updateSimpleProductPage->getValidationMessageForImage(), 'Image code must be unique within this product.');
     }
 
     /**
@@ -836,10 +744,7 @@ final class ManagingProductsContext implements Context
         /** @var UpdateSimpleProductPageInterface|UpdateConfigurableProductPageInterface $currentPage */
         $currentPage = $this->resolveCurrentPage();
 
-        Assert::same(
-            $currentPage->getValidationMessageForImage(),
-            'Please enter an image code.'
-        );
+        Assert::same($currentPage->getValidationMessageForImage(), 'Please enter an image code.');
     }
 
     /**
@@ -849,14 +754,9 @@ final class ManagingProductsContext implements Context
     {
         $this->iWantToModifyAProduct($product);
 
-        /** @var UpdateSimpleProductPageInterface|UpdateConfigurableProductPageInterface $currentPage */
         $currentPage = $this->resolveCurrentPage();
 
-        Assert::same(
-            1,
-            $currentPage->countImages(),
-            'This product has %2$s images, but it should have only one.'
-        );
+        Assert::same($currentPage->countImages(), 1);
     }
 
     /**
@@ -866,10 +766,7 @@ final class ManagingProductsContext implements Context
     {
         $this->productReviewIndexPage->open();
 
-        Assert::false(
-            $this->productReviewIndexPage->isSingleResourceOnPage(['reviewSubject' => $product->getName()]),
-            sprintf('There should be no reviews of %s.', $product->getName())
-        );
+        Assert::false($this->productReviewIndexPage->isSingleResourceOnPage(['reviewSubject' => $product->getName()]));
     }
 
     /**
@@ -884,7 +781,7 @@ final class ManagingProductsContext implements Context
             Assert::true(
                 $this->updateSimpleProductPage->hasAssociatedProduct($productName, $productAssociationType),
                 sprintf(
-                    'This product should have an association %s with product %s, but it does not.',
+                    'This product should have an association %s with product %s.',
                     $productAssociationType->getName(),
                     $productName
                 )
@@ -899,14 +796,7 @@ final class ManagingProductsContext implements Context
         ProductAssociationTypeInterface $productAssociationType,
         $productName
     ) {
-        Assert::false(
-            $this->updateSimpleProductPage->hasAssociatedProduct($productName, $productAssociationType),
-            sprintf(
-                'This product should not have an association %s with product %s, but it does.',
-                $productAssociationType->getName(),
-                $productName
-            )
-        );
+        Assert::false($this->updateSimpleProductPage->hasAssociatedProduct($productName, $productAssociationType));
     }
 
     /**
@@ -963,10 +853,7 @@ final class ManagingProductsContext implements Context
      */
     public function theyShouldHaveOrderLikeAnd(...$productNames)
     {
-        Assert::true(
-            $this->indexPerTaxonPage->hasProductsInOrder($productNames),
-            'The products have wrong order.'
-        );
+        Assert::true($this->indexPerTaxonPage->hasProductsInOrder($productNames));
     }
 
     /**
@@ -990,11 +877,7 @@ final class ManagingProductsContext implements Context
      */
     public function thisProductElementShouldHaveSlugIn($slug, $language)
     {
-        Assert::same(
-            $this->updateSimpleProductPage->getSlug($language),
-            $slug,
-            'Expected slug %2$s, but found %s.'
-        );
+        Assert::same($this->updateSimpleProductPage->getSlug($language), $slug);
     }
 
     /**
@@ -1013,10 +896,7 @@ final class ManagingProductsContext implements Context
     {
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
 
-        Assert::same(
-            $this->updateSimpleProductPage->getPriceForChannel($channelName),
-            $price
-        );
+        Assert::same($this->updateSimpleProductPage->getPriceForChannel($channelName), $price);
     }
 
     /**
@@ -1071,9 +951,7 @@ final class ManagingProductsContext implements Context
         Assert::isInstanceOf($currentPage, UpdatePageInterface::class);
 
         Assert::true(
-            $currentPage->hasResourceValues(
-                [$element => $value]
-            ),
+            $currentPage->hasResourceValues([$element => $value]),
             sprintf('Product should have %s with %s value.', $element, $value)
         );
     }
@@ -1091,7 +969,7 @@ final class ManagingProductsContext implements Context
     }
 
     /**
-     * @return SymfonyPageInterface
+     * @return IndexPageInterface|IndexPerTaxonPageInterface|CreateSimpleProductPageInterface|CreateConfigurableProductPageInterface|UpdateSimpleProductPageInterface|UpdateConfigurableProductPageInterface
      */
     private function resolveCurrentPage()
     {

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionCouponsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionCouponsContext.php
@@ -249,11 +249,7 @@ final class ManagingPromotionCouponsContext implements Context
     {
         $this->indexPage->open(['promotionId' => $promotion->getId()]);
 
-        Assert::same(
-            (int) $number,
-            $this->indexPage->countItems(),
-            'There should be %s coupons but is %s'
-        );
+        Assert::same($this->indexPage->countItems(), (int) $number);
     }
 
     /**
@@ -261,10 +257,7 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function thereShouldBeCouponWithCode($code)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['code' => $code]),
-            sprintf('There should be coupon with code %s but it is not.', $code)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $code]));
     }
 
     /**
@@ -272,10 +265,7 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function thisCouponShouldBeValidUntil(\DateTime $date)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['expiresAt' => date('d-m-Y', $date->getTimestamp())]),
-            sprintf('There should be coupon with expires date %s', date('d-m-Y', $date->getTimestamp()))
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['expiresAt' => date('d-m-Y', $date->getTimestamp())]));
     }
 
     /**
@@ -283,10 +273,7 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function thisCouponShouldHaveUsageLimit($limit)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['usageLimit' => $limit]),
-            sprintf('There should be coupon with %s usage limit', $limit)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['usageLimit' => $limit]));
     }
 
     /**
@@ -294,10 +281,7 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function couponShouldHaveUsageLimit(PromotionCouponInterface $promotionCoupon, $used)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['code' => $promotionCoupon->getCode(), 'used' => $used]),
-            sprintf('Coupon %s should be used % time', $promotionCoupon->getCode(), $used)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $promotionCoupon->getCode(), 'used' => $used]));
     }
 
     /**
@@ -305,10 +289,7 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function thisCouponShouldHavePerCustomerUsageLimit($limit)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['perCustomerUsageLimit' => $limit]),
-            sprintf('There should be coupon with %s per customer usage limit', $limit)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['perCustomerUsageLimit' => $limit]));
     }
 
     /**
@@ -316,10 +297,7 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeDisabled(),
-            'Code field should be disabled'
-        );
+        Assert::true($this->updatePage->isCodeDisabled());
     }
 
     /**
@@ -349,10 +327,7 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function iShouldBeNotifiedThatGenerateAmountIsRequired()
     {
-        Assert::true(
-            $this->generatePage->checkAmountValidation('Please enter amount of coupons to generate.'),
-            'Generate amount violation message should appear on page, but it does not.'
-        );
+        Assert::true($this->generatePage->checkAmountValidation('Please enter amount of coupons to generate.'));
     }
 
     /**
@@ -360,10 +335,7 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function iShouldBeNotifiedThatCodeLengthIsRequired()
     {
-        Assert::true(
-            $this->generatePage->checkCodeLengthValidation('Please enter coupon code length.'),
-            'Generate code length violation message should appear on page, but it does not.'
-        );
+        Assert::true($this->generatePage->checkCodeLengthValidation('Please enter coupon code length.'));
     }
 
     /**
@@ -373,10 +345,7 @@ final class ManagingPromotionCouponsContext implements Context
     {
         $this->indexPage->open(['promotionId' => $promotion->getId()]);
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['code' => $code]),
-            sprintf('There is no coupon with code %s.', $code)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $code]));
     }
 
     /**
@@ -395,10 +364,7 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function couponShouldNotExistInTheRegistry(PromotionCouponInterface $coupon)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['code' => $coupon->getCode()]),
-            sprintf('Coupon with code %s should not exist.', $coupon->getCode())
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $coupon->getCode()]));
     }
 
     /**
@@ -425,10 +391,7 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function couponShouldStillExistInTheRegistry(PromotionCouponInterface $coupon)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['code' => $coupon->getCode()]),
-            sprintf('Coupon with code %s should exist.', $coupon->getCode())
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $coupon->getCode()]));
     }
 
     /**
@@ -438,9 +401,6 @@ final class ManagingPromotionCouponsContext implements Context
     {
         $message = sprintf('Invalid coupons code length or coupons amount. It is not possible to generate %d unique coupons with code length equals %d. Possible generate amount is 8.', $amount, $codeLength);
 
-        Assert::true(
-            $this->generatePage->checkGenerationValidation($message),
-            'Generate violation message should appear on page, but it does not.'
-        );
+        Assert::true($this->generatePage->checkGenerationValidation($message));
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -127,10 +127,7 @@ final class ManagingPromotionsContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['name' => $promotionName]),
-            sprintf('Promotion with name %s has not been found.', $promotionName)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $promotionName]));
     }
 
     /**
@@ -274,10 +271,7 @@ final class ManagingPromotionsContext implements Context
      */
     public function thisPromotionShouldBeCouponBased(PromotionInterface $promotion)
     {
-        Assert::true(
-            $this->indexPage->isCouponBasedFor($promotion),
-            sprintf('Promotion with name "%s" should be coupon based', $promotion->getName())
-        );
+        Assert::true($this->indexPage->isCouponBasedFor($promotion));
     }
 
     /**
@@ -285,10 +279,7 @@ final class ManagingPromotionsContext implements Context
      */
     public function iShouldBeAbleToManageCouponsForThisPromotion(PromotionInterface $promotion)
     {
-        Assert::true(
-            $this->indexPage->isAbleToManageCouponsFor($promotion),
-            sprintf('I should be able to manage coupons for given promotion with name %s but apparently i am not.', $promotion->getName())
-        );
+        Assert::true($this->indexPage->isAbleToManageCouponsFor($promotion));
     }
 
     /**
@@ -322,10 +313,7 @@ final class ManagingPromotionsContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage([$element => $name]),
-            sprintf('Promotion with %s "%s" has been created, but it should not.', $element, $name)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage([$element => $name]));
     }
 
     /**
@@ -335,10 +323,7 @@ final class ManagingPromotionsContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage([$element => $value]),
-            sprintf('Promotion with %s "%s" cannot be found.', $element, $value)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
     /**
@@ -358,10 +343,7 @@ final class ManagingPromotionsContext implements Context
     {
         $this->iWantToModifyAPromotion($promotion);
 
-        Assert::true(
-            $this->updatePage->hasResourceValues(['usage_limit' => $usageLimit]),
-            sprintf('Promotion %s does not have usage limit set to %s.', $promotion->getName(), $usageLimit)
-        );
+        Assert::true($this->updatePage->hasResourceValues(['usage_limit' => $usageLimit]));
     }
 
     /**
@@ -417,10 +399,7 @@ final class ManagingPromotionsContext implements Context
     {
         $this->iWantToModifyAPromotion($promotion);
 
-        Assert::true(
-            $this->updatePage->checkChannelsState($channelName),
-            sprintf('Promotion %s is not %s, but it should be.', $promotion->getName(), $channelName)
-        );
+        Assert::true($this->updatePage->checkChannelsState($channelName));
     }
 
     /**
@@ -438,10 +417,7 @@ final class ManagingPromotionsContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeDisabled(),
-            'Code should be immutable, but it does not.'
-        );
+        Assert::true($this->updatePage->isCodeDisabled());
     }
 
     /**
@@ -472,10 +448,7 @@ final class ManagingPromotionsContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['code' => $promotion->getCode()]),
-            sprintf('Promotion with code %s exists but should not.', $promotion->getCode())
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $promotion->getCode()]));
     }
 
     /**
@@ -507,15 +480,9 @@ final class ManagingPromotionsContext implements Context
     {
         $this->iWantToModifyAPromotion($promotion);
 
-        Assert::true(
-            $this->updatePage->hasStartsAt($startsDate),
-            sprintf('Promotion %s should starts at %s, but it isn\'t.', $promotion->getName(), date('D, d M Y H:i:s', $startsDate->getTimestamp()))
-        );
+        Assert::true($this->updatePage->hasStartsAt($startsDate));
 
-        Assert::true(
-            $this->updatePage->hasEndsAt($endsDate),
-            sprintf('Promotion %s should ends at %s, but it isn\'t.', $promotion->getName(), date('D, d M Y H:i:s', $endsDate->getTimestamp()))
-        );
+        Assert::true($this->updatePage->hasEndsAt($endsDate));
     }
 
     /**
@@ -656,9 +623,6 @@ final class ManagingPromotionsContext implements Context
     {
         $this->iWantToModifyAPromotion($promotion);
 
-        Assert::true(
-            $this->updatePage->hasResourceValues([$field => 1]),
-            sprintf('Promotion %s is not %s, but it should be.', $promotion->getName(), str_replace('_', ' ', $field))
-        );
+        Assert::true($this->updatePage->hasResourceValues([$field => 1]));
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingCategoriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingCategoriesContext.php
@@ -75,12 +75,7 @@ class ManagingShippingCategoriesContext implements Context
      */
     public function iShouldSeeShippingCategoriesInTheList($numberOfShippingCategories)
     {
-        $foundRows = $this->indexPage->countItems();
-
-        Assert::true(
-            ((int) $numberOfShippingCategories) === $foundRows,
-            sprintf('%s rows with shipping categories should appear on page, %s rows has been found', $numberOfShippingCategories, $foundRows)
-        );
+        Assert::same($this->indexPage->countItems(), (int) $numberOfShippingCategories);
     }
 
     /**
@@ -137,10 +132,7 @@ class ManagingShippingCategoriesContext implements Context
     {
         $this->iWantToBrowseShippingCategories();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['code' => $shippingCategory->getCode()]),
-            sprintf('The shipping category with code %s has not been found.', $shippingCategory->getCode())
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $shippingCategory->getCode()]));
     }
 
     /**
@@ -157,10 +149,7 @@ class ManagingShippingCategoriesContext implements Context
      */
     public function thisShippingCategoryShouldNoLongerExistInTheRegistry(ShippingCategoryInterface $shippingCategory)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['code' => $shippingCategory->getCode()]),
-            sprintf('Shipping category with code %s exists but should not.', $shippingCategory->getCode())
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $shippingCategory->getCode()]));
     }
 
     /**
@@ -168,10 +157,7 @@ class ManagingShippingCategoriesContext implements Context
      */
     public function shippingCategoryWithNameShouldNotBeAdded($shippingCategoryName)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['name' => $shippingCategoryName]),
-            sprintf('Shipping category with name %s exists but should not.', $shippingCategoryName)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['name' => $shippingCategoryName]));
     }
 
     /**
@@ -204,10 +190,7 @@ class ManagingShippingCategoriesContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeDisabled(),
-            'Code should be immutable, but it does not.'
-        );
+        Assert::true($this->updatePage->isCodeDisabled());
     }
 
     /**
@@ -215,10 +198,7 @@ class ManagingShippingCategoriesContext implements Context
      */
     public function thisShippingCategoryNameShouldBe($shippingCategoryName)
     {
-        Assert::true(
-            $this->updatePage->hasResourceValues(['name' => $shippingCategoryName]),
-            sprintf('Shipping category should have name %s, but it does not.', $shippingCategoryName)
-        );
+        Assert::true($this->updatePage->hasResourceValues(['name' => $shippingCategoryName]));
     }
 
     /**
@@ -239,9 +219,6 @@ class ManagingShippingCategoriesContext implements Context
     {
         $this->iWantToBrowseShippingCategories();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['code' => $code]),
-            sprintf('Shipping method with code %s cannot be found.', $code)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $code]));
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingMethodsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingMethodsContext.php
@@ -166,10 +166,7 @@ final class ManagingShippingMethodsContext implements Context
     {
         $this->iWantToBrowseShippingMethods();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['name' => $shipmentMethodName]),
-            sprintf('The shipping method with name %s has not been found.', $shipmentMethodName)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $shipmentMethodName]));
     }
 
     /**
@@ -189,10 +186,7 @@ final class ManagingShippingMethodsContext implements Context
     ) {
         $this->iWantToModifyAShippingMethod($shippingMethod);
 
-        Assert::true(
-            $this->updatePage->isAvailableInChannel($channelName),
-            sprintf('Shipping method should be available in channel "%s" but it does not.', $channelName)
-        );
+        Assert::true($this->updatePage->isAvailableInChannel($channelName));
     }
 
     /**
@@ -210,10 +204,7 @@ final class ManagingShippingMethodsContext implements Context
     {
         $this->iWantToBrowseShippingMethods();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage([$element => $code]),
-            sprintf('Shipping method with %s %s cannot be found.', $element, $code)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([$element => $code]));
     }
 
     /**
@@ -230,10 +221,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeDisabled(),
-            'Code should be immutable, but it does not.'
-        );
+        Assert::true($this->updatePage->isCodeDisabled());
     }
 
     /**
@@ -244,15 +232,10 @@ final class ManagingShippingMethodsContext implements Context
     {
         $this->iWantToBrowseShippingMethods();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(
-                [
-                    'code' => $shippingMethod->getCode(),
-                    'name' => $shippingMethodName,
-                ]
-            ),
-            sprintf('Shipping method name %s has not been assigned properly.', $shippingMethodName)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([
+            'code' => $shippingMethod->getCode(),
+            'name' => $shippingMethodName,
+        ]));
     }
 
     /**
@@ -314,11 +297,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function thereShouldBeNoShippingMethodsOnTheList($count)
     {
-        Assert::same(
-            $this->indexPage->countItems(),
-            (int) $count,
-            'There should be %2$d shipping methods on the list, found %d instead.'
-        );
+        Assert::same($this->indexPage->countItems(), (int) $count);
     }
 
     /**
@@ -326,15 +305,8 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function theOnlyShippingMethodOnTheListShouldBe($name)
     {
-        Assert::same(
-            (int) $this->indexPage->countItems(),
-            1,
-            'There should be only one shipping method on the list, found %d instead.'
-        );
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['name' => $name]),
-            sprintf('Shipping method "%s" was not found on the list.', $name)
-        );
+        Assert::same((int) $this->indexPage->countItems(), 1);
+        Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $name]));
     }
 
     /**
@@ -344,10 +316,7 @@ final class ManagingShippingMethodsContext implements Context
     {
         $this->iWantToBrowseShippingMethods();
 
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage([$element => $name]),
-            sprintf('Shipping method with %s %s was created, but it should not.', $element, $name)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage([$element => $name]));
     }
 
     /**
@@ -424,13 +393,8 @@ final class ManagingShippingMethodsContext implements Context
     public function theFirstShippingMethodOnTheListShouldHave($field, $value)
     {
         $fields = $this->indexPage->getColumnFields($field);
-        $actualValue = reset($fields);
 
-        Assert::same(
-            $actualValue,
-            $value,
-            sprintf('Expected first shipping method\'s %s to be "%s", but it is "%s".', $field, $value, $actualValue)
-        );
+        Assert::same(reset($fields), $value);
     }
 
     /**
@@ -439,13 +403,8 @@ final class ManagingShippingMethodsContext implements Context
     public function theLastShippingMethodOnTheListShouldHave($field, $value)
     {
         $fields = $this->indexPage->getColumnFields($field);
-        $actualValue = end($fields);
 
-        Assert::same(
-            $actualValue,
-            $value,
-            sprintf('Expected last shipping method\'s %s to be "%s", but it is "%s".', $field, $value, $actualValue)
-        );
+        Assert::same(end($fields), $value);
     }
 
     /**
@@ -463,12 +422,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function iShouldSeeShippingMethodsInTheList($numberOfShippingMethods)
     {
-        $foundRows = $this->indexPage->countItems();
-
-        Assert::true(
-            ((int) $numberOfShippingMethods) === $foundRows,
-            sprintf('%s rows with shipping methods should appear on page, %s rows has been found', $numberOfShippingMethods, $foundRows)
-        );
+        Assert::same($this->indexPage->countItems(), (int) $numberOfShippingMethods);
     }
 
     /**
@@ -518,10 +472,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function thisShippingMethodShouldNoLongerExistInTheRegistry(ShippingMethodInterface $shippingMethod)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['code' => $shippingMethod->getCode()]),
-            sprintf('Shipping method with code %s exists but should not.', $shippingMethod->getCode())
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $shippingMethod->getCode()]));
     }
 
     /**
@@ -566,12 +517,9 @@ final class ManagingShippingMethodsContext implements Context
     {
         $this->iWantToBrowseShippingMethods();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(
-                [
-                    'name' => $shippingMethod->getName(),
-                    'enabled' => $state,
-                ]
-            ), sprintf('Shipping method with name %s and state %s has not been found.', $shippingMethod->getName(), $state));
+        Assert::true($this->indexPage->isSingleResourceOnPage([
+            'name' => $shippingMethod->getName(),
+            'enabled' => $state,
+        ]));
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxCategoriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxCategoriesContext.php
@@ -76,10 +76,7 @@ final class ManagingTaxCategoriesContext implements Context
      */
     public function thisTaxCategoryShouldNoLongerExistInTheRegistry(TaxCategoryInterface $taxCategory)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['code' => $taxCategory->getCode()]),
-            sprintf('Tax category with code %s exists but should not.', $taxCategory->getCode())
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $taxCategory->getCode()]));
     }
 
     /**
@@ -125,10 +122,7 @@ final class ManagingTaxCategoriesContext implements Context
     public function theTaxCategoryShouldAppearInTheRegistry($taxCategoryName)
     {
         $this->indexPage->open();
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['nameAndDescription' => $taxCategoryName]),
-            sprintf('Tax category with name %s has not been found.', $taxCategoryName)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['nameAndDescription' => $taxCategoryName]));
     }
 
     /**
@@ -162,10 +156,7 @@ final class ManagingTaxCategoriesContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeDisabled(),
-            'Code should be immutable, but it does not.'
-        );
+        Assert::true($this->updatePage->isCodeDisabled());
     }
 
     /**
@@ -175,10 +166,7 @@ final class ManagingTaxCategoriesContext implements Context
     public function thisTaxCategoryNameShouldBe(TaxCategoryInterface $taxCategory, $taxCategoryName)
     {
         $this->indexPage->open();
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['code' => $taxCategory->getCode(), 'nameAndDescription' => $taxCategoryName]),
-            sprintf('Tax category name %s was not assigned properly.', $taxCategoryName)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $taxCategory->getCode(), 'nameAndDescription' => $taxCategoryName]));
     }
 
     /**
@@ -195,10 +183,7 @@ final class ManagingTaxCategoriesContext implements Context
     public function thereShouldStillBeOnlyOneTaxCategoryWith($element, $code)
     {
         $this->indexPage->open();
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage([$element => $code]),
-            sprintf('Tax category with %s %s cannot be found.', $element, $code)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([$element => $code]));
     }
 
     /**
@@ -218,9 +203,6 @@ final class ManagingTaxCategoriesContext implements Context
     public function taxCategoryWithElementValueShouldNotBeAdded($element, $name)
     {
         $this->indexPage->open();
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage([$element => $name]),
-            sprintf('Tax category with %s %s was created, but it should not.', $element, $name)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage([$element => $name]));
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxRateContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxRateContext.php
@@ -142,10 +142,7 @@ final class ManagingTaxRateContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['name' => $taxRateName]),
-            sprintf('Tax rate with name %s has not been found.', $taxRateName)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['name' => $taxRateName]));
     }
 
     /**
@@ -162,10 +159,7 @@ final class ManagingTaxRateContext implements Context
      */
     public function thisTaxRateShouldNoLongerExistInTheRegistry(TaxRateInterface $taxRate)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['code' => $taxRate->getCode()]),
-            sprintf('Tax rate with code %s exists but should not.', $taxRate->getCode())
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $taxRate->getCode()]));
     }
 
     /**
@@ -182,10 +176,7 @@ final class ManagingTaxRateContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeDisabled(),
-            'Code should be immutable, but it does not.'
-        );
+        Assert::true($this->updatePage->isCodeDisabled());
     }
 
     /**
@@ -230,10 +221,7 @@ final class ManagingTaxRateContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage([$element => $code]),
-            sprintf('Tax rate with %s %s cannot be found.', $element, $code)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage([$element => $code]));
     }
 
     /**
@@ -275,10 +263,7 @@ final class ManagingTaxRateContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage([$element => $name]),
-            sprintf('Tax rate with %s %s was created, but it should not.', $element, $name)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage([$element => $name]));
     }
 
     /**
@@ -315,12 +300,10 @@ final class ManagingTaxRateContext implements Context
         $this->indexPage->open();
 
         Assert::true(
-            $this->indexPage->isSingleResourceOnPage(
-                [
+            $this->indexPage->isSingleResourceOnPage([
                     'code' => $taxRate->getCode(),
                     $element => $taxRateElement,
-                ]
-            ),
+            ]),
             sprintf('Tax rate %s %s has not been assigned properly.', $element, $taxRateElement)
         );
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
@@ -145,10 +145,7 @@ final class ManagingTaxonsContext implements Context
      */
     public function theSlugFieldShouldNotBeEditable($language = 'en_US')
     {
-        Assert::true(
-            $this->updatePage->isSlugReadOnly($language),
-            sprintf('Slug in "%s" should be immutable, but it does not.', $language)
-        );
+        Assert::true($this->updatePage->isSlugReadOnly($language));
     }
 
     /**
@@ -234,10 +231,7 @@ final class ManagingTaxonsContext implements Context
     public function theTaxonShouldAppearInTheRegistry(TaxonInterface $taxon)
     {
         $this->updatePage->open(['id' => $taxon->getId()]);
-        Assert::true(
-            $this->updatePage->hasResourceValues(['code' => $taxon->getCode()]),
-            sprintf('Taxon %s should be in the registry.', $taxon->getName())
-        );
+        Assert::true($this->updatePage->hasResourceValues(['code' => $taxon->getCode()]));
     }
 
     /**
@@ -245,10 +239,7 @@ final class ManagingTaxonsContext implements Context
      */
     public function thisTaxonElementShouldBe($element, $value)
     {
-        Assert::true(
-            $this->updatePage->hasResourceValues([$element => $value]),
-            sprintf('Taxon with %s should have %s value.', $element, $value)
-        );
+        Assert::true($this->updatePage->hasResourceValues([$element => $value]));
     }
 
     /**
@@ -260,11 +251,7 @@ final class ManagingTaxonsContext implements Context
             $this->updatePage->activateLanguageTab($language);
         }
 
-        Assert::same(
-            $this->updatePage->getSlug($language),
-            $value,
-            sprintf('Taxon should have slug "%s" but it has not.', $value)
-        );
+        Assert::same($this->updatePage->getSlug($language), $value);
     }
 
     /**
@@ -272,10 +259,7 @@ final class ManagingTaxonsContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeDisabled(),
-            'Code field should be disabled but it is not.'
-        );
+        Assert::true($this->updatePage->isCodeDisabled());
     }
 
     /**
@@ -285,10 +269,7 @@ final class ManagingTaxonsContext implements Context
     {
         $this->updatePage->open(['id' => $taxon->getId()]);
 
-        Assert::true(
-            $this->updatePage->hasResourceValues(['slug' => $slug]),
-            sprintf('Taxon\'s slug should be %s.', $slug)
-        );
+        Assert::true($this->updatePage->hasResourceValues(['slug' => $slug]));
     }
 
     /**
@@ -296,10 +277,7 @@ final class ManagingTaxonsContext implements Context
      */
     public function thisTaxonShouldBelongsTo(TaxonInterface $taxon)
     {
-        Assert::true(
-            $this->updatePage->hasResourceValues(['parent' => $taxon->getId()]),
-            sprintf('Current taxon should have %s parent taxon.', $taxon->getName())
-        );
+        Assert::true($this->updatePage->hasResourceValues(['parent' => $taxon->getId()]));
     }
 
     /**
@@ -307,12 +285,7 @@ final class ManagingTaxonsContext implements Context
      */
     public function itShouldNotBelongToAnyOtherTaxon()
     {
-        $parent = $this->updatePage->getParent();
-
-        Assert::isEmpty(
-            $parent,
-            sprintf('Current taxon should not belong to any other, but it does belong to "%s"', $parent)
-        );
+        Assert::isEmpty($this->updatePage->getParent());
     }
 
     /**
@@ -353,10 +326,7 @@ final class ManagingTaxonsContext implements Context
      */
     public function thereShouldStillBeOnlyOneTaxonWithCode($code)
     {
-        Assert::true(
-            $this->updatePage->hasResourceValues(['code' => $code]),
-            sprintf('Taxon with code %s cannot be found.', $code)
-        );
+        Assert::true($this->updatePage->hasResourceValues(['code' => $code]));
     }
 
     /**
@@ -365,11 +335,7 @@ final class ManagingTaxonsContext implements Context
      */
     public function taxonNamedShouldNotBeAdded($name)
     {
-        Assert::eq(
-            0,
-            $this->createPage->countTaxonsByName($name),
-            sprintf('Taxon %s should not exist.', $name)
-        );
+        Assert::same($this->createPage->countTaxonsByName($name), 0);
     }
 
     /**
@@ -377,13 +343,7 @@ final class ManagingTaxonsContext implements Context
      */
     public function iShouldSeeTaxonsInTheList($number)
     {
-        $taxonsOnPage = $this->createPage->countTaxons();
-
-        Assert::same(
-            (int) $number,
-            $taxonsOnPage,
-            sprintf('On list should be %d taxons but get %d.', $number, $taxonsOnPage)
-        );
+        Assert::same($this->createPage->countTaxons(), (int) $number);
     }
 
     /**
@@ -391,11 +351,7 @@ final class ManagingTaxonsContext implements Context
      */
     public function iShouldSeeTheTaxonNamedInTheList($name)
     {
-        Assert::eq(
-            1,
-            $this->createPage->countTaxonsByName($name),
-            sprintf('Taxon %s does not exist or multiple taxons with this name exist.', $name)
-        );
+        Assert::same($this->createPage->countTaxonsByName($name), 1);
     }
 
     /**
@@ -422,10 +378,7 @@ final class ManagingTaxonsContext implements Context
      */
     public function thisTaxonShouldHaveAnImageWithCode($code)
     {
-        Assert::true(
-            $this->updatePage->isImageWithCodeDisplayed($code),
-            sprintf('Image with a code %s should have been displayed.', $code)
-        );
+        Assert::true($this->updatePage->isImageWithCodeDisplayed($code));
     }
 
     /**
@@ -433,10 +386,7 @@ final class ManagingTaxonsContext implements Context
      */
     public function thisTaxonShouldNotHaveAnImageWithCode($code)
     {
-        Assert::false(
-            $this->updatePage->isImageWithCodeDisplayed($code),
-            sprintf('Image with a code %s should not have been displayed.', $code)
-        );
+        Assert::false($this->updatePage->isImageWithCodeDisplayed($code));
     }
 
     /**
@@ -462,11 +412,7 @@ final class ManagingTaxonsContext implements Context
     {
         $this->iWantToModifyATaxon($taxon);
 
-        Assert::eq(
-            0,
-            $this->updatePage->countImages(),
-            'This taxon has %2$s, but it should not have.'
-        );
+        Assert::same($this->updatePage->countImages(), 0);
     }
 
     /**
@@ -503,11 +449,7 @@ final class ManagingTaxonsContext implements Context
     {
         $this->iWantToModifyATaxon($taxon);
 
-        Assert::eq(
-            1,
-            $this->updatePage->countImages(),
-            'This taxon has %2$s images, but it should have only one.'
-        );
+        Assert::same($this->updatePage->countImages(), 1);
     }
 
     /**
@@ -515,10 +457,7 @@ final class ManagingTaxonsContext implements Context
      */
     public function theImageCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isImageCodeDisabled(),
-            'Image code field should be disabled but it is not.'
-        );
+        Assert::true($this->updatePage->isImageCodeDisabled());
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingZonesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingZonesContext.php
@@ -209,13 +209,7 @@ final class ManagingZonesContext implements Context
      */
     public function itsScopeShouldBe($scope)
     {
-        $zoneScope = $this->updatePage->getScope();
-
-        Assert::same(
-            $scope,
-            $zoneScope,
-            sprintf('Zone should have scope "%s" but it has "%s".', $scope, $zoneScope)
-        );
+        Assert::same($this->updatePage->getScope(), $scope);
     }
 
     /**
@@ -225,11 +219,7 @@ final class ManagingZonesContext implements Context
     {
         $this->assertZoneAndItsMember($zone, $zoneMember);
 
-        Assert::eq(
-            1,
-            $this->updatePage->countMembers(),
-            sprintf('Zone %s should have only %s zone member', $zone->getName(), $zoneMember->getCode())
-        );
+        Assert::same($this->updatePage->countMembers(), 1);
     }
 
     /**
@@ -237,10 +227,7 @@ final class ManagingZonesContext implements Context
      */
     public function thisZoneNameShouldBe(ZoneInterface $zone, $name)
     {
-        Assert::true(
-            $this->updatePage->hasResourceValues(['code' => $zone->getCode(), 'name' => $name]),
-            sprintf('Zone should be named %s, but is %s', $name, $zone->getName())
-        );
+        Assert::true($this->updatePage->hasResourceValues(['code' => $zone->getCode(), 'name' => $name]));
     }
 
     /**
@@ -248,10 +235,7 @@ final class ManagingZonesContext implements Context
      */
     public function theCodeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->updatePage->isCodeDisabled(),
-            'Code field should be disabled but it is not'
-        );
+        Assert::true($this->updatePage->isCodeDisabled());
     }
 
     /**
@@ -272,10 +256,7 @@ final class ManagingZonesContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['code' => $code]),
-            sprintf('Zone with code %s cannot be found.', $code)
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $code]));
     }
 
     /**
@@ -296,10 +277,7 @@ final class ManagingZonesContext implements Context
     {
         $this->indexPage->open();
 
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage([$element => $value]),
-            sprintf('Zone with %s %s was added, but it should not.', $element, $value)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage([$element => $value]));
     }
 
     /**
@@ -307,10 +285,7 @@ final class ManagingZonesContext implements Context
      */
     public function iShouldBeNotifiedThatAtLeastOneZoneMemberIsRequired()
     {
-        Assert::true(
-            $this->createPage->checkValidationMessageForMembers('Please add at least 1 zone member.'),
-            'I should be notified that zone needs at least one zone member.'
-        );
+        Assert::true($this->createPage->checkValidationMessageForMembers('Please add at least 1 zone member.'));
     }
 
     /**
@@ -318,10 +293,7 @@ final class ManagingZonesContext implements Context
      */
     public function theTypeFieldShouldBeDisabled()
     {
-        Assert::true(
-            $this->createPage->isTypeFieldDisabled(),
-            'Type field should be disabled but it is not'
-        );
+        Assert::true($this->createPage->isTypeFieldDisabled());
     }
 
     /**
@@ -329,10 +301,7 @@ final class ManagingZonesContext implements Context
      */
     public function itShouldBeOfType($type)
     {
-        Assert::true(
-            $this->createPage->hasType($type),
-            sprintf('Zone should be of %s type', $type)
-        );
+        Assert::true($this->createPage->hasType($type));
     }
 
     /**
@@ -340,10 +309,7 @@ final class ManagingZonesContext implements Context
      */
     public function thisZoneShouldNoLongerExistInTheRegistry($zoneName)
     {
-        Assert::false(
-            $this->indexPage->isSingleResourceOnPage(['name' => $zoneName]),
-            sprintf('Zone named %s should no longer exist', $zoneName)
-        );
+        Assert::false($this->indexPage->isSingleResourceOnPage(['name' => $zoneName]));
     }
 
     /**
@@ -351,13 +317,7 @@ final class ManagingZonesContext implements Context
      */
     public function iShouldSeeZonesInTheList($number)
     {
-        $resourcesOnPage = $this->indexPage->countItems();
-
-        Assert::same(
-            (int) $number,
-            $resourcesOnPage,
-            sprintf('On list should be %d zones but get %d', $number, $resourcesOnPage)
-        );
+        Assert::same($this->indexPage->countItems(), (int) $number);
     }
 
     /**
@@ -365,10 +325,7 @@ final class ManagingZonesContext implements Context
      */
     public function iShouldSeeTheZoneNamedInTheList(ZoneInterface $zone)
     {
-        Assert::true(
-            $this->indexPage->isSingleResourceOnPage(['code' => $zone->getCode(), 'name' => $zone->getName()]),
-            sprintf('Zone named %s should exist in the registry', $zone->getName())
-        );
+        Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $zone->getCode(), 'name' => $zone->getName()]));
     }
 
     /**
@@ -395,9 +352,6 @@ final class ManagingZonesContext implements Context
             sprintf('Zone %s is not valid', $zone->getName())
         );
 
-        Assert::true(
-            $this->updatePage->hasMember($zoneMember),
-            sprintf('Zone %s has not %s zone member', $zone->getName(), $zoneMember->getCode())
-        );
+        Assert::true($this->updatePage->hasMember($zoneMember));
     }
 }

--- a/src/Sylius/Behat/Context/Ui/EmailContext.php
+++ b/src/Sylius/Behat/Context/Ui/EmailContext.php
@@ -50,10 +50,7 @@ final class EmailContext implements Context
      */
     public function anEmailShouldBeSentTo($recipient)
     {
-        Assert::true(
-            $this->emailChecker->hasRecipient($recipient),
-            sprintf('An email should have been sent to %s.', $recipient)
-        );
+        Assert::true($this->emailChecker->hasRecipient($recipient));
     }
 
     /**
@@ -61,17 +58,7 @@ final class EmailContext implements Context
      */
     public function numberOfEmailsShouldBeSentTo($count, $recipient)
     {
-        $actualMessagesCount = $this->emailChecker->countMessagesTo($recipient);
-
-        Assert::eq(
-            $actualMessagesCount,
-            $count,
-            sprintf(
-                '%d messages were sent, while there should be %d.',
-                $actualMessagesCount,
-                $count
-            )
-        );
+        Assert::same($this->emailChecker->countMessagesTo($recipient), (int) $count);
     }
 
     /**
@@ -114,10 +101,7 @@ final class EmailContext implements Context
      */
     private function assertEmailContainsMessageTo($message, $recipient)
     {
-        Assert::true(
-            $this->emailChecker->hasMessageTo($message, $recipient),
-            sprintf('Message "%s" was not sent to "%s".', $message, $recipient)
-        );
+        Assert::true($this->emailChecker->hasMessageTo($message, $recipient));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Shop/AccountContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/AccountContext.php
@@ -143,10 +143,7 @@ final class AccountContext implements Context
     {
         $this->dashboardPage->open();
 
-        Assert::true(
-            $this->dashboardPage->hasCustomerName($name),
-            sprintf('Cannot find customer name "%s".', $name)
-        );
+        Assert::true($this->dashboardPage->hasCustomerName($name));
     }
 
     /**
@@ -157,10 +154,7 @@ final class AccountContext implements Context
     {
         $this->dashboardPage->open();
 
-        Assert::true(
-            $this->dashboardPage->hasCustomerEmail($email),
-            sprintf('Cannot find customer email "%s".', $email)
-        );
+        Assert::true($this->dashboardPage->hasCustomerEmail($email));
     }
 
     /**
@@ -294,11 +288,7 @@ final class AccountContext implements Context
      */
     public function iShouldSeeASingleOrderInTheList()
     {
-        Assert::same(
-            1,
-            $this->orderIndexPage->countOrders(),
-            '%s rows with orders should appear on page, %s rows have been found.'
-        );
+        Assert::same($this->orderIndexPage->countOrders(), 1);
     }
 
     /**
@@ -306,10 +296,7 @@ final class AccountContext implements Context
      */
     public function thisOrderShouldHaveNumber(OrderInterface $order)
     {
-        Assert::true(
-            $this->orderIndexPage->isOrderWithNumberInTheList($order->getNumber()),
-            sprintf('Cannot find order with number "%s" in the list.', $order->getNumber())
-        );
+        Assert::true($this->orderIndexPage->isOrderWithNumberInTheList($order->getNumber()));
     }
 
     /**
@@ -334,11 +321,7 @@ final class AccountContext implements Context
      */
     public function itShouldHasNumber($orderNumber)
     {
-        Assert::same(
-            $this->orderShowPage->getNumber(),
-            $orderNumber,
-            'The number of an order is %s, but should be %s.'
-        );
+        Assert::same($this->orderShowPage->getNumber(), $orderNumber);
     }
 
     /**
@@ -346,10 +329,7 @@ final class AccountContext implements Context
      */
     public function iShouldSeeAsShippingAddress($customerName, $street, $postcode, $city, $countryName)
     {
-        Assert::true(
-            $this->orderShowPage->hasShippingAddress($customerName, $street, $postcode, $city, $countryName),
-            sprintf('Cannot find shipping address "%s, %s %s, %s".', $street, $postcode, $city, $countryName)
-        );
+        Assert::true($this->orderShowPage->hasShippingAddress($customerName, $street, $postcode, $city, $countryName));
     }
 
     /**
@@ -357,10 +337,7 @@ final class AccountContext implements Context
      */
     public function itShouldBeShippedTo($customerName, $street, $postcode, $city, $countryName)
     {
-        Assert::true(
-            $this->orderShowPage->hasBillingAddress($customerName, $street, $postcode, $city, $countryName),
-            sprintf('Cannot find shipping address "%s, %s %s, %s".', $street, $postcode, $city, $countryName)
-        );
+        Assert::true($this->orderShowPage->hasBillingAddress($customerName, $street, $postcode, $city, $countryName));
     }
 
     /**
@@ -368,11 +345,7 @@ final class AccountContext implements Context
      */
     public function iShouldSeeAsOrderSTotal($total)
     {
-        Assert::same(
-            $this->orderShowPage->getTotal(),
-            $total,
-            'Total is %s, but should be %s.'
-        );
+        Assert::same($this->orderShowPage->getTotal(), $total);
     }
 
     /**
@@ -380,11 +353,7 @@ final class AccountContext implements Context
      */
     public function iShouldSeeAsOrderSSubtotal($subtotal)
     {
-        Assert::same(
-            $this->orderShowPage->getSubtotal(),
-            $subtotal,
-            'Subtotal is %s, but should be %s.'
-        );
+        Assert::same($this->orderShowPage->getSubtotal(), $subtotal);
     }
 
     /**
@@ -393,11 +362,7 @@ final class AccountContext implements Context
      */
     public function iShouldSeeIHaveToPayForThisOrder($paymentAmount)
     {
-        Assert::same(
-            $this->orderShowPage->getPaymentPrice(),
-            $paymentAmount,
-            'Payment total is %s, but should be %s.'
-        );
+        Assert::same($this->orderShowPage->getPaymentPrice(), $paymentAmount);
     }
 
     /**
@@ -405,11 +370,7 @@ final class AccountContext implements Context
      */
     public function iShouldSeeItemsInTheList($numberOfItems)
     {
-        Assert::same(
-            (int) $numberOfItems,
-            $this->orderShowPage->countItems(),
-            '%s items should appear on order page, but %s rows has been found.'
-        );
+        Assert::same($this->orderShowPage->countItems(), (int) $numberOfItems);
     }
 
     /**
@@ -417,10 +378,7 @@ final class AccountContext implements Context
      */
     public function theProductShouldBeInTheItemsList($productName)
     {
-        Assert::true(
-            $this->orderShowPage->isProductInTheList($productName),
-            sprintf('Product %s is not in the item list.', $productName)
-        );
+        Assert::true($this->orderShowPage->isProductInTheList($productName));
     }
 
     /**
@@ -428,11 +386,7 @@ final class AccountContext implements Context
      */
     public function iShouldSeeAsItemPrice($itemPrice)
     {
-        Assert::same(
-            $this->orderShowPage->getItemPrice(),
-            $itemPrice,
-            'Item price is %s, but should be %s.'
-        );
+        Assert::same($this->orderShowPage->getItemPrice(), $itemPrice);
     }
 
     /**
@@ -448,10 +402,7 @@ final class AccountContext implements Context
      */
     public function iShouldBeSubscribedToTheNewsletter()
     {
-        Assert::true(
-            $this->profileUpdatePage->isSubscribedToTheNewsletter(),
-            'I should be subscribed to the newsletter, but I am not.'
-        );
+        Assert::true($this->profileUpdatePage->isSubscribedToTheNewsletter());
     }
 
     /**
@@ -459,10 +410,7 @@ final class AccountContext implements Context
      */
     public function iShouldSeeAsProvinceInTheShippingAddress($provinceName)
     {
-        Assert::true(
-            $this->orderShowPage->hasShippingProvinceName($provinceName),
-            sprintf('Cannot find shipping address with province %s', $provinceName)
-        );
+        Assert::true($this->orderShowPage->hasShippingProvinceName($provinceName));
     }
 
     /**
@@ -470,10 +418,7 @@ final class AccountContext implements Context
      */
     public function iShouldSeeAsProvinceInTheBillingAddress($provinceName)
     {
-        Assert::true(
-            $this->orderShowPage->hasBillingProvinceName($provinceName),
-            sprintf('Cannot find shipping address with province %s', $provinceName)
-        );
+        Assert::true($this->orderShowPage->hasBillingProvinceName($provinceName));
     }
 
     /**
@@ -481,10 +426,7 @@ final class AccountContext implements Context
      */
     public function iShouldBeAbleToChangePaymentMethodForThisOrder(OrderInterface $order)
     {
-        Assert::true(
-            $this->orderIndexPage->isItPossibleToChangePaymentMethodForOrder($order),
-            sprintf('I should be able to change payment method for %s.', $order->getNumber())
-        );
+        Assert::true($this->orderIndexPage->isItPossibleToChangePaymentMethodForOrder($order));
     }
 
     /**
@@ -494,9 +436,6 @@ final class AccountContext implements Context
      */
     private function assertFieldValidationMessage(PageInterface $page, $element, $expectedMessage)
     {
-        Assert::true(
-            $page->checkValidationMessageFor($element, $expectedMessage),
-            sprintf('There should be a message: "%s".', $expectedMessage)
-        );
+        Assert::true($page->checkValidationMessageFor($element, $expectedMessage));
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Shop/AddressBookContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/AddressBookContext.php
@@ -233,10 +233,7 @@ final class AddressBookContext implements Context
      */
     public function thisAddressShouldHavePersonFirstNameAndLastName($fullName)
     {
-        Assert::true(
-            $this->addressBookIndexPage->hasAddressOf($fullName),
-            sprintf('An address of "%s" should be on the list.', $fullName)
-        );
+        Assert::true($this->addressBookIndexPage->hasAddressOf($fullName));
     }
 
     /**
@@ -244,10 +241,7 @@ final class AddressBookContext implements Context
      */
     public function iShouldStillBeOnAddressAdditionPage()
     {
-        Assert::true(
-            $this->addressBookCreatePage->isOpen(),
-            'The address creation page should be opened.'
-        );
+        Assert::true($this->addressBookCreatePage->isOpen());
     }
 
     /**
@@ -265,13 +259,7 @@ final class AddressBookContext implements Context
      */
     public function iShouldStillHaveAsMySpecifiedProvince($value)
     {
-        $actualValue = $this->addressBookUpdatePage->getSpecifiedProvince();
-
-        Assert::same(
-            $actualValue,
-            $value,
-            sprintf('Address\'s province should be %s, but is %s.', $value, $actualValue)
-        );
+        Assert::same($this->addressBookUpdatePage->getSpecifiedProvince(), $value);
     }
 
     /**
@@ -279,13 +267,7 @@ final class AddressBookContext implements Context
      */
     public function iShouldStillHaveAsMyChosenProvince($value)
     {
-        $actualValue = $this->addressBookUpdatePage->getSelectedProvince();
-
-        Assert::same(
-            $actualValue,
-            $value,
-            sprintf('Address\'s province should be %s, but is %s.', $value, $actualValue)
-        );
+        Assert::same($this->addressBookUpdatePage->getSelectedProvince(), $value);
     }
 
     /**
@@ -293,10 +275,7 @@ final class AddressBookContext implements Context
      */
     public function iShouldBeNotifiedThatTheProvinceNeedsToBeSpecified()
     {
-        Assert::true(
-            $this->addressBookCreatePage->hasProvinceValidationMessage(),
-            'Province validation messages should be visible.'
-        );
+        Assert::true($this->addressBookCreatePage->hasProvinceValidationMessage());
     }
 
     /**
@@ -304,13 +283,7 @@ final class AddressBookContext implements Context
      */
     public function iShouldBeNotifiedAboutErrors($expectedCount)
     {
-        $actualCount = $this->addressBookCreatePage->countValidationMessages();
-
-        Assert::same(
-            (int) $expectedCount,
-            $actualCount,
-            sprintf('There should be %d validation messages, but %d has been found.', $expectedCount, $actualCount)
-        );
+        Assert::same($this->addressBookCreatePage->countValidationMessages(), (int) $expectedCount);
     }
 
     /**
@@ -318,10 +291,7 @@ final class AddressBookContext implements Context
      */
     public function thereShouldBeNoAddresses()
     {
-        Assert::true(
-            $this->addressBookIndexPage->hasNoAddresses(),
-            'There should be no addresses on the list.'
-        );
+        Assert::true($this->addressBookIndexPage->hasNoAddresses());
     }
 
     /**
@@ -329,10 +299,7 @@ final class AddressBookContext implements Context
      */
     public function iShouldNotSeeAddressOf($fullName)
     {
-        Assert::false(
-            $this->addressBookIndexPage->hasAddressOf($fullName),
-            sprintf('The address of "%s" should not be on the list.', $fullName)
-        );
+        Assert::false($this->addressBookIndexPage->hasAddressOf($fullName));
     }
 
     /**
@@ -343,7 +310,7 @@ final class AddressBookContext implements Context
     {
         $this->addressBookIndexPage->open();
 
-        $this->assertAddressesCountOnPage((int) $count);
+        Assert::same($this->addressBookIndexPage->getAddressesCount(), (int) $count);
     }
 
     /**
@@ -369,14 +336,7 @@ final class AddressBookContext implements Context
     {
         $address = $this->getAddressOf($this->sharedStorage->getLatestResource());
 
-        Assert::false(
-            $this->addressBookUpdatePage->isOpen(['id' => $address->getId()]),
-            sprintf(
-                'I should be unable to edit the address of "%s %s"',
-                $address->getFirstName(),
-                $address->getLastName()
-            )
-        );
+        Assert::false($this->addressBookUpdatePage->isOpen(['id' => $address->getId()]));
     }
 
     /**
@@ -400,10 +360,7 @@ final class AddressBookContext implements Context
      */
     public function iShouldHaveNoDefaultAddress()
     {
-        Assert::true(
-            $this->addressBookIndexPage->hasNoDefaultAddress(),
-            'There should be no default address.'
-        );
+        Assert::true($this->addressBookIndexPage->hasNoDefaultAddress());
     }
 
     /**
@@ -414,11 +371,7 @@ final class AddressBookContext implements Context
         $actualFullName = $this->addressBookIndexPage->getFullNameOfDefaultAddress();
         $expectedFullName = sprintf('%s %s', $address->getFirstName(), $address->getLastName());
 
-        Assert::same(
-            $expectedFullName,
-            $actualFullName,
-            sprintf('The default address should be of "%s", but is of "%s".', $expectedFullName, $actualFullName)
-        );
+        Assert::same($actualFullName, $expectedFullName);
     }
 
     /**
@@ -448,25 +401,5 @@ final class AddressBookContext implements Context
                 $this->addressBookCreatePage,
                 $this->addressBookUpdatePage
         ]);
-    }
-
-    /**
-     * @param int $expectedCount
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function assertAddressesCountOnPage($expectedCount)
-    {
-        $actualCount = $this->addressBookIndexPage->getAddressesCount();
-
-        Assert::same(
-            $expectedCount,
-            $actualCount,
-            sprintf(
-                'There should be %d addresses on the list, but %d addresses has been found.',
-                $expectedCount,
-                $actualCount
-            )
-        );
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -91,10 +91,7 @@ final class CartContext implements Context
     {
         $this->summaryPage->open();
 
-        Assert::true(
-             $this->summaryPage->isEmpty(),
-            'There should appear information about empty cart, but it does not.'
-        );
+        Assert::true($this->summaryPage->isEmpty());
     }
 
     /**
@@ -122,11 +119,8 @@ final class CartContext implements Context
     public function myCartTotalShouldBe($total)
     {
         $this->summaryPage->open();
-        Assert::same(
-            $this->summaryPage->getGrandTotal(),
-            $total,
-            'Grand total should be %2$s, but it is %s.'
-        );
+
+        Assert::same($this->summaryPage->getGrandTotal(), $total);
     }
 
     /**
@@ -136,11 +130,7 @@ final class CartContext implements Context
     {
         $this->summaryPage->open();
 
-        Assert::same(
-            $this->summaryPage->getBaseGrandTotal(),
-            $total,
-            'Base grand total should be %2$s, but it is %s.'
-        );
+        Assert::same($this->summaryPage->getBaseGrandTotal(), $total);
     }
 
     /**
@@ -150,11 +140,7 @@ final class CartContext implements Context
     {
         $this->summaryPage->open();
 
-        Assert::same(
-            $this->summaryPage->getTaxTotal(),
-            $taxTotal,
-            'Tax total value should be %2$s, but it is %s.'
-        );
+        Assert::same($this->summaryPage->getTaxTotal(), $taxTotal);
     }
 
     /**
@@ -165,11 +151,7 @@ final class CartContext implements Context
     {
         $this->summaryPage->open();
 
-        Assert::same(
-            $this->summaryPage->getShippingTotal(),
-            $shippingTotal,
-            'Shipping total value should be %2$s, but it is %s.'
-        );
+        Assert::same($this->summaryPage->getShippingTotal(), $shippingTotal);
     }
 
     /**
@@ -179,11 +161,7 @@ final class CartContext implements Context
     {
         $this->summaryPage->open();
 
-        Assert::same(
-            $this->summaryPage->getPromotionTotal(),
-            $promotionsTotal,
-            'Promotion total value should be %2$s, but it is %s.'
-        );
+        Assert::same($this->summaryPage->getPromotionTotal(), $promotionsTotal);
     }
 
     /**
@@ -230,11 +208,7 @@ final class CartContext implements Context
         $itemTotal = $this->summaryPage->getItemTotal($product->getName());
         $regularUnitPrice = $this->summaryPage->getItemUnitRegularPrice($product->getName());
 
-        Assert::same(
-            ($quantity * $regularUnitPrice) - $amount,
-            $this->getPriceFromString($itemTotal),
-            'Price after discount should be %s, but it is %2$s.'
-        );
+        Assert::same($this->getPriceFromString($itemTotal), ($quantity * $regularUnitPrice) - $amount);
     }
 
     /**
@@ -244,10 +218,7 @@ final class CartContext implements Context
     {
         $this->summaryPage->open();
 
-        Assert::false(
-            $this->summaryPage->isItemDiscounted($product->getName()),
-            'The price should not be decreased, but it is.'
-        );
+        Assert::false($this->summaryPage->isItemDiscounted($product->getName()));
     }
 
     /**
@@ -315,10 +286,7 @@ final class CartContext implements Context
     {
         $this->summaryPage->waitForRedirect(3);
 
-        Assert::true(
-            $this->summaryPage->isOpen(),
-            'Cart summary page should be open, but it does not.'
-        );
+        Assert::true($this->summaryPage->isOpen());
     }
 
     /**
@@ -334,10 +302,7 @@ final class CartContext implements Context
      */
     public function thereShouldBeOneItemInMyCart()
     {
-        Assert::true(
-            $this->summaryPage->isSingleItemOnPage(),
-            'There should be only one item on list, but it does not.'
-        );
+        Assert::true($this->summaryPage->isSingleItemOnPage());
     }
 
     /**
@@ -345,10 +310,7 @@ final class CartContext implements Context
      */
     public function thisProductShouldHaveName($itemName)
     {
-        Assert::true(
-            $this->summaryPage->hasItemNamed($itemName),
-            sprintf('The product with name %s should appear on the list, but it does not.', $itemName)
-        );
+        Assert::true($this->summaryPage->hasItemNamed($itemName));
     }
 
     /**
@@ -356,10 +318,7 @@ final class CartContext implements Context
      */
     public function thisItemShouldHaveVariant($variantName)
     {
-        Assert::true(
-            $this->summaryPage->hasItemWithVariantNamed($variantName),
-            sprintf('The product with variant %s should appear on the list, but it does not.', $variantName)
-        );
+        Assert::true($this->summaryPage->hasItemWithVariantNamed($variantName));
     }
 
     /**
@@ -367,10 +326,7 @@ final class CartContext implements Context
      */
     public function thisItemShouldHaveCode($variantCode)
     {
-        Assert::true(
-            $this->summaryPage->hasItemWithCode($variantCode),
-            sprintf('The product with code %s should appear on the list, but it does not.', $variantCode)
-        );
+        Assert::true($this->summaryPage->hasItemWithCode($variantCode));
     }
 
     /**
@@ -389,10 +345,7 @@ final class CartContext implements Context
      */
     public function thisItemShouldHaveOptionValue(ProductInterface $product, $optionName, $optionValue)
     {
-        Assert::true(
-            $this->summaryPage->hasItemWithOptionValue($product->getName(), $optionName, $optionValue),
-            sprintf('Product in cart "%s" should have option %s with value %s, but it has not.', $product->getName(), $optionName, $optionValue)
-        );
+        Assert::true($this->summaryPage->hasItemWithOptionValue($product->getName(), $optionName, $optionValue));
     }
 
     /**
@@ -408,11 +361,7 @@ final class CartContext implements Context
      */
     public function iShouldSeeWithQuantityInMyCart($productName, $quantity)
     {
-        Assert::same(
-            $this->summaryPage->getQuantity($productName),
-            (int) $quantity,
-            'The quantity of product should be %2$s, but it is %s'
-        );
+        Assert::same($this->summaryPage->getQuantity($productName), (int) $quantity);
     }
 
     /**
@@ -420,11 +369,7 @@ final class CartContext implements Context
      */
     public function iShouldSeeProductWithUnitPriceInMyCart($productName, $unitPrice)
     {
-        Assert::same(
-            $this->summaryPage->getItemUnitPrice($productName),
-            $unitPrice,
-            'The unit price of product should be %2$s, but it is %s.'
-        );
+        Assert::same($this->summaryPage->getItemUnitPrice($productName), $unitPrice);
     }
 
     /**
@@ -440,10 +385,7 @@ final class CartContext implements Context
      */
     public function iShouldBeNotifiedThatCouponIsInvalid()
     {
-        Assert::same(
-            $this->summaryPage->getPromotionCouponValidationMessage(),
-            'Coupon code is invalid.'
-        );
+        Assert::same($this->summaryPage->getPromotionCouponValidationMessage(), 'Coupon code is invalid.');
     }
 
     /**
@@ -453,10 +395,7 @@ final class CartContext implements Context
     {
         $this->summaryPage->open();
 
-        Assert::same(
-            $this->summaryPage->getItemTotal($productName),
-            $productPrice
-        );
+        Assert::same($this->summaryPage->getItemTotal($productName), $productPrice);
     }
 
     /**
@@ -464,10 +403,7 @@ final class CartContext implements Context
      */
     public function iShouldBeNotifiedThatThisProductDoesNotHaveSufficientStock(ProductInterface $product)
     {
-        Assert::true(
-            $this->summaryPage->hasProductOutOfStockValidationMessage($product),
-            sprintf('I should see validation message for %s product', $product->getName())
-        );
+        Assert::true($this->summaryPage->hasProductOutOfStockValidationMessage($product));
     }
 
     /**
@@ -475,10 +411,7 @@ final class CartContext implements Context
      */
     public function iShouldNotBeNotifiedThatThisProductCannotBeUpdated(ProductInterface $product)
     {
-        Assert::false(
-            $this->summaryPage->hasProductOutOfStockValidationMessage($product),
-            sprintf('I should see validation message for %s product', $product->getName())
-        );
+        Assert::false($this->summaryPage->hasProductOutOfStockValidationMessage($product));
     }
 
     /**
@@ -488,11 +421,7 @@ final class CartContext implements Context
     {
         $this->summaryPage->open();
 
-        Assert::same(
-            $total,
-            $this->summaryPage->getCartTotal(),
-            'Cart should have %s total, but it has %2$s.'
-        );
+        Assert::same($this->summaryPage->getCartTotal(), $total);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
@@ -274,7 +274,7 @@ final class CheckoutAddressingContext implements Context
      */
     public function iShouldHaveSelectedAsCountry($countryName)
     {
-        Assert::same($countryName, $this->addressPage->getShippingAddressCountry());
+        Assert::same($this->addressPage->getShippingAddressCountry(), $countryName);
     }
 
     /**
@@ -282,7 +282,7 @@ final class CheckoutAddressingContext implements Context
      */
     public function iShouldHaveNoCountrySelected()
     {
-        Assert::same('Select', $this->addressPage->getShippingAddressCountry());
+        Assert::same($this->addressPage->getShippingAddressCountry(), 'Select');
     }
 
     /**
@@ -397,9 +397,6 @@ final class CheckoutAddressingContext implements Context
     private function assertElementValidationMessage($type, $element, $expectedMessage)
     {
         $element = sprintf('%s_%s', $type, implode('_', explode(' ', $element)));
-        Assert::true(
-            $this->addressPage->checkValidationMessageFor($element, $expectedMessage),
-            sprintf('The %s should be required.', $element)
-        );
+        Assert::true($this->addressPage->checkValidationMessageFor($element, $expectedMessage));
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutCompleteContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutCompleteContext.php
@@ -258,6 +258,6 @@ final class CheckoutCompleteContext implements Context
      */
     public function thisPromotionShouldGiveDiscount(PromotionInterface $promotion, $discount)
     {
-        Assert::same($discount, $this->completePage->getShippingPromotionDiscount($promotion->getName()));
+        Assert::same($this->completePage->getShippingPromotionDiscount($promotion->getName()), $discount);
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutPaymentContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutPaymentContext.php
@@ -137,9 +137,8 @@ final class CheckoutPaymentContext implements Context
     public function iShouldHavePaymentMethodAvailableAsFirstChoice($paymentMethodName)
     {
         $paymentMethods = $this->selectPaymentPage->getPaymentMethods();
-        $firstPaymentMethod = reset($paymentMethods);
 
-        Assert::same($paymentMethodName, $firstPaymentMethod);
+        Assert::same(reset($paymentMethods), $paymentMethodName);
     }
 
     /**
@@ -148,8 +147,7 @@ final class CheckoutPaymentContext implements Context
     public function iShouldHavePaymentMethodAvailableAsLastChoice($paymentMethodName)
     {
         $paymentMethods = $this->selectPaymentPage->getPaymentMethods();
-        $lastPaymentMethod = end($paymentMethods);
 
-        Assert::same($paymentMethodName, $lastPaymentMethod);
+        Assert::same(end($paymentMethods), $paymentMethodName);
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutShippingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutShippingContext.php
@@ -108,9 +108,8 @@ final class CheckoutShippingContext implements Context
     public function iShouldHaveShippingMethodAvailableAsFirstChoice($shippingMethodName)
     {
         $shippingMethods = $this->selectShippingPage->getShippingMethods();
-        $firstShippingMethod = reset($shippingMethods);
 
-        Assert::same($shippingMethodName, $firstShippingMethod);
+        Assert::same(reset($shippingMethods), $shippingMethodName);
     }
 
     /**
@@ -119,9 +118,8 @@ final class CheckoutShippingContext implements Context
     public function iShouldHaveShippingMethodAvailableAsLastChoice($shippingMethodName)
     {
         $shippingMethods = $this->selectShippingPage->getShippingMethods();
-        $lastShippingMethod = end($shippingMethods);
 
-        Assert::same($shippingMethodName, $lastShippingMethod);
+        Assert::same(end($shippingMethods), $shippingMethodName);
     }
 
     /**
@@ -198,6 +196,6 @@ final class CheckoutShippingContext implements Context
      */
     public function iShouldBeCheckingOutAs($email)
     {
-        Assert::same('Checking out as '.$email.'.', $this->selectShippingPage->getPurchaserEmail());
+        Assert::same($this->selectShippingPage->getPurchaserEmail(), 'Checking out as '.$email.'.');
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CheckoutContext.php
@@ -214,8 +214,6 @@ final class CheckoutContext implements Context
             $this->completePage,
         ]);
 
-        $actualPrice = $currentPage->getItemSubtotal($item);
-
-        Assert::eq($actualPrice, $price, sprintf('The %s subtotal should be %s, but is %s', $item, $price, $actualPrice));
+        Assert::eq($currentPage->getItemSubtotal($item), $price);
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Shop/ContactContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/ContactContext.php
@@ -133,12 +133,6 @@ final class ContactContext implements Context
      */
     private function assertFieldValidationMessage(PageInterface $page, $element, $expectedMessage)
     {
-        $currentMessage = $page->getValidationMessageFor($element);
-
-        Assert::same(
-            $currentMessage,
-            $expectedMessage,
-            'There is a message: "%s", but should be: "%s".'
-        );
+        Assert::same($page->getValidationMessageFor($element), $expectedMessage);
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Shop/CurrencyContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CurrencyContext.php
@@ -50,7 +50,7 @@ final class CurrencyContext implements Context
     {
         $this->homePage->open();
 
-        Assert::same($currencyCode, $this->homePage->getActiveCurrency());
+        Assert::same($this->homePage->getActiveCurrency(), $currencyCode);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Shop/HomepageContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/HomepageContext.php
@@ -54,12 +54,6 @@ final class HomepageContext implements Context
      */
     public function iShouldSeeProductsInTheList($numberOfProducts)
     {
-        $foundProductsNames = $this->homePage->getLatestProductsNames();
-
-        Assert::same(
-            (int) $numberOfProducts,
-            count($foundProductsNames),
-            '%d rows with products should appear on page, %d rows has been found'
-        );
+        Assert::same(count($this->homePage->getLatestProductsNames()), (int) $numberOfProducts);
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Shop/LocaleContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/LocaleContext.php
@@ -53,7 +53,7 @@ final class LocaleContext implements Context
     {
         $this->homePage->open();
 
-        Assert::same($localeName, $this->homePage->getActiveLocale());
+        Assert::same($this->homePage->getActiveLocale(), $localeName);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Shop/LoginContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/LoginContext.php
@@ -150,14 +150,8 @@ final class LoginContext implements Context
      */
     public function iShouldBeLoggedIn()
     {
-        Assert::true(
-            $this->homePage->isOpen(),
-            'I should be on the homepage.'
-        );
-        Assert::true(
-            $this->homePage->hasLogoutButton(),
-            'I should be able to sign out.'
-        );
+        Assert::true($this->homePage->isOpen());
+        Assert::true($this->homePage->hasLogoutButton());
     }
 
     /**
@@ -165,10 +159,7 @@ final class LoginContext implements Context
      */
     public function iShouldNotBeLoggedIn()
     {
-        Assert::false(
-            $this->homePage->hasLogoutButton(),
-            'I should not be logged in.'
-        );
+        Assert::false($this->homePage->hasLogoutButton());
     }
 
     /**
@@ -176,10 +167,7 @@ final class LoginContext implements Context
      */
     public function iShouldBeNotifiedAboutBadCredentials()
     {
-        Assert::true(
-            $this->loginPage->hasValidationErrorWith('Error Invalid credentials.'),
-            'I should see validation error.'
-        );
+        Assert::true($this->loginPage->hasValidationErrorWith('Error Invalid credentials.'));
     }
 
     /**
@@ -187,10 +175,7 @@ final class LoginContext implements Context
      */
     public function iShouldBeNotifiedAboutDisabledAccount()
     {
-        Assert::true(
-            $this->loginPage->hasValidationErrorWith('Error Account is disabled.'),
-            'I should see validation error.'
-        );
+        Assert::true($this->loginPage->hasValidationErrorWith('Error Account is disabled.'));
     }
 
     /**
@@ -206,10 +191,7 @@ final class LoginContext implements Context
      */
     public function iShouldBeNotifiedThatElementIsRequired($elementName)
     {
-        Assert::true(
-            $this->resetPasswordPage->checkValidationMessageFor($elementName, sprintf('Please enter your %s.', $elementName)),
-            sprintf('The %s should be required.', $elementName)
-        );
+        Assert::true($this->resetPasswordPage->checkValidationMessageFor($elementName, sprintf('Please enter your %s.', $elementName)));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
@@ -64,10 +64,7 @@ final class ProductContext implements Context
     {
         $this->showPage->tryToOpen(['slug' => $product->getSlug()]);
 
-        Assert::true(
-            $this->showPage->isOpen(['slug' => $product->getSlug()]),
-            'Product show page should be open, but it does not.'
-        );
+        Assert::true($this->showPage->isOpen(['slug' => $product->getSlug()]));
     }
 
     /**
@@ -77,10 +74,7 @@ final class ProductContext implements Context
     {
         $this->showPage->tryToOpen(['slug' => $product->getSlug()]);
 
-        Assert::false(
-            $this->showPage->isOpen(['slug' => $product->getSlug()]),
-            'Product show page should not be open, but it does.'
-        );
+        Assert::false($this->showPage->isOpen(['slug' => $product->getSlug()]));
     }
 
     /**
@@ -97,11 +91,7 @@ final class ProductContext implements Context
      */
     public function iShouldSeeProductName($name)
     {
-        Assert::same(
-            $name,
-            $this->showPage->getName(),
-            'Product should have name %s, but it has %s'
-        );
+        Assert::same($this->showPage->getName(), $name);
     }
 
     /**
@@ -118,10 +108,7 @@ final class ProductContext implements Context
      */
     public function iShouldBeOnProductDetailedPage(ProductInterface $product)
     {
-        Assert::true(
-            $this->showPage->isOpen(['slug' => $product->getSlug()]),
-            sprintf('Product %s show page should be open, but it does not.', $product->getName())
-        );
+        Assert::true($this->showPage->isOpen(['slug' => $product->getSlug()]));
     }
 
     /**
@@ -129,17 +116,7 @@ final class ProductContext implements Context
      */
     public function iShouldSeeTheProductAttributeWithValue($attributeName, $expectedAttribute)
     {
-        $certainAttribute = $this->showPage->getAttributeByName($attributeName);
-        Assert::same(
-            $certainAttribute,
-            $expectedAttribute,
-            sprintf(
-                'Product should have attribute %s with value %s, but has %s.',
-                $attributeName,
-                $expectedAttribute,
-                $certainAttribute
-            )
-        );
+        Assert::same($this->showPage->getAttributeByName($attributeName), $expectedAttribute);
     }
 
     /**
@@ -147,13 +124,7 @@ final class ProductContext implements Context
      */
     public function iShouldSeeAttributes($count)
     {
-        $attributes = $this->getProductAttributes();
-
-        Assert::same(
-            count($attributes),
-            (int) $count,
-            'Product should have %2$d attributes, but has %d instead.'
-        );
+        Assert::same(count($this->getProductAttributes()), (int) $count);
     }
 
     /**
@@ -162,13 +133,8 @@ final class ProductContext implements Context
     public function theFirstAttributeShouldBe($name)
     {
         $attributes = $this->getProductAttributes();
-        $firstAttribute = reset($attributes);
 
-        Assert::same(
-            $firstAttribute->getText(),
-            $name,
-            'Expected the first attribute to be %2$s, found %s instead.'
-        );
+        Assert::same(reset($attributes)->getText(), $name);
     }
 
     /**
@@ -177,13 +143,8 @@ final class ProductContext implements Context
     public function theLastAttributeShouldBe($name)
     {
         $attributes = $this->getProductAttributes();
-        $lastAttribute = end($attributes);
 
-        Assert::same(
-            $lastAttribute->getText(),
-            $name,
-            'Expected the first attribute to be %2$s, found %s instead.'
-        );
+        Assert::same(end($attributes)->getText(), $name);
     }
 
     /**
@@ -247,10 +208,7 @@ final class ProductContext implements Context
      */
     public function iShouldSeeProduct($productName)
     {
-        Assert::true(
-            $this->indexPage->isProductOnList($productName),
-            sprintf('The product %s should appear on page, but it does not.', $productName)
-        );
+        Assert::true($this->indexPage->isProductOnList($productName));
     }
 
     /**
@@ -258,10 +216,7 @@ final class ProductContext implements Context
      */
     public function iShouldNotSeeProduct($productName)
     {
-        Assert::false(
-            $this->indexPage->isProductOnList($productName),
-            sprintf('The product %s should not appear on page, but it does.', $productName)
-        );
+        Assert::false($this->indexPage->isProductOnList($productName));
     }
 
     /**
@@ -269,10 +224,7 @@ final class ProductContext implements Context
      */
     public function iShouldSeeEmptyListOfProducts()
     {
-        Assert::true(
-            $this->indexPage->isEmpty(),
-            'There should appear information about empty list of products, but it does not.'
-        );
+        Assert::true($this->indexPage->isEmpty());
     }
 
     /**
@@ -280,10 +232,7 @@ final class ProductContext implements Context
      */
     public function iShouldSeeItIsOutOfStock()
     {
-        Assert::true(
-            $this->showPage->isOutOfStock(),
-            'Out of stock label should be visible.'
-        );
+        Assert::true($this->showPage->isOutOfStock());
     }
 
     /**
@@ -291,10 +240,7 @@ final class ProductContext implements Context
      */
     public function iShouldBeUnableToAddItToTheCart()
     {
-        Assert::false(
-            $this->showPage->hasAddToCartButton(),
-            'Add to cart button should be absent or disabled.'
-        );
+        Assert::false($this->showPage->hasAddToCartButton());
     }
 
     /**
@@ -303,11 +249,7 @@ final class ProductContext implements Context
      */
     public function iShouldSeeTheProductPrice($price)
     {
-        Assert::same(
-            $price,
-            $this->showPage->getPrice(),
-            'Product should have price %2$s, but it has %s'
-        );
+        Assert::same($this->showPage->getPrice(), $price);
     }
 
     /**
@@ -331,7 +273,7 @@ final class ProductContext implements Context
      */
     public function itsCurrentVariantShouldBeNamed($name)
     {
-        Assert::same($name, $this->showPage->getCurrentVariantName());
+        Assert::same($this->showPage->getCurrentVariantName(), $name);
     }
 
     /**
@@ -339,10 +281,7 @@ final class ProductContext implements Context
      */
     public function iShouldSeeTheProductWithPrice($productName, $productPrice)
     {
-        Assert::true(
-            $this->indexPage->isProductWithPriceOnList($productName, $productPrice),
-            sprintf('The product %s with price %s should appear on page, but it does not.', $productName, $productPrice)
-        );
+        Assert::true($this->indexPage->isProductWithPriceOnList($productName, $productPrice));
     }
 
     /**
@@ -350,10 +289,7 @@ final class ProductContext implements Context
      */
     public function iShouldBeNotifiedThatThisProductDoesNotHaveSufficientStock(ProductInterface $product)
     {
-        Assert::true(
-            $this->showPage->hasProductOutOfStockValidationMessage($product),
-            sprintf('I should see validation message for %s product', $product->getName())
-        );
+        Assert::true($this->showPage->hasProductOutOfStockValidationMessage($product));
     }
 
     /**
@@ -361,10 +297,7 @@ final class ProductContext implements Context
      */
     public function iShouldNotBeNotifiedThatThisProductDoesNotHaveSufficientStock(ProductInterface $product)
     {
-        Assert::false(
-            $this->showPage->hasProductOutOfStockValidationMessage($product),
-            sprintf('I should see validation message for %s product', $product->getName())
-        );
+        Assert::false($this->showPage->hasProductOutOfStockValidationMessage($product));
     }
 
     /**
@@ -372,10 +305,7 @@ final class ProductContext implements Context
      */
     public function iShouldSeeAMainImage()
     {
-        Assert::true(
-            $this->showPage->isMainImageDisplayed(),
-            'The main image should have been displayed.'
-        );
+        Assert::true($this->showPage->isMainImageDisplayed());
     }
 
     /**
@@ -393,13 +323,7 @@ final class ProductContext implements Context
      */
     public function iShouldSeeProductsInTheList($numberOfProducts)
     {
-        $foundRows = $this->indexPage->countProductsItems();
-
-        Assert::same(
-            (int) $numberOfProducts,
-            $foundRows,
-            '%s rows with products should appear on page, %s rows has been found'
-        );
+        Assert::same($this->indexPage->countProductsItems(), (int) $numberOfProducts);
     }
 
     /**
@@ -407,10 +331,7 @@ final class ProductContext implements Context
      */
     public function iShouldSeeProductWithName($name)
     {
-        Assert::true(
-            $this->indexPage->isProductOnPageWithName($name),
-            sprintf('The product with name "%s" has not been found.', $name)
-        );
+        Assert::true($this->indexPage->isProductOnPageWithName($name));
     }
 
     /**
@@ -418,13 +339,7 @@ final class ProductContext implements Context
      */
     public function theFirstProductOnTheListShouldHaveName($name)
     {
-        $actualName = $this->indexPage->getFirstProductNameFromList();
-
-        Assert::same(
-            $actualName,
-            $name,
-            sprintf('Expected first product\'s name to be "%s", but it is "%s".', $name, $actualName)
-        );
+        Assert::same($this->indexPage->getFirstProductNameFromList(), $name);
     }
 
     /**
@@ -432,13 +347,7 @@ final class ProductContext implements Context
      */
     public function theLastProductOnTheListShouldHaveName($name)
     {
-        $actualName = $this->indexPage->getLastProductNameFromList();
-
-        Assert::same(
-            $actualName,
-            $name,
-            sprintf('Expected last product\'s name to be "%s", but it is "%s".', $name, $actualName)
-        );
+        Assert::same($this->indexPage->getLastProductNameFromList(), $name);
     }
 
     /**
@@ -446,11 +355,7 @@ final class ProductContext implements Context
      */
     public function iShouldSeeProductReviews($count)
     {
-        Assert::same(
-            (int) $count,
-            $this->showPage->countReviews(),
-            'Product has %2$s reviews, but should have %s.'
-        );
+        Assert::same($this->showPage->countReviews(), (int) $count);
     }
 
     /**
@@ -471,10 +376,7 @@ final class ProductContext implements Context
      */
     public function iShouldNotSeeReviewTitled($title)
     {
-        Assert::false(
-            $this->showPage->hasReviewTitled($title),
-            sprintf('Product should not have review titled "%s" but it does.', $title)
-        );
+        Assert::false($this->showPage->hasReviewTitled($title));
     }
 
     /**
@@ -490,11 +392,7 @@ final class ProductContext implements Context
      */
     public function iShouldSeeNumberOfProductReviewsInTheList($count)
     {
-        Assert::same(
-            (int) $count,
-            $this->productReviewsIndexPage->countReviews(),
-            'Product has %2$s reviews in the list, but should have %s.'
-        );
+        Assert::same($this->productReviewsIndexPage->countReviews(), (int) $count);
     }
 
     /**
@@ -502,10 +400,7 @@ final class ProductContext implements Context
      */
     public function iShouldNotSeeReviewTitledInTheList($title)
     {
-        Assert::false(
-            $this->productReviewsIndexPage->hasReviewTitled($title),
-            sprintf('Product should not have review titled "%s" but it does.', $title)
-        );
+        Assert::false($this->productReviewsIndexPage->hasReviewTitled($title));
     }
 
     /**
@@ -513,10 +408,7 @@ final class ProductContext implements Context
      */
     public function iShouldBeNotifiedThatThereAreNoReviews()
     {
-        Assert::true(
-            $this->productReviewsIndexPage->hasNoReviewsMessage(),
-            'There should be message about no reviews but there is not.'
-        );
+        Assert::true($this->productReviewsIndexPage->hasNoReviewsMessage());
     }
 
     /**
@@ -524,13 +416,7 @@ final class ProductContext implements Context
      */
     public function iShouldSeeAsItsAverageRating($rating)
     {
-        $averageRating = $this->showPage->getAverageRating();
-
-        Assert::same(
-            (float) $rating,
-            $averageRating,
-            'Product should have average rating %2$s but has %s.'
-        );
+        Assert::same($this->showPage->getAverageRating(), (float) $rating);
     }
 
     /**
@@ -562,10 +448,7 @@ final class ProductContext implements Context
      */
     public function theyShouldHaveOrderLikeAnd(...$productNames)
     {
-        Assert::true(
-            $this->indexPage->hasProductsInOrder($productNames),
-            'The products have wrong order.'
-        );
+        Assert::true($this->indexPage->hasProductsInOrder($productNames));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Shop/ProductReviewContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/ProductReviewContext.php
@@ -117,11 +117,7 @@ final class ProductReviewContext implements Context
      */
     public function iShouldBeNotifiedThatIMustCheckReviewRating()
     {
-        Assert::same(
-            $this->createPage->getRateValidationMessage(),
-            'You must check review rating.',
-            'There should be rate validation error, but there is not.'
-        );
+        Assert::same($this->createPage->getRateValidationMessage(), 'You must check review rating.');
     }
 
     /**
@@ -129,11 +125,7 @@ final class ProductReviewContext implements Context
      */
     public function iShouldBeNotifiedThatTitleIsRequired()
     {
-        Assert::same(
-            $this->createPage->getTitleValidationMessage(),
-            'Review title should not be blank.',
-            'There should be title validation error, but there is not.'
-        );
+        Assert::same($this->createPage->getTitleValidationMessage(), 'Review title should not be blank.');
     }
 
     /**
@@ -141,11 +133,7 @@ final class ProductReviewContext implements Context
      */
     public function iShouldBeNotifiedThatTitleMustHaveAtLeast2Characters()
     {
-        Assert::same(
-            'Review title must have at least 2 characters.',
-            $this->createPage->getTitleValidationMessage(),
-            'There should be title length validation error, but there is not.'
-        );
+        Assert::same($this->createPage->getTitleValidationMessage(), 'Review title must have at least 2 characters.');
     }
 
     /**
@@ -153,11 +141,7 @@ final class ProductReviewContext implements Context
      */
     public function iShouldBeNotifiedThatTitleMustHaveAtMost255Characters()
     {
-        Assert::same(
-            'Review title must have at most 255 characters.',
-            $this->createPage->getTitleValidationMessage(),
-            'There should be title length validation error, but there is not.'
-        );
+        Assert::same($this->createPage->getTitleValidationMessage(), 'Review title must have at most 255 characters.');
     }
 
     /**
@@ -165,11 +149,7 @@ final class ProductReviewContext implements Context
      */
     public function iShouldBeNotifiedThatCommentIsRequired()
     {
-        Assert::same(
-            $this->createPage->getCommentValidationMessage(),
-            'Review comment should not be blank.',
-            'There should be comment validation error, but there is not.'
-        );
+        Assert::same($this->createPage->getCommentValidationMessage(), 'Review comment should not be blank.');
     }
 
     /**
@@ -177,11 +157,7 @@ final class ProductReviewContext implements Context
      */
     public function iShouldBeNotifiedThatIMustEnterMyEmail()
     {
-        Assert::same(
-            $this->createPage->getAuthorValidationMessage(),
-            'Please enter your email.',
-            'There should be author validation error, but there is not.'
-        );
+        Assert::same($this->createPage->getAuthorValidationMessage(), 'Please enter your email.');
     }
 
     /**
@@ -191,8 +167,7 @@ final class ProductReviewContext implements Context
     {
         Assert::same(
             $this->createPage->getAuthorValidationMessage(),
-            'This email is already registered, please login or use forgotten password.',
-            'There should be author validation error, but there is not.'
+            'This email is already registered, please login or use forgotten password.'
         );
     }
 

--- a/src/Sylius/Behat/Context/Ui/Shop/RegistrationContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/RegistrationContext.php
@@ -186,10 +186,7 @@ class RegistrationContext implements Context
     {
         $this->dashboardPage->open();
 
-        Assert::true(
-            $this->dashboardPage->hasCustomerEmail($email),
-            sprintf('Cannot find customer email "%s".', $email)
-        );
+        Assert::true($this->dashboardPage->hasCustomerEmail($email));
     }
 
     /**
@@ -233,10 +230,7 @@ class RegistrationContext implements Context
      */
     public function iShouldBeLoggedIn()
     {
-        Assert::true(
-            $this->homePage->hasLogoutButton(),
-            'I should be able to sign out.'
-        );
+        Assert::true($this->homePage->hasLogoutButton());
     }
 
     /**
@@ -244,10 +238,7 @@ class RegistrationContext implements Context
      */
     public function iShouldNotBeLoggedIn()
     {
-        Assert::false(
-            $this->homePage->hasLogoutButton(),
-            'I should not be logged in.'
-        );
+        Assert::false($this->homePage->hasLogoutButton());
     }
 
     /**
@@ -266,10 +257,7 @@ class RegistrationContext implements Context
     {
         $this->iLogInAsWithPassword($email, $password);
 
-        Assert::true(
-            $this->loginPage->hasValidationErrorWith('Error Account is disabled.'),
-            'I should see validation error.'
-        );
+        Assert::true($this->loginPage->hasValidationErrorWith('Error Account is disabled.'));
     }
 
     /**
@@ -302,10 +290,7 @@ class RegistrationContext implements Context
      */
     public function myAccountShouldBeVerified()
     {
-        Assert::true(
-            $this->dashboardPage->isVerified(),
-            'My account should be verified.'
-        );
+        Assert::true($this->dashboardPage->isVerified());
     }
 
     /**
@@ -361,10 +346,7 @@ class RegistrationContext implements Context
     {
         $this->dashboardPage->open();
 
-        Assert::false(
-            $this->dashboardPage->isVerified(),
-            'Account should not be verified.'
-        );
+        Assert::false($this->dashboardPage->isVerified());
     }
 
     /**
@@ -374,10 +356,7 @@ class RegistrationContext implements Context
     {
         $this->dashboardPage->open();
 
-        Assert::false(
-            $this->dashboardPage->hasResendVerificationEmailButton(),
-            'You should not be able to resend the verification email.'
-        );
+        Assert::false($this->dashboardPage->hasResendVerificationEmailButton());
     }
 
     /**
@@ -422,10 +401,7 @@ class RegistrationContext implements Context
     {
         $this->profileUpdatePage->open();
 
-        Assert::true(
-            $this->profileUpdatePage->isSubscribedToTheNewsletter(),
-            'I should be subscribed to the newsletter, but I am not'
-        );
+        Assert::true($this->profileUpdatePage->isSubscribedToTheNewsletter());
     }
 
     /**
@@ -434,9 +410,6 @@ class RegistrationContext implements Context
      */
     private function assertFieldValidationMessage($element, $expectedMessage)
     {
-        Assert::true(
-            $this->registerPage->checkValidationMessageFor($element, $expectedMessage),
-            sprintf('The %s should be required.', $element)
-        );
+        Assert::true($this->registerPage->checkValidationMessageFor($element, $expectedMessage));
     }
 }

--- a/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
@@ -95,7 +95,6 @@
             <argument type="service" id="__symfony__.sylius.factory.order" />
             <argument type="service" id="__symfony__.sylius.factory.order_item" />
             <argument type="service" id="__symfony__.sylius.order_item_quantity_modifier" />
-            <argument type="service" id="__symfony__.sylius.repository.currency" />
             <argument type="service" id="__symfony__.sylius.factory.customer" />
             <argument type="service" id="__symfony__.sylius.repository.customer" />
             <argument type="service" id="__symfony__.doctrine.orm.entity_manager" />
@@ -117,10 +116,8 @@
         <service id="sylius.behat.context.setup.product" class="Sylius\Behat\Context\Setup\ProductContext">
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="__symfony__.sylius.repository.product" />
-            <argument type="service" id="__symfony__.sylius.repository.product_attribute" />
             <argument type="service" id="__symfony__.sylius.factory.product" />
             <argument type="service" id="__symfony__.sylius.factory.product_translation" />
-            <argument type="service" id="__symfony__.sylius.factory.product_attribute" />
             <argument type="service" id="__symfony__.sylius.factory.product_variant" />
             <argument type="service" id="__symfony__.sylius.factory.product_variant_translation" />
             <argument type="service" id="__symfony__.sylius.factory.channel_pricing" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

Changes:
 - [x] `Assert::same($expected, $actual)` changed to `Assert::same($actual, $expected)`, so we can get friendly error messages by default, which leads to removing unnecessary custom messages, therefore making most of them oneliners
 - [x] removed obvious custom messages like `I should see validation error` in `I should be notified about bad credentials` step or `Order should be cancelled, but its not.` for `this order should be automatically cancelled`
 - [x] minor contexts cleanup