### PR TITLE
[Documentation] Missing path for facebook login

### DIFF
--- a/docs/cookbook/facebook-login.rst
+++ b/docs/cookbook/facebook-login.rst
@@ -44,6 +44,9 @@ Set up the HWIOAuthBundle
         resource: "@HWIOAuthBundle/Resources/config/routing/login.xml"
         prefix:   /login
 
+    facebook:
+        path: "/login/check-facebook"
+
 Configure the connection to Facebook
 ------------------------------------
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

Without this change, I keep receiving the `RouteNotFound` error.

<img width="1023" alt="zrzut ekranu 2017-02-23 o 11 39 04" src="https://cloud.githubusercontent.com/assets/6213903/23255694/ddbb0d24-f9bc-11e6-9f83-1d883b6ad50f.png">


**Update:**
 - Some docs about requiring a path without any controller: https://github.com/hwi/HWIOAuthBundle/blob/master/Resources/doc/3-configuring_the_security_layer.md#b-configure-the-oauth-firewall
 - And comment on issue with some explanation: https://github.com/hwi/HWIOAuthBundle/issues/781#issuecomment-100463435