### PR TITLE
Add 'configuration' node in 'product_attribute' fixture

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/ProductAttributeFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ProductAttributeFixture.php
@@ -55,6 +55,7 @@ class ProductAttributeFixture extends AbstractResourceFixture
                 ->scalarNode('name')->cannotBeEmpty()->end()
                 ->scalarNode('code')->cannotBeEmpty()->end()
                 ->enumNode('type')->values($this->attributeTypes)->cannotBeEmpty()->end()
+                ->variableNode('configuration')->end()
         ;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |

Adds the 'configuration' node to the 'product_attribute' fixture. It was now missing, as it's only done inside fixtures like 'mug_product'. Simply allows an array with configuration options, as there are many possibilities based on each type.