### PR TITLE
[CoreBundle] Installer Requirements - fix

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Installer/Requirement/FilesystemRequirements.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Requirement/FilesystemRequirements.php
@@ -36,12 +36,6 @@ final class FilesystemRequirements extends RequirementCollection
                 true,
                 $translator->trans('sylius.installer.filesystem.logs.help', ['%path%' => $logDir])
             ))
-            ->add(new Requirement(
-                $translator->trans('sylius.installer.filesystem.parameters.header', []),
-                is_writable($root.'/config/parameters.yml'),
-                true,
-                $translator->trans('sylius.installer.filesystem.parameters.help', ['%path%' => $root.'/config/parameters.yml'])
-            ))
         ;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

Our Installer should not be writing to `parameters.yml`, therefore the `is_writable` check is redundant.