### PR TITLE
[documentation] Fix supplier field type

### DIFF
--- a/docs/cookbook/custom-model.rst
+++ b/docs/cookbook/custom-model.rst
@@ -129,7 +129,7 @@ To have templates for your Entity administration out of the box you can use Grid
                         type: string
                         label: sylius.ui.name
                     description:
-                        type: text
+                        type: string
                         label: sylius.ui.description
                     enabled:
                         type: twig


### PR DESCRIPTION
There is no SyliusGridBundle built-in field type called "text". Replaced with "string".

| Q               | A
| --------------- | ---
| Doc fix?        | yes |
| New docs?    | no |
| Related tickets |  |
| License         | MIT |
