### PR TITLE
Add pre & post content blocks to UiBundle layouts

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/views/Layout/centered.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Layout/centered.html.twig
@@ -16,7 +16,13 @@
     {% endblock %}
 </head>
 <body class="centered">
+{% block pre_content %}
+{% endblock %}
+
 {% block content %}
+{% endblock %}
+
+{% block post_content %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Layout/sidebar.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Layout/sidebar.html.twig
@@ -30,7 +30,13 @@
         <div id="content">
             {% include '@SyliusUi/_flashes.html.twig' %}
 
+            {% block pre_content %}
+            {% endblock %}
+
             {% block content %}
+            {% endblock %}
+
+            {% block post_content %}
             {% endblock %}
         </div>
     </div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

When implementing custom pages in admin interface, we need to put some markup directly before and after the rendered content. We could do it in the full view template itself which extends from the layout, but sometimes, we're including some pages and routes which are not Sylius specific and are used on other CMSes, like eZ Platform in which case this additional pre-content and post-content markup would not make sense.

This PR adds two blocks called `pre_content` and `post_content` to UiBundle layouts which allow to inject some markup before and after the content when needed.