### PR TITLE
[RFC] [Core] [Shop] [Admin] Move listeners to the proper bundle

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/EventListener/ShipmentShipListener.php
+++ b/src/Sylius/Bundle/AdminBundle/EventListener/ShipmentShipListener.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\EventListener;
+namespace Sylius\Bundle\AdminBundle\EventListener;
 
 use Sylius\Bundle\CoreBundle\EmailManager\ShipmentEmailManagerInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -15,18 +15,13 @@
     <imports>
         <import resource="services/controller.xml" />
         <import resource="services/menu.xml" />
+        <import resource="services/listener.xml" />
     </imports>
 
     <services>
         <service id="sylius.context.locale.admin_based" class="Sylius\Bundle\AdminBundle\Context\AdminBasedLocaleContext">
             <argument type="service" id="security.token_storage" />
             <tag name="sylius.context.locale" priority="128" />
-        </service>
-
-        <service id="sylius.event_subscriber.resource_delete" class="Sylius\Bundle\AdminBundle\EventListener\ResourceDeleteSubscriber">
-            <argument type="service" id="router" />
-            <argument type="service" id="session" />
-            <tag name="kernel.event_subscriber" event="kernel.exception" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/listener.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/listener.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sylius.listener.shipment_ship" class="Sylius\Bundle\AdminBundle\EventListener\ShipmentShipListener">
+            <argument type="service" id="sylius.email_manager.shipment" />
+            <tag name="kernel.event_listener" event="sylius.shipment.post_ship" method="sendConfirmationEmail" />
+        </service>
+
+        <service id="sylius.event_subscriber.resource_delete" class="Sylius\Bundle\AdminBundle\EventListener\ResourceDeleteSubscriber">
+            <argument type="service" id="router" />
+            <argument type="service" id="session" />
+            <tag name="kernel.event_subscriber" event="kernel.exception" />
+        </service>
+    </services>
+</container>

--- a/src/Sylius/Bundle/AdminBundle/spec/EventListener/ShipmentShipListenerSpec.php
+++ b/src/Sylius/Bundle/AdminBundle/spec/EventListener/ShipmentShipListenerSpec.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace spec\Sylius\Bundle\CoreBundle\EventListener;
+namespace spec\Sylius\Bundle\AdminBundle\EventListener;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\AdminBundle\EventListener\ShipmentShipListener;
 use Sylius\Bundle\CoreBundle\EmailManager\ShipmentEmailManagerInterface;
-use Sylius\Bundle\CoreBundle\EventListener\ShipmentShipListener;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -48,12 +48,6 @@
             <tag name="doctrine.event_listener" event="prePersist" />
             <tag name="doctrine.event_listener" event="preUpdate" />
         </service>
-        <service id="sylius.listener.user_registration" class="Sylius\Bundle\CoreBundle\EventListener\UserRegistrationListener">
-            <argument type="service" id="sylius.manager.shop_user" />
-            <argument type="service" id="sylius.shop_user.token_generator.email_verification" />
-            <argument type="service" id="event_dispatcher" />
-            <tag name="kernel.event_listener" event="sylius.customer.post_register" method="sendVerificationEmail" />
-        </service>
         <service id="sylius.listener.password_updater" class="Sylius\Bundle\CoreBundle\EventListener\PasswordUpdaterListener">
             <argument type="service" id="sylius.security.password_updater" />
             <tag name="kernel.event_listener" event="sylius.user.pre_password_reset" method="genericEventUpdater" />
@@ -72,40 +66,9 @@
             <argument>_sylius.cart</argument>
             <tag name="kernel.event_subscriber" />
         </service>
-        <service id="sylius.listener.order_customer_ip" class="Sylius\Bundle\CoreBundle\EventListener\OrderCustomerIpListener">
-            <argument type="service" id="sylius.customer_ip_assigner" />
-            <argument type="service" id="request_stack" />
-            <tag name="kernel.event_listener" event="sylius.order.pre_complete" method="assignCustomerIpToOrder" />
-        </service>
-        <service id="sylius.listener.order_complete" class="Sylius\Bundle\CoreBundle\EventListener\OrderCompleteListener">
-            <argument type="service" id="sylius.email_manager.order" />
-            <tag name="kernel.event_listener" event="sylius.order.post_complete" method="sendConfirmationEmail" />
-        </service>
-        <service id="sylius.listener.shipment_ship" class="Sylius\Bundle\CoreBundle\EventListener\ShipmentShipListener">
-            <argument type="service" id="sylius.email_manager.shipment" />
-            <tag name="kernel.event_listener" event="sylius.shipment.post_ship" method="sendConfirmationEmail" />
-        </service>
         <service id="sylius.listener.review_create" class="Sylius\Bundle\CoreBundle\EventListener\ReviewCreateListener">
             <argument type="service" id="sylius.context.customer" />
             <tag name="kernel.event_listener" event="sylius.product_review.pre_create" method="ensureReviewHasAuthor" />
-        </service>
-        <service id="sylius.listener.order_promotion_integrity_checker" class="Sylius\Bundle\CoreBundle\EventListener\OrderPromotionIntegrityChecker">
-            <argument type="service" id="sylius.promotion_eligibility_checker" />
-            <argument type="service" id="event_dispatcher" />
-            <argument type="service" id="router" />
-            <tag name="kernel.event_listener" event="sylius.order.pre_complete" method="check" />
-        </service>
-
-        <service id="sylius.listener.order_total_integrity_checker" class="Sylius\Bundle\CoreBundle\EventListener\OrderTotalIntegrityChecker">
-            <argument type="service" id="sylius.order_processing.order_processor" />
-            <argument type="service" id="router" />
-            <argument type="service" id="sylius.manager.order" />
-            <tag name="kernel.event_listener" event="sylius.order.pre_complete" method="check" />
-        </service>
-
-        <service id="sylius.order_locale_assigner" class="Sylius\Bundle\CoreBundle\EventListener\OrderLocaleAssigner">
-            <argument type="service" id="sylius.context.locale" />
-            <tag name="kernel.event_listener" event="sylius.order.pre_complete" method="assignLocale" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ShopBundle/EventListener/OrderCompleteListener.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/OrderCompleteListener.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\EventListener;
+namespace Sylius\Bundle\ShopBundle\EventListener;
 
 use Sylius\Bundle\CoreBundle\EmailManager\OrderEmailManagerInterface;
 use Sylius\Component\Core\Model\OrderInterface;

--- a/src/Sylius/Bundle/ShopBundle/EventListener/OrderCustomerIpListener.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/OrderCustomerIpListener.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\EventListener;
+namespace Sylius\Bundle\ShopBundle\EventListener;
 
 use Sylius\Bundle\CoreBundle\Assigner\IpAssignerInterface;
 use Sylius\Component\Core\Model\OrderInterface;

--- a/src/Sylius/Bundle/ShopBundle/EventListener/OrderLocaleAssigner.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/OrderLocaleAssigner.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\EventListener;
+namespace Sylius\Bundle\ShopBundle\EventListener;
 
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 use Sylius\Component\Core\Model\OrderInterface;

--- a/src/Sylius/Bundle/ShopBundle/EventListener/OrderPromotionIntegrityChecker.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/OrderPromotionIntegrityChecker.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\EventListener;
+namespace Sylius\Bundle\ShopBundle\EventListener;
 
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 use Sylius\Component\Core\Model\OrderInterface;

--- a/src/Sylius/Bundle/ShopBundle/EventListener/OrderTotalIntegrityChecker.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/OrderTotalIntegrityChecker.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\EventListener;
+namespace Sylius\Bundle\ShopBundle\EventListener;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;

--- a/src/Sylius/Bundle/ShopBundle/EventListener/UserRegistrationListener.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/UserRegistrationListener.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Sylius\Bundle\CoreBundle\EventListener;
+namespace Sylius\Bundle\ShopBundle\EventListener;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Bundle\UserBundle\UserEvents;

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services.xml
@@ -15,5 +15,6 @@
     <imports>
         <import resource="services/controller.xml" />
         <import resource="services/menu.xml" />
+        <import resource="services/listeners.xml" />
     </imports>
 </container>

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/listeners.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sylius.listener.order_customer_ip" class="Sylius\Bundle\ShopBundle\EventListener\OrderCustomerIpListener">
+            <argument type="service" id="sylius.customer_ip_assigner" />
+            <argument type="service" id="request_stack" />
+            <tag name="kernel.event_listener" event="sylius.order.pre_complete" method="assignCustomerIpToOrder" />
+        </service>
+
+        <service id="sylius.listener.order_complete" class="Sylius\Bundle\ShopBundle\EventListener\OrderCompleteListener">
+            <argument type="service" id="sylius.email_manager.order" />
+            <tag name="kernel.event_listener" event="sylius.order.post_complete" method="sendConfirmationEmail" />
+        </service>
+
+        <service id="sylius.listener.user_registration" class="Sylius\Bundle\ShopBundle\EventListener\UserRegistrationListener">
+            <argument type="service" id="sylius.manager.shop_user" />
+            <argument type="service" id="sylius.shop_user.token_generator.email_verification" />
+            <argument type="service" id="event_dispatcher" />
+            <tag name="kernel.event_listener" event="sylius.customer.post_register" method="sendVerificationEmail" />
+        </service>
+
+        <service id="sylius.listener.order_promotion_integrity_checker" class="Sylius\Bundle\ShopBundle\EventListener\OrderPromotionIntegrityChecker">
+            <argument type="service" id="sylius.promotion_eligibility_checker" />
+            <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="router" />
+            <tag name="kernel.event_listener" event="sylius.order.pre_complete" method="check" />
+        </service>
+
+        <service id="sylius.listener.order_total_integrity_checker" class="Sylius\Bundle\ShopBundle\EventListener\OrderTotalIntegrityChecker">
+            <argument type="service" id="sylius.order_processing.order_processor" />
+            <argument type="service" id="router" />
+            <argument type="service" id="sylius.manager.order" />
+            <tag name="kernel.event_listener" event="sylius.order.pre_complete" method="check" />
+        </service>
+
+        <service id="sylius.order_locale_assigner" class="Sylius\Bundle\ShopBundle\EventListener\OrderLocaleAssigner">
+            <argument type="service" id="sylius.context.locale" />
+            <tag name="kernel.event_listener" event="sylius.order.pre_complete" method="assignLocale" />
+        </service>
+    </services>
+</container>

--- a/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderCompleteListenerSpec.php
+++ b/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderCompleteListenerSpec.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace spec\Sylius\Bundle\CoreBundle\EventListener;
+namespace spec\Sylius\Bundle\ShopBundle\EventListener;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\CoreBundle\EmailManager\OrderEmailManagerInterface;
-use Sylius\Bundle\CoreBundle\EventListener\OrderCompleteListener;
+use Sylius\Bundle\ShopBundle\EventListener\OrderCompleteListener;
 use Sylius\Component\Core\Model\OrderInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 

--- a/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderCustomerIpListenerSpec.php
+++ b/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderCustomerIpListenerSpec.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace spec\Sylius\Bundle\CoreBundle\EventListener;
+namespace spec\Sylius\Bundle\ShopBundle\EventListener;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\CoreBundle\Assigner\IpAssignerInterface;
-use Sylius\Bundle\CoreBundle\EventListener\OrderCustomerIpListener;
+use Sylius\Bundle\ShopBundle\EventListener\OrderCustomerIpListener;
 use Sylius\Component\Core\Model\OrderInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\Request;

--- a/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderLocaleAssignerSpec.php
+++ b/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderLocaleAssignerSpec.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace spec\Sylius\Bundle\CoreBundle\EventListener;
+namespace spec\Sylius\Bundle\ShopBundle\EventListener;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;

--- a/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderPromotionIntegrityCheckerSpec.php
+++ b/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderPromotionIntegrityCheckerSpec.php
@@ -9,12 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace spec\Sylius\Bundle\CoreBundle\EventListener;
+namespace spec\Sylius\Bundle\ShopBundle\EventListener;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Sylius\Bundle\CoreBundle\EventListener\OrderPromotionIntegrityChecker;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
+use Sylius\Bundle\ShopBundle\EventListener\OrderPromotionIntegrityChecker;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PromotionInterface;
 use Sylius\Component\Promotion\Checker\Eligibility\PromotionEligibilityCheckerInterface;

--- a/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderTotalIntegrityCheckerSpec.php
+++ b/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderTotalIntegrityCheckerSpec.php
@@ -9,13 +9,13 @@
  * file that was distributed with this source code.
  */
 
-namespace spec\Sylius\Bundle\CoreBundle\EventListener;
+namespace spec\Sylius\Bundle\ShopBundle\EventListener;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Sylius\Bundle\CoreBundle\EventListener\OrderTotalIntegrityChecker;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
+use Sylius\Bundle\ShopBundle\EventListener\OrderTotalIntegrityChecker;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets |  |
| License         | MIT |

I have noticed that some of the listeners listen to the custom events from Admin or Shop. Probably it will be cleaner to place them in the appropriate bundle. It is just a proposal, so I'm open for votes should we move them or not. If yes, I will update an UPGRADE file as well. 