### PR TITLE
[Docs] Adjust :php to :http endpoint for Platform.sh configuration

### DIFF
--- a/docs/cookbook/platform-sh.rst
+++ b/docs/cookbook/platform-sh.rst
@@ -136,7 +136,7 @@ This is how this file should look like for Sylius:
     # .platform/routes.yaml
     "http://{default}/":
         type: upstream
-        upstream: "sylius:php"
+        upstream: "sylius:http"
 
     "http://www.{default}/":
         type: redirect


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |

According to the Platform.sh docs (https://docs.platform.sh/configuration/routes.html):

`
note For the moment, the value of upstream is always in the form: <application-name>:http. <application-name> is the name defined in .platform.app.yaml file. :php is a deprecated application endpoint; use :http instead. In the future, Platform.sh will support multiple endpoints per application.
`