### PR TITLE
Fix wrong assertion which prevented default admin user creation

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Command/SetupCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/SetupCommand.php
@@ -106,7 +106,7 @@ EOT
         $userRepository = $this->get('sylius.repository.admin_user');
 
         if ($input->getOption('no-interaction')) {
-            Assert::notNull($userRepository->findOneByEmail('sylius@example.com'));
+            Assert::null($userRepository->findOneByEmail('sylius@example.com'));
 
             $user->setEmail('sylius@example.com');
             $user->setPlainPassword('sylius');


### PR DESCRIPTION
Fix wrong assertion which prevented default admin user creation (sylius@example.com / sylius) when installing with '--no-interaction' option

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |
