### PR TITLE
[Docs] Unify some paths in documentation

### DIFF
--- a/docs/customization/factory.rst
+++ b/docs/customization/factory.rst
@@ -91,7 +91,7 @@ Take its interface (``Sylius\Component\Product\Factory\ProductFactoryInterface``
     }
 
 2. In order to decorate the base ProductFactory with your implementation you need to configure it
-as a decorating service in the ``app\Resources\config\services.yml``.
+as a decorating service in the ``app/Resources/config/services.yml``.
 
 .. code-block:: yaml
 

--- a/docs/customization/validation.rst
+++ b/docs/customization/validation.rst
@@ -11,10 +11,10 @@ Let's take the example of changing the length of ``name`` for the ``Product`` en
 In the ``sylius`` validation group the minimum length is equal to 2.
 What if you'd want to have at least 10 characters?
 
-1. Create the ``AppBundle\Resources\config\validation.yml``.
+1. Create the ``AppBundle/Resources/config/validation.yml``.
 
 In this file you need to overwrite the whole validation of your field that you are willing to modify.
-Take this configuration from the ``Sylius\Bundle\ProductBundle\Resources\config\validation.xml`` - you can choose format ``xml`` or ``yaml``.
+Take this configuration from the ``Sylius/Bundle/ProductBundle/Resources/config/validation.xml`` - you can choose format ``xml`` or ``yaml``.
 
 Give it a new, custom validation group - ``[app_product]``.
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | |
| License         | MIT |

I suppose that `\` should be used for namespaces, but `/` for directories/paths.