### PR TITLE
Add support to ORM Purger (Fixtures) to exclude tables

### DIFF
--- a/docs/bundles/SyliusFixturesBundle/builtin_listeners.rst
+++ b/docs/bundles/SyliusFixturesBundle/builtin_listeners.rst
@@ -43,6 +43,7 @@ Configuration options:
 
     - ``purge_mode`` - sets how database is purged, available values: ``delete`` (default), ``truncate``
     - ``managers`` - an array of entity managers' names used to purge the database, ``[null]`` by default
+    - ``exclude`` - an array of table/view names to be excluded from purge, ``[]`` by default
 
 Example configuration:
 
@@ -57,6 +58,8 @@ Example configuration:
                             purge_mode: truncate
                             managers:
                                 - custom_manager
+                            exclude:
+                                - custom_entity_table_name
 
 PHPCR / MongoDB Purger (``phpcr_purger`` / ``mongodb_purger``)
 --------------------------------------------------------------

--- a/src/Sylius/Bundle/FixturesBundle/Listener/ORMPurgerListener.php
+++ b/src/Sylius/Bundle/FixturesBundle/Listener/ORMPurgerListener.php
@@ -86,8 +86,8 @@ final class ORMPurgerListener extends AbstractListener implements BeforeSuiteLis
 
         $optionsNodeBuilder
             ->arrayNode('exclude')
-            ->defaultValue([])
-            ->prototype('scalar')
+                ->defaultValue([])
+                ->prototype('scalar')
         ;
     }
 }

--- a/src/Sylius/Bundle/FixturesBundle/Listener/ORMPurgerListener.php
+++ b/src/Sylius/Bundle/FixturesBundle/Listener/ORMPurgerListener.php
@@ -51,7 +51,7 @@ final class ORMPurgerListener extends AbstractListener implements BeforeSuiteLis
             /** @var EntityManagerInterface $manager */
             $manager = $this->managerRegistry->getManager($managerName);
 
-            $purger = new ORMPurger($manager);
+            $purger = new ORMPurger($manager, $options['exclude']);
             $purger->setPurgeMode(static::$purgeModes[$options['mode']]);
             $purger->purge();
         }
@@ -82,6 +82,12 @@ final class ORMPurgerListener extends AbstractListener implements BeforeSuiteLis
             ->arrayNode('managers')
                 ->defaultValue([null])
                 ->prototype('scalar')
+        ;
+
+        $optionsNodeBuilder
+            ->arrayNode('exclude')
+            ->defaultValue([])
+            ->prototype('scalar')
         ;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| License         | MIT |

In my project I have some tables that do not need to be purged or give problems purging (JMS Queue Bundle). The exclude option is already present in the ORM Purger itself, it was just not supported by the fixtures bundle.