### PR TITLE
Allow writing product options via API

### DIFF
--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/product_option.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/product_option.yml
@@ -6,7 +6,6 @@ sylius_admin_api_product_option:
         identifier: code
         alias: sylius.product_option
         section: admin_api
-        only: ['index', 'show']
         serialization_version: $version
         criteria:
             code: $code

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductOption.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductOption.yml
@@ -19,6 +19,10 @@ Sylius\Component\Product\Model\ProductOption:
             expose: true
             type: array
             groups: [Default, Detailed]
+        translations:
+            expose: true
+            type: array
+            groups: [Default, Detailed]
     relations:
         -   rel: self
             href:

--- a/tests/Controller/ProductOptionApiTest.php
+++ b/tests/Controller/ProductOptionApiTest.php
@@ -23,6 +23,14 @@ final class ProductOptionApiTest extends JsonApiTestCase
     /**
      * @var array
      */
+    private static $authorizedHeaderWithContentType = [
+        'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+        'CONTENT_TYPE' => 'application/json',
+    ];
+
+    /**
+     * @var array
+     */
     private static $authorizedHeaderWithAccept = [
         'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
         'ACCEPT' => 'application/json',
@@ -82,6 +90,246 @@ final class ProductOptionApiTest extends JsonApiTestCase
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'product_option/show_response', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_delete_product_option_if_it_does_not_exist()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('DELETE', '/api/v1/product-options/-1', [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_delete_product_option()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $productOptions = $this->loadFixturesFromFile('resources/product_options.yml');
+        $productOption = $productOptions['mug-size'];
+
+        $this->client->request('DELETE', $this->getProductOptionUrl($productOption), [], [], static::$authorizedHeaderWithContentType, []);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+
+        $this->client->request('GET', '/api/v1/product-options/', [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product_option/index_response_after_delete', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_create_product_option_with_multiple_translations()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/locales.yml');
+
+        $data = <<<EOT
+{
+    "code": "MUG_SIZE",
+    "translations": {
+        "de_CH": {
+            "name": "Bechergröße"
+        },
+        "en_US": {
+            "name": "Mug size"
+        }
+    },
+    "values": [
+        {
+            "code": "MUG_SIZE_S",
+            "translations": {
+                "de_CH": {
+                    "value": "Klein"
+                },
+                "en_US": {
+                    "value": "Small"
+                }
+            }
+        },
+        {
+            "code": "MUG_SIZE_L",
+            "translations": {
+                "de_CH": {
+                    "value": "Groß"
+                },
+                "en_US": {
+                    "value": "Large"
+                }
+            }
+        }
+    ]
+}
+EOT;
+
+        $this->client->request('POST', '/api/v1/product-options/', [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product_option/create_response', Response::HTTP_CREATED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_create_product_option_without_required_fields()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('POST', '/api/v1/product-options/', [], [], static::$authorizedHeaderWithContentType, []);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product_option/create_validation_fail_response', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_update_product_option_with_multiple_translations()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/locales.yml');
+        $productOptions = $this->loadFixturesFromFile('resources/product_options.yml');
+        $productOption = $productOptions['mug-size'];
+
+        $data = <<<EOT
+{
+    "code": "MUG_SIZE",
+    "position": 2,
+    "translations": {
+        "de_CH": {
+            "name": "Bechergröße"
+        },
+        "en_US": {
+            "name": "Mug size"
+        }
+    },
+    "values": [
+        {
+            "code": "MUG_SIZE_S",
+            "translations": {
+                "de_CH": {
+                    "value": "Klein"
+                },
+                "en_US": {
+                    "value": "Small"
+                }
+            }
+        },
+        {
+            "code": "MUG_SIZE_L",
+            "translations": {
+                "de_CH": {
+                    "value": "Groß"
+                },
+                "en_US": {
+                    "value": "Large"
+                }
+            }
+        },
+        {
+            "code": "MUG_SIZE_M",
+            "translations": {
+                "de_CH": {
+                    "value": "Mittel"
+                },
+                "en_US": {
+                    "value": "Medium"
+                }
+            }
+        }
+    ]
+}
+EOT;
+
+        $this->client->request('PUT', $this->getProductOptionUrl($productOption), [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+
+        $this->client->request('GET', $this->getProductOptionUrl($productOption), [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product_option/show_response_after_update', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_partially_update_product_option_with_multiple_translations()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/locales.yml');
+        $productOptions = $this->loadFixturesFromFile('resources/product_options.yml');
+        $productOption = $productOptions['mug-size'];
+
+        $data = <<<EOT
+{
+    "code": "MUG_SIZE",
+    "translations": {
+        "de_CH": {
+            "name": "Bechergröße"
+        },
+        "en_US": {
+            "name": "Mug size"
+        }
+    },
+    "values": [
+        {
+            "code": "MUG_SIZE_S",
+            "translations": {
+                "de_CH": {
+                    "value": "Klein"
+                },
+                "en_US": {
+                    "value": "Small"
+                }
+            }
+        },
+        {
+            "code": "MUG_SIZE_L",
+            "translations": {
+                "de_CH": {
+                    "value": "Groß"
+                },
+                "en_US": {
+                    "value": "Large"
+                }
+            }
+        },
+        {
+            "code": "MUG_SIZE_M",
+            "translations": {
+                "de_CH": {
+                    "value": "Mittel"
+                },
+                "en_US": {
+                    "value": "Medium"
+                }
+            }
+        }
+    ]
+}
+EOT;
+
+        $this->client->request('PATCH', $this->getProductOptionUrl($productOption), [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+
+        $this->client->request('GET', $this->getProductOptionUrl($productOption), [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product_option/show_response_after_partial_update', Response::HTTP_OK);
     }
 
     /**

--- a/tests/Responses/Expected/product/create_with_options_response.json
+++ b/tests/Responses/Expected/product/create_with_options_response.json
@@ -30,6 +30,7 @@
                     }
                 }
             ],
+            "translations": {},
             "_links": {
                 "self": {
                     "href": "\/api\/v1\/products\/MUG_SIZE"
@@ -41,6 +42,7 @@
             "code": "MUG_COLOR",
             "position": 1,
             "values": [],
+            "translations": {},
             "_links": {
                 "self": {
                     "href": "\/api\/v1\/products\/MUG_COLOR"

--- a/tests/Responses/Expected/product_option/create_response.json
+++ b/tests/Responses/Expected/product_option/create_response.json
@@ -1,0 +1,54 @@
+{
+    "id": @integer@,
+    "code": "MUG_SIZE",
+    "position": 0,
+    "translations": {
+        "en_US": {
+            "id": @integer@,
+            "locale": "en_US",
+            "name": "Mug size"
+        },
+        "de_CH": {
+            "id": @integer@,
+            "locale": "de_CH",
+            "name": "Bechergröße"
+        }
+    },
+    "values": [
+        {
+            "code": "MUG_SIZE_S",
+            "translations": {
+                "en_US": {
+                    "id": @integer@,
+                    "locale": "en_US",
+                    "value": "Small"
+                },
+                "de_CH": {
+                    "id": @integer@,
+                    "locale": "de_CH",
+                    "value": "Klein"
+                }
+            }
+        },
+        {
+            "code": "MUG_SIZE_L",
+            "translations": {
+                "de_CH": {
+                    "id": @integer@,
+                    "locale": "de_CH",
+                    "value": "Groß"
+                },
+                "en_US": {
+                    "id": @integer@,
+                    "locale": "en_US",
+                    "value": "Large"
+                }
+            }
+        }
+    ],
+    "_links": {
+        "self": {
+            "href": "\/api\/v1\/products\/MUG_SIZE"
+        }
+    }
+}

--- a/tests/Responses/Expected/product_option/create_validation_fail_response.json
+++ b/tests/Responses/Expected/product_option/create_validation_fail_response.json
@@ -1,0 +1,19 @@
+{
+    "code": 400,
+    "message": "Validation Failed",
+    "errors": {
+        "errors": [
+            "Please add at least 2 option values."
+        ],
+        "children": {
+            "position": {},
+            "translations": {},
+            "values": {},
+            "code": {
+                "errors": [
+                    "Please enter option code."
+                ]
+            }
+        }
+    }
+}

--- a/tests/Responses/Expected/product_option/index_response.json
+++ b/tests/Responses/Expected/product_option/index_response.json
@@ -20,6 +20,7 @@
                 "id": @integer@,
                 "code": "MUG_SIZE",
                 "position": 0,
+                "translations": {},
                 "values": [
                     {
                         "code": "MUG_SIZE_S",
@@ -52,6 +53,7 @@
                 "id": @integer@,
                 "code": "MUG_COLOR",
                 "position": 1,
+                "translations": {},
                 "values": [],
                 "_links": {
                     "self": {

--- a/tests/Responses/Expected/product_option/index_response_after_delete.json
+++ b/tests/Responses/Expected/product_option/index_response_after_delete.json
@@ -1,0 +1,33 @@
+{
+    "page": 1,
+    "limit": 10,
+    "pages": 1,
+    "total": 1,
+    "_links": {
+        "self": {
+            "href": "\/api\/v1\/product-options\/?page=1&limit=10"
+        },
+        "first": {
+            "href": "\/api\/v1\/product-options\/?page=1&limit=10"
+        },
+        "last": {
+            "href": "\/api\/v1\/product-options\/?page=1&limit=10"
+        }
+    },
+    "_embedded": {
+        "items": [
+            {
+                "id": @integer@,
+                "code": "MUG_COLOR",
+                "position": 0,
+                "translations": {},
+                "values": [],
+                "_links": {
+                    "self": {
+                        "href": "\/api\/v1\/products\/MUG_COLOR"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/tests/Responses/Expected/product_option/show_response.json
+++ b/tests/Responses/Expected/product_option/show_response.json
@@ -2,6 +2,7 @@
     "id": @integer@,
     "code": "MUG_SIZE",
     "position": 0,
+    "translations": {},
     "values": [
         {
             "code": "MUG_SIZE_S",

--- a/tests/Responses/Expected/product_option/show_response_after_partial_update.json
+++ b/tests/Responses/Expected/product_option/show_response_after_partial_update.json
@@ -1,0 +1,69 @@
+{
+    "id": @integer@,
+    "code": "MUG_SIZE",
+    "position": 0,
+    "translations": {
+        "en_US": {
+            "id": @integer@,
+            "locale": "en_US",
+            "name": "Mug size"
+        },
+        "de_CH": {
+            "id": @integer@,
+            "locale": "de_CH",
+            "name": "Bechergröße"
+        }
+    },
+    "values": [
+        {
+            "code": "MUG_SIZE_S",
+            "translations": {
+                "en_US": {
+                    "id": @integer@,
+                    "locale": "en_US",
+                    "value": "Small"
+                },
+                "de_CH": {
+                    "id": @integer@,
+                    "locale": "de_CH",
+                    "value": "Klein"
+                }
+            }
+        },
+        {
+            "code": "MUG_SIZE_L",
+            "translations": {
+                "en_US": {
+                    "id": @integer@,
+                    "locale": "en_US",
+                    "value": "Large"
+                },
+                "de_CH": {
+                    "id": @integer@,
+                    "locale": "de_CH",
+                    "value": "Groß"
+                }
+            }
+        },
+        {
+            "code": "MUG_SIZE_M",
+            "translations": {
+                "en_US": {
+                    "id": @integer@,
+                    "locale": "en_US",
+                    "value": "Medium"
+                },
+                "de_CH": {
+                    "id": @integer@,
+                    "locale": "de_CH",
+                    "value": "Mittel"
+                }
+            }
+        }
+    ],
+    "_links": {
+        "self": {
+            "href": "\/api\/v1\/products\/MUG_SIZE"
+        }
+    }
+}

--- a/tests/Responses/Expected/product_option/show_response_after_update.json
+++ b/tests/Responses/Expected/product_option/show_response_after_update.json
@@ -1,0 +1,69 @@
+{
+    "id": @integer@,
+    "code": "MUG_SIZE",
+    "position": 1,
+    "translations": {
+        "en_US": {
+            "id": @integer@,
+            "locale": "en_US",
+            "name": "Mug size"
+        },
+        "de_CH": {
+            "id": @integer@,
+            "locale": "de_CH",
+            "name": "Bechergröße"
+        }
+    },
+    "values": [
+        {
+            "code": "MUG_SIZE_S",
+            "translations": {
+                "en_US": {
+                    "id": @integer@,
+                    "locale": "en_US",
+                    "value": "Small"
+                },
+                "de_CH": {
+                    "id": @integer@,
+                    "locale": "de_CH",
+                    "value": "Klein"
+                }
+            }
+        },
+        {
+            "code": "MUG_SIZE_L",
+            "translations": {
+                "en_US": {
+                    "id": @integer@,
+                    "locale": "en_US",
+                    "value": "Large"
+                },
+                "de_CH": {
+                    "id": @integer@,
+                    "locale": "de_CH",
+                    "value": "Groß"
+                }
+            }
+        },
+        {
+            "code": "MUG_SIZE_M",
+            "translations": {
+                "en_US": {
+                    "id": @integer@,
+                    "locale": "en_US",
+                    "value": "Medium"
+                },
+                "de_CH": {
+                    "id": @integer@,
+                    "locale": "de_CH",
+                    "value": "Mittel"
+                }
+            }
+        }
+    ],
+    "_links": {
+        "self": {
+            "href": "\/api\/v1\/products\/MUG_SIZE"
+        }
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | first introduced in #7547 |
| License         | MIT |

This PR replaces #7547. It exposes the `translations` property for product options to the API. It also re-introduces creating, updating and deleting product options via the API, which was removed in #7482.