### PR TITLE
Product variant images

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductImage.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductImage.orm.xml
@@ -16,7 +16,7 @@
         <many-to-one field="owner" target-entity="Sylius\Component\Product\Model\ProductInterface" inversed-by="images">
             <join-column name="owner_id" referenced-column-name="id" nullable="false" on-delete="CASCADE"/>
         </many-to-one>
-        <many-to-many field="productVariants" target-entity="Sylius\Component\Product\Model\ProductVariantInterface" orphan-removal="true">
+        <many-to-many field="productVariants" target-entity="Sylius\Component\Product\Model\ProductVariantInterface" inversed-by="images" orphan-removal="true">
             <join-table name="sylius_product_image_product_variants">
                 <join-columns>
                     <join-column name="image_id" referenced-column-name="id" on-delete="CASCADE" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductVariant.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductVariant.orm.xml
@@ -43,5 +43,11 @@
                 <cascade-all/>
             </cascade>
         </one-to-many>
+        <many-to-many
+            field="images"
+            target-entity="Sylius\Component\Core\Model\ProductImageInterface"
+            mapped-by="productVariants"
+        >
+        </many-to-many>
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductVariant.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductVariant.orm.xml
@@ -48,6 +48,9 @@
             target-entity="Sylius\Component\Core\Model\ProductImageInterface"
             mapped-by="productVariants"
         >
+            <cascade>
+                <cascade-all/>
+            </cascade>
         </many-to-many>
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sylius/Component/Core/Model/ProductImagesAwareInterface.php
+++ b/src/Sylius/Component/Core/Model/ProductImagesAwareInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Model;
+
+use Doctrine\Common\Collections\Collection;
+
+/**
+ * @author Ahmed Kooli <kooliahmd@gmail.com>
+ */
+interface ProductImagesAwareInterface
+{
+    /**
+     * @return Collection|ImageInterface[]
+     */
+    public function getImages();
+
+    /**
+     * @param string $type
+     *
+     * @return Collection|ImageInterface[]
+     */
+    public function getImagesByType($type);
+
+    /**
+     * @return bool
+     */
+    public function hasImages();
+
+    /**
+     * @param ImageInterface $image
+     *
+     * @return bool
+     */
+    public function hasImage(ProductImageInterface $image);
+
+    /**
+     * @param ImageInterface $image
+     */
+    public function addImage(ProductImageInterface $image);
+
+    /**
+     * @param ImageInterface $image
+     */
+    public function removeImage(ProductImageInterface $image);
+}

--- a/src/Sylius/Component/Core/Model/ProductVariant.php
+++ b/src/Sylius/Component/Core/Model/ProductVariant.php
@@ -447,6 +447,9 @@ class ProductVariant extends BaseVariant implements ProductVariantInterface
      */
     public function addImage(ProductImageInterface $image)
     {
+        if ($this->hasImage($image)) {
+            return;
+        }
         $image->setOwner($this->getProduct());
         $image->addProductVariant($this);
         $this->images->add($image);

--- a/src/Sylius/Component/Core/Model/ProductVariant.php
+++ b/src/Sylius/Component/Core/Model/ProductVariant.php
@@ -408,7 +408,6 @@ class ProductVariant extends BaseVariant implements ProductVariantInterface
         $this->shippingRequired = $shippingRequired;
     }
 
-
     /**
      * {@inheritdoc}
      */
@@ -462,5 +461,4 @@ class ProductVariant extends BaseVariant implements ProductVariantInterface
             $this->images->removeElement($image);
         }
     }
-
 }

--- a/src/Sylius/Component/Core/Model/ProductVariant.php
+++ b/src/Sylius/Component/Core/Model/ProductVariant.php
@@ -83,11 +83,17 @@ class ProductVariant extends BaseVariant implements ProductVariantInterface
      */
     protected $shippingRequired = true;
 
+    /**
+     * @var Collection|ProductImageInterface[]
+     */
+    protected $images;
+
     public function __construct()
     {
         parent::__construct();
 
         $this->channelPricings = new ArrayCollection();
+        $this->images = new ArrayCollection();
     }
 
     /**
@@ -401,4 +407,60 @@ class ProductVariant extends BaseVariant implements ProductVariantInterface
     {
         $this->shippingRequired = $shippingRequired;
     }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getImages()
+    {
+        return $this->images;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getImagesByType($type)
+    {
+        return $this->images->filter(function (ProductImageInterface $image) use ($type) {
+            return $type === $image->getType();
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasImages()
+    {
+        return !$this->images->isEmpty();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasImage(ProductImageInterface $image)
+    {
+        return $this->images->contains($image);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addImage(ProductImageInterface $image)
+    {
+        $image->setOwner($this->getProduct());
+        $image->addProductVariant($this);
+        $this->images->add($image);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeImage(ProductImageInterface $image)
+    {
+        if ($this->hasImage($image)) {
+            $this->images->removeElement($image);
+        }
+    }
+
 }

--- a/src/Sylius/Component/Core/Model/ProductVariantInterface.php
+++ b/src/Sylius/Component/Core/Model/ProductVariantInterface.php
@@ -28,7 +28,8 @@ interface ProductVariantInterface extends
     ShippableInterface,
     StockableInterface,
     TaxableInterface,
-    VersionedInterface
+    VersionedInterface,
+    ProductImagesAwareInterface
 {
     /**
      * @return float

--- a/src/Sylius/Component/Core/spec/Model/ProductVariantSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ProductVariantSpec.php
@@ -273,7 +273,7 @@ final class ProductVariantSpec extends ObjectBehavior
     {
         $image->getType()->willReturn('thumbnail');
 
-        $image->setOwner($this->getProduct())->shouldBeCalled();
+        $image->setOwner($product)->shouldBeCalled();
         $image->addProductVariant($this)->shouldBeCalled();
 
         $this->setProduct($product);

--- a/src/Sylius/Component/Core/spec/Model/ProductVariantSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ProductVariantSpec.php
@@ -269,13 +269,15 @@ final class ProductVariantSpec extends ObjectBehavior
         $this->hasImage($image)->shouldReturn(false);
     }
 
-    function it_returns_images_by_type(ProductImageInterface $image,Product $product)
+    function it_returns_images_by_type(ProductImageInterface $image, Product $product)
     {
-        $this->setProduct($product);
-        $this->addImage($image);
         $image->getType()->willReturn('thumbnail');
+
         $image->setOwner($this->getProduct())->shouldBeCalled();
         $image->addProductVariant($this)->shouldBeCalled();
+
+        $this->setProduct($product);
+        $this->addImage($image);
         $this->getImagesByType('thumbnail')->shouldBeLike(new ArrayCollection([$image->getWrappedObject()]));
     }
 }

--- a/src/Sylius/Component/Core/spec/Model/ProductVariantSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ProductVariantSpec.php
@@ -12,7 +12,11 @@
 namespace spec\Sylius\Component\Core\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\Product;
+use Sylius\Component\Core\Model\ProductImagesAwareInterface;
+use Sylius\Component\Core\Model\ProductImageInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductVariant;
@@ -57,6 +61,11 @@ final class ProductVariantSpec extends ObjectBehavior
     function it_implements_versioned_interface()
     {
         $this->shouldImplement(VersionedInterface::class);
+    }
+
+    function it_implements_a_product_image_aware_interface()
+    {
+        $this->shouldImplement(ProductImagesAwareInterface::class);
     }
 
     function it_has_version_1_by_default()
@@ -239,5 +248,34 @@ final class ProductVariantSpec extends ObjectBehavior
     {
         $this->setShippingRequired(false);
         $this->isShippingRequired()->shouldReturn(false);
+    }
+
+    function it_initializes_image_collection_by_default()
+    {
+        $this->getImages()->shouldHaveType(Collection::class);
+    }
+
+    function it_adds_an_image(ProductImageInterface $image)
+    {
+        $this->addImage($image);
+        $this->hasImages()->shouldReturn(true);
+        $this->hasImage($image)->shouldReturn(true);
+    }
+
+    function it_removes_an_image(ProductImageInterface $image)
+    {
+        $this->addImage($image);
+        $this->removeImage($image);
+        $this->hasImage($image)->shouldReturn(false);
+    }
+
+    function it_returns_images_by_type(ProductImageInterface $image,Product $product)
+    {
+        $this->setProduct($product);
+        $this->addImage($image);
+        $image->getType()->willReturn('thumbnail');
+        $image->setOwner($this->getProduct())->shouldBeCalled();
+        $image->addProductVariant($this)->shouldBeCalled();
+        $this->getImagesByType('thumbnail')->shouldBeLike(new ArrayCollection([$image->getWrappedObject()]));
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets | fixes #7993|
| License         | MIT |

Add the possibility to get variant's images directly from product variant entity without loading images of parent product.
