### PR TITLE
Do not make product variant's fields empty while editing simple product

### DIFF
--- a/features/product/managing_products/editing_product.feature
+++ b/features/product/managing_products/editing_product.feature
@@ -23,6 +23,15 @@ Feature: Editing a product
         And this product name should be "7 Wonders"
 
     @ui
+    Scenario: Renaming a simple product does not change its variant name
+        Given this product only variant was renamed to "Dice Brewing: The Game"
+        And I want to modify this product
+        When I rename it to "7 Wonders" in "English (United States)"
+        And I save my changes
+        And I want to view all variants of this product
+        Then the first variant in the list should have name "Dice Brewing: The Game"
+
+    @ui
     Scenario: Changing a simple product price
         Given I want to modify the "Dice Brewing" product
         When I change its price to $15.00 for "United States" channel

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -464,6 +464,20 @@ final class ProductContext implements Context
     }
 
     /**
+     * @Given /^(this product) only variant was renamed to "([^"]+)"$/
+     */
+    public function productOnlyVariantWasRenamed(ProductInterface $product, $variantName)
+    {
+        Assert::true($product->isSimple());
+
+        /** @var ProductVariantInterface $productVariant */
+        $productVariant = $product->getVariants()->first();
+        $productVariant->setName($variantName);
+
+        $this->objectManager->flush();
+    }
+
+    /**
      * @Given /^there is product "([^"]+)" available in ((?:this|that|"[^"]+") channel)$/
      * @Given /^the store has a product "([^"]+)" available in ("([^"]+)" channel)$/
      */

--- a/src/Sylius/Behat/Context/Ui/Admin/BrowsingProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/BrowsingProductVariantsContext.php
@@ -1,0 +1,287 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Behat\Context\Ui\Admin;
+
+use Behat\Behat\Context\Context;
+use Sylius\Behat\Page\Admin\ProductVariant\IndexPageInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * @author Kamil Kokot <kamil.kokot@lakion.com>
+ */
+final class BrowsingProductVariantsContext implements Context
+{
+    /**
+     * @var IndexPageInterface
+     */
+    private $indexPage;
+
+    /**
+     * @var ProductVariantResolverInterface
+     */
+    private $defaultProductVariantResolver;
+
+    /**
+     * @param IndexPageInterface $indexPage
+     * @param ProductVariantResolverInterface $defaultProductVariantResolver
+     */
+    public function __construct(
+        IndexPageInterface $indexPage,
+        ProductVariantResolverInterface $defaultProductVariantResolver
+    ) {
+        $this->indexPage = $indexPage;
+        $this->defaultProductVariantResolver = $defaultProductVariantResolver;
+    }
+
+    /**
+     * @When I start sorting variants by :field
+     */
+    public function iSortProductsBy($field)
+    {
+        $this->indexPage->sortBy($field);
+    }
+
+    /**
+     * @Then the :productVariantCode variant of the :product product should appear in the store
+     */
+    public function theProductVariantShouldAppearInTheShop($productVariantCode, ProductInterface $product)
+    {
+        $this->indexPage->open(['productId' => $product->getId()]);
+
+        Assert::true($this->indexPage->isSingleResourceOnPage(['code' => $productVariantCode]));
+    }
+
+    /**
+     * @Then the :productVariantCode variant of the :product product should not appear in the store
+     */
+    public function theProductVariantShouldNotAppearInTheShop($productVariantCode, ProductInterface $product)
+    {
+        $this->indexPage->open(['productId' => $product->getId()]);
+
+        Assert::false($this->indexPage->isSingleResourceOnPage(['code' => $productVariantCode]));
+    }
+
+    /**
+     * @Then the :product product should have no variants
+     */
+    public function theProductShouldHaveNoVariants(ProductInterface $product)
+    {
+        $this->indexPage->open(['productId' => $product->getId()]);
+
+        $this->assertNumberOfVariantsOnProductPage(0);
+    }
+
+    /**
+     * @Then the :product product should have only one variant
+     */
+    public function theProductShouldHaveOnlyOneVariant(ProductInterface $product)
+    {
+        $this->indexPage->open(['productId' => $product->getId()]);
+
+        $this->assertNumberOfVariantsOnProductPage(1);
+    }
+
+    /**
+     * @When /^I (?:|want to )view all variants of (this product)$/
+     * @When /^I view(?:| all) variants of the (product "[^"]+")$/
+     */
+    public function iWantToViewAllVariantsOfThisProduct(ProductInterface $product)
+    {
+        $this->indexPage->open(['productId' => $product->getId()]);
+    }
+
+    /**
+     * @Then I should see :numberOfProductVariants variants in the list
+     * @Then I should see :numberOfProductVariants variant in the list
+     * @Then I should not see any variants in the list
+     */
+    public function iShouldSeeProductVariantsInTheList($numberOfProductVariants = 0)
+    {
+        Assert::same($this->indexPage->countItems(), (int) $numberOfProductVariants);
+    }
+
+    /**
+     * @Then /^(this variant) should not exist in the product catalog$/
+     */
+    public function productVariantShouldNotExist(ProductVariantInterface $productVariant)
+    {
+        $this->indexPage->open(['productId' => $productVariant->getProduct()->getId()]);
+
+        Assert::false($this->indexPage->isSingleResourceOnPage(['name' => $productVariant->getName()]));
+    }
+
+    /**
+     * @Then /^(this variant) should still exist in the product catalog$/
+     */
+    public function productShouldExistInTheProductCatalog(ProductVariantInterface $productVariant)
+    {
+        $this->theProductVariantShouldAppearInTheShop($productVariant->getCode(), $productVariant->getProduct());
+    }
+
+    /**
+     * @Then /^the variant "([^"]+)" should have (\d+) items on hand$/
+     */
+    public function thisVariantShouldHaveItemsOnHand($productVariantName, $quantity)
+    {
+        Assert::true($this->indexPage->isSingleResourceWithSpecificElementOnPage(
+            ['name' => $productVariantName],
+            sprintf('td > div.ui.label:contains("%s")', $quantity)
+        ));
+    }
+
+    /**
+     * @Then /^the "([^"]+)" variant of ("[^"]+" product) should have (\d+) items on hand$/
+     */
+    public function theVariantOfProductShouldHaveItemsOnHand($productVariantName, ProductInterface $product, $quantity)
+    {
+        $this->indexPage->open(['productId' => $product->getId()]);
+
+        Assert::true($this->indexPage->isSingleResourceWithSpecificElementOnPage(
+            ['name' => $productVariantName],
+            sprintf('td > div.ui.label:contains("%s")', $quantity)
+        ));
+    }
+
+    /**
+     * @Then /^I should see that the ("([^"]+)" variant) is not tracked$/
+     */
+    public function iShouldSeeThatIsNotTracked(ProductVariantInterface $productVariant)
+    {
+        Assert::true($this->indexPage->isSingleResourceOnPage([
+            'name' => $productVariant->getName(),
+            'inventory' => 'Not tracked',
+        ]));
+    }
+
+    /**
+     * @Then /^I should see that the ("[^"]+" variant) has zero on hand quantity$/
+     */
+    public function iShouldSeeThatTheVariantHasZeroOnHandQuantity(ProductVariantInterface $productVariant)
+    {
+        Assert::true($this->indexPage->isSingleResourceOnPage([
+            'name' => $productVariant->getName(),
+            'inventory' => '0 Available on hand',
+        ]));
+    }
+
+    /**
+     * @Then /^(\d+) units of (this product) should be on hold$/
+     */
+    public function unitsOfThisProductShouldBeOnHold($quantity, ProductInterface $product)
+    {
+        /** @var ProductVariantInterface $variant */
+        $variant = $this->defaultProductVariantResolver->getVariant($product);
+
+        $this->assertOnHoldQuantityOfVariant($quantity, $variant);
+    }
+
+    /**
+     * @Then /^(\d+) units of (this product) should be on hand$/
+     */
+    public function unitsOfThisProductShouldBeOnHand($quantity, ProductInterface $product)
+    {
+        /** @var ProductVariantInterface $variant */
+        $variant = $this->defaultProductVariantResolver->getVariant($product);
+
+        Assert::same($this->indexPage->getOnHandQuantityFor($variant), (int) $quantity);
+    }
+
+    /**
+     * @Then /^there should be no units of (this product) on hold$/
+     */
+    public function thereShouldBeNoUnitsOfThisProductOnHold(ProductInterface $product)
+    {
+        /** @var ProductVariantInterface $variant */
+        $variant = $this->defaultProductVariantResolver->getVariant($product);
+
+        $this->assertOnHoldQuantityOfVariant(0, $variant);
+    }
+
+    /**
+     * @Then the :variant variant should have :amount items on hold
+     */
+    public function thisVariantShouldHaveItemsOnHold(ProductVariantInterface $variant, $amount)
+    {
+        $this->assertOnHoldQuantityOfVariant((int) $amount, $variant);
+    }
+
+    /**
+     * @Then the :variant variant of :product product should have :amount items on hold
+     */
+    public function theVariantOfProductShouldHaveItemsOnHold(ProductVariantInterface $variant, ProductInterface $product, $amount)
+    {
+        $this->indexPage->open(['productId' => $product->getId()]);
+
+        $this->assertOnHoldQuantityOfVariant((int) $amount, $variant);
+    }
+
+    /**
+     * @Then the first variant in the list should have :field :value
+     */
+    public function theFirstVariantInTheListShouldHave($field, $value)
+    {
+        Assert::same($this->indexPage->getColumnFields($field)[0], $value);
+    }
+
+    /**
+     * @Then the last variant in the list should have :field :value
+     */
+    public function theLastVariantInTheListShouldHave($field, $value)
+    {
+        $values = $this->indexPage->getColumnFields($field);
+
+        Assert::same(end($values), $value);
+    }
+
+    /**
+     * @Then /^(this variant) should have a (\d+) item currently in stock$/
+     */
+    public function thisVariantShouldHaveAItemCurrentlyInStock(ProductVariantInterface $productVariant, $amountInStock)
+    {
+        $this->indexPage->open(['productId' => $productVariant->getProduct()->getId()]);
+
+        Assert::same($this->indexPage->getOnHandQuantityFor($productVariant), (int) $amountInStock);
+    }
+
+    /**
+     * @param int $expectedAmount
+     * @param ProductVariantInterface $variant
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function assertOnHoldQuantityOfVariant($expectedAmount, $variant)
+    {
+        $actualAmount = $this->indexPage->getOnHoldQuantityFor($variant);
+
+        Assert::same(
+            $actualAmount,
+            (int) $expectedAmount,
+            sprintf(
+                'Unexpected on hold quantity for "%s" variant. It should be "%s" but is "%s"',
+                $variant->getName(),
+                $expectedAmount,
+                $actualAmount
+            )
+        );
+    }
+
+    /**
+     * @param int $amount
+     */
+    private function assertNumberOfVariantsOnProductPage($amount)
+    {
+        Assert::same((int) $this->indexPage->countItems(), $amount, 'Product has %d variants, but should have %d');
+    }
+}

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -169,13 +169,18 @@
 
         <service id="sylius.behat.context.ui.admin.managing_product_variants" class="Sylius\Behat\Context\Ui\Admin\ManagingProductVariantsContext">
             <argument type="service" id="sylius.behat.shared_storage" />
-            <argument type="service" id="__symfony__.sylius.product_variant_resolver.default" />
             <argument type="service" id="sylius.behat.page.admin.product_variant.create" />
             <argument type="service" id="sylius.behat.page.admin.product_variant.index" />
             <argument type="service" id="sylius.behat.page.admin.product_variant.update" />
             <argument type="service" id="sylius.behat.page.admin.product_variant.generate" />
             <argument type="service" id="sylius.behat.current_page_resolver" />
             <argument type="service" id="sylius.behat.notification_checker" />
+            <tag name="fob.context_service" />
+        </service>
+
+        <service id="sylius.behat.context.ui.admin.browsing_product_variants" class="Sylius\Behat\Context\Ui\Admin\BrowsingProductVariantsContext">
+            <argument type="service" id="sylius.behat.page.admin.product_variant.index" />
+            <argument type="service" id="__symfony__.sylius.product_variant_resolver.default" />
             <tag name="fob.context_service" />
         </service>
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/inventory/checkout_inventory.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/inventory/checkout_inventory.yml
@@ -25,6 +25,7 @@ default:
                 - sylius.behat.context.transform.shared_storage
                 - sylius.behat.context.transform.shipping_method
 
+                - sylius.behat.context.ui.admin.browsing_product_variants
                 - sylius.behat.context.ui.admin.managing_product_variants
                 - sylius.behat.context.ui.shop.cart
                 - sylius.behat.context.ui.shop.checkout

--- a/src/Sylius/Behat/Resources/config/suites/ui/inventory/managing_inventory.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/inventory/managing_inventory.yml
@@ -27,6 +27,7 @@ default:
                 - sylius.behat.context.transform.shared_storage
                 - sylius.behat.context.transform.shipping_method
 
+                - sylius.behat.context.ui.admin.browsing_product_variants
                 - sylius.behat.context.ui.admin.managing_inventory
                 - sylius.behat.context.ui.admin.managing_product_variants
                 - sylius.behat.context.ui.admin.notification

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_variants.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_variants.yml
@@ -32,6 +32,7 @@ default:
                 - sylius.behat.context.setup.product
                 - sylius.behat.context.setup.admin_security
 
+                - sylius.behat.context.ui.admin.browsing_product_variants
                 - sylius.behat.context.ui.admin.managing_product_variants
                 - sylius.behat.context.ui.admin.notification
             filters:

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_products.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_products.yml
@@ -40,6 +40,7 @@ default:
                 - sylius.behat.context.setup.taxonomy
                 - sylius.behat.context.setup.zone
 
+                - sylius.behat.context.ui.admin.browsing_product_variants
                 - sylius.behat.context.ui.admin.managing_products
                 - sylius.behat.context.ui.admin.notification
                 - sylius.behat.context.ui.shop.locale

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_details.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_details.html.twig
@@ -20,6 +20,9 @@
 
                 {# Nothing to see here. #}
                 <div class="ui hidden element">
+                    {% if product.simple %}
+                        {{ form_row(form.variant.translations) }}
+                    {% endif %}
                     {{ form_row(form.variantSelectionMethod) }}
                 </div>
             </div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #7735 |
| License         | MIT |

TODO:
 - [x] Regression tests (null set to product variant's name after saving simple product)