### PR TITLE
Fix product slug field in Admin

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_slugField.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_slugField.html.twig
@@ -1,6 +1,6 @@
 <div class="{% if slugField.vars.required %}required {% endif %}field{% if slugField.vars.errors|length > 0 %} error{% endif %} ui loadable form">
     {{ form_label(slugField) }}
-    {% if resource.slug == null %}
+    {% if slugField.vars.value == null %}
         {{ form_widget(slugField, {'attr': {'data-url': path('sylius_admin_ajax_generate_product_slug')}}) }}
     {% else %}
     <div class="ui action input">


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | |
| License         | MIT |

When you want to add a translation to a Product in admin, the slug field is locked when you have a slug for the default locale. I think that the slug field should not be locked by default if there is no value.