### PR TITLE
[Resource] [DX] Add short message to not found exception

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -463,7 +463,7 @@ class ResourceController extends Controller
     protected function findOr404(RequestConfiguration $configuration)
     {
         if (null === $resource = $this->singleResourceProvider->get($configuration, $this->repository)) {
-            throw new NotFoundHttpException();
+            throw new NotFoundHttpException(sprintf('The "%s" has not been found', $this->metadata->getHumanizedName()));
         }
 
         return $resource;

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
@@ -131,6 +131,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         RepositoryInterface $repository,
         SingleResourceProviderInterface $singleResourceProvider
     ) {
+        $metadata->getHumanizedName()->willReturn('product');
         $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
         $configuration->hasPermission()->willReturn(true);
         $configuration->getPermission(ResourceActions::SHOW)->willReturn('sylius.product.show');
@@ -139,7 +140,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $singleResourceProvider->get($configuration, $repository)->willReturn(null);
 
         $this
-            ->shouldThrow(new NotFoundHttpException())
+            ->shouldThrow(new NotFoundHttpException('The "product" has not been found'))
             ->during('showAction', [$request])
         ;
     }
@@ -687,6 +688,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         RepositoryInterface $repository,
         SingleResourceProviderInterface $singleResourceProvider
     ) {
+        $metadata->getHumanizedName()->willReturn('product');
         $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
         $configuration->hasPermission()->willReturn(true);
         $configuration->getPermission(ResourceActions::UPDATE)->willReturn('sylius.product.update');
@@ -695,7 +697,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $singleResourceProvider->get($configuration, $repository)->willReturn(null);
 
         $this
-            ->shouldThrow(new NotFoundHttpException())
+            ->shouldThrow(new NotFoundHttpException('The "product" has not been found'))
             ->during('updateAction', [$request])
         ;
     }
@@ -1205,6 +1207,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         RepositoryInterface $repository,
         SingleResourceProviderInterface $singleResourceProvider
     ) {
+        $metadata->getHumanizedName()->willReturn('product');
         $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
         $configuration->hasPermission()->willReturn(true);
         $configuration->getPermission(ResourceActions::DELETE)->willReturn('sylius.product.delete');
@@ -1213,7 +1216,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $singleResourceProvider->get($configuration, $repository)->willReturn(null);
 
         $this
-            ->shouldThrow(new NotFoundHttpException())
+            ->shouldThrow(new NotFoundHttpException('The "product" has not been found'))
             ->during('deleteAction', [$request])
         ;
     }
@@ -1491,6 +1494,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         RepositoryInterface $repository,
         SingleResourceProviderInterface $singleResourceProvider
     ) {
+        $metadata->getHumanizedName()->willReturn('product');
         $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
         $configuration->hasPermission()->willReturn(true);
         $configuration->getPermission(ResourceActions::UPDATE)->willReturn('sylius.product.update');
@@ -1499,7 +1503,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $singleResourceProvider->get($configuration, $repository)->willReturn(null);
 
         $this
-            ->shouldThrow(new NotFoundHttpException())
+            ->shouldThrow(new NotFoundHttpException('The "product" has not been found'))
             ->during('applyStateMachineTransitionAction', [$request])
         ;
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | |
| License         | MIT |

Small dx improvement to have at least some message in returned exception.
Before:
```json
{"code":404,"message":""}
```
After:
```json
{"code":404,"message":"The \"order\" has not been found"}
```
or in UI:
<img width="695" alt="zrzut ekranu 2017-02-14 o 11 38 26" src="https://cloud.githubusercontent.com/assets/6213903/22925733/22860fc2-f2aa-11e6-93ea-5f7d7cc80efd.png">

Another thing is the translation of this error, but the same problem lays on the every exception in Sylius. 