### PR TITLE
[Docs] Adjust instructions for customizing model with translations (fixes #7914)

### DIFF
--- a/docs/customization/model.rst
+++ b/docs/customization/model.rst
@@ -184,15 +184,15 @@ Just like for regular models you can also check the class of translatable models
         /**
          * {@inheritdoc}
          */
-        public static function getTranslationClass()
+        protected function createTranslation()
         {
-            return ShippingMethodTranslation::class;
+            return new ShippingMethodTranslation();
         }
     }
 
 .. note::
 
-    Remember to set the translation class properly, just like above in the ``getTranslationClass()`` method.
+    Remember to set the translation class properly, just like above in the ``createTranslation()`` method.
 
 **2.** Next define your entity's mapping.
 
@@ -359,12 +359,12 @@ The file should be placed in ``AppBundle/Resources/config/doctrine/ShippingMetho
             return $this->getTranslation()->getDeliveryConditions();
         }
 
-       /**
+        /**
          * {@inheritdoc}
          */
-        public static function getTranslationClass()
+        protected function createTranslation()
         {
-            return ShippingMethodTranslation::class;
+            return new ShippingMethodTranslation();
         }
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #7914 |
| License         | MIT |

It seems the docs describe usage of a static method to point to the proper translation class. In #7914 @lasotaartur showed that that doesn't work and that it works by overriding the `createTranslation` method in the entity class. Instead of rewriting the code to make it work with the static method call, I've adjusted the docs. I have the impression static method calls are not used that often in Sylius anyway, so it feels a bit out of style :)