### PR TITLE
[Admin][JS] Fixed way too imprecise selector for errors rendering in the tabular form

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-compound-form-errors.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-compound-form-errors.js
@@ -13,13 +13,12 @@
     $.fn.extend({
         addTabErrors: function () {
             var element = $(this);
-            var tabElements = element.find('.ui.segment');
 
-            $(tabElements).each(function () {
+            $('.ui.segment > .ui.tab').each(function () {
                 var errors = $(this).find('.sylius-validation-error');
 
                 if(0 !== errors.length) {
-                    var tabName = $(this).find('.ui.tab').attr('data-tab');
+                    var tabName = $(this).attr('data-tab');
                     var tabWithErrors = $(element).find('a.item[data-tab="' + tabName + '"]');
 
                     var label = tabWithErrors.html();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

Turns out the previous selector (namely `element.find('.ui.segment')`) was going way too deep down the rabbit hole, losing the names of the tabs with errors.
The outcome being **every** error was aggregated onto the first tab of the menu.