### PR TITLE
Improve table display for order checkout process

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Order/Table/_promotion.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Order/Table/_promotion.html.twig
@@ -1,10 +1,10 @@
 {% import "@SyliusShop/Common/Macro/money.html.twig" as money %}
 
 {% set orderPromotionAdjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT') %}
+{% set orderPromotions = sylius_aggregate_adjustments(order.getAdjustmentsRecursively(orderPromotionAdjustment)) %}
 
-<td colspan="2" id="promotion-discounts">
-    {% set orderPromotions = sylius_aggregate_adjustments(order.getAdjustmentsRecursively(orderPromotionAdjustment)) %}
-    {% if not orderPromotions is empty %}
+{% if not orderPromotions is empty %}
+    <td colspan="2" id="promotion-discounts">
         <div class="ui relaxed divided list">
             {% for label, amount in orderPromotions %}
                 <div class="item">
@@ -17,9 +17,9 @@
                 </div>
             {% endfor %}
         </div>
-    {% endif %}
-</td>
-<td colspan="2" id="promotion-total" class="right aligned">
+    </td>
+{% endif %}
+<td colspan="{% if not orderPromotions is empty %}2{% else %}4{% endif %}" id="promotion-total" class="right aligned">
     {{ 'sylius.ui.promotion_total'|trans }}:
     {{ money.format(order.orderPromotionTotal, order.currencyCode) }}
 </td>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Order/Table/_shipping.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Order/Table/_shipping.html.twig
@@ -1,10 +1,10 @@
 {% import "@SyliusShop/Common/Macro/money.html.twig" as money %}
 
 {% set orderShippingPromotionAdjustment = constant('Sylius\\Component\\Core\\Model\\AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT') %}
+{% set orderShippingPromotions = sylius_aggregate_adjustments(order.getAdjustmentsRecursively(orderShippingPromotionAdjustment)) %}
 
-<td colspan="2" id="promotion-shipping-discounts">
-    {% set orderShippingPromotions = sylius_aggregate_adjustments(order.getAdjustmentsRecursively(orderShippingPromotionAdjustment)) %}
-    {% if not orderShippingPromotions is empty %}
+{% if not orderShippingPromotions is empty %}
+    <td colspan="2" id="promotion-shipping-discounts">
         <div class="ui relaxed divided list">
             {% for label, amount in orderShippingPromotions %}
                 <div class="item">
@@ -17,9 +17,9 @@
                 </div>
             {% endfor %}
         </div>
-    {% endif %}
-</td>
-<td colspan="4" class="right aligned" id="shipping-total">
+    </td>
+{% endif %}
+<td colspan="{% if not orderShippingPromotions is empty %}2{% else %}4{% endif %}" class="right aligned" id="shipping-total">
     {{ 'sylius.ui.shipping_total'|trans }}:
     {{ money.format(order.shippingTotal, order.currencyCode) }}
 </td>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

The shipping and promotion table rows in the order tables conditionally show some data, but the display of the table cells isn't really optimized for this.  This improves the handling a bit to not display an empty table cell and to improve the calculation for the colspans for the always displayed cells.