### PR TITLE
Translate hardcoded English string in product taxonomy layout

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_taxonomy.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_taxonomy.html.twig
@@ -2,7 +2,7 @@
     <h3 class="ui dividing header">{{ 'sylius.ui.taxonomy'|trans }}</h3>
     {{ form_row(form.mainTaxon, {'remote_url': path('sylius_admin_ajax_taxon_by_name_phrase'), 'remote_criteria_type': 'contains', 'remote_criteria_name': 'phrase', 'load_edit_url': path('sylius_admin_ajax_taxon_by_code')}) }}
 
-    <h4>Product Taxon</h4>
+    <h4>{{ 'sylius.ui.product_taxon'|trans }}</h4>
     <div id="sylius-product-taxonomy-tree"
          data-taxon-root-nodes-url="{{ path('sylius_admin_ajax_taxon_root_nodes') }}"
          data-taxon-leafs-url="{{ path('sylius_admin_ajax_taxon_leafs') }}"

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
@@ -623,6 +623,7 @@ sylius:
         product_options: 'Product options'
         product_review: 'Product review'
         product_reviews: 'Product reviews'
+        product_taxon: 'Product taxon'
         product_variants: 'Product variants'
         products: 'Products'
         products_categorized_as_name: 'Products categorized as "%name%"'


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

There's a hardcoded string in the admin product taxonomy layout.  Make it translatable.