### PR TITLE
Remove unncesessary `use`

### DIFF
--- a/src/Sylius/Component/Resource/Translation/TranslatableEntityLocaleAssigner.php
+++ b/src/Sylius/Component/Resource/Translation/TranslatableEntityLocaleAssigner.php
@@ -13,7 +13,6 @@ namespace Sylius\Component\Resource\Translation;
 
 use Sylius\Component\Resource\Model\TranslatableInterface;
 use Sylius\Component\Resource\Translation\Provider\TranslationLocaleProviderInterface;
-use Sylius\Component\Resource\Translation\TranslatableEntityLocaleAssignerInterface;
 
 /**
  * @author Michał Marcinkowski <michal.marcinkowski@lakion.com>


### PR DESCRIPTION
This is not needed?
`use Sylius\Component\Resource\Translation\TranslatableEntityLocaleAssignerInterface;`

| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |
