### PR TITLE
[OrderBundle] Add missing selects/joins to cart query builder

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
@@ -40,6 +40,10 @@ class OrderRepository extends EntityRepository implements OrderRepositoryInterfa
     public function createCartQueryBuilder()
     {
         return $this->createQueryBuilder('o')
+            ->addSelect('channel')
+            ->addSelect('customer')
+            ->innerJoin('o.channel', 'channel')
+            ->leftJoin('o.customer', 'customer')
             ->andWhere('o.state = :state')
             ->setParameter('state', OrderInterface::STATE_CART)
         ;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #7859 |
| License         | MIT |

The [Cart API allows filtering](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/AdminApiBundle/Resources/config/grids/cart.yml#L39-L51) by customer/channel, but they're missing from the query builder.