### PR TITLE
Show main taxon in admin product grid

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product.yml
@@ -25,6 +25,11 @@ sylius_grid:
                     type: string
                     label: sylius.ui.name
                     sortable: translation.name
+                mainTaxon:
+                    type: twig
+                    label: sylius.ui.main_taxon
+                    options:
+                        template: "@SyliusAdmin/Product/Grid/Field/mainTaxon.html.twig"
                 enabled:
                     type: twig
                     label: sylius.ui.enabled

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Grid/Field/mainTaxon.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Grid/Field/mainTaxon.html.twig
@@ -1,0 +1,1 @@
+{% if data is not null %}{{ data.name }}{% endif %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | partially #7815 |
| License         | MIT |

The main taxon field on Product objects is really kind of hidden away as described in #7815.  One way to at least help with addressing this is to show the field on the admin grid, so this PR adds that column.

Note for now that I haven't made the column sortable nor is it filterable.

Screenshot for reference:

![screen shot 2017-04-10 at 9 27 35 am](https://cloud.githubusercontent.com/assets/368545/24866537/03db63be-1dd0-11e7-9426-317c9bbb35bb.png)
