### PR TITLE
[Core][Taxon] Add missing createdAt/updatedAt mappings to Taxon.orm.xml

### DIFF
--- a/app/migrations/Version20170327135945.php
+++ b/app/migrations/Version20170327135945.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170327135945 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_taxon ADD created_at DATETIME DEFAULT NULL, ADD updated_at DATETIME DEFAULT NULL');
+        $this->addSql('UPDATE sylius_taxon SET created_at = NOW()');
+        $this->addSql('ALTER TABLE sylius_taxon MODIFY created_at DATETIME NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_taxon DROP created_at, DROP updated_at');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Taxon.orm.xml
@@ -13,10 +13,18 @@
 
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
-                                      http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+                  xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping"
+    xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+    http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <mapped-superclass name="Sylius\Component\Core\Model\Taxon" table="sylius_taxon">
+        <field name="createdAt" column="created_at" type="datetime">
+            <gedmo:timestampable on="create"/>
+        </field>
+        <field name="updatedAt" column="updated_at" type="datetime" nullable="true">
+            <gedmo:timestampable on="update"/>
+        </field>
+
         <one-to-many field="images" target-entity="Sylius\Component\Core\Model\TaxonImageInterface" mapped-by="owner" orphan-removal="true">
             <cascade>
                 <cascade-all/>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

So the Taxon API docs say [here](https://github.com/Sylius/Sylius/blob/master/docs/api/taxons.rst#definition-2) that `(optional) Field and direction of sorting, by default ‘desc’ and ‘createdAt’`. Which led me to the database where I couldn't find any dates for the `sylius_taxon` table.

Checking the [beta1 migration file](https://github.com/Sylius/Sylius/blob/master/app/migrations/Version20161202011555.php#L80) shows that those fields really didn't make it, but `Sylius\Component\Core\Model\Taxon` uses the `TimestampableTrait`.

First of all, is this a correct fix?

Additional questions:
* How about BC?
* Do I have to do anything else to make this work? Editing a taxon does not update the `updatedAt` for me?

**ToDo**
- [x] Migration file