### PR TITLE
[Travis] Skip application tests if only *.md files were changed

### DIFF
--- a/etc/travis/suites/application/is_suitable.sh
+++ b/etc/travis/suites/application/is_suitable.sh
@@ -6,7 +6,7 @@ if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
     exit 0 # Always execute full suite on branch builds
 fi
 
-if [ $(git diff --name-only HEAD origin/master | grep -c -v -e ^docs) -eq 0 ]; then
+if [ $(git diff --name-only HEAD origin/master | grep -c -v -e ^docs -e ^CHANGELOG.md -e ^CONTRIBUTING.md -e ^LICENSE -e ^PULL_REQUEST_TEMPLATE.md -e ^README.md -e ^UPGRADE.md) -eq 0 ]; then
     print_header "Skipped suite" "Application"
     print_warning "No other changes than those in docs/* were found"
     exit 1


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

Excluded files:
 - `CHANGELOG.md`
 - `CONTRIBUTING.md`
 - `LICENSE`
 - `PULL_REQUEST_TEMPLATE.md`
 - `README.md`
 - `UPGRADE.md`

This prevents application from being tested on Travis by PRs like #7436.