### PR TITLE
Remove count constraint on option values collection

### DIFF
--- a/features/product/managing_product_options/adding_product_option.feature
+++ b/features/product/managing_product_options/adding_product_option.feature
@@ -18,3 +18,23 @@ Feature: Adding a new product option
         And I add it
         Then I should be notified that it has been successfully created
         And the product option "T-Shirt size" should appear in the registry
+
+    @ui
+    Scenario: Adding a new product option without any option values
+        Given I want to create a new product option
+        When I name it "T-Shirt size" in "English (United States)"
+        And I specify its code as "t_shirt_size"
+        But I do not add an option value
+        And I try to add it
+        Then I should be notified that it has been successfully created
+        And the product option "T-Shirt size" should appear in the registry
+
+    @ui @javascript
+    Scenario: Adding a new product option with one option value
+        Given I want to create a new product option
+        When I name it "T-Shirt size" in "English (United States)"
+        And I specify its code as "t_shirt_size"
+        And I add the "S" option value identified by "OV1"
+        And I try to add it
+        Then I should be notified that it has been successfully created
+        And the product option "T-Shirt size" should appear in the registry

--- a/features/product/managing_product_options/product_option_validation.feature
+++ b/features/product/managing_product_options/product_option_validation.feature
@@ -38,23 +38,3 @@ Feature: Product option validation
         And I try to save my changes
         Then I should be notified that name is required
         And this product option should still be named "T-Shirt color"
-
-    @ui
-    Scenario: Trying to add a new product option without any option values
-        Given I want to create a new product option
-        When I name it "T-Shirt size" in "English (United States)"
-        And I specify its code as "t_shirt_size"
-        But I do not add an option value
-        And I try to add it
-        Then I should be notified that at least two option values are required
-        And the product option with name "T-Shirt size" should not be added
-
-    @ui @javascript
-    Scenario: Trying to add a new product option with one option value
-        Given I want to create a new product option
-        When I name it "T-Shirt size" in "English (United States)"
-        And I specify its code as "t_shirt_size"
-        And I add the "S" option value identified by "OV1"
-        And I try to add it
-        Then I should be notified that at least two option values are required
-        And the product option with name "T-Shirt size" should not be added

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/validation/ProductOption.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/validation/ProductOption.xml
@@ -31,11 +31,6 @@
         </property>
         <property name="values">
             <constraint name="Valid" />
-            <constraint name="Count">
-                <option name="min">2</option>
-                <option name="minMessage">sylius.option.values.min_count</option>
-                <option name="groups">sylius</option>
-            </constraint>
         </property>
         <property name="translations">
             <constraint name="Valid" />

--- a/tests/Responses/Expected/product_option/create_validation_fail_response.json
+++ b/tests/Responses/Expected/product_option/create_validation_fail_response.json
@@ -2,9 +2,6 @@
     "code": 400,
     "message": "Validation Failed",
     "errors": {
-        "errors": [
-            "Please add at least 2 option values."
-        ],
         "children": {
             "position": {},
             "translations": {},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | / |
| License         | MIT |

Currently, a product option must have at least two values for it to be valid. While it may not make a lot of sense to have product options with only one value, there is also no reason for those options not to exist.

In our case, a product may be available in one or more colors. Since colors in a clothing store range from your usual colors (red, blue, green) to weird combinations (striped red and blue) we create a new option for each product using the API. However, if a product were only available in a single color, that color would have to be added as an attribute, which makes looking for all products that are available in a blueish (= color field contains "blue") color difficult.

Unfortunately, removing this limit is not possible without re-implementing the `ProductOption` entity completely, which we'd like to avoid (validation constraints can only be added, not removed in an extending class).