### PR TITLE
Payment description configurable with translation and placeholders (Sylius/Sylius#7971)

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Provider/PaymentDescriptionProvider.php
+++ b/src/Sylius/Bundle/PayumBundle/Provider/PaymentDescriptionProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\PayumBundle\Provider;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * @author Stefan Doorn <stefan@efectos.nl>
+ */
+final class PaymentDescriptionProvider implements PaymentDescriptionProviderInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPaymentDescription(PaymentInterface $payment)
+    {
+        /** @var OrderInterface $order */
+        $order = $payment->getOrder();
+
+        return $this->translator->transChoice(
+            'sylius.payum_action.payment.description',
+            $order->getItems()->count(),
+            [
+                '%items%' => $order->getItems()->count(),
+                '%total%' => round($order->getTotal() / 100, 2),
+            ]
+        );
+    }
+}

--- a/src/Sylius/Bundle/PayumBundle/Provider/PaymentDescriptionProviderInterface.php
+++ b/src/Sylius/Bundle/PayumBundle/Provider/PaymentDescriptionProviderInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Bundle\PayumBundle\Provider;
+
+use Sylius\Component\Core\Model\PaymentInterface;
+
+/**
+ * @author Stefan Doorn <stefan@efectos.nl>
+ */
+interface PaymentDescriptionProviderInterface
+{
+    /**
+     * @param PaymentInterface $payment
+     *
+     * @return string
+     */
+    public function getPaymentDescription(PaymentInterface $payment);
+}

--- a/src/Sylius/Bundle/PayumBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/config/services.xml
@@ -21,6 +21,7 @@
         <import resource="services/controller.xml" />
         <import resource="services/extension.xml" />
         <import resource="services/form.xml" />
+        <import resource="services/provider.xml" />
     </imports>
 
     <services>

--- a/src/Sylius/Bundle/PayumBundle/Resources/config/services/action.xml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/config/services/action.xml
@@ -7,6 +7,7 @@
     <services>
         <!-- Generic -->
         <service id="sylius.payum_action.capture_payment" class="Sylius\Bundle\PayumBundle\Action\CapturePaymentAction">
+            <argument type="service" id="sylius.payment_description_provider" />
             <tag name="payum.action" all="true" alias="sylius.capture_payment" />
         </service>
         <service id="sylius.payum_action.execute_same_request_with_payment_details" class="Sylius\Bundle\PayumBundle\Action\ExecuteSameRequestWithPaymentDetailsAction">

--- a/src/Sylius/Bundle/PayumBundle/Resources/config/services/provider.xml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/config/services/provider.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="sylius.payment_description_provider" class="Sylius\Bundle\PayumBundle\Provider\PaymentDescriptionProvider">
+            <argument type="service" id="translator" />
+        </service>
+    </services>
+</container>

--- a/src/Sylius/Bundle/PayumBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/translations/messages.en.yml
@@ -15,3 +15,6 @@ sylius:
         offline: Offline
         paypal_express_checkout: Paypal express checkout
         stripe_checkout: Stripe checkout
+    payum_action:
+        payment:
+            description: Payment contains %items% item for a total of %total%|Payment contains %items% items for a total of %total%

--- a/src/Sylius/Bundle/PayumBundle/spec/Action/CapturePaymentActionSpec.php
+++ b/src/Sylius/Bundle/PayumBundle/spec/Action/CapturePaymentActionSpec.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace spec\Sylius\Bundle\PayumBundle\Action;
+
+use Payum\Core\Action\GatewayAwareAction;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\GatewayInterface;
+use Payum\Core\Request\Capture;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\PayumBundle\Action\CapturePaymentAction;
+use Sylius\Bundle\PayumBundle\Provider\PaymentDescriptionProviderInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+
+/**
+ * @author Stefan Doorn <stefan@efectos.nl>
+ */
+final class CapturePaymentActionSpec extends ObjectBehavior
+{
+    function let(PaymentDescriptionProviderInterface $paymentDescriptionProvider)
+    {
+        $this->beConstructedWith($paymentDescriptionProvider);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(CapturePaymentAction::class);
+    }
+
+    function it_extends_gateway_aware_action()
+    {
+        $this->shouldHaveType(GatewayAwareAction::class);
+    }
+
+    function it_should_throw_exception_when_unsupported_request(Capture $capture)
+    {
+        $this->shouldThrow('\Payum\Core\Exception\RequestNotSupportedException')->duringExecute($capture);
+    }
+
+    function it_should_perform_basic_capture(
+        PaymentDescriptionProviderInterface $paymentDescriptionProvider,
+        GatewayInterface $gateway,
+        Capture $capture,
+        PaymentInterface $payment,
+        OrderInterface $order
+    ) {
+        $this->setGateway($gateway);
+
+        $payment->getOrder()->willReturn($order);
+        $payment->getDetails()->willReturn([]);
+        $capture->getModel()->willReturn($payment);
+
+        $payment->setDetails([])->shouldBeCalled();
+        $capture->setModel(new ArrayObject())->shouldBeCalled();
+
+        $this->execute($capture);
+    }
+}

--- a/src/Sylius/Bundle/PayumBundle/spec/Provider/PaymentDescriptionProviderSpec.php
+++ b/src/Sylius/Bundle/PayumBundle/spec/Provider/PaymentDescriptionProviderSpec.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace spec\Sylius\Bundle\PayumBundle\Provider;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Sylius\Bundle\PayumBundle\Provider\PaymentDescriptionProvider;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItem;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * @author Stefan Doorn <stefan@efectos.nl>
+ */
+final class PaymentDescriptionProviderSpec extends ObjectBehavior
+{
+    function let(TranslatorInterface $translator)
+    {
+        $translator->transChoice('sylius.payum_action.payment.description', 2, [
+            '%items%' => 2,
+            '%total%' => 100.00,
+        ])->willReturn('Payment contains 2 items for a total of 100');
+
+        $this->beConstructedWith($translator);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PaymentDescriptionProvider::class);
+    }
+
+    function it_should_generate_a_description_string(PaymentInterface $payment, OrderInterface $order)
+    {
+        $order->getItems()->willReturn(new ArrayCollection([new OrderItem(), new OrderItem()]));
+        $order->getTotal()->willReturn(10000);
+        $payment->getOrder()->willReturn($order);
+
+        $this->getPaymentDescription($payment)->shouldReturn('Payment contains 2 items for a total of 100');
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | fixes #7971 |
| License         | MIT |

Made a quick concept for #7971. Added some of the order/payment object variables, but list can be way longer. Can also be automated to get all properties from an entity maybe.

Looking forward for feedback on it. 