### PR TITLE
[Docs] Put options of 'orm_purger' in child node

### DIFF
--- a/docs/bundles/SyliusFixturesBundle/builtin_listeners.rst
+++ b/docs/bundles/SyliusFixturesBundle/builtin_listeners.rst
@@ -53,9 +53,10 @@ Example configuration:
             my_suite:
                 listeners:
                     orm_purger:
-                        purge_mode: truncate
-                        managers:
-                            - custom_manager
+                        options:
+                            purge_mode: truncate
+                            managers:
+                                - custom_manager
 
 PHPCR / MongoDB Purger (``phpcr_purger`` / ``mongodb_purger``)
 --------------------------------------------------------------
@@ -75,6 +76,7 @@ Example configuration:
             my_suite:
                 listeners:
                     phpcr_purger:
-                        managers:
-                            - custom_manager # Uses custom document manager
+                        options:
+                            managers:
+                                - custom_manager # Uses custom document manager
                     mongodb_purger: ~ # Uses default document manager


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no|
| BC breaks?      | no|
| License         | MIT |

Looking at the code and testing it, the settings for a purger need to be under the 'options' node, not directly at the purger level. At least this is how I got it working in beta.1 for 'orm_purger'.