### PR TITLE
Add a method for finding all children of a taxonomy node, use this for the main taxon menu

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/taxon.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/taxon.yml
@@ -28,3 +28,16 @@ sylius_shop_partial_taxon_index_by_code:
                 arguments:
                     - $code
                     - "expr:service('sylius.context.locale').getLocaleCode()"
+
+sylius_shop_partial_taxon_index_all_by_code:
+    path: /all-by-code/{code}
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.taxon:indexAction
+        _sylius:
+            template: $template
+            repository:
+                method: findAllChildren
+                arguments:
+                    - $code
+                    - "expr:service('sylius.context.locale').getLocaleCode()"

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_horizontalMenu.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_horizontalMenu.html.twig
@@ -21,7 +21,9 @@
 {% if taxons|length > 0 %}
 <div class="ui large stackable menu">
     {% for taxon in taxons %}
-        {{ macros.item(taxon) }}
+        {% if taxon.level == 1 %}
+            {{ macros.item(taxon) }}
+        {% endif %}
     {% endfor %}
 </div>
 {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_horizontalMenu.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_horizontalMenu.html.twig
@@ -21,7 +21,7 @@
 {% if taxons|length > 0 %}
 <div class="ui large stackable menu">
     {% for taxon in taxons %}
-        {% if taxon.level == 1 %}
+        {% if taxon.parent.code == app.request.get('code') %}
             {{ macros.item(taxon) }}
         {% endif %}
     {% endfor %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
@@ -46,7 +46,7 @@
 
                 {{ sonata_block_render_event('sylius.shop.layout.after_header') }}
 
-                {{ render(url('sylius_shop_partial_taxon_index_by_code', {'code': 'category', 'template': '@SyliusShop/Taxon/_horizontalMenu.html.twig'})) }}
+                {{ render(url('sylius_shop_partial_taxon_index_all_by_code', {'code': 'category', 'template': '@SyliusShop/Taxon/_horizontalMenu.html.twig'})) }}
             </header>
         {% endblock %}
 

--- a/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
@@ -25,6 +25,34 @@ class TaxonRepository extends EntityRepository implements TaxonRepositoryInterfa
     /**
      * {@inheritdoc}
      */
+    public function findAllChildren($parentCode, $locale = null)
+    {
+        // Get the root node first
+        /** @var \Sylius\Component\Taxonomy\Model\TaxonInterface $rootNode */
+        $rootNode = $this->createQueryBuilder('o')
+            ->where('o.code = :code')
+            ->setParameter('code', $parentCode)
+            ->getQuery()
+            ->getSingleResult();
+
+        return $this->createTranslationBasedQueryBuilder($locale)
+            ->addSelect('child')
+            ->innerJoin('o.parent', 'parent')
+            ->leftJoin('o.children', 'child')
+            ->andWhere('o.left > :treeLeft')
+            ->andWhere('o.right < :treeRight')
+            ->addOrderBy('o.level', 'ASC')
+            ->addOrderBy('o.position', 'ASC')
+            ->setParameter('treeLeft', $rootNode->getLeft())
+            ->setParameter('treeRight', $rootNode->getRight())
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function findChildren($parentCode, $locale = null)
     {
         return $this->createTranslationBasedQueryBuilder($locale)

--- a/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
+++ b/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
@@ -31,6 +31,14 @@ interface TaxonRepositoryInterface extends RepositoryInterface
      *
      * @return TaxonInterface[]
      */
+    public function findAllChildren($parentCode, $locale = null);
+
+    /**
+     * @param string $parentCode
+     * @param string|null $locale
+     *
+     * @return TaxonInterface[]
+     */
     public function findChildren($parentCode, $locale = null);
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | yes |
| Related tickets | N/A |
| License         | MIT |

Right now, rendering the main taxon menu can be a little not performant because the children for each level 1 item must be queried separately (in one of my builds, this resulted in a lot of extra queries for each level 1's children, then each level 2's children, etc.).  My way around this was to create a new repository method that would find all of the children for a given code and load those.

So this PR adds a new partial route making use of the new repository method and changes the `_horizontalMenu` layout to account for this.  The repository method doesn't place items in a proper tree structure, so the most efficient thing was to explicitly check for the top level items in this layout.

### B/C Breaks

- A new method in `TaxonRepositoryInterface`
- ~~The `_horizontalMenu` layout loses some reusability by adding the `{% if taxon.level == 1 %}` check, it basically makes this layout only work with this new repository method and only when loading all children of a root node (i.e. the category root)~~