### PR TITLE
Implement comparison method on all ExpressionBuilderInterface classes

### DIFF
--- a/src/Sylius/Bundle/GridBundle/Doctrine/DBAL/ExpressionBuilder.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/DBAL/ExpressionBuilder.php
@@ -53,8 +53,7 @@ final class ExpressionBuilder implements ExpressionBuilderInterface
      */
     public function comparison($field, $operator, $value)
     {
-        throw new \BadMethodCallException('Not supported yet.');
-        // TODO: Implement comparison() method.
+        return $this->queryBuilder->expr()->comparison($field, $operator, $value);
     }
 
     /**

--- a/src/Sylius/Bundle/GridBundle/Doctrine/ORM/ExpressionBuilder.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/ORM/ExpressionBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\GridBundle\Doctrine\ORM;
 
+use Doctrine\ORM\Query\Expr\Comparison;
 use Doctrine\ORM\QueryBuilder;
 use Sylius\Component\Grid\Data\ExpressionBuilderInterface;
 
@@ -53,8 +54,7 @@ class ExpressionBuilder implements ExpressionBuilderInterface
      */
     public function comparison($field, $operator, $value)
     {
-        throw new \BadMethodCallException('Not supported yet.');
-        // TODO: Implement comparison() method.
+        return new Comparison($field, $operator, $value);
     }
 
     /**

--- a/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/ExpressionBuilder.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/ExpressionBuilder.php
@@ -60,7 +60,7 @@ class ExpressionBuilder implements ExpressionBuilderInterface
      */
     public function comparison($field, $operator, $value)
     {
-        throw new \BadMethodCallException('Not supported yet.');
+        return new Comparison($field, $operator, $value);
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

Each of the `Sylius\Component\Grid\Data\ExpressionBuilderInterface` implementations right now have a stub `comparison()` method that throws a `BadMethodCallException` because the methods aren't actually implemented.  This PR adds them.

The DBAL adapter just proxies directly to the expression builder's method.  Since the other two don't expose a similar method, the internals from those expression builders are copied and a `Comparison` object is instantiated and returned directly.