### PR TITLE
Require Semantic UI CSS maximum at 2.2.7 because min JS missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "jquery": "^2.2.0",
     "lightbox2": "^2.9.0",
-    "semantic-ui-css": "^2.2.0"
+    "semantic-ui-css": "<=2.2.7"
   },
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #7571 (temporary fix I think) |
| License         | MIT |

Semantic UI CSS minified JS file is missing in version 2.2.8, which is required by the ShopBundle (Gulpfile.js). This PR fixes it temporary by requiring maximum 2.2.7, until the issue might be fixed on Semantic UI CSS side.

Another option could be to load the JS version if the min.js version is missing and minify it ourselves. 

I think we should keep an eye on https://github.com/Semantic-Org/Semantic-UI-CSS/issues/29 how it will be solved on their side and adjust based on this. For now this fix will make sure people installing Sylius from master get atleast a working version out of the box.
