### PR TITLE
Move the before head hook lower due to conflict with W3 specs

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
@@ -2,8 +2,6 @@
 
 <html lang="{{ app.request.locale|slice(0, 2) }}">
 <head>
-    {{ sonata_block_render_event('sylius.shop.layout.before_head') }}
-
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
@@ -20,7 +18,7 @@
         {{ sonata_block_render_event('sylius.shop.layout.stylesheets') }}
     {% endblock %}
 
-    {{ sonata_block_render_event('sylius.shop.layout.after_head') }}
+    {{ sonata_block_render_event('sylius.shop.layout.head') }}
 </head>
 
 <body class="pushable">


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no|
| BC breaks?      | no |
| Related tickets | mentioned in https://github.com/Sylius/Sylius/pull/7999#issuecomment-300183360 |
| License         | MIT |

As @psren pointed out in the comment linked above, it might be better to move the 'before_head' listener a bit lower based on this information: https://www.w3.org/International/questions/qa-html-encoding-declarations.

Also it seems that the X-UA-Compatible meta tag should be high too: https://msdn.microsoft.com/en-us/library/jj676915%28v=vs.85%29.aspx.