### PR TITLE
Do not overwrite user changes after PRE_EMAIL_VERIFICATION

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Controller/UserController.php
+++ b/src/Sylius/Bundle/UserBundle/Controller/UserController.php
@@ -164,12 +164,12 @@ class UserController extends ResourceController
             return $this->redirectToRoute($redirectRoute);
         }
 
-        $eventDispatcher = $this->container->get('event_dispatcher');
-        $eventDispatcher->dispatch(UserEvents::PRE_EMAIL_VERIFICATION, new GenericEvent($user));
-
         $user->setVerifiedAt(new \DateTime());
         $user->setEmailVerificationToken(null);
         $user->enable();
+
+        $eventDispatcher = $this->container->get('event_dispatcher');
+        $eventDispatcher->dispatch(UserEvents::PRE_EMAIL_VERIFICATION, new GenericEvent($user));
 
         $this->manager->flush();
 


### PR DESCRIPTION
Current event dispatching positioning does not allow to keep user disabled after the registration. `$user->disable()` would be overwritten with `$user->enable()` in this case.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |
