### PR TITLE
Add API for managing product association types

### DIFF
--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/main.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/main.yml
@@ -54,6 +54,9 @@ sylius_api_product:
 sylius_api_product_attribute:
     resource: "@SyliusAdminApiBundle/Resources/config/routing/product_attribute.yml"
 
+sylius_api_product_association_type:
+    resource: "@SyliusAdminApiBundle/Resources/config/routing/product_association_type.yml"
+
 sylius_api_product_option:
     resource: "@SyliusAdminApiBundle/Resources/config/routing/product_option.yml"
 

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/product_association_type.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/product_association_type.yml
@@ -1,0 +1,12 @@
+# This file is part of the Sylius package.
+# (c) Paweł Jędrzejewski
+
+sylius_admin_api_product_association_type:
+    resource: |
+        identifier: code
+        alias: sylius.product_association_type
+        section: admin_api
+        serialization_version: $version
+        criteria:
+            code: $code
+    type: sylius.resource_api

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductAssociationType.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductAssociationType.yml
@@ -15,6 +15,18 @@ Sylius\Component\Product\Model\ProductAssociationType:
             expose: true
             type: array
             groups: [Default, Detailed]
-    virtual_properties:
-        getName:
-            serialized_name: name
+        createdAt:
+            expose: true
+            type: DateTime
+            groups: [Detailed]
+        updatedAt:
+            expose: true
+            type: DateTime
+            groups: [Detailed]
+    relations:
+        -   rel: self
+            href:
+                route: sylius_admin_api_product_association_type_show
+                parameters:
+                    code: expr(object.getCode())
+                    version: 1

--- a/tests/Controller/ProductAssociationTypeApiTest.php
+++ b/tests/Controller/ProductAssociationTypeApiTest.php
@@ -1,0 +1,327 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Tests\Controller;
+
+use Lakion\ApiTestCase\JsonApiTestCase;
+use Sylius\Component\Product\Model\ProductAssociationTypeInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @author Kamil Kokot <kamil@kokot.me>
+ */
+final class ProductAssociationTypeApiTest extends JsonApiTestCase
+{
+    /**
+     * @test
+     */
+    public function it_denies_creating_product_association_type_for_non_authenticated_user()
+    {
+        $this->client->request('POST', '/api/v1/product-association-types/');
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_create_product_association_type_without_specifying_required_data()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('POST', '/api/v1/product-association-types/', [], [], [
+            'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+            'CONTENT_TYPE' => 'application/json',
+        ]);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product_association_type/create_validation_fail_response', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_create_product_association_type()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/locales.yml');
+
+        $data =
+<<<EOT
+        {
+            "code": "cross_sell",
+            "translations": {
+                "en_US": {
+                    "name": "Cross sell"
+                }
+            }
+        }
+EOT;
+
+        $this->client->request('POST', '/api/v1/product-association-types/', [], [], [
+            'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+            'CONTENT_TYPE' => 'application/json',
+        ], $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product_association_type/create_response', Response::HTTP_CREATED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_denies_getting_product_association_types_for_non_authenticated_user()
+    {
+        $this->client->request('GET', '/api/v1/product-association-types/');
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_get_product_association_types()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/product_association_types.yml');
+
+        $this->client->request('GET', '/api/v1/product-association-types/', [], [], [
+            'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+        ]);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product_association_type/index_response', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_denies_getting_product_association_type_for_non_authenticated_user()
+    {
+        $this->client->request('GET', '/api/v1/product-association-types/1');
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_not_found_response_when_requesting_details_of_a_product_association_type_which_does_not_exist()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('GET', '/api/v1/product-association-types/-1', [], [], [
+            'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+            'ACCEPT' => 'application/json',
+        ]);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_get_product_association_type()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $productAssociationTypes = $this->loadFixturesFromFile('resources/product_association_types.yml');
+        $productAssociationType = $productAssociationTypes['productAssociationType1'];
+
+        $this->client->request('GET', $this->getAssociationTypeUrl($productAssociationType), [], [], [
+            'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+            'ACCEPT' => 'application/json',
+        ]);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product_association_type/show_response', Response::HTTP_OK);
+    }
+
+    /**
+     * @test
+     */
+    public function it_denies_updating_product_association_type_for_non_authenticated_user()
+    {
+        $this->client->request('PUT', '/api/v1/product-association-types/1');
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'authentication/access_denied_response', Response::HTTP_UNAUTHORIZED);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_not_found_response_when_trying_to_update_product_association_type_which_does_not_exist()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('PUT', '/api/v1/product-association-types/-1', [], [], [
+            'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+            'ACCEPT' => 'application/json',
+        ]);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_allow_to_update_product_association_type_without_specifying_required_data()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/locales.yml');
+        $productAssociationTypes = $this->loadFixturesFromFile('resources/product_association_types.yml');
+        $productAssociationType = $productAssociationTypes['productAssociationType1'];
+
+        $this->client->request('PUT', $this->getAssociationTypeUrl($productAssociationType), [], [], [
+            'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+            'CONTENT_TYPE' => 'application/json',
+        ]);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product_association_type/update_validation_fail_response', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_update_product_association_type()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/locales.yml');
+        $productAssociationTypes = $this->loadFixturesFromFile('resources/product_association_types.yml');
+        $productAssociationType = $productAssociationTypes['productAssociationType1'];
+
+        $data =
+<<<EOT
+        {
+            "translations": {
+                "en_US": {
+                    "name": "Cross sell (old)"
+                },
+                "nl_NL": {
+                    "name": "Cross sell (old, nl_NL)"
+                }
+            }
+        }
+EOT;
+
+        $this->client->request('PUT', $this->getAssociationTypeUrl($productAssociationType), [], [], [
+            'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+            'CONTENT_TYPE' => 'application/json',
+        ], $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_not_found_response_when_trying_to_partially_update_product_association_type_which_does_not_exist()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('PATCH', '/api/v1/product-association-types/-1', [], [], [
+            'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+            'ACCEPT' => 'application/json',
+        ]);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_partially_update_product_association_type()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/locales.yml');
+        $productAssociationTypes = $this->loadFixturesFromFile('resources/product_association_types.yml');
+        $productAssociationType = $productAssociationTypes['productAssociationType1'];
+
+        $data =
+<<<EOT
+        {
+            "translations": {
+                "en_US": {
+                    "name": "Cross sell (old)"
+                }
+            }
+        }
+EOT;
+
+        $this->client->request('PATCH', $this->getAssociationTypeUrl($productAssociationType), [], [], [
+            'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+            'CONTENT_TYPE' => 'application/json',
+        ], $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_not_found_response_when_trying_to_delete_product_association_type_which_does_not_exist()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+
+        $this->client->request('DELETE', '/api/v1/product-association-types/-1', [], [], [
+            'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+            'ACCEPT' => 'application/json',
+        ]);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_delete_product_association_type()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $productAssociationTypes = $this->loadFixturesFromFile('resources/product_association_types.yml');
+        $productAssociationType = $productAssociationTypes['productAssociationType1'];
+
+        $this->client->request('DELETE', $this->getAssociationTypeUrl($productAssociationType), [], [], [
+            'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+            'CONTENT_TYPE' => 'application/json',
+        ], []);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+
+        $this->client->request('GET', $this->getAssociationTypeUrl($productAssociationType), [], [], [
+            'HTTP_Authorization' => 'Bearer SampleTokenNjZkNjY2MDEwMTAzMDkxMGE0OTlhYzU3NzYyMTE0ZGQ3ODcyMDAwM2EwMDZjNDI5NDlhMDdlMQ',
+            'ACCEPT' => 'application/json',
+        ]);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'error/not_found_response', Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @param ProductAssociationTypeInterface $productAssociationType
+     *
+     * @return string
+     */
+    private function getAssociationTypeUrl(ProductAssociationTypeInterface $productAssociationType)
+    {
+        return 'api/v1/product-association-types/' . $productAssociationType->getCode();
+    }
+}

--- a/tests/DataFixtures/ORM/resources/product_association_types.yml
+++ b/tests/DataFixtures/ORM/resources/product_association_types.yml
@@ -1,0 +1,33 @@
+Sylius\Component\Product\Model\ProductAssociationTypeTranslation:
+    associationTypeTranslation1nl:
+        locale: nl_NL
+        name: 'Cross sell (nl_NL)'
+        translatable: "@productAssociationType1"
+    associationTypeTranslation1en:
+        locale: en_US
+        name: 'Cross sell'
+        translatable: "@productAssociationType1"
+    associationTypeTranslation2nl:
+        locale: nl_NL
+        name: 'Up sell (nl_NL)'
+        translatable: "@productAssociationType2"
+    associationTypeTranslation2en:
+        locale: en_US
+        name: 'Up sell'
+        translatable: "@productAssociationType2"
+
+Sylius\Component\Product\Model\ProductAssociationType:
+    productAssociationType1:
+        fallbackLocale: en_US
+        currentLocale: nl_NL
+        code: cross_sell
+        translations:
+            - "@associationTypeTranslation1nl"
+            - "@associationTypeTranslation1en"
+    productAssociationType2:
+        fallbackLocale: en_US
+        currentLocale: nl_NL
+        code: up_sell
+        translations:
+            - "@associationTypeTranslation2nl"
+            - "@associationTypeTranslation2en"

--- a/tests/Responses/Expected/product/create_with_associations_response.json
+++ b/tests/Responses/Expected/product/create_with_associations_response.json
@@ -10,10 +10,17 @@
             "type": {
                 "id": @integer@,
                 "code": "similar",
+                "createdAt": "@string@.isDateTime()",
+                "updatedAt": "@string@.isDateTime()",
                 "translations": {
                     "en": {
                         "id": @integer@,
                         "locale": "en"
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "@string@"
                     }
                 }
             },
@@ -24,10 +31,17 @@
             "type": {
                 "id": @integer@,
                 "code": "accessories",
+                "createdAt": "@string@.isDateTime()",
+                "updatedAt": "@string@.isDateTime()",
                 "translations": {
                     "en": {
                         "id": @integer@,
                         "locale": "en"
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "@string@"
                     }
                 }
             },

--- a/tests/Responses/Expected/product_association_type/create_response.json
+++ b/tests/Responses/Expected/product_association_type/create_response.json
@@ -1,0 +1,18 @@
+{
+    "id": @integer@,
+    "code": "cross_sell",
+    "createdAt": "@string@.isDateTime()",
+    "updatedAt": "@string@.isDateTime()",
+    "translations": {
+        "en_US": {
+            "id": @integer@,
+            "locale": "en_US",
+            "name": "Cross sell"
+        }
+    },
+    "_links": {
+        "self": {
+            "href": "@string@"
+        }
+    }
+}

--- a/tests/Responses/Expected/product_association_type/create_validation_fail_response.json
+++ b/tests/Responses/Expected/product_association_type/create_validation_fail_response.json
@@ -1,0 +1,14 @@
+{
+    "code": 400,
+    "message": "Validation Failed",
+    "errors": {
+        "children": {
+            "translations": {},
+            "code": {
+                "errors": [
+                    "Please enter association type code."
+                ]
+            }
+        }
+    }
+}

--- a/tests/Responses/Expected/product_association_type/index_response.json
+++ b/tests/Responses/Expected/product_association_type/index_response.json
@@ -1,0 +1,63 @@
+{
+    "page": 1,
+    "limit": 10,
+    "pages": 1,
+    "total": 2,
+    "_links": {
+        "self": {
+            "href": "\/api\/v1\/product-association-types\/?page=1&limit=10"
+        },
+        "first": {
+            "href": "\/api\/v1\/product-association-types\/?page=1&limit=10"
+        },
+        "last": {
+            "href": "\/api\/v1\/product-association-types\/?page=1&limit=10"
+        }
+    },
+    "_embedded": {
+        "items": [
+            {
+                "id": @integer@,
+                "code": "cross_sell",
+                "translations": {
+                    "en_US": {
+                        "id": @integer@,
+                        "locale": "en_US",
+                        "name": "Cross sell"
+                    },
+                    "nl_NL": {
+                        "id": @integer@,
+                        "locale": "nl_NL",
+                        "name": "Cross sell (nl_NL)"
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "@string@"
+                    }
+                }
+            },
+            {
+                "id": @integer@,
+                "code": "up_sell",
+                "translations": {
+                    "en_US": {
+                        "id": @integer@,
+                        "locale": "en_US",
+                        "name": "Up sell"
+                    },
+                    "nl_NL": {
+                        "id": @integer@,
+                        "locale": "nl_NL",
+                        "name": "Up sell (nl_NL)"
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "@string@"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/tests/Responses/Expected/product_association_type/show_response.json
+++ b/tests/Responses/Expected/product_association_type/show_response.json
@@ -1,0 +1,23 @@
+{
+    "id": @integer@,
+    "code": "cross_sell",
+    "translations": {
+        "en_US": {
+            "id": @integer@,
+            "locale": "en_US",
+            "name": "Cross sell"
+        },
+        "nl_NL": {
+            "id": @integer@,
+            "locale": "nl_NL",
+            "name": "Cross sell (nl_NL)"
+        }
+    },
+    "createdAt": "@string@.isDateTime()",
+    "updatedAt": "@string@.isDateTime()",
+    "_links": {
+        "self": {
+            "href": "\/api\/v1\/product-association-types\/cross_sell"
+        }
+    }
+}

--- a/tests/Responses/Expected/product_association_type/update_response.json
+++ b/tests/Responses/Expected/product_association_type/update_response.json
@@ -1,0 +1,12 @@
+{
+    "id": @integer@,
+    "code": "cross_sell",
+    "name": "Cross sell (old)",
+    "createdAt": "@string@.isDateTime()",
+    "updatedAt": "@string@.isDateTime()",
+    "_links": {
+        "self": {
+            "href": "@string@"
+        }
+    }
+}

--- a/tests/Responses/Expected/product_association_type/update_validation_fail_response.json
+++ b/tests/Responses/Expected/product_association_type/update_validation_fail_response.json
@@ -1,0 +1,41 @@
+{
+    "code": 400,
+    "message": "Validation Failed",
+    "errors": {
+        "children": {
+            "translations": {
+                "children": {
+                    "en_US": {
+                        "children": {
+                            "name": {
+                                "errors": [
+                                    "Please enter association type name."
+                                ]
+                            }
+                        }
+                    },
+                    "nl_NL": {
+                        "children": {
+                            "name": {
+                                "errors": [
+                                    "Please enter association type name."
+                                ]
+                            }
+                        }
+                    },
+                    "fr_FR": {
+                        "children": {
+                            "name": {}
+                        }
+                    },
+                    "de_CH": {
+                        "children": {
+                            "name": {}
+                        }
+                    }
+                }
+            },
+            "code": {}
+        }
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | kind of |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

API endpoints for product association types were missing.