### PR TITLE
[API] [Checkout] Remove email from address type

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Form/Type/AddressType.php
+++ b/src/Sylius/Bundle/ApiBundle/Form/Type/AddressType.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ApiBundle\Form\Type;
+
+use Sylius\Bundle\AddressingBundle\Form\Type\AddressType as SyliusAddressType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\Constraints\Valid;
+
+/**
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ */
+final class AddressType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('shippingAddress', SyliusAddressType::class, [
+                'shippable' => true,
+                'constraints' => [new Valid()],
+            ])
+            ->add('billingAddress', SyliusAddressType::class, [
+                'constraints' => [new Valid()],
+            ])
+            ->add('differentBillingAddress', CheckboxType::class, [
+                'mapped' => false,
+                'required' => false,
+                'label' => 'sylius.form.checkout.addressing.different_billing_address',
+            ])
+            ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+                $orderData = $event->getData();
+
+                if (isset($orderData['shippingAddress']) && (!isset($orderData['differentBillingAddress']) || false === $orderData['differentBillingAddress'])) {
+                    $orderData['billingAddress'] = $orderData['shippingAddress'];
+
+                    $event->setData($orderData);
+                }
+            })
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'sylius_api_checkout_address';
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/checkout.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/checkout.yml
@@ -17,7 +17,7 @@ sylius_api_checkout_addressing:
         _controller: sylius.controller.order:updateAction
         _sylius:
             serialization_version: $version
-            form: Sylius\Bundle\CoreBundle\Form\Type\Checkout\AddressType
+            form: Sylius\Bundle\ApiBundle\Form\Type\AddressType
             repository:
                 method: find
                 arguments: [$orderId]

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/form.xml
@@ -52,6 +52,11 @@
         <service id="sylius.form.type.api_product_variant" class="Sylius\Bundle\ApiBundle\Form\Type\ProductVariantType">
             <tag name="form.type" />
         </service>
+
+        <service id="sylius.form.type.api_checkout_address" class="Sylius\Bundle\ApiBundle\Form\Type\AddressType">
+            <tag name="form.type" />
+        </service>
+
         <service id="sylius.form.extension.type.api_order_item" class="Sylius\Bundle\ApiBundle\Form\Type\OrderItemType">
             <argument type="service" id="sylius.repository.product_variant" />
             <tag name="form.type" />

--- a/tests/Controller/CheckoutAddressingApiTest.php
+++ b/tests/Controller/CheckoutAddressingApiTest.php
@@ -48,42 +48,22 @@ final class CheckoutAddressingApiTest extends CheckoutApiTestCase
     /**
      * @test
      */
-    public function it_does_not_allow_to_address_order_without_specifying_customer_email()
-    {
-        $this->loadFixturesFromFile('authentication/api_administrator.yml');
-        $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
-
-        /** @var OrderInterface $cart */
-        $cart = $checkoutData['order1'];
-
-        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType);
-
-        $response = $this->client->getResponse();
-        $this->assertResponse($response, 'checkout/addressing_invalid_customer', Response::HTTP_BAD_REQUEST);
-    }
-
-    /**
-     * @test
-     */
     public function it_does_not_allow_to_address_order_without_specifying_shipping_address()
     {
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
-        $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
+        $this->loadFixturesFromFile('resources/checkout.yml');
 
-        /** @var OrderInterface $cart */
-        $cart = $checkoutData['order1'];
+        $cartId = $this->createCart();
+        $this->addItemToCart($cartId);
 
         $data =
 <<<EOT
         {
-            "different_billing_address": false,
-            "customer": {
-                "email": "john@doe.com"
-            }
+            "different_billing_address": false
         }
 EOT;
 
-        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $data);
+        $this->client->request('PUT', $this->getAddressingUrl($cartId), [], [], static::$authorizedHeaderWithContentType, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/addressing_validation_failed_shipping_address', Response::HTTP_BAD_REQUEST);
@@ -96,10 +76,10 @@ EOT;
     {
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $this->loadFixturesFromFile('resources/countries.yml');
-        $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
+        $this->loadFixturesFromFile('resources/checkout.yml');
 
-        /** @var OrderInterface $cart */
-        $cart = $checkoutData['order1'];
+        $cartId = $this->createCart();
+        $this->addItemToCart($cartId);
 
         $data =
 <<<EOT
@@ -112,14 +92,11 @@ EOT;
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "different_billing_address": false,
-            "customer": {
-                "email": "john@doe.com"
-            }
+            "different_billing_address": false
         }
 EOT;
 
-        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $data);
+        $this->client->request('PUT', $this->getAddressingUrl($cartId), [], [], static::$authorizedHeaderWithContentType, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
@@ -133,10 +110,10 @@ EOT;
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $this->loadFixturesFromFile('resources/countries.yml');
         $this->loadFixturesFromFile('resources/customers.yml');
-        $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
+        $this->loadFixturesFromFile('resources/checkout.yml');
 
-        /** @var OrderInterface $cart */
-        $cart = $checkoutData['order1'];
+        $cartId = $this->createCart();
+        $this->addItemToCart($cartId);
 
         $data =
 <<<EOT
@@ -149,14 +126,11 @@ EOT;
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "different_billing_address": true,
-            "customer": {
-                "email": "john@doe.com"
-            }
+            "different_billing_address": true
         }
 EOT;
 
-        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $data);
+        $this->client->request('PUT', $this->getAddressingUrl($cartId), [], [], static::$authorizedHeaderWithContentType, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/addressing_validation_failed_billing_address', Response::HTTP_BAD_REQUEST);
@@ -169,10 +143,10 @@ EOT;
     {
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $this->loadFixturesFromFile('resources/countries.yml');
-        $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
+        $this->loadFixturesFromFile('resources/checkout.yml');
 
-        /** @var OrderInterface $cart */
-        $cart = $checkoutData['order1'];
+        $cartId = $this->createCart();
+        $this->addItemToCart($cartId);
 
         $data =
 <<<EOT
@@ -193,19 +167,16 @@ EOT;
                 "city": "Groot Zundert",
                 "postcode": "88-888"
             },
-            "different_billing_address": true,
-            "customer": {
-                "email": "john@doe.com"
-            }
+            "different_billing_address": true
         }
 EOT;
 
-        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $data);
+        $this->client->request('PUT', $this->getAddressingUrl($cartId), [], [], static::$authorizedHeaderWithContentType, $data);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
 
-        $this->client->request('GET', $this->getCheckoutSummaryUrl($cart), [], [], static::$authorizedHeaderWithAccept);
+        $this->client->request('GET', $this->getCheckoutSummaryUrl($cartId), [], [], static::$authorizedHeaderWithAccept);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'checkout/addressed_order_response');
@@ -218,10 +189,10 @@ EOT;
     {
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $this->loadFixturesFromFile('resources/countries.yml');
-        $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
+        $this->loadFixturesFromFile('resources/checkout.yml');
 
-        /** @var OrderInterface $cart */
-        $cart = $checkoutData['order1'];
+        $cartId = $this->createCart();
+        $this->addItemToCart($cartId);
 
         $data =
 <<<EOT
@@ -234,14 +205,11 @@ EOT;
                 "city": "Groot Zundert",
                 "postcode": "88-888"
             },
-            "different_billing_address": false,
-            "customer": {
-                "email": "john@doe.com"
-            }
+            "different_billing_address": false
         }
 EOT;
 
-        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $data);
+        $this->client->request('PUT', $this->getAddressingUrl($cartId), [], [], static::$authorizedHeaderWithContentType, $data);
 
         $newData =
 <<<EOT
@@ -254,14 +222,11 @@ EOT;
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "different_billing_address": false,
-            "customer": {
-                "email": "john@doe.com"
-            }
+            "different_billing_address": false
         }
 EOT;
 
-        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $newData);
+        $this->client->request('PUT', $this->getAddressingUrl($cartId), [], [], static::$authorizedHeaderWithContentType, $newData);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
@@ -274,10 +239,10 @@ EOT;
     {
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $this->loadFixturesFromFile('resources/countries.yml');
-        $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
+        $this->loadFixturesFromFile('resources/checkout.yml');
 
-        /** @var OrderInterface $cart */
-        $cart = $checkoutData['order1'];
+        $cartId = $this->createCart();
+        $this->addItemToCart($cartId);
 
         $addressData =
 <<<EOT
@@ -290,16 +255,13 @@ EOT;
                 "city": "Groot Zundert",
                 "postcode": "88-888"
             },
-            "different_billing_address": false,
-            "customer": {
-                "email": "john@doe.com"
-            }
+            "different_billing_address": false
         }
 EOT;
 
-        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $addressData);
+        $this->client->request('PUT', $this->getAddressingUrl($cartId), [], [], static::$authorizedHeaderWithContentType, $addressData);
 
-        $this->selectOrderShippingMethod($cart);
+        $this->selectOrderShippingMethod($cartId);
 
         $newAddressData =
 <<<EOT
@@ -312,14 +274,11 @@ EOT;
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "different_billing_address": false,
-            "customer": {
-                "email": "john@doe.com"
-            }
+            "different_billing_address": false
         }
 EOT;
 
-        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $newAddressData);
+        $this->client->request('PUT', $this->getAddressingUrl($cartId), [], [], static::$authorizedHeaderWithContentType, $newAddressData);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
@@ -332,10 +291,10 @@ EOT;
     {
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
         $this->loadFixturesFromFile('resources/countries.yml');
-        $checkoutData = $this->loadFixturesFromFile('resources/checkout.yml');
+        $this->loadFixturesFromFile('resources/checkout.yml');
 
-        /** @var OrderInterface $cart */
-        $cart = $checkoutData['order1'];
+        $cartId = $this->createCart();
+        $this->addItemToCart($cartId);
 
         $addressData =
 <<<EOT
@@ -348,17 +307,14 @@ EOT;
                 "city": "Groot Zundert",
                 "postcode": "88-888"
             },
-            "different_billing_address": false,
-            "customer": {
-                "email": "john@doe.com"
-            }
+            "different_billing_address": false
         }
 EOT;
 
-        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $addressData);
+        $this->client->request('PUT', $this->getAddressingUrl($cartId), [], [], static::$authorizedHeaderWithContentType, $addressData);
 
-        $this->selectOrderShippingMethod($cart);
-        $this->selectOrderPaymentMethod($cart);
+        $this->selectOrderShippingMethod($cartId);
+        $this->selectOrderPaymentMethod($cartId);
 
         $newAddressData =
 <<<EOT
@@ -371,26 +327,23 @@ EOT;
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "different_billing_address": false,
-            "customer": {
-                "email": "john@doe.com"
-            }
+            "different_billing_address": false
         }
 EOT;
 
-        $this->client->request('PUT', $this->getAddressingUrl($cart), [], [], static::$authorizedHeaderWithContentType, $newAddressData);
+        $this->client->request('PUT', $this->getAddressingUrl($cartId), [], [], static::$authorizedHeaderWithContentType, $newAddressData);
 
         $response = $this->client->getResponse();
         $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
     }
 
     /**
-     * @param OrderInterface $cart
+     * @param mixed $cartId
      *
      * @return string
      */
-    private function getAddressingUrl(OrderInterface $cart)
+    private function getAddressingUrl($cartId)
     {
-        return sprintf('/api/v1/checkouts/addressing/%d', $cart->getId());
+        return sprintf('/api/v1/checkouts/addressing/%d', $cartId);
     }
 }

--- a/tests/Controller/CheckoutApiTestCase.php
+++ b/tests/Controller/CheckoutApiTestCase.php
@@ -38,9 +38,49 @@ class CheckoutApiTestCase extends JsonApiTestCase
     ];
 
     /**
-     * @param OrderInterface $order
+     * @return mixed
      */
-    protected function addressOrder(OrderInterface $order)
+    protected function createCart()
+    {
+        $data =
+<<<EOT
+        {
+            "customer": "oliver.queen@star-city.com",
+            "channel": "CHANNEL",
+            "locale_code": "en_US"
+        }
+EOT;
+
+        $this->client->request('POST', '/api/v1/carts/', [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $rawResponse = json_decode($response->getContent(), true);
+
+        return $rawResponse['id'];
+    }
+
+    /**
+     * @param mixed $cartId
+     */
+    protected function addItemToCart($cartId)
+    {
+        $url = sprintf('/api/v1/carts/%d/items/', $cartId);
+
+        $data =
+<<<EOT
+        {
+            "variant": "MUG_SW",
+            "quantity": 1
+        }
+EOT;
+
+        $this->client->request('POST', $url, [], [], static::$authorizedHeaderWithContentType, $data);
+    }
+
+    /**
+     * @param mixed $cartId
+     */
+    protected function addressOrder($cartId)
     {
         $this->loadFixturesFromFile('resources/countries.yml');
 
@@ -63,23 +103,20 @@ class CheckoutApiTestCase extends JsonApiTestCase
                 "city": "Groot Zundert",
                 "postcode": "88-888"
             },
-            "different_billing_address": true,
-            "customer": {
-                "email": "john@doe.com"
-            }
+            "different_billing_address": true
         }
 EOT;
 
-        $url = sprintf('/api/v1/checkouts/addressing/%d', $order->getId());
+        $url = sprintf('/api/v1/checkouts/addressing/%d', $cartId);
         $this->client->request('PUT', $url, [], [], static::$authorizedHeaderWithContentType, $data);
     }
 
     /**
-     * @param OrderInterface $order
+     * @param mixed $cartId
      */
-    protected function selectOrderShippingMethod(OrderInterface $order)
+    protected function selectOrderShippingMethod($cartId)
     {
-        $url = sprintf('/api/v1/checkouts/select-shipping/%d', $order->getId());
+        $url = sprintf('/api/v1/checkouts/select-shipping/%d', $cartId);
 
         $this->client->request('GET', $url, [], [], static::$authorizedHeaderWithContentType);
 
@@ -101,11 +138,11 @@ EOT;
     }
 
     /**
-     * @param OrderInterface $order
+     * @param mixed $cartId
      */
-    protected function selectOrderPaymentMethod(OrderInterface $order)
+    protected function selectOrderPaymentMethod($cartId)
     {
-        $url = sprintf('/api/v1/checkouts/select-payment/%d', $order->getId());
+        $url = sprintf('/api/v1/checkouts/select-payment/%d', $cartId);
 
         $this->client->request('GET', $url, [], [], static::$authorizedHeaderWithContentType);
 
@@ -127,12 +164,12 @@ EOT;
     }
 
     /**
-     * @param OrderInterface $cart
+     * @param mixed $cartId
      *
      * @return string
      */
-    protected function getCheckoutSummaryUrl(OrderInterface $cart)
+    protected function getCheckoutSummaryUrl($cartId)
     {
-        return sprintf('/api/v1/checkouts/%d', $cart->getId());
+        return sprintf('/api/v1/checkouts/%d', $cartId);
     }
 }

--- a/tests/DataFixtures/ORM/resources/checkout.yml
+++ b/tests/DataFixtures/ORM/resources/checkout.yml
@@ -1,21 +1,3 @@
-Sylius\Component\Core\Model\Order:
-    order1:
-        channel: "@channel"
-        currencyCode: "EUR"
-        addItem: ["@orderItem1"]
-        localeCode: "en_US"
-
-Sylius\Component\Core\Model\OrderItem:
-    orderItem1:
-        quantity: 1
-        unitPrice: 2000
-        addUnit: ["@orderItemUnit1"]
-        variant: "@productVariant1"
-
-Sylius\Component\Core\Model\OrderItemUnit:
-    orderItemUnit1:
-        __construct: ["@orderItem1"]
-
 Sylius\Component\Core\Model\Channel:
     channel:
         code: "CHANNEL"
@@ -30,46 +12,53 @@ Sylius\Component\Core\Model\Channel:
         currencies: ["@currency"]
 
 Sylius\Component\Core\Model\Product:
-    product1:
-        updatedAt: 2015-10-10
+    mug:
+        code: MUG
+        channels: ["@channel"]
         currentLocale: en_US
-        currentTranslation: "@productTranslation1"
-        variants: ["@productVariant1"]
-        code: MUG_SW
-    product2:
-        updatedAt: 2015-10-04
-        currentLocale: en_US
-        currentTranslation: "@productTranslation2"
-        variants: ["@productVariant2"]
-        code: MUG_LOTR
+        currentTranslation: "@mug_translation"
 
 Sylius\Component\Core\Model\ProductTranslation:
-    productTranslation1:
-        slug: mug-star-wars
+    mug_translation:
+        slug: mug
         locale: en_US
-        name: 'Star wars mug'
+        name: 'Mug'
         description: <paragraph(2)>
-        translatable: "@product1"
-    productTranslation2:
-        slug: mug-lotr
-        locale: en_US
-        name: 'Lotr mug'
-        description: <paragraph(2)>
-        translatable: "@product2"
+        translatable: "@mug"
 
 Sylius\Component\Core\Model\ProductVariant:
-    productVariant1:
-        code: MUG_1
-        channelPricings: ["@channelPricing1"]
-    productVariant2:
-        code: MUG_2
-        channelPricings: ["@channelPricing2"]
+    mug_sw:
+        code: MUG_SW
+        product: "@mug"
+        currentLocale: en_US
+        currentTranslation: "@sw_mug_translation"
+        updatedAt: 2015-10-10
+        channelPricings: ["@sw_mug_web_channel_pricing"]
+    hard_available_mug:
+        code: HARD_AVAILABLE_MUG
+        product: "@mug"
+        currentLocale: en_US
+        currentTranslation: "@hard_available_mug_translation"
+        updatedAt: 2015-10-05
+        channelPricings: ["@hard_available_mug_web_channel_pricing"]
+        tracked: true
+        onHand: 2
+
+Sylius\Component\Product\Model\ProductVariantTranslation:
+    sw_mug_translation:
+        locale: en_US
+        name: 'Star wars mug'
+        translatable: "@mug_sw"
+    hard_available_mug_translation:
+        locale: en_US
+        name: 'Breaking bad mug'
+        translatable: "@hard_available_mug"
 
 Sylius\Component\Core\Model\ChannelPricing:
-    channelPricing1:
+    sw_mug_web_channel_pricing:
         channel: "@channel"
         price: 20
-    channelPricing2:
+    hard_available_mug_web_channel_pricing:
         channel: "@channel"
         price: 20
 
@@ -151,3 +140,11 @@ Sylius\Component\Addressing\Model\Zone:
 Sylius\Component\Addressing\Model\ZoneMember:
     member_{NL, BE}:
         code: <current()>
+
+Sylius\Component\Core\Model\Customer:
+    customer_oliver:
+        firstName: Oliver
+        lastName: Queen
+        email: oliver.queen@star-city.com
+        emailCanonical: oliver.queen@star-city.com
+        birthday: <date()>

--- a/tests/Responses/Expected/checkout/addressed_order_response.json
+++ b/tests/Responses/Expected/checkout/addressed_order_response.json
@@ -8,8 +8,11 @@
     "state": "cart",
     "customer": {
         "id": @integer@,
-        "email": "john@doe.com",
-        "email_canonical": "john@doe.com",
+        "email": "oliver.queen@star-city.com",
+        "email_canonical": "oliver.queen@star-city.com",
+        "first_name": "Oliver",
+        "last_name": "Queen",
+        "birthday": "@string@.isDateTime()",
         "gender": "u",
         "_links": {
             "self": {

--- a/tests/Responses/Expected/checkout/addressing_invalid_customer.json
+++ b/tests/Responses/Expected/checkout/addressing_invalid_customer.json
@@ -75,16 +75,7 @@
           }
         }
       },
-      "differentBillingAddress": {},
-      "customer": {
-        "children": {
-          "email": {
-            "errors": [
-              "Please enter your email."
-            ]
-          }
-        }
-      }
+      "differentBillingAddress": {}
     }
   }
 }

--- a/tests/Responses/Expected/checkout/addressing_validation_failed_billing_address.json
+++ b/tests/Responses/Expected/checkout/addressing_validation_failed_billing_address.json
@@ -52,12 +52,7 @@
                     }
                 }
             },
-            "differentBillingAddress": {},
-            "customer": {
-                "children": {
-                    "email": {}
-                }
-            }
+            "differentBillingAddress": {}
         }
     }
 }

--- a/tests/Responses/Expected/checkout/addressing_validation_failed_shipping_address.json
+++ b/tests/Responses/Expected/checkout/addressing_validation_failed_shipping_address.json
@@ -75,12 +75,7 @@
                     }
                 }
             },
-            "differentBillingAddress": {},
-            "customer": {
-                "children": {
-                    "email": {}
-                }
-            }
+            "differentBillingAddress": {}
         }
     }
 }

--- a/tests/Responses/Expected/checkout/completed_order_response.json
+++ b/tests/Responses/Expected/checkout/completed_order_response.json
@@ -10,8 +10,11 @@
     "state": "new",
     "customer": {
         "id": @integer@,
-        "email": "john@doe.com",
-        "email_canonical": "john@doe.com",
+        "email": "oliver.queen@star-city.com",
+        "email_canonical": "oliver.queen@star-city.com",
+        "first_name": "Oliver",
+        "last_name": "Queen",
+        "birthday": "@string@.isDateTime()",
         "gender": "u",
         "_links": {
             "self": {

--- a/tests/Responses/Expected/checkout/payment_selected_order_response.json
+++ b/tests/Responses/Expected/checkout/payment_selected_order_response.json
@@ -8,8 +8,11 @@
   "state": "cart",
   "customer": {
     "id": @integer@,
-    "email": "john@doe.com",
-    "email_canonical": "john@doe.com",
+    "email": "oliver.queen@star-city.com",
+    "email_canonical": "oliver.queen@star-city.com",
+    "first_name": "Oliver",
+    "last_name": "Queen",
+    "birthday": "@string@.isDateTime()",
     "gender": "u",
     "_links": {
       "self": {

--- a/tests/Responses/Expected/checkout/shipping_invalid_order_state.json
+++ b/tests/Responses/Expected/checkout/shipping_invalid_order_state.json
@@ -1,4 +1,25 @@
 {
-    "code": 500,
-    "message": "Transition \"select_shipping\" cannot be applied on state \"cart\" of object \"Sylius\\Component\\Core\\Model\\Order\" with graph \"sylius_order_checkout\""
+    "code": 400,
+    "message": "Validation Failed",
+    "errors": {
+        "children": {
+            "shipments": {
+                "children": [
+                    {
+                        "children": {
+                            "method": {
+                                "errors": [
+                                    "Please select shipping method."
+                                ],
+                                "children": [
+                                    {},
+                                    {}
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
 }

--- a/tests/Responses/Expected/checkout/shipping_selected_order_response.json
+++ b/tests/Responses/Expected/checkout/shipping_selected_order_response.json
@@ -8,8 +8,11 @@
     "state": "cart",
     "customer": {
         "id": @integer@,
-        "email": "john@doe.com",
-        "email_canonical": "john@doe.com",
+        "email": "oliver.queen@star-city.com",
+        "email_canonical": "oliver.queen@star-city.com",
+        "first_name": "Oliver",
+        "last_name": "Queen",
+        "birthday": "@string@.isDateTime()",
         "gender": "u",
         "_links": {
             "self": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes but only in API |
| Related tickets |  |
| License         | MIT |

I have removed an email field from AddressType, because email is required to create a car anyway. There is no need to send it one more time. I have also refactored the whole checkout test suite. Now, to start checkout the cart is built from the scratch, a new item is added, and then the checkout can proceed.