### PR TITLE
[Shop][Ui] Div tags are not allowed as a child to h2

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_support.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_support.html.twig
@@ -1,9 +1,9 @@
 <h2 class="ui center aligned icon header">
     <i class="circular phone icon"></i>
     +48 123 456 789
-    <div class="sub header">
+    <span class="sub header">
         {{ 'sylius.ui.need_assistance'|trans }} {{ 'sylius.ui.call_us'|trans }}
-    </div>
+    </span>
 </h2>
 
 <div class="ui divider"></div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

Let's use span instead, identical looks thanks to ".sub.header".