### PR TITLE
Deprecated 'property' form option

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/Form/Builder/DefaultFormBuilder.php
+++ b/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/Form/Builder/DefaultFormBuilder.php
@@ -69,7 +69,7 @@ class DefaultFormBuilder implements DefaultFormBuilderInterface
 
         foreach ($classMetadata->getAssociationMappings() as $fieldName => $associationMapping) {
             if (ClassMetadataInfo::ONE_TO_MANY !== $associationMapping['type']) {
-                $formBuilder->add($fieldName, null, ['property' => 'id']);
+                $formBuilder->add($fieldName, null, ['choice_label' => 'id']);
             }
         }
     }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Doctrine/ORM/Form/Builder/DefaultFormBuilderSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Doctrine/ORM/Form/Builder/DefaultFormBuilderSpec.php
@@ -180,7 +180,7 @@ final class DefaultFormBuilderSpec extends ObjectBehavior
         $formBuilder->add('description', null, [])->shouldBeCalled();
         $formBuilder->add('enabled', null, [])->shouldBeCalled();
         $formBuilder->add('publishedAt', null, ['widget' => 'single_text'])->shouldBeCalled();
-        $formBuilder->add('category', null, ['property' => 'id'])->shouldBeCalled();
+        $formBuilder->add('category', null, ['choice_label' => 'id'])->shouldBeCalled();
         $formBuilder->add('users', Argument::cetera())->shouldNotBeCalled();
 
         $this->build($metadata, $formBuilder, []);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Related tickets | 
| License         | MIT |

`property` is no longer available in Symfony > 3.0, it has been replaced by `choice_label`:
http://symfony.com/doc/2.8/reference/forms/types/entity.html#choice-label



