### PR TITLE
[Checkout] Creating Payment Method skip channel option, effective if …

### DIFF
--- a/app/migrations/Version20170401200415.php
+++ b/app/migrations/Version20170401200415.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170401200415 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_channel ADD skipping_payment_step_allowed TINYINT(1) NOT NULL');
+        $this->addSql('UPDATE sylius_channel SET skipping_payment_step_allowed = 0');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_channel DROP skipping_payment_step_allowed');
+    }
+}

--- a/features/channel/managing_channels/adding_channel.feature
+++ b/features/channel/managing_channels/adding_channel.feature
@@ -32,6 +32,7 @@ Feature: Adding a new channel
         And I choose "Euro" as the base currency
         And I choose "English (United States)" as a default locale
         And I allow to skip shipping step if only one shipping method is available
+        And I allow to skip payment step if only one payment method is available
         And I add it
         Then I should be notified that it has been successfully created
         And the channel "Mobile channel" should appear in the registry

--- a/features/checkout/skipping_payment_method_step_when_only_one_payment_method_is_available.feature
+++ b/features/checkout/skipping_payment_method_step_when_only_one_payment_method_is_available.feature
@@ -1,0 +1,39 @@
+@checkout @javascript
+Feature: Skipping payment step when only one payment method is available
+    In order to not select payment method if its unnecessary
+    As a Customer
+    I want to be redirected directly to checkout complete
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store ships everywhere for free
+        And on this channel payment step is skipped if only a single payment method is available
+        And the store has a product "Guards! Guards!" priced at "$20.00"
+        And the store allows paying with "Paypal Express Checkout"
+
+    @ui
+    Scenario: Seeing checkout completion page after shipping if only one payment method is available
+        Given I have product "Guards! Guards!" in the cart
+        And I have completed addressing step with email "guest@example.com" and "United States" based shipping address
+        And I try to complete the shipping step
+        Then I should be on the checkout complete step
+        And my order's payment method should be "Paypal Express Checkout"
+
+    @ui
+    Scenario: Seeing checkout completion page after shipping if only one payment method is available
+        Given the store has "Offline" payment method not assigned to any channel
+        And I have product "Guards! Guards!" in the cart
+        And I have completed addressing step with email "guest@example.com" and "United States" based shipping address
+        And I try to complete the shipping step
+        Then I should be on the checkout complete step
+        And my order's payment method should be "Paypal Express Checkout"
+
+    @ui
+    Scenario: Seeing checkout completion page after shipping if only one payment method is available
+        Given the store allows paying with "Offline"
+        And the payment method "Offline" is disabled
+        And I have product "Guards! Guards!" in the cart
+        And I have completed addressing step with email "guest@example.com" and "United States" based shipping address
+        And I try to complete the shipping step
+        Then I should be on the checkout complete step
+        And my order's payment method should be "Paypal Express Checkout"

--- a/src/Sylius/Behat/Context/Setup/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Setup/ChannelContext.php
@@ -174,6 +174,18 @@ final class ChannelContext implements Context
     }
 
     /**
+     * @Given /^on (this channel) payment step is skipped if only a single payment method is available$/
+     */
+    public function onThisChannelPaymentStepIsSkippedIfOnlyASinglePaymentMethodIsAvailable(
+        ChannelInterface $channel
+    )
+    {
+        $channel->setSkippingPaymentStepAllowed(true);
+
+        $this->channelManager->flush();
+    }
+
+    /**
      * @Given /^on (this channel) account verification is not required$/
      */
     public function onThisChannelAccountVerificationIsNotRequired(ChannelInterface $channel)

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
@@ -128,6 +128,14 @@ final class ManagingChannelsContext implements Context
     }
 
     /**
+     * @When I allow to skip payment step if only one payment method is available
+     */
+    public function iAllowToSkipPaymentStepIfOnlyOnePaymentMethodIsAvailable()
+    {
+        $this->createPage->allowToSkipPaymentStep();
+    }
+
+    /**
      * @When I add it
      * @When I try to add it
      */

--- a/src/Sylius/Behat/Page/Admin/Channel/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/CreatePage.php
@@ -110,6 +110,11 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $this->getDocument()->checkField('Skip shipping step if only one shipping method is available?');
     }
 
+    public function allowToSkipPaymentStep()
+    {
+        $this->getDocument()->checkField('Skip payment step if only one payment method is available?');
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Sylius/Behat/Page/Admin/Channel/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/CreatePageInterface.php
@@ -83,4 +83,6 @@ interface CreatePageInterface extends BaseCreatePageInterface
     public function chooseTaxCalculationStrategy($taxCalculationStrategy);
 
     public function allowToSkipShippingStep();
+
+    public function allowToSkipPaymentStep();
 }

--- a/src/Sylius/Behat/Page/SymfonyPage.php
+++ b/src/Sylius/Behat/Page/SymfonyPage.php
@@ -74,6 +74,7 @@ abstract class SymfonyPage extends Page implements SymfonyPageInterface
         $url = $this->getDriver()->getCurrentUrl();
         $path = parse_url($url)['path'];
 
+        $path = preg_replace('#^/app(_dev|_test|_test_cached)?\.php/#', '/', $path);
         $matchedRoute = $this->router->match($path);
 
         if (isset($matchedRoute['_locale'])) {

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Channel/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Channel/_form.html.twig
@@ -35,6 +35,7 @@
             {{ form_row(form.defaultTaxZone) }}
             {{ form_row(form.taxCalculationStrategy) }}
             {{ form_row(form.skippingShippingStepAllowed) }}
+            {{ form_row(form.skippingPaymentStepAllowed) }}
             {{ form_row(form.accountVerificationRequired) }}
         </div>
     </div>

--- a/src/Sylius/Bundle/CoreBundle/Fixture/ChannelFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ChannelFixture.php
@@ -41,6 +41,7 @@ class ChannelFixture extends AbstractResourceFixture
                 ->scalarNode('tax_calculation_strategy')->end()
                 ->booleanNode('enabled')->end()
                 ->booleanNode('skipping_shipping_step_allowed')->end()
+                ->booleanNode('skipping_payment_step_allowed')->end()
                 ->scalarNode('default_locale')->cannotBeEmpty()->end()
                 ->arrayNode('locales')->prototype('scalar')->end()->end()
                 ->scalarNode('base_currency')->cannotBeEmpty()->end()

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -98,6 +98,7 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
         $channel->setThemeName($options['theme_name']);
         $channel->setContactEmail($options['contact_email']);
         $channel->setSkippingShippingStepAllowed($options['skipping_shipping_step_allowed']);
+        $channel->setSkippingPaymentStepAllowed($options['skipping_payment_step_allowed']);
 
         $channel->setDefaultLocale($options['default_locale']);
         foreach ($options['locales'] as $locale) {
@@ -136,6 +137,8 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
             ->setAllowedTypes('enabled', 'bool')
             ->setDefault('skipping_shipping_step_allowed', false)
             ->setAllowedTypes('skipping_shipping_step_allowed', 'bool')
+            ->setDefault('skipping_payment_step_allowed', false)
+            ->setAllowedTypes('skipping_payment_step_allowed', 'bool')
             ->setDefault('default_tax_zone', LazyOption::randomOne($this->zoneRepository))
             ->setAllowedTypes('default_tax_zone', ['null', 'string', ZoneInterface::class])
             ->setNormalizer('default_tax_zone', LazyOption::findOneBy($this->zoneRepository, 'code'))

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
@@ -73,6 +73,10 @@ final class ChannelTypeExtension extends AbstractTypeExtension
                 'label' => 'sylius.form.channel.skipping_shipping_step_allowed',
                 'required' => false,
             ])
+            ->add('skippingPaymentStepAllowed', CheckboxType::class, [
+                'label' => 'sylius.form.channel.skipping_payment_step_allowed',
+                'required' => false,
+            ])
             ->add('accountVerificationRequired', CheckboxType::class, [
                 'label' => 'sylius.form.channel.account_verification_required',
                 'required' => false,

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order_checkout.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order_checkout.yml
@@ -34,7 +34,7 @@ winzou_state_machine:
         callbacks:
             after:
                 sylius_process_cart:
-                    on: ["select_shipping", "address", "select_payment", "skip_shipping"]
+                    on: ["select_shipping", "address", "select_payment", "skip_shipping", "skip_payment"]
                     do: ["@sylius.order_processing.order_processor", "process"]
                     args: ["object"]
                 sylius_create_order:

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
@@ -21,6 +21,7 @@
         <field name="taxCalculationStrategy" column="tax_calculation_strategy" type="string" />
         <field name="contactEmail" column="contact_email" type="string" nullable="true" />
         <field name="skippingShippingStepAllowed" column="skipping_shipping_step_allowed" type="boolean" />
+        <field name="skippingPaymentStepAllowed" column="skipping_payment_step_allowed" type="boolean" />
         <field name="accountVerificationRequired" column="account_verification_required" type="boolean" />
 
         <many-to-one field="defaultLocale" target-entity="Sylius\Component\Locale\Model\LocaleInterface">

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/checkers.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/checkers.xml
@@ -16,6 +16,8 @@
         <service id="sylius.checker.order_shipping_method_selection_requirement" class="Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementChecker">
             <argument type="service" id="sylius.shipping_methods_resolver" />
         </service>
-        <service id="sylius.checker.order_payment_method_selection_requirement" class="Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementChecker" />
+        <service id="sylius.checker.order_payment_method_selection_requirement" class="Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementChecker" >
+            <argument type="service" id="sylius.payment_methods_resolver"/>
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
@@ -32,6 +32,7 @@ sylius:
             payment_methods: Payment Methods
             shipping_methods: Shipping Methods
             skipping_shipping_step_allowed: Skip shipping step if only one shipping method is available?
+            skipping_payment_step_allowed: Skip payment step if only one payment method is available?
             tax_calculation_strategy: Tax calculation strategy
             tax_zone_default: Default tax zone
             taxonomies: Taxonomies

--- a/src/Sylius/Component/Core/Model/Channel.php
+++ b/src/Sylius/Component/Core/Model/Channel.php
@@ -71,6 +71,11 @@ class Channel extends BaseChannel implements ChannelInterface
     /**
      * @var bool
      */
+    protected $skippingPaymentStepAllowed = false;
+
+    /**
+     * @var bool
+     */
     protected $accountVerificationRequired = true;
 
     public function __construct()
@@ -263,6 +268,22 @@ class Channel extends BaseChannel implements ChannelInterface
     public function setSkippingShippingStepAllowed($skippingShippingStepAllowed)
     {
         $this->skippingShippingStepAllowed = $skippingShippingStepAllowed;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isSkippingPaymentStepAllowed()
+    {
+        return $this->skippingPaymentStepAllowed;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSkippingPaymentStepAllowed($skippingPaymentStepAllowed)
+    {
+        $this->skippingPaymentStepAllowed = $skippingPaymentStepAllowed;
     }
 
     /**

--- a/src/Sylius/Component/Core/Model/ChannelInterface.php
+++ b/src/Sylius/Component/Core/Model/ChannelInterface.php
@@ -99,6 +99,16 @@ interface ChannelInterface extends
     /**
      * @return bool
      */
+    public function isSkippingPaymentStepAllowed();
+
+    /**
+     * @param bool $skippingPaymentStepAllowed
+     */
+    public function setSkippingPaymentStepAllowed($skippingPaymentStepAllowed);
+
+    /**
+     * @return bool
+     */
     public function isAccountVerificationRequired();
 
     /**

--- a/src/Sylius/Component/Core/spec/Model/ChannelSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ChannelSpec.php
@@ -150,6 +150,12 @@ final class ChannelSpec extends ObjectBehavior
         $this->isSkippingShippingStepAllowed()->shouldReturn(true);
     }
 
+    function it_can_allow_to_skip_payment_step_if_only_a_single_payment_method_is_resolved()
+    {
+        $this->setSkippingPaymentStepAllowed(true);
+        $this->isSkippingPaymentStepAllowed()->shouldReturn(true);
+    }
+
     function it_has_account_verification_required_by_default()
     {
         $this->isAccountVerificationRequired()->shouldReturn(true);


### PR DESCRIPTION
…there is only 1 Payment Method available

| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| License         | MIT |

Implements a switch in Admin Channel page, to allow skipping the Payment Step of the checkout if there is only 1 available payment method.

It has been inspired and works the same way as https://github.com/Sylius/Sylius/pull/7488

