### PR TITLE
[API] [Currency] ExchangeRate CRUD and add TimestampableTrait

### DIFF
--- a/app/migrations/Version20170217141621.php
+++ b/app/migrations/Version20170217141621.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170217141621 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_exchange_rate ADD created_at DATETIME NOT NULL, ADD updated_at DATETIME DEFAULT NULL');
+        $this->addSql('UPDATE sylius_exchange_rate SET created_at = NOW()');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_exchange_rate DROP created_at, DROP updated_at');
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/exchange_rate.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/exchange_rate.yml
@@ -1,0 +1,9 @@
+# This file is part of the Sylius package.
+# (c) Paweł Jędrzejewski
+
+sylius_api_exchange_rate:
+    resource: |
+        alias: sylius.exchange_rate
+        section: api
+        serialization_version: $version
+    type: sylius.resource_api

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/exchange_rate.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/exchange_rate.yml
@@ -5,5 +5,42 @@ sylius_api_exchange_rate:
     resource: |
         alias: sylius.exchange_rate
         section: api
+        only: [index, create]
         serialization_version: $version
     type: sylius.resource_api
+
+sylius_api_exchange_rate_update:
+    path: /exchange-rates/{sourceCurrencyCode}-{targetCurrencyCode}
+    methods: [PUT, PATCH]
+    defaults:
+        _controller: sylius.controller.exchange_rate:updateAction
+        _sylius:
+            serialization_version: $version
+            serialization_groups: [Default, Detailed]
+            repository:
+                method: findOneWithCurrencyPair
+                arguments: [$sourceCurrencyCode, $targetCurrencyCode]
+
+sylius_api_exchange_rate_delete:
+    path: /exchange-rates/{sourceCurrencyCode}-{targetCurrencyCode}
+    methods: [DELETE]
+    defaults:
+        _controller: sylius.controller.exchange_rate:deleteAction
+        _sylius:
+            serialization_version: $version
+            repository:
+                method: findOneWithCurrencyPair
+                arguments: [$sourceCurrencyCode, $targetCurrencyCode]
+            csrf_protection: false
+
+sylius_api_exchange_rate_show:
+    path: /exchange-rates/{sourceCurrencyCode}-{targetCurrencyCode}
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.exchange_rate:showAction
+        _sylius:
+            serialization_version: $version
+            serialization_groups: [Default, Detailed]
+            repository:
+                method: findOneWithCurrencyPair
+                arguments: [$sourceCurrencyCode, $targetCurrencyCode]

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/main.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/main.yml
@@ -88,6 +88,9 @@ sylius_api_country:
     resource: "@SyliusApiBundle/Resources/config/routing/country.yml"
     prefix: /countries
 
+sylius_api_exchange_rate:
+    resource: "@SyliusApiBundle/Resources/config/routing/exchange_rate.yml"
+
 sylius_api_province:
     resource: "@SyliusApiBundle/Resources/config/routing/province.yml"
     prefix: /countries/{countryCode}/provinces

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/doctrine/model/ExchangeRate.orm.xml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/doctrine/model/ExchangeRate.orm.xml
@@ -11,7 +11,11 @@
 
 -->
 
-<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <mapped-superclass name="Sylius\Component\Currency\Model\ExchangeRate" table="sylius_exchange_rate">
         <unique-constraints>
             <unique-constraint columns="source_currency,target_currency"/>
@@ -22,6 +26,13 @@
         </id>
 
         <field name="ratio" column="ratio" type="decimal" precision="10" scale="5" />
+
+        <field name="createdAt" column="created_at" type="datetime">
+            <gedmo:timestampable on="create"/>
+        </field>
+        <field name="updatedAt" column="updated_at" type="datetime" nullable="true">
+            <gedmo:timestampable on="update"/>
+        </field>
 
         <many-to-one field="sourceCurrency" target-entity="Sylius\Component\Currency\Model\Currency">
             <join-column name="source_currency" referenced-column-name="id" nullable="false" on-delete="CASCADE" />

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/serializer/Model.Currency.yml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/serializer/Model.Currency.yml
@@ -19,11 +19,3 @@ Sylius\Component\Currency\Model\Currency:
             expose: true
             type: boolean
             groups: [Default, Detailed]
-        createdAt:
-            expose: true
-            type: DateTime
-            groups: [Detailed]
-        updatedAt:
-            expose: true
-            type: DateTime
-            groups: [Detailed]

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/serializer/Model.ExchangeRate.yml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/serializer/Model.ExchangeRate.yml
@@ -9,8 +9,11 @@ Sylius\Component\Currency\Model\ExchangeRate:
         ratio:
             expose: true
             type: float
+            groups: [Default, Detailed]
         sourceCurrency:
             expose: true
+            groups: [Default, Detailed]
         targetCurrency:
             expose: true
+            groups: [Default, Detailed]
 

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/serializer/Model.ExchangeRate.yml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/serializer/Model.ExchangeRate.yml
@@ -16,4 +16,6 @@ Sylius\Component\Currency\Model\ExchangeRate:
         targetCurrency:
             expose: true
             groups: [Default, Detailed]
-
+        updatedAt:
+            expose: true
+            groups: [Default, Detailed]

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/serializer/Model.ExchangeRate.yml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/serializer/Model.ExchangeRate.yml
@@ -19,3 +19,13 @@ Sylius\Component\Currency\Model\ExchangeRate:
         updatedAt:
             expose: true
             groups: [Default, Detailed]
+    relations:
+        - rel: self
+          href:
+            route: sylius_api_exchange_rate_show
+            parameters:
+                sourceCurrencyCode: expr(object.getSourceCurrency().getCode())
+                targetCurrencyCode: expr(object.getTargetCurrency().getCode())
+                version: 1
+            exclusion:
+                groups: [Default, Detailed]

--- a/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/UniqueCurrencyPairValidator.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Validator/Constraints/UniqueCurrencyPairValidator.php
@@ -49,6 +49,10 @@ class UniqueCurrencyPairValidator extends ConstraintValidator
             return;
         }
 
+        if (null === $value->getSourceCurrency() || null === $value->getTargetCurrency()) {
+            return;
+        }
+
         if (!$this->isCurrencyPairUnique($value->getSourceCurrency(), $value->getTargetCurrency())) {
             $this->context->buildViolation($constraint->message)->addViolation();
         }

--- a/src/Sylius/Component/Currency/Model/ExchangeRate.php
+++ b/src/Sylius/Component/Currency/Model/ExchangeRate.php
@@ -61,7 +61,7 @@ class ExchangeRate implements ExchangeRateInterface
      */
     public function setRatio($ratio)
     {
-        Assert::float($ratio);
+        Assert::nullOrFloat($ratio);
 
         $this->ratio = $ratio;
     }

--- a/src/Sylius/Component/Currency/Model/ExchangeRate.php
+++ b/src/Sylius/Component/Currency/Model/ExchangeRate.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Component\Currency\Model;
 
+use Sylius\Component\Resource\Model\TimestampableTrait;
 use Webmozart\Assert\Assert;
 
 /**
@@ -18,6 +19,8 @@ use Webmozart\Assert\Assert;
  */
 class ExchangeRate implements ExchangeRateInterface
 {
+    use TimestampableTrait;
+
     /**
      * @var mixed
      */
@@ -37,6 +40,11 @@ class ExchangeRate implements ExchangeRateInterface
      * @var CurrencyInterface
      */
     protected $targetCurrency;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTime();
+    }
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Currency/spec/Model/ExchangeRateSpec.php
+++ b/src/Sylius/Component/Currency/spec/Model/ExchangeRateSpec.php
@@ -36,7 +36,6 @@ final class ExchangeRateSpec extends ObjectBehavior
         $this->shouldThrow(\InvalidArgumentException::class)->during('setRatio', ['1.01']);
         $this->shouldThrow(\InvalidArgumentException::class)->during('setRatio', ['asd']);
         $this->shouldThrow(\InvalidArgumentException::class)->during('setRatio', [[]]);
-        $this->shouldThrow(\InvalidArgumentException::class)->during('setRatio', [null]);
         $this->shouldThrow(\InvalidArgumentException::class)->during('setRatio', [false]);
         $this->shouldThrow(\InvalidArgumentException::class)->during('setRatio', [new \stdClass()]);
     }

--- a/src/Sylius/Component/Currency/spec/Model/ExchangeRateSpec.php
+++ b/src/Sylius/Component/Currency/spec/Model/ExchangeRateSpec.php
@@ -62,4 +62,26 @@ final class ExchangeRateSpec extends ObjectBehavior
         $this->setTargetCurrency($currency);
         $this->getTargetCurrency()->shouldReturn($currency);
     }
+
+    function it_initializes_creation_date_by_default()
+    {
+        $this->getCreatedAt()->shouldHaveType(\DateTime::class);
+    }
+
+    function its_creation_date_is_mutable(\DateTime $date)
+    {
+        $this->setCreatedAt($date);
+        $this->getCreatedAt()->shouldReturn($date);
+    }
+
+    function it_has_no_last_update_date_by_default()
+    {
+        $this->getUpdatedAt()->shouldReturn(null);
+    }
+
+    function its_last_update_date_is_mutable(\DateTime $date)
+    {
+        $this->setUpdatedAt($date);
+        $this->getUpdatedAt()->shouldReturn($date);
+    }
 }

--- a/tests/Controller/ExchangeRateApiTest.php
+++ b/tests/Controller/ExchangeRateApiTest.php
@@ -136,7 +136,7 @@ EOT;
      */
     public function it_denies_getting_exchange_rate_for_non_authenticated_user()
     {
-        $this->client->request('GET', '/api/v1/exchange-rates/1');
+        $this->client->request('GET', '/api/v1/exchange-rates/EUR-USD');
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
@@ -149,7 +149,7 @@ EOT;
     {
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
 
-        $this->client->request('GET', '/api/v1/exchange-rates/-1', [], [], static::$authorizedHeaderWithAccept);
+        $this->client->request('GET', '/api/v1/exchange-rates/EUR-USD', [], [], static::$authorizedHeaderWithAccept);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
@@ -177,7 +177,7 @@ EOT;
      */
     public function it_denies_updating_exchange_rate_for_non_authenticated_user()
     {
-        $this->client->request('PUT', '/api/v1/exchange-rates/1');
+        $this->client->request('PUT', '/api/v1/exchange-rates/EUR-USD');
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
@@ -190,7 +190,7 @@ EOT;
     {
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
 
-        $this->client->request('PUT', '/api/v1/exchange-rates/-1', [], [], static::$authorizedHeaderWithAccept);
+        $this->client->request('PUT', '/api/v1/exchange-rates/EUR-USD', [], [], static::$authorizedHeaderWithAccept);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
@@ -273,7 +273,7 @@ EOT;
     {
         $this->loadFixturesFromFile('authentication/api_administrator.yml');
 
-        $this->client->request('DELETE', '/api/v1/exchange-rates/-1', [], [], static::$authorizedHeaderWithAccept);
+        $this->client->request('DELETE', '/api/v1/exchange-rates/EUR-USD', [], [], static::$authorizedHeaderWithAccept);
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
@@ -308,6 +308,6 @@ EOT;
      */
     private function getExchangeRateUrl(ExchangeRateInterface $exchangeRate)
     {
-        return '/api/v1/exchange-rates/' . $exchangeRate->getId();
+        return sprintf('/api/v1/exchange-rates/%s-%s', $exchangeRate->getSourceCurrency()->getCode(), $exchangeRate->getTargetCurrency()->getCode());
     }
 }

--- a/tests/Controller/ExchangeRateApiTest.php
+++ b/tests/Controller/ExchangeRateApiTest.php
@@ -1,0 +1,313 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Tests\Controller;
+
+use Lakion\ApiTestCase\JsonApiTestCase;
+use Sylius\Component\Currency\Model\ExchangeRateInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ */
+final class ExchangeRateApiTest extends JsonApiTestCase
+{
+    /**
+     * @var array
+     */
+    private static $authorizedHeaderWithContentType = [
+        'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+        'CONTENT_TYPE' => 'application/json',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $authorizedHeaderWithAccept = [
+        'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+        'Accept' => 'application/json',
+    ];
+
+    /**
+     * @test
+     */
+    public function it_denies_creating_exchange_rate_for_non_authenticated_user()
+    {
+        $this->client->request('POST', '/api/v1/exchange-rates/');
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_create_exchange_rate_without_specifying_required_data()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('POST', '/api/v1/exchange-rates/', [], [], static::$authorizedHeaderWithContentType);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'exchange_rate/create_validation_fail_response', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_create_exchange_rate()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/currencies.yml');
+
+        $data =
+<<<EOT
+        {
+            "ratio": "0,8515706",
+            "source_currency": "EUR",
+            "target_currency": "GBP"
+        }
+EOT;
+
+        $this->client->request('POST', '/api/v1/exchange-rates/', [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'exchange_rate/create_response', Response::HTTP_CREATED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_create_exchange_rate_with_duplicated_currency_pair()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/exchange_rates.yml');
+
+        $data =
+<<<EOT
+        {
+            "ratio": "0,8515706",
+            "source_currency": "EUR",
+            "target_currency": "GBP"
+        }
+EOT;
+
+        $this->client->request('POST', '/api/v1/exchange-rates/', [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'exchange_rate/non_unique_pair_validation_fail_response', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_denies_getting_exchange_rates_for_non_authenticated_user()
+    {
+        $this->client->request('GET', '/api/v1/exchange-rates/');
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_get_exchange_rates_list()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/exchange_rates.yml');
+
+        $this->client->request('GET', '/api/v1/exchange-rates/', [], [], static::$authorizedHeaderWithContentType);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'exchange_rate/index_response', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_denies_getting_exchange_rate_for_non_authenticated_user()
+    {
+        $this->client->request('GET', '/api/v1/exchange-rates/1');
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_not_found_response_when_requesting_details_of_a_exchange_rate_which_does_not_exist()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('GET', '/api/v1/exchange-rates/-1', [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_get_exchange_rate()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $exchangeRates = $this->loadFixturesFromFile('resources/exchange_rates.yml');
+
+        /** @var ExchangeRateInterface $exchangeRate */
+        $exchangeRate = $exchangeRates['eur_gbp_exchange_rate'];
+
+        $this->client->request('GET', $this->getExchangeRateUrl($exchangeRate), [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'exchange_rate/show_response', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_denies_updating_exchange_rate_for_non_authenticated_user()
+    {
+        $this->client->request('PUT', '/api/v1/exchange-rates/1');
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_not_found_response_when_updating_exchange_rate_which_does_not_exist()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('PUT', '/api/v1/exchange-rates/-1', [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_update_exchange_rate_without_specifying_required_data()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $exchangeRates = $this->loadFixturesFromFile('resources/exchange_rates.yml');
+
+        /** @var ExchangeRateInterface $exchangeRate */
+        $exchangeRate = $exchangeRates['eur_usd_exchange_rate'];
+
+        $this->client->request('PUT', $this->getExchangeRateUrl($exchangeRate), [], [], static::$authorizedHeaderWithContentType);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'exchange_rate/update_validation_fail_response', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_update_exchange_rate()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $exchangeRates = $this->loadFixturesFromFile('resources/exchange_rates.yml');
+
+        /** @var ExchangeRateInterface $exchangeRate */
+        $exchangeRate = $exchangeRates['eur_usd_exchange_rate'];
+
+        $data =
+<<<EOT
+        {
+            "ratio": "0.84"
+        }
+EOT;
+
+        $this->client->request('PUT', $this->getExchangeRateUrl($exchangeRate), [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+
+        $this->client->request('GET', $this->getExchangeRateUrl($exchangeRate), [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'exchange_rate/update_response', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_update_exchange_rate_if_ratio_is_not_a_number()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $exchangeRates = $this->loadFixturesFromFile('resources/exchange_rates.yml');
+
+        /** @var ExchangeRateInterface $exchangeRate */
+        $exchangeRate = $exchangeRates['eur_usd_exchange_rate'];
+
+        $data =
+<<<EOT
+        {
+            "ratio": "its-a-trap"
+        }
+EOT;
+
+        $this->client->request('PUT', $this->getExchangeRateUrl($exchangeRate), [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'exchange_rate/update_ratio_with_string_validation_fail_response', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_not_found_response_when_trying_to_delete_exchange_rate_which_does_not_exist()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('DELETE', '/api/v1/exchange-rates/-1', [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_delete_exchange_rate()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $exchangeRates = $this->loadFixturesFromFile('resources/exchange_rates.yml');
+
+        /** @var ExchangeRateInterface $exchangeRate */
+        $exchangeRate = $exchangeRates['eur_gbp_exchange_rate'];
+
+        $this->client->request('DELETE', $this->getExchangeRateUrl($exchangeRate), [], [], static::$authorizedHeaderWithContentType, []);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+
+        $this->client->request('GET', $this->getExchangeRateUrl($exchangeRate), [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @param ExchangeRateInterface $exchangeRate
+     *
+     * @return string
+     */
+    private function getExchangeRateUrl(ExchangeRateInterface $exchangeRate)
+    {
+        return '/api/v1/exchange-rates/' . $exchangeRate->getId();
+    }
+}

--- a/tests/DataFixtures/ORM/resources/exchange_rates.yml
+++ b/tests/DataFixtures/ORM/resources/exchange_rates.yml
@@ -1,0 +1,21 @@
+Sylius\Component\Currency\Model\Currency:
+    USD:
+        code: USD
+    EUR:
+        code: EUR
+    GBP:
+        code: GBP
+
+Sylius\Component\Currency\Model\ExchangeRate:
+    eur_gbp_exchange_rate:
+        ratio: 0.85
+        sourceCurrency: "@EUR"
+        targetCurrency: "@GBP"
+    eur_usd_exchange_rate:
+        ratio: 1.06
+        sourceCurrency: "@EUR"
+        targetCurrency: "@USD"
+    usd_gbp_exchange_rate:
+        ratio: 1.24
+        sourceCurrency: "@USD"
+        targetCurrency: "@GBP"

--- a/tests/Responses/Expected/currency/create_response.json
+++ b/tests/Responses/Expected/currency/create_response.json
@@ -1,6 +1,4 @@
 {
     "id": @integer@,
-    "code": "USD",
-    "created_at": "@string@.isDateTime()",
-    "updated_at": "@string@.isDateTime()"
+    "code": "USD"
 }

--- a/tests/Responses/Expected/currency/show_response.json
+++ b/tests/Responses/Expected/currency/show_response.json
@@ -1,6 +1,4 @@
 {
     "id": @integer@,
-    "code": "USD",
-    "created_at": "@string@.isDateTime()",
-    "updated_at": "@string@.isDateTime()"
+    "code": "USD"
 }

--- a/tests/Responses/Expected/exchange_rate/create_response.json
+++ b/tests/Responses/Expected/exchange_rate/create_response.json
@@ -8,5 +8,6 @@
     "target_currency": {
         "id": @integer@,
         "code": "GBP"
-    }
+    },
+    "updated_at": "@string@.isDateTime()"
 }

--- a/tests/Responses/Expected/exchange_rate/create_response.json
+++ b/tests/Responses/Expected/exchange_rate/create_response.json
@@ -1,0 +1,12 @@
+{
+    "id": @integer@,
+    "ratio": 0.85157,
+    "source_currency": {
+        "id": @integer@,
+        "code": "EUR"
+    },
+    "target_currency": {
+        "id": @integer@,
+        "code": "GBP"
+    }
+}

--- a/tests/Responses/Expected/exchange_rate/create_response.json
+++ b/tests/Responses/Expected/exchange_rate/create_response.json
@@ -9,5 +9,10 @@
         "id": @integer@,
         "code": "GBP"
     },
-    "updated_at": "@string@.isDateTime()"
+    "updated_at": "@string@.isDateTime()",
+    "_links": {
+        "self": {
+            "href": "\/api\/v1\/exchange-rates\/EUR-GBP"
+        }
+    }
 }

--- a/tests/Responses/Expected/exchange_rate/create_validation_fail_response.json
+++ b/tests/Responses/Expected/exchange_rate/create_validation_fail_response.json
@@ -1,0 +1,26 @@
+{
+    "code": 400,
+    "message": "Validation Failed",
+    "errors": {
+        "errors": [
+            "The source and target currencies must differ."
+        ],
+        "children": {
+            "ratio": {
+                "errors": [
+                    "Please enter exchange rate ratio."
+                ]
+            },
+            "sourceCurrency": {
+                "errors": [
+                    "This value is not valid."
+                ]
+            },
+            "targetCurrency": {
+                "errors": [
+                    "This value is not valid."
+                ]
+            }
+        }
+    }
+}

--- a/tests/Responses/Expected/exchange_rate/index_response.json
+++ b/tests/Responses/Expected/exchange_rate/index_response.json
@@ -26,7 +26,8 @@
                 "target_currency": {
                     "id": @integer@,
                     "code": "GBP"
-                }
+                },
+                "updated_at": "@string@.isDateTime()"
             },
             {
                 "id": @integer@,
@@ -38,7 +39,8 @@
                 "target_currency": {
                     "id": @integer@,
                     "code": "USD"
-                }
+                },
+                "updated_at": "@string@.isDateTime()"
             },
             {
                 "id": @integer@,
@@ -50,7 +52,8 @@
                 "target_currency": {
                     "id": @integer@,
                     "code": "GBP"
-                }
+                },
+                "updated_at": "@string@.isDateTime()"
             }
         ]
     }

--- a/tests/Responses/Expected/exchange_rate/index_response.json
+++ b/tests/Responses/Expected/exchange_rate/index_response.json
@@ -27,7 +27,12 @@
                     "id": @integer@,
                     "code": "GBP"
                 },
-                "updated_at": "@string@.isDateTime()"
+                "updated_at": "@string@.isDateTime()",
+                "_links": {
+                    "self": {
+                        "href": "\/api\/v1\/exchange-rates\/EUR-GBP"
+                    }
+                }
             },
             {
                 "id": @integer@,
@@ -40,7 +45,12 @@
                     "id": @integer@,
                     "code": "USD"
                 },
-                "updated_at": "@string@.isDateTime()"
+                "updated_at": "@string@.isDateTime()",
+                "_links": {
+                    "self": {
+                        "href": "\/api\/v1\/exchange-rates\/EUR-USD"
+                    }
+                }
             },
             {
                 "id": @integer@,
@@ -53,7 +63,12 @@
                     "id": @integer@,
                     "code": "GBP"
                 },
-                "updated_at": "@string@.isDateTime()"
+                "updated_at": "@string@.isDateTime()",
+                "_links": {
+                    "self": {
+                        "href": "\/api\/v1\/exchange-rates\/USD-GBP"
+                    }
+                }
             }
         ]
     }

--- a/tests/Responses/Expected/exchange_rate/index_response.json
+++ b/tests/Responses/Expected/exchange_rate/index_response.json
@@ -1,0 +1,57 @@
+{
+    "page": 1,
+    "limit": 10,
+    "pages": 1,
+    "total": 3,
+    "_links": {
+        "self": {
+            "href": "\/api\/v1\/exchange-rates\/?page=1&limit=10"
+        },
+        "first": {
+            "href": "\/api\/v1\/exchange-rates\/?page=1&limit=10"
+        },
+        "last": {
+            "href": "\/api\/v1\/exchange-rates\/?page=1&limit=10"
+        }
+    },
+    "_embedded": {
+        "items": [
+            {
+                "id": @integer@,
+                "ratio": 0.85,
+                "source_currency": {
+                    "id": @integer@,
+                    "code": "EUR"
+                },
+                "target_currency": {
+                    "id": @integer@,
+                    "code": "GBP"
+                }
+            },
+            {
+                "id": @integer@,
+                "ratio": 1.06,
+                "source_currency": {
+                    "id": @integer@,
+                    "code": "EUR"
+                },
+                "target_currency": {
+                    "id": @integer@,
+                    "code": "USD"
+                }
+            },
+            {
+                "id": @integer@,
+                "ratio": 1.24,
+                "source_currency": {
+                    "id": @integer@,
+                    "code": "USD"
+                },
+                "target_currency": {
+                    "id": @integer@,
+                    "code": "GBP"
+                }
+            }
+        ]
+    }
+}

--- a/tests/Responses/Expected/exchange_rate/non_unique_pair_validation_fail_response.json
+++ b/tests/Responses/Expected/exchange_rate/non_unique_pair_validation_fail_response.json
@@ -1,0 +1,17 @@
+{
+    "code": 400,
+    "message": "Validation Failed",
+    "errors": {
+        "errors": [
+            "The currency pair must be unique."
+        ],
+        "children": {
+            "ratio": {
+            },
+            "sourceCurrency": {
+            },
+            "targetCurrency": {
+            }
+        }
+    }
+}

--- a/tests/Responses/Expected/exchange_rate/show_response.json
+++ b/tests/Responses/Expected/exchange_rate/show_response.json
@@ -8,5 +8,6 @@
     "target_currency": {
         "id": @integer@,
         "code": "GBP"
-    }
+    },
+    "updated_at": "@string@.isDateTime()"
 }

--- a/tests/Responses/Expected/exchange_rate/show_response.json
+++ b/tests/Responses/Expected/exchange_rate/show_response.json
@@ -9,5 +9,10 @@
         "id": @integer@,
         "code": "GBP"
     },
-    "updated_at": "@string@.isDateTime()"
+    "updated_at": "@string@.isDateTime()",
+    "_links": {
+        "self": {
+            "href": "\/api\/v1\/exchange-rates\/EUR-GBP"
+        }
+    }
 }

--- a/tests/Responses/Expected/exchange_rate/show_response.json
+++ b/tests/Responses/Expected/exchange_rate/show_response.json
@@ -1,0 +1,12 @@
+{
+    "id": @integer@,
+    "ratio": 0.85,
+    "source_currency": {
+        "id": @integer@,
+        "code": "EUR"
+    },
+    "target_currency": {
+        "id": @integer@,
+        "code": "GBP"
+    }
+}

--- a/tests/Responses/Expected/exchange_rate/update_ratio_with_string_validation_fail_response.json
+++ b/tests/Responses/Expected/exchange_rate/update_ratio_with_string_validation_fail_response.json
@@ -8,8 +8,10 @@
                     "The ratio must be a number."
                 ]
             },
-            "sourceCurrency": {},
-            "targetCurrency": {}
+            "sourceCurrency": {
+            },
+            "targetCurrency": {
+            }
         }
     }
 }

--- a/tests/Responses/Expected/exchange_rate/update_ratio_with_string_validation_fail_response.json
+++ b/tests/Responses/Expected/exchange_rate/update_ratio_with_string_validation_fail_response.json
@@ -1,0 +1,15 @@
+{
+    "code": 400,
+    "message": "Validation Failed",
+    "errors": {
+        "children": {
+            "ratio": {
+                "errors": [
+                    "The ratio must be a number."
+                ]
+            },
+            "sourceCurrency": {},
+            "targetCurrency": {}
+        }
+    }
+}

--- a/tests/Responses/Expected/exchange_rate/update_response.json
+++ b/tests/Responses/Expected/exchange_rate/update_response.json
@@ -1,0 +1,12 @@
+{
+    "id": @integer@,
+    "ratio": 0.84,
+    "source_currency": {
+        "id": @integer@,
+        "code": "EUR"
+    },
+    "target_currency": {
+        "id": @integer@,
+        "code": "USD"
+    }
+}

--- a/tests/Responses/Expected/exchange_rate/update_response.json
+++ b/tests/Responses/Expected/exchange_rate/update_response.json
@@ -9,5 +9,10 @@
         "id": @integer@,
         "code": "USD"
     },
-    "updated_at": "@string@.isDateTime()"
+    "updated_at": "@string@.isDateTime()",
+    "_links": {
+        "self": {
+            "href": "\/api\/v1\/exchange-rates\/EUR-USD"
+        }
+    }
 }

--- a/tests/Responses/Expected/exchange_rate/update_response.json
+++ b/tests/Responses/Expected/exchange_rate/update_response.json
@@ -8,5 +8,6 @@
     "target_currency": {
         "id": @integer@,
         "code": "USD"
-    }
+    },
+    "updated_at": "@string@.isDateTime()"
 }

--- a/tests/Responses/Expected/exchange_rate/update_validation_fail_response.json
+++ b/tests/Responses/Expected/exchange_rate/update_validation_fail_response.json
@@ -1,0 +1,15 @@
+{
+    "code": 400,
+    "message": "Validation Failed",
+    "errors": {
+        "children": {
+            "ratio": {
+                "errors": [
+                    "Please enter exchange rate ratio."
+                ]
+            },
+            "sourceCurrency": {},
+            "targetCurrency": {}
+        }
+    }
+}

--- a/tests/Responses/Expected/exchange_rate/update_validation_fail_response.json
+++ b/tests/Responses/Expected/exchange_rate/update_validation_fail_response.json
@@ -8,8 +8,10 @@
                     "Please enter exchange rate ratio."
                 ]
             },
-            "sourceCurrency": {},
-            "targetCurrency": {}
+            "sourceCurrency": {
+            },
+            "targetCurrency": {
+            }
         }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | [comment](https://github.com/Sylius/Sylius/pull/7541#discussion_r101720622) |
| License         | MIT |

This PR adds the TimestampableTrait to exchange rates and test it via API. 

Based on #7541 