### PR TITLE
[ProductVariant] Add getImages to product variant

### DIFF
--- a/src/Sylius/Component/Core/Model/ProductVariant.php
+++ b/src/Sylius/Component/Core/Model/ProductVariant.php
@@ -401,4 +401,22 @@ class ProductVariant extends BaseVariant implements ProductVariantInterface
     {
         $this->shippingRequired = $shippingRequired;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getImages()
+    {
+        $images = [];
+
+        foreach ($this->product->getImages() as $image) {
+            foreach ($image->getProductVariants() as $productVariant) {
+                if ($this === $productVariant){
+                    $images[] = $image;
+                }
+            }
+        }
+
+        return $images;
+    }
 }

--- a/src/Sylius/Component/Core/Model/ProductVariantInterface.php
+++ b/src/Sylius/Component/Core/Model/ProductVariantInterface.php
@@ -125,4 +125,9 @@ interface ProductVariantInterface extends
      * @param bool $shippingRequired
      */
     public function setShippingRequired($shippingRequired);
+
+    /**
+     * @return ProductImageInterface[]
+     */
+    public function getImages();
 }

--- a/src/Sylius/Component/Core/spec/Model/ProductVariantSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ProductVariantSpec.php
@@ -15,6 +15,8 @@ use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
+use Sylius\Component\Core\Model\ProductImageInterface;
+use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariant;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Product\Model\ProductVariant as BaseProductVariant;
@@ -239,5 +241,22 @@ final class ProductVariantSpec extends ObjectBehavior
     {
         $this->setShippingRequired(false);
         $this->isShippingRequired()->shouldReturn(false);
+    }
+
+    function it_returns_variant_images(
+        ProductImageInterface $firstVariantImage,
+        ProductImageInterface $secondVariantImage,
+        ProductImageInterface $differentImage,
+        ProductInterface $product
+    ) {
+        $product->getImages()->willReturn([$firstVariantImage, $secondVariantImage, $differentImage]);
+
+        $firstVariantImage->getProductVariants()->willReturn([$this]);
+        $secondVariantImage->getProductVariants()->willReturn([$this]);
+        $differentImage->getProductVariants()->willReturn([]);
+
+        $this->setProduct($product);
+
+        $this->getImages()->shouldReturn([$firstVariantImage, $secondVariantImage]);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets |  |
| License         | MIT |

The simplest implementation for providing related images from variant. It is not an unusual use-case so it will slightly improve DX, but on the other hand, it is not a pretty solution and also it is a BC-break. I'm not sure is it worthy to merge to the master at this stage, but I had to implement it one way or another, so you can decide :)

Also, usage of this function will be really expensive from performance point of view if a lot of images will be defined on a product. 