### PR TITLE
[Grid] Add enabled items twig extension

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Index/_actions.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Index/_actions.html.twig
@@ -1,7 +1,7 @@
 <div class="middle aligned column">
     <div class="ui right floated buttons">
-        {% if definition.actionGroups.main is defined and definition.getActions('main')|length > 0 %}
-            {% for action in definition.getActions('main') if action.enabled %}
+        {% if definition.actionGroups.main is defined %}
+            {% for action in definition.getActions('main')|sylius_enabled_items %}
                 {{ sylius_grid_render_action(resources, action, null) }}
             {% endfor %}
         {% endif %}

--- a/src/Sylius/Bundle/GridBundle/Resources/config/services/templating.xml
+++ b/src/Sylius/Bundle/GridBundle/Resources/config/services/templating.xml
@@ -17,5 +17,8 @@
             <argument type="service" id="sylius.grid.renderer" />
             <tag name="templating.helper" alias="sylius_grid" />
         </service>
+        <service id="sylius.templating.helper.enabled_items" class="Sylius\Bundle\GridBundle\Templating\Helper\EnabledItemsHelper" lazy="true">
+            <tag name="templating.helper" alias="sylius_enabled_items" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/GridBundle/Resources/config/services/twig.xml
+++ b/src/Sylius/Bundle/GridBundle/Resources/config/services/twig.xml
@@ -26,5 +26,9 @@
             <argument type="service" id="sylius.templating.helper.grid" />
             <tag name="twig.extension" />
         </service>
+        <service id="sylius.twig.extension.enabled_items" class="Sylius\Bundle\GridBundle\Twig\EnabledItemsExtension" public="false">
+            <argument type="service" id="sylius.templating.helper.enabled_items" />
+            <tag name="twig.extension" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/GridBundle/Templating/Helper/EnabledItemsHelper.php
+++ b/src/Sylius/Bundle/GridBundle/Templating/Helper/EnabledItemsHelper.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\GridBundle\Templating\Helper;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Component\Templating\Helper\Helper;
+
+/**
+ * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
+ */
+class EnabledItemsHelper extends Helper
+{
+    /**
+     * @param array $items
+     * @param bool $enabled
+     *
+     * @return mixed
+     */
+    public function getEnabledItems(array $items, $enabled = true)
+    {
+        $itemsCollection = new ArrayCollection($items);
+
+        return $itemsCollection->filter(
+            function ($item) use ($enabled) {
+                return ($item->isEnabled() === $enabled);
+            }
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'sylius_enabled_items';
+    }
+}

--- a/src/Sylius/Bundle/GridBundle/Twig/EnabledItemsExtension.php
+++ b/src/Sylius/Bundle/GridBundle/Twig/EnabledItemsExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\GridBundle\Twig;
+
+use Sylius\Bundle\GridBundle\Templating\Helper\EnabledItemsHelper;
+
+/**
+ * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
+ */
+final class EnabledItemsExtension extends \Twig_Extension
+{
+    /**
+     * @var EnabledItemsHelper
+     */
+    private $enabledItemsHelper;
+
+    /**
+     * @param EnabledItemsHelper $enabledItemsHelper
+     */
+    public function __construct(EnabledItemsHelper $enabledItemsHelper)
+    {
+        $this->enabledItemsHelper = $enabledItemsHelper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return array(
+            new \Twig_SimpleFilter('sylius_enabled_items', [$this->enabledItemsHelper, 'getEnabledItems']),
+        );
+    }
+}

--- a/src/Sylius/Bundle/GridBundle/spec/Templating/Helper/EnabledItemsHelperSpec.php
+++ b/src/Sylius/Bundle/GridBundle/spec/Templating/Helper/EnabledItemsHelperSpec.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Sylius\Bundle\GridBundle\Templating\Helper;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\GridBundle\Templating\Helper\EnabledItemsHelper;
+use Sylius\Component\Grid\Definition\Action;
+use Symfony\Component\Templating\Helper\Helper;
+use Symfony\Component\Templating\Helper\HelperInterface;
+
+/**
+ * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
+ */
+final class EnabledItemsHelperSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(EnabledItemsHelper::class);
+    }
+
+    function it_is_a_symfony_templating_helper()
+    {
+        $this->shouldImplement(HelperInterface::class);
+    }
+
+    function it_extends_a_base_symfony_templating_helper()
+    {
+        $this->shouldHaveType(Helper::class);
+    }
+
+    function it_returns_only_enabled_items(Action $firstAction, Action $secondAction, Action $thirdAction)
+    {
+        $firstAction->isEnabled()->willReturn(true);
+        $secondAction->isEnabled()->willReturn(false);
+        $thirdAction->isEnabled()->willReturn(false);
+
+        $this->getEnabledItems([$firstAction, $secondAction, $thirdAction])->shouldHaveCount(1);
+    }
+
+    function it_returns_only_disabled_items(Action $firstAction, Action $secondAction, Action $thirdAction)
+    {
+        $firstAction->isEnabled()->willReturn(true);
+        $secondAction->isEnabled()->willReturn(false);
+        $thirdAction->isEnabled()->willReturn(false);
+
+        $this->getEnabledItems([$firstAction, $secondAction, $thirdAction], false)->shouldHaveCount(2);
+    }
+
+    function it_has_name()
+    {
+        $this->getName()->shouldReturn('sylius_enabled_items');
+    }
+}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_search.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_search.html.twig
@@ -2,7 +2,7 @@
     <form method="get" action="{{ path('sylius_shop_product_index', {'slug': app.request.attributes.get('slug')}) }}" class="ui loadable form">
         <div class="ui stackable grid">
             <div class="eleven wide column">
-                {% for filter in products.definition.filters %}
+                {% for filter in products.definition.filters|sylius_enabled_items %}
                     {{ sylius_grid_render_filter(products, filter) }}
                 {% endfor %}
             </div>

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
@@ -8,7 +8,7 @@
 
 {% set path = path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')) %}
 
-{% if definition.filters|length > 0 %}
+{% if definition.filters|sylius_enabled_items|length > 0 %}
     <div class="ui hidden divider"></div>
     <div class="ui styled fluid accordion">
         <div class="title active">
@@ -18,7 +18,7 @@
         <div class="content active">
             <form method="get" action="{{ path }}" class="ui loadable form">
                 <div class="two fields">
-                {% for filter in definition.filters|sort_by('position') if filter.enabled %}
+                {% for filter in definition.filters|sylius_enabled_items|sort_by('position') %}
                     {{ sylius_grid_render_filter(grid, filter) }}
 
                     {% if loop.index0 % 2 %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Macro/table.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Macro/table.html.twig
@@ -17,27 +17,21 @@
 
 {% macro row(grid, definition, row) %}
     <tr class="item">
-    {% for field in definition.fields|sort_by('position') %}
-        {% if field.enabled %}
-            <td>{{ sylius_grid_render_field(grid, field, row) }}</td>
-        {% endif %}
+    {% for field in definition.fields|sylius_enabled_items|sort_by('position') %}
+        <td>{{ sylius_grid_render_field(grid, field, row) }}</td>
     {% endfor %}
     {% if definition.actionGroups.item is defined and definition.getActions('item')|length > 0 %}
         <td>
             <div class="ui buttons">
-                {% for action in definition.getActions('item')|sort_by('position') %}
-                    {% if action.enabled %}
-                        {{ sylius_grid_render_action(grid, action, row) }}
-                    {% endif %}
+                {% for action in definition.getActions('item')|sylius_enabled_items|sort_by('position') %}
+                    {{ sylius_grid_render_action(grid, action, row) }}
                 {% endfor %}
             </div>
             {% if definition.actionGroups.subitem is defined and definition.getActions('subitem')|length > 0 %}
             <div class="ui divider"></div>
             <div class="ui buttons">
-                {% for action in definition.getActions('subitem')|sort_by('position') %}
-                    {% if action.enabled %}
-                        {{ sylius_grid_render_action(grid, action, row) }}
-                    {% endif %}
+                {% for action in definition.getActions('subitem')|sylius_enabled_items|sort_by('position') %}
+                    {{ sylius_grid_render_action(grid, action, row) }}
                 {% endfor %}
             </div>
             {% endif %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

This PR fixes a problem with customizing grids, because now, for example when we disable all filters, that there will remain empty filter block above table.

Before:
![zrzut ekranu 2017-03-06 o 14 46 35](https://cloud.githubusercontent.com/assets/6140884/23612444/bf6e8446-027b-11e7-9de3-15033e7f60f7.png)

After:
![zrzut ekranu 2017-03-06 o 14 44 44](https://cloud.githubusercontent.com/assets/6140884/23612358/7b791210-027b-11e7-9864-b6088165468d.png)