### PR TITLE
[Docs] Adjust paths in Docs/Book/Architecture/Emails & Contact

### DIFF
--- a/docs/book/architecture/contact.rst
+++ b/docs/book/architecture/contact.rst
@@ -40,7 +40,7 @@ The routing for contact can be found in the ``Sylius/Bundle/ShopBundle/Resources
 By overriding that routing you will be able to customize **redirect url, error flash, success flash, form and its template**.
 
 You can also change the template of the email that is being sent by simply overriding it
-in your project in the ``app/Resources/SyliusCoreBundle/views/Email/contactRequest.html.twig`` file.
+in your project in the ``app/Resources/SyliusShopBundle/views/Email/contactRequest.html.twig`` file.
 
 Learn more
 ----------

--- a/docs/book/architecture/emails.rst
+++ b/docs/book/architecture/emails.rst
@@ -14,7 +14,7 @@ Every time a customer registers via the registration form, a user registration e
 
 **Code**: ``user_registration``
 
-**The default template**: ``SyliusCoreBundle:Email:userRegistration.html.twig``
+**The default template**: ``SyliusShopBundle:Email:userRegistration.html.twig``
 
 You also have the following parameters available:
 
@@ -27,7 +27,7 @@ When a customer registers via the registration form, besides the User Confirmati
 
 **Code**: ``verification_token``
 
-**The default template**: ``SyliusCoreBundle:Email:verification.html.twig``
+**The default template**: ``SyliusShopBundle:Email:verification.html.twig``
 
 You also have the following parameters available:
 
@@ -40,7 +40,7 @@ This e-mail is used when the user requests to reset their password in the login 
 
 **Code**: ``reset_password_token``
 
-**The default template**: ``SyliusCoreBundle:Email:passwordReset.html.twig``
+**The default template**: ``SyliusShopBundle:Email:passwordReset.html.twig``
 
 You also have the following parameters available:
 
@@ -53,7 +53,7 @@ This e-mail is sent when order is placed.
 
 **Code**: ``order_confirmation``
 
-**The default template**: ``SyliusCoreBundle:Email:orderConfirmation.html.twig``
+**The default template**: ``SyliusShopBundle:Email:orderConfirmation.html.twig``
 
 You also have the following parameters available:
 
@@ -66,7 +66,7 @@ This e-mail is sent when the order's shipping process has started.
 
 **Code**: ``shipment_confirmation``
 
-**The default template**: ``SyliusCoreBundle:Email:shipmentConfirmation.html.twig``
+**The default template**: ``SyliusAdminBundle:Email:shipmentConfirmation.html.twig``
 
 You have the following parameters available:
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no|
| BC breaks?      | no|
| License         | MIT |

Wrong paths are mentioned in the docs about the location of the email templates. The upgrade file mentioned them, but docs were not adjusted accordingly.