### PR TITLE
[Admin] Add template events in admin panel 

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_content.html.twig
@@ -6,7 +6,7 @@
         {{ form_widget(form) }}
     {% endif %}
 
-    {{ sonata_block_render_event(eventPrefix ~ '.form', { 'resource': resource }) }}
+    {{ sonata_block_render_event(event_prefix ~ '.form', {'resource': resource}) }}
 
     {% include '@SyliusUi/Form/Buttons/_create.html.twig' with {'paths': {'cancel': path(configuration.getRouteName('index'), configuration.vars.route.parameters|default({}))}} %}
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_content.html.twig
@@ -6,6 +6,8 @@
         {{ form_widget(form) }}
     {% endif %}
 
+    {{ sonata_block_render_event(eventPrefix ~ '.form', { 'resource': resource }) }}
+
     {% include '@SyliusUi/Form/Buttons/_create.html.twig' with {'paths': {'cancel': path(configuration.getRouteName('index'), configuration.vars.route.parameters|default({}))}} %}
 
     {{ form_row(form._token) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_header.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_header.html.twig
@@ -3,7 +3,7 @@
         {% include configuration.vars.templates.header_title|default('@SyliusAdmin/Crud/Create/_headerTitle.html.twig') %}
         {% include configuration.vars.templates.breadcrumb|default('@SyliusAdmin/Crud/Create/_breadcrumb.html.twig') %}
 
-        {{ sonata_block_render_event(eventPrefix ~ '.header', { 'resource': resource }) }}
+        {{ sonata_block_render_event(event_prefix ~ '.header', {'resource': resource}) }}
     </div>
     <div class="middle aligned column">
         {% include configuration.vars.templates.toolbar|default('@SyliusAdmin/Crud/_toolbar.html.twig') ignore missing %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_header.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_header.html.twig
@@ -2,6 +2,8 @@
     <div class="column">
         {% include configuration.vars.templates.header_title|default('@SyliusAdmin/Crud/Create/_headerTitle.html.twig') %}
         {% include configuration.vars.templates.breadcrumb|default('@SyliusAdmin/Crud/Create/_breadcrumb.html.twig') %}
+
+        {{ sonata_block_render_event(eventPrefix ~ '.header', { 'resource': resource }) }}
     </div>
     <div class="middle aligned column">
         {% include configuration.vars.templates.toolbar|default('@SyliusAdmin/Crud/_toolbar.html.twig') ignore missing %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Index/_header.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Index/_header.html.twig
@@ -2,6 +2,8 @@
     <div class="column">
         {% include configuration.vars.templates.header_title|default('@SyliusAdmin/Crud/Index/_headerTitle.html.twig') %}
         {% include configuration.vars.templates.breadcrumb|default('@SyliusAdmin/Crud/Index/_breadcrumb.html.twig') %}
+
+        {{ sonata_block_render_event(eventPrefix ~ '.header', { 'resources': resources }) }}
     </div>
 
     {% include '@SyliusAdmin/Crud/Index/_actions.html.twig' %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Index/_header.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Index/_header.html.twig
@@ -3,7 +3,7 @@
         {% include configuration.vars.templates.header_title|default('@SyliusAdmin/Crud/Index/_headerTitle.html.twig') %}
         {% include configuration.vars.templates.breadcrumb|default('@SyliusAdmin/Crud/Index/_breadcrumb.html.twig') %}
 
-        {{ sonata_block_render_event(eventPrefix ~ '.header', { 'resources': resources }) }}
+        {{ sonata_block_render_event(event_prefix ~ '.header', {'resources': resources}) }}
     </div>
 
     {% include '@SyliusAdmin/Crud/Index/_actions.html.twig' %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
@@ -6,6 +6,9 @@
     {% else %}
         {{ form_widget(form) }}
     {% endif %}
+
+    {{ sonata_block_render_event(eventPrefix ~ '.form', { 'resource': resource }) }}
+
     {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': path(configuration.getRouteName('index'), configuration.vars.route.parameters|default({}))}} %}
     {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
@@ -7,7 +7,7 @@
         {{ form_widget(form) }}
     {% endif %}
 
-    {{ sonata_block_render_event(eventPrefix ~ '.form', { 'resource': resource }) }}
+    {{ sonata_block_render_event(event_prefix ~ '.form', {'resource': resource}) }}
 
     {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': path(configuration.getRouteName('index'), configuration.vars.route.parameters|default({}))}} %}
     {{ form_row(form._token) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_header.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_header.html.twig
@@ -2,6 +2,8 @@
     <div class="column">
         {% include configuration.vars.templates.header_title|default('@SyliusAdmin/Crud/Update/_headerTitle.html.twig') %}
         {% include configuration.vars.templates.breadcrumb|default('@SyliusAdmin/Crud/Update/_breadcrumb.html.twig') %}
+
+        {{ sonata_block_render_event(eventPrefix ~ '.header', { 'resource': resource }) }}
     </div>
     <div class="middle aligned column">
         {% include configuration.vars.templates.toolbar|default('@SyliusAdmin/Crud/_toolbar.html.twig') ignore missing %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_header.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_header.html.twig
@@ -3,7 +3,7 @@
         {% include configuration.vars.templates.header_title|default('@SyliusAdmin/Crud/Update/_headerTitle.html.twig') %}
         {% include configuration.vars.templates.breadcrumb|default('@SyliusAdmin/Crud/Update/_breadcrumb.html.twig') %}
 
-        {{ sonata_block_render_event(eventPrefix ~ '.header', { 'resource': resource }) }}
+        {{ sonata_block_render_event(event_prefix ~ '.header', {'resource': resource}) }}
     </div>
     <div class="middle aligned column">
         {% include configuration.vars.templates.toolbar|default('@SyliusAdmin/Crud/_toolbar.html.twig') ignore missing %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/create.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/create.html.twig
@@ -3,7 +3,7 @@
 {% import 'SyliusUiBundle:Macro:headers.html.twig' as headers %}
 
 {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.new_'~metadata.name) %}
-{% set event_prefix = app.request.attributes.get('_route')|replace('_', '.') %}
+{% set event_prefix = metadata.applicationName ~ '.admin.' ~ metadata.name ~ '.create' %}
 
 {% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/create.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/create.html.twig
@@ -3,20 +3,20 @@
 {% import 'SyliusUiBundle:Macro:headers.html.twig' as headers %}
 
 {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.new_'~metadata.name) %}
-{% set eventPrefix = app.request.attributes.get('_route')|replace('_', '.') %}
+{% set event_prefix = app.request.attributes.get('_route')|replace('_', '.') %}
 
 {% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
 
 {% form_theme form '@SyliusAdmin/Form/theme.html.twig' %}
 
 {% block content %}
-{{ sonata_block_render_event(eventPrefix ~ '.before_header', { 'resource': resource }) }}
+{{ sonata_block_render_event(event_prefix ~ '.before_header', {'resource': resource}) }}
 
 {% include '@SyliusAdmin/Crud/Create/_header.html.twig' %}
 
-{{ sonata_block_render_event(eventPrefix ~ '.after_header', { 'resource': resource }) }}
+{{ sonata_block_render_event(event_prefix ~ '.after_header', {'resource': resource}) }}
 
 {% include '@SyliusAdmin/Crud/Create/_content.html.twig' %}
 
-{{ sonata_block_render_event(eventPrefix ~ '.after_content', { 'resource': resource }) }}
+{{ sonata_block_render_event(event_prefix ~ '.after_content', {'resource': resource}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/create.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/create.html.twig
@@ -3,12 +3,20 @@
 {% import 'SyliusUiBundle:Macro:headers.html.twig' as headers %}
 
 {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.new_'~metadata.name) %}
+{% set eventPrefix = app.request.attributes.get('_route')|replace('_', '.') %}
 
 {% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
 
 {% form_theme form '@SyliusAdmin/Form/theme.html.twig' %}
 
 {% block content %}
+{{ sonata_block_render_event(eventPrefix ~ '.before_header', { 'resource': resource }) }}
+
 {% include '@SyliusAdmin/Crud/Create/_header.html.twig' %}
+
+{{ sonata_block_render_event(eventPrefix ~ '.after_header', { 'resource': resource }) }}
+
 {% include '@SyliusAdmin/Crud/Create/_content.html.twig' %}
+
+{{ sonata_block_render_event(eventPrefix ~ '.after_content', { 'resource': resource }) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/index.html.twig
@@ -4,7 +4,7 @@
 
 {% set definition = resources.definition %}
 {% set data = resources.data %}
-{% set event_prefix = app.request.attributes.get('_route')|replace('_', '.') %}
+{% set event_prefix = metadata.applicationName ~ '.admin.' ~ metadata.name ~ '.index' %}
 
 {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/index.html.twig
@@ -4,12 +4,20 @@
 
 {% set definition = resources.definition %}
 {% set data = resources.data %}
+{% set eventPrefix = app.request.attributes.get('_route')|replace('_', '.') %}
 
 {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
 
 {% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
 
 {% block content %}
+{{ sonata_block_render_event(eventPrefix ~ '.before_header', { 'resources': resources }) }}
+
 {% include '@SyliusAdmin/Crud/Index/_header.html.twig' %}
+
+{{ sonata_block_render_event(eventPrefix ~ '.after_header', { 'resources': resources }) }}
+
 {% include '@SyliusAdmin/Crud/Index/_content.html.twig' %}
+
+{{ sonata_block_render_event(eventPrefix ~ '.after_content', { 'resources': resources }) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/index.html.twig
@@ -4,20 +4,20 @@
 
 {% set definition = resources.definition %}
 {% set data = resources.data %}
-{% set eventPrefix = app.request.attributes.get('_route')|replace('_', '.') %}
+{% set event_prefix = app.request.attributes.get('_route')|replace('_', '.') %}
 
 {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
 
 {% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
 
 {% block content %}
-{{ sonata_block_render_event(eventPrefix ~ '.before_header', { 'resources': resources }) }}
+{{ sonata_block_render_event(event_prefix ~ '.before_header', {'resources': resources}) }}
 
 {% include '@SyliusAdmin/Crud/Index/_header.html.twig' %}
 
-{{ sonata_block_render_event(eventPrefix ~ '.after_header', { 'resources': resources }) }}
+{{ sonata_block_render_event(event_prefix ~ '.after_header', {'resources': resources}) }}
 
 {% include '@SyliusAdmin/Crud/Index/_content.html.twig' %}
 
-{{ sonata_block_render_event(eventPrefix ~ '.after_content', { 'resources': resources }) }}
+{{ sonata_block_render_event(event_prefix ~ '.after_content', {'resources': resources}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/update.html.twig
@@ -4,7 +4,7 @@
 {% import 'SyliusUiBundle:Macro:buttons.html.twig' as buttons %}
 
 {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.edit_'~metadata.name) %}
-{% set event_prefix = app.request.attributes.get('_route')|replace('_', '.') %}
+{% set event_prefix = metadata.applicationName ~ '.admin.' ~ metadata.name ~ '.update' %}
 
 {% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/update.html.twig
@@ -4,20 +4,20 @@
 {% import 'SyliusUiBundle:Macro:buttons.html.twig' as buttons %}
 
 {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.edit_'~metadata.name) %}
-{% set eventPrefix = app.request.attributes.get('_route')|replace('_', '.') %}
+{% set event_prefix = app.request.attributes.get('_route')|replace('_', '.') %}
 
 {% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
 
 {% form_theme form '@SyliusAdmin/Form/theme.html.twig' %}
 
 {% block content %}
-{{ sonata_block_render_event(eventPrefix ~ '.before_header', { 'resource': resource }) }}
+{{ sonata_block_render_event(event_prefix ~ '.before_header', {'resource': resource}) }}
 
 {% include '@SyliusAdmin/Crud/Update/_header.html.twig' %}
 
-{{ sonata_block_render_event(eventPrefix ~ '.after_header', { 'resource': resource }) }}
+{{ sonata_block_render_event(event_prefix ~ '.after_header', {'resource': resource}) }}
 
 {% include '@SyliusAdmin/Crud/Update/_content.html.twig' %}
 
-{{ sonata_block_render_event(eventPrefix ~ '.after_content', { 'resource': resource }) }}
+{{ sonata_block_render_event(event_prefix ~ '.after_content', {'resource': resource}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/update.html.twig
@@ -4,12 +4,20 @@
 {% import 'SyliusUiBundle:Macro:buttons.html.twig' as buttons %}
 
 {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.edit_'~metadata.name) %}
+{% set eventPrefix = app.request.attributes.get('_route')|replace('_', '.') %}
 
 {% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
 
 {% form_theme form '@SyliusAdmin/Form/theme.html.twig' %}
 
 {% block content %}
+{{ sonata_block_render_event(eventPrefix ~ '.before_header', { 'resource': resource }) }}
+
 {% include '@SyliusAdmin/Crud/Update/_header.html.twig' %}
+
+{{ sonata_block_render_event(eventPrefix ~ '.after_header', { 'resource': resource }) }}
+
 {% include '@SyliusAdmin/Crud/Update/_content.html.twig' %}
+
+{{ sonata_block_render_event(eventPrefix ~ '.after_content', { 'resource': resource }) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/_address.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/_address.html.twig
@@ -1,5 +1,5 @@
 <div class="eight wide column">
-    {{ sonata_block_render_event('sylius.admin.customer.show.before_address', { 'resource': resource }) }}
+    {{ sonata_block_render_event('sylius.admin.customer.show.before_address', {'resource': resource}) }}
 
     <h4 class="ui top attached styled header">
         {{ 'sylius.ui.default_address'|trans }}
@@ -13,5 +13,5 @@
         {% endif %}
     </div>
 
-    {{ sonata_block_render_event('sylius.admin.customer.show.after_address', { 'resource': resource }) }}
+    {{ sonata_block_render_event('sylius.admin.customer.show.after_address', {'resource': resource}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/_address.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/_address.html.twig
@@ -1,4 +1,6 @@
 <div class="eight wide column">
+    {{ sonata_block_render_event('sylius.admin.customer.show.before_address', { 'resource': resource }) }}
+
     <h4 class="ui top attached styled header">
         {{ 'sylius.ui.default_address'|trans }}
     </h4>
@@ -10,4 +12,6 @@
             {{ 'sylius.ui.this_customer_does_not_have_a_default_address'|trans }}
         {% endif %}
     </div>
+
+    {{ sonata_block_render_event('sylius.admin.customer.show.after_address', { 'resource': resource }) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/_content.html.twig
@@ -1,5 +1,7 @@
 <div class="eight wide column" id="info">
     <div class="ui fluid card">
+        {{ sonata_block_render_event('sylius.admin.customer.show.before_information', { 'resource': resource }) }}
+
         <div class="content">
             <a href="{{ path('sylius_admin_customer_update', {'id': customer.id}) }}" class="header">
                 {{ customer.fullName|default('sylius.ui.guest_customer'|trans) }}
@@ -37,5 +39,7 @@
                 </div>
             {% endif %}
         </div>
+
+        {{ sonata_block_render_event('sylius.admin.customer.show.after_information', { 'resource': resource }) }}
     </div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/_content.html.twig
@@ -1,6 +1,6 @@
 <div class="eight wide column" id="info">
     <div class="ui fluid card">
-        {{ sonata_block_render_event('sylius.admin.customer.show.before_information', { 'resource': resource }) }}
+        {{ sonata_block_render_event('sylius.admin.customer.show.before_information', {'resource': resource}) }}
 
         <div class="content">
             <a href="{{ path('sylius_admin_customer_update', {'id': customer.id}) }}" class="header">
@@ -40,6 +40,6 @@
             {% endif %}
         </div>
 
-        {{ sonata_block_render_event('sylius.admin.customer.show.after_information', { 'resource': resource }) }}
+        {{ sonata_block_render_event('sylius.admin.customer.show.after_information', {'resource': resource}) }}
     </div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/show.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/show.html.twig
@@ -6,20 +6,32 @@
 {% block title %}{{ parent() }} {{ 'sylius.ui.customer'|trans ~' '~ customer.email }}{% endblock %}
 
 {% block content %}
+    {{ sonata_block_render_event('sylius.admin.customer.show.before_header', { 'resource': resource }) }}
+
     <div class="ui stackable two column grid">
         {% include '@SyliusAdmin/Customer/Show/_header.html.twig' %}
+
+        {{ sonata_block_render_event('sylius.admin.customer.show.header', { 'resource': resource }) }}
 
         {% set menu = knp_menu_get('sylius.admin.customer.show', [], {'customer': customer}) %}
         {{ knp_menu_render(menu, {'template': '@SyliusUi/Menu/top.html.twig'}) }}
     </div>
 
+    {{ sonata_block_render_event('sylius.admin.customer.show.after_header', { 'resource': resource }) }}
+
     <div class="ui divider"></div>
     {% include '@SyliusAdmin/Customer/Show/_breadcrumb.html.twig' %}
 
+    {{ sonata_block_render_event('sylius.admin.customer.show.after_breadcrumb', { 'resource': resource }) }}
+
     {{ render(path('sylius_admin_customer_orders_statistics', {'customerId': customer.id})) }}
+
+    {{ sonata_block_render_event('sylius.admin.customer.show.after_statistics', { 'resource': resource }) }}
 
     <div class="ui stackable grid">
         {% include '@SyliusAdmin/Customer/Show/_content.html.twig' %}
         {% include '@SyliusAdmin/Customer/Show/_address.html.twig' %}
     </div>
+
+    {{ sonata_block_render_event('sylius.admin.customer.show.after_content', { 'resource': resource }) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/show.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/show.html.twig
@@ -6,32 +6,32 @@
 {% block title %}{{ parent() }} {{ 'sylius.ui.customer'|trans ~' '~ customer.email }}{% endblock %}
 
 {% block content %}
-    {{ sonata_block_render_event('sylius.admin.customer.show.before_header', { 'resource': resource }) }}
+    {{ sonata_block_render_event('sylius.admin.customer.show.before_header', {'resource': resource}) }}
 
     <div class="ui stackable two column grid">
         {% include '@SyliusAdmin/Customer/Show/_header.html.twig' %}
 
-        {{ sonata_block_render_event('sylius.admin.customer.show.header', { 'resource': resource }) }}
+        {{ sonata_block_render_event('sylius.admin.customer.show.header', {'resource': resource}) }}
 
         {% set menu = knp_menu_get('sylius.admin.customer.show', [], {'customer': customer}) %}
         {{ knp_menu_render(menu, {'template': '@SyliusUi/Menu/top.html.twig'}) }}
     </div>
 
-    {{ sonata_block_render_event('sylius.admin.customer.show.after_header', { 'resource': resource }) }}
+    {{ sonata_block_render_event('sylius.admin.customer.show.after_header', {'resource': resource}) }}
 
     <div class="ui divider"></div>
     {% include '@SyliusAdmin/Customer/Show/_breadcrumb.html.twig' %}
 
-    {{ sonata_block_render_event('sylius.admin.customer.show.after_breadcrumb', { 'resource': resource }) }}
+    {{ sonata_block_render_event('sylius.admin.customer.show.after_breadcrumb', {'resource': resource}) }}
 
     {{ render(path('sylius_admin_customer_orders_statistics', {'customerId': customer.id})) }}
 
-    {{ sonata_block_render_event('sylius.admin.customer.show.after_statistics', { 'resource': resource }) }}
+    {{ sonata_block_render_event('sylius.admin.customer.show.after_statistics', {'resource': resource}) }}
 
     <div class="ui stackable grid">
         {% include '@SyliusAdmin/Customer/Show/_content.html.twig' %}
         {% include '@SyliusAdmin/Customer/Show/_address.html.twig' %}
     </div>
 
-    {{ sonata_block_render_event('sylius.admin.customer.show.after_content', { 'resource': resource }) }}
+    {{ sonata_block_render_event('sylius.admin.customer.show.after_content', {'resource': resource}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_header.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_header.html.twig
@@ -3,6 +3,8 @@
 <div class="ui stackable grid">
     <div class="twelve wide column">
         {{ headers.default('sylius.ui.dashboard'|trans, 'home', 'sylius.ui.overview_of_your_store'|trans) }}
+
+        {{ sonata_block_render_event('sylius.admin.dashboard.header', { 'channel': channel, 'statistics': statistics }) }}
     </div>
     <div class="four wide middle aligned column">
         {{ render(url('sylius_admin_partial_channel_index', {'template': '@SyliusAdmin/Dashboard/_channelSwitch.html.twig', 'channel': channel.code})) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_header.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_header.html.twig
@@ -4,7 +4,7 @@
     <div class="twelve wide column">
         {{ headers.default('sylius.ui.dashboard'|trans, 'home', 'sylius.ui.overview_of_your_store'|trans) }}
 
-        {{ sonata_block_render_event('sylius.admin.dashboard.header', { 'channel': channel, 'statistics': statistics }) }}
+        {{ sonata_block_render_event('sylius.admin.dashboard.header', {'channel': channel, 'statistics': statistics}) }}
     </div>
     <div class="four wide middle aligned column">
         {{ render(url('sylius_admin_partial_channel_index', {'template': '@SyliusAdmin/Dashboard/_channelSwitch.html.twig', 'channel': channel.code})) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/index.html.twig
@@ -3,9 +3,20 @@
 {% block title %}{{ parent() }}{{ 'sylius.ui.dashboard'|trans }}{% endblock %}
 
 {% block content %}
+
+{{ sonata_block_render_event('sylius.admin.dashboard.before_header', { 'channel': channel, 'statistics': statistics }) }}
+
 {% include '@SyliusAdmin/Dashboard/_header.html.twig' %}
+
+{{ sonata_block_render_event('sylius.admin.dashboard.after_header', { 'channel': channel, 'statistics': statistics }) }}
+
 {% include '@SyliusAdmin/Dashboard/_menu.html.twig' %}
+
+{{ sonata_block_render_event('sylius.admin.dashboard.after_menu', { 'channel': channel, 'statistics': statistics }) }}
+
 {% include '@SyliusAdmin/Dashboard/_statistics.html.twig' %}
+
+{{ sonata_block_render_event('sylius.admin.dashboard.after_statistics', { 'channel': channel, 'statistics': statistics }) }}
 
 <div class="ui two column stackable grid">
     <div class="column">
@@ -15,4 +26,6 @@
         {{ render(path('sylius_admin_partial_order_latest_in_channel', {'channelCode': channel.code, 'count': 5, 'template': '@SyliusAdmin/Dashboard/_orders.html.twig'})) }}
     </div>
 </div>
+
+{{ sonata_block_render_event('sylius.admin.dashboard.after_content', { 'channel': channel, 'statistics': statistics }) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/index.html.twig
@@ -4,19 +4,19 @@
 
 {% block content %}
 
-{{ sonata_block_render_event('sylius.admin.dashboard.before_header', { 'channel': channel, 'statistics': statistics }) }}
+{{ sonata_block_render_event('sylius.admin.dashboard.before_header', {'channel': channel, 'statistics': statistics}) }}
 
 {% include '@SyliusAdmin/Dashboard/_header.html.twig' %}
 
-{{ sonata_block_render_event('sylius.admin.dashboard.after_header', { 'channel': channel, 'statistics': statistics }) }}
+{{ sonata_block_render_event('sylius.admin.dashboard.after_header', {'channel': channel, 'statistics': statistics}) }}
 
 {% include '@SyliusAdmin/Dashboard/_menu.html.twig' %}
 
-{{ sonata_block_render_event('sylius.admin.dashboard.after_menu', { 'channel': channel, 'statistics': statistics }) }}
+{{ sonata_block_render_event('sylius.admin.dashboard.after_menu', {'channel': channel, 'statistics': statistics}) }}
 
 {% include '@SyliusAdmin/Dashboard/_statistics.html.twig' %}
 
-{{ sonata_block_render_event('sylius.admin.dashboard.after_statistics', { 'channel': channel, 'statistics': statistics }) }}
+{{ sonata_block_render_event('sylius.admin.dashboard.after_statistics', {'channel': channel, 'statistics': statistics}) }}
 
 <div class="ui two column stackable grid">
     <div class="column">
@@ -27,5 +27,5 @@
     </div>
 </div>
 
-{{ sonata_block_render_event('sylius.admin.dashboard.after_content', { 'channel': channel, 'statistics': statistics }) }}
+{{ sonata_block_render_event('sylius.admin.dashboard.after_content', {'channel': channel, 'statistics': statistics}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/history.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/history.html.twig
@@ -5,6 +5,8 @@
 {% block title %}{{ parent() }} {{ 'sylius.ui.order'|trans }} #{{ order.number }} - {{ 'sylius.ui.order_history'|trans }}{% endblock %}
 
 {% block content %}
+{{ sonata_block_render_event('sylius.admin.order.history.before_header', { 'resource': resource }) }}
+
 <div class="ui stackable two column grid">
     <div class="twelve wide column">
         {% include '@SyliusAdmin/Order/History/_header.html.twig' %}
@@ -13,10 +15,18 @@
         {% include '@SyliusAdmin/Order/History/_actions.html.twig' %}
     </div>
 </div>
+
+{{ sonata_block_render_event('sylius.admin.order.history.after_header', { 'resource': resource }) }}
+
 {% include '@SyliusAdmin/Order/History/_breadcrumb.html.twig' %}
+
+{{ sonata_block_render_event('sylius.admin.order.history.after_breadcrumb', { 'resource': resource }) }}
+
 <div class="ui one column grid">
     <div class="column">
         {% include '@SyliusAdmin/Order/History/_addresses.html.twig' %}
     </div>
 </div>
+
+{{ sonata_block_render_event('sylius.admin.order.history.after_content', { 'resource': resource }) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/history.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/history.html.twig
@@ -5,7 +5,7 @@
 {% block title %}{{ parent() }} {{ 'sylius.ui.order'|trans }} #{{ order.number }} - {{ 'sylius.ui.order_history'|trans }}{% endblock %}
 
 {% block content %}
-{{ sonata_block_render_event('sylius.admin.order.history.before_header', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.order.history.before_header', {'resource': resource}) }}
 
 <div class="ui stackable two column grid">
     <div class="twelve wide column">
@@ -16,11 +16,11 @@
     </div>
 </div>
 
-{{ sonata_block_render_event('sylius.admin.order.history.after_header', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.order.history.after_header', {'resource': resource}) }}
 
 {% include '@SyliusAdmin/Order/History/_breadcrumb.html.twig' %}
 
-{{ sonata_block_render_event('sylius.admin.order.history.after_breadcrumb', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.order.history.after_breadcrumb', {'resource': resource}) }}
 
 <div class="ui one column grid">
     <div class="column">
@@ -28,5 +28,5 @@
     </div>
 </div>
 
-{{ sonata_block_render_event('sylius.admin.order.history.after_content', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.order.history.after_content', {'resource': resource}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/show.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/show.html.twig
@@ -7,6 +7,8 @@
 {% set customer = order.customer %}
 
 {% block content %}
+{{ sonata_block_render_event('sylius.admin.order.show.before_header', { 'resource': resource }) }}
+
 <div class="ui stackable two column grid">
     <div class="ten wide column">
         {% include '@SyliusAdmin/Order/Show/_header.html.twig' %}
@@ -15,21 +17,44 @@
     {% set menu = knp_menu_get('sylius.admin.order.show', [], {'order': order}) %}
     {{ knp_menu_render(menu, {'template': '@SyliusUi/Menu/top.html.twig'}) }}
 </div>
+
+{{ sonata_block_render_event('sylius.admin.order.show.after_header', { 'resource': resource }) }}
+
 {% include '@SyliusAdmin/Order/Show/_breadcrumb.html.twig' %}
+
+{{ sonata_block_render_event('sylius.admin.order.show.after_breadcrumb', { 'resource': resource }) }}
+
 <div class="ui stackable grid">
     <div class="twelve wide column">
+        {{ sonata_block_render_event('sylius.admin.order.show.before_summary', { 'resource': resource }) }}
+
         <div class="ui segment">
             {% include '@SyliusAdmin/Order/Show/_summary.html.twig' %}
         </div>
+
+        {{ sonata_block_render_event('sylius.admin.order.show.after_summary', { 'resource': resource }) }}
+
         {% include '@SyliusAdmin/Order/Show/_notes.html.twig' %}
     </div>
     <div class="four wide column">
+        {{ sonata_block_render_event('sylius.admin.order.show.before_customer_information', { 'resource': resource }) }}
+
         {% include '@SyliusAdmin/Order/Show/_customer.html.twig' %}
+
+        {{ sonata_block_render_event('sylius.admin.order.show.before_addresses', { 'resource': resource }) }}
+
         {% include '@SyliusAdmin/Order/Show/_addresses.html.twig' %}
+
+        {{ sonata_block_render_event('sylius.admin.order.show.before_payments', { 'resource': resource }) }}
+
         {% include '@SyliusAdmin/Order/Show/_payments.html.twig' %}
         {% if order.hasShipments %}
             {% include '@SyliusAdmin/Order/Show/_shipments.html.twig' %}
         {% endif %}
+
+        {{ sonata_block_render_event('sylius.admin.order.show.after_shipments', { 'resource': resource }) }}
     </div>
 </div>
+
+{{ sonata_block_render_event('sylius.admin.order.show.after_content', { 'resource': resource }) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/show.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/show.html.twig
@@ -7,7 +7,7 @@
 {% set customer = order.customer %}
 
 {% block content %}
-{{ sonata_block_render_event('sylius.admin.order.show.before_header', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.order.show.before_header', {'resource': resource}) }}
 
 <div class="ui stackable two column grid">
     <div class="ten wide column">
@@ -18,43 +18,43 @@
     {{ knp_menu_render(menu, {'template': '@SyliusUi/Menu/top.html.twig'}) }}
 </div>
 
-{{ sonata_block_render_event('sylius.admin.order.show.after_header', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.order.show.after_header', {'resource': resource}) }}
 
 {% include '@SyliusAdmin/Order/Show/_breadcrumb.html.twig' %}
 
-{{ sonata_block_render_event('sylius.admin.order.show.after_breadcrumb', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.order.show.after_breadcrumb', {'resource': resource}) }}
 
 <div class="ui stackable grid">
     <div class="twelve wide column">
-        {{ sonata_block_render_event('sylius.admin.order.show.before_summary', { 'resource': resource }) }}
+        {{ sonata_block_render_event('sylius.admin.order.show.before_summary', {'resource': resource}) }}
 
         <div class="ui segment">
             {% include '@SyliusAdmin/Order/Show/_summary.html.twig' %}
         </div>
 
-        {{ sonata_block_render_event('sylius.admin.order.show.after_summary', { 'resource': resource }) }}
+        {{ sonata_block_render_event('sylius.admin.order.show.after_summary', {'resource': resource}) }}
 
         {% include '@SyliusAdmin/Order/Show/_notes.html.twig' %}
     </div>
     <div class="four wide column">
-        {{ sonata_block_render_event('sylius.admin.order.show.before_customer_information', { 'resource': resource }) }}
+        {{ sonata_block_render_event('sylius.admin.order.show.before_customer_information', {'resource': resource}) }}
 
         {% include '@SyliusAdmin/Order/Show/_customer.html.twig' %}
 
-        {{ sonata_block_render_event('sylius.admin.order.show.before_addresses', { 'resource': resource }) }}
+        {{ sonata_block_render_event('sylius.admin.order.show.before_addresses', {'resource': resource}) }}
 
         {% include '@SyliusAdmin/Order/Show/_addresses.html.twig' %}
 
-        {{ sonata_block_render_event('sylius.admin.order.show.before_payments', { 'resource': resource }) }}
+        {{ sonata_block_render_event('sylius.admin.order.show.before_payments', {'resource': resource}) }}
 
         {% include '@SyliusAdmin/Order/Show/_payments.html.twig' %}
         {% if order.hasShipments %}
             {% include '@SyliusAdmin/Order/Show/_shipments.html.twig' %}
         {% endif %}
 
-        {{ sonata_block_render_event('sylius.admin.order.show.after_shipments', { 'resource': resource }) }}
+        {{ sonata_block_render_event('sylius.admin.order.show.after_shipments', {'resource': resource}) }}
     </div>
 </div>
 
-{{ sonata_block_render_event('sylius.admin.order.show.after_content', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.order.show.after_content', {'resource': resource}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/update.html.twig
@@ -8,6 +8,8 @@
 {% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
 
 {% block content %}
+{{ sonata_block_render_event('sylius.admin.order.update.before_header', { 'resource': resource }) }}
+
 <div class="ui stackable two column grid">
     <div class="twelve wide column">
         {% include '@SyliusAdmin/Order/Show/_header.html.twig' %}
@@ -17,7 +19,11 @@
     </div>
 </div>
 
+{{ sonata_block_render_event('sylius.admin.order.update.after_header', { 'resource': resource }) }}
+    
 {% include '@SyliusAdmin/Order/Update/_breadcrumb.html.twig' %}
+
+{{ sonata_block_render_event('sylius.admin.order.update.after_breadcrumb', { 'resource': resource }) }}
 
 {{ form_start(form, {'action': path('sylius_admin_order_update', {'id': order.id}), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate'}}) }}
     <div class="ui segment">
@@ -33,8 +39,12 @@
             {% include '@SyliusAdmin/Common/Form/_address.html.twig' with {'form': form.billingAddress} %}
         </div>
 
+        {{ sonata_block_render_event('sylius.admin.order.update.form', { 'resource': resource }) }}
+
         {{ form_row(form._token) }}
         {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': path('sylius_admin_order_index')}} %}
     </div>
 {{ form_end(form, {'render_rest': false}) }}
+
+{{ sonata_block_render_event('sylius.admin.order.update.after_content', { 'resource': resource }) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/update.html.twig
@@ -8,7 +8,7 @@
 {% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
 
 {% block content %}
-{{ sonata_block_render_event('sylius.admin.order.update.before_header', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.order.update.before_header', {'resource': resource}) }}
 
 <div class="ui stackable two column grid">
     <div class="twelve wide column">
@@ -19,11 +19,11 @@
     </div>
 </div>
 
-{{ sonata_block_render_event('sylius.admin.order.update.after_header', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.order.update.after_header', {'resource': resource}) }}
     
 {% include '@SyliusAdmin/Order/Update/_breadcrumb.html.twig' %}
 
-{{ sonata_block_render_event('sylius.admin.order.update.after_breadcrumb', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.order.update.after_breadcrumb', {'resource': resource}) }}
 
 {{ form_start(form, {'action': path('sylius_admin_order_update', {'id': order.id}), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate'}}) }}
     <div class="ui segment">
@@ -39,12 +39,12 @@
             {% include '@SyliusAdmin/Common/Form/_address.html.twig' with {'form': form.billingAddress} %}
         </div>
 
-        {{ sonata_block_render_event('sylius.admin.order.update.form', { 'resource': resource }) }}
+        {{ sonata_block_render_event('sylius.admin.order.update.form', {'resource': resource}) }}
 
         {{ form_row(form._token) }}
         {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': path('sylius_admin_order_index')}} %}
     </div>
 {{ form_end(form, {'render_rest': false}) }}
 
-{{ sonata_block_render_event('sylius.admin.order.update.after_content', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.order.update.after_content', {'resource': resource}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Index/_header.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Index/_header.html.twig
@@ -9,6 +9,8 @@
         {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
         {{ headers.default(header|trans, configuration.vars.icon|default('cube'), configuration.vars.subheader|default('sylius.ui.manage_your_product_catalog')|trans) }}
 
+        {{ sonata_block_render_event('sylius.admin.product.index.header', { 'resources': resources }) }}
+
         {% include configuration.vars.templates.breadcrumb|default('@SyliusAdmin/Product/Index/_breadcrumb.html.twig') %}
     </div>
 {% endif %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Index/_header.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Index/_header.html.twig
@@ -9,7 +9,7 @@
         {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
         {{ headers.default(header|trans, configuration.vars.icon|default('cube'), configuration.vars.subheader|default('sylius.ui.manage_your_product_catalog')|trans) }}
 
-        {{ sonata_block_render_event('sylius.admin.product.index.header', { 'resources': resources }) }}
+        {{ sonata_block_render_event('sylius.admin.product.index.header', {'resources': resources}) }}
 
         {% include configuration.vars.templates.breadcrumb|default('@SyliusAdmin/Product/Index/_breadcrumb.html.twig') %}
     </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_associations.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_associations.html.twig
@@ -21,4 +21,6 @@
             {{ form_errors(associationForm) }}
         </div>
     {% endfor %}
+
+    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_associations', { 'form': form }) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_associations.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_associations.html.twig
@@ -22,5 +22,5 @@
         </div>
     {% endfor %}
 
-    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_associations', {'form': form}) }}
+    {{ sonata_block_render_event('sylius.admin.product.' ~ action ~ '.tab_associations', {'form': form}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_associations.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_associations.html.twig
@@ -22,5 +22,5 @@
         </div>
     {% endfor %}
 
-    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_associations', { 'form': form }) }}
+    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_associations', {'form': form}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_attributes.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_attributes.html.twig
@@ -7,5 +7,5 @@
         {{ form_widget(form.attributes, {'attr': {'translations': form.translations} }) }}
     </div>
 
-    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_attributes', {'form': form}) }}
+    {{ sonata_block_render_event('sylius.admin.product.' ~ action ~ '.tab_attributes', {'form': form}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_attributes.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_attributes.html.twig
@@ -6,4 +6,6 @@
     <div id="attributesContainer" data-count="{{ form.attributes|length }}">
         {{ form_widget(form.attributes, {'attr': {'translations': form.translations} }) }}
     </div>
+
+    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_attributes', { 'form': form }) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_attributes.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_attributes.html.twig
@@ -7,5 +7,5 @@
         {{ form_widget(form.attributes, {'attr': {'translations': form.translations} }) }}
     </div>
 
-    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_attributes', { 'form': form }) }}
+    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_attributes', {'form': form}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_details.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_details.html.twig
@@ -56,4 +56,6 @@
         </div>
     </div>
     {% endif %}
+
+    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_details', { 'form': form }) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_details.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_details.html.twig
@@ -57,5 +57,5 @@
     </div>
     {% endif %}
 
-    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_details', {'form': form}) }}
+    {{ sonata_block_render_event('sylius.admin.product.' ~ action ~ '.tab_details', {'form': form}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_details.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_details.html.twig
@@ -57,5 +57,5 @@
     </div>
     {% endif %}
 
-    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_details', { 'form': form }) }}
+    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_details', {'form': form}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_media.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_media.html.twig
@@ -4,4 +4,6 @@
     <h3 class="ui dividing header">{{ 'sylius.ui.media'|trans }}</h3>
     <br>
     {{ form_row(form.images, {'label': false}) }}
+
+    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_media', { 'form': form }) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_media.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_media.html.twig
@@ -5,5 +5,5 @@
     <br>
     {{ form_row(form.images, {'label': false}) }}
 
-    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_media', { 'form': form }) }}
+    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_media', {'form': form}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_media.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_media.html.twig
@@ -5,5 +5,5 @@
     <br>
     {{ form_row(form.images, {'label': false}) }}
 
-    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_media', {'form': form}) }}
+    {{ sonata_block_render_event('sylius.admin.product.' ~ action ~ '.tab_media', {'form': form}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_taxonomy.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_taxonomy.html.twig
@@ -13,5 +13,5 @@
         </div>
     </div>
 
-    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_taxonomy', { 'form': form }) }}
+    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_taxonomy', {'form': form}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_taxonomy.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_taxonomy.html.twig
@@ -13,5 +13,5 @@
         </div>
     </div>
 
-    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_taxonomy', {'form': form}) }}
+    {{ sonata_block_render_event('sylius.admin.product.' ~ action ~ '.tab_taxonomy', {'form': form}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_taxonomy.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_taxonomy.html.twig
@@ -12,4 +12,6 @@
             <div class="ui loader"></div>
         </div>
     </div>
+
+    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_taxonomy', { 'form': form }) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_menu.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_menu.html.twig
@@ -1,5 +1,11 @@
 {% extends 'knp_menu.html.twig' %}
 
+{% if 'create' in app.request.attributes.get('_route') %}
+    {% set action = 'create' %}
+{% else %}
+    {% set action = 'update' %}
+{% endif %}
+
 {% block list %}
 {% set form = (options.form) %}
 <div class="ui stackable grid sylius-tabular-form">

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/index.html.twig
@@ -10,29 +10,29 @@
 {% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
 
 {% block content %}
-    {{ sonata_block_render_event('sylius.admin.product.index.before_header', { 'resources': resources }) }}
+    {{ sonata_block_render_event('sylius.admin.product.index.before_header', {'resources': resources}) }}
 
     <div class="ui stackable two column grid">
         {% include '@SyliusAdmin/Product/Index/_header.html.twig' %}
         {% include '@SyliusAdmin/Crud/Index/_actions.html.twig' %}
     </div>
 
-    {{ sonata_block_render_event('sylius.admin.product.index.after_header', { 'resources': resources }) }}
+    {{ sonata_block_render_event('sylius.admin.product.index.after_header', {'resources': resources}) }}
 
     <div class="ui two column stackable grid">
         <div class="three wide column">
-            {{ sonata_block_render_event('sylius.admin.product.index.before_taxon_tree', { 'resources': resources }) }}
+            {{ sonata_block_render_event('sylius.admin.product.index.before_taxon_tree', {'resources': resources}) }}
 
             {{ render(path('sylius_admin_partial_taxon_tree', {'template': '@SyliusAdmin/Taxon/_treeWithoutButtons.html.twig'})) }}
 
-            {{ sonata_block_render_event('sylius.admin.product.index.after_taxon_tree', { 'resources': resources }) }}
+            {{ sonata_block_render_event('sylius.admin.product.index.after_taxon_tree', {'resources': resources}) }}
         </div>
         <div class="thirteen wide column sylius-product-index">
-            {{ sonata_block_render_event('sylius.admin.product.index.before_filters', { 'resources': resources }) }}
+            {{ sonata_block_render_event('sylius.admin.product.index.before_filters', {'resources': resources}) }}
 
             {% include '@SyliusAdmin/Crud/Index/_content.html.twig' %}
         </div>
     </div>
 
-    {{ sonata_block_render_event('sylius.admin.product.index.after_content', { 'resources': resources }) }}
+    {{ sonata_block_render_event('sylius.admin.product.index.after_content', {'resources': resources}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/index.html.twig
@@ -10,17 +10,29 @@
 {% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
 
 {% block content %}
+    {{ sonata_block_render_event('sylius.admin.product.index.before_header', { 'resources': resources }) }}
+
     <div class="ui stackable two column grid">
         {% include '@SyliusAdmin/Product/Index/_header.html.twig' %}
         {% include '@SyliusAdmin/Crud/Index/_actions.html.twig' %}
     </div>
 
+    {{ sonata_block_render_event('sylius.admin.product.index.after_header', { 'resources': resources }) }}
+
     <div class="ui two column stackable grid">
         <div class="three wide column">
+            {{ sonata_block_render_event('sylius.admin.product.index.before_taxon_tree', { 'resources': resources }) }}
+
             {{ render(path('sylius_admin_partial_taxon_tree', {'template': '@SyliusAdmin/Taxon/_treeWithoutButtons.html.twig'})) }}
+
+            {{ sonata_block_render_event('sylius.admin.product.index.after_taxon_tree', { 'resources': resources }) }}
         </div>
         <div class="thirteen wide column sylius-product-index">
+            {{ sonata_block_render_event('sylius.admin.product.index.before_filters', { 'resources': resources }) }}
+
             {% include '@SyliusAdmin/Crud/Index/_content.html.twig' %}
         </div>
     </div>
+
+    {{ sonata_block_render_event('sylius.admin.product.index.after_content', { 'resources': resources }) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Index/_productHeader.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Index/_productHeader.html.twig
@@ -3,5 +3,7 @@
 <div class="column">
     {{ headers.default(product.name, configuration.vars.icon|default('cubes'), configuration.vars.subheader|default('sylius.ui.manage_variants')|trans) }}
 
+    {{ sonata_block_render_event('sylius.admin.product_variant.index.header', { 'resource': resource }) }}
+
     {% include configuration.vars.templates.breadcrumb|default('@SyliusAdmin/ProductVariant/Index/_breadcrumb.html.twig') %}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Index/_productHeader.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Index/_productHeader.html.twig
@@ -3,7 +3,7 @@
 <div class="column">
     {{ headers.default(product.name, configuration.vars.icon|default('cubes'), configuration.vars.subheader|default('sylius.ui.manage_variants')|trans) }}
 
-    {{ sonata_block_render_event('sylius.admin.product_variant.index.header', { 'resource': resource }) }}
+    {{ sonata_block_render_event('sylius.admin.product_variant.index.header', {'resource': resource}) }}
 
     {% include configuration.vars.templates.breadcrumb|default('@SyliusAdmin/ProductVariant/Index/_breadcrumb.html.twig') %}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_details.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_details.html.twig
@@ -47,5 +47,5 @@
         </div>
     </div>
 
-    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_details', {'form': form}) }}
+    {{ sonata_block_render_event('sylius.admin.product_variant.' ~ action ~ '.tab_details', {'form': form}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_details.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_details.html.twig
@@ -47,5 +47,5 @@
         </div>
     </div>
 
-    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_details', { 'form': form }) }}
+    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_details', {'form': form}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_details.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_details.html.twig
@@ -46,4 +46,6 @@
             </div>
         </div>
     </div>
+
+    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_details', { 'form': form }) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_taxes.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_taxes.html.twig
@@ -2,5 +2,5 @@
     <h3 class="ui dividing header">{{ 'sylius.ui.taxes'|trans }}</h3>
     {{ form_row(form.taxCategory) }}
 
-    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_taxes', {'form': form}) }}
+    {{ sonata_block_render_event('sylius.admin.product_variant.' ~ action ~ '.tab_taxes', {'form': form}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_taxes.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_taxes.html.twig
@@ -1,4 +1,6 @@
 <div class="ui tab" data-tab="taxes">
     <h3 class="ui dividing header">{{ 'sylius.ui.taxes'|trans }}</h3>
     {{ form_row(form.taxCategory) }}
+
+    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_taxes', { 'form': form }) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_taxes.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_taxes.html.twig
@@ -2,5 +2,5 @@
     <h3 class="ui dividing header">{{ 'sylius.ui.taxes'|trans }}</h3>
     {{ form_row(form.taxCategory) }}
 
-    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_taxes', { 'form': form }) }}
+    {{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.tab_taxes', {'form': form}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/_menu.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/_menu.html.twig
@@ -1,5 +1,11 @@
 {% extends 'knp_menu.html.twig' %}
 
+{% if 'create' in app.request.attributes.get('_route') %}
+    {% set action = 'create' %}
+{% else %}
+    {% set action = 'update' %}
+{% endif %}
+
 {% block list %}
 {% set form = (options.form) %}
 <div class="ui stackable grid sylius-tabular-form">

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/generate.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/generate.html.twig
@@ -9,9 +9,15 @@
 {% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
 
 {% block content %}
+{{ sonata_block_render_event('sylius.admin.product_variant.generate.before_header', { 'resource': resource }) }}
+
 {{ headers.default(product.name, 'random', configuration.vars.subheader|default(header)|trans) }}
 
+{{ sonata_block_render_event('sylius.admin.product_variant.generate.after_header', { 'resource': resource }) }}
+
 {% include '@SyliusAdmin/ProductVariant/Generate/_breadcrumb.html.twig' %}
+
+{{ sonata_block_render_event('sylius.admin.product_variant.generate.after_breadcrumb', { 'resource': resource }) }}
 
 {{ form_start(form, {'action': path('sylius_admin_product_variant_generate', {'productId': product.id}), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate'}}) }}
 <div class="ui segment">
@@ -23,7 +29,11 @@
             {% include '@SyliusUi/Form/Buttons/_cancel.html.twig' with {'path': path(configuration.getRouteName('index'), {'productId': product.id})} %}
         </div>
     </div>
+
+    {{ sonata_block_render_event('sylius.admin.product_variant.generate.form', { 'resource': resource }) }}
 </div>
 {{ form_row(form._token) }}
 {{ form_end(form, {'render_rest': false}) }}
+
+{{ sonata_block_render_event('sylius.admin.product_variant.generate.after_content', { 'resource': resource }) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/generate.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/generate.html.twig
@@ -9,15 +9,15 @@
 {% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
 
 {% block content %}
-{{ sonata_block_render_event('sylius.admin.product_variant.generate.before_header', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.product_variant.generate.before_header', {'resource': resource}) }}
 
 {{ headers.default(product.name, 'random', configuration.vars.subheader|default(header)|trans) }}
 
-{{ sonata_block_render_event('sylius.admin.product_variant.generate.after_header', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.product_variant.generate.after_header', {'resource': resource}) }}
 
 {% include '@SyliusAdmin/ProductVariant/Generate/_breadcrumb.html.twig' %}
 
-{{ sonata_block_render_event('sylius.admin.product_variant.generate.after_breadcrumb', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.product_variant.generate.after_breadcrumb', {'resource': resource}) }}
 
 {{ form_start(form, {'action': path('sylius_admin_product_variant_generate', {'productId': product.id}), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate'}}) }}
 <div class="ui segment">
@@ -30,10 +30,10 @@
         </div>
     </div>
 
-    {{ sonata_block_render_event('sylius.admin.product_variant.generate.form', { 'resource': resource }) }}
+    {{ sonata_block_render_event('sylius.admin.product_variant.generate.form', {'resource': resource}) }}
 </div>
 {{ form_row(form._token) }}
 {{ form_end(form, {'render_rest': false}) }}
 
-{{ sonata_block_render_event('sylius.admin.product_variant.generate.after_content', { 'resource': resource }) }}
+{{ sonata_block_render_event('sylius.admin.product_variant.generate.after_content', {'resource': resource}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/index.html.twig
@@ -10,16 +10,16 @@
 {% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
 
 {% block content %}
-    {{ sonata_block_render_event('sylius.admin.product_variant.index.before_header', { 'resources': resources }) }}
+    {{ sonata_block_render_event('sylius.admin.product_variant.index.before_header', {'resources': resources}) }}
 
     <div class="ui stackable two column grid">
         {% include '@SyliusAdmin/ProductVariant/Index/_header.html.twig' %}
         {% include '@SyliusAdmin/Crud/Index/_actions.html.twig' %}
     </div>
 
-    {{ sonata_block_render_event('sylius.admin.product_variant.index.after_header', { 'resources': resources }) }}
+    {{ sonata_block_render_event('sylius.admin.product_variant.index.after_header', {'resources': resources}) }}
 
     {% include '@SyliusAdmin/Crud/Index/_content.html.twig' %}
 
-    {{ sonata_block_render_event('sylius.admin.product_variant.index.after_content', { 'resources': resources }) }}
+    {{ sonata_block_render_event('sylius.admin.product_variant.index.after_content', {'resources': resources}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/index.html.twig
@@ -10,10 +10,16 @@
 {% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
 
 {% block content %}
+    {{ sonata_block_render_event('sylius.admin.product_variant.index.before_header', { 'resources': resources }) }}
+
     <div class="ui stackable two column grid">
         {% include '@SyliusAdmin/ProductVariant/Index/_header.html.twig' %}
         {% include '@SyliusAdmin/Crud/Index/_actions.html.twig' %}
     </div>
 
+    {{ sonata_block_render_event('sylius.admin.product_variant.index.after_header', { 'resources': resources }) }}
+
     {% include '@SyliusAdmin/Crud/Index/_content.html.twig' %}
+
+    {{ sonata_block_render_event('sylius.admin.product_variant.index.after_content', { 'resources': resources }) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/generate.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/generate.html.twig
@@ -9,15 +9,15 @@
 {% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
 
 {% block content %}
-{{ sonata_block_render_event('sylius.admin.promotion.generate.before_header', {'resource': promotion}) }}
+{{ sonata_block_render_event('sylius.admin.promotion_coupon.generate.before_header', {'resource': promotion}) }}
 
 {{ headers.default(promotion.name, 'random', configuration.vars.subheader|default(header)|trans) }}
 
-{{ sonata_block_render_event('sylius.admin.promotion.generate.after_header', {'resource': promotion}) }}
+{{ sonata_block_render_event('sylius.admin.promotion_coupon.generate.after_header', {'resource': promotion}) }}
 
 {% include '@SyliusAdmin/PromotionCoupon/Generate/_breadcrumb.html.twig' %}
 
-{{ sonata_block_render_event('sylius.admin.promotion.generate.after_breadcrumb', {'resource': promotion}) }}
+{{ sonata_block_render_event('sylius.admin.promotion_coupon.generate.after_breadcrumb', {'resource': promotion}) }}
 
 {{ form_start(form, {'action': path('sylius_admin_promotion_coupon_generate', {'promotionId': promotion.id}), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate'}}) }}
 <div class="ui segment">
@@ -30,10 +30,10 @@
         </div>
     </div>
 
-    {{ sonata_block_render_event('sylius.admin.promotion.generate.form', {'resource': promotion}) }}
+    {{ sonata_block_render_event('sylius.admin.promotion_coupon.generate.form', {'resource': promotion}) }}
 </div>
 {{ form_row(form._token) }}
 {{ form_end(form, {'render_rest': false}) }}
 
-{{ sonata_block_render_event('sylius.admin.promotion.generate.after_content', {'resource': promotion}) }}
+{{ sonata_block_render_event('sylius.admin.promotion_coupon.generate.after_content', {'resource': promotion}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/generate.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/generate.html.twig
@@ -9,15 +9,15 @@
 {% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
 
 {% block content %}
-{{ sonata_block_render_event('sylius.admin.promotion.generate.before_header', { 'resource': promotion }) }}
+{{ sonata_block_render_event('sylius.admin.promotion.generate.before_header', {'resource': promotion}) }}
 
 {{ headers.default(promotion.name, 'random', configuration.vars.subheader|default(header)|trans) }}
 
-{{ sonata_block_render_event('sylius.admin.promotion.generate.after_header', { 'resource': promotion }) }}
+{{ sonata_block_render_event('sylius.admin.promotion.generate.after_header', {'resource': promotion}) }}
 
 {% include '@SyliusAdmin/PromotionCoupon/Generate/_breadcrumb.html.twig' %}
 
-{{ sonata_block_render_event('sylius.admin.promotion.generate.after_breadcrumb', { 'resource': promotion }) }}
+{{ sonata_block_render_event('sylius.admin.promotion.generate.after_breadcrumb', {'resource': promotion}) }}
 
 {{ form_start(form, {'action': path('sylius_admin_promotion_coupon_generate', {'promotionId': promotion.id}), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate'}}) }}
 <div class="ui segment">
@@ -30,10 +30,10 @@
         </div>
     </div>
 
-    {{ sonata_block_render_event('sylius.admin.promotion.generate.form', { 'resource': promotion }) }}
+    {{ sonata_block_render_event('sylius.admin.promotion.generate.form', {'resource': promotion}) }}
 </div>
 {{ form_row(form._token) }}
 {{ form_end(form, {'render_rest': false}) }}
 
-{{ sonata_block_render_event('sylius.admin.promotion.generate.after_content', { 'resource': promotion }) }}
+{{ sonata_block_render_event('sylius.admin.promotion.generate.after_content', {'resource': promotion}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/generate.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/generate.html.twig
@@ -9,9 +9,15 @@
 {% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
 
 {% block content %}
+{{ sonata_block_render_event('sylius.admin.promotion.generate.before_header', { 'resource': promotion }) }}
+
 {{ headers.default(promotion.name, 'random', configuration.vars.subheader|default(header)|trans) }}
 
+{{ sonata_block_render_event('sylius.admin.promotion.generate.after_header', { 'resource': promotion }) }}
+
 {% include '@SyliusAdmin/PromotionCoupon/Generate/_breadcrumb.html.twig' %}
+
+{{ sonata_block_render_event('sylius.admin.promotion.generate.after_breadcrumb', { 'resource': promotion }) }}
 
 {{ form_start(form, {'action': path('sylius_admin_promotion_coupon_generate', {'promotionId': promotion.id}), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate'}}) }}
 <div class="ui segment">
@@ -23,7 +29,11 @@
             {% include '@SyliusUi/Form/Buttons/_cancel.html.twig' with {'path': path(configuration.getRouteName('index'), {'promotionId': promotion.id})} %}
         </div>
     </div>
+
+    {{ sonata_block_render_event('sylius.admin.promotion.generate.form', { 'resource': promotion }) }}
 </div>
 {{ form_row(form._token) }}
 {{ form_end(form, {'render_rest': false}) }}
+
+{{ sonata_block_render_event('sylius.admin.promotion.generate.after_content', { 'resource': promotion }) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/index.html.twig
@@ -10,10 +10,16 @@
 {% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
 
 {% block content %}
+    {{ sonata_block_render_event('sylius.admin.promotion_coupon.index.before_header', {'resources': resources}) }}
+
     <div class="ui stackable two column grid">
         {% include '@SyliusAdmin/PromotionCoupon/Index/_header.html.twig' %}
         {% include '@SyliusAdmin/Crud/Index/_actions.html.twig' %}
     </div>
 
+    {{ sonata_block_render_event('sylius.admin.promotion_coupon.index.after_header', {'resources': resources}) }}
+
     {% include '@SyliusAdmin/Crud/Index/_content.html.twig' %}
+    
+    {{ sonata_block_render_event('sylius.admin.promotion_coupon.index.after_content', {'resources': resources}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Security/login.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Security/login.html.twig
@@ -7,11 +7,11 @@
 {% endblock %}
 
 {% block content %}
-{{ sonata_block_render_event('sylius.admin.login.before_content', { 'form': form }) }}
+{{ sonata_block_render_event('sylius.admin.login.before_content', {'form': form}) }}
 
 {% include '@SyliusUi/Security/_login.html.twig' with {'action': path('sylius_admin_login_check'), 'paths': {'logo': 'assets/admin/img/logo.png'}} %}
 
-{{ sonata_block_render_event('sylius.admin.login.after_content', { 'form': form }) }}
+{{ sonata_block_render_event('sylius.admin.login.after_content', {'form': form}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Security/login.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Security/login.html.twig
@@ -7,7 +7,11 @@
 {% endblock %}
 
 {% block content %}
+{{ sonata_block_render_event('sylius.admin.login.before_content', { 'form': form }) }}
+
 {% include '@SyliusUi/Security/_login.html.twig' with {'action': path('sylius_admin_login_check'), 'paths': {'logo': 'assets/admin/img/logo.png'}} %}
+
+{{ sonata_block_render_event('sylius.admin.login.after_content', { 'form': form }) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/create.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/create.html.twig
@@ -1,9 +1,15 @@
 {% extends '@SyliusAdmin/Crud/create.html.twig' %}
 
 {% block content %}
+    {{ sonata_block_render_event('sylius.admin.taxon.create.before_content', { 'resource': resource }) }}
+
     <div class="ui two column stackable grid">
         <div class="four wide column">
+            {{ sonata_block_render_event('sylius.admin.taxon.create.before_taxon_tree', { 'resource': resource }) }}
+
             {{ render(path('sylius_admin_partial_taxon_tree', {'template': '@SyliusAdmin/Taxon/_treeWithButtons.html.twig'})) }}
+
+            {{ sonata_block_render_event('sylius.admin.taxon.create.after_taxon_tree', { 'resource': resource }) }}
         </div>
         <div class="twelve wide column">
             {{ parent() }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/create.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/create.html.twig
@@ -1,15 +1,15 @@
 {% extends '@SyliusAdmin/Crud/create.html.twig' %}
 
 {% block content %}
-    {{ sonata_block_render_event('sylius.admin.taxon.create.before_content', { 'resource': resource }) }}
+    {{ sonata_block_render_event('sylius.admin.taxon.create.before_content', {'resource': resource}) }}
 
     <div class="ui two column stackable grid">
         <div class="four wide column">
-            {{ sonata_block_render_event('sylius.admin.taxon.create.before_taxon_tree', { 'resource': resource }) }}
+            {{ sonata_block_render_event('sylius.admin.taxon.create.before_taxon_tree', {'resource': resource}) }}
 
             {{ render(path('sylius_admin_partial_taxon_tree', {'template': '@SyliusAdmin/Taxon/_treeWithButtons.html.twig'})) }}
 
-            {{ sonata_block_render_event('sylius.admin.taxon.create.after_taxon_tree', { 'resource': resource }) }}
+            {{ sonata_block_render_event('sylius.admin.taxon.create.after_taxon_tree', {'resource': resource}) }}
         </div>
         <div class="twelve wide column">
             {{ parent() }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/update.html.twig
@@ -1,9 +1,15 @@
 {% extends '@SyliusAdmin/Crud/update.html.twig' %}
 
 {% block content %}
+    {{ sonata_block_render_event('sylius.admin.taxon.update.before_content', { 'resource': resource }) }}
+
     <div class="ui two column stackable grid">
         <div class="four wide column">
+            {{ sonata_block_render_event('sylius.admin.taxon.update.before_taxon_tree', { 'resource': resource }) }}
+
             {{ render(path('sylius_admin_partial_taxon_tree', {'template': '@SyliusAdmin/Taxon/_treeWithButtons.html.twig'})) }}
+
+            {{ sonata_block_render_event('sylius.admin.taxon.update.after_taxon_tree', { 'resource': resource }) }}
         </div>
         <div class="twelve wide column">
             {{ parent() }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/update.html.twig
@@ -1,15 +1,15 @@
 {% extends '@SyliusAdmin/Crud/update.html.twig' %}
 
 {% block content %}
-    {{ sonata_block_render_event('sylius.admin.taxon.update.before_content', { 'resource': resource }) }}
+    {{ sonata_block_render_event('sylius.admin.taxon.update.before_content', {'resource': resource}) }}
 
     <div class="ui two column stackable grid">
         <div class="four wide column">
-            {{ sonata_block_render_event('sylius.admin.taxon.update.before_taxon_tree', { 'resource': resource }) }}
+            {{ sonata_block_render_event('sylius.admin.taxon.update.before_taxon_tree', {'resource': resource}) }}
 
             {{ render(path('sylius_admin_partial_taxon_tree', {'template': '@SyliusAdmin/Taxon/_treeWithButtons.html.twig'})) }}
 
-            {{ sonata_block_render_event('sylius.admin.taxon.update.after_taxon_tree', { 'resource': resource }) }}
+            {{ sonata_block_render_event('sylius.admin.taxon.update.after_taxon_tree', {'resource': resource}) }}
         </div>
         <div class="twelve wide column">
             {{ parent() }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
@@ -1,6 +1,6 @@
 {% extends 'SyliusUiBundle:Layout:sidebar.html.twig' %}
 
-{% set eventPrefix = app.request.attributes.get('_route')|replace('_', '.') %}
+{% set event_prefix = app.request.attributes.get('_route')|replace('_', '.') %}
 
 {% block title %}Sylius | {% endblock %}
 
@@ -13,25 +13,25 @@
         <i class="sidebar icon"></i>
     </a>
 
-    {{ sonata_block_render_event(eventPrefix ~ '.topbar_left') }}
+    {{ sonata_block_render_event(event_prefix ~ '.topbar_left') }}
 
     {{ render(url('sylius_admin_partial_channel_index', {'template': '@SyliusAdmin/_channelLinks.html.twig'})) }}
     {% include '@SyliusAdmin/_search.html.twig' %}
 
-    {{ sonata_block_render_event(eventPrefix ~ '.topbar_middle') }}
+    {{ sonata_block_render_event(event_prefix ~ '.topbar_middle') }}
 
     {% include '@SyliusAdmin/_security.html.twig' %}
 
-    {{ sonata_block_render_event(eventPrefix ~ '.topbar_right') }}
+    {{ sonata_block_render_event(event_prefix ~ '.topbar_right') }}
 {% endblock %}
 
 {% block sidebar %}
-    {{ sonata_block_render_event(eventPrefix ~ '.sidebar_top') }}
+    {{ sonata_block_render_event(event_prefix ~ '.sidebar_top') }}
 
     <a class="item" href="{{ path('sylius_admin_dashboard') }}"><b>Sylius</b></a>
     {{ knp_menu_render('sylius.admin.main', {'template': 'SyliusUiBundle:Menu:sidebar.html.twig', 'currentClass': 'active'}) }}
 
-    {{ sonata_block_render_event(eventPrefix ~ '.sidebar_down') }}
+    {{ sonata_block_render_event(event_prefix ~ '.sidebar_down') }}
 {% endblock %}
 
 {% block footer %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
@@ -1,5 +1,7 @@
 {% extends 'SyliusUiBundle:Layout:sidebar.html.twig' %}
 
+{% set eventPrefix = app.request.attributes.get('_route')|replace('_', '.') %}
+
 {% block title %}Sylius | {% endblock %}
 
 {% block stylesheets %}
@@ -10,14 +12,26 @@
     <a class="icon item" id="sidebar-toggle" title="{{ 'sylius.ui.toggle_sidebar'|trans }}">
         <i class="sidebar icon"></i>
     </a>
+
+    {{ sonata_block_render_event(eventPrefix ~ '.topbar_left') }}
+
     {{ render(url('sylius_admin_partial_channel_index', {'template': '@SyliusAdmin/_channelLinks.html.twig'})) }}
     {% include '@SyliusAdmin/_search.html.twig' %}
+
+    {{ sonata_block_render_event(eventPrefix ~ '.topbar_middle') }}
+
     {% include '@SyliusAdmin/_security.html.twig' %}
+
+    {{ sonata_block_render_event(eventPrefix ~ '.topbar_right') }}
 {% endblock %}
 
 {% block sidebar %}
+    {{ sonata_block_render_event(eventPrefix ~ '.sidebar_top') }}
+
     <a class="item" href="{{ path('sylius_admin_dashboard') }}"><b>Sylius</b></a>
     {{ knp_menu_render('sylius.admin.main', {'template': 'SyliusUiBundle:Menu:sidebar.html.twig', 'currentClass': 'active'}) }}
+
+    {{ sonata_block_render_event(eventPrefix ~ '.sidebar_down') }}
 {% endblock %}
 
 {% block footer %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
@@ -1,7 +1,5 @@
 {% extends 'SyliusUiBundle:Layout:sidebar.html.twig' %}
 
-{% set event_prefix = app.request.attributes.get('_route')|replace('_', '.') %}
-
 {% block title %}Sylius | {% endblock %}
 
 {% block stylesheets %}
@@ -13,25 +11,25 @@
         <i class="sidebar icon"></i>
     </a>
 
-    {{ sonata_block_render_event(event_prefix ~ '.topbar_left') }}
+    {{ sonata_block_render_event('sylius.admin.layout.topbar_left') }}
 
     {{ render(url('sylius_admin_partial_channel_index', {'template': '@SyliusAdmin/_channelLinks.html.twig'})) }}
     {% include '@SyliusAdmin/_search.html.twig' %}
 
-    {{ sonata_block_render_event(event_prefix ~ '.topbar_middle') }}
+    {{ sonata_block_render_event('sylius.admin.layout.topbar_middle') }}
 
     {% include '@SyliusAdmin/_security.html.twig' %}
 
-    {{ sonata_block_render_event(event_prefix ~ '.topbar_right') }}
+    {{ sonata_block_render_event('sylius.admin.layout.topbar_right') }}
 {% endblock %}
 
 {% block sidebar %}
-    {{ sonata_block_render_event(event_prefix ~ '.sidebar_top') }}
+    {{ sonata_block_render_event('sylius.admin.layout.sidebar_top') }}
 
     <a class="item" href="{{ path('sylius_admin_dashboard') }}"><b>Sylius</b></a>
     {{ knp_menu_render('sylius.admin.main', {'template': 'SyliusUiBundle:Menu:sidebar.html.twig', 'currentClass': 'active'}) }}
 
-    {{ sonata_block_render_event(event_prefix ~ '.sidebar_down') }}
+    {{ sonata_block_render_event('sylius.admin.layout.sidebar_down') }}
 {% endblock %}
 
 {% block footer %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
@@ -34,8 +34,6 @@
     </div>
 {% endif %}
 
-{{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.before_grid', { 'grid': grid }) }}
-
 <div class="ui segment">
     {% if definition.limits|length > 1 and data|length > min(definition.limits) %}
     <div class="ui two column fluid stackable grid">

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
@@ -34,6 +34,8 @@
     </div>
 {% endif %}
 
+{{ sonata_block_render_event(app.request.attributes.get('_route')|replace('_', '.') ~ '.before_grid', { 'grid': grid }) }}
+
 <div class="ui segment">
     {% if definition.limits|length > 1 and data|length > min(definition.limits) %}
     <div class="ui two column fluid stackable grid">

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Security/_login.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Security/_login.html.twig
@@ -4,7 +4,7 @@
 
 <div class="ui middle aligned center aligned grid">
     <div class="column">
-        {{ sonata_block_render_event('sylius.admin.login.before_form', { 'form': form }) }}
+        {{ sonata_block_render_event('sylius.admin.login.before_form', {'form': form}) }}
 
         {% if paths.logo is defined %}
         <img src="{{ asset(paths.logo) }}" class="ui fluid image" id="logo">
@@ -25,7 +25,7 @@
                 <button type="submit" class="ui fluid large primary submit button">Login</button>
             </div>
 
-            {{ sonata_block_render_event('sylius.admin.login.form', { 'form': form }) }}
+            {{ sonata_block_render_event('sylius.admin.login.form', {'form': form}) }}
 
         {{ form_end(form, {'render_rest': false}) }}
     </div>

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Security/_login.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Security/_login.html.twig
@@ -4,6 +4,8 @@
 
 <div class="ui middle aligned center aligned grid">
     <div class="column">
+        {{ sonata_block_render_event('sylius.admin.login.before_form', { 'form': form }) }}
+
         {% if paths.logo is defined %}
         <img src="{{ asset(paths.logo) }}" class="ui fluid image" id="logo">
         {% endif %}
@@ -22,6 +24,9 @@
                 <input type="hidden" name="_csrf_admin_security_token" value="{{ csrf_token('admin_authenticate') }}">
                 <button type="submit" class="ui fluid large primary submit button">Login</button>
             </div>
+
+            {{ sonata_block_render_event('sylius.admin.login.form', { 'form': form }) }}
+
         {{ form_end(form, {'render_rest': false}) }}
     </div>
 </div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | based on #7704 |
| License         | MIT |

The proposed naming convention for these events is to follow the routing to the place where we are adding it, but instead of `_` we are using `.`, followed by a _slot_ name (like `sylius_admin_customer_show` route results in the `sylius.admin.customer.show.slot_name` event). The slot name describes where exactly in the template's structure should the event occur.