### PR TITLE
Ordered CountryChoiceType

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
@@ -44,10 +44,16 @@ final class CountryChoiceType extends AbstractType
             ->setDefaults([
                 'choices' => function (Options $options) {
                     if (null === $options['enabled']) {
-                        return $this->countryRepository->findAll();
+                        $countries = $this->countryRepository->findAll();
+                    } else {
+                        $countries = $this->countryRepository->findBy(['enabled' => $options['enabled']]);
                     }
 
-                    return $this->countryRepository->findBy(['enabled' => $options['enabled']]);
+                    usort($countries, function($a, $b) {
+                        return $a->getName() < $b->getName() ? -1 : 1;
+                    });
+
+                    return $countries;
                 },
                 'choice_value' => 'code',
                 'choice_label' => 'name',

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
@@ -49,7 +49,11 @@ final class CountryChoiceType extends AbstractType
                         $countries = $this->countryRepository->findBy(['enabled' => $options['enabled']]);
                     }
 
-                    usort($countries, function($a, $b) {
+                    /*
+                     * PHP 5.* bug, fixed in PHP 7: https://bugs.php.net/bug.php?id=50688
+                     * "usort(): Array was modified by the user comparison function"
+                     */
+                    @usort($countries, function($a, $b) {
                         return $a->getName() < $b->getName() ? -1 : 1;
                     });
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #7232 |
| License         | MIT |

As mentioned in #7232, country list was mantaining the order from the DB. When changing between languages it results in bad UX.

I decided to use `usort` but maybe this has to be done at repository level (not sure about this).