### PR TITLE
[POC] [Resource] [API] Conditional update response	

### DIFF
--- a/docs/bundles/SyliusResourceBundle/update_resource.rst
+++ b/docs/bundles/SyliusResourceBundle/update_resource.rst
@@ -136,6 +136,30 @@ You can also perform more complex redirects, with parameters. For example:
                     route: app_genre_show
                     parameters: { id: $genreId }
 
+[API] Returning resource or no content
+--------------------------------------
+
+Depending on your app approach it can be useful to return a changed object or only the ``204 HTTP Code``, which indicates that everything worked smoothly.
+Sylius, by default is returning the ``204 HTTP Code``, which indicates an empty response. If you would like to receive a whole object as a response you should set a `return_content` option to true.
+
+.. code-block:: yaml
+
+    # app/config/routing.yml
+
+    app_book_update:
+        path: /books/{title}/edit
+        methods: [GET, PUT]
+        defaults:
+            _controller: app.controller.book:updateAction
+            _sylius:
+                criteria: { title: $title }
+                return_content: true
+
+.. warning::
+
+    The `return_content` flag is available for the `applyStateMachineTransitionAction` method as well. But these are the only ones which can be configured this way.
+    It is worth noticing, that the `applyStateMachineTransitionAction` returns a default `200 HTTP Code` response with a fully serialized object.
+
 Configuration Reference
 -----------------------
 
@@ -160,3 +184,4 @@ Configuration Reference
                 redirect:
                     route: app_book_show
                     parameters: { title: resource.title }
+                return_content: true

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/order.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/order.yml
@@ -20,6 +20,7 @@ sylius_api_order_cancel:
             state_machine:
                 graph: sylius_order
                 transition: cancel
+            return_content: false
 
 sylius_api_order_shipment_ship:
     path: /orders/{orderId}/shipments/{id}/ship
@@ -55,3 +56,4 @@ sylius_api_order_payment_complete:
                 graph: sylius_payment
                 transition: complete
             section: api
+            return_content: false

--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -345,7 +345,9 @@ class ResourceController extends Controller
             $postEvent = $this->eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource);
 
             if (!$configuration->isHtmlRequest()) {
-                return $this->viewHandler->handle($configuration, View::create(null, Response::HTTP_NO_CONTENT));
+                $view = $configuration->getParameters()->get('return_content', false) ? View::create($resource, Response::HTTP_OK) : View::create(null, Response::HTTP_NO_CONTENT);
+
+                return $this->viewHandler->handle($configuration, $view);
             }
 
             $this->flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource);
@@ -461,7 +463,9 @@ class ResourceController extends Controller
         $this->eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource);
 
         if (!$configuration->isHtmlRequest()) {
-            return $this->viewHandler->handle($configuration, View::create($resource, Response::HTTP_OK));
+            $view = $configuration->getParameters()->get('return_content', true) ? View::create($resource, Response::HTTP_OK) : View::create(null, Response::HTTP_NO_CONTENT);
+
+            return $this->viewHandler->handle($configuration, $view);
         }
 
         $this->flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource);

--- a/tests/Controller/OrderApiTest.php
+++ b/tests/Controller/OrderApiTest.php
@@ -115,6 +115,11 @@ final class OrderApiTest extends CheckoutApiTestCase
         $this->client->request('PUT', $this->getCancelUrl($orderId), [], [], static::$authorizedHeaderWithAccept);
 
         $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+
+        $this->client->request('GET', $this->getOrderUrl($orderId), [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
         $this->assertResponse($response, 'order/order_canceled_show_response', Response::HTTP_OK);
     }
 
@@ -276,6 +281,11 @@ EOT;
         $this->client->request('PUT', $this->getCompleteOrderPaymentUrl($orderId, $rawResponse['payments'][0]['id']), [], [], static::$authorizedHeaderWithAccept);
 
         $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+
+        $this->client->request('GET', $this->getOrderUrl($orderId), [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
         $this->assertResponse($response, 'order/order_payed_show_response', Response::HTTP_OK);
     }
 
@@ -302,7 +312,7 @@ EOT;
         $this->client->request('PUT', $this->getCompleteOrderPaymentUrl($orderId, $rawResponse['payments'][0]['id']), [], [], static::$authorizedHeaderWithAccept);
 
         $response = $this->client->getResponse();
-        $this->assertResponse($response, 'order/order_payed_show_response', Response::HTTP_OK);
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
 
         $this->client->request('GET', $this->getOrderUrl($orderId), [], [], static::$authorizedHeaderWithAccept);
 

--- a/tests/Responses/Expected/order/order_payed_show_response.json
+++ b/tests/Responses/Expected/order/order_payed_show_response.json
@@ -1,50 +1,226 @@
 {
     "id": @integer@,
-    "method": {
-        "id": @integer@,
-        "code": "cod",
-        "channels": [
-            {
+    "checkoutCompletedAt": "@string@.isDateTime()",
+    "number": "000000001",
+    "items": [
+        {
+            "id": @integer@,
+            "quantity": 1,
+            "unitPrice": 20,
+            "total": 20,
+            "units": [
+                {
+                    "id": @integer@,
+                    "adjustments": [],
+                    "adjustmentsTotal": 0
+                }
+            ],
+            "unitsTotal": 20,
+            "adjustments": [],
+            "adjustmentsTotal": 0,
+            "variant": {
                 "id": @integer@,
-                "code": "CHANNEL",
-                "name": "Channel",
-                "description": "Lorem ipsum",
-                "hostname": "localhost",
-                "color": "black",
-                "createdAt": "@string@.isDateTime()",
-                "updatedAt": "@string@.isDateTime()",
-                "enabled": true,
-                "taxCalculationStrategy": "order_items_based",
+                "code": "MUG_SW",
+                "optionValues": [],
+                "position": 0,
+                "translations": {
+                    "en_US": {
+                        "locale": "en_US",
+                        "id": @integer@,
+                        "name": "Star wars mug"
+                    }
+                },
+                "onHold": 0,
+                "onHand": 0,
+                "tracked": false,
+                "channelPricings": [
+                    {
+                        "channel": {
+                            "id": @integer@,
+                            "code": "CHANNEL",
+                            "name": "Channel",
+                            "description": "Lorem ipsum",
+                            "hostname": "localhost",
+                            "color": "black",
+                            "createdAt": "@string@.isDateTime()",
+                            "updatedAt": "@string@.isDateTime()",
+                            "enabled": true,
+                            "taxCalculationStrategy": "order_items_based",
+                            "_links": {
+                                "self": {
+                                    "href": "\/api\/v1\/channels\/CHANNEL"
+                                }
+                            }
+                        },
+                        "price": 20
+                    }
+                ],
                 "_links": {
                     "self": {
-                        "href": "\/api\/v1\/channels\/CHANNEL"
+                        "href": "\/api\/v1\/products\/MUG\/variants\/MUG_SW"
+                    },
+                    "product": {
+                        "href": "\/api\/v1\/products\/MUG"
                     }
                 }
+            },
+            "_links": {
+                "order": {
+                    "href": "@string@"
+                },
+                "product": {
+                    "href": "\/api\/v1\/products\/MUG"
+                },
+                "variant": {
+                    "href": "\/api\/v1\/products\/MUG\/variants\/MUG_SW"
+                }
             }
-        ],
-        "gatewayConfig": {
+        }
+    ],
+    "itemsTotal": 20,
+    "adjustments": [
+        {
             "id": @integer@,
-            "gatewayName": "Offline",
-            "factoryName": "offline",
-            "config": []
-        },
+            "type": "shipping",
+            "label": "UPS",
+            "amount": 10
+        }
+    ],
+    "adjustmentsTotal": 10,
+    "total": 30,
+    "state": "new",
+    "customer": {
+        "id": @integer@,
+        "email": "oliver.queen@star-city.com",
+        "emailCanonical": "oliver.queen@star-city.com",
+        "firstName": "Oliver",
+        "lastName": "Queen",
+        "birthday": "@string@.isDateTime()",
+        "gender": "u",
         "_links": {
             "self": {
-                "href": "\/api\/v1\/payment-methods\/cod"
+                "href": "@string@"
             }
         }
     },
-    "amount": 30,
-    "state": "completed",
-    "_links": {
-        "self": {
-            "href": "@string@"
-        },
-        "payment-method": {
-            "href": "\/api\/v1\/payment-methods\/cod"
-        },
-        "order": {
-            "href": "@string@"
+    "channel": {
+        "id": @integer@,
+        "code": "CHANNEL",
+        "name": "Channel",
+        "description": "Lorem ipsum",
+        "hostname": "localhost",
+        "color": "black",
+        "createdAt": "@string@.isDateTime()",
+        "updatedAt": "@string@.isDateTime()",
+        "enabled": true,
+        "taxCalculationStrategy": "order_items_based",
+        "_links": {
+            "self": {
+                "href": "\/api\/v1\/channels\/CHANNEL"
+            }
         }
-    }
+    },
+    "shippingAddress": {
+        "id": @integer@,
+        "firstName": "Hieronim",
+        "lastName": "Bosch",
+        "countryCode": "NL",
+        "street": "Surrealism St.",
+        "city": "\u2019s-Hertogenbosch",
+        "postcode": "99-999"
+    },
+    "billingAddress": {
+        "id": @integer@,
+        "firstName": "Vincent",
+        "lastName": "van Gogh",
+        "countryCode": "NL",
+        "street": "Post-Impressionism St.",
+        "city": "Groot Zundert",
+        "postcode": "88-888"
+    },
+    "payments": [
+        {
+            "id": @integer@,
+            "method": {
+                "id": @integer@,
+                "code": "cod",
+                "channels": [
+                    {
+                        "id": @integer@,
+                        "code": "CHANNEL",
+                        "name": "Channel",
+                        "description": "Lorem ipsum",
+                        "hostname": "localhost",
+                        "color": "black",
+                        "createdAt": "@string@.isDateTime()",
+                        "updatedAt": "@string@.isDateTime()",
+                        "enabled": true,
+                        "taxCalculationStrategy": "order_items_based",
+                        "_links": {
+                            "self": {
+                                "href": "\/api\/v1\/channels\/CHANNEL"
+                            }
+                        }
+                    }
+                ],
+                "gatewayConfig": {
+                    "id": @integer@,
+                    "gatewayName": "Offline",
+                    "factoryName": "offline",
+                    "config": []
+                },
+                "_links": {
+                    "self": {
+                        "href": "\/api\/v1\/payment-methods\/cod"
+                    }
+                }
+            },
+            "amount": 30,
+            "state": "completed",
+            "_links": {
+                "self": {
+                    "href": "@string@"
+                },
+                "payment-method": {
+                    "href": "\/api\/v1\/payment-methods\/cod"
+                },
+                "order": {
+                    "href": "@string@"
+                }
+            }
+        }
+    ],
+    "shipments": [
+        {
+            "id": @integer@,
+            "state": "ready",
+            "method": {
+                "id": @integer@,
+                "code": "UPS",
+                "enabled": true,
+                "_links": {
+                    "self": {
+                        "href": "\/api\/v1\/shipping-methods\/UPS"
+                    },
+                    "zone": {
+                        "href": "\/api\/v1\/zones\/EU"
+                    }
+                }
+            },
+            "_links": {
+                "self": {
+                    "href": "@string@"
+                },
+                "method": {
+                    "href": "\/api\/v1\/shipping-methods\/UPS"
+                },
+                "order": {
+                    "href": "@string@"
+                }
+            }
+        }
+    ],
+    "currencyCode": "EUR",
+    "localeCode": "en_US",
+    "checkoutState": "completed"
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

The second approach to the #7483 problem. With this solution, it will be easy to customize returning content after an update or state machine transition. What do you think? /cc @steffenbrem @bendavies It is based on your suggestions :) You can check the second commit to see the changes. The first one is needed for the test purposes. 

Based on #7484.