### PR TITLE
[Core][Shipping] Add missing default shipping method resolver service definition

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -67,6 +67,9 @@
         <service id="sylius.payment_method_resolver.default" class="Sylius\Component\Core\Resolver\DefaultPaymentMethodResolver">
             <argument type="service" id="sylius.repository.payment_method" />
         </service>
+        <service id="sylius.shipping_method_resolver.default" class="Sylius\Component\Core\Resolver\DefaultShippingMethodResolver">
+            <argument type="service" id="sylius.repository.shipping_method" />
+        </service>
         <service id="sylius.updater.order.exchange_rate" class="Sylius\Component\Core\Updater\OrderExchangeRateUpdater">
             <argument type="service" id="sylius.repository.currency" />
         </service>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/order_processing.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/order_processing.xml
@@ -18,7 +18,7 @@
         </service>
 
         <service id="sylius.order_processing.order_shipment_processor" class="Sylius\Component\Core\OrderProcessing\OrderShipmentProcessor">
-            <argument type="service" id="sylius.resolver.default_shipping_method" />
+            <argument type="service" id="sylius.shipping_method_resolver.default" />
             <argument type="service" id="sylius.factory.shipment" />
             <tag name="sylius.order_processor" priority="50"/>
         </service>

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
@@ -42,7 +42,7 @@
             <tag name="sylius.shipping_method_resolver" type="default" label="Default" />
         </service>
 
-        <service id="sylius.resolver.default_shipping_method" class="Sylius\Component\Shipping\Resolver\DefaultShippingMethodResolver">
+        <service id="sylius.shipping_method_resolver.default" class="Sylius\Component\Shipping\Resolver\DefaultShippingMethodResolver">
             <argument type="service" id="sylius.repository.shipping_method" />
         </service>
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #7231 and #7314 |
| License         | MIT |

Quick fix for a problem with adding a product to a new channel without a shipping method.