### PR TITLE
Fix broken mail links

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/_content.html.twig
@@ -37,7 +37,7 @@
                 {% endif %}
             </div>
             <div class="extra content">
-                <a href="mailto: {{ customer.email }}">
+                <a href="mailto:{{ customer.email }}">
                     <i class="envelope icon"></i> {{ customer.email }}
                 </a>
             </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/_info.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/_info.html.twig
@@ -6,7 +6,7 @@
         </div>
     </div>
     <div class="extra content">
-        <a href="mailto: {{ customer.email }}">
+        <a href="mailto:{{ customer.email }}">
             <i class="envelope icon"></i>
             {{ customer.email }}
         </a>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

The links to mail a customer are broken due to having a space in them.