### PR TITLE
Add missing validation group to Channel::taxCalculationStrategy

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation/Channel.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation/Channel.xml
@@ -30,6 +30,7 @@
         </property>
         <property name="taxCalculationStrategy">
             <constraint name="NotBlank" />
+          <option name="groups">sylius</option>
         </property>
         <property name="contactEmail">
             <constraint name="Length">


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #7414 |
| License         | MIT |
