### PR TITLE
[Grid] Fixed sorting filter in grid by position parameter

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
@@ -12,7 +12,7 @@
     <div class="ui segment">
         <form method="get" action="{{ path }}" class="ui loadable form">
             <div class="two fields">
-            {% for filter in definition.filters if filter.enabled %}
+            {% for filter in definition.filters|sort_by('position') if filter.enabled %}
                 {{ sylius_grid_render_filter(grid, filter) }}
 
                 {% if loop.index0 % 2 %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

Hi,
sorting fields in grid by position parameter works nice, but not for filters. Added sort_by in filter loop - simple fix.