### PR TITLE
Removed weird chars in Model.ProductVariant.yml

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductVariant.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductVariant.yml
@@ -8,21 +8,21 @@ Sylius\Component\Product\Model\ProductVariant:
             xml_attribute: true
             groups: [Default, Detailed, DetailedCart, Autocomplete]
         code:
-            expose: true 
-            type: string 
-            groups: [Default, Detailed, DetailedCart, Autocomplete] 
+            expose: true
+            type: string
+            groups: [Default, Detailed, DetailedCart, Autocomplete]
         position:
-            expose: true 
-            type: integer 
-            groups: [Default, Detailed, DetailedCart] 
+            expose: true
+            type: integer
+            groups: [Default, Detailed, DetailedCart]
         optionValues:
-            expose: true 
-            type: array 
-            groups: [Default, Detailed, DetailedCart] 
+            expose: true
+            type: array
+            groups: [Default, Detailed, DetailedCart]
         translations:
-            expose: true 
-            type: array 
-            groups: [Default, Detailed, DetailedCart] 
+            expose: true
+            type: array
+            groups: [Default, Detailed, DetailedCart]
     virtual_properties:
         getDescriptor:
             serialized_name: descriptor


### PR DESCRIPTION
Some weird chars got introduced at the end of the line (probably MacOS or Windows style line ending) in this commit https://github.com/Sylius/Sylius/commit/01ffece60a87ab88aeb25e6d614e8ba6be152a9f#diff-8eb0e5bc2c23fef1cdc63d93a85f949a

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | none |
| License         | MIT |
