### PR TITLE
Fix issue-7765. Allow ordering payment methods by gateway config name

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/payment_method.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/payment_method.yml
@@ -29,7 +29,7 @@ sylius_grid:
                     type: string
                     path: gatewayConfig.gatewayName
                     label: sylius.ui.gateway
-                    sortable: ~
+                    sortable: gatewayConfig.gatewayName
                 enabled:
                     type: twig
                     label: sylius.ui.enabled

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/PaymentMethodRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/PaymentMethodRepository.php
@@ -23,6 +23,7 @@ class PaymentMethodRepository extends BasePaymentMethodRepository implements Pay
     public function createListQueryBuilder($locale)
     {
         return $this->createQueryBuilder('o')
+            ->leftJoin('o.gatewayConfig', 'gatewayConfig')
             ->leftJoin('o.translations', 'translation', 'WITH', 'translation.locale = :locale')
             ->setParameter('locale', $locale)
         ;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #7765  |
| License         | MIT |

See the link for the error. in the fix i join with the gateway config table and then set the correct property to do the order. 
