### PR TITLE
[Resource] Throw 404 if expression is invalid

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/order.yml
@@ -19,5 +19,5 @@ sylius_admin_partial_order_latest_in_channel:
                 method: findLatestInChannel
                 arguments:
                     count: $count
-                    channel: expr:service('sylius.repository.channel').findOneByCode($channelCode)
+                    channel: expr:notFoundOnNull(service('sylius.repository.channel').findOneByCode($channelCode))
             template: $template

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_variant.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_variant.yml
@@ -26,7 +26,7 @@ sylius_admin_product_variant_create:
             factory:
                 method: createForProduct
                 arguments:
-                  - expr:service('sylius.repository.product').find($productId)
+                  - expr:notFoundOnNull(service('sylius.repository.product').find($productId))
             template: "@SyliusAdmin/Crud/create.html.twig"
             grid: sylius_admin_product_variant
             section: admin

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/promotion_coupon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/promotion_coupon.yml
@@ -26,7 +26,7 @@ sylius_admin_promotion_coupon_create:
             factory:
                 method: createForPromotion
                 arguments:
-                  - expr:service('sylius.repository.promotion').find($promotionId)
+                  - expr:notFoundOnNull(service('sylius.repository.promotion').find($promotionId))
             template: "@SyliusAdmin/Crud/create.html.twig"
             grid: sylius_admin_promotion_coupon
             section: admin

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/taxon.yml
@@ -32,7 +32,7 @@ sylius_admin_taxon_create_for_parent:
             redirect: sylius_admin_taxon_update
             factory:
                 method: createForParent
-                arguments: ['expr:service("sylius.repository.taxon").find($id)']
+                arguments: ['expr:notFoundOnNull(service("sylius.repository.taxon").find($id))']
             vars:
                 subheader: sylius.ui.manage_categorization_of_your_product
                 templates:

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/cart_item.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/cart_item.yml
@@ -12,7 +12,7 @@ sylius_api_cart_item_create:
             factory:
                 method: createForCart
                 arguments:
-                  - "expr:service('sylius.repository.order').findCartById($cartId)"
+                  - "expr:notFoundOnNull(service('sylius.repository.order').findCartById($cartId))"
             serialization_groups: [DetailedCart]
 
 sylius_api_cart_item:

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/routing/product_variant.yml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/routing/product_variant.yml
@@ -28,7 +28,7 @@ sylius_api_product_variant_create:
             factory:
                 method: createForProduct
                 arguments:
-                  - expr:service('sylius.repository.product').findOneByCode($productCode)
+                  - expr:notFoundOnNull(service('sylius.repository.product').findOneByCode($productCode))
 
 sylius_api_product_variant_update:
     path: /{code}

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -65,7 +65,7 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
     /**
      * {@inheritdoc}
      */
-    public function createShopListQueryBuilder(ChannelInterface $channel, TaxonInterface $taxon, $locale, array $sorting)
+    public function createShopListQueryBuilder(ChannelInterface $channel, TaxonInterface $taxon, $locale, array $sorting = [])
     {
         $queryBuilder = $this->createQueryBuilder('o')
             ->addSelect('translation')

--- a/src/Sylius/Bundle/ResourceBundle/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Sylius/Bundle/ResourceBundle/ExpressionLanguage/ExpressionLanguage.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\ExpressionLanguage;
+
+use Symfony\Component\DependencyInjection\ExpressionLanguage as BaseExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\ParserCache\ParserCacheInterface;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class ExpressionLanguage extends BaseExpressionLanguage
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(ParserCacheInterface $parser = null, array $providers = array())
+    {
+        array_unshift($providers, new NotNullExpressionFunctionProvider());
+
+        parent::__construct($parser, $providers);
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/ExpressionLanguage/NotNullExpressionFunctionProvider.php
+++ b/src/Sylius/Bundle/ResourceBundle/ExpressionLanguage/NotNullExpressionFunctionProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ResourceBundle\ExpressionLanguage;
+
+use Symfony\Component\ExpressionLanguage\ExpressionFunction;
+use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+final class NotNullExpressionFunctionProvider implements ExpressionFunctionProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new ExpressionFunction('notFoundOnNull', function ($result) {
+                return sprintf('(null !== %1$s) ? %1$s : throw new NotFoundHttpException(\'Requested page is invalid.\')', $result);
+            }, function ($arguments, $result) {
+                if (null === $result) {
+                    throw new NotFoundHttpException('Requested page is invalid.');
+                }
+
+                return $result;
+            }),
+        ];
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/services.xml
@@ -31,7 +31,7 @@
 
         <service id="sylius.resource_registry" class="Sylius\Component\Resource\Metadata\Registry" public="false" />
 
-        <service id="sylius.expression_language" class="Symfony\Component\DependencyInjection\ExpressionLanguage" public="false" />
+        <service id="sylius.expression_language" class="Sylius\Bundle\ResourceBundle\ExpressionLanguage\ExpressionLanguage" public="false" />
 
         <service id="sylius.form.extension.type.collection" class="Sylius\Bundle\ResourceBundle\Form\Extension\CollectionTypeExtension">
             <tag name="form.type_extension" extended-type="Symfony\Component\Form\Extension\Core\Type\CollectionType" />

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/grids/product.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/grids/product.yml
@@ -12,7 +12,7 @@ sylius_grid:
                         method: createShopListQueryBuilder
                         arguments:
                             channel: "expr:service('sylius.context.channel').getChannel()"
-                            taxon: "expr:service('sylius.repository.taxon').findOneBySlug($slug, service('sylius.context.locale').getLocaleCode())"
+                            taxon: "expr:notFoundOnNull(service('sylius.repository.taxon').findOneBySlug($slug, service('sylius.context.locale').getLocaleCode()))"
                             locale: "expr:service('sylius.context.locale').getLocaleCode()"
                             sorting: "expr:service('request_stack').getCurrentRequest().get('sorting', [])"
             sorting:

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/ajax/cart.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/ajax/cart.yml
@@ -10,11 +10,11 @@ sylius_shop_ajax_cart_add_item:
         _sylius:
             factory:
                 method: createForProduct
-                arguments: [expr:service('sylius.repository.product').find($productId)]
+                arguments: [expr:notFoundOnNull(service('sylius.repository.product').find($productId))]
             form:
                 type: Sylius\Bundle\CoreBundle\Form\Type\Order\AddToCartType
                 options:
-                    product: expr:service('sylius.repository.product').find($productId)
+                    product: expr:notFoundOnNull(service('sylius.repository.product').find($productId))
             redirect:
                 route: sylius_shop_cart_summary
                 parameters: {}

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/cart.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/cart.yml
@@ -18,11 +18,11 @@ sylius_shop_partial_cart_add_item:
             template: $template
             factory:
                 method: createForProduct
-                arguments: [expr:service('sylius.repository.product').find($productId)]
+                arguments: [expr:notFoundOnNull(service('sylius.repository.product').find($productId))]
             form:
                 type: Sylius\Bundle\CoreBundle\Form\Type\Order\AddToCartType
                 options:
-                    product: expr:service('sylius.repository.product').find($productId)
+                    product: expr:notFoundOnNull(service('sylius.repository.product').find($productId))
             redirect:
                 route: sylius_shop_cart_summary
                 parameters: {}

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/product_review.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/product_review.yml
@@ -28,7 +28,7 @@ sylius_shop_product_review_create:
             factory:
                 method: createForSubjectWithReviewer
                 arguments:
-                    - "expr:service('sylius.repository.product').findOneByChannelAndSlug(service('sylius.context.channel').getChannel(), service('sylius.context.locale').getLocaleCode(), $slug)"
+                    - "expr:notFoundOnNull(service('sylius.repository.product').findOneByChannelAndSlug(service('sylius.context.channel').getChannel(), service('sylius.context.locale').getLocaleCode(), $slug))"
                     - "expr:service('sylius.context.customer').getCustomer()"
             redirect:
                 route: sylius_shop_product_show

--- a/src/Sylius/Component/Core/Repository/ProductRepositoryInterface.php
+++ b/src/Sylius/Component/Core/Repository/ProductRepositoryInterface.php
@@ -38,7 +38,7 @@ interface ProductRepositoryInterface extends BaseProductRepositoryInterface
      *
      * @return QueryBuilder
      */
-    public function createShopListQueryBuilder(ChannelInterface $channel, TaxonInterface $taxon, $locale, array $sorting);
+    public function createShopListQueryBuilder(ChannelInterface $channel, TaxonInterface $taxon, $locale, array $sorting = []);
 
     /**
      * @param ChannelInterface $channel


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | |
| License         | MIT |

With current implementation, if expression (for example in grid) returns `null` value it's passed further and results in some nasty errors.

Example for unexisting taxon slug on shop:
![zrzut ekranu 2017-03-01 o 14 54 05](https://cloud.githubusercontent.com/assets/6212718/23462725/3f09ecb8-fe8f-11e6-960d-2919d5e91012.png)

With this simple change, we can display pretty 404 page if anything gone bad.

![zrzut ekranu 2017-03-01 o 14 51 30](https://cloud.githubusercontent.com/assets/6212718/23462750/5c7075f6-fe8f-11e6-8ab0-18072cbd1b45.png)

