### PR TITLE
Removed hardcoded 'customer' relation

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Type/AddressChoiceType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/AddressChoiceType.php
@@ -47,7 +47,7 @@ final class AddressChoiceType extends AbstractType
                     return $this->addressRepository->findAll();
                 }
 
-                return $this->addressRepository->findBy(['customer' => $options['customer']]);
+                return $this->addressRepository->findByCustomer($options['customer']);
             },
             'choice_value' => 'id',
             'choice_translation_domain' => false,


### PR DESCRIPTION
Replaced `findBy(['customer' => $options['customer']])` in favor of `findByCustomer($options['customer'])` in AddressChoiceType to allow overrides

| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| Related tickets | fixes #7672 |
| License         | MIT |
