### PR TITLE
[CoreBundle] Add sylius_order_payment missing transitions

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order_payment.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order_payment.yml
@@ -17,6 +17,7 @@ winzou_state_machine:
                 from: [cart]
                 to: awaiting_payment
             partially_pay:
+                from: [awaiting_payment, partially_paid]
                 to: partially_paid
             cancel:
                 from: [awaiting_payment]
@@ -25,9 +26,10 @@ winzou_state_machine:
                 from: [awaiting_payment, partially_paid]
                 to: paid
             partially_refund:
+                from: [paid, partially_paid, partially_refunded]
                 to: partially_refunded
             refund:
-                from: [paid, partially_refunded]
+                from: [paid,, partially_paid, partially_refunded]
                 to: refunded
         callbacks:
             after:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

The `from` parts of `partially_pay` and `partially_refund` were missing :)