### PR TITLE
Add a class to the variant price cell for better JS targeting

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-variants-prices.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-variants-prices.js
@@ -44,7 +44,7 @@ function handleProductOptionsChange() {
 
 function handleProductVariantsChange() {
     $('[name="sylius_add_to_cart[cartItem][variant]"]').on('change', function() {
-        var $price = $(this).parents('tr').find('td:nth-child(2)').text();
+        var $price = $(this).parents('tr').find('.sylius-product-variant-price').text();
         $('#product-price').text($price);
     });
 }

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_variants.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_variants.html.twig
@@ -23,7 +23,7 @@
                     </div>
                 {% endif %}
             </td>
-            <td>{{ money.calculatePrice(variant) }}</td>
+            <td class="sylius-product-variant-price">{{ money.calculatePrice(variant) }}</td>
             <td class="right aligned">
                 {{ form_widget(form.cartItem.variant[loop.index0], {'label': false}) }}
             </td>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

The `handleProductVariantsChange` JavaScript function is a little not optimal in that it searches for the price based a cell in a specific position in the table.  Instead of doing this, let's add a class to that cell and target that in the function instead.  With this, you wouldn't need to override this function if you change the layout file going forward.