### PR TITLE
Use appropriate labels and placeholders

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Form/EventListener/BuildAddressFormSubscriber.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/EventListener/BuildAddressFormSubscriber.php
@@ -137,6 +137,8 @@ final class BuildAddressFormSubscriber implements EventSubscriberInterface
         return $this->formFactory->createNamed('provinceCode', ProvinceCodeChoiceType::class, $provinceCode, [
             'country' => $country,
             'auto_initialize' => false,
+            'label' => 'sylius.form.address.province',
+            'placeholder' => 'sylius.form.province.select',
         ]);
     }
 
@@ -150,6 +152,7 @@ final class BuildAddressFormSubscriber implements EventSubscriberInterface
         return $this->formFactory->createNamed('provinceName', TextType::class, $provinceName, [
             'required' => false,
             'auto_initialize' => false,
+            'label' => 'sylius.form.address.province',
         ]);
     }
 }


### PR DESCRIPTION
When the form is loaded without ajax on the form post, the label should be correct immediately. See https://github.com/Sylius/Sylius/issues/8152

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/8152, partially #Y, mentioned in #Z |
| License         | MIT |
