### PR TITLE
Update redirect after email verification

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/shop_user.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/shop_user.yml
@@ -13,4 +13,4 @@ sylius_shop_user_verification:
     defaults:
         _controller: sylius.controller.shop_user:verifyAction
         _sylius:
-            redirect: sylius_shop_homepage
+            redirect: sylius_shop_account_dashboard


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

Usually, after successful registration, users will immediately check the post and follow the link in the email and thinking that have already entered, but it is not. This changes will redirect user to login page or to account dashboard.