### PR TITLE
[documentation] Fix ShippingMethodImageType use path

### DIFF
--- a/docs/cookbook/images-on-entity.rst
+++ b/docs/cookbook/images-on-entity.rst
@@ -255,7 +255,7 @@ set the ``allow_add`` option to ``true``.
 
     namespace AppBundle\Form\Extension;
 
-    use AppBundle\Form\Type\ShippingMethod\ShippingMethodImageType;
+    use AppBundle\Form\Type\ShippingMethodImageType;
     use Sylius\Bundle\ShippingBundle\Form\Type\ShippingMethodType;
     use Symfony\Component\Form\AbstractTypeExtension;
     use Symfony\Component\Form\Extension\Core\Type\CollectionType;


### PR DESCRIPTION
The use statement path of class ShippingMethodImageType is wrong.

`use AppBundle\Form\Type\ShippingMethod\ShippingMethodImageType`
 must become
`use AppBundle\Form\Type\ShippingMethodImageType`

| Q               | A
| --------------- | ---
| Doc fix?        | yes |
| New docs?    | no |
| Related tickets |  |
| License         | MIT |
