### PR TITLE
[Ui] Fixed cart's layout

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_coupon.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_coupon.html.twig
@@ -1,4 +1,4 @@
-<div id="sylius-coupon">
+<div id="sylius-coupon" class="coupon field">
     <div class="ui coupon action input">
         {{ form_widget(form, {'attr': {'placeholder': 'sylius.ui.enter_your_code'|trans~'...'}}) }}
         <button type="submit" id="sylius-save" class="ui teal icon labeled button"><i class="ticket icon"></i> {{ 'sylius.ui.apply_coupon'|trans }}</button>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_totals.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_totals.html.twig
@@ -21,7 +21,7 @@
             <td id="sylius-cart-promotion-total" class="right aligned">{{ money.convertAndFormat(cart.orderPromotionTotal) }}</td>
         </tr>
         {% endif %}
-        <tr style="font-size: 2em;">
+        <tr class="grand total">
             <td>{{ 'sylius.ui.order_total'|trans }}:</td>
             <td id="sylius-cart-grand-total" class="right aligned">{{ money.convertAndFormat(cart.total) }}</td>
         </tr>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Order/Table/_totals.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Order/Table/_totals.html.twig
@@ -17,7 +17,7 @@
     {% include '@SyliusShop/Common/Order/Table/_promotion.html.twig' with {'order': order} %}
 </tr>
 <tr>
-    <td colspan="4" class="right aligned" style="font-size: 1.5em;" id="total">
+    <td colspan="4" class="right aligned grand total" id="total">
         {{ 'sylius.ui.total'|trans }}: {{ money.format(order.total, order.currencyCode) }}
     </td>
 </tr>

--- a/src/Sylius/Bundle/UiBundle/Resources/private/sass/main.scss
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/sass/main.scss
@@ -110,6 +110,9 @@ th {
   right: 0;
   left: auto;
 }
+div.coupon.field {
+  width: 75% !important;
+}
 
 .ui.table tr[class*="grand total"] {
   font-size: 2em;
@@ -119,6 +122,10 @@ th {
 }
 
 @media only screen and (max-width: 1200px) {
+  div.coupon.field {
+    width: 100% !important;
+  }
+
   .ui.table [class*="single line"], .ui.table[class*="single line"] {
     white-space: normal;
   }

--- a/src/Sylius/Bundle/UiBundle/Resources/private/sass/main.scss
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/sass/main.scss
@@ -110,3 +110,22 @@ th {
   right: 0;
   left: auto;
 }
+
+.ui.table tr[class*="grand total"] {
+  font-size: 2em;
+}
+.ui.table td[class*="grand total"] {
+  font-size: 1.5em;
+}
+
+@media only screen and (max-width: 1200px) {
+  .ui.table [class*="single line"], .ui.table[class*="single line"] {
+    white-space: normal;
+  }
+}
+@media only screen and (min-width: 767px) and (max-width: 1200px) {
+  .ui.table tr[class*="grand total"], .ui.table td[class*="grand total"] {
+    font-size: 1em;
+    font-weight: bold;
+  }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

Although it still needs some work regarding the image placement, at least now you can clearly see the prices and coupon field.

# >1200px
## Before
![screen shot 2017-05-16 at 12 56 55](https://cloud.githubusercontent.com/assets/9448101/26103079/2601d9b2-3a38-11e7-8324-d8e3f8f849e1.png)
## After
![screen shot 2017-05-16 at 12 48 41](https://cloud.githubusercontent.com/assets/9448101/26103148/6a31a3ba-3a38-11e7-9626-e352a2d01af2.png)

# 1200~991px
## Before
![screen shot 2017-05-16 at 12 57 48](https://cloud.githubusercontent.com/assets/9448101/26103199/a53a2586-3a38-11e7-9760-910ac1fb65b9.png)
## After
![screen shot 2017-05-16 at 12 49 06](https://cloud.githubusercontent.com/assets/9448101/26103212/b4a9cbb6-3a38-11e7-9a8d-83e7ea3e95e4.png)

# 991~767px
## Before
![screen shot 2017-05-16 at 12 58 01](https://cloud.githubusercontent.com/assets/9448101/26103276/05f185cc-3a39-11e7-9170-d8d37637a509.png)
## After
![screen shot 2017-05-16 at 13 00 37](https://cloud.githubusercontent.com/assets/9448101/26103285/0fa96508-3a39-11e7-8b7f-db6589ad52a2.png)

# <767px
## Before
![screen shot 2017-05-16 at 12 58 16](https://cloud.githubusercontent.com/assets/9448101/26103319/337c4482-3a39-11e7-835d-0ac73e970801.png)
![screen shot 2017-05-16 at 12 58 25](https://cloud.githubusercontent.com/assets/9448101/26103327/3733e558-3a39-11e7-9bbc-76123cd6e3df.png)
## After
![screen shot 2017-05-16 at 12 49 27](https://cloud.githubusercontent.com/assets/9448101/26103336/3d40c934-3a39-11e7-85f9-dfc63a8bf4e9.png)
![screen shot 2017-05-16 at 12 49 39](https://cloud.githubusercontent.com/assets/9448101/26103340/40d3fc10-3a39-11e7-9f73-8e39f5b77b41.png)
