### PR TITLE
[API] [Product] Add path to default serialization

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.Image.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.Image.yml
@@ -14,7 +14,7 @@ Sylius\Component\Core\Model\Image:
         path:
             expose: true
             type: string
-            groups: [Detailed]
+            groups: [Default, Detailed]
         owner:
             expose: true
             groups: [Detailed]

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.ProductImage.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/serializer/Model.ProductImage.yml
@@ -1,16 +1,3 @@
 Sylius\Component\Core\Model\ProductImage:
     exclusion_policy: ALL
     xml_root_name: product-image
-    properties:
-        id:
-            expose: true
-            type: integer
-            xml_attribute: true
-            groups: [Default, Detailed]
-        type:
-            expose: true
-            type: string
-            groups: [Default, Detailed]
-        owner:
-            expose: true
-            groups: [Detailed]

--- a/tests/DataFixtures/ORM/resources/products.yml
+++ b/tests/DataFixtures/ORM/resources/products.yml
@@ -23,6 +23,7 @@ Sylius\Component\Core\Model\Product:
         fallbackLocale: 'en_US'
         currentLocale: 'en_US'
         code: 'MUG_SW'
+        images: ["@product_thumbnail"]
         translations:
             - "@productTranslation1"
             - "@productTranslation2"
@@ -42,3 +43,8 @@ Sylius\Component\Core\Model\Product:
         slug: 'mug-breaking-bad'
         name: 'Breaking bad mug'
         description: <paragraph(2)>
+
+Sylius\Component\Core\Model\ProductImage:
+    product_thumbnail:
+        type: "thumbnail"
+        path: "/uo/product.jpg"

--- a/tests/Responses/Expected/product/index_response.json
+++ b/tests/Responses/Expected/product/index_response.json
@@ -51,7 +51,13 @@
                 "code": "MUG_SW",
                 "options": [],
                 "averageRating": 0,
-                "images": [],
+                "images": [
+                    {
+                        "id": @integer@,
+                        "type": "thumbnail",
+                        "path": "\/uo\/product.jpg"
+                    }
+                ],
                 "_links": {
                     "self": {
                         "href": "\/api\/v1\/products\/MUG_SW"

--- a/tests/Responses/Expected/product/show_response.json
+++ b/tests/Responses/Expected/product/show_response.json
@@ -25,7 +25,13 @@
     "channels": [],
     "reviews": [],
     "averageRating": 0,
-    "images": [],
+    "images": [
+        {
+            "id": @integer@,
+            "type": "thumbnail",
+            "path": "\/uo\/product.jpg"
+        }
+    ],
     "_links": {
         "self": {
             "href": "\/api\/v1\/products\/MUG_SW"

--- a/tests/Responses/Expected/product/sorted_index_response.json
+++ b/tests/Responses/Expected/product/sorted_index_response.json
@@ -51,7 +51,13 @@
                 "code": "MUG_SW",
                 "options": [],
                 "averageRating": 0,
-                "images": [],
+                "images": [
+                    {
+                        "id": @integer@,
+                        "type": "thumbnail",
+                        "path": "\/uo\/product.jpg"
+                    }
+                ],
                 "_links": {
                     "self": {
                         "href": "\/api\/v1\/products\/MUG_SW"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #7898 |
| License         | MIT |

The path will be included in default serialization. I have also added a new fixture to avoid regression. The question for later is, should also send an information about related variants. 