### PR TITLE
Improve permissions checking while installing assets

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Installer/Checker/CommandDirectoryChecker.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Checker/CommandDirectoryChecker.php
@@ -14,8 +14,6 @@ namespace Sylius\Bundle\CoreBundle\Installer\Checker;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Finder\Iterator\RecursiveDirectoryIterator;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -45,8 +43,24 @@ final class CommandDirectoryChecker
      */
     public function ensureDirectoryExists($directory, OutputInterface $output)
     {
-        if (!is_dir($directory)) {
-            $this->createDirectory($directory, $output);
+        if (is_dir($directory)) {
+            return;
+        }
+
+        try {
+            $this->filesystem->mkdir($directory, 0755);
+
+            $output->writeln(sprintf('<comment>Created "%s" directory.</comment>', realpath($directory)));
+        } catch (IOException $exception) {
+            $output->writeln('');
+            $output->writeln('<error>Cannot run command due to unexisting directory (tried to create it automatically, failed).</error>');
+            $output->writeln('');
+
+            throw new \RuntimeException(sprintf(
+                'Create directory "%s" and run command "<comment>%s</comment>"',
+                realpath($directory),
+                $this->name
+            ));
         }
     }
 
@@ -55,15 +69,24 @@ final class CommandDirectoryChecker
      */
     public function ensureDirectoryIsWritable($directory, OutputInterface $output)
     {
-        try {
-            $this->changePermissionsRecursively($directory, $output);
-        } catch (AccessDeniedException $exception) {
-            $output->writeln('');
-            $output->writeln($this->createBadPermissionsMessage());
+        if (is_writable($directory)) {
+            return;
+        }
 
-            throw new \RuntimeException(
-                sprintf('Set "%s" writable recursively and run command "<comment>%s</comment>"', $exception->getMessage(), $this->name)
-            );
+        try {
+            $this->filesystem->chmod($directory, 0755);
+
+            $output->writeln(sprintf('<comment>Changed "%s" permissions to 0755.</comment>', realpath($directory)));
+        } catch (IOException $exception) {
+            $output->writeln('');
+            $output->writeln('<error>Cannot run command due to bad directory permissions (tried to change permissions to 0755).</error>');
+            $output->writeln('');
+
+            throw new \RuntimeException(sprintf(
+                'Set "%s" writable and run command "<comment>%s</comment>"',
+                realpath(dirname($directory)),
+                $this->name
+            ));
         }
     }
 
@@ -73,81 +96,5 @@ final class CommandDirectoryChecker
     public function setCommandName($name)
     {
         $this->name = $name;
-    }
-
-    /**
-     * @param string $directory
-     * @param OutputInterface $output
-     */
-    private function createDirectory($directory, OutputInterface $output)
-    {
-        try {
-            $this->filesystem->mkdir($directory, 0755);
-        } catch (IOException $exception) {
-            $output->writeln('');
-            $output->writeln($this->createUnexistingDirectoryMessage());
-
-            throw new \RuntimeException(
-                sprintf('Create directory "%s" and run command "<comment>%s</comment>"', realpath($directory), $this->name)
-            );
-        }
-
-        $output->writeln(sprintf('<comment>Created "%s" directory.</comment>', realpath($directory)));
-    }
-
-    /**
-     * @param string $directory
-     * @param OutputInterface $output
-     */
-    private function changePermissionsRecursively($directory, OutputInterface $output)
-    {
-        if (is_file($directory) && is_writable($directory)) {
-            return;
-        }
-
-        if (!is_writable($directory)) {
-            $this->changePermissions($directory, $output);
-
-            return;
-        }
-
-        foreach (new RecursiveDirectoryIterator($directory, \FilesystemIterator::CURRENT_AS_FILEINFO) as $subdirectory) {
-            if ('.' !== $subdirectory->getFilename()[0]) {
-                $this->changePermissionsRecursively($subdirectory->getPathname(), $output);
-            }
-        }
-    }
-
-    /**
-     * @param string $directory
-     * @param OutputInterface $output
-     *
-     * @throws AccessDeniedException if directory/file permissions cannot be changed
-     */
-    private function changePermissions($directory, OutputInterface $output)
-    {
-        try {
-            $this->filesystem->chmod($directory, 0755, 0000, true);
-
-            $output->writeln(sprintf('<comment>Changed "%s" permissions to 0755.</comment>', realpath($directory)));
-        } catch (IOException $exception) {
-            throw new AccessDeniedException(realpath(dirname($directory)));
-        }
-    }
-
-    /**
-     * @return string
-     */
-    private function createUnexistingDirectoryMessage()
-    {
-        return '<error>Cannot run command due to unexisting directory (tried to create it automatically, failed).</error>'.PHP_EOL;
-    }
-
-    /**
-     * @return string
-     */
-    private function createBadPermissionsMessage()
-    {
-        return '<error>Cannot run command due to bad directory permissions (tried to change permissions to 0755).</error>'.PHP_EOL;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

It used to crash with:
```
$ bin/console sylius:install:assets
Installing Sylius assets for environment dev.

Cannot run command due to bad directory permissions (tried to change permissions to 0755).

Set "/Users/pamil/Projects/Sylius/Sylius-Standard/web/bundles" writable recursively and run command "sylius:install:assets"
```

While `web/bundles/` had `0755` permissions (but there was a symlink inside).