### PR TITLE
Added unique constraints on product_taxon and product_channel_pricing

### DIFF
--- a/app/migrations/Version20170208103250.php
+++ b/app/migrations/Version20170208103250.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170208103250 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE UNIQUE INDEX product_variant_channel_idx ON sylius_channel_pricing (product_variant_id, channel_id)');
+        $this->addSql('CREATE UNIQUE INDEX product_taxon_idx ON sylius_product_taxon (product_id, taxon_id)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX product_variant_channel_idx ON sylius_channel_pricing');
+        $this->addSql('DROP INDEX product_taxon_idx ON sylius_product_taxon');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ChannelPricing.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ChannelPricing.orm.xml
@@ -18,6 +18,10 @@
 >
 
     <mapped-superclass name="Sylius\Component\Core\Model\ChannelPricing" table="sylius_channel_pricing">
+        <unique-constraints>
+            <unique-constraint columns="product_variant_id,channel_id" name="product_variant_channel_idx" />
+        </unique-constraints>
+    
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductTaxon.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductTaxon.orm.xml
@@ -18,6 +18,10 @@
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <mapped-superclass name="Sylius\Component\Core\Model\ProductTaxon" table="sylius_product_taxon">
+        <unique-constraints>
+            <unique-constraint columns="product_id,taxon_id" name="product_taxon_idx" />
+        </unique-constraints>
+    
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>


### PR DESCRIPTION
Added unique constraints on product_taxon and product_channel_pricing entities

[Core] added unique constraints on following entities:
product_variant_id/channel_id combination in sylius_channel_pricing
product_id/taxon_id combination in sylius_product_taxon

| Q                        | A
| ---------------  | ---
| Bug fix?              | yes
| New feature?     | no
| BC breaks?        | no
| Related tickets  | fixes https://github.com/Sylius/Sylius-Standard/issues/158
| License              | MIT
