### PR TITLE
[Symfony 3.3] Remove trusted_proxies config

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -21,7 +21,6 @@ framework:
     validation: { enable_annotations: true }
     templating: { engines: ["twig"] }
     default_locale: "%locale%"
-    trusted_proxies: ~
     session:
         handler_id: ~
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

This removes `trusted_proxies` config from `app/config/config.yml` since it results in the following exception on Symfony 3.3:

```
[InvalidArgumentException]
The "framework.trusted_proxies" configuration key has been removed in Symfony
3.3. Use the Request::setTrustedProxies() method in your front controller instead.
```