### PR TITLE
Make the label for the string filter input translatable

### DIFF
--- a/src/Sylius/Bundle/GridBundle/Form/Type/Filter/StringFilterType.php
+++ b/src/Sylius/Bundle/GridBundle/Form/Type/Filter/StringFilterType.php
@@ -47,7 +47,10 @@ final class StringFilterType extends AbstractType
         }
 
         $builder
-            ->add('value', TextType::class, ['required' => false])
+            ->add('value', TextType::class, [
+                'required' => false,
+                'label' => 'sylius.ui.value',
+            ])
         ;
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

The label for the string filter field's text input isn't translatable.  Let's change that.