### PR TITLE
Remove strong typing on updateUserLastLogin event

### DIFF
--- a/src/Sylius/Bundle/UserBundle/EventListener/UserLastLoginSubscriber.php
+++ b/src/Sylius/Bundle/UserBundle/EventListener/UserLastLoginSubscriber.php
@@ -72,7 +72,7 @@ class UserLastLoginSubscriber implements EventSubscriberInterface
     /**
      * @param UserInterface $user
      */
-    protected function updateUserLastLogin(UserInterface $user)
+    protected function updateUserLastLogin($user)
     {
         if ($user instanceof $this->userClass) {
             $user->setLastLogin(new \DateTime());


### PR DESCRIPTION
If you have two way of login in one app (sylius and an other user provider / form), the event onSecurityInteractiveLogin or onImplicitLogin is fired but your entity User is not a Sylius entity user with the user interface UserInterface from sylius. So you have a php error because your 2nd user entity doesn't have the UserInterface implemented.

The strong typing is useless, because on first line we check the user class.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes |
| License         | MIT |
