### PR TITLE
[Grid] Fix validation errors with multiple filters

### DIFF
--- a/src/Sylius/Bundle/GridBundle/Renderer/TwigGridRenderer.php
+++ b/src/Sylius/Bundle/GridBundle/Renderer/TwigGridRenderer.php
@@ -137,8 +137,9 @@ final class TwigGridRenderer implements GridRendererInterface
         $template = $this->getFilterTemplate($filter);
 
         $form = $this->formFactory->createNamed('criteria', FormType::class, [], [
+            'allow_extra_fields' => true,
             'csrf_protection' => false,
-            'required' => false
+            'required' => false,
         ]);
         $form->add(
             $filter->getName(),


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | somewhat |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

There's a slight bug with submitting filter form, when more than one filter is present.
Doesn't matter whether or not we provide all information the form wants from us, **always** a validation error will occur.
The cause is every filter has a parent with the same name (`criteria`), so at submit, all data gets concocted as if it was coming from a single form.