### PR TITLE
Don't change passwordRequestedAt on expiration check

### DIFF
--- a/src/Sylius/Component/User/Model/User.php
+++ b/src/Sylius/Component/User/Model/User.php
@@ -414,7 +414,13 @@ class User implements UserInterface
      */
     public function isPasswordRequestNonExpired(\DateInterval $ttl)
     {
-        return null !== $this->passwordRequestedAt && new \DateTime() <= $this->passwordRequestedAt->add($ttl);
+        if (null === $this->passwordRequestedAt) {
+            return false;
+        }
+        
+        $threshold = new \DateTime();
+        $threshold->sub($ttl);
+        return $threshold <= $this->passwordRequestedAt;
     }
 
     /**


### PR DESCRIPTION
The `\DateTime::add()` changes the object itself, not just returns a changed copy.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |
