### PR TITLE
Allow attribute type 'select' values to include non-allowed characters

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeChoicesCollectionType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeChoicesCollectionType.php
@@ -11,6 +11,7 @@
 
 namespace Sylius\Bundle\AttributeBundle\Form\Type\AttributeType\Configuration;
 
+use Sylius\Component\Core\Formatter\FormAllowedCharacters;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -34,7 +35,7 @@ class SelectAttributeChoicesCollectionType extends AbstractType
             if (null !== $data) {
                 $fixedArray = [];
                 foreach ($data as $key => $value) {
-                    $newKey = strtolower(str_replace(' ', '_', $value));
+                    $newKey = FormAllowedCharacters::nameToAllowedCharacters($value);
                     $fixedArray[$newKey] = $value;
 
                     if ($form->offsetExists($key)) {

--- a/src/Sylius/Component/Core/Formatter/FormAllowedCharacters.php
+++ b/src/Sylius/Component/Core/Formatter/FormAllowedCharacters.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sylius\Component\Core\Formatter;
+
+/**
+ * @author Stefan Doorn <stefan@efectos.nl>
+ */
+final class FormAllowedCharacters
+{
+    /**
+     * @param $value
+     * @return string
+     *
+     * Transform values to avoid error below.
+     *
+     * The name "25% discount!" contains illegal characters. Names should start with a letter,
+     * digit or underscore and only contain letters, digits, numbers, underscores ("_"),
+     * hyphens ("-") and colons (":").
+     */
+    public static function nameToAllowedCharacters($value)
+    {
+        return self::startCharacter(self::consecutiveCharacters($value));
+    }
+
+    /**
+     * @param $value
+     * @return string
+     */
+    private static function startCharacter($value)
+    {
+        // If we match the first character for above error, we just return
+        if (preg_match('/[a-zA-Z0-9_]/', substr($value, 0, 1)) === 1) {
+            return $value;
+        }
+
+        // Else remove first character and try again
+        return self::startCharacter(substr($value, 1));
+    }
+
+    /**
+     * @param $value
+     * @return mixed
+     */
+    private static function consecutiveCharacters($value)
+    {
+        return preg_replace('/[^:0-9a-zA-Z_-]/', '', $value);
+    }
+
+    private function __construct()
+    {
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no|
| BC breaks?      | no|
| Related tickets | fixes #8111, 
| License         | MIT |

As mentioned in #8111, it is not allowed in the 'select' attribute type to use non-allowed Symfony form characters, e.g. this value would not be allowed: '25% discount!', as % and ! are not allowed in Symfony form keys. This core formatter (next to StringInflector) does check the first character and the consecutive characters to prevent this error:

```
The name "25% discount!" contains illegal characters. Names should start with a letter, digit or underscore and only contain letters, digits, numbers, underscores ("_"), hyphens ("-") and colons (":").
```