### PR TITLE
[Core][RFC] Images related semantic fixes

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/ImagesUploadListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/ImagesUploadListener.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Sylius\Component\Core\Model\ImageAwareInterface;
+use Sylius\Component\Core\Model\ImagesAwareInterface;
 use Sylius\Component\Core\Uploader\ImageUploaderInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Webmozart\Assert\Assert;
@@ -19,7 +19,7 @@ use Webmozart\Assert\Assert;
 /**
  * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
  */
-final class ImageUploadListener
+final class ImagesUploadListener
 {
     /**
      * @var ImageUploaderInterface
@@ -37,18 +37,18 @@ final class ImageUploadListener
     /**
      * @param GenericEvent $event
      */
-    public function uploadImage(GenericEvent $event)
+    public function uploadImages(GenericEvent $event)
     {
         $subject = $event->getSubject();
-        Assert::isInstanceOf($subject, ImageAwareInterface::class);
+        Assert::isInstanceOf($subject, ImagesAwareInterface::class);
 
-        $this->uploadImages($subject);
+        $this->uploadSubjectImages($subject);
     }
 
     /**
-     * @param ImageAwareInterface $subject
+     * @param ImagesAwareInterface $subject
      */
-    private function uploadImages(ImageAwareInterface $subject)
+    private function uploadSubjectImages(ImagesAwareInterface $subject)
     {
         $images = $subject->getImages();
         foreach ($images as $image) {

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -23,12 +23,12 @@
             <argument type="service" id="sylius.repository.channel" />
             <tag name="kernel.event_listener" event="sylius.channel.pre_delete" method="onChannelPreDelete" />
         </service>
-        <service id="sylius.listener.image_upload" class="Sylius\Bundle\CoreBundle\EventListener\ImageUploadListener">
+        <service id="sylius.listener.images_upload" class="Sylius\Bundle\CoreBundle\EventListener\ImagesUploadListener">
             <argument type="service" id="sylius.image_uploader" />
-            <tag name="kernel.event_listener" event="sylius.product.pre_create" method="uploadImage" />
-            <tag name="kernel.event_listener" event="sylius.product.pre_update" method="uploadImage" />
-            <tag name="kernel.event_listener" event="sylius.taxon.pre_create" method="uploadImage" />
-            <tag name="kernel.event_listener" event="sylius.taxon.pre_update" method="uploadImage" />
+            <tag name="kernel.event_listener" event="sylius.product.pre_create" method="uploadImages" />
+            <tag name="kernel.event_listener" event="sylius.product.pre_update" method="uploadImages" />
+            <tag name="kernel.event_listener" event="sylius.taxon.pre_create" method="uploadImages" />
+            <tag name="kernel.event_listener" event="sylius.taxon.pre_update" method="uploadImages" />
         </service>
         <service id="sylius.listener.order_recalculation" class="Sylius\Bundle\CoreBundle\EventListener\OrderRecalculationListener">
             <argument type="service" id="sylius.order_processing.order_processor" />

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/ImagesUploadListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/ImagesUploadListenerSpec.php
@@ -12,8 +12,8 @@
 namespace spec\Sylius\Bundle\CoreBundle\EventListener;
 
 use PhpSpec\ObjectBehavior;
-use Sylius\Bundle\CoreBundle\EventListener\ImageUploadListener;
-use Sylius\Component\Core\Model\ImageAwareInterface;
+use Sylius\Bundle\CoreBundle\EventListener\ImagesUploadListener;
+use Sylius\Component\Core\Model\ImagesAwareInterface;
 use Sylius\Component\Core\Model\ImageInterface;
 use Sylius\Component\Core\Uploader\ImageUploaderInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -21,7 +21,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 /**
  * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
  */
-final class ImageUploadListenerSpec extends ObjectBehavior
+final class ImagesUploadListenerSpec extends ObjectBehavior
 {
     function let(ImageUploaderInterface $uploader)
     {
@@ -30,12 +30,12 @@ final class ImageUploadListenerSpec extends ObjectBehavior
 
     function it_is_initializable()
     {
-        $this->shouldHaveType(ImageUploadListener::class);
+        $this->shouldHaveType(ImagesUploadListener::class);
     }
 
     function it_uses_image_uploader_to_upload_images(
         GenericEvent $event,
-        ImageAwareInterface $subject,
+        ImagesAwareInterface $subject,
         ImageInterface $image,
         ImageUploaderInterface $uploader
     ) {
@@ -45,7 +45,7 @@ final class ImageUploadListenerSpec extends ObjectBehavior
         $image->getPath()->willReturn('some_path');
         $uploader->upload($image)->shouldBeCalled();
 
-        $this->uploadImage($event);
+        $this->uploadImages($event);
     }
 
     function it_throws_exception_if_event_subject_is_not_an_image_aware(
@@ -56,7 +56,7 @@ final class ImageUploadListenerSpec extends ObjectBehavior
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)
-            ->duringUploadImage($event)
+            ->duringUploadImages($event)
         ;
     }
 }

--- a/src/Sylius/Component/Core/Model/Image.php
+++ b/src/Sylius/Component/Core/Model/Image.php
@@ -37,7 +37,7 @@ abstract class Image implements ImageInterface
     protected $path;
 
     /**
-     * @var ImageAwareInterface
+     * @var ImagesAwareInterface
      */
     protected $owner;
 
@@ -129,7 +129,7 @@ abstract class Image implements ImageInterface
     /**
      * {@inheritdoc}
      */
-    public function setOwner(ImageAwareInterface $owner = null)
+    public function setOwner(ImagesAwareInterface $owner = null)
     {
         $this->owner = $owner;
     }

--- a/src/Sylius/Component/Core/Model/Image.php
+++ b/src/Sylius/Component/Core/Model/Image.php
@@ -37,7 +37,7 @@ abstract class Image implements ImageInterface
     protected $path;
 
     /**
-     * @var ImagesAwareInterface
+     * @var ImageOwnerInterface
      */
     protected $owner;
 
@@ -129,7 +129,7 @@ abstract class Image implements ImageInterface
     /**
      * {@inheritdoc}
      */
-    public function setOwner(ImagesAwareInterface $owner = null)
+    public function setOwner(ImageOwnerInterface $owner = null)
     {
         $this->owner = $owner;
     }

--- a/src/Sylius/Component/Core/Model/ImageInterface.php
+++ b/src/Sylius/Component/Core/Model/ImageInterface.php
@@ -55,12 +55,12 @@ interface ImageInterface extends ResourceInterface
     public function setPath($path);
 
     /**
-     * @return ImageAwareInterface
+     * @return ImagesAwareInterface
      */
     public function getOwner();
 
     /**
-     * @param ImageAwareInterface|null $owner
+     * @param ImagesAwareInterface|null $owner
      */
-    public function setOwner(ImageAwareInterface $owner = null);
+    public function setOwner(ImagesAwareInterface $owner = null);
 }

--- a/src/Sylius/Component/Core/Model/ImageInterface.php
+++ b/src/Sylius/Component/Core/Model/ImageInterface.php
@@ -11,7 +11,6 @@
 
 namespace Sylius\Component\Core\Model;
 
-use Sylius\Component\Resource\Model\CodeAwareInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 
 /**
@@ -55,12 +54,12 @@ interface ImageInterface extends ResourceInterface
     public function setPath($path);
 
     /**
-     * @return ImagesAwareInterface
+     * @return ImageOwnerInterface
      */
     public function getOwner();
 
     /**
-     * @param ImagesAwareInterface|null $owner
+     * @param ImageOwnerInterface|null $owner
      */
-    public function setOwner(ImagesAwareInterface $owner = null);
+    public function setOwner(ImageOwnerInterface $owner = null);
 }

--- a/src/Sylius/Component/Core/Model/ImageOwnerInterface.php
+++ b/src/Sylius/Component/Core/Model/ImageOwnerInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Model;
+
+/**
+ * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
+ */
+interface ImageOwnerInterface
+{
+}

--- a/src/Sylius/Component/Core/Model/ImagesAwareInterface.php
+++ b/src/Sylius/Component/Core/Model/ImagesAwareInterface.php
@@ -16,7 +16,7 @@ use Doctrine\Common\Collections\Collection;
 /**
  * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
  */
-interface ImagesAwareInterface
+interface ImagesAwareInterface extends ImageOwnerInterface
 {
     /**
      * @return Collection|ImageInterface[]

--- a/src/Sylius/Component/Core/Model/ImagesAwareInterface.php
+++ b/src/Sylius/Component/Core/Model/ImagesAwareInterface.php
@@ -16,7 +16,7 @@ use Doctrine\Common\Collections\Collection;
 /**
  * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
  */
-interface ImageAwareInterface
+interface ImagesAwareInterface
 {
     /**
      * @return Collection|ImageInterface[]

--- a/src/Sylius/Component/Core/Model/ProductInterface.php
+++ b/src/Sylius/Component/Core/Model/ProductInterface.php
@@ -25,7 +25,7 @@ interface ProductInterface extends
     ProductTaxonsAwareInterface,
     ChannelsAwareInterface,
     ReviewableInterface,
-    ImageAwareInterface
+    ImagesAwareInterface
 {
     /*
      * Variant selection methods.

--- a/src/Sylius/Component/Core/Model/TaxonInterface.php
+++ b/src/Sylius/Component/Core/Model/TaxonInterface.php
@@ -17,7 +17,7 @@ use Sylius\Component\Taxonomy\Model\TaxonInterface as BaseTaxonInterface;
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  */
-interface TaxonInterface extends BaseTaxonInterface, ImageAwareInterface
+interface TaxonInterface extends BaseTaxonInterface, ImagesAwareInterface
 {
 
 }

--- a/src/Sylius/Component/Core/spec/Model/ProductImageSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ProductImageSpec.php
@@ -14,7 +14,7 @@ namespace spec\Sylius\Component\Core\Model;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\Image;
-use Sylius\Component\Core\Model\ImagesAwareInterface;
+use Sylius\Component\Core\Model\ImageOwnerInterface;
 use Sylius\Component\Core\Model\ProductImage;
 use Sylius\Component\Core\Model\ProductImageInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -79,7 +79,7 @@ final class ProductImageSpec extends ObjectBehavior
         $this->getOwner()->shouldReturn(null);
     }
 
-    function its_owner_is_mutable(ImagesAwareInterface $owner)
+    function its_owner_is_mutable(ImageOwnerInterface $owner)
     {
         $this->setOwner($owner);
         $this->getOwner()->shouldReturn($owner);

--- a/src/Sylius/Component/Core/spec/Model/ProductImageSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ProductImageSpec.php
@@ -14,7 +14,7 @@ namespace spec\Sylius\Component\Core\Model;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\Image;
-use Sylius\Component\Core\Model\ImageAwareInterface;
+use Sylius\Component\Core\Model\ImagesAwareInterface;
 use Sylius\Component\Core\Model\ProductImage;
 use Sylius\Component\Core\Model\ProductImageInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -79,7 +79,7 @@ final class ProductImageSpec extends ObjectBehavior
         $this->getOwner()->shouldReturn(null);
     }
 
-    function its_owner_is_mutable(ImageAwareInterface $owner)
+    function its_owner_is_mutable(ImagesAwareInterface $owner)
     {
         $this->setOwner($owner);
         $this->getOwner()->shouldReturn($owner);

--- a/src/Sylius/Component/Core/spec/Model/ProductSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ProductSpec.php
@@ -14,7 +14,7 @@ namespace spec\Sylius\Component\Core\Model;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Core\Model\ImageAwareInterface;
+use Sylius\Component\Core\Model\ImagesAwareInterface;
 use Sylius\Component\Core\Model\ImageInterface;
 use Sylius\Component\Core\Model\Product;
 use Sylius\Component\Core\Model\ProductInterface;
@@ -48,7 +48,7 @@ final class ProductSpec extends ObjectBehavior
 
     function it_implements_an_image_aware_interface()
     {
-        $this->shouldImplement(ImageAwareInterface::class);
+        $this->shouldImplement(ImagesAwareInterface::class);
     }
 
     function it_extends_a_product_model()

--- a/src/Sylius/Component/Core/spec/Model/TaxonImageSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/TaxonImageSpec.php
@@ -13,7 +13,7 @@ namespace spec\Sylius\Component\Core\Model;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\Image;
-use Sylius\Component\Core\Model\ImageAwareInterface;
+use Sylius\Component\Core\Model\ImagesAwareInterface;
 use Sylius\Component\Core\Model\TaxonImage;
 
 /**
@@ -71,7 +71,7 @@ final class TaxonImageSpec extends ObjectBehavior
         $this->getOwner()->shouldReturn(null);
     }
 
-    function its_owner_is_mutable(ImageAwareInterface $owner)
+    function its_owner_is_mutable(ImagesAwareInterface $owner)
     {
         $this->setOwner($owner);
         $this->getOwner()->shouldReturn($owner);

--- a/src/Sylius/Component/Core/spec/Model/TaxonImageSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/TaxonImageSpec.php
@@ -13,7 +13,7 @@ namespace spec\Sylius\Component\Core\Model;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\Image;
-use Sylius\Component\Core\Model\ImagesAwareInterface;
+use Sylius\Component\Core\Model\ImageOwnerInterface;
 use Sylius\Component\Core\Model\TaxonImage;
 
 /**
@@ -71,7 +71,7 @@ final class TaxonImageSpec extends ObjectBehavior
         $this->getOwner()->shouldReturn(null);
     }
 
-    function its_owner_is_mutable(ImagesAwareInterface $owner)
+    function its_owner_is_mutable(ImageOwnerInterface $owner)
     {
         $this->setOwner($owner);
         $this->getOwner()->shouldReturn($owner);

--- a/src/Sylius/Component/Core/spec/Model/TaxonSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/TaxonSpec.php
@@ -14,7 +14,7 @@ namespace spec\Sylius\Component\Core\Model;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Core\Model\ImageAwareInterface;
+use Sylius\Component\Core\Model\ImagesAwareInterface;
 use Sylius\Component\Core\Model\ImageInterface;
 use Sylius\Component\Core\Model\Taxon;
 use Sylius\Component\Core\Model\TaxonInterface;
@@ -36,7 +36,7 @@ final class TaxonSpec extends ObjectBehavior
 
     function it_implements_an_image_aware_interface()
     {
-        $this->shouldImplement(ImageAwareInterface::class);
+        $this->shouldImplement(ImagesAwareInterface::class);
     }
 
     function it_initializes_an_image_collection_by_default()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets | |
| License         | MIT |

While woking on a project I encountered some problems with semantics of images-related interfaces and classes. I started from being mislead by `ImageUploaderListener` which in fact listens for **images** rather than **image** uploading. And then my story began :smile:
Proposed changes:

1. Change `ImageAwareInterface` to `ImagesAwareInterface`, as it contains methods for images collection. It's also consistent with other `*AwareInterface`s like `CurrenciesAwareInterface`, `ChannelsAwareInterface`, `ChannelAwareInterface` and `LocalesAwareInterface`.
2. Change `ImageUploadListener` to `ImagesUploadListener` and its method `uploadImage` to `uploadImages` (the same reason).
3. Introduce `ImageOwnerInterface` to base on this abstraction in `Image` class rather than on `ImagesAwareInterface`.

I'm not 100% sure about the last change (also about naming) but I think it would be useful to not couple `Image` with `ImagesAwareInterface`. If, for example, someone would like to create entity with only **one** image (it was my case), it would be easy to create `ImageAwareInterface` which extends the `ImageOwnerInterface` and use *Sylius* `Image` class rather than being forced to implement their own.

Let me know what do you think about this change 🐃  ;)