### PR TITLE
[BugFix] Make sure query parameters are retained properly when filtering.

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_pagination.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_pagination.html.twig
@@ -7,7 +7,7 @@
             <i class="dropdown icon"></i>
             <div class="menu">
             {% for limit in paginationLimits if limit != resources.data.maxPerPage %}
-                {% set path = path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')|merge({'limit': limit})) %}
+                {% set path = path(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')|merge(app.request.query.all)|merge({'limit': limit})) %}
                 <a class="item" href="{{ path }}">{{ limit }}</a>
             {% endfor %}
             </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_sorting.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_sorting.html.twig
@@ -7,13 +7,13 @@
 
 {% set criteria = app.request.query.get('criteria', {}) %}
 
-{% set default_path = path(route, {'criteria': criteria}|merge(route_parameters)) %}
-{% set from_a_to_z_path = path(route, {'sorting': {'name': 'asc'}, 'criteria': criteria}|merge(route_parameters)) %}
-{% set from_z_to_a_path = path(route, {'sorting': {'name': 'desc'}, 'criteria': criteria}|merge(route_parameters)) %}
-{% set oldest_first_path = path(route, {'sorting': {'createdAt': 'asc'}, 'criteria': criteria}|merge(route_parameters)) %}
-{% set newest_first_path = path(route, {'sorting': {'createdAt': 'desc'}, 'criteria': criteria}|merge(route_parameters)) %}
-{% set cheapest_first_path = path(route, {'sorting': {'price': 'asc'}, 'criteria': criteria}|merge(route_parameters)) %}
-{% set most_expensive_first_path = path(route, {'sorting': {'price': 'desc'}, 'criteria': criteria}|merge(route_parameters)) %}
+{% set default_path = path(route, route_parameters|merge({'criteria': criteria})) %}
+{% set from_a_to_z_path = path(route, route_parameters|merge({'sorting': {'name': 'asc'}, 'criteria': criteria})) %}
+{% set from_z_to_a_path = path(route, route_parameters|merge({'sorting': {'name': 'desc'}, 'criteria': criteria})) %}
+{% set oldest_first_path = path(route, route_parameters|merge({'sorting': {'createdAt': 'asc'}, 'criteria': criteria})) %}
+{% set newest_first_path = path(route, route_parameters|merge({'sorting': {'createdAt': 'desc'}, 'criteria': criteria})) %}
+{% set cheapest_first_path = path(route, route_parameters|merge({'sorting': {'price': 'asc'}, 'criteria': criteria})) %}
+{% set most_expensive_first_path = path(route, route_parameters|merge({'sorting': {'price': 'desc'}, 'criteria': criteria})) %}
 
 {% if app.request.query.get('sorting') is empty %}
     {% set current_sorting_label = 'sylius.ui.by_position'|trans|lower %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

Without these changes, some filter states are lost due to improper merging of the query parameters. If you would for example filter on 50 products per page and change the order to display the products, the limit is for example lost. These changes fix this.