### PR TITLE
Fix address log entry column names

### DIFF
--- a/app/migrations/Version20170518123056.php
+++ b/app/migrations/Version20170518123056.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20170518123056 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_address_log_entries CHANGE loggedat logged_at DATETIME NOT NULL, CHANGE objectid object_id VARCHAR(64) DEFAULT NULL, CHANGE objectclass object_class VARCHAR(255) NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_address_log_entries CHANGE logged_at loggedAt DATETIME NOT NULL, CHANGE object_id objectId VARCHAR(64) DEFAULT NULL COLLATE utf8_unicode_ci, CHANGE object_class objectClass VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci');
+    }
+}

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/AddressLogEntry.orm.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/doctrine/model/AddressLogEntry.orm.xml
@@ -11,20 +11,18 @@
 
 -->
 
-<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping">
-
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <mapped-superclass name="Sylius\Component\Addressing\Model\AddressLogEntry" table="sylius_address_log_entries">
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />
         </id>
 
-        <field name="action" type="string" />
-        <field name="loggedAt" type="datetime" />
-        <field name="objectId" length="64" nullable="true" />
-        <field name="objectClass" type="string" />
-        <field name="version" type="integer" />
-        <field name="data" type="array" />
-        <field name="username" type="string" nullable="true" />
+        <field name="action" column="action" type="string" />
+        <field name="loggedAt" column="logged_at" type="datetime" />
+        <field name="objectId" column="object_id" length="64" nullable="true" />
+        <field name="objectClass" column="object_class" type="string" />
+        <field name="version" column="version" type="integer" />
+        <field name="data" column="data" type="array" />
+        <field name="username" column="username" type="string" nullable="true" />
     </mapped-superclass>
-
 </doctrine-mapping>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

This uses snake_cased column names for the AddressLogEntry entity, which was missing `column` declaration in mappings. This can cause issues when people change the default naming strategy for ORM and is the only entity that didn't have `column` properties in field mappings.