### PR TITLE
[RFC] [Admin] Allow to easily extend javascript nad stylesheets blocks

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
@@ -4,6 +4,10 @@
 
 {% block stylesheets %}
     {% include 'SyliusUiBundle::_stylesheets.html.twig' with {'path': 'assets/admin/css/style.css'} %}
+
+    {% if configuration.vars.stylesheets is defined %}
+        {% include configuration.vars.stylesheets %}
+    {% endif %}
 {% endblock %}
 
 {% block topbar %}
@@ -26,4 +30,8 @@
 
 {% block javascripts %}
     {% include 'SyliusUiBundle::_javascripts.html.twig' with {'path': 'assets/admin/js/app.js'} %}
+
+    {% if configuration.vars.javascripts is defined %}
+        {% include configuration.vars.javascripts %}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

During work on some external addon to Sylius, I had to add some additional js scripts what wasn't that easy with the current implementation. This change will allow us to easily extend some inside route definition. Same problem can be with custom CSS files. 

## Example:
I want to use regular Sylius CRUD templates for my project with some customization inside a `_form.html.twig`. But I need to add custom js script to this view.

### Implementation:
```yml
app_resource:
    resource: |
        alias: app.resource
        section: admin
        templates: SyliusAdminBundle:Crud
        grid: app_resource
        vars:
            all:
                templates:
                    form: "@App/_form.html.twig"
            index:
                icon: cart
            create:
                javascripts: "@App/_javascripts.html.twig"
    type: sylius.resource
```

Of course, it should be documented, as it can be really useful feature, but I don't know where will be the best place for it. /cc @TheMadeleine 