### PR TITLE
Remove invalid placeholder arguments

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/assets.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/assets.xml
@@ -30,7 +30,7 @@
         <!-- Overridden services -->
         <service id="assets.path_package" class="Sylius\Bundle\ThemeBundle\Asset\Package\PathPackage" abstract="true">
             <argument /> <!-- base path -->
-            <argument type="service" /> <!-- version strategy -->
+            <argument /> <!-- version strategy -->
             <argument type="service" id="sylius.context.theme" />
             <argument type="service" id="sylius.theme.asset.path_resolver" />
             <argument type="service" id="assets.context" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | https://github.com/symfony/symfony/pull/22529 |
| License         | MIT |

This fixes an issue with Symfony 3.3 (currently in Beta): service arguments are now required to have an ID. Since the argument is replaced by a compiler pass, we can omit the type.