### PR TITLE
[HWIOAuthBundle] OAuth tokens aren't updated on reconnexion

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
@@ -99,7 +99,7 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
         ]);
 
         if ($oauth instanceof UserOAuthInterface) {
-            return $oauth->getUser();
+            return $this->updateUserByOAuthUserResponse($oauth->getUser(), $response);
         }
 
         if (null !== $response->getEmail()) {
@@ -167,9 +167,12 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
      */
     private function updateUserByOAuthUserResponse(UserInterface $user, UserResponseInterface $response)
     {
-        $oauth = $this->oauthFactory->createNew();
-        $oauth->setIdentifier($response->getUsername());
-        $oauth->setProvider($response->getResourceOwner()->getName());
+
+        if (null == $oauth = $user->getOAuthAccount($response->getResourceOwner()->getName())) {
+            $oauth = $this->oauthFactory->createNew();
+            $oauth->setIdentifier($response->getUsername());
+            $oauth->setProvider($response->getResourceOwner()->getName());
+        }
         $oauth->setAccessToken($response->getAccessToken());
         $oauth->setRefreshToken($response->getRefreshToken());
 

--- a/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
@@ -167,12 +167,12 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
      */
     private function updateUserByOAuthUserResponse(UserInterface $user, UserResponseInterface $response)
     {
-
         if (null == $oauth = $user->getOAuthAccount($response->getResourceOwner()->getName())) {
             $oauth = $this->oauthFactory->createNew();
             $oauth->setIdentifier($response->getUsername());
             $oauth->setProvider($response->getResourceOwner()->getName());
         }
+
         $oauth->setAccessToken($response->getAccessToken());
         $oauth->setRefreshToken($response->getRefreshToken());
 

--- a/src/Sylius/Bundle/CoreBundle/spec/OAuth/UserProviderSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/OAuth/UserProviderSpec.php
@@ -187,4 +187,31 @@ final class UserProviderSpec extends ObjectBehavior
 
         $this->loadUserByOAuthUserResponse($response)->shouldReturn($user);
     }
+
+    function it_should_update_token_when_oauth_succeed(
+        $oauthRepository,
+        ShopUserInterface $user,
+        UserOAuthInterface $oauth,
+        UserResponseInterface $response,
+        ResourceOwnerInterface $resourceOwner
+    ) {
+        $resourceOwner->getName()->willReturn('google');
+
+        $response->getUsername()->willReturn('username');
+        $response->getAccessToken()->willReturn('new_access_token');
+        $response->getRefreshToken()->willReturn('new_refresh_token');
+        $response->getResourceOwner()->willReturn($resourceOwner);
+
+        $oauthRepository->findOneBy(['provider' => 'google', 'identifier' => 'username'])->willReturn($oauth);
+
+        $user->getOAuthAccount('google')->willReturn($oauth);
+
+        $oauth->getUser()->willReturn($user);
+        
+        $oauth->setAccessToken('new_access_token')->shouldBeCalled();
+        $oauth->setRefreshToken('new_refresh_token')->shouldBeCalled();
+
+        $this->loadUserByOAuthUserResponse($response);
+    }
+
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #7463 |
| License         | MIT |


Hello, please find a patch fixing this issue : *OAuth tokens aren't updated on reconnexion*

I've tried to add a new phpspec entry `UserProviderSpec::it_should_update_token_when_oauth_succeed` but I'm not competent enough with phpsec so the test fail, sorry


*edit : I noted the PR has "BC breaks" by error in the synthesis table*