### PR TITLE
Add section for 1.0.0 upgrade & document change in PayumBundle (UPGRADE.MD)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,11 @@
+# UPGRADE FROM 1.0.0-beta.2 to 1.0.0
+
+## Packages:
+
+### PayumBundle
+
+* Constructor of `CapturePaymentAction` now takes a `PaymentDescriptionProviderInterface` as first argument. This allows granular customisation of the payment description.
+
 # UPGRADE FROM 1.0.0-beta.1 to 1.0.0-beta.2
 
 * Bundles, container extensions and bundles configurations were made final and can't be extended anymore, follow Symfony


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | no|
| BC breaks?      | no|
| Related tickets | mentioned in #7979 |
| License         | MIT |

@lchrusciel There was no section yet for 1.0.0, so I've added it in the same style as beta1 -> beta2. Hopefully this is what you meant.