### PR TITLE
Use proper path for shop user deletion route

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing.yml
@@ -93,6 +93,7 @@ sylius_admin_taxon:
 
 sylius_admin_shop_user:
     resource: "@SyliusAdminBundle/Resources/config/routing/shop_user.yml"
+    prefix: /shop-user/
 
 sylius_admin_tax_category:
     resource: "@SyliusAdminBundle/Resources/config/routing/tax_category.yml"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

Right now `sylius_admin_shop_user_delete` is located at `/admin/{id}`.