### PR TITLE
[Fixtures] adding default_tax_zone in the ChannelFixture configuration

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/ChannelFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ChannelFixture.php
@@ -37,6 +37,7 @@ class ChannelFixture extends AbstractResourceFixture
                 ->scalarNode('code')->cannotBeEmpty()->end()
                 ->scalarNode('hostname')->cannotBeEmpty()->end()
                 ->scalarNode('color')->cannotBeEmpty()->end()
+                ->scalarNode('default_tax_zone')->end()
                 ->scalarNode('tax_calculation_strategy')->end()
                 ->booleanNode('enabled')->end()
                 ->scalarNode('default_locale')->cannotBeEmpty()->end()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

Sorry, I forgot to include the actual configuration change in PR https://github.com/Sylius/Sylius/pull/7659