### PR TITLE
Add support for a Composer script to install theme assets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -149,7 +149,7 @@
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
+            "Sylius\\Bundle\\ThemeBundle\\Composer\\ScriptHandler::installThemeAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
         ],
@@ -157,7 +157,7 @@
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
+            "Sylius\\Bundle\\ThemeBundle\\Composer\\ScriptHandler::installThemeAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
         ]

--- a/docs/bundles/SyliusThemeBundle/important_changes.rst
+++ b/docs/bundles/SyliusThemeBundle/important_changes.rst
@@ -31,12 +31,16 @@ Changed loading order (priority descending):
 Assets
 ------
 
-Theme assets are installed by ``sylius:theme:assets:install`` command, which is supplementary for and should be used after ``assets:install``.
+Theme assets are installed by ``sylius:theme:assets:install`` command, which is supplementary for and replaces ``assets:install``.
 
 The command run with ``--symlink`` or ``--relative`` parameters creates symlinks for every installed asset file,
-not for entire asset directory (eg. if ``AcmeBundle/Resources/public/asset.js`` exists, it creates symlink ``web/bundles/acme/asset.js`` 
-leading to ``AcmeBundle/Resources/public/asset.js`` instead of symlink ``web/bundles/acme/`` leading to ``AcmeBundle/Resources/public/``). 
+not for entire asset directory (eg. if ``AcmeBundle/Resources/public/asset.js`` exists, it creates symlink ``web/bundles/acme/asset.js``
+leading to ``AcmeBundle/Resources/public/asset.js`` instead of symlink ``web/bundles/acme/`` leading to ``AcmeBundle/Resources/public/``).
 When you create a new asset or delete an existing one, it is required to rerun this command to apply changes (just as the hard copy option works).
+
+When using themes, you can also trigger this command as a Composer script. In your ``composer.json`` file, replace
+the calls for ``"Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets"`` in the ``post-install-cmd``
+and ``post-update-cmd`` script sections with ``"Sylius\\Bundle\\ThemeBundle\\Composer\\ScriptHandler::installThemeAssets"``.
 
 Assetic
 -------

--- a/src/Sylius/Bundle/ThemeBundle/Composer/ScriptHandler.php
+++ b/src/Sylius/Bundle/ThemeBundle/Composer/ScriptHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ThemeBundle\Composer;
+
+use Composer\Script\Event;
+use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as BaseScriptHandler;
+
+class ScriptHandler extends BaseScriptHandler
+{
+    /**
+     * Installs the Sylius theme assets under the web root directory.
+     *
+     * For better interoperability, assets are copied instead of symlinked by default.
+     *
+     * Even if symlinks work on Windows, this is only true on Windows Vista and later,
+     * but then, only when running the console with admin rights or when disabling the
+     * strict user permission checks (which can be done on Windows 7 but not on Windows
+     * Vista).
+     *
+     * @param Event $event
+     */
+    public static function installThemeAssets(Event $event)
+    {
+        $options = static::getOptions($event);
+        $consoleDir = static::getConsoleDir($event, 'install assets');
+
+        if (null === $consoleDir) {
+            return;
+        }
+
+        $webDir = $options['symfony-web-dir'];
+
+        $symlink = '';
+        if ('symlink' == $options['symfony-assets-install']) {
+            $symlink = '--symlink ';
+        } elseif ('relative' == $options['symfony-assets-install']) {
+            $symlink = '--symlink --relative ';
+        }
+
+        if (!static::hasDirectory($event, 'symfony-web-dir', $webDir, 'install Sylius theme assets')) {
+            return;
+        }
+
+        static::executeCommand($event, $consoleDir, 'sylius:theme:assets:install '.$symlink.escapeshellarg($webDir), $options['process-timeout']);
+    }
+}

--- a/src/Sylius/Bundle/ThemeBundle/composer.json
+++ b/src/Sylius/Bundle/ThemeBundle/composer.json
@@ -23,6 +23,7 @@
         "php": "^7.1",
 
         "doctrine/common": "^2.5",
+        "sensio/distribution-bundle": "^5.0",
         "symfony/symfony": "^3.2",
         "zendframework/zend-hydrator": "^2.2"
     },


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

Symfony (through the `SensioDistributionBundle`) has a hook point to trigger the `assets:install` command after a `composer install` or `composer update`.  When using the `SyliusThemeBundle`, you basically need to run `sylius:theme:assets:install` at the same time to handle having assets installed in the right place.  To simplify this, we can also create a Composer hook to do the job for us.

This PR adds a new class extending `Sensio\Bundle\DistributionBundle\Composer\ScriptHandler` to add support for triggering the `sylius:theme:assets:install` command.  To use it, one would just need to add `"Sylius\\Bundle\\ThemeBundle\\Composer\\ScriptHandler::installThemeAssets"` to their `post-install-cmd` and `post-update-cmd` scripts.