### PR TITLE
Allow .woff2 files in platform.sh config

### DIFF
--- a/docs/cookbook/platform-sh.rst
+++ b/docs/cookbook/platform-sh.rst
@@ -95,6 +95,7 @@ This is how this file should look like for Sylius:
           - \.ttf$
           - \.eot$
           - \.woff$
+          - \.woff2$
           - \.otf$
 
           - /robots\.txt$


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |

Sylius admin tries to load a .woff2 file (icons.woff2) but the platform.sh config does not allow it which results in a 404.