### PR TITLE
[RFC] [Core] Introduce Plugin concept

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Application/Plugin.php
+++ b/src/Sylius/Bundle/CoreBundle/Application/Plugin.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\CoreBundle\Application;
+
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * Provides a common logic for Sylius Plugins.
+ * Each of a plugins should be created with Plugin instead of Bundle suffix for the root class and inherit from this class.
+ *
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ */
+abstract class Plugin extends Bundle
+{
+    /**
+     * Returns the plugin's container extension.
+     *
+     * @return ExtensionInterface|null The container extension
+     *
+     * @throws \LogicException
+     */
+    public function getContainerExtension()
+    {
+        if (null === $this->extension) {
+            $extension = $this->createContainerExtension();
+
+            if (null !== $extension) {
+                if (!$extension instanceof ExtensionInterface) {
+                    throw new \LogicException(sprintf('Extension %s must implement Symfony\Component\DependencyInjection\Extension\ExtensionInterface.', get_class($extension)));
+                }
+
+                // check naming convention for Sylius Plugins
+                $basename = preg_replace('/Plugin$/', '', $this->getName());
+                $expectedAlias = Container::underscore($basename);
+
+                if ($expectedAlias != $extension->getAlias()) {
+                    throw new \LogicException(sprintf(
+                        'Users will expect the alias of the default extension of a plugin to be the underscored version of the plugin name ("%s"). You can override "Bundle::getContainerExtension()" if you want to use "%s" or another alias.',
+                        $expectedAlias, $extension->getAlias()
+                    ));
+                }
+
+                $this->extension = $extension;
+            } else {
+                $this->extension = false;
+            }
+        }
+
+        if ($this->extension) {
+            return $this->extension;
+        }
+    }
+
+    /**
+     * Returns the plugin's container extension class.
+     *
+     * @return string
+     */
+    protected function getContainerExtensionClass()
+    {
+        $basename = preg_replace('/Plugin$/', '', $this->getName());
+
+        return $this->getNamespace().'\\DependencyInjection\\'.$basename.'Extension';
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

# Hello, Folks! 👋 
As you probably know, one of the key concepts for Sylius is to introduce an easy way of creating external plugins which will extend the core logic and don't mess with the core itself. It can be useful to somehow differentiate them from regular Symfony bundles. And this is the main topic of this PR. This abstract class will slightly change the default behaviour of SymfonyBundle and will require creating AppPlugin instead of AppBundle. Also, it will change the way, how the config files should be included. 

## Changes
Let's assume that we have created `SylusSomeBundle` as a plugin with routing, grids and templates inside and want to take advantage of this change

### Routing:
Before:
```yml
some_plugin:
    resource: "@SyliusSomeBundle/Resources/config/app/routing.yml"
```
After:
```yml
some_plugin:
    resource: "@SyliusSomePlugin/Resources/config/app/routing.yml"
```
### Config:
Before:
```yml
imports:
    - { resource: "@SyliusSomeBundle/Resources/config/app/grid.yml" }
```
After:
```yml
imports:
    - { resource: "@SyliusSomePlugin/Resources/config/app/grid.yml" }
```
### Templates:
Before:
```yml
form: "@SyliusSome/_form.html.twig"
```
After:
```yml
form: "@SyliusSomePlugin/_form.html.twig"
```
### DI
Convention for DependencyInjection stay the same, so we still have `SyliusSomeExtension`