### PR TITLE
Fix self reference in product options API

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductOption.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductOption.yml
@@ -26,7 +26,7 @@ Sylius\Component\Product\Model\ProductOption:
     relations:
         -   rel: self
             href:
-                route: sylius_admin_api_product_show
+                route: sylius_admin_api_product_option_show
                 parameters:
                     code: expr(object.getCode())
                     version: 1

--- a/tests/Responses/Expected/product/create_with_options_response.json
+++ b/tests/Responses/Expected/product/create_with_options_response.json
@@ -33,7 +33,7 @@
             "translations": {},
             "_links": {
                 "self": {
-                    "href": "\/api\/v1\/products\/MUG_SIZE"
+                    "href": "\/api\/v1\/product-options\/MUG_SIZE"
                 }
             }
         },
@@ -45,7 +45,7 @@
             "translations": {},
             "_links": {
                 "self": {
-                    "href": "\/api\/v1\/products\/MUG_COLOR"
+                    "href": "\/api\/v1\/product-options\/MUG_COLOR"
                 }
             }
         }

--- a/tests/Responses/Expected/product_option/create_response.json
+++ b/tests/Responses/Expected/product_option/create_response.json
@@ -48,7 +48,7 @@
     ],
     "_links": {
         "self": {
-            "href": "\/api\/v1\/products\/MUG_SIZE"
+            "href": "\/api\/v1\/product-options\/MUG_SIZE"
         }
     }
 }

--- a/tests/Responses/Expected/product_option/index_response.json
+++ b/tests/Responses/Expected/product_option/index_response.json
@@ -45,7 +45,7 @@
                 ],
                 "_links": {
                     "self": {
-                        "href": "\/api\/v1\/products\/MUG_SIZE"
+                        "href": "\/api\/v1\/product-options\/MUG_SIZE"
                     }
                 }
             },
@@ -57,7 +57,7 @@
                 "values": [],
                 "_links": {
                     "self": {
-                        "href": "\/api\/v1\/products\/MUG_COLOR"
+                        "href": "\/api\/v1\/product-options\/MUG_COLOR"
                     }
                 }
             }

--- a/tests/Responses/Expected/product_option/index_response_after_delete.json
+++ b/tests/Responses/Expected/product_option/index_response_after_delete.json
@@ -24,7 +24,7 @@
                 "values": [],
                 "_links": {
                     "self": {
-                        "href": "\/api\/v1\/products\/MUG_COLOR"
+                        "href": "\/api\/v1\/product-options\/MUG_COLOR"
                     }
                 }
             }

--- a/tests/Responses/Expected/product_option/show_response.json
+++ b/tests/Responses/Expected/product_option/show_response.json
@@ -27,7 +27,7 @@
     ],
     "_links": {
         "self": {
-            "href": "\/api\/v1\/products\/MUG_SIZE"
+            "href": "\/api\/v1\/product-options\/MUG_SIZE"
         }
     }
 }

--- a/tests/Responses/Expected/product_option/show_response_after_partial_update.json
+++ b/tests/Responses/Expected/product_option/show_response_after_partial_update.json
@@ -63,7 +63,7 @@
     ],
     "_links": {
         "self": {
-            "href": "\/api\/v1\/products\/MUG_SIZE"
+            "href": "\/api\/v1\/product-options\/MUG_SIZE"
         }
     }
 }

--- a/tests/Responses/Expected/product_option/show_response_after_update.json
+++ b/tests/Responses/Expected/product_option/show_response_after_update.json
@@ -63,7 +63,7 @@
     ],
     "_links": {
         "self": {
-            "href": "\/api\/v1\/products\/MUG_SIZE"
+            "href": "\/api\/v1\/product-options\/MUG_SIZE"
         }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

Fixes the link generated in the `self` reference when serializing a product option. This incorrectly generated a URL to the product show page.