### PR TITLE
[Product] Added serialization for ProductAssociation classes

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductAssociation.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductAssociation.yml
@@ -1,0 +1,19 @@
+Sylius\Component\Product\Model\ProductAssociation:
+    exclusion_policy: ALL
+    xml_root_name: product-association
+    properties:
+        id:
+            expose: true
+            type: integer
+            xml_attribute: true
+            groups: [Default, Detailed]
+        type:
+            expose: true
+            groups: [Default, Detailed]
+        product:
+            expose: true
+            groups: [Default, Detailed]
+        associatedProducts:
+            expose: true
+            type: array
+            groups: [Default, Detailed]

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductAssociationType.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductAssociationType.yml
@@ -1,0 +1,20 @@
+Sylius\Component\Product\Model\ProductAssociationType:
+    exclusion_policy: ALL
+    xml_root_name: product-association-type
+    properties:
+        id:
+            expose: true
+            type: integer
+            xml_attribute: true
+            groups: [Default, Detailed]
+        code:
+            expose: true
+            type: string
+            groups: [Default, Detailed]
+        translations:
+            expose: true
+            type: array
+            groups: [Default, Detailed]
+    virtual_properties:
+        getName:
+            serialized_name: name

--- a/tests/Controller/ProductApiTest.php
+++ b/tests/Controller/ProductApiTest.php
@@ -280,7 +280,7 @@ EOT;
     /**
      * @test
      */
-    public function it_allows_creating_product_with_main_taxon() 
+    public function it_allows_creating_product_with_main_taxon()
     {
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $this->loadFixturesFromFile('resources/taxons.yml');
@@ -343,7 +343,7 @@ EOT;
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $this->loadFixturesFromFile('resources/channels.yml');
 
-        $data = 
+        $data =
 <<<EOT
         {
             "code": "MUG_TH",

--- a/tests/Responses/Expected/product/create_with_associations_response.json
+++ b/tests/Responses/Expected/product/create_with_associations_response.json
@@ -11,40 +11,28 @@
             "type": {
                 "id": @integer@,
                 "code": "similar",
-                "created_at": "@string@.isDateTime()",
-                "updated_at": "@string@.isDateTime()",
-                "translations": [
-                    {
-                      "id": @integer@,
-                      "locale": "en"
+                "translations": {
+                    "en": {
+                        "id": @integer@,
+                        "locale": "en"
                     }
-                ],
-                "current_locale": "en",
-                "fallback_locale": "en_US"
+                }
             },
-            "associated_products": @array@,
-            "created_at": "@string@.isDateTime()",
-            "updated_at": "@string@.isDateTime()"
+            "associated_products": @array@
         },
         {
             "id": @integer@,
             "type": {
                 "id": @integer@,
                 "code": "accessories",
-                "created_at": "@string@.isDateTime()",
-                "updated_at": "@string@.isDateTime()",
-                "translations": [
-                    {
-                      "id": @integer@,
-                      "locale": "en"
+                "translations": {
+                    "en": {
+                        "id": @integer@,
+                        "locale": "en"
                     }
-                ],
-                "current_locale": "en",
-                "fallback_locale": "en_US"
+                }
             },
-            "associated_products": @array@,
-            "created_at": "@string@.isDateTime()",
-            "updated_at": "@string@.isDateTime()"
+            "associated_products": @array@
         }
     ],
     "translations": {


### PR DESCRIPTION
Removed current/fallback locales and timestamps from API's product associations responses.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |