### PR TITLE
Double check promotions are eligible in PromotionProcessor

### DIFF
--- a/features/promotion/receiving_discount/receiving_stacked_promotions_with_changing_context.feature
+++ b/features/promotion/receiving_discount/receiving_stacked_promotions_with_changing_context.feature
@@ -1,28 +1,28 @@
 @receiving_discount
 Feature: Receiving stacked promotion with changing context
-  In order to pay proper amount while buying promoted goods
-  As a Customer
-  I want to receive discount for my purchase
+    In order to pay proper amount while buying promoted goods
+    As a Customer
+    I want to receive discount for my purchase
 
-  Background:
-    Given the store operates on a single channel in "United States"
-    And the store has "DHL" shipping method with "$10.00" fee
-    And the store has a product "PHP T-Shirt" priced at "$120.00"
-    And there is a promotion "Holiday promotion" with priority 1
-    And it gives "50%" discount to every order
-    And there is a promotion "Free shiping over" with priority 0
-    And it gives free shipping to every order over "$100"
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has "DHL" shipping method with "$10.00" fee
+        And the store has a product "PHP T-Shirt" priced at "$120.00"
+        And there is a promotion "Holiday promotion" with priority 1
+        And it gives "50%" discount to every order
+        And there is a promotion "Free shiping over" with priority 0
+        And it gives free shipping to every order over "$100"
 
-  @ui
-  Scenario: Receiving only the "Holiday promotion"
-    When I add product "PHP T-Shirt" to the cart
-    Then my cart total should be "$70.00"
-    And my discount should be "-$60.00"
-    And my cart shipping total should be "$10.00"
+    @ui
+    Scenario: Receiving only the "Holiday promotion"
+        When I add product "PHP T-Shirt" to the cart
+        Then my cart total should be "$70.00"
+        And my discount should be "-$60.00"
+        And my cart shipping total should be "$10.00"
 
-  @ui
-  Scenario: Receiving the "Holiday promotion" and the free shipping discount
-    When I add 2 products "PHP T-Shirt" to the cart
-    Then my cart total should be "$120.00"
-    And my discount should be "-$120.00"
-    And my cart shipping total should be "$0.00"
+    @ui
+    Scenario: Receiving the "Holiday promotion" and the free shipping discount
+        When I add 2 products "PHP T-Shirt" to the cart
+        Then my cart total should be "$120.00"
+        And my discount should be "-$120.00"
+        And my cart shipping total should be "$0.00"

--- a/features/promotion/receiving_discount/receiving_stacked_promotions_with_changing_context.feature
+++ b/features/promotion/receiving_discount/receiving_stacked_promotions_with_changing_context.feature
@@ -1,0 +1,28 @@
+@receiving_discount
+Feature: Receiving stacked promotion with changing context
+  In order to pay proper amount while buying promoted goods
+  As a Customer
+  I want to receive discount for my purchase
+
+  Background:
+    Given the store operates on a single channel in "United States"
+    And the store has "DHL" shipping method with "$10.00" fee
+    And the store has a product "PHP T-Shirt" priced at "$120.00"
+    And there is a promotion "Holiday promotion" with priority 1
+    And it gives "50%" discount to every order
+    And there is a promotion "Free shiping over" with priority 0
+    And it gives free shipping to every order over "$100"
+
+  @ui
+  Scenario: Receiving only the "Holiday promotion"
+    When I add product "PHP T-Shirt" to the cart
+    Then my cart total should be "$70.00"
+    And my discount should be "-$60.00"
+    And my cart shipping total should be "$10.00"
+
+  @ui
+  Scenario: Receiving the "Holiday promotion" and the free shipping discount
+    When I add 2 products "PHP T-Shirt" to the cart
+    Then my cart total should be "$120.00"
+    And my discount should be "-$120.00"
+    And my cart shipping total should be "$0.00"

--- a/src/Sylius/Behat/Context/Setup/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/PromotionContext.php
@@ -680,8 +680,7 @@ final class PromotionContext implements Context
         PromotionInterface $promotion,
         $discount,
         $itemTotal
-    )
-    {
+    ) {
         $channelCode = $this->sharedStorage->get('channel')->getCode();
         $rule = $this->ruleFactory->createItemTotal($channelCode, $itemTotal);
         $action = $this->actionFactory->createShippingPercentageDiscount($discount);

--- a/src/Sylius/Behat/Context/Setup/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/PromotionContext.php
@@ -674,6 +674,30 @@ final class PromotionContext implements Context
     }
 
     /**
+     * @Given /^([^"]+) gives ("[^"]+%") discount on shipping to every order over ("(?:€|£|\$)[^"]+")$/
+     */
+    public function itGivesDiscountOnShippingToEveryOrderOver(
+        PromotionInterface $promotion,
+        $discount,
+        $itemTotal
+    )
+    {
+        $channelCode = $this->sharedStorage->get('channel')->getCode();
+        $rule = $this->ruleFactory->createItemTotal($channelCode, $itemTotal);
+        $action = $this->actionFactory->createShippingPercentageDiscount($discount);
+
+        $this->persistPromotion($promotion, $action, [], $rule);
+    }
+
+    /**
+     * @Given /^([^"]+) gives free shipping to every order over ("(?:€|£|\$)[^"]+")$/
+     */
+    public function itGivesFreeShippingToEveryOrderOver(PromotionInterface $promotion, $itemTotal)
+    {
+        $this->itGivesDiscountOnShippingToEveryOrderOver($promotion, 1, $itemTotal);
+    }
+
+    /**
      * @param array $taxonCodes
      *
      * @return array

--- a/src/Sylius/Component/Promotion/Processor/PromotionProcessor.php
+++ b/src/Sylius/Component/Promotion/Processor/PromotionProcessor.php
@@ -60,9 +60,9 @@ final class PromotionProcessor implements PromotionProcessorInterface
             $this->promotionApplicator->revert($subject, $promotion);
         }
 
-        $eligiblePromotions = [];
+        $preQualifiedPromotions = $this->preQualifiedPromotionsProvider->getPromotions($subject);
 
-        foreach ($this->preQualifiedPromotionsProvider->getPromotions($subject) as $promotion) {
+        foreach ($preQualifiedPromotions as $promotion) {
             if (!$this->promotionEligibilityChecker->isEligible($subject, $promotion)) {
                 continue;
             }
@@ -72,12 +72,12 @@ final class PromotionProcessor implements PromotionProcessorInterface
 
                 return;
             }
-
-            $eligiblePromotions[] = $promotion;
         }
 
-        foreach ($eligiblePromotions as $promotion) {
-            $this->promotionApplicator->apply($subject, $promotion);
+        foreach ($preQualifiedPromotions as $promotion) {
+            if($this->promotionEligibilityChecker->isEligible($subject, $promotion) && !$promotion->isExclusive()) {
+                $this->promotionApplicator->apply($subject, $promotion);
+            }
         }
     }
 }

--- a/src/Sylius/Component/Promotion/Processor/PromotionProcessor.php
+++ b/src/Sylius/Component/Promotion/Processor/PromotionProcessor.php
@@ -63,11 +63,7 @@ final class PromotionProcessor implements PromotionProcessorInterface
         $preQualifiedPromotions = $this->preQualifiedPromotionsProvider->getPromotions($subject);
 
         foreach ($preQualifiedPromotions as $promotion) {
-            if (!$this->promotionEligibilityChecker->isEligible($subject, $promotion)) {
-                continue;
-            }
-
-            if ($promotion->isExclusive()) {
+            if ($this->promotionEligibilityChecker->isEligible($subject, $promotion) && $promotion->isExclusive()) {
                 $this->promotionApplicator->apply($subject, $promotion);
 
                 return;

--- a/src/Sylius/Component/Promotion/Processor/PromotionProcessor.php
+++ b/src/Sylius/Component/Promotion/Processor/PromotionProcessor.php
@@ -63,7 +63,7 @@ final class PromotionProcessor implements PromotionProcessorInterface
         $preQualifiedPromotions = $this->preQualifiedPromotionsProvider->getPromotions($subject);
 
         foreach ($preQualifiedPromotions as $promotion) {
-            if ($this->promotionEligibilityChecker->isEligible($subject, $promotion) && $promotion->isExclusive()) {
+            if ($promotion->isExclusive() && $this->promotionEligibilityChecker->isEligible($subject, $promotion)) {
                 $this->promotionApplicator->apply($subject, $promotion);
 
                 return;
@@ -71,7 +71,7 @@ final class PromotionProcessor implements PromotionProcessorInterface
         }
 
         foreach ($preQualifiedPromotions as $promotion) {
-            if($this->promotionEligibilityChecker->isEligible($subject, $promotion) && !$promotion->isExclusive()) {
+            if (!$promotion->isExclusive() && $this->promotionEligibilityChecker->isEligible($subject, $promotion)) {
                 $this->promotionApplicator->apply($subject, $promotion);
             }
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #7584 |
| License         | MIT |

As mentioned in #7584:

>[PromotionProcessor](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Component/Promotion/Processor/PromotionProcessor.php) is responsible of applying adjustment to the order according to promotion rules. It checks for elegible promotions but it does not apply them until the end. This causes issues with promotions that need to take into account previously applied promotion such use an order total amount reduction.

**The fix**

We first try to find an exclusive promotion and apply it if exists. In case it doesn't, we iterate and start applying "normal" promotions. This way we always have the correct `$subject` context to validate if promotion is eligible. It this loop we only check for non exclusive promotion as exclusive ones should have been applied before. In cases when a exclusive promotion is eligible after applying a promotion before they have to be ignored.