### PR TITLE
[Documentation] Add missing 'form-type' attribute

### DIFF
--- a/docs/cookbook/custom-promotion-action.rst
+++ b/docs/cookbook/custom-promotion-action.rst
@@ -82,20 +82,6 @@ This class needs also a ``isConfigurationValid()`` method which was omitted in t
         }
     }
 
-Register the action as a service
---------------------------------
-
-In the ``app/config/services.yml`` configure:
-
-.. code-block:: yaml
-
-    # app/config/services.yml
-    app.promotion_action.cheapest_product_discount:
-        class: AppBundle\Promotion\Action\CheapestProductDiscountPromotionActionCommand
-        arguments: ['@sylius.proportional_integer_distributor', '@sylius.promotion.units_promotion_adjustments_applicator']
-        tags:
-            - { name: sylius.promotion_action, type: cheapest_product_discount, label: Cheapest product discount }
-
 Prepare a configuration form type for the admin panel
 -----------------------------------------------------
 
@@ -119,6 +105,21 @@ The new action needs a form type to be available in the admin panel, while creat
             return 'app_promotion_action_cheapest_product_discount_configuration';
         }
     }
+
+Register the action as a service
+--------------------------------
+
+In the ``app/config/services.yml`` configure:
+
+.. code-block:: yaml
+
+    # app/config/services.yml
+    app.promotion_action.cheapest_product_discount:
+        class: AppBundle\Promotion\Action\CheapestProductDiscountPromotionActionCommand
+        arguments: ['@sylius.proportional_integer_distributor', '@sylius.promotion.units_promotion_adjustments_applicator']
+        tags:
+            - { name: sylius.promotion_action, type: cheapest_product_discount, form-type: AppBundle\Form\Type\Action\CheapestProductDiscountConfigurationType, label: Cheapest product discount }
+
 
 Register the form type as a service
 -----------------------------------

--- a/docs/cookbook/custom-promotion-rule.rst
+++ b/docs/cookbook/custom-promotion-rule.rst
@@ -41,16 +41,6 @@ The new Rule needs a RuleChecker class:
         }
     }
 
-Register the new rule checker as a service in the ``app/config/services.yml``:
-
-.. code-block:: yaml
-
-    # apps/config/services.yml
-    app.promotion_rule_checker.premium_customer:
-        class: AppBundle\Promotion\Checker\Rule\PremiumCustomerRuleChecker
-        tags:
-            - { name: sylius.promotion_rule_checker, type: premium_customer, label: Premium customer }
-
 Prepare a configuration form type for your new rule
 ---------------------------------------------------
 
@@ -86,6 +76,18 @@ And configure it in the ``app/config/services.yml``:
         class: AppBundle\Form\Type\Rule\PremiumCustomerConfigurationType
         tags:
             - { name: form.type }
+
+
+Register the new rule checker as a service in the ``app/config/services.yml``:
+
+.. code-block:: yaml
+
+    # apps/config/services.yml
+    app.promotion_rule_checker.premium_customer:
+        class: AppBundle\Promotion\Checker\Rule\PremiumCustomerRuleChecker
+        tags:
+            - { name: sylius.promotion_rule_checker, type: premium_customer, form-type: AppBundle\Form\Type\Rule\PremiumCustomerConfigurationType, label: Premium customer }
+
 
 That's all. You will now be able to choose the new rule while creating a new promotion.
 

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/RegisterPromotionActionsPass.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/RegisterPromotionActionsPass.php
@@ -35,7 +35,7 @@ final class RegisterPromotionActionsPass implements CompilerPassInterface
         $promotionActionTypeToLabelMap = [];
         foreach ($container->findTaggedServiceIds('sylius.promotion_action') as $id => $attributes) {
             if (!isset($attributes[0]['type'], $attributes[0]['label'], $attributes[0]['form-type'])) {
-                throw new \InvalidArgumentException('Tagged promotion action needs to have `type`, `form-type` and `label` attributes.');
+                throw new \InvalidArgumentException('Tagged promotion action `'.$id.'` needs to have `type`, `form-type` and `label` attributes.');
             }
 
             $promotionActionTypeToLabelMap[$attributes[0]['type']] = $attributes[0]['label'];

--- a/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/RegisterRuleCheckersPass.php
+++ b/src/Sylius/Bundle/PromotionBundle/DependencyInjection/Compiler/RegisterRuleCheckersPass.php
@@ -35,7 +35,7 @@ final class RegisterRuleCheckersPass implements CompilerPassInterface
         $promotionRuleCheckerTypeToLabelMap = [];
         foreach ($container->findTaggedServiceIds('sylius.promotion_rule_checker') as $id => $attributes) {
             if (!isset($attributes[0]['type'], $attributes[0]['label'], $attributes[0]['form-type'])) {
-                throw new \InvalidArgumentException('Tagged rule checker needs to have `type`, `form-type` and `label` attributes.');
+                throw new \InvalidArgumentException('Tagged rule checker `'.$id.'` needs to have `type`, `form-type` and `label` attributes.');
             }
 
             $promotionRuleCheckerTypeToLabelMap[$attributes[0]['type']] = $attributes[0]['label'];


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| doc fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |

Not sure if this is the right way to amend the docs but when updating to latest master, a missing `form-type` attribute error popped up, apparently not mentioned in the docs for custom rule checkers and actions.

I added a more meaningful Exception message too in the RuleCheckersPass to detect the misbehaving service declaration.

Hope it helps.