### PR TITLE
[Cart] Add default serialization group for cart

### DIFF
--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/cart.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/cart.yml
@@ -19,7 +19,7 @@ sylius_admin_api_cart_create:
         _sylius:
             serialization_version: $version
             form: Sylius\Bundle\AdminApiBundle\Form\Type\OrderType
-            serialization_groups: [DetailedCart]
+            serialization_groups: [Default, DetailedCart]
 
 sylius_admin_api_cart_update:
     path: /{id}
@@ -29,7 +29,7 @@ sylius_admin_api_cart_update:
         _sylius:
             serialization_version: $version
             form: Sylius\Bundle\AdminApiBundle\Form\Type\OrderPromotionCouponType
-            serialization_groups: [DetailedCart]
+            serialization_groups: [Default, DetailedCart]
 
 sylius_admin_api_cart_delete:
     path: /{id}
@@ -54,4 +54,4 @@ sylius_admin_api_cart_show:
             repository:
                 method: findCartById
                 arguments: [$id]
-            serialization_groups: [DetailedCart]
+            serialization_groups: [Default, DetailedCart]

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/cart_item.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/cart_item.yml
@@ -13,7 +13,7 @@ sylius_admin_api_cart_item_create:
                 method: createForCart
                 arguments:
                   - "expr:notFoundOnNull(service('sylius.repository.order').findCartById($cartId))"
-            serialization_groups: [DetailedCart]
+            serialization_groups: [Default, DetailedCart]
 
 sylius_admin_api_cart_item:
     resource: |

--- a/tests/Responses/Expected/cart/add_to_cart_hard_available_item_response.json
+++ b/tests/Responses/Expected/cart/add_to_cart_hard_available_item_response.json
@@ -21,6 +21,7 @@
                 "code": "MUG_SIZE_L",
                 "translations": {
                     "en_US": {
+                        "locale": "en_US",
                         "id": @integer@,
                         "value": "Size L"
                     }
@@ -30,15 +31,22 @@
         "position": 1,
         "translations": {
             "en_US": {
+                "locale": "en_US",
                 "id": @integer@,
                 "name": "Breaking bad mug"
             }
         },
+        "version": 1,
         "tracked": true,
         "channelPricings": {
             "WEB": {
                 "channelCode": "WEB",
                 "price": 20
+            }
+        },
+        "_links": {
+            "self": {
+                "href": "\/api\/v1\/products\/MUG\/variants\/HARD_AVAILABLE_MUG"
             }
         }
     },

--- a/tests/Responses/Expected/cart/add_to_cart_response.json
+++ b/tests/Responses/Expected/cart/add_to_cart_response.json
@@ -21,6 +21,7 @@
                 "code": "MUG_SIZE_S",
                 "translations": {
                     "en_US": {
+                        "locale": "en_US",
                         "id": @integer@,
                         "value": "Size S"
                     }
@@ -30,15 +31,22 @@
         "position": 0,
         "translations": {
             "en_US": {
+                "locale": "en_US",
                 "id": @integer@,
                 "name": "Star wars mug"
             }
         },
+        "version": 1,
         "tracked": false,
         "channelPricings": {
             "WEB": {
                 "channelCode": "WEB",
                 "price": 20
+            }
+        },
+        "_links": {
+            "self": {
+                "href": "\/api\/v1\/products\/MUG\/variants\/MUG_SW"
             }
         }
     },

--- a/tests/Responses/Expected/cart/add_to_cart_with_bigger_quantity_response.json
+++ b/tests/Responses/Expected/cart/add_to_cart_with_bigger_quantity_response.json
@@ -31,6 +31,7 @@
                 "code": "MUG_SIZE_S",
                 "translations": {
                     "en_US": {
+                        "locale": "en_US",
                         "id": @integer@,
                         "value": "Size S"
                     }
@@ -40,15 +41,22 @@
         "position": 0,
         "translations": {
             "en_US": {
+                "locale": "en_US",
                 "id": @integer@,
                 "name": "Star wars mug"
             }
         },
+        "version": 1,
         "tracked": false,
         "channelPricings": {
             "WEB": {
                 "channelCode": "WEB",
                 "price": 20
+            }
+        },
+        "_links": {
+            "self": {
+                "href": "\/api\/v1\/products\/MUG\/variants\/MUG_SW"
             }
         }
     },

--- a/tests/Responses/Expected/cart/increase_quantity_response.json
+++ b/tests/Responses/Expected/cart/increase_quantity_response.json
@@ -33,15 +33,22 @@
                 "position": 0,
                 "translations": {
                     "en_US": {
+                        "locale": "en_US",
                         "id": @integer@,
                         "name": "Star wars mug"
                     }
                 },
+                "version": 1,
                 "tracked": false,
                 "channelPricings": {
                     "WEB": {
                         "channelCode": "WEB",
                         "price": 20
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "\/api\/v1\/products\/MUG\/variants\/MUG_SW"
                     }
                 }
             },
@@ -79,15 +86,22 @@
                 "position": 3,
                 "translations": {
                     "en_US": {
+                        "locale": "en_US",
                         "id": @integer@,
                         "name": "Breaking bad mug"
                     }
                 },
+                "version": 1,
                 "tracked": true,
                 "channelPricings": {
                     "WEB": {
                         "channelCode": "WEB",
                         "price": 20
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "\/api\/v1\/products\/MUG\/variants\/HARD_AVAILABLE_MUG"
                     }
                 }
             },
@@ -120,6 +134,7 @@
         }
     },
     "channel": {
+        "id": @integer@,
         "code": "WEB",
         "_links": {
             "self": {

--- a/tests/Responses/Expected/cart/recalculated_items_total_response.json
+++ b/tests/Responses/Expected/cart/recalculated_items_total_response.json
@@ -28,15 +28,22 @@
                 "position": 0,
                 "translations": {
                     "en_US": {
+                        "locale": "en_US",
                         "id": @integer@,
                         "name": "Star wars mug"
                     }
                 },
+                "version": 1,
                 "tracked": false,
                 "channelPricings": {
                     "WEB": {
                         "channelCode": "WEB",
                         "price": 20
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "\/api\/v1\/products\/MUG\/variants\/MUG_SW"
                     }
                 }
             },
@@ -69,6 +76,7 @@
         }
     },
     "channel": {
+        "id": @integer@,
         "code": "WEB",
         "_links": {
             "self": {

--- a/tests/Responses/Expected/cart/show_response.json
+++ b/tests/Responses/Expected/cart/show_response.json
@@ -17,6 +17,7 @@
         }
     },
     "channel": {
+        "id": @integer@,
         "code": "WEB",
         "_links": {
             "self": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

Currently the cart list serialize more information than the
show/update/create routes. To fix this we add the default group for the specific routes.