### PR TITLE
[API] [Checkout] Get available shipping and payment methods

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Controller/ShowAvailablePaymentMethodsController.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/ShowAvailablePaymentMethodsController.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ApiBundle\Controller;
+
+use FOS\RestBundle\View\View;
+use FOS\RestBundle\View\ViewHandlerInterface;
+use SM\Factory\FactoryInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\OrderCheckoutTransitions;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Payment\Resolver\PaymentMethodsResolverInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ */
+final class ShowAvailablePaymentMethodsController
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $stateMachineFactory;
+
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var PaymentMethodsResolverInterface
+     */
+    private $paymentMethodResolver;
+
+    /**
+     * @var ViewHandlerInterface
+     */
+    private $restViewHandler;
+
+    /**
+     * @param FactoryInterface $stateMachineFactory
+     * @param OrderRepositoryInterface $orderRepository
+     * @param PaymentMethodsResolverInterface $paymentMethodResolver
+     * @param ViewHandlerInterface $restViewHandler
+     */
+    public function __construct(
+        FactoryInterface $stateMachineFactory,
+        OrderRepositoryInterface $orderRepository,
+        PaymentMethodsResolverInterface $paymentMethodResolver,
+        ViewHandlerInterface $restViewHandler
+    ) {
+        $this->stateMachineFactory = $stateMachineFactory;
+        $this->orderRepository = $orderRepository;
+        $this->paymentMethodResolver = $paymentMethodResolver;
+        $this->restViewHandler = $restViewHandler;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function showAction(Request $request)
+    {
+        /** @var OrderInterface $cart */
+        $cart = $this->getCartOr404($request->attributes->get('orderId'));
+
+        if (!$this->isCheckoutTransitionPossible($cart, OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT)) {
+            throw new BadRequestHttpException('The payment methods cannot be resolved in the current state of cart!');
+        }
+
+        $payments = [];
+
+        foreach ($cart->getPayments() as $payment) {
+            $payments['payments'][] = [
+                'methods' => $this->getPaymentMethods($payment, $cart->getLocaleCode()),
+            ];
+        }
+
+        return $this->restViewHandler->handle(View::create($payments));
+    }
+
+    /**
+     * @param mixed $cartId
+     *
+     * @return OrderInterface
+     */
+    private function getCartOr404($cartId)
+    {
+        $cart = $this->orderRepository->findCartById($cartId);
+
+        if (null === $cart) {
+            throw new NotFoundHttpException(sprintf("The cart with %s id could not be found!", $cartId));
+        }
+
+        return $cart;
+    }
+
+    /**
+     * @param OrderInterface $cart
+     * @param string $transition
+     *
+     * @return bool
+     */
+    private function isCheckoutTransitionPossible(OrderInterface $cart, $transition)
+    {
+        return $this->stateMachineFactory->get($cart, OrderCheckoutTransitions::GRAPH)->can($transition);
+    }
+
+    /**
+     * @param PaymentInterface $payment
+     * @param string $locale
+     *
+     * @return array
+     */
+    private function getPaymentMethods(PaymentInterface $payment, $locale)
+    {
+        $paymentMethods =  $this->paymentMethodResolver->getSupportedMethods($payment);
+
+        $rawPaymentMethods = [];
+
+        foreach ($paymentMethods as $paymentMethod) {
+            $rawPaymentMethods[] = [
+                'id' => $paymentMethod->getId(),
+                'code' => $paymentMethod->getCode(),
+                'name' => $paymentMethod->getTranslation($locale)->getName(),
+                'description' => $paymentMethod->getTranslation($locale)->getDescription(),
+            ];
+        }
+
+        return $rawPaymentMethods;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Controller/ShowAvailableShippingMethodsController.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/ShowAvailableShippingMethodsController.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ApiBundle\Controller;
+
+use FOS\RestBundle\View\View;
+use FOS\RestBundle\View\ViewHandlerInterface;
+use SM\Factory\FactoryInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+use Sylius\Component\Core\OrderCheckoutTransitions;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Registry\ServiceRegistryInterface;
+use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ */
+final class ShowAvailableShippingMethodsController
+{
+    /**
+     * @var FactoryInterface
+     */
+    private $stateMachineFactory;
+
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var ShippingMethodsResolverInterface
+     */
+    private $shippingMethodsResolver;
+
+    /**
+     * @var ViewHandlerInterface
+     */
+    private $restViewHandler;
+
+    /**
+     * @var ServiceRegistryInterface
+     */
+    private $calculators;
+
+    /**
+     * @param FactoryInterface $stateMachineFactory
+     * @param OrderRepositoryInterface $orderRepository
+     * @param ShippingMethodsResolverInterface $shippingMethodsResolver
+     * @param ViewHandlerInterface $restViewHandler
+     * @param ServiceRegistryInterface $calculators
+     */
+    public function __construct(
+        FactoryInterface $stateMachineFactory,
+        OrderRepositoryInterface $orderRepository,
+        ShippingMethodsResolverInterface $shippingMethodsResolver,
+        ViewHandlerInterface $restViewHandler,
+        ServiceRegistryInterface $calculators
+    ) {
+        $this->stateMachineFactory = $stateMachineFactory;
+        $this->orderRepository = $orderRepository;
+        $this->shippingMethodsResolver = $shippingMethodsResolver;
+        $this->restViewHandler = $restViewHandler;
+        $this->calculators = $calculators;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function showAction(Request $request)
+    {
+        /** @var OrderInterface $cart */
+        $cart = $this->getCartOr404($request->attributes->get('orderId'));
+
+        if (!$this->isCheckoutTransitionPossible($cart, OrderCheckoutTransitions::TRANSITION_SELECT_SHIPPING)) {
+            throw new BadRequestHttpException('The shipment methods cannot be resolved in the current state of cart!');
+        }
+
+        $shipments = [];
+
+        foreach ($cart->getShipments() as $shipment) {
+            $shipments['shipments'][] = [
+                'methods' => $this->getCalculatedShippingMethods($shipment, $cart->getLocaleCode()),
+            ];
+        }
+
+        return $this->restViewHandler->handle(View::create($shipments));
+    }
+
+    /**
+     * @param mixed $cartId
+     *
+     * @return OrderInterface
+     */
+    private function getCartOr404($cartId)
+    {
+        $cart = $this->orderRepository->findCartById($cartId);
+
+        if (null === $cart) {
+            throw new NotFoundHttpException(sprintf("The cart with %s id could not be found!", $cartId));
+        }
+
+        return $cart;
+    }
+
+    /**
+     * @param OrderInterface $cart
+     * @param string $transition
+     *
+     * @return bool
+     */
+    private function isCheckoutTransitionPossible(OrderInterface $cart, $transition)
+    {
+        return $this->stateMachineFactory->get($cart, OrderCheckoutTransitions::GRAPH)->can($transition);
+    }
+
+    /**
+     * @param ShipmentInterface $shipment
+     * @param string $locale
+     *
+     * @return array
+     */
+    private function getCalculatedShippingMethods(ShipmentInterface $shipment, $locale)
+    {
+        $shippingMethods =  $this->shippingMethodsResolver->getSupportedMethods($shipment);
+
+        $rawShippingMethods = [];
+
+        foreach ($shippingMethods as $shippingMethod) {
+            $calculator = $this->calculators->get($shippingMethod->getCalculator());
+
+            $rawShippingMethods[] = [
+                'id' => $shippingMethod->getId(),
+                'code' => $shippingMethod->getCode(),
+                'name' => $shippingMethod->getTranslation($locale)->getName(),
+                'description' => $shippingMethod->getTranslation($locale)->getDescription(),
+                'price' => $calculator->calculate($shipment, $shippingMethod->getConfiguration()),
+            ];
+        }
+
+        return $rawShippingMethods;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/checkout.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/checkout.yml
@@ -1,6 +1,7 @@
 # This file is part of the Sylius package.
 # (c) Paweł Jędrzejewski
 #
+
 sylius_api_checkout_show:
     path: /{id}
     methods: [GET]
@@ -23,6 +24,14 @@ sylius_api_checkout_addressing:
             state_machine:
                 graph: sylius_order_checkout
                 transition: address
+
+sylius_api_checkout_available_shipping_methods:
+    path: /select-shipping/{orderId}
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.order:showAvailableShippingMethodsAction
+        _sylius:
+            serialization_version: $version
 
 sylius_api_checkout_select_shipping:
     path: /select-shipping/{orderId}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/checkout.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/checkout.yml
@@ -29,7 +29,7 @@ sylius_api_checkout_available_shipping_methods:
     path: /select-shipping/{orderId}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:showAvailableShippingMethodsAction
+        _controller: sylius.controller.show_available_shipping_methods:showAction
         _sylius:
             serialization_version: $version
 
@@ -52,7 +52,7 @@ sylius_api_checkout_available_payment_methods:
     path: /select-payment/{orderId}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:showAvailablePaymentMethodsAction
+        _controller: sylius.controller.show_available_payment_methods:showAction
         _sylius:
             serialization_version: $version
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/checkout.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/checkout.yml
@@ -48,6 +48,14 @@ sylius_api_checkout_select_shipping:
                 graph: sylius_order_checkout
                 transition: select_shipping
 
+sylius_api_checkout_available_payment_methods:
+    path: /select-payment/{orderId}
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.order:showAvailablePaymentMethodsAction
+        _sylius:
+            serialization_version: $version
+
 sylius_api_checkout_select_payment:
     path: /select-payment/{orderId}
     methods: [PUT, PATCH]

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/payment_method.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/payment_method.yml
@@ -22,26 +22,32 @@ sylius_api_payment_method_create:
             serialization_version: $version
 
 sylius_api_payment_method_update:
-    path: /{id}
+    path: /{code}
     methods: [PUT, PATCH]
     defaults:
         _controller: sylius.controller.payment_method:updateAction
         _sylius:
             serialization_version: $version
+            criteria:
+                code: $code
 
 sylius_api_payment_method_delete:
-    path: /{id}
+    path: /{code}
     methods: [DELETE]
     defaults:
         _controller: sylius.controller.payment_method:deleteAction
         _sylius:
             serialization_version: $version
+            criteria:
+                code: $code
             csrf_protection: false
 
 sylius_api_payment_method_show:
-    path: /{id}
+    path: /{code}
     methods: [GET]
     defaults:
         _controller: sylius.controller.payment_method:showAction
         _sylius:
             serialization_version: $version
+            criteria:
+                code: $code

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -13,6 +13,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <imports>
+        <import resource="services/controller.xml" />
         <import resource="services/form.xml" />
         <import resource="services/fixture.xml" />
         <import resource="services/fixtures_factories.xml" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/controller.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sylius.controller.show_available_payment_methods" class="Sylius\Bundle\ApiBundle\Controller\ShowAvailablePaymentMethodsController">
+            <argument type="service" id="sm.factory" />
+            <argument type="service" id="sylius.repository.order" />
+            <argument type="service" id="sylius.payment_methods_resolver" />
+            <argument type="service" id="fos_rest.view_handler" />
+        </service>
+        <service id="sylius.controller.show_available_shipping_methods" class="Sylius\Bundle\ApiBundle\Controller\ShowAvailableShippingMethodsController">
+            <argument type="service" id="sm.factory" />
+            <argument type="service" id="sylius.repository.order" />
+            <argument type="service" id="sylius.shipping_methods_resolver" />
+            <argument type="service" id="fos_rest.view_handler" />
+            <argument type="service" id="sylius.registry.shipping_calculator" />
+        </service>
+    </services>
+</container>

--- a/src/Sylius/Bundle/CoreBundle/Controller/OrderController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/OrderController.php
@@ -12,15 +12,9 @@
 namespace Sylius\Bundle\CoreBundle\Controller;
 
 use FOS\RestBundle\View\View;
-use SM\StateMachine\StateMachineInterface;
 use Sylius\Bundle\OrderBundle\Controller\OrderController as BaseOrderController;
-use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Payment\Resolver\PaymentMethodsResolverInterface;
-use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Webmozart\Assert\Assert;
 
 class OrderController extends BaseOrderController
@@ -58,102 +52,5 @@ class OrderController extends BaseOrderController
         ;
 
         return $this->viewHandler->handle($configuration, $view);
-    }
-
-    /**
-     * @param Request $request
-     *
-     * @return Response
-     */
-    public function showAvailableShippingMethodsAction(Request $request)
-    {
-        $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);
-
-        /** @var OrderInterface $cart */
-        $cart = $this->getCartOr404($request->attributes->get('orderId'));
-
-        if (!$this->isCheckoutTransitionPossible($cart, 'select_shipping')) {
-            throw new BadRequestHttpException('The shipment methods cannot be resolved in the current state of cart!');
-        }
-
-        $shipments = [];
-
-        foreach ($cart->getShipments() as $shipment) {
-            $shipments['shipments'][] = [
-                'methods' => $this->getShippingMethodsResolver()->getSupportedMethods($shipment),
-            ];
-        }
-
-        return $this->viewHandler->handle($configuration, View::create($shipments));
-    }
-
-    /**
-     * @param Request $request
-     *
-     * @return Response
-     */
-    public function showAvailablePaymentMethodsAction(Request $request)
-    {
-        $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);
-
-        /** @var OrderInterface $cart */
-        $cart = $this->getCartOr404($request->attributes->get('orderId'));
-
-        if (!$this->isCheckoutTransitionPossible($cart, 'select_payment')) {
-            throw new BadRequestHttpException('The payment methods cannot be resolved in the current state of cart!');
-        }
-
-        $payments = [];
-
-        foreach ($cart->getPayments() as $payment) {
-            $payments['payments'][] = [
-                'methods' => $this->getPaymentMethodsResolver()->getSupportedMethods($payment),
-            ];
-        }
-
-        return $this->viewHandler->handle($configuration, View::create($payments));
-    }
-
-    /**
-     * @return ShippingMethodsResolverInterface
-     */
-    protected function getShippingMethodsResolver()
-    {
-        return $this->get('sylius.shipping_methods_resolver');
-    }
-
-    /**
-     * @return PaymentMethodsResolverInterface
-     */
-    protected function getPaymentMethodsResolver()
-    {
-        return $this->get('sylius.payment_methods_resolver');
-    }
-
-    /**
-     * @param mixed $cartId
-     *
-     * @return OrderInterface
-     */
-    protected function getCartOr404($cartId)
-    {
-        $cart = $this->get('sylius.repository.order')->findCartById($cartId);
-
-        if (null === $cart) {
-            throw new NotFoundHttpException();
-        }
-
-        return $cart;
-    }
-
-    /**
-     * @param OrderInterface $cart
-     * @param string $transition
-     *
-     * @return bool
-     */
-    private function isCheckoutTransitionPossible(OrderInterface $cart, $transition)
-    {
-        return $this->get('sm.factory')->get($cart, 'sylius_order_checkout')->can($transition);
     }
 }

--- a/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentMethodChoiceType.php
+++ b/src/Sylius/Bundle/PaymentBundle/Form/Type/PaymentMethodChoiceType.php
@@ -76,7 +76,7 @@ final class PaymentMethodChoiceType extends AbstractType
 
                     return $this->paymentMethodRepository->findAll();
                 },
-                'choice_value' => 'id',
+                'choice_value' => 'code',
                 'choice_label' => 'name',
                 'choice_translation_domain' => false,
             ])

--- a/src/Sylius/Bundle/PaymentBundle/Resources/config/serializer/Model.Payment.yml
+++ b/src/Sylius/Bundle/PaymentBundle/Resources/config/serializer/Model.Payment.yml
@@ -38,5 +38,5 @@ Sylius\Component\Payment\Model\Payment:
           href:
                 route: sylius_api_payment_method_show
                 parameters:
-                    id: expr(object.getMethod().getId())
+                    code: expr(object.getMethod().getCode())
                     version: 1

--- a/src/Sylius/Bundle/PaymentBundle/Resources/config/serializer/Model.PaymentMethod.yml
+++ b/src/Sylius/Bundle/PaymentBundle/Resources/config/serializer/Model.PaymentMethod.yml
@@ -23,5 +23,5 @@ Sylius\Component\Payment\Model\PaymentMethod:
           href:
                 route: sylius_api_payment_method_show
                 parameters:
-                    id: expr(object.getId())
+                    code: expr(object.getCode())
                     version: 1

--- a/tests/Controller/CheckoutAddressingApiTest.php
+++ b/tests/Controller/CheckoutAddressingApiTest.php
@@ -11,6 +11,9 @@
 
 namespace Sylius\Tests\Controller;
 
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Core\Model\ShippingMethodInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -50,8 +53,10 @@ final class CheckoutAddressingApiTest extends CheckoutApiTestCase
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
 
-        $url = sprintf('/api/v1/checkouts/addressing/%d', $checkoutData['order1']->getId());
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType);
+        /** @var OrderInterface $cart */
+        $cart = $checkoutData['order1'];
+
+        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/addressing_invalid_customer', Response::HTTP_BAD_REQUEST);
@@ -65,6 +70,9 @@ final class CheckoutAddressingApiTest extends CheckoutApiTestCase
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
 
+        /** @var OrderInterface $cart */
+        $cart = $checkoutData['order1'];
+
         $data =
 <<<EOT
         {
@@ -75,8 +83,7 @@ final class CheckoutAddressingApiTest extends CheckoutApiTestCase
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/addressing/%d', $checkoutData['order1']->getId());
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $data);
+        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/addressing_validation_failed_shipping_address', Response::HTTP_BAD_REQUEST);
@@ -90,6 +97,9 @@ EOT;
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $this->loadFixturesFromFile('resources/countries.yml');
         $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
+
+        /** @var OrderInterface $cart */
+        $cart = $checkoutData['order1'];
 
         $data =
 <<<EOT
@@ -109,8 +119,7 @@ EOT;
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/addressing/%d', $checkoutData['order1']->getId());
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $data);
+        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
@@ -123,8 +132,11 @@ EOT;
     {
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $this->loadFixturesFromFile('resources/countries.yml');
-        $customers = $this->loadFixturesFromFile('resources/customers.yml');
+        $this->loadFixturesFromFile('resources/customers.yml');
         $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
+
+        /** @var OrderInterface $cart */
+        $cart = $checkoutData['order1'];
 
         $data =
 <<<EOT
@@ -144,8 +156,7 @@ EOT;
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/addressing/%d', $checkoutData['order1']->getId());
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $data);
+        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/addressing_validation_failed_billing_address', Response::HTTP_BAD_REQUEST);
@@ -159,6 +170,9 @@ EOT;
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $this->loadFixturesFromFile('resources/countries.yml');
         $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
+
+        /** @var OrderInterface $cart */
+        $cart = $checkoutData['order1'];
 
         $data =
 <<<EOT
@@ -186,13 +200,12 @@ EOT;
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/addressing/%d', $checkoutData['order1']->getId());
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $data);
+        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
 
-        $this->client->request('GET', sprintf('/api/v1/checkouts/%d', $checkoutData['order1']->getId()), [], [], static::$authorizedHeaderWithAccept);
+        $this->client->request('GET', $this->getCheckoutSummaryUrl($cart), [], [], static::$authorizedHeaderWithAccept);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/addressed_order_response');
@@ -206,6 +219,9 @@ EOT;
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $this->loadFixturesFromFile('resources/countries.yml');
         $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
+
+        /** @var OrderInterface $cart */
+        $cart = $checkoutData['order1'];
 
         $data =
 <<<EOT
@@ -225,10 +241,7 @@ EOT;
         }
 EOT;
 
-        $orderId = $checkoutData['order1']->getId();
-
-        $url = sprintf('/api/v1/checkouts/addressing/%d', $orderId);
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $data);
+        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $data);
 
         $newData =
 <<<EOT
@@ -248,8 +261,7 @@ EOT;
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/addressing/%d', $checkoutData['order1']->getId());
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $newData);
+        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $newData);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
@@ -264,6 +276,11 @@ EOT;
         $this->loadFixturesFromFile('resources/countries.yml');
         $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
 
+        /** @var OrderInterface $cart */
+        $cart = $checkoutData['order1'];
+        /** @var ShippingMethodInterface $shippingMethod */
+        $shippingMethod = $checkoutData['ups'];
+
         $addressData =
 <<<EOT
         {
@@ -282,12 +299,9 @@ EOT;
         }
 EOT;
 
-        $orderId = $checkoutData['order1']->getId();
+        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $addressData);
 
-        $url = sprintf('/api/v1/checkouts/addressing/%d', $orderId);
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $addressData);
-
-        $this->selectOrderShippingMethod($orderId, $checkoutData['ups']->getId());
+        $this->selectOrderShippingMethod($cart, $shippingMethod);
 
         $newAddressData =
 <<<EOT
@@ -307,8 +321,7 @@ EOT;
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/addressing/%d', $checkoutData['order1']->getId());
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $newAddressData);
+        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $newAddressData);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
@@ -323,6 +336,13 @@ EOT;
         $this->loadFixturesFromFile('resources/countries.yml');
         $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
 
+        /** @var OrderInterface $cart */
+        $cart = $checkoutData['order1'];
+        /** @var ShippingMethodInterface $shippingMethod */
+        $shippingMethod = $checkoutData['ups'];
+        /** @var PaymentMethodInterface $paymentMethod */
+        $paymentMethod = $checkoutData['cash_on_delivery'];
+
         $addressData =
 <<<EOT
         {
@@ -341,13 +361,10 @@ EOT;
         }
 EOT;
 
-        $orderId = $checkoutData['order1']->getId();
+        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $addressData);
 
-        $url = sprintf('/api/v1/checkouts/addressing/%d', $orderId);
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $addressData);
-
-        $this->selectOrderShippingMethod($orderId, $checkoutData['ups']->getId());
-        $this->selectOrderPaymentMethod($orderId, $checkoutData['cash_on_delivery']->getId());
+        $this->selectOrderShippingMethod($cart, $shippingMethod);
+        $this->selectOrderPaymentMethod($cart, $paymentMethod);
 
         $newAddressData =
 <<<EOT
@@ -367,10 +384,19 @@ EOT;
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/addressing/%d', $checkoutData['order1']->getId());
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $newAddressData);
+        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $newAddressData);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * @param OrderInterface $cart
+     *
+     * @return string
+     */
+    private function getAddressingUrl(OrderInterface $cart)
+    {
+        return sprintf('/api/v1/checkouts/addressing/%d', $cart->getId());
     }
 }

--- a/tests/Controller/CheckoutAddressingApiTest.php
+++ b/tests/Controller/CheckoutAddressingApiTest.php
@@ -278,8 +278,6 @@ EOT;
 
         /** @var OrderInterface $cart */
         $cart = $checkoutData['order1'];
-        /** @var ShippingMethodInterface $shippingMethod */
-        $shippingMethod = $checkoutData['ups'];
 
         $addressData =
 <<<EOT
@@ -301,7 +299,7 @@ EOT;
 
         $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $addressData);
 
-        $this->selectOrderShippingMethod($cart, $shippingMethod);
+        $this->selectOrderShippingMethod($cart);
 
         $newAddressData =
 <<<EOT
@@ -338,8 +336,6 @@ EOT;
 
         /** @var OrderInterface $cart */
         $cart = $checkoutData['order1'];
-        /** @var ShippingMethodInterface $shippingMethod */
-        $shippingMethod = $checkoutData['ups'];
         /** @var PaymentMethodInterface $paymentMethod */
         $paymentMethod = $checkoutData['cash_on_delivery'];
 
@@ -363,7 +359,7 @@ EOT;
 
         $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $addressData);
 
-        $this->selectOrderShippingMethod($cart, $shippingMethod);
+        $this->selectOrderShippingMethod($cart);
         $this->selectOrderPaymentMethod($cart, $paymentMethod);
 
         $newAddressData =

--- a/tests/Controller/CheckoutAddressingApiTest.php
+++ b/tests/Controller/CheckoutAddressingApiTest.php
@@ -336,8 +336,6 @@ EOT;
 
         /** @var OrderInterface $cart */
         $cart = $checkoutData['order1'];
-        /** @var PaymentMethodInterface $paymentMethod */
-        $paymentMethod = $checkoutData['cash_on_delivery'];
 
         $addressData =
 <<<EOT
@@ -360,7 +358,7 @@ EOT;
         $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $addressData);
 
         $this->selectOrderShippingMethod($cart);
-        $this->selectOrderPaymentMethod($cart, $paymentMethod);
+        $this->selectOrderPaymentMethod($cart);
 
         $newAddressData =
 <<<EOT

--- a/tests/Controller/CheckoutApiTestCase.php
+++ b/tests/Controller/CheckoutApiTestCase.php
@@ -12,6 +12,9 @@
 namespace Sylius\Tests\Controller;
 
 use Lakion\ApiTestCase\JsonApiTestCase;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Core\Model\ShippingMethodInterface;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -35,9 +38,9 @@ class CheckoutApiTestCase extends JsonApiTestCase
     ];
 
     /**
-     * @param int $orderId
+     * @param OrderInterface $order
      */
-    protected function addressOrder($orderId)
+    protected function addressOrder(OrderInterface $order)
     {
         $this->loadFixturesFromFile('resources/countries.yml');
 
@@ -67,49 +70,59 @@ class CheckoutApiTestCase extends JsonApiTestCase
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/addressing/%d', $orderId);
+        $url = sprintf('/api/v1/checkouts/addressing/%d', $order->getId());
         $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $data);
     }
 
     /**
-     * @param int $orderId
-     * @param int $shippingMethodCode
+     * @param OrderInterface $order
+     * @param ShippingMethodInterface $shippingMethod
      */
-    protected function selectOrderShippingMethod($orderId, $shippingMethodCode)
+    protected function selectOrderShippingMethod(OrderInterface $order, ShippingMethodInterface $shippingMethod)
     {
         $data =
 <<<EOT
         {
             "shipments": [
                 {
-                    "method": "{$shippingMethodCode}"
+                    "method": "{$shippingMethod->getCode()}"
                 }
             ]
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/select-shipping/%d', $orderId);
+        $url = sprintf('/api/v1/checkouts/select-shipping/%d', $order->getId());
         $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $data);
     }
 
     /**
-     * @param int $orderId
-     * @param int $paymentMethodId
+     * @param OrderInterface $order
+     * @param PaymentMethodInterface $paymentMethod
      */
-    protected function selectOrderPaymentMethod($orderId, $paymentMethodId)
+    protected function selectOrderPaymentMethod(OrderInterface $order, PaymentMethodInterface $paymentMethod)
     {
         $data =
 <<<EOT
         {
             "payments": [
                 {
-                    "method": {$paymentMethodId}
+                    "method": {$paymentMethod->getId()}
                 }
             ]
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/select-payment/%d', $orderId);
+        $url = sprintf('/api/v1/checkouts/select-payment/%d', $order->getId());
         $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $data);
+    }
+
+    /**
+     * @param OrderInterface $cart
+     *
+     * @return string
+     */
+    protected function getCheckoutSummaryUrl(OrderInterface $cart)
+    {
+        return sprintf('/api/v1/checkouts/%d', $cart->getId());
     }
 }

--- a/tests/Controller/CheckoutApiTestCase.php
+++ b/tests/Controller/CheckoutApiTestCase.php
@@ -78,20 +78,26 @@ EOT;
      * @param OrderInterface $order
      * @param ShippingMethodInterface $shippingMethod
      */
-    protected function selectOrderShippingMethod(OrderInterface $order, ShippingMethodInterface $shippingMethod)
+    protected function selectOrderShippingMethod(OrderInterface $order)
     {
+        $url = sprintf('/api/v1/checkouts/select-shipping/%d', $order->getId());
+
+        $this->client->request('GET', $url, [], [], static::$authorizedHeaderWithContentType);
+
+        $response = $this->client->getResponse();
+        $rawResponse = json_decode($response->getContent());
+
         $data =
 <<<EOT
         {
             "shipments": [
                 {
-                    "method": "{$shippingMethod->getCode()}"
+                    "method": "{$rawResponse->shipments[0]->methods[0]->code}"
                 }
             ]
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/select-shipping/%d', $order->getId());
         $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $data);
     }
 

--- a/tests/Controller/CheckoutApiTestCase.php
+++ b/tests/Controller/CheckoutApiTestCase.php
@@ -76,7 +76,6 @@ EOT;
 
     /**
      * @param OrderInterface $order
-     * @param ShippingMethodInterface $shippingMethod
      */
     protected function selectOrderShippingMethod(OrderInterface $order)
     {
@@ -85,14 +84,14 @@ EOT;
         $this->client->request('GET', $url, [], [], static::$authorizedHeaderWithContentType);
 
         $response = $this->client->getResponse();
-        $rawResponse = json_decode($response->getContent());
+        $rawResponse = json_decode($response->getContent(), true);
 
         $data =
 <<<EOT
         {
             "shipments": [
                 {
-                    "method": "{$rawResponse->shipments[0]->methods[0]->code}"
+                    "method": "{$rawResponse['shipments'][0]['methods'][0]['code']}"
                 }
             ]
         }
@@ -103,22 +102,27 @@ EOT;
 
     /**
      * @param OrderInterface $order
-     * @param PaymentMethodInterface $paymentMethod
      */
-    protected function selectOrderPaymentMethod(OrderInterface $order, PaymentMethodInterface $paymentMethod)
+    protected function selectOrderPaymentMethod(OrderInterface $order)
     {
+        $url = sprintf('/api/v1/checkouts/select-payment/%d', $order->getId());
+
+        $this->client->request('GET', $url, [], [], static::$authorizedHeaderWithContentType);
+
+        $response = $this->client->getResponse();
+        $rawResponse = json_decode($response->getContent(), true);
+
         $data =
 <<<EOT
         {
             "payments": [
                 {
-                    "method": {$paymentMethod->getId()}
+                    "method": "{$rawResponse['payments'][0]['methods'][0]['code']}"
                 }
             ]
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/select-payment/%d', $order->getId());
         $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $data);
     }
 

--- a/tests/Controller/CheckoutCompleteApiTest.php
+++ b/tests/Controller/CheckoutCompleteApiTest.php
@@ -59,8 +59,7 @@ final class CheckoutCompleteApiTest extends CheckoutApiTestCase
         $this->addressOrder($cart);
         $this->selectOrderShippingMethod($cart);
 
-        $url = sprintf('/api/v1/checkouts/complete/%d', $cart->getId());
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType);
+        $this->client->request('PUT', $this->getCheckoutCompleteUrl($cart), [], [], static::$authorizedHeaderWithContentType);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/complete_invalid_order_state', Response::HTTP_INTERNAL_SERVER_ERROR);
@@ -76,15 +75,12 @@ final class CheckoutCompleteApiTest extends CheckoutApiTestCase
 
         /** @var OrderInterface $cart */
         $cart = $checkoutData['order1'];
-        /** @var PaymentMethodInterface $paymentMethod */
-        $paymentMethod = $checkoutData['cash_on_delivery'];
 
         $this->addressOrder($cart);
         $this->selectOrderShippingMethod($cart);
-        $this->selectOrderPaymentMethod($cart, $paymentMethod);
+        $this->selectOrderPaymentMethod($cart);
 
-        $url = sprintf('/api/v1/checkouts/complete/%d', $cart->getId());
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType);
+        $this->client->request('PUT', $this->getCheckoutCompleteUrl($cart), [], [], static::$authorizedHeaderWithContentType);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
@@ -93,5 +89,15 @@ final class CheckoutCompleteApiTest extends CheckoutApiTestCase
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/completed_order_response');
+    }
+
+    /**
+     * @param OrderInterface $cart
+     *
+     * @return string
+     */
+    private function getCheckoutCompleteUrl(OrderInterface $cart)
+    {
+        return sprintf('/api/v1/checkouts/complete/%d', $cart->getId());
     }
 }

--- a/tests/Controller/CheckoutCompleteApiTest.php
+++ b/tests/Controller/CheckoutCompleteApiTest.php
@@ -55,11 +55,9 @@ final class CheckoutCompleteApiTest extends CheckoutApiTestCase
 
         /** @var OrderInterface $cart */
         $cart = $checkoutData['order1'];
-        /** @var ShippingMethodInterface $shippingMethod */
-        $shippingMethod = $checkoutData['ups'];
 
         $this->addressOrder($cart);
-        $this->selectOrderShippingMethod($cart, $shippingMethod);
+        $this->selectOrderShippingMethod($cart);
 
         $url = sprintf('/api/v1/checkouts/complete/%d', $cart->getId());
         $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType);
@@ -78,13 +76,11 @@ final class CheckoutCompleteApiTest extends CheckoutApiTestCase
 
         /** @var OrderInterface $cart */
         $cart = $checkoutData['order1'];
-        /** @var ShippingMethodInterface $shippingMethod */
-        $shippingMethod = $checkoutData['ups'];
         /** @var PaymentMethodInterface $paymentMethod */
         $paymentMethod = $checkoutData['cash_on_delivery'];
 
         $this->addressOrder($cart);
-        $this->selectOrderShippingMethod($cart, $shippingMethod);
+        $this->selectOrderShippingMethod($cart);
         $this->selectOrderPaymentMethod($cart, $paymentMethod);
 
         $url = sprintf('/api/v1/checkouts/complete/%d', $cart->getId());

--- a/tests/Controller/CheckoutPaymentApiTest.php
+++ b/tests/Controller/CheckoutPaymentApiTest.php
@@ -119,7 +119,7 @@ EOT;
     /**
      * @test
      */
-    public function it_does_not_provide_details_about_available_payment_method2_before_addressing()
+    public function it_does_not_provide_details_about_available_payment_methods_before_addressing()
     {
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');

--- a/tests/Controller/CheckoutPaymentApiTest.php
+++ b/tests/Controller/CheckoutPaymentApiTest.php
@@ -74,11 +74,9 @@ final class CheckoutPaymentApiTest extends CheckoutApiTestCase
 
         /** @var OrderInterface $cart */
         $cart = $checkoutData['order1'];
-        /** @var ShippingMethodInterface $shippingMethod */
-        $shippingMethod = $checkoutData['ups'];
 
         $this->addressOrder($cart);
-        $this->selectOrderShippingMethod($cart, $shippingMethod);
+        $this->selectOrderShippingMethod($cart);
 
         $data =
 <<<EOT
@@ -108,13 +106,11 @@ EOT;
 
         /** @var OrderInterface $cart */
         $cart = $checkoutData['order1'];
-        /** @var ShippingMethodInterface $shippingMethod */
-        $shippingMethod = $checkoutData['ups'];
         /** @var PaymentMethodInterface $paymentMethod */
         $paymentMethod = $checkoutData['cash_on_delivery'];
 
         $this->addressOrder($cart);
-        $this->selectOrderShippingMethod($cart, $shippingMethod);
+        $this->selectOrderShippingMethod($cart);
 
         $data =
 <<<EOT
@@ -148,13 +144,11 @@ EOT;
 
         /** @var OrderInterface $cart */
         $cart = $checkoutData['order1'];
-        /** @var ShippingMethodInterface $shippingMethod */
-        $shippingMethod = $checkoutData['ups'];
         /** @var PaymentMethodInterface $paymentMethod */
         $paymentMethod = $checkoutData['cash_on_delivery'];
 
         $this->addressOrder($cart);
-        $this->selectOrderShippingMethod($cart, $shippingMethod);
+        $this->selectOrderShippingMethod($cart);
         $this->selectOrderPaymentMethod($cart, $paymentMethod);
 
         $data =

--- a/tests/Controller/CheckoutShippingApiTest.php
+++ b/tests/Controller/CheckoutShippingApiTest.php
@@ -11,6 +11,9 @@
 
 namespace Sylius\Tests\Controller;
 
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentMethodInterface;
+use Sylius\Component\Core\Model\ShippingMethodInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -50,8 +53,10 @@ final class CheckoutShippingApiTest extends CheckoutApiTestCase
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
 
-        $url = sprintf('/api/v1/checkouts/select-shipping/%d', $checkoutData['order1']->getId());
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType);
+        /** @var OrderInterface $cart */
+        $cart = $checkoutData['order1'];
+
+        $this->client->request('PUT', $this->getSelectShippingUrl($cart), [], [], static::$authorizedHeaderWithContentType);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/shipping_invalid_order_state', Response::HTTP_INTERNAL_SERVER_ERROR);
@@ -74,8 +79,10 @@ final class CheckoutShippingApiTest extends CheckoutApiTestCase
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
 
-        $orderId = $checkoutData['order1']->getId();
-        $this->addressOrder($orderId);
+        /** @var OrderInterface $cart */
+        $cart = $checkoutData['order1'];
+
+        $this->addressOrder($cart);
 
         $data =
 <<<EOT
@@ -88,8 +95,7 @@ final class CheckoutShippingApiTest extends CheckoutApiTestCase
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/select-shipping/%d', $orderId);
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $data);
+        $this->client->request('PUT', $this->getSelectShippingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $data);
 
         $response = $this->client->getResponse();
 
@@ -104,27 +110,30 @@ EOT;
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
 
-        $orderId = $checkoutData['order1']->getId();
-        $this->addressOrder($orderId);
+        /** @var OrderInterface $cart */
+        $cart = $checkoutData['order1'];
+        /** @var ShippingMethodInterface $shippingMethod */
+        $shippingMethod = $checkoutData['ups'];
+
+        $this->addressOrder($cart);
 
         $data =
 <<<EOT
         {
             "shipments": [
                 {
-                    "method": "{$checkoutData['ups']->getCode()}"
+                    "method": "{$shippingMethod->getCode()}"
                 }
             ]
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/select-shipping/%d', $orderId);
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $data);
+        $this->client->request('PUT', $this->getSelectShippingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
 
-        $this->client->request('GET', sprintf('/api/v1/checkouts/%d', $checkoutData['order1']->getId()), [], [], static::$authorizedHeaderWithAccept);
+        $this->client->request('GET', $this->getCheckoutSummaryUrl($cart), [], [], static::$authorizedHeaderWithAccept);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/shipping_selected_order_response');
@@ -138,23 +147,26 @@ EOT;
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
 
-        $orderId = $checkoutData['order1']->getId();
-        $this->addressOrder($orderId);
-        $this->selectOrderShippingMethod($orderId, $checkoutData['ups']->getCode());
+        /** @var OrderInterface $cart */
+        $cart = $checkoutData['order1'];
+        /** @var ShippingMethodInterface $shippingMethod */
+        $shippingMethod = $checkoutData['ups'];
+
+        $this->addressOrder($cart);
+        $this->selectOrderShippingMethod($cart, $shippingMethod);
 
         $data =
 <<<EOT
         {
             "shipments": [
                 {
-                    "method": "{$checkoutData['dhl']->getCode()}"
+                    "method": "{$shippingMethod->getCode()}"
                 }
             ]
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/select-shipping/%d', $orderId);
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $data);
+        $this->client->request('PUT', $this->getSelectShippingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
@@ -168,26 +180,41 @@ EOT;
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
 
-        $orderId = $checkoutData['order1']->getId();
-        $this->addressOrder($orderId);
-        $this->selectOrderShippingMethod($orderId, $checkoutData['ups']->getCode());
-        $this->selectOrderPaymentMethod($orderId, $checkoutData['cash_on_delivery']->getId());
+        /** @var OrderInterface $cart */
+        $cart = $checkoutData['order1'];
+        /** @var ShippingMethodInterface $shippingMethod */
+        $shippingMethod = $checkoutData['ups'];
+        /** @var PaymentMethodInterface $paymentMethod */
+        $paymentMethod = $checkoutData['cash_on_delivery'];
+
+        $this->addressOrder($cart);
+        $this->selectOrderShippingMethod($cart, $shippingMethod);
+        $this->selectOrderPaymentMethod($cart, $paymentMethod);
 
         $data =
 <<<EOT
         {
             "shipments": [
                 {
-                    "method": "{$checkoutData['dhl']->getCode()}"
+                    "method": "{$shippingMethod->getCode()}"
                 }
             ]
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/select-shipping/%d', $orderId);
-        $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $data);
+        $this->client->request('PUT', $this->getSelectShippingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * @param OrderInterface $cart
+     *
+     * @return string
+     */
+    private function getSelectShippingUrl(OrderInterface $cart)
+    {
+        return sprintf('/api/v1/checkouts/select-shipping/%d', $cart->getId());
     }
 }

--- a/tests/Controller/CheckoutShippingApiTest.php
+++ b/tests/Controller/CheckoutShippingApiTest.php
@@ -166,14 +166,14 @@ EOT;
         $this->client->request('GET', $this->getSelectShippingUrl($cart), [], [], static::$authorizedHeaderWithContentType);
 
         $response = $this->client->getResponse();
-        $rawResponse = json_decode($response->getContent());
+        $rawResponse = json_decode($response->getContent(), true);
 
         $data =
 <<<EOT
         {
             "shipments": [
                 {
-                    "method": "{$rawResponse->shipments[0]->methods[0]->code}"
+                    "method": "{$rawResponse['shipments'][0]['methods'][0]['code']}"
                 }
             ]
         }
@@ -207,14 +207,14 @@ EOT;
         $this->client->request('GET', $this->getSelectShippingUrl($cart), [], [], static::$authorizedHeaderWithContentType);
 
         $response = $this->client->getResponse();
-        $rawResponse = json_decode($response->getContent());
+        $rawResponse = json_decode($response->getContent(), true);
 
         $data =
 <<<EOT
         {
             "shipments": [
                 {
-                    "method": "{$rawResponse->shipments[0]->methods[0]->code}"
+                    "method": "{$rawResponse['shipments'][0]['methods'][0]['code']}"
                 }
             ]
         }
@@ -236,24 +236,22 @@ EOT;
 
         /** @var OrderInterface $cart */
         $cart = $checkoutData['order1'];
-        /** @var PaymentMethodInterface $paymentMethod */
-        $paymentMethod = $checkoutData['cash_on_delivery'];
 
         $this->addressOrder($cart);
         $this->selectOrderShippingMethod($cart);
-        $this->selectOrderPaymentMethod($cart, $paymentMethod);
+        $this->selectOrderPaymentMethod($cart);
 
         $this->client->request('GET', $this->getSelectShippingUrl($cart), [], [], static::$authorizedHeaderWithContentType);
 
         $response = $this->client->getResponse();
-        $rawResponse = json_decode($response->getContent());
+        $rawResponse = json_decode($response->getContent(), true);
 
         $data =
 <<<EOT
         {
             "shipments": [
                 {
-                    "method": "{$rawResponse->shipments[0]->methods[0]->code}"
+                    "method": "{$rawResponse['shipments'][0]['methods'][0]['code']}"
                 }
             ]
         }

--- a/tests/DataFixtures/ORM/resources/checkout.yml
+++ b/tests/DataFixtures/ORM/resources/checkout.yml
@@ -99,11 +99,13 @@ Sylius\Component\Shipping\Model\ShippingMethodTranslation:
     upsTranslation1:
         name: 'UPS'
         locale: 'en_US'
+        description: <paragraph(2)>
         translatable: "@ups"
     dhlTranslation1:
         name: 'DHL'
         locale: 'en_US'
         translatable: "@dhl"
+        description: <paragraph(2)>
 
 Sylius\Component\Core\Model\PaymentMethod:
     cash_on_delivery:
@@ -123,10 +125,12 @@ Sylius\Component\Payment\Model\PaymentMethodTranslation:
     cash_on_delivery_translation1:
         name: 'Cach on delivery'
         locale: 'en_US'
+        description: <paragraph(2)>
         translatable: "@cash_on_delivery"
     pay_by_check_translation1:
         name: 'Pay by check'
         locale: 'en_US'
+        description: <paragraph(2)>
         translatable: "@pay_by_check"
 
 Sylius\Component\Currency\Model\Currency:

--- a/tests/Responses/Expected/checkout/get_available_payment_methods.json
+++ b/tests/Responses/Expected/checkout/get_available_payment_methods.json
@@ -1,0 +1,68 @@
+{
+    "payments": [
+        {
+            "methods": [
+                {
+                    "id": @integer@,
+                    "code": "cod",
+                    "created_at": "@string@.isDateTime()",
+                    "updated_at": "@string@.isDateTime()",
+                    "channels": [
+                        {
+                            "id": @integer@,
+                            "code": "CHANNEL",
+                            "name": "Channel",
+                            "description": "Lorem ipsum",
+                            "hostname": "localhost",
+                            "color": "black",
+                            "created_at": "@string@.isDateTime()",
+                            "updated_at": "@string@.isDateTime()",
+                            "enabled": true,
+                            "tax_calculation_strategy": "order_items_based",
+                            "_links": {
+                                "self": {
+                                    "href": "@string@"
+                                }
+                            }
+                        }
+                    ],
+                    "_links": {
+                        "self": {
+                            "href": "\/api\/v1\/payment-methods\/cod"
+                        }
+                    }
+                },
+                {
+                    "id": @integer@,
+                    "code": "pbc",
+                    "created_at": "@string@.isDateTime()",
+                    "updated_at": "@string@.isDateTime()",
+                    "channels": [
+                        {
+                            "id": @integer@,
+                            "code": "CHANNEL",
+                            "name": "Channel",
+                            "description": "Lorem ipsum",
+                            "hostname": "localhost",
+                            "color": "black",
+                            "created_at": "@string@.isDateTime()",
+                            "updated_at": "@string@.isDateTime()",
+                            "enabled": true,
+                            "tax_calculation_strategy": "order_items_based",
+                            "_links": {
+                                "self": {
+                                    "href": "@string@"
+                                }
+                            }
+                        }
+                    ],
+                    "_links": {
+                        "self": {
+                            "href": "\/api\/v1\/payment-methods\/pbc"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/Responses/Expected/checkout/get_available_payment_methods.json
+++ b/tests/Responses/Expected/checkout/get_available_payment_methods.json
@@ -5,62 +5,14 @@
                 {
                     "id": @integer@,
                     "code": "cod",
-                    "created_at": "@string@.isDateTime()",
-                    "updated_at": "@string@.isDateTime()",
-                    "channels": [
-                        {
-                            "id": @integer@,
-                            "code": "CHANNEL",
-                            "name": "Channel",
-                            "description": "Lorem ipsum",
-                            "hostname": "localhost",
-                            "color": "black",
-                            "created_at": "@string@.isDateTime()",
-                            "updated_at": "@string@.isDateTime()",
-                            "enabled": true,
-                            "tax_calculation_strategy": "order_items_based",
-                            "_links": {
-                                "self": {
-                                    "href": "@string@"
-                                }
-                            }
-                        }
-                    ],
-                    "_links": {
-                        "self": {
-                            "href": "\/api\/v1\/payment-methods\/cod"
-                        }
-                    }
+                    "name": "Cach on delivery",
+                    "description": "@string@"
                 },
                 {
                     "id": @integer@,
                     "code": "pbc",
-                    "created_at": "@string@.isDateTime()",
-                    "updated_at": "@string@.isDateTime()",
-                    "channels": [
-                        {
-                            "id": @integer@,
-                            "code": "CHANNEL",
-                            "name": "Channel",
-                            "description": "Lorem ipsum",
-                            "hostname": "localhost",
-                            "color": "black",
-                            "created_at": "@string@.isDateTime()",
-                            "updated_at": "@string@.isDateTime()",
-                            "enabled": true,
-                            "tax_calculation_strategy": "order_items_based",
-                            "_links": {
-                                "self": {
-                                    "href": "@string@"
-                                }
-                            }
-                        }
-                    ],
-                    "_links": {
-                        "self": {
-                            "href": "\/api\/v1\/payment-methods\/pbc"
-                        }
-                    }
+                    "name": "Pay by check",
+                    "description": "@string@"
                 }
             ]
         }

--- a/tests/Responses/Expected/checkout/get_available_payment_methods_failed.json
+++ b/tests/Responses/Expected/checkout/get_available_payment_methods_failed.json
@@ -1,0 +1,4 @@
+{
+    "code": 400,
+    "message": "The payment methods cannot be resolved in the current state of cart!"
+}

--- a/tests/Responses/Expected/checkout/get_available_shipping_methods.json
+++ b/tests/Responses/Expected/checkout/get_available_shipping_methods.json
@@ -5,46 +5,16 @@
                 {
                     "id": @integer@,
                     "code": "UPS",
-                    "category_requirement": 1,
-                    "calculator": "flat_rate",
-                    "configuration": {
-                        "CHANNEL": {
-                            "amount": 10
-                        }
-                    },
-                    "created_at": "@string@.isDateTime()",
-                    "updated_at": "@string@.isDateTime()",
-                    "enabled": true,
-                    "_links": {
-                        "self": {
-                            "href": "\/api\/v1\/shipping-methods\/UPS"
-                        },
-                        "zone": {
-                            "href": "\/api\/v1\/zones\/EU"
-                        }
-                    }
+                    "name": "UPS",
+                    "description": "@string@",
+                    "price": 10
                 },
                 {
                     "id": @integer@,
                     "code": "DHL",
-                    "category_requirement": 1,
-                    "calculator": "flat_rate",
-                    "configuration": {
-                        "CHANNEL": {
-                            "amount": 20
-                        }
-                    },
-                    "created_at": "@string@.isDateTime()",
-                    "updated_at": "@string@.isDateTime()",
-                    "enabled": true,
-                    "_links": {
-                        "self": {
-                            "href": "\/api\/v1\/shipping-methods\/DHL"
-                        },
-                        "zone": {
-                            "href": "\/api\/v1\/zones\/EU"
-                        }
-                    }
+                    "name": "DHL",
+                    "description": "@string@",
+                    "price": 20
                 }
             ]
         }

--- a/tests/Responses/Expected/checkout/get_available_shipping_methods.json
+++ b/tests/Responses/Expected/checkout/get_available_shipping_methods.json
@@ -1,0 +1,52 @@
+{
+    "shipments": [
+        {
+            "methods": [
+                {
+                    "id": @integer@,
+                    "code": "UPS",
+                    "category_requirement": 1,
+                    "calculator": "flat_rate",
+                    "configuration": {
+                        "CHANNEL": {
+                            "amount": 10
+                        }
+                    },
+                    "created_at": "@string@.isDateTime()",
+                    "updated_at": "@string@.isDateTime()",
+                    "enabled": true,
+                    "_links": {
+                        "self": {
+                            "href": "\/api\/v1\/shipping-methods\/UPS"
+                        },
+                        "zone": {
+                            "href": "\/api\/v1\/zones\/EU"
+                        }
+                    }
+                },
+                {
+                    "id": @integer@,
+                    "code": "DHL",
+                    "category_requirement": 1,
+                    "calculator": "flat_rate",
+                    "configuration": {
+                        "CHANNEL": {
+                            "amount": 20
+                        }
+                    },
+                    "created_at": "@string@.isDateTime()",
+                    "updated_at": "@string@.isDateTime()",
+                    "enabled": true,
+                    "_links": {
+                        "self": {
+                            "href": "\/api\/v1\/shipping-methods\/DHL"
+                        },
+                        "zone": {
+                            "href": "\/api\/v1\/zones\/EU"
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/Responses/Expected/checkout/get_available_shipping_methods_failed.json
+++ b/tests/Responses/Expected/checkout/get_available_shipping_methods_failed.json
@@ -1,0 +1,4 @@
+{
+    "code": 400,
+    "message": "The shipment methods cannot be resolved in the current state of cart!"
+}

--- a/tests/Responses/Expected/checkout/shipping_selected_order_response.json
+++ b/tests/Responses/Expected/checkout/shipping_selected_order_response.json
@@ -35,20 +35,22 @@
             "method": {
                 "id": @integer@,
                 "code": "UPS",
-                "category_requirement": @integer@,
+                "category_requirement": 1,
                 "calculator": "flat_rate",
                 "configuration": {
-                    "amount": 10
+                    "CHANNEL": {
+                        "amount": 10
+                    }
                 },
                 "created_at": "@string@.isDateTime()",
                 "updated_at": "@string@.isDateTime()",
                 "enabled": true,
                 "_links": {
                     "self": {
-                        "href": @string@
+                        "href": "\/api\/v1\/shipping-methods\/UPS"
                     },
                     "zone": {
-                        "href": @string@
+                        "href": "\/api\/v1\/zones\/EU"
                     }
                 }
             },
@@ -59,7 +61,7 @@
                     "href": @string@
                 },
                 "method": {
-                    "href": @string@
+                    "href": "\/api\/v1\/shipping-methods\/UPS"
                 },
                 "order": {
                     "href": @string@


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

From now on it will be possible to fetch available shipping and payments method based submitted data(e.g. address for shipment). I have also made a little refactor of CheckoutApiTest. 

TODOs:
   - [x] Create get available payment methods endpoint
- [ ] ~~Rebase to #7297 (I need its serialization)~~
- [ ] ~~Write documentation~~

It would be easier to review if I wait for #7297 and I will write a documentation in separate PR. 