### PR TITLE
Add alt attribute to main product image

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/_mainImage.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/_mainImage.html.twig
@@ -6,4 +6,4 @@
     {% set path = '//placehold.it/200x200' %}
 {% endif %}
 
-<img src="{{ path }}" alt="" class="ui bordered image" />
+<img src="{{ path }}" alt="{{ product.name }}" class="ui bordered image" />


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no|
| License         | MIT |

ALT tag was empty, but we can easily insert the product name.