### PR TITLE
Don't allow the flashes layout to force a session start

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/views/_flashes.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/_flashes.html.twig
@@ -1,29 +1,31 @@
-{% for type in ['success', 'error', 'info', 'warning'] %}
-    {% for flash in app.session.flashbag.get(type) %}
-        {% if 'error' == type %}
-            {% set result = 'negative' %}
-            {% set icon = 'remove' %}
-        {% endif %}
-        {% if 'info' == type %}
-            {% set result = 'info' %}
-            {% set icon = 'info' %}
-        {% endif %}
-        <div class="ui icon {{ result|default('positive') }} message" id="sylius-flash-messages">
-            <i class="close icon"></i>
-            <i class="{{ icon|default('checkmark') }} icon"></i>
-            <div class="content">
-                <div class="header">
-                    {% set header = 'sylius.ui.'~type %}
-                    {{ header|trans }}
+{% if app.session is not null and app.session.started %}
+    {% for type in ['success', 'error', 'info', 'warning'] %}
+        {% for flash in app.session.flashbag.get(type) %}
+            {% if 'error' == type %}
+                {% set result = 'negative' %}
+                {% set icon = 'remove' %}
+            {% endif %}
+            {% if 'info' == type %}
+                {% set result = 'info' %}
+                {% set icon = 'info' %}
+            {% endif %}
+            <div class="ui icon {{ result|default('positive') }} message" id="sylius-flash-messages">
+                <i class="close icon"></i>
+                <i class="{{ icon|default('checkmark') }} icon"></i>
+                <div class="content">
+                    <div class="header">
+                        {% set header = 'sylius.ui.'~type %}
+                        {{ header|trans }}
+                    </div>
+                    <p>
+                    {% if flash is iterable %}
+                        {{ flash.message|trans(flash.parameters, 'flashes') }}
+                    {% else %}
+                        {{ flash|trans({}, 'flashes') }}
+                    {% endif %}
+                    </p>
                 </div>
-                <p>
-                {% if flash is iterable %}
-                    {{ flash.message|trans(flash.parameters, 'flashes') }}
-                {% else %}
-                    {{ flash|trans({}, 'flashes') }}
-                {% endif %}
-                </p>
             </div>
-        </div>
+        {% endfor %}
     {% endfor %}
-{% endfor %}
+{% endif %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

Right now including the `@SyliusUi/_flashes.html.twig` layout will always force a session to start by reading into the flashbag.  Even if other parts of the request cause a session to get started, this layout shouldn't arbitrarily force it, so check for an active session before reading the data.