### PR TITLE
Run Travis with PHP 7.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ matrix:
     include:
         -
             sudo: required
-            php: 7.1
+            php: 7.1.0 # PHP 7.1.2 breaks our test suite because of https://bugs.php.net/bug.php?id=74157
             env: SYLIUS_SUITE="application"
             services:
                 - memcached
         -
             sudo: false
-            php: 7.1
+            php: 7.1.0 # PHP 7.1.2 breaks our test suite because of https://bugs.php.net/bug.php?id=74157
             env: SYLIUS_SUITE="docs packages"
             addons:
                 apt:


### PR DESCRIPTION
Travis' builds are all broken now after upgrade to PHP 7.1.2.