### PR TITLE
Use codes of option value & option instead of ID in variant generator

### DIFF
--- a/src/Sylius/Component/Product/Generator/ProductVariantGenerator.php
+++ b/src/Sylius/Component/Product/Generator/ProductVariantGenerator.php
@@ -63,8 +63,8 @@ final class ProductVariantGenerator implements ProductVariantGeneratorInterface
 
         foreach ($product->getOptions() as $key => $option) {
             foreach ($option->getValues() as $value) {
-                $optionSet[$key][] = $value->getId();
-                $optionMap[$value->getId()] = $value;
+                $optionSet[$key][] = $value->getCode();
+                $optionMap[$value->getCode()] = $value;
             }
         }
 
@@ -108,8 +108,8 @@ final class ProductVariantGenerator implements ProductVariantGeneratorInterface
             return;
         }
 
-        foreach ($permutation as $id) {
-            $variant->addOptionValue($optionMap[$id]);
+        foreach ($permutation as $code) {
+            $variant->addOptionValue($optionMap[$code]);
         }
     }
 }

--- a/src/Sylius/Component/Product/spec/Generator/ProductVariantGeneratorSpec.php
+++ b/src/Sylius/Component/Product/spec/Generator/ProductVariantGeneratorSpec.php
@@ -67,9 +67,9 @@ final class ProductVariantGeneratorSpec extends ObjectBehavior
 
         $colorOption->getValues()->willReturn([$blackColor, $whiteColor, $redColor]);
 
-        $blackColor->getId()->willReturn('black1');
-        $whiteColor->getId()->willReturn('white2');
-        $redColor->getId()->willReturn('red3');
+        $blackColor->getCode()->willReturn('black1');
+        $whiteColor->getCode()->willReturn('white2');
+        $redColor->getCode()->willReturn('red3');
 
         $variantsParityChecker->checkParity($permutationVariant, $productVariable)->willReturn(false);
 
@@ -97,9 +97,9 @@ final class ProductVariantGeneratorSpec extends ObjectBehavior
 
         $colorOption->getValues()->willReturn([$blackColor, $whiteColor, $redColor]);
 
-        $blackColor->getId()->willReturn('black1');
-        $whiteColor->getId()->willReturn('white2');
-        $redColor->getId()->willReturn('red3');
+        $blackColor->getCode()->willReturn('black1');
+        $whiteColor->getCode()->willReturn('white2');
+        $redColor->getCode()->willReturn('red3');
 
         $variantsParityChecker->checkParity($permutationVariant, $productVariable)->willReturn(true);
 
@@ -132,12 +132,12 @@ final class ProductVariantGeneratorSpec extends ObjectBehavior
         $colorOption->getValues()->willReturn([$blackColor, $whiteColor, $redColor]);
         $sizeOption->getValues()->willReturn([$smallSize, $mediumSize, $largeSize]);
 
-        $blackColor->getId()->willReturn('black1');
-        $whiteColor->getId()->willReturn('white2');
-        $redColor->getId()->willReturn('red3');
-        $smallSize->getId()->willReturn('small4');
-        $mediumSize->getId()->willReturn('medium5');
-        $largeSize->getId()->willReturn('large6');
+        $blackColor->getCode()->willReturn('black1');
+        $whiteColor->getCode()->willReturn('white2');
+        $redColor->getCode()->willReturn('red3');
+        $smallSize->getCode()->willReturn('small4');
+        $mediumSize->getCode()->willReturn('medium5');
+        $largeSize->getCode()->willReturn('large6');
 
         $variantsParityChecker->checkParity($permutationVariant, $productVariable)->willReturn(false);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | no|
| BC breaks?      | no|
| License         | MIT |

Use case: I wanted to use it in an unit test, but it's based around the entities ID's and as I didn't want to persist them, there is no way (as I see it) to assign an ID to easily. That makes it harder to use it in stand-alone situations. 

The `code` field of the entities is also a required field, which should be there if there is also an ID, but using `code` allows to use setters to use this generator stand-alone for such use-cases.