### PR TITLE
[Admin][Shop] Prevent from leaving page with unsaved form data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "jquery": "^2.2.0",
+    "jquery.dirtyforms": "^2.0.0",
     "lightbox2": "^2.9.0",
     "semantic-ui-css": "^2.2.0"
   },

--- a/src/Sylius/Bundle/AdminBundle/Gulpfile.js
+++ b/src/Sylius/Bundle/AdminBundle/Gulpfile.js
@@ -22,6 +22,7 @@ var paths = {
     admin: {
         js: [
             nodeModulesPath + 'jquery/dist/jquery.min.js',
+            nodeModulesPath + 'jquery.dirtyforms/jquery.dirtyforms.js',
             nodeModulesPath + 'semantic-ui-css/semantic.min.js',
             vendorUiPath + 'Resources/private/js/**',
             vendorAdminPath + 'Resources/private/js/**'

--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
@@ -54,5 +54,7 @@
 
         $(document).productSlugGenerator();
         $(document).taxonSlugGenerator();
+
+        $('form:not(#filters)').dirtyForms();
     });
 })(jQuery);

--- a/src/Sylius/Bundle/ShopBundle/Gulpfile.js
+++ b/src/Sylius/Bundle/ShopBundle/Gulpfile.js
@@ -22,6 +22,7 @@ var paths = {
     shop: {
         js: [
             nodeModulesPath + 'jquery/dist/jquery.min.js',
+            nodeModulesPath + 'jquery.dirtyforms/jquery.dirtyforms.js',
             nodeModulesPath + 'semantic-ui-css/semantic.min.js',
             nodeModulesPath + 'lightbox2/dist/js/lightbox.js',
             vendorUiPath + 'Resources/private/js/**',

--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/app.js
@@ -55,5 +55,8 @@
         $('#sylius-billing-address').addressBook();
         $(document).provinceField();
         $(document).variantPrices();
+
+        $('form[name="sylius_customer_profile"]').dirtyForms();
+        $('form[name="sylius_address"]').dirtyForms();
     });
 })(jQuery);

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
@@ -10,7 +10,7 @@
 
 {% if definition.filters|length > 0 %}
     <div class="ui segment">
-        <form method="get" action="{{ path }}" class="ui loadable form">
+        <form method="get" action="{{ path }}" id="filters" class="ui loadable form">
             <div class="two fields">
             {% for filter in definition.filters|sort_by('position') if filter.enabled %}
                 {{ sylius_grid_render_filter(grid, filter) }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | |
| License         | MIT |

It's one of the most important UX feature. From now, leaving the page with form that was not submitted will require a confirmation (for now it's just a browser default alert box).

Protected forms:
 - all forms on Admin panel (except filters - I think it's unnecessary for them)
 - **personal info** form on my account page in Shop
 - **address** forms on my account page in Shop

![zrzut ekranu 2017-02-24 o 15 06 56](https://cloud.githubusercontent.com/assets/6212718/23306432/dc40bc90-faa3-11e6-9b75-c92c60522b28.png)
![zrzut ekranu 2017-02-24 o 15 08 49](https://cloud.githubusercontent.com/assets/6212718/23306433/dc4244ac-faa3-11e6-92a5-6b6af23e462c.png)
