### PR TITLE
Set default username on existing customer binding

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/DefaultUsernameORMListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/DefaultUsernameORMListener.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\UnitOfWork;
 use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Core\Model\ShopUserInterface;
 
 /**
  * Keeps user's username synchronized with email.
@@ -42,13 +43,20 @@ final class DefaultUsernameORMListener
      */
     private function processEntities($entities, EntityManagerInterface $entityManager, UnitOfWork $unitOfWork)
     {
-        foreach ($entities as $customer) {
-            if (!$customer instanceof CustomerInterface) {
-                continue;
-            }
-
-            $user = $customer->getUser();
-            if (null === $user) {
+        foreach ($entities as $entity) {
+            if ($entity instanceof CustomerInterface) {
+                $customer = $entity;
+                $user = $customer->getUser();
+                if (null === $user) {
+                    continue;
+                }
+            } elseif ($entity instanceof ShopUserInterface) {
+                $user = $entity;
+                $customer = $user->getCustomer();
+                if (null === $customer) {
+                    continue;
+                }
+            } else {
                 continue;
             }
 


### PR DESCRIPTION
Existing customer may be kept untouched on user creation because the relation is stored on the user table. So, listener should react to both shop user and customer flush, in order to guarantee the username is set.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |
