### PR TITLE
[Translations] added translations to admin user form

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/User/AdminUserType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/User/AdminUserType.php
@@ -30,10 +30,10 @@ final class AdminUserType extends UserType
 
         $builder
             ->add('firstName', TextType::class, [
-            	'label' => 'sylius.ui.first_name',
+            	'label' => 'sylius.form.user.first_name',
             ])
             ->add('lastName', TextType::class, [
-            	'label' => 'sylius.ui.last_name',
+            	'label' => 'sylius.form.user.last_name',
             ])
             ->add('localeCode', LocaleType::class, [
                 'label' => 'sylius.ui.locale',

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/User/AdminUserType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/User/AdminUserType.php
@@ -28,8 +28,12 @@ final class AdminUserType extends UserType
         parent::buildForm($builder, $options);
 
         $builder
-            ->add('firstName')
-            ->add('lastName')
+            ->add('firstName', null, [
+            	'label' => 'sylius.ui.first_name'
+            ])
+            ->add('lastName', null, [
+            	'label' => 'sylius.ui.last_name'
+            ])
             ->add('localeCode', LocaleType::class, [
                 'label' => 'sylius.ui.locale',
                 'placeholder' => null,

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/User/AdminUserType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/User/AdminUserType.php
@@ -13,6 +13,7 @@ namespace Sylius\Bundle\CoreBundle\Form\Type\User;
 
 use Sylius\Bundle\UserBundle\Form\Type\UserType;
 use Symfony\Component\Form\Extension\Core\Type\LocaleType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -28,11 +29,11 @@ final class AdminUserType extends UserType
         parent::buildForm($builder, $options);
 
         $builder
-            ->add('firstName', null, [
-            	'label' => 'sylius.ui.first_name'
+            ->add('firstName', TextType::class, [
+            	'label' => 'sylius.ui.first_name',
             ])
-            ->add('lastName', null, [
-            	'label' => 'sylius.ui.last_name'
+            ->add('lastName', TextType::class, [
+            	'label' => 'sylius.ui.last_name',
             ])
             ->add('localeCode', LocaleType::class, [
                 'label' => 'sylius.ui.locale',


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

Hi,
it's simple commit adding translations to admin user form (firstName and lastName fields, which was hardcoded earlier). 