### PR TITLE
Allow easier decoration for 3rd party extensions

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/services.xml
@@ -17,7 +17,7 @@
     </imports>
 
     <services>
-        <service id="sylius.custom_factory.zone" class="Sylius\Component\Addressing\Factory\ZoneFactory" decorates="sylius.factory.zone" public="false">
+        <service id="sylius.custom_factory.zone" class="Sylius\Component\Addressing\Factory\ZoneFactory" decorates="sylius.factory.zone" decoration-priority="256" public="false">
             <argument type="service" id="sylius.custom_factory.zone.inner" />
             <argument type="service" id="sylius.factory.zone_member" />
         </service>

--- a/src/Sylius/Bundle/ChannelBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ChannelBundle/Resources/config/services.xml
@@ -19,7 +19,7 @@
     </parameters>
 
     <services>
-        <service id="sylius.custom_factory.channel" class="Sylius\Component\Channel\Factory\ChannelFactory" decorates="sylius.factory.channel" public="false">
+        <service id="sylius.custom_factory.channel" class="Sylius\Component\Channel\Factory\ChannelFactory" decorates="sylius.factory.channel" decoration-priority="256" public="false">
             <argument type="service" id="sylius.custom_factory.channel.inner" />
         </service>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -77,12 +77,12 @@
         </service>
         <service id="sylius.inventory.order_inventory_operator" class="Sylius\Component\Core\Inventory\Operator\OrderInventoryOperator"/>
 
-        <service id="sylius.custom_factory.order_item" class="Sylius\Component\Core\Factory\CartItemFactory" decorates="sylius.factory.order_item" public="false">
+        <service id="sylius.custom_factory.order_item" class="Sylius\Component\Core\Factory\CartItemFactory" decorates="sylius.factory.order_item" decoration-priority="256" public="false">
             <argument type="service" id="sylius.custom_factory.order_item.inner" />
             <argument type="service" id="sylius.product_variant_resolver.default" />
         </service>
         <service id="sylius.factory.cart_item" alias="sylius.custom_factory.order_item" />
-        <service id="sylius.custom_factory.address" class="Sylius\Component\Core\Factory\AddressFactory" decorates="sylius.factory.address" public="false">
+        <service id="sylius.custom_factory.address" class="Sylius\Component\Core\Factory\AddressFactory" decorates="sylius.factory.address" decoration-priority="256" public="false">
             <argument type="service" id="sylius.custom_factory.address.inner" />
         </service>
 
@@ -104,7 +104,7 @@
             <argument type="service" id="sylius.customer_unique_address_adder" />
         </service>
 
-        <service id="sylius.order_item_quantity_modifier.limiting" class="Sylius\Component\Core\Cart\Modifier\LimitingOrderItemQuantityModifier" decorates="sylius.order_item_quantity_modifier">
+        <service id="sylius.order_item_quantity_modifier.limiting" class="Sylius\Component\Core\Cart\Modifier\LimitingOrderItemQuantityModifier" decorates="sylius.order_item_quantity_modifier" decoration-priority="256">
             <argument type="service" id="sylius.order_item_quantity_modifier.limiting.inner" />
             <argument>9999</argument>
         </service>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/context.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/context.xml
@@ -13,7 +13,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylius.context.channel.cached" class="Sylius\Component\Channel\Context\CachedPerRequestChannelContext" decorates="sylius.context.channel" public="false">
+        <service id="sylius.context.channel.cached" class="Sylius\Component\Channel\Context\CachedPerRequestChannelContext" decorates="sylius.context.channel" decoration-priority="256" public="false">
             <argument type="service" id="sylius.context.channel.cached.inner" />
             <argument type="service" id="request_stack" />
         </service>
@@ -30,11 +30,11 @@
             <argument type="service" id="sylius.context.customer" />
         </service>
 
-        <service id="sylius.context.cart.new_shop_based" class="Sylius\Component\Core\Cart\Context\ShopBasedCartContext" decorates="sylius.context.cart.new" public="false">
+        <service id="sylius.context.cart.new_shop_based" class="Sylius\Component\Core\Cart\Context\ShopBasedCartContext" decorates="sylius.context.cart.new" decoration-priority="256" public="false">
             <argument type="service" id="sylius.context.cart.new_shop_based.inner" />
             <argument type="service" id="sylius.context.shopper" />
         </service>
-        <service id="sylius.context.cart.session_and_channel_based" class="Sylius\Bundle\CoreBundle\Context\SessionAndChannelBasedCartContext" decorates="sylius.context.cart.session_based">
+        <service id="sylius.context.cart.session_and_channel_based" class="Sylius\Bundle\CoreBundle\Context\SessionAndChannelBasedCartContext" decorates="sylius.context.cart.session_based" decoration-priority="256">
             <argument type="service" id="session" />
             <argument>_sylius.cart</argument>
             <argument type="service" id="sylius.context.channel.cached" />
@@ -47,7 +47,7 @@
             <tag name="sylius.context.cart" priority="-555" />
         </service>
 
-        <service id="sylius.currency_provider.channel_based" class="Sylius\Component\Core\Provider\ChannelBasedCurrencyProvider" decorates="sylius.currency_provider">
+        <service id="sylius.currency_provider.channel_based" class="Sylius\Component\Core\Provider\ChannelBasedCurrencyProvider" decorates="sylius.currency_provider" decoration-priority="256">
             <argument type="service" id="sylius.context.channel" />
         </service>
 
@@ -67,7 +67,7 @@
             <tag name="sylius.context.currency" priority="-999" />
         </service>
 
-        <service id="sylius.locale_provider.channel_based" class="Sylius\Component\Core\Provider\ChannelBasedLocaleProvider" decorates="sylius.locale_provider">
+        <service id="sylius.locale_provider.channel_based" class="Sylius\Component\Core\Provider\ChannelBasedLocaleProvider" decorates="sylius.locale_provider" decoration-priority="256">
             <argument type="service" id="sylius.context.channel" />
             <argument>%locale%</argument>
         </service>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/promotion.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/promotion.xml
@@ -13,10 +13,10 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylius.custom_factory.promotion_action" class="Sylius\Component\Core\Factory\PromotionActionFactory" decorates="sylius.factory.promotion_action" public="false">
+        <service id="sylius.custom_factory.promotion_action" class="Sylius\Component\Core\Factory\PromotionActionFactory" decorates="sylius.factory.promotion_action" decoration-priority="256" public="false">
             <argument type="service" id="sylius.custom_factory.promotion_action.inner" />
         </service>
-        <service id="sylius.custom_factory.promotion_rule" class="Sylius\Component\Core\Factory\PromotionRuleFactory" decorates="sylius.factory.promotion_rule" public="false">
+        <service id="sylius.custom_factory.promotion_rule" class="Sylius\Component\Core\Factory\PromotionRuleFactory" decorates="sylius.factory.promotion_rule" decoration-priority="256" public="false">
             <argument type="service" id="sylius.custom_factory.promotion_rule.inner" />
         </service>
 
@@ -45,7 +45,7 @@
         <service id="sylius.promotion_rule_checker.contains_product" class="Sylius\Component\Core\Promotion\Checker\Rule\ContainsProductRuleChecker">
             <tag name="sylius.promotion_rule_checker" type="contains_product" label="Contains product" />
         </service>
-        <service id="sylius.channel_aware_promotion_rule_checker.item_total" class="Sylius\Component\Core\Promotion\Checker\Rule\ItemTotalRuleChecker" decorates="sylius.promotion_rule_checker.item_total" public="false">
+        <service id="sylius.channel_aware_promotion_rule_checker.item_total" class="Sylius\Component\Core\Promotion\Checker\Rule\ItemTotalRuleChecker" decorates="sylius.promotion_rule_checker.item_total" decoration-priority="256" public="false">
             <argument type="service" id="sylius.channel_aware_promotion_rule_checker.item_total.inner" />
         </service>
 

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/services.xml
@@ -17,7 +17,7 @@
     </imports>
 
     <services>
-        <service id="sylius.context.currency.composite" class="Sylius\Component\Currency\Context\CompositeCurrencyContext" decorates="sylius.context.currency" public="false" />
+        <service id="sylius.context.currency.composite" class="Sylius\Component\Currency\Context\CompositeCurrencyContext" decorates="sylius.context.currency" decoration-priority="256" public="false" />
 
         <service id="sylius.currency_converter" class="Sylius\Component\Currency\Converter\CurrencyConverter">
             <argument type="service" id="sylius.repository.exchange_rate" />

--- a/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
@@ -34,7 +34,7 @@
             <argument>%sylius_locale.locale%</argument>
         </service>
 
-        <service id="sylius.context.locale.composite" class="Sylius\Component\Locale\Context\CompositeLocaleContext" decorates="sylius.context.locale" public="false" />
+        <service id="sylius.context.locale.composite" class="Sylius\Component\Locale\Context\CompositeLocaleContext" decorates="sylius.context.locale" decoration-priority="256" public="false" />
 
         <service id="sylius.locale_provider" class="Sylius\Component\Locale\Provider\LocaleProvider">
             <argument type="service" id="sylius.repository.locale" />

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
@@ -53,7 +53,7 @@
 
         <service id="sylius.adjustments_aggregator" class="Sylius\Component\Order\Aggregator\AdjustmentsByLabelAggregator" />
 
-        <service id="sylius.custom_factory.adjustment" class="Sylius\Component\Order\Factory\AdjustmentFactory" decorates="sylius.factory.adjustment" public="false">
+        <service id="sylius.custom_factory.adjustment" class="Sylius\Component\Order\Factory\AdjustmentFactory" decorates="sylius.factory.adjustment" decoration-priority="256" public="false">
             <argument type="service" id="sylius.custom_factory.adjustment.inner" />
         </service>
 

--- a/src/Sylius/Bundle/PaymentBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/PaymentBundle/Resources/config/services.xml
@@ -21,7 +21,7 @@
     </parameters>
 
     <services>
-        <service id="sylius.custom_factory.payment" class="Sylius\Component\Payment\Factory\PaymentFactory" decorates="sylius.factory.payment" public="false">
+        <service id="sylius.custom_factory.payment" class="Sylius\Component\Payment\Factory\PaymentFactory" decorates="sylius.factory.payment" decoration-priority="256" public="false">
             <argument type="service" id="sylius.custom_factory.payment.inner" />
         </service>
 

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/services.xml
@@ -23,10 +23,10 @@
             </call>
         </service>
 
-        <service id="sylius.custom_factory.product_variant" class="Sylius\Component\Product\Factory\ProductVariantFactory" decorates="sylius.factory.product_variant" public="false">
+        <service id="sylius.custom_factory.product_variant" class="Sylius\Component\Product\Factory\ProductVariantFactory" decorates="sylius.factory.product_variant" decoration-priority="256" public="false">
             <argument type="service" id="sylius.custom_factory.product_variant.inner" />
         </service>
-        <service id="sylius.custom_factory.product" class="Sylius\Component\Product\Factory\ProductFactory" decorates="sylius.factory.product" public="false">
+        <service id="sylius.custom_factory.product" class="Sylius\Component\Product\Factory\ProductFactory" decorates="sylius.factory.product" decoration-priority="256" public="false">
             <argument type="service" id="sylius.custom_factory.product.inner" />
             <argument type="service" id="sylius.factory.product_variant" />
         </service>

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/services.xml
@@ -18,7 +18,7 @@
     </imports>
 
     <services>
-        <service id="sylius.custom_factory.promotion_coupon" class="Sylius\Component\Promotion\Factory\PromotionCouponFactory" decorates="sylius.factory.promotion_coupon" public="false">
+        <service id="sylius.custom_factory.promotion_coupon" class="Sylius\Component\Promotion\Factory\PromotionCouponFactory" decorates="sylius.factory.promotion_coupon" decoration-priority="256" public="false">
             <argument type="service" id="sylius.custom_factory.promotion_coupon.inner" />
         </service>
 

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
@@ -26,7 +26,7 @@
     <services>
         <service id="sylius.form.type_extension.form.request_handler"
                  class="Sylius\Bundle\ResourceBundle\Form\Extension\HttpFoundation\HttpFoundationRequestHandler"
-                 decorates="form.type_extension.form.request_handler" public="false" />
+                 decorates="form.type_extension.form.request_handler" decoration-priority="256" public="false" />
 
         <service id="sylius.resource_registry" class="Sylius\Component\Resource\Metadata\Registry" public="false" />
 

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/services/integrations/grid.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/services/integrations/grid.xml
@@ -18,13 +18,13 @@
             <argument type="service" id="sylius.resource_controller.parameters_parser" />
         </service>
 
-        <service id="sylius.resource_controller.resources_resolver.grid_aware" class="Sylius\Bundle\ResourceBundle\Grid\Controller\ResourcesResolver" decorates="sylius.resource_controller.resources_resolver">
+        <service id="sylius.resource_controller.resources_resolver.grid_aware" class="Sylius\Bundle\ResourceBundle\Grid\Controller\ResourcesResolver" decorates="sylius.resource_controller.resources_resolver" decoration-priority="256">
             <argument type="service" id="sylius.resource_controller.resources_resolver.grid_aware.inner" />
             <argument type="service" id="sylius.grid.provider" />
             <argument type="service" id="sylius.grid.resource_view_factory" />
         </service>
 
-        <service id="sylius.custom_grid_renderer.twig" class="Sylius\Bundle\ResourceBundle\Grid\Renderer\TwigGridRenderer" decorates="sylius.grid.renderer.twig">
+        <service id="sylius.custom_grid_renderer.twig" class="Sylius\Bundle\ResourceBundle\Grid\Renderer\TwigGridRenderer" decorates="sylius.grid.renderer.twig" decoration-priority="256">
             <argument type="service" id="sylius.custom_grid_renderer.twig.inner" />
             <argument type="service" id="twig" />
             <argument type="service" id="sylius.grid_options_parser" />

--- a/src/Sylius/Bundle/TaxonomyBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/TaxonomyBundle/Resources/config/services.xml
@@ -23,7 +23,7 @@
             </call>
         </service>
 
-        <service id="sylius.custom_factory.taxon" class="Sylius\Component\Taxonomy\Factory\TaxonFactory" decorates="sylius.factory.taxon" public="false">
+        <service id="sylius.custom_factory.taxon" class="Sylius\Component\Taxonomy\Factory\TaxonFactory" decorates="sylius.factory.taxon" decoration-priority="256" public="false">
             <argument type="service" id="sylius.custom_factory.taxon.inner" />
         </service>
 

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/assets.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/assets.xml
@@ -21,7 +21,7 @@
             <argument type="service" id="sylius.theme.asset.path_resolver" />
         </service>
 
-        <service id="sylius.theme.asset.assets_installer.output_aware" class="Sylius\Bundle\ThemeBundle\Asset\Installer\OutputAwareAssetsInstaller" decorates="sylius.theme.asset.assets_installer">
+        <service id="sylius.theme.asset.assets_installer.output_aware" class="Sylius\Bundle\ThemeBundle\Asset\Installer\OutputAwareAssetsInstaller" decorates="sylius.theme.asset.assets_installer" decoration-priority="256">
             <argument type="service" id="sylius.theme.asset.assets_installer.output_aware.inner" />
         </service>
 

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/templating.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/templating.xml
@@ -27,7 +27,7 @@
             <argument type="service" id="kernel" />
         </service>
 
-        <service id="sylius.theme.templating.name_parser" class="Sylius\Bundle\ThemeBundle\Templating\TemplateNameParser" decorates="templating.name_parser" public="false">
+        <service id="sylius.theme.templating.name_parser" class="Sylius\Bundle\ThemeBundle\Templating\TemplateNameParser" decorates="templating.name_parser" decoration-priority="256" public="false">
             <argument type="service" id="sylius.theme.templating.name_parser.inner" />
             <argument type="service" id="kernel" />
         </service>
@@ -38,12 +38,12 @@
             <argument type="service" id="sylius.theme.locator.resource" />
         </service>
 
-        <service id="sylius.theme.templating.locator.cached" class="Sylius\Bundle\ThemeBundle\Templating\Locator\CachedTemplateLocator" decorates="sylius.theme.templating.locator" public="false">
+        <service id="sylius.theme.templating.locator.cached" class="Sylius\Bundle\ThemeBundle\Templating\Locator\CachedTemplateLocator" decorates="sylius.theme.templating.locator" decoration-priority="256" public="false">
             <argument type="service" id="sylius.theme.templating.locator.cached.inner" />
             <argument type="service" id="sylius.theme.templating.cache" />
         </service>
 
-        <service id="sylius.theme.templating.file_locator" class="Sylius\Bundle\ThemeBundle\Templating\Locator\TemplateFileLocator" decorates="templating.locator" public="false">
+        <service id="sylius.theme.templating.file_locator" class="Sylius\Bundle\ThemeBundle\Templating\Locator\TemplateFileLocator" decorates="templating.locator" decoration-priority="256" public="false">
             <argument type="service" id="sylius.theme.templating.file_locator.inner" />
             <argument type="service" id="sylius.context.theme" />
             <argument type="service" id="sylius.theme.hierarchy_provider" />

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/translations.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/translations.xml
@@ -13,7 +13,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylius.theme.translation.translator" class="Sylius\Bundle\ThemeBundle\Translation\Translator" decorates="translator.default" public="false">
+        <service id="sylius.theme.translation.translator" class="Sylius\Bundle\ThemeBundle\Translation\Translator" decorates="translator.default" decoration-priority="256" public="false">
             <argument type="service" id="sylius.theme.translation.loader_provider" />
             <argument type="service" id="sylius.theme.translation.resource_provider" />
             <argument type="service" id="sylius.theme.translation.fallback_locales_provider" />
@@ -25,7 +25,7 @@
             </argument>
         </service>
 
-        <service id="sylius.theme.translation.theme_aware_translator" class="Sylius\Bundle\ThemeBundle\Translation\ThemeAwareTranslator" decorates="sylius.theme.translation.translator" public="false">
+        <service id="sylius.theme.translation.theme_aware_translator" class="Sylius\Bundle\ThemeBundle\Translation\ThemeAwareTranslator" decorates="sylius.theme.translation.translator" decoration-priority="256" public="false">
             <argument type="service" id="sylius.theme.translation.theme_aware_translator.inner" />
             <argument type="service" id="sylius.context.theme" />
         </service>
@@ -55,7 +55,7 @@
             <argument type="service" id="sylius.theme.finder_factory" />
         </service>
 
-        <service id="sylius.theme.translation.ordering_files_finder" class="Sylius\Bundle\ThemeBundle\Translation\Finder\OrderingTranslationFilesFinder" decorates="sylius.theme.translation.files_finder" public="false">
+        <service id="sylius.theme.translation.ordering_files_finder" class="Sylius\Bundle\ThemeBundle\Translation\Finder\OrderingTranslationFilesFinder" decorates="sylius.theme.translation.files_finder" decoration-priority="256" public="false">
             <argument type="service" id="sylius.theme.translation.ordering_files_finder.inner" />
         </service>
 

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/twig.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/twig.xml
@@ -13,7 +13,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylius.theme.twig.loader" class="Sylius\Bundle\ThemeBundle\Twig\ThemeFilesystemLoader" decorates="twig.loader" public="false">
+        <service id="sylius.theme.twig.loader" class="Sylius\Bundle\ThemeBundle\Twig\ThemeFilesystemLoader" decorates="twig.loader" decoration-priority="256" public="false">
             <argument type="service" id="sylius.theme.twig.loader.inner" />
             <argument type="service" id="templating.locator" />
             <argument type="service" id="templating.name_parser" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #7403 |
| License         | MIT |

This ensures that custom, 3rd party decorations without specified priority are made after the Sylius ones.