### PR TITLE
[RFC][WIP] Expose product option information in API

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductOption.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductOption.yml
@@ -3,8 +3,10 @@ Sylius\Component\Product\Model\ProductOption:
     xml_root_name: option
     properties:
         code:
-            exopse: true
-            type: string
-        name:
             expose: true
             type: string
+        values:
+            expose: true
+    virtual_properties:
+        getName:
+            serialized_name: name

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductOptionValue.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductOptionValue.yml
@@ -5,9 +5,8 @@ Sylius\Component\Product\Model\ProductOptionValue:
         code:
             expose: true
             type: string
-        value:
-            expose: true
-            type: string
     virtual_properties:
         getName:
             serialized_name: name
+        getValue:
+            serialized_name: value

--- a/tests/Controller/ProductOptionApiTest.php
+++ b/tests/Controller/ProductOptionApiTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Tests\Controller;
+
+use Lakion\ApiTestCase\JsonApiTestCase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author alcaeus <alcaeus@alcaeus.org>
+ */
+final class ProductOptionTest extends JsonApiTestCase
+{
+    /**
+     * @var array
+     */
+    private static $authorizedHeaderWithContentType = [
+        'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+        'CONTENT_TYPE' => 'application/json',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $authorizedHeaderWithAccept = [
+        'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+        'ACCEPT' => 'application/json',
+    ];
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_show_product_options_list_when_access_is_denied()
+    {
+        $this->client->request('GET', '/api/v1/product-options/');
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_listing_product_options()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/product_options.yml');
+
+        $this->client->request('GET', '/api/v1/product-options/', [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product_option/index_response', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_delete_product_option_if_it_does_not_exist()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('DELETE', '/api/v1/product-options/-1', [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_delete_product_option()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $productOptions = $this->loadFixturesFromFile('resources/product_options.yml');
+
+        $this->client->request('DELETE', '/api/v1/product-options/'.$productOptions['productOption1']->getId(), [], [], static::$authorizedHeaderWithContentType, []);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+
+        $this->client->request('GET', '/api/v1/product-options/', [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product_option/index_response_after_delete', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_create_product_option_with_multiple_translations()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/locales.yml');
+
+        $data =
+<<<EOT
+        {
+            "code": "MUG_SIZE",
+            "translations": {
+                "de_CH": {
+                    "name": "Bechergröße"
+                },
+                "en_US": {
+                    "name": "Mug size"
+                }
+            },
+            "values": [
+                {
+                    "code": "MUG_SIZE_SMALL",
+                    "translations": {
+                        "de_CH": {
+                            "value": "Klein"
+                        },
+                        "en_US": {
+                            "value": "Small"
+                        }
+                    }
+                },
+                {
+                    "code": "MUG_SIZE_LARGE",
+                    "translations": {
+                        "de_CH": {
+                            "value": "Groß"
+                        },
+                        "en_US": {
+                            "value": "Large"
+                        }
+                    }
+                }
+            ]
+        }
+EOT;
+
+        $this->client->request('POST', '/api/v1/product-options/', [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product_option/create_response', Response::HTTP_CREATED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_create_product_option_without_required_fields()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('POST', '/api/v1/product-options/', [], [], static::$authorizedHeaderWithContentType, []);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product_option/create_validation_fail_response', Response::HTTP_BAD_REQUEST);
+    }
+}

--- a/tests/Responses/Expected/product/create_with_options_response.json
+++ b/tests/Responses/Expected/product/create_with_options_response.json
@@ -6,10 +6,12 @@
     "variants": [],
     "options": [
         {
-            "code": "MUG_SIZE"
+            "code": "MUG_SIZE",
+            "values": []
         },
         {
-            "code": "MUG_COLOR"
+            "code": "MUG_COLOR",
+            "values": []
         }
     ],
     "associations": [],

--- a/tests/Responses/Expected/product_option/create_response.json
+++ b/tests/Responses/Expected/product_option/create_response.json
@@ -1,0 +1,16 @@
+{
+    "name": "Mug size",
+    "code": "MUG_SIZE",
+    "values": [
+        {
+            "name": "Mug size",
+            "value": "Small",
+            "code": "MUG_SIZE_SMALL"
+        },
+        {
+            "name": "Mug size",
+            "value": "Large",
+            "code": "MUG_SIZE_LARGE"
+        }
+    ]
+}

--- a/tests/Responses/Expected/product_option/create_validation_fail_response.json
+++ b/tests/Responses/Expected/product_option/create_validation_fail_response.json
@@ -1,0 +1,19 @@
+{
+    "code": 400,
+    "message": "Validation Failed",
+    "errors": {
+        "errors": [
+            "Please add at least 2 option values."
+        ],
+        "children": {
+            "position": {},
+            "translations": {},
+            "values": {},
+            "code": {
+                "errors": [
+                    "Please enter option code."
+                ]
+            }
+        }
+    }
+}

--- a/tests/Responses/Expected/product_option/index_response.json
+++ b/tests/Responses/Expected/product_option/index_response.json
@@ -1,0 +1,29 @@
+{
+    "page": 1,
+    "limit": 10,
+    "pages": 1,
+    "total": 2,
+    "_links": {
+        "self": {
+            "href": "\/api\/v1\/product-options\/?page=1&limit=10"
+        },
+        "first": {
+            "href": "\/api\/v1\/product-options\/?page=1&limit=10"
+        },
+        "last": {
+            "href": "\/api\/v1\/product-options\/?page=1&limit=10"
+        }
+    },
+    "_embedded": {
+        "items": [
+            {
+                "code": "MUG_SIZE",
+                "values": []
+            },
+            {
+                "code": "MUG_COLOR",
+                "values": []
+            }
+        ]
+    }
+}

--- a/tests/Responses/Expected/product_option/index_response_after_delete.json
+++ b/tests/Responses/Expected/product_option/index_response_after_delete.json
@@ -1,0 +1,25 @@
+{
+    "page": 1,
+    "limit": 10,
+    "pages": 1,
+    "total": 1,
+    "_links": {
+        "self": {
+            "href": "\/api\/v1\/product-options\/?page=1&limit=10"
+        },
+        "first": {
+            "href": "\/api\/v1\/product-options\/?page=1&limit=10"
+        },
+        "last": {
+            "href": "\/api\/v1\/product-options\/?page=1&limit=10"
+        }
+    },
+    "_embedded": {
+        "items": [
+            {
+                "code": "MUG_COLOR",
+                "values": []
+            }
+        ]
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | yes |
| BC breaks?      | yes |
| License         | MIT |

The serializer configuration for product options currently does not correctly expose values: options only expose their codes, no names, no values. The `name` property is no longer used, instead this should be a virtual `getName`. The same goes for option values, affecting the `value` attribute.

Unfortunately, exposing option values triggers an error when creating a new option. The `ProductOptionValueType` creates a new `ProductOptionValue` object through the forms `empty_data` closure. However, the resulting object has no locale information, so when the result of the create is serialized, the following error occurs:
> No locale has been set and current locale is undefined.

Obviously, the forms should create new objects not through the default `empty_data` function, but rather through the respective resource factory. Since such a change affects all form classes and might be considered a BC break (it involves adding a required `factory` argument to `AbstractResourceType::__construct`), I wanted to get some input on the issue before going out and changing all forms and services. What do you think?