### PR TITLE
Update label for street field in address form

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.en.yml
@@ -8,7 +8,7 @@ sylius:
             last_name: Last name
             phone_number: Phone number
             postcode: Postcode
-            street: Street
+            street: Street address
             province: Province
             zone: Zone
         country:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

Usually street field is called 'Street address'. Because it's not just the name of the street.