### PR TITLE
[Documenation] Change `the the` to `the`

### DIFF
--- a/docs/api/product_variants.rst
+++ b/docs/api/product_variants.rst
@@ -381,7 +381,7 @@ Definition
 Example
 ^^^^^^^
 
-To see the details of the the product variant with ``code = medium-theme-mug``, which is defined for the product with ``code = MUG-TH`` use the below method.
+To see the details of the product variant with ``code = medium-theme-mug``, which is defined for the product with ``code = MUG-TH`` use the below method.
 
 .. code-block:: bash
 

--- a/docs/api/tax_rates.rst
+++ b/docs/api/tax_rates.rst
@@ -58,7 +58,7 @@ Definition
 Example
 ^^^^^^^
 
-To see the details of the the tax rate with ``code = clothing_sales_tax_7`` use the below method:
+To see the details of the tax rate with ``code = clothing_sales_tax_7`` use the below method:
 
 .. code-block:: bash
 

--- a/docs/api/taxons.rst
+++ b/docs/api/taxons.rst
@@ -368,7 +368,7 @@ Definition
 Example
 ^^^^^^^
 
-To see the details of the the taxon with ``code = toys`` use the below method:
+To see the details of the taxon with ``code = toys`` use the below method:
 
 .. code-block:: bash
 

--- a/docs/api/zones.rst
+++ b/docs/api/zones.rst
@@ -183,7 +183,7 @@ Definition
 Example
 ^^^^^^^
 
-To see the details of the the zone with ``code = EU`` use the below method:
+To see the details of the zone with ``code = EU`` use the below method:
 
 .. code-block:: bash
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

It appears that we have missed a few mistakes in our docs