### PR TITLE
[Core] Fix default shipping method resolver

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -67,6 +67,9 @@
         <service id="sylius.payment_method_resolver.default" class="Sylius\Component\Core\Resolver\DefaultPaymentMethodResolver">
             <argument type="service" id="sylius.repository.payment_method" />
         </service>
+        <service id="sylius.resolver.default_shipping_method" class="Sylius\Component\Core\Resolver\DefaultShippingMethodResolver">
+            <argument type="service" id="sylius.repository.shipping_method" />
+        </service>
         <service id="sylius.updater.order.exchange_rate" class="Sylius\Component\Core\Updater\OrderExchangeRateUpdater">
             <argument type="service" id="sylius.repository.currency" />
         </service>

--- a/src/Sylius/Component/Core/Resolver/DefaultShippingMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/DefaultShippingMethodResolver.php
@@ -52,7 +52,7 @@ class DefaultShippingMethodResolver implements DefaultShippingMethodResolverInte
         if (empty($shippingMethods)) {
             throw new UnresolvedDefaultShippingMethodException();
         }
-        
+
         return $shippingMethods[0];
     }
 }

--- a/src/Sylius/Component/Shipping/Resolver/DefaultShippingMethodResolver.php
+++ b/src/Sylius/Component/Shipping/Resolver/DefaultShippingMethodResolver.php
@@ -42,7 +42,7 @@ final class DefaultShippingMethodResolver implements DefaultShippingMethodResolv
         if (empty($shippingMethods)) {
             throw new UnresolvedDefaultShippingMethodException();
         }
-        
+
         return $shippingMethods[0];
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

The service from `Core` was not used and even not registered causing invalid shipping method to be assigned to a cart (even not enabled for current channel).