### PR TITLE
[Resource] Return 204 HTTP code for state machine transitions

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -422,7 +422,7 @@ class ResourceController extends Controller
         $this->eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource);
 
         if (!$configuration->isHtmlRequest()) {
-            return $this->viewHandler->handle($configuration, View::create($resource, Response::HTTP_OK));
+            return $this->viewHandler->handle($configuration, View::create(null, Response::HTTP_NO_CONTENT));
         }
 
         $this->flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource);

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
@@ -1610,7 +1610,7 @@ final class ResourceControllerSpec extends ObjectBehavior
 
         $eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource)->shouldBeCalled();
 
-        $expectedView = View::create($resource, 200);
+        $expectedView = View::create(null, 204);
 
         $viewHandler->handle($configuration, Argument::that($this->getViewComparingCallback($expectedView)))->willReturn($response);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets |  |
| License         | MIT |

We used to return a whole serialized service for `applyStateMachineTransitionAction`. But it creates a cohesion problem when working with many transitions together. For example, when you work with checkout in API some actions returns HTTP 204, and some HTTP 200 and whole object. At the end we would have the  following actions on Order:
 * complete -> return 204 if succeed 
 * cancel -> return 200 and order object if succeed 
 * ship -> return 204 if succeed
 * complete payment -> return 200 and payment object and  if succeed 
when all of this actions mainly are making just transitions on the same order object.

With this fix, every update will return 204, and one will have to call endpoint with the `GET` method to receive 200 and object. 

