### PR TITLE
[DX] Create product autocomplete form type

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Form/theme.html.twig
@@ -4,10 +4,6 @@
     {{ form_row(form, {'remote_url': path('sylius_admin_ajax_taxon_by_name_phrase'), 'load_edit_url': path('sylius_admin_ajax_taxon_by_code')}) }}
 {% endblock %}
 
-{% block _sylius_promotion_rules_entry_configuration_product_code_row %}
-    {{ form_row(form, {'remote_url': path('sylius_admin_ajax_product_by_name_phrase'), 'remote_criteria_type': 'contains', 'remote_criteria_name': 'phrase', 'load_edit_url': path('sylius_admin_ajax_product_by_code')}) }}
-{% endblock %}
-
-{% block _sylius_promotion_actions_entry_configuration_entry_filters_products_filter_products_row %}
-    {{ form_row(form, {'remote_url': path('sylius_admin_ajax_product_by_name_phrase'), 'remote_criteria_type': 'contains', 'remote_criteria_name': 'phrase', 'load_edit_url': path('sylius_admin_ajax_product_by_code')}) }}
+{% block sylius_product_autocomplete_choice_row %}
+    {{ form_row(form, {'remote_url': path('sylius_admin_ajax_product_by_name_phrase'), 'load_edit_url': path('sylius_admin_ajax_product_by_code')}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Filter/ProductFilterConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Filter/ProductFilterConfigurationType.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Bundle\CoreBundle\Form\Type\Promotion\Filter;
 
-use Sylius\Bundle\ResourceBundle\Form\Type\ResourceAutocompleteChoiceType;
+use Sylius\Bundle\ProductBundle\Form\Type\ProductAutocompleteChoiceType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -40,11 +40,8 @@ final class ProductFilterConfigurationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('products', ResourceAutocompleteChoiceType::class, [
+            ->add('products', ProductAutocompleteChoiceType::class, [
                 'label' => 'sylius.form.promotion_filter.products',
-                'resource' => 'sylius.product',
-                'choice_name' => 'name',
-                'choice_value' => 'code',
                 'multiple' => true,
             ])
         ;

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ContainsProductConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Promotion/Rule/ContainsProductConfigurationType.php
@@ -11,8 +11,8 @@
 
 namespace Sylius\Bundle\CoreBundle\Form\Type\Promotion\Rule;
 
+use Sylius\Bundle\ProductBundle\Form\Type\ProductAutocompleteChoiceType;
 use Sylius\Bundle\ResourceBundle\Form\DataTransformer\ResourceToIdentifierTransformer;
-use Sylius\Bundle\ResourceBundle\Form\Type\ResourceAutocompleteChoiceType;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -45,11 +45,8 @@ final class ContainsProductConfigurationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('product_code', ResourceAutocompleteChoiceType::class, [
+            ->add('product_code', ProductAutocompleteChoiceType::class, [
                 'label' => 'sylius.form.promotion_action.add_product_configuration.product',
-                'resource' => 'sylius.product',
-                'choice_name' => 'name',
-                'choice_value' => 'code',
                 'constraints' => [
                     new NotBlank(['groups' => ['sylius']]),
                     new Type(['type' => 'string', 'groups' => ['sylius']]),

--- a/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAutocompleteChoiceType.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/Type/ProductAutocompleteChoiceType.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\ProductBundle\Form\Type;
+
+use Sylius\Bundle\ResourceBundle\Form\Type\ResourceAutocompleteChoiceType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Łukasz Chruściel <lukasz.chrusciel@lakion.com>
+ */
+final class ProductAutocompleteChoiceType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'resource' => 'sylius.product',
+            'choice_name' => 'name',
+            'choice_value' => 'code',
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['remote_criteria_type'] = 'contains';
+        $view->vars['remote_criteria_name'] = 'phrase';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'sylius_product_autocomplete_choice';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return ResourceAutocompleteChoiceType::class;
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

This change will just increase a DX for developers which would like to take an advantage of product autocomplete feature. Right now, it is not possible without creating a new block definition. With this change, it would be enough to just use `ProductAutocompleteChoiceType`