### PR TITLE
[Grid] Add methods for getting only enabled fields, actions and filters

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Index/_actions.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Index/_actions.html.twig
@@ -1,7 +1,7 @@
 <div class="middle aligned column">
     <div class="ui right floated buttons">
-        {% if definition.actionGroups.main is defined and definition.getActions('main')|length > 0 %}
-            {% for action in definition.getActions('main') if action.enabled %}
+        {% if definition.actionGroups.main is defined %}
+            {% for action in definition.getEnabledActions('main') %}
                 {{ sylius_grid_render_action(resources, action, null) }}
             {% endfor %}
         {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_search.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_search.html.twig
@@ -2,7 +2,7 @@
     <form method="get" action="{{ path('sylius_shop_product_index', {'slug': app.request.attributes.get('slug')}) }}" class="ui loadable form">
         <div class="ui stackable grid">
             <div class="eleven wide column">
-                {% for filter in products.definition.filters %}
+                {% for filter in products.definition.enabledFilters %}
                     {{ sylius_grid_render_filter(products, filter) }}
                 {% endfor %}
             </div>

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
@@ -8,7 +8,7 @@
 
 {% set path = path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')) %}
 
-{% if definition.filters|length > 0 %}
+{% if definition.enabledFilters|length > 0 %}
     <div class="ui hidden divider"></div>
     <div class="ui styled fluid accordion">
         <div class="title active">
@@ -18,7 +18,7 @@
         <div class="content active">
             <form method="get" action="{{ path }}" class="ui loadable form">
                 <div class="two fields">
-                {% for filter in definition.filters|sort_by('position') if filter.enabled %}
+                {% for filter in definition.enabledFilters|sort_by('position') if filter.enabled %}
                     {{ sylius_grid_render_filter(grid, filter) }}
 
                     {% if loop.index0 % 2 %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Macro/table.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Macro/table.html.twig
@@ -17,27 +17,21 @@
 
 {% macro row(grid, definition, row) %}
     <tr class="item">
-    {% for field in definition.fields|sort_by('position') %}
-        {% if field.enabled %}
-            <td>{{ sylius_grid_render_field(grid, field, row) }}</td>
-        {% endif %}
+    {% for field in definition.enabledFields|sort_by('position') %}
+        <td>{{ sylius_grid_render_field(grid, field, row) }}</td>
     {% endfor %}
-    {% if definition.actionGroups.item is defined and definition.getActions('item')|length > 0 %}
+    {% if definition.actionGroups.item is defined and definition.getEnabledActions('item')|length > 0 %}
         <td>
             <div class="ui buttons">
-                {% for action in definition.getActions('item')|sort_by('position') %}
-                    {% if action.enabled %}
-                        {{ sylius_grid_render_action(grid, action, row) }}
-                    {% endif %}
+                {% for action in definition.getEnabledActions('item')|sort_by('position') %}
+                    {{ sylius_grid_render_action(grid, action, row) }}
                 {% endfor %}
             </div>
-            {% if definition.actionGroups.subitem is defined and definition.getActions('subitem')|length > 0 %}
+            {% if definition.actionGroups.subitem is defined and definition.getEnabledActions('subitem')|length > 0 %}
             <div class="ui divider"></div>
             <div class="ui buttons">
-                {% for action in definition.getActions('subitem')|sort_by('position') %}
-                    {% if action.enabled %}
-                        {{ sylius_grid_render_action(grid, action, row) }}
-                    {% endif %}
+                {% for action in definition.getEnabledActions('subitem')|sort_by('position') %}
+                    {{ sylius_grid_render_action(grid, action, row) }}
                 {% endfor %}
             </div>
             {% endif %}

--- a/src/Sylius/Component/Grid/Definition/Grid.php
+++ b/src/Sylius/Component/Grid/Definition/Grid.php
@@ -152,6 +152,14 @@ class Grid
     }
 
     /**
+     * @return array
+     */
+    public function getEnabledFields()
+    {
+        return $this->getEnabledItems($this->getFields());
+    }
+
+    /**
      * @param Field $field
      */
     public function addField(Field $field)
@@ -218,6 +226,14 @@ class Grid
     }
 
     /**
+     * @return array
+     */
+    public function getEnabledActionGroups()
+    {
+        return $this->getEnabledItems($this->getActionGroups());
+    }
+
+    /**
      * @param ActionGroup $actionGroup
      */
     public function addActionGroup(ActionGroup $actionGroup)
@@ -276,6 +292,14 @@ class Grid
     }
 
     /**
+     * @return array
+     */
+    public function getEnabledActions($groupName)
+    {
+        return $this->getEnabledItems($this->getActions($groupName));
+    }
+
+    /**
      * @param string $name
      *
      * @return bool
@@ -291,6 +315,14 @@ class Grid
     public function getFilters()
     {
         return $this->filters;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEnabledFilters()
+    {
+        return $this->getEnabledItems($this->getFilters());
     }
 
     /**
@@ -347,5 +379,22 @@ class Grid
     public function hasFilter($name)
     {
         return array_key_exists($name, $this->filters);
+    }
+
+    /**
+     * @param array $items
+     *
+     * @return array
+     */
+    private function getEnabledItems(array $items)
+    {
+        $filteredItems = [];
+        foreach ($items as $item) {
+            if ($item->isEnabled()) {
+                $filteredItems[] = $item;
+            }
+        }
+
+        return $filteredItems;
     }
 }

--- a/src/Sylius/Component/Grid/spec/Definition/GridSpec.php
+++ b/src/Sylius/Component/Grid/spec/Definition/GridSpec.php
@@ -138,6 +138,28 @@ final class GridSpec extends ObjectBehavior
         $this->getField('enabled')->shouldReturn($secondField);
     }
 
+    function it_can_return_fields(Field $firstField, Field $secondField)
+    {
+        $firstField->getName()->willReturn('first');
+        $secondField->getName()->willReturn('second');
+        $this->addField($firstField);
+        $this->addField($secondField);
+
+        $this->getFields()->shouldHaveCount(2);
+    }
+
+    function it_can_return_only_enabled_fields(Field $firstField, Field $secondField)
+    {
+        $firstField->getName()->willReturn('first');
+        $firstField->isEnabled()->willReturn(true);
+        $secondField->getName()->willReturn('second');
+        $secondField->isEnabled()->willReturn(false);
+        $this->addField($firstField);
+        $this->addField($secondField);
+
+        $this->getEnabledFields()->shouldHaveCount(1);
+    }
+
     function it_does_not_have_any_action_groups_by_default()
     {
         $this->getActionGroups()->shouldReturn([]);
@@ -201,6 +223,20 @@ final class GridSpec extends ObjectBehavior
         $this->getActions('row')->shouldReturn([$action]);
     }
 
+    function it_returns_only_enabled_actions_for_given_group(
+        ActionGroup $actionGroup,
+        Action $firstAction,
+        Action $secondAction
+    ) {
+        $firstAction->isEnabled()->willReturn(true);
+        $secondAction->isEnabled()->willReturn(false);
+        $actionGroup->getName()->willReturn('row');
+        $actionGroup->getActions()->willReturn([$firstAction, $secondAction]);
+        $this->addActionGroup($actionGroup);
+
+        $this->getEnabledActions('row')->shouldReturn([$firstAction]);
+    }
+
     function it_does_not_have_any_filters_by_default()
     {
         $this->getFilters()->shouldReturn([]);
@@ -253,5 +289,27 @@ final class GridSpec extends ObjectBehavior
 
         $this->setFilter($secondFilter);
         $this->getFilter('enabled')->shouldReturn($secondFilter);
+    }
+
+    function it_can_return_filters(Filter $firstFilter, Filter $secondFilter)
+    {
+        $firstFilter->getName()->willReturn('first');
+        $secondFilter->getName()->willReturn('second');
+        $this->addFilter($firstFilter);
+        $this->addFilter($secondFilter);
+
+        $this->getFilters()->shouldHaveCount(2);
+    }
+
+    function it_can_return_only_enabled_filters(Filter $firstFilter, Filter $secondFilter)
+    {
+        $firstFilter->getName()->willReturn('first');
+        $firstFilter->isEnabled()->willReturn(true);
+        $secondFilter->getName()->willReturn('second');
+        $secondFilter->isEnabled()->willReturn(false);
+        $this->addFilter($firstFilter);
+        $this->addFilter($secondFilter);
+
+        $this->getEnabledFilters()->shouldHaveCount(1);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

This PR fixes a problem with customizing grids, because now, for example when we disable all filters, that there will remain empty filter block above table.

Before:
![zrzut ekranu 2017-03-06 o 14 46 35](https://cloud.githubusercontent.com/assets/6140884/23612444/bf6e8446-027b-11e7-9de3-15033e7f60f7.png)

After:
![zrzut ekranu 2017-03-06 o 14 44 44](https://cloud.githubusercontent.com/assets/6140884/23612358/7b791210-027b-11e7-9864-b6088165468d.png)