### PR TITLE
 	Removed "GROUP BY" clause in ProductRepository#createShopListQueryBuilder

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -74,7 +74,6 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
             ->andWhere('productTaxon.taxon = :taxon')
             ->andWhere(':channel MEMBER OF o.channels')
             ->andWhere('o.enabled = true')
-//            ->addGroupBy('o.id')
             ->setParameter('locale', $locale)
             ->setParameter('taxon', $taxon)
             ->setParameter('channel', $channel)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

The query for retrieving the products list in the shop does not work in PostgreSQL :
```
SQLSTATE[42803]: Grouping error: 7 ERROR: column "s1_.name" must appear in the GROUP BY clause or be used in an aggregate function
```
The problem is, that in PostgreSQL you need to add all the columns you want to have in your select to your group by.
This is not specific to PostgreSQL, this is required by the SQL standard. 
The query works in MySQL, but MySQL's sloppy implementation of this is more like a bug than a feature.