### PR TITLE
Add layout events for head & body

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
@@ -2,6 +2,8 @@
 
 <html lang="{{ app.request.locale|slice(0, 2) }}">
 <head>
+    {{ sonata_block_render_event('sylius.shop.layout.before_head') }}
+
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
@@ -17,9 +19,12 @@
 
         {{ sonata_block_render_event('sylius.shop.layout.stylesheets') }}
     {% endblock %}
+
+    {{ sonata_block_render_event('sylius.shop.layout.after_head') }}
 </head>
 
 <body class="pushable">
+{{ sonata_block_render_event('sylius.shop.layout.before_body') }}
 <div class="pusher">
     {% block top %}
         <div id="menu" class="ui large sticky inverted stackable menu">
@@ -69,5 +74,6 @@
 {% endblock %}
 
 {% include '@SyliusUi/Modal/_confirmation.html.twig' %}
+{{ sonata_block_render_event('sylius.shop.layout.after_body') }}
 </body>
 </html>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| License         | MIT |

Makes it easier for plugin development to add things to head / end of body etc.