### PR TITLE
[Admin] [Order] Fix missing order prefix

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,6 +11,7 @@
 
 * Route `sylius_admin_order_shipment_ship` has been added to have specific end point only for updating via http PUT method and `sylius_admin_partial_shipment_ship` route is only for rendering the form.
 * Rename any `sylius_admin_address_log_entry_index` usages to `sylius_admin_partial_log_entry_index`.
+* The `sylius_admin_order_shipment_ship` path has been changed from `/{id}/ship` to `/orders/{id}/ship` to keep consistency. Change the path definition or redeclare it if you are using an absolute path instead of twig helper.
 
 ### ApiBundle
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
@@ -89,7 +89,7 @@ sylius_admin_order_payment_refund:
             flash: sylius.payment.refunded
 
 sylius_admin_order_shipment_ship:
-    path: /{id}/ship
+    path: /orders/{id}/ship
     methods: [PUT]
     defaults:
         _controller: sylius.controller.shipment:updateAction


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets | |
| License         | MIT |

All the paths in this folder have the `/orders/` prefix, so probably this one should have it too. 