### PR TITLE
[Checkout] Skip shipping step if only one shipping method is available

### DIFF
--- a/app/migrations/Version20170214104908.php
+++ b/app/migrations/Version20170214104908.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170214104908 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_channel ADD skipping_shipping_step_allowed TINYINT(1) NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_channel DROP skipping_shipping_step_allowed');
+    }
+}

--- a/app/migrations/Version20170214104908.php
+++ b/app/migrations/Version20170214104908.php
@@ -19,6 +19,7 @@ class Version20170214104908 extends AbstractMigration
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('ALTER TABLE sylius_channel ADD skipping_shipping_step_allowed TINYINT(1) NOT NULL');
+        $this->addSql('UPDATE sylius_channel SET skipping_shipping_step_allowed = 0');
     }
 
     /**

--- a/features/channel/managing_channels/adding_channel.feature
+++ b/features/channel/managing_channels/adding_channel.feature
@@ -31,6 +31,7 @@ Feature: Adding a new channel
         And I define its color as "blue"
         And I choose "Euro" as the base currency
         And I choose "English (United States)" as a default locale
+        And I allow to skip shipping step if only one shipping method is available
         And I add it
         Then I should be notified that it has been successfully created
         And the channel "Mobile channel" should appear in the registry

--- a/features/checkout/skipping_shipping_step_when_only_one_shipping_method_is_available.feature
+++ b/features/checkout/skipping_shipping_step_when_only_one_shipping_method_is_available.feature
@@ -7,19 +7,22 @@ Feature: Skipping shipping step when only one shipping method is available
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a product "Guards! Guards!" priced at "$20.00"
+        And the store allows paying with "Paypal Express Checkout"
         And I am a logged in customer
 
-    @todo
+    @ui
     Scenario: Seeing checkout payment page after addressing if only one shipping method is available
         Given the store has "DHL" shipping method with "$5.00" fee
         And I have product "Guards! Guards!" in the cart
         And I am at the checkout addressing step
         When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
-        Then I should be on the checkout payment step
+        And I select "Paypal Express Checkout" payment method
+        And I complete the payment step
+        Then I should be on the checkout complete step
         And my order's shipping method should be "DHL"
 
-    @todo
+    @ui
     Scenario: Seeing checkout payment page after addressing if only one shipping method is available for current channel
         Given the store has "DHL" shipping method with "$5.00" fee
         Given the store has "FedEx" shipping method with "$15.00" fee not assigned to any channel
@@ -27,10 +30,12 @@ Feature: Skipping shipping step when only one shipping method is available
         And I am at the checkout addressing step
         When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
-        Then I should be on the checkout payment step
+        And I select "Paypal Express Checkout" payment method
+        And I complete the payment step
+        Then I should be on the checkout complete step
         And my order's shipping method should be "DHL"
 
-    @todo
+    @ui
     Scenario: Seeing checkout payment page after addressing if only one shipping method is enabled for current channel
         Given the store has "DHL" shipping method with "$5.00" fee
         Given the store has disabled "FedEx" shipping method with "$15.00" fee
@@ -38,5 +43,7 @@ Feature: Skipping shipping step when only one shipping method is available
         And I am at the checkout addressing step
         When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
-        Then I should be on the checkout payment step
+        And I select "Paypal Express Checkout" payment method
+        And I complete the payment step
+        Then I should be on the checkout complete step
         And my order's shipping method should be "DHL"

--- a/features/checkout/skipping_shipping_step_when_only_one_shipping_method_is_available.feature
+++ b/features/checkout/skipping_shipping_step_when_only_one_shipping_method_is_available.feature
@@ -26,7 +26,7 @@ Feature: Skipping shipping step when only one shipping method is available
     @ui
     Scenario: Seeing checkout payment page after addressing if only one shipping method is available for current channel
         Given the store has "DHL" shipping method with "$5.00" fee
-        Given the store has "FedEx" shipping method with "$15.00" fee not assigned to any channel
+        And the store has "FedEx" shipping method with "$15.00" fee not assigned to any channel
         And I have product "Guards! Guards!" in the cart
         And I am at the checkout addressing step
         When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
@@ -39,7 +39,7 @@ Feature: Skipping shipping step when only one shipping method is available
     @ui
     Scenario: Seeing checkout payment page after addressing if only one shipping method is enabled for current channel
         Given the store has "DHL" shipping method with "$5.00" fee
-        Given the store has disabled "FedEx" shipping method with "$15.00" fee
+        And the store has disabled "FedEx" shipping method with "$15.00" fee
         And I have product "Guards! Guards!" in the cart
         And I am at the checkout addressing step
         When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"

--- a/features/checkout/skipping_shipping_step_when_only_one_shipping_method_is_available.feature
+++ b/features/checkout/skipping_shipping_step_when_only_one_shipping_method_is_available.feature
@@ -6,6 +6,7 @@ Feature: Skipping shipping step when only one shipping method is available
 
     Background:
         Given the store operates on a single channel in "United States"
+        And on this channel shipping step is skipped if only a single shipping method is available
         And the store has a product "Guards! Guards!" priced at "$20.00"
         And the store allows paying with "Paypal Express Checkout"
         And I am a logged in customer

--- a/features/checkout/skipping_shipping_step_when_only_one_shipping_method_is_available.feature
+++ b/features/checkout/skipping_shipping_step_when_only_one_shipping_method_is_available.feature
@@ -1,0 +1,42 @@
+@checkout
+Feature: Skipping shipping step when only one shipping method is available
+    In order to not select shipping method if its unnecessary
+    As a Customer
+    I want to be redirected directly to payment selection
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Guards! Guards!" priced at "$20.00"
+        And I am a logged in customer
+
+    @todo
+    Scenario: Seeing checkout payment page after addressing if only one shipping method is available
+        Given the store has "DHL" shipping method with "$5.00" fee
+        And I have product "Guards! Guards!" in the cart
+        And I am at the checkout addressing step
+        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I complete the addressing step
+        Then I should be on the checkout payment step
+        And my order's shipping method should be "DHL"
+
+    @todo
+    Scenario: Seeing checkout payment page after addressing if only one shipping method is available for current channel
+        Given the store has "DHL" shipping method with "$5.00" fee
+        Given the store has "FedEx" shipping method with "$15.00" fee not assigned to any channel
+        And I have product "Guards! Guards!" in the cart
+        And I am at the checkout addressing step
+        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I complete the addressing step
+        Then I should be on the checkout payment step
+        And my order's shipping method should be "DHL"
+
+    @todo
+    Scenario: Seeing checkout payment page after addressing if only one shipping method is enabled for current channel
+        Given the store has "DHL" shipping method with "$5.00" fee
+        Given the store has disabled "FedEx" shipping method with "$15.00" fee
+        And I have product "Guards! Guards!" in the cart
+        And I am at the checkout addressing step
+        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I complete the addressing step
+        Then I should be on the checkout payment step
+        And my order's shipping method should be "DHL"

--- a/src/Sylius/Behat/Context/Setup/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Setup/ChannelContext.php
@@ -173,4 +173,14 @@ final class ChannelContext implements Context
         $this->channelManager->flush();
         $this->sharedStorage->set('channel', $channel);
     }
+
+    /**
+     * @Given /^on (this channel) shipping step is skipped if only a single shipping method is available$/
+     */
+    public function onThisChannelShippingStepIsSkippedIfOnlyASingleShippingMethodIsAvailable(ChannelInterface $channel)
+    {
+        $channel->setSkippingShippingStepAllowed(true);
+
+        $this->channelManager->flush();
+    }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
@@ -120,6 +120,14 @@ final class ManagingChannelsContext implements Context
     }
 
     /**
+     * @When I allow to skip shipping step if only one shipping method is available
+     */
+    public function iAllowToSkipShippingStepIfOnlyOneShippingMethodIsAvailable()
+    {
+        $this->createPage->allowToSkipShippingStep();
+    }
+
+    /**
      * @When I add it
      * @When I try to add it
      */

--- a/src/Sylius/Behat/Page/Admin/Channel/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/CreatePage.php
@@ -105,6 +105,11 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $this->getDocument()->selectFieldOption('Tax calculation strategy', $taxZone);
     }
 
+    public function allowToSkipShippingStep()
+    {
+        $this->getDocument()->checkField('Skip shipping step if only one shipping method is available?');
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Sylius/Behat/Page/Admin/Channel/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/CreatePageInterface.php
@@ -81,4 +81,6 @@ interface CreatePageInterface extends BaseCreatePageInterface
      * @param string $taxCalculationStrategy
      */
     public function chooseTaxCalculationStrategy($taxCalculationStrategy);
+
+    public function allowToSkipShippingStep();
 }

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Channel/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Channel/_form.html.twig
@@ -34,6 +34,7 @@
             {{ form_row(form.baseCurrency) }}
             {{ form_row(form.defaultTaxZone) }}
             {{ form_row(form.taxCalculationStrategy) }}
+            {{ form_row(form.skippingShippingStepAllowed) }}
         </div>
     </div>
 </div>

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
@@ -20,6 +20,7 @@ use Sylius\Bundle\CurrencyBundle\Form\Type\CurrencyChoiceType;
 use Sylius\Bundle\LocaleBundle\Form\Type\LocaleChoiceType;
 use Sylius\Bundle\ThemeBundle\Form\Type\ThemeNameChoiceType;
 use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -66,6 +67,10 @@ final class ChannelTypeExtension extends AbstractTypeExtension
             ])
             ->add('contactEmail', EmailType::class, [
                 'label' => 'sylius.form.channel.contact_email',
+                'required' => false,
+            ])
+            ->add('skippingShippingStepAllowed', CheckboxType::class, [
+                'label' => 'sylius.form.channel.skipping_shipping_step_allowed',
                 'required' => false,
             ])
             ->addEventSubscriber(new AddBaseCurrencySubscriber())

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order_checkout.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order_checkout.yml
@@ -34,7 +34,7 @@ winzou_state_machine:
         callbacks:
             after:
                 sylius_process_cart:
-                    on: ["select_shipping", "address", "select_payment"]
+                    on: ["select_shipping", "address", "select_payment", "skip_shipping"]
                     do: ["@sylius.order_processing.order_processor", "process"]
                     args: ["object"]
                 sylius_create_order:

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
@@ -20,6 +20,7 @@
         <field name="themeName" column="theme_name" type="string" nullable="true" />
         <field name="taxCalculationStrategy" column="tax_calculation_strategy" type="string" />
         <field name="contactEmail" column="contact_email" type="string" nullable="true" />
+        <field name="skippingShippingStepAllowed" column="skipping_shipping_step_allowed" type="boolean" />
 
         <many-to-one field="defaultLocale" target-entity="Sylius\Component\Locale\Model\LocaleInterface">
             <join-column name="default_locale_id" referenced-column-name="id" nullable="false" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -13,6 +13,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <imports>
+        <import resource="services/checkers.xml" />
         <import resource="services/checkout.xml" />
         <import resource="services/context.xml" />
         <import resource="services/dashboard.xml" />
@@ -92,6 +93,11 @@
 
         <service id="sylius.twig.extension.product_variants_prices" class="Sylius\Bundle\CoreBundle\Twig\ProductVariantsPricesExtension" public="false">
             <argument type="service" id="sylius.templating.helper.product_variants_prices" />
+            <tag name="twig.extension" />
+        </service>
+
+        <service id="sylius.twig.extension.checkout_steps" class="Sylius\Bundle\CoreBundle\Twig\CheckoutStepsExtension" public="false">
+            <argument type="service" id="sylius.templating.helper.checkout_steps" />
             <tag name="twig.extension" />
         </service>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/checkers.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/checkers.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sylius.checker.order_shipping_method_selection_requirement" class="Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementChecker">
+            <argument type="service" id="sylius.shipping_methods_resolver" />
+        </service>
+    </services>
+</container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/checkers.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/checkers.xml
@@ -16,5 +16,6 @@
         <service id="sylius.checker.order_shipping_method_selection_requirement" class="Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementChecker">
             <argument type="service" id="sylius.shipping_methods_resolver" />
         </service>
+        <service id="sylius.checker.order_payment_method_selection_requirement" class="Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementChecker" />
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/state_resolvers.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/state_resolvers.xml
@@ -18,7 +18,7 @@
         </service>
         <service id="sylius.state_resolver.order_checkout" class="Sylius\Component\Core\StateResolver\CheckoutStateResolver">
             <argument type="service" id="sm.factory" />
-            <argument type="service" id="sylius.shipping_methods_resolver" />
+            <argument type="service" id="sylius.checker.order_shipping_method_selection_requirement" />
         </service>
         <service id="sylius.state_resolver.order_payment" class="Sylius\Component\Core\StateResolver\OrderPaymentStateResolver">
             <argument type="service" id="sm.factory" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/state_resolvers.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/state_resolvers.xml
@@ -18,6 +18,7 @@
         </service>
         <service id="sylius.state_resolver.order_checkout" class="Sylius\Component\Core\StateResolver\CheckoutStateResolver">
             <argument type="service" id="sm.factory" />
+            <argument type="service" id="sylius.checker.order_payment_method_selection_requirement" />
             <argument type="service" id="sylius.checker.order_shipping_method_selection_requirement" />
         </service>
         <service id="sylius.state_resolver.order_payment" class="Sylius\Component\Core\StateResolver\OrderPaymentStateResolver">

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/state_resolvers.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/state_resolvers.xml
@@ -18,6 +18,7 @@
         </service>
         <service id="sylius.state_resolver.order_checkout" class="Sylius\Component\Core\StateResolver\CheckoutStateResolver">
             <argument type="service" id="sm.factory" />
+            <argument type="service" id="sylius.shipping_methods_resolver" />
         </service>
         <service id="sylius.state_resolver.order_payment" class="Sylius\Component\Core\StateResolver\OrderPaymentStateResolver">
             <argument type="service" id="sm.factory" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
@@ -39,6 +39,7 @@
         </service>
 
         <service id="sylius.templating.helper.checkout_steps" class="Sylius\Bundle\CoreBundle\Templating\Helper\CheckoutStepsHelper" lazy="true">
+            <argument type="service" id="sylius.checker.order_payment_method_selection_requirement" />
             <argument type="service" id="sylius.checker.order_shipping_method_selection_requirement" />
             <tag name="templating.helper" alias="sylius_checkout_steps" />
         </service>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/templating.xml
@@ -37,5 +37,10 @@
             <argument type="service" id="sylius.templating.helper.variant_resolver" />
             <tag name="twig.extension" />
         </service>
+
+        <service id="sylius.templating.helper.checkout_steps" class="Sylius\Bundle\CoreBundle\Templating\Helper\CheckoutStepsHelper" lazy="true">
+            <argument type="service" id="sylius.checker.order_shipping_method_selection_requirement" />
+            <tag name="templating.helper" alias="sylius_checkout_steps" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
@@ -22,18 +22,19 @@ sylius:
             name: Name
             roles: Roles
         channel:
-            taxonomies: Taxonomies
+            contact_email: Contact email
+            currencies: Currencies
+            currency_base: Base currency
+            hostname: Hostname
             locale_default: Default locale
             locales: Locales
-            contact_email: Contact email
-            currency_base: Base currency
-            currencies: Currencies
-            shipping_methods: Shipping Methods
             payment_methods: Payment Methods
+            shipping_methods: Shipping Methods
+            skipping_shipping_step_allowed: Skip shipping step if only one shipping method is available?
             tax_calculation_strategy: Tax calculation strategy
             tax_zone_default: Default tax zone
+            taxonomies: Taxonomies
             theme: Theme
-            hostname: Hostname
         image:
             type: Type
             file: Image

--- a/src/Sylius/Bundle/CoreBundle/Templating/Helper/CheckoutStepsHelper.php
+++ b/src/Sylius/Bundle/CoreBundle/Templating/Helper/CheckoutStepsHelper.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\CoreBundle\Templating\Helper;
 
+use Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementCheckerInterface;
 use Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementCheckerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Symfony\Component\Templating\Helper\Helper;
@@ -21,16 +22,24 @@ use Symfony\Component\Templating\Helper\Helper;
 class CheckoutStepsHelper extends Helper
 {
     /**
+     * @var OrderPaymentMethodSelectionRequirementCheckerInterface
+     */
+    private $orderPaymentMethodSelectionRequirementChecker;
+
+    /**
      * @var OrderShippingMethodSelectionRequirementCheckerInterface
      */
     private $orderShippingMethodSelectionRequirementChecker;
 
     /**
+     * @param OrderPaymentMethodSelectionRequirementCheckerInterface $orderPaymentMethodSelectionRequirementChecker
      * @param OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker
      */
     public function __construct(
+        OrderPaymentMethodSelectionRequirementCheckerInterface $orderPaymentMethodSelectionRequirementChecker,
         OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker
     ) {
+        $this->orderPaymentMethodSelectionRequirementChecker = $orderPaymentMethodSelectionRequirementChecker;
         $this->orderShippingMethodSelectionRequirementChecker = $orderShippingMethodSelectionRequirementChecker;
     }
 
@@ -51,7 +60,7 @@ class CheckoutStepsHelper extends Helper
      */
     public function isPaymentRequired(OrderInterface $order)
     {
-        return 0 < $order->getTotal();
+        return $this->orderPaymentMethodSelectionRequirementChecker->isPaymentMethodSelectionRequired($order);
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Templating/Helper/CheckoutStepsHelper.php
+++ b/src/Sylius/Bundle/CoreBundle/Templating/Helper/CheckoutStepsHelper.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Templating\Helper;
+
+use Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementCheckerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Symfony\Component\Templating\Helper\Helper;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+class CheckoutStepsHelper extends Helper
+{
+    /**
+     * @var OrderShippingMethodSelectionRequirementCheckerInterface
+     */
+    private $orderShippingMethodSelectionRequirementChecker;
+
+    /**
+     * @param OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker
+     */
+    public function __construct(
+        OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker
+    ) {
+        $this->orderShippingMethodSelectionRequirementChecker = $orderShippingMethodSelectionRequirementChecker;
+    }
+
+    /**
+     * @param OrderInterface $order
+     *
+     * @return bool
+     */
+    public function isShippingRequired(OrderInterface $order)
+    {
+        return $this->orderShippingMethodSelectionRequirementChecker->isShippingMethodSelectionRequired($order);
+    }
+
+    /**
+     * @param OrderInterface $order
+     *
+     * @return bool
+     */
+    public function isPaymentRequired(OrderInterface $order)
+    {
+        return 0 < $order->getTotal();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sylius_checkout_steps';
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Twig/CheckoutStepsExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/CheckoutStepsExtension.php
@@ -37,8 +37,8 @@ final class CheckoutStepsExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('is_shipping_required', [$this->checkoutStepsHelper, 'isShippingRequired']),
-            new \Twig_SimpleFunction('is_payment_required', [$this->checkoutStepsHelper, 'isPaymentRequired']),
+            new \Twig_SimpleFunction('sylius_is_shipping_required', [$this->checkoutStepsHelper, 'isShippingRequired']),
+            new \Twig_SimpleFunction('sylius_is_payment_required', [$this->checkoutStepsHelper, 'isPaymentRequired']),
         ];
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Twig/CheckoutStepsExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/CheckoutStepsExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Twig;
+
+use Sylius\Bundle\CoreBundle\Templating\Helper\CheckoutStepsHelper;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class CheckoutStepsExtension extends \Twig_Extension
+{
+    /**
+     * @var CheckoutStepsHelper
+     */
+    private $checkoutStepsHelper;
+
+    /**
+     * @param CheckoutStepsHelper $checkoutStepsHelper
+     */
+    public function __construct(CheckoutStepsHelper $checkoutStepsHelper)
+    {
+        $this->checkoutStepsHelper = $checkoutStepsHelper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction('is_shipping_required', [$this->checkoutStepsHelper, 'isShippingRequired']),
+            new \Twig_SimpleFunction('is_payment_required', [$this->checkoutStepsHelper, 'isPaymentRequired']),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'sylius_shipping_steps';
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/spec/Templating/Helper/CheckoutStepsHelperSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Templating/Helper/CheckoutStepsHelperSpec.php
@@ -13,6 +13,7 @@ namespace spec\Sylius\Bundle\CoreBundle\Templating\Helper;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\CoreBundle\Templating\Helper\CheckoutStepsHelper;
+use Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementCheckerInterface;
 use Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementCheckerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Symfony\Component\Templating\Helper\Helper;
@@ -22,9 +23,14 @@ use Symfony\Component\Templating\Helper\Helper;
  */
 final class CheckoutStepsHelperSpec extends ObjectBehavior
 {
-    function let(OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker)
-    {
-        $this->beConstructedWith($orderShippingMethodSelectionRequirementChecker);
+    function let(
+        OrderPaymentMethodSelectionRequirementCheckerInterface $orderPaymentMethodSelectionRequirementChecker,
+        OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker
+    ) {
+        $this->beConstructedWith(
+            $orderPaymentMethodSelectionRequirementChecker,
+            $orderShippingMethodSelectionRequirementChecker
+        );
     }
 
     function it_is_initializable()
@@ -46,13 +52,12 @@ final class CheckoutStepsHelperSpec extends ObjectBehavior
         $this->isShippingRequired($order)->shouldReturn(true);
     }
 
-    function it_checks_if_order_required_payment(OrderInterface $order)
-    {
-        $order->getTotal()->willReturn(100);
+    function it_checks_if_order_required_payment(
+        OrderInterface $order,
+        OrderPaymentMethodSelectionRequirementCheckerInterface $orderPaymentMethodSelectionRequirementChecker
+    ) {
+        $orderPaymentMethodSelectionRequirementChecker->isPaymentMethodSelectionRequired($order)->willReturn(true);
         $this->isPaymentRequired($order)->shouldReturn(true);
-
-        $order->getTotal()->willReturn(0);
-        $this->isPaymentRequired($order)->shouldReturn(false);
     }
 
     function it_has_name()

--- a/src/Sylius/Bundle/CoreBundle/spec/Templating/Helper/CheckoutStepsHelperSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Templating/Helper/CheckoutStepsHelperSpec.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\CoreBundle\Templating\Helper;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\CoreBundle\Templating\Helper\CheckoutStepsHelper;
+use Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementCheckerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Symfony\Component\Templating\Helper\Helper;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class CheckoutStepsHelperSpec extends ObjectBehavior
+{
+    function let(OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker)
+    {
+        $this->beConstructedWith($orderShippingMethodSelectionRequirementChecker);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(CheckoutStepsHelper::class);
+    }
+
+    function it_is_helper()
+    {
+        $this->shouldHaveType(Helper::class);
+    }
+
+    function it_checks_if_order_requires_shipping(
+        OrderInterface $order,
+        OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker
+    ) {
+        $orderShippingMethodSelectionRequirementChecker->isShippingMethodSelectionRequired($order)->willReturn(true);
+
+        $this->isShippingRequired($order)->shouldReturn(true);
+    }
+
+    function it_checks_if_order_required_payment(OrderInterface $order)
+    {
+        $order->getTotal()->willReturn(100);
+        $this->isPaymentRequired($order)->shouldReturn(true);
+
+        $order->getTotal()->willReturn(0);
+        $this->isPaymentRequired($order)->shouldReturn(false);
+    }
+
+    function it_has_name()
+    {
+        $this->getName()->shouldReturn('sylius_checkout_steps');
+    }
+
+}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_navigation.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_navigation.html.twig
@@ -2,7 +2,7 @@
 
 <div class="ui two column grid">
     <div class="column">
-        {% if is_shipping_required(order) %}
+        {% if sylius_is_shipping_required(order) %}
             <a href="{{ path('sylius_shop_checkout_select_shipping') }}" class="ui large icon labeled button"><i class="arrow left icon"></i> {{ 'sylius.ui.change_shipping_method'|trans }}</a>
         {% else %}
             <a href="{{ path('sylius_shop_checkout_address') }}" class="ui large icon labeled button"><i class="arrow left icon"></i> {{ 'sylius.ui.change_address'|trans }}</a>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_navigation.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_navigation.html.twig
@@ -2,7 +2,11 @@
 
 <div class="ui two column grid">
     <div class="column">
-        <a href="{{ path('sylius_shop_checkout_select_shipping') }}" class="ui large icon labeled button"><i class="arrow left icon"></i> {{ 'sylius.ui.change_shipping_method'|trans }}</a>
+        {% if is_shipping_required(order) %}
+            <a href="{{ path('sylius_shop_checkout_select_shipping') }}" class="ui large icon labeled button"><i class="arrow left icon"></i> {{ 'sylius.ui.change_shipping_method'|trans }}</a>
+        {% else %}
+            <a href="{{ path('sylius_shop_checkout_address') }}" class="ui large icon labeled button"><i class="arrow left icon"></i> {{ 'sylius.ui.change_address'|trans }}</a>
+        {% endif %}
     </div>
     <div class="right aligned column">
         <button type="submit" id="next-step" class="ui large primary icon labeled{% if not enabled %} disabled{% endif %} button">

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_steps.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_steps.html.twig
@@ -8,8 +8,8 @@
     {% set steps = {'address': 'completed', 'select_shipping': 'completed', 'select_payment': 'completed', 'complete': 'active'} %}
 {% endif %}
 
-{% set order_requires_payment = is_payment_required(order) %}
-{% set order_requires_shipping = is_shipping_required(order) %}
+{% set order_requires_payment = sylius_is_payment_required(order) %}
+{% set order_requires_shipping = sylius_is_shipping_required(order) %}
 
 {% set steps_count = 'four' %}
 {% if not order_requires_payment and not order_requires_shipping %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_steps.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_steps.html.twig
@@ -8,8 +8,8 @@
     {% set steps = {'address': 'completed', 'select_shipping': 'completed', 'select_payment': 'completed', 'complete': 'active'} %}
 {% endif %}
 
-{% set order_requires_payment = (order.total != 0) %}
-{% set order_requires_shipping = (order.shipments|length > 0) %}
+{% set order_requires_payment = is_payment_required(order) %}
+{% set order_requires_shipping = is_shipping_required(order) %}
 
 {% set steps_count = 'four' %}
 {% if not order_requires_payment and not order_requires_shipping %}

--- a/src/Sylius/Component/Core/Checker/OrderPaymentMethodSelectionRequirementChecker.php
+++ b/src/Sylius/Component/Core/Checker/OrderPaymentMethodSelectionRequirementChecker.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Checker;
+
+use Sylius\Component\Core\Model\OrderInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class OrderPaymentMethodSelectionRequirementChecker implements OrderPaymentMethodSelectionRequirementCheckerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isPaymentMethodSelectionRequired(OrderInterface $order)
+    {
+        return 0 < $order->getTotal();
+    }
+}

--- a/src/Sylius/Component/Core/Checker/OrderPaymentMethodSelectionRequirementCheckerInterface.php
+++ b/src/Sylius/Component/Core/Checker/OrderPaymentMethodSelectionRequirementCheckerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Checker;
+
+use Sylius\Component\Core\Model\OrderInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+interface OrderPaymentMethodSelectionRequirementCheckerInterface
+{
+    /**
+     * @param OrderInterface $order
+     *
+     * @return bool
+     */
+    public function isPaymentMethodSelectionRequired(OrderInterface $order);
+}

--- a/src/Sylius/Component/Core/Checker/OrderShippingMethodSelectionRequirementChecker.php
+++ b/src/Sylius/Component/Core/Checker/OrderShippingMethodSelectionRequirementChecker.php
@@ -47,6 +47,10 @@ final class OrderShippingMethodSelectionRequirementChecker implements OrderShipp
             return true;
         }
 
+        if (!$order->getChannel()->isSkippingShippingStepAllowed()) {
+            return true;
+        }
+
         /** @var ShipmentInterface $shipment */
         foreach ($order->getShipments() as $shipment) {
             if (1 !== count($this->shippingMethodsResolver->getSupportedMethods($shipment))) {

--- a/src/Sylius/Component/Core/Checker/OrderShippingMethodSelectionRequirementChecker.php
+++ b/src/Sylius/Component/Core/Checker/OrderShippingMethodSelectionRequirementChecker.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Checker;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class OrderShippingMethodSelectionRequirementChecker implements OrderShippingMethodSelectionRequirementCheckerInterface
+{
+    /**
+     * @var ShippingMethodsResolverInterface
+     */
+    private $shippingMethodsResolver;
+
+    /**
+     * @param ShippingMethodsResolverInterface $shippingMethodsResolver
+     */
+    public function __construct(ShippingMethodsResolverInterface $shippingMethodsResolver)
+    {
+        $this->shippingMethodsResolver = $shippingMethodsResolver;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isShippingMethodSelectionRequired(OrderInterface $order)
+    {
+        if (!$this->ifItemsRequireShipping($order)) {
+            return false;
+        }
+
+        if (!$order->hasShipments()) {
+            return true;
+        }
+
+        /** @var ShipmentInterface $shipment */
+        foreach ($order->getShipments() as $shipment) {
+            if (1 !== count($this->shippingMethodsResolver->getSupportedMethods($shipment))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param OrderInterface $order
+     *
+     * @return bool
+     */
+    private function ifItemsRequireShipping(OrderInterface $order)
+    {
+        /** @var OrderItemInterface $orderItem */
+        foreach ($order->getItems() as $orderItem) {
+            if ($orderItem->getVariant()->isShippingRequired()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Sylius/Component/Core/Checker/OrderShippingMethodSelectionRequirementCheckerInterface.php
+++ b/src/Sylius/Component/Core/Checker/OrderShippingMethodSelectionRequirementCheckerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Checker;
+
+use Sylius\Component\Core\Model\OrderInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+interface OrderShippingMethodSelectionRequirementCheckerInterface
+{
+    /**
+     * @param OrderInterface $order
+     *
+     * @return bool
+     */
+    public function isShippingMethodSelectionRequired(OrderInterface $order);
+}

--- a/src/Sylius/Component/Core/Model/Channel.php
+++ b/src/Sylius/Component/Core/Model/Channel.php
@@ -63,6 +63,11 @@ class Channel extends BaseChannel implements ChannelInterface
      */
     protected $contactEmail;
 
+    /**
+     * @var bool
+     */
+    protected $skippingShippingStepAllowed = false;
+
     public function __construct()
     {
         parent::__construct();
@@ -237,5 +242,21 @@ class Channel extends BaseChannel implements ChannelInterface
     public function setContactEmail($contactEmail)
     {
         $this->contactEmail = $contactEmail;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isSkippingShippingStepAllowed()
+    {
+        return $this->skippingShippingStepAllowed;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSkippingShippingStepAllowed($skippingShippingStepAllowed)
+    {
+        $this->skippingShippingStepAllowed = $skippingShippingStepAllowed;
     }
 }

--- a/src/Sylius/Component/Core/Model/ChannelInterface.php
+++ b/src/Sylius/Component/Core/Model/ChannelInterface.php
@@ -85,4 +85,14 @@ interface ChannelInterface extends
      * @param string $contactEmail
      */
     public function setContactEmail($contactEmail);
+
+    /**
+     * @return bool
+     */
+    public function isSkippingShippingStepAllowed();
+
+    /**
+     * @param bool $skippingShippingStepAllowed
+     */
+    public function setSkippingShippingStepAllowed($skippingShippingStepAllowed);
 }

--- a/src/Sylius/Component/Core/StateResolver/CheckoutStateResolver.php
+++ b/src/Sylius/Component/Core/StateResolver/CheckoutStateResolver.php
@@ -12,6 +12,7 @@
 namespace Sylius\Component\Core\StateResolver;
 
 use SM\Factory\FactoryInterface;
+use Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementCheckerInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\OrderCheckoutTransitions;
@@ -21,6 +22,7 @@ use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
 
 /**
  * @author Anna Walasek <anna.walasek@lakion.com>
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
 final class CheckoutStateResolver implements StateResolverInterface
 {
@@ -30,20 +32,20 @@ final class CheckoutStateResolver implements StateResolverInterface
     private $stateMachineFactory;
 
     /**
-     * @var ShippingMethodsResolverInterface
+     * @var OrderShippingMethodSelectionRequirementCheckerInterface
      */
-    private $shippingMethodsResolver;
+    private $orderShippingMethodSelectionRequirementChecker;
 
     /**
      * @param FactoryInterface $stateMachineFactory
-     * @param ShippingMethodsResolverInterface $shippingMethodsResolver
+     * @param OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker
      */
     public function __construct(
         FactoryInterface $stateMachineFactory,
-        ShippingMethodsResolverInterface $shippingMethodsResolver
+        OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker
     ) {
         $this->stateMachineFactory = $stateMachineFactory;
-        $this->shippingMethodsResolver = $shippingMethodsResolver;
+        $this->orderShippingMethodSelectionRequirementChecker = $orderShippingMethodSelectionRequirementChecker;
     }
 
     /**
@@ -54,7 +56,7 @@ final class CheckoutStateResolver implements StateResolverInterface
         $stateMachine = $this->stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH);
 
         if (
-            (!$this->isShippingRequired($order) || $this->isOnlyOneShippingMethodAvailableForEachShipment($order))
+            !$this->orderShippingMethodSelectionRequirementChecker->isShippingMethodSelectionRequired($order)
             && $stateMachine->can(OrderCheckoutTransitions::TRANSITION_SKIP_SHIPPING)
         ) {
             $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SKIP_SHIPPING);
@@ -63,44 +65,5 @@ final class CheckoutStateResolver implements StateResolverInterface
         if (0 === $order->getTotal() && $stateMachine->can(OrderCheckoutTransitions::TRANSITION_SKIP_PAYMENT)) {
             $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_SKIP_PAYMENT);
         }
-    }
-
-
-    /**
-     * @param OrderInterface $order
-     *
-     * @return bool
-     */
-    private function isShippingRequired(OrderInterface $order)
-    {
-        /** @var OrderItemInterface $orderItem */
-        foreach ($order->getItems() as $orderItem) {
-            if ($orderItem->getVariant()->isShippingRequired()) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @param OrderInterface $order
-     *
-     * @return bool
-     */
-    private function isOnlyOneShippingMethodAvailableForEachShipment(OrderInterface $order)
-    {
-        if (!$order->hasShipments()) {
-            return false;
-        }
-
-        /** @var ShipmentInterface $shipment */
-        foreach ($order->getShipments() as $shipment) {
-            if (1 !== count($this->shippingMethodsResolver->getSupportedMethods($shipment))) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/src/Sylius/Component/Core/spec/Checker/OrderPaymentMethodSelectionRequirementCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Checker/OrderPaymentMethodSelectionRequirementCheckerSpec.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Core\Checker;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementChecker;
+use Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementCheckerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class OrderPaymentMethodSelectionRequirementCheckerSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(OrderPaymentMethodSelectionRequirementChecker::class);
+    }
+
+    function it_implements_order_payment_necessity_checker_interface()
+    {
+        $this->shouldImplement(OrderPaymentMethodSelectionRequirementCheckerInterface::class);
+    }
+
+    function it_says_that_payment_method_have_to_be_selected_if_order_total_is_bigger_than_0(OrderInterface $order)
+    {
+        $order->getTotal()->willReturn(1000);
+
+        $this->isPaymentMethodSelectionRequired($order)->shouldReturn(true);
+    }
+
+    function it_says_that_payment_method_do_not_have_to_be_selected_if_order_total_is_0(OrderInterface $order)
+    {
+        $order->getTotal()->willReturn(0);
+
+        $this->isPaymentMethodSelectionRequired($order)->shouldReturn(false);
+    }
+}

--- a/src/Sylius/Component/Core/spec/Checker/OrderShippingMethodSelectionRequirementCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Checker/OrderShippingMethodSelectionRequirementCheckerSpec.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Component\Core\Checker;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementChecker;
+use Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementCheckerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+use Sylius\Component\Core\Model\ShippingMethodInterface;
+use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class OrderShippingMethodSelectionRequirementCheckerSpec extends ObjectBehavior
+{
+    function let(ShippingMethodsResolverInterface $shippingMethodsResolver)
+    {
+        $this->beConstructedWith($shippingMethodsResolver);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(OrderShippingMethodSelectionRequirementChecker::class);
+    }
+
+    function it_implements_order_shipping_necessity_checker_interface()
+    {
+        $this->shouldImplement(OrderShippingMethodSelectionRequirementCheckerInterface::class);
+    }
+
+    function it_says_that_shipping_method_do_not_have_to_be_selected_if_none_of_variants_from_order_requires_shipping(
+        OrderInterface $order,
+        OrderItemInterface $firstItem,
+        OrderItemInterface $secondItem,
+        ProductVariantInterface $firstProductVariant,
+        ProductVariantInterface $secondProductVariant
+    ) {
+        $order->getItems()->willReturn([$firstItem, $secondItem]);
+
+        $firstItem->getVariant()->willReturn($firstProductVariant);
+        $secondItem->getVariant()->willReturn($secondProductVariant);
+
+        $firstProductVariant->isShippingRequired()->willReturn(false);
+        $secondProductVariant->isShippingRequired()->willReturn(false);
+
+        $order->hasShipments()->willReturn(false);
+
+        $this->isShippingMethodSelectionRequired($order)->shouldReturn(false);
+    }
+
+    function it_says_that_shipping_method_do_not_have_to_be_selected_if_order_variants_require_shipping_but_there_is_only_one_shipping_method_available(
+        OrderInterface $order,
+        OrderItemInterface $firstItem,
+        OrderItemInterface $secondItem,
+        ProductVariantInterface $firstProductVariant,
+        ProductVariantInterface $secondProductVariant,
+        ShipmentInterface $shipment,
+        ShippingMethodInterface $shippingMethod,
+        ShippingMethodsResolverInterface $shippingMethodsResolver
+    ) {
+        $order->getItems()->willReturn([$firstItem, $secondItem]);
+
+        $firstItem->getVariant()->willReturn($firstProductVariant);
+        $secondItem->getVariant()->willReturn($secondProductVariant);
+
+        $firstProductVariant->isShippingRequired()->willReturn(false);
+        $secondProductVariant->isShippingRequired()->willReturn(true);
+
+        $order->hasShipments()->willReturn(true);
+        $order->getShipments()->willReturn([$shipment]);
+
+        $shippingMethodsResolver->getSupportedMethods($shipment)->willReturn([$shippingMethod]);
+
+        $this->isShippingMethodSelectionRequired($order)->shouldReturn(false);
+    }
+
+    function it_says_that_shipping_method_have_to_be_selected_if_order_variants_require_shipping_and_order_has_not_shipments_yet(
+        OrderInterface $order,
+        OrderItemInterface $firstItem,
+        OrderItemInterface $secondItem,
+        ProductVariantInterface $firstProductVariant,
+        ProductVariantInterface $secondProductVariant
+    ) {
+        $order->getItems()->willReturn([$firstItem, $secondItem]);
+
+        $firstItem->getVariant()->willReturn($firstProductVariant);
+        $secondItem->getVariant()->willReturn($secondProductVariant);
+
+        $firstProductVariant->isShippingRequired()->willReturn(false);
+        $secondProductVariant->isShippingRequired()->willReturn(true);
+
+        $order->hasShipments()->willReturn(false);
+
+        $this->isShippingMethodSelectionRequired($order)->shouldReturn(true);
+    }
+
+    function it_says_that_shipping_method_have_to_be_selected_if_order_variants_require_shipping_and_there_is_more_than_one_shipping_method_available(
+        OrderInterface $order,
+        OrderItemInterface $firstItem,
+        OrderItemInterface $secondItem,
+        ProductVariantInterface $firstProductVariant,
+        ProductVariantInterface $secondProductVariant,
+        ShipmentInterface $shipment,
+        ShippingMethodInterface $firstShippingMethod,
+        ShippingMethodInterface $secondShippingMethod,
+        ShippingMethodsResolverInterface $shippingMethodsResolver
+    ) {
+        $order->getItems()->willReturn([$firstItem, $secondItem]);
+
+        $firstItem->getVariant()->willReturn($firstProductVariant);
+        $secondItem->getVariant()->willReturn($secondProductVariant);
+
+        $firstProductVariant->isShippingRequired()->willReturn(false);
+        $secondProductVariant->isShippingRequired()->willReturn(true);
+
+        $order->hasShipments()->willReturn(true);
+        $order->getShipments()->willReturn([$shipment]);
+
+        $shippingMethodsResolver->getSupportedMethods($shipment)->willReturn([$firstShippingMethod, $secondShippingMethod]);
+
+        $this->isShippingMethodSelectionRequired($order)->shouldReturn(true);
+    }
+}

--- a/src/Sylius/Component/Core/spec/Model/ChannelSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ChannelSpec.php
@@ -143,4 +143,10 @@ final class ChannelSpec extends ObjectBehavior
         $this->setContactEmail($contactEmail);
         $this->getContactEmail()->shouldReturn($contactEmail);
     }
+
+    function it_can_allow_to_skip_shipping_step_if_only_a_single_shipping_method_is_resolved()
+    {
+        $this->setSkippingShippingStepAllowed(true);
+        $this->isSkippingShippingStepAllowed()->shouldReturn(true);
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | yes |
| Related tickets | based on https://github.com/Sylius/Sylius/pull/7276 |
| License         | MIT |

Of course, we should finish iterating over parent PR before merging it, I just open it to have it already on the PRs list.

To-do:
 - [x] solve problems with failing checkout scenarios due to single shipping method setup