### PR TITLE
Fixed typo

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/translations/messages.lt.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/translations/messages.lt.yml
@@ -31,7 +31,7 @@ sylius:
                 customers:
                     customers: Klientai
                     groups: Grupės
-                    header: Klienta
+                    header: Klientai
                 sales:
                     header: Pardavimai
                     orders: Užsakymai


### PR DESCRIPTION
Missing last letter. `sylius.menu.admin.main.customers.customers` is proper translation.

| Q               | A
| --------------- | ---
| Bug fix?        | yes(?) |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |
