### PR TITLE
Change paypal password to TextType from PasswordType

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Form/Type/PaypalGatewayConfigurationType.php
+++ b/src/Sylius/Bundle/PayumBundle/Form/Type/PaypalGatewayConfigurationType.php
@@ -15,7 +15,6 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -42,7 +41,7 @@ final class PaypalGatewayConfigurationType extends AbstractType
                     ])
                 ],
             ])
-            ->add('password', PasswordType::class, [
+            ->add('password', TextType::class, [
                 'label' => 'sylius.form.gateway_configuration.paypal.password',
                 'constraints' => [
                     new NotBlank([


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

With password type, the form doesn't show any values when editing.

Edit: Just took a look at the failing test - it doesn't seem related.