### PR TITLE
Payment state update for NotifyNullAction

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Extension/UpdatePaymentStateExtension.php
+++ b/src/Sylius/Bundle/PayumBundle/Extension/UpdatePaymentStateExtension.php
@@ -56,11 +56,13 @@ final class UpdatePaymentStateExtension implements ExtensionInterface
     public function onPostExecute(Context $context)
     {
         $previousStack = $context->getPrevious();
-        $stackSize = count($previousStack);
+        $previousStackSize = count($previousStack);
         
-        if ($stackSize > 1) {
+        if ($previousStackSize > 1) {
             return;
-        } elseif ($stackSize === 1) {
+        } 
+        
+        if ($previousStackSize === 1) {
             $previousActionClassName = get_class($previousStack[0]->getAction());
             if (false === stripos($previousActionClassName, 'NotifyNullAction')) {
                 return;

--- a/src/Sylius/Bundle/PayumBundle/Extension/UpdatePaymentStateExtension.php
+++ b/src/Sylius/Bundle/PayumBundle/Extension/UpdatePaymentStateExtension.php
@@ -55,8 +55,16 @@ final class UpdatePaymentStateExtension implements ExtensionInterface
      */
     public function onPostExecute(Context $context)
     {
-        if ($context->getPrevious()) {
+        $previousStack = $context->getPrevious();
+        $stackSize = count($previousStack);
+        
+        if ($stackSize > 1) {
             return;
+        } elseif ($stackSize === 1) {
+            $previousActionClassName = get_class($previousStack[0]->getAction());
+            if (false === stripos($previousActionClassName, 'NotifyNullAction')) {
+                return;
+            }
         }
 
         /** @var Generic $request */


### PR DESCRIPTION
Payum provides a mechanism to use a NotifyNullAction for gateways that do not have a per-payment notification URL capability to call the "payum_notify_do_unsafe" route for the URL "/payment/notify/unsafe/{gateway}"

The issue happens because in this scenario, the NotifyNullAction is the last item in the Payum processing stack, as it is the first action that has been called, and due to it's stateless nature, it does not have a PaymentInterface model (getFirstModel returns "null"), meaning the extension can't update the payment status.

This means that Payum's built-in Be2Bill should fail too, but I have my own local gateway provider that has the same workflow. It took me quite a while to figure it out and I have done extensive testing on this.
This is the best idea I came up with how to handle it.

In essence, I look up the next action in the stack and if I see a class names "NotifyNullAction" - I'm not doing a "return" as it done originally.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | none |
| License         | MIT |
