### PR TITLE
Add missing permission flag to the admin routes for the authorization check to actually work

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product.yml
@@ -11,6 +11,7 @@ sylius_admin_ajax_product_by_name_phrase:
         _controller: sylius.controller.product:indexAction
         _sylius:
             serialization_groups: [Autocomplete]
+            permission: true
             repository:
                 method: findByNamePart
                 arguments:
@@ -24,6 +25,7 @@ sylius_admin_ajax_product_by_code:
         _controller: sylius.controller.product:indexAction
         _sylius:
             serialization_groups: [Autocomplete]
+            permission: true
             repository:
                 method: findBy
                 arguments: [code: $code]
@@ -34,4 +36,5 @@ sylius_admin_ajax_product_index:
     defaults:
         _controller: sylius.controller.product:indexAction
         _sylius:
+            permission: true
             grid: sylius_admin_product

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product_taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product_taxon.yml
@@ -3,3 +3,5 @@ sylius_admin_ajax_product_taxons_update_position:
     methods: [PUT]
     defaults:
         _controller: sylius.controller.product_taxon:updatePositionsAction
+        _sylius:
+            permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product_variant.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product_variant.yml
@@ -3,6 +3,8 @@ sylius_admin_ajax_product_variants_update_position:
     methods: [PUT]
     defaults:
         _controller: sylius.controller.product_variant:updatePositionsAction
+        _sylius:
+            permission: true
 
 sylius_admin_ajax_product_variants_by_phrase:
     path: /search
@@ -11,6 +13,7 @@ sylius_admin_ajax_product_variants_by_phrase:
         _controller: sylius.controller.product_variant:indexAction
         _sylius:
             serialization_groups: [Autocomplete]
+            permission: true
             repository:
                 method: findByPhraseAndProductCode
                 arguments:
@@ -25,6 +28,7 @@ sylius_admin_ajax_product_variants_by_code:
         _controller: sylius.controller.product_variant:indexAction
         _sylius:
             serialization_groups: [Autocomplete]
+            permission: true
             repository:
                 method: findByCodeAndProductCode
                 arguments:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/taxon.yml
@@ -5,6 +5,7 @@ sylius_admin_ajax_taxon_root_nodes:
         _controller: sylius.controller.taxon:indexAction
         _sylius:
             serialization_groups: [Autocomplete]
+            permission: true
             repository:
                 method: findRootNodes
 
@@ -15,6 +16,7 @@ sylius_admin_ajax_taxon_leafs:
         _controller: sylius.controller.taxon:indexAction
         _sylius:
             serialization_groups: [Autocomplete]
+            permission: true
             repository:
                 method: findChildren
                 arguments:
@@ -28,6 +30,7 @@ sylius_admin_ajax_taxon_by_code:
         _controller: sylius.controller.taxon:indexAction
         _sylius:
             serialization_groups: [Autocomplete]
+            permission: true
             repository:
                 method: findBy
                 arguments: [code: $code]
@@ -39,6 +42,7 @@ sylius_admin_ajax_taxon_by_name_phrase:
         _controller: sylius.controller.taxon:indexAction
         _sylius:
             serialization_groups: [Autocomplete]
+            permission: true
             repository:
                 method: findByNamePart
                 arguments:
@@ -57,4 +61,5 @@ sylius_admin_ajax_taxon_move:
     defaults:
         _controller: sylius.controller.taxon:updateAction
         _sylius:
+            permission: true
             form: Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonPositionType

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer.yml
@@ -32,6 +32,7 @@ sylius_admin_customer_order_index:
         _controller: sylius.controller.order:indexAction
         _sylius:
             section: admin
+            permission: true
             template: "@SyliusAdmin/Crud/index.html.twig"
             grid: sylius_admin_customer_order
             vars:
@@ -51,3 +52,4 @@ sylius_admin_customer_orders_statistics:
         _controller: sylius.controller.customer_statistics:renderAction
         _sylius:
             section: admin
+            permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/inventory.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/inventory.yml
@@ -7,6 +7,7 @@ sylius_admin_inventory_index:
             template: "@SyliusAdmin/Crud/index.html.twig"
             grid: sylius_admin_inventory
             section: admin
+            permission: true
             vars:
                 icon: history
                 templates:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
@@ -5,6 +5,7 @@ sylius_admin_order:
         templates: SyliusAdminBundle:Crud
         only: ['index']
         grid: sylius_admin_order
+        permission: true
         vars:
           all:
               subheader: sylius.ui.process_your_orders
@@ -19,6 +20,7 @@ sylius_admin_order_show:
         _controller: sylius.controller.order:showAction
         _sylius:
             section: admin
+            permission: true
             template: SyliusAdminBundle:Order:show.html.twig
 
 sylius_admin_order_history:
@@ -28,6 +30,7 @@ sylius_admin_order_history:
         _controller: sylius.controller.order:showAction
         _sylius:
             section: admin
+            permission: true
             template: SyliusAdminBundle:Order:history.html.twig
 
 sylius_admin_order_update:
@@ -37,6 +40,7 @@ sylius_admin_order_update:
         _controller: sylius.controller.order:updateAction
         _sylius:
             section: admin
+            permission: true
             template: SyliusAdminBundle:Order:update.html.twig
             form:
                 options:
@@ -49,6 +53,7 @@ sylius_admin_order_cancel:
     defaults:
         _controller: sylius.controller.order:applyStateMachineTransitionAction
         _sylius:
+            permission: true
             state_machine:
                 graph: sylius_order
                 transition: cancel
@@ -61,6 +66,7 @@ sylius_admin_order_payment_complete:
         _controller: sylius.controller.payment:applyStateMachineTransitionAction
         _sylius:
             event: complete
+            permission: true
             repository:
                 method: findOneByOrderId
                 arguments:
@@ -77,6 +83,7 @@ sylius_admin_order_payment_refund:
     defaults:
         _controller: sylius.controller.payment:applyStateMachineTransitionAction
         _sylius:
+            permission: true
             repository:
                 method: findOneByOrderId
                 arguments:
@@ -105,6 +112,7 @@ sylius_admin_order_shipment_ship:
                 transition: ship
             redirect: referer
             section: admin
+            permission: true
             form: Sylius\Bundle\ShippingBundle\Form\Type\ShipmentShipType
             vars:
                 route:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/address.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/address.yml
@@ -7,3 +7,4 @@ sylius_admin_partial_address_log_entry_index:
             template: "@SyliusUi/Grid/_history.html.twig"
             grid: sylius_admin_address_log_entry
             section: admin
+            permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/channel.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/channel.yml
@@ -7,3 +7,4 @@ sylius_admin_partial_channel_index:
             repository:
                 method: findAll
             template: $template
+            permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/customer.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/customer.yml
@@ -11,6 +11,7 @@ sylius_admin_partial_customer_latest:
                 method: findLatest
                 arguments: [$count]
             template: $template
+            permission: true
 
 sylius_admin_partial_customer_show:
     path: /{id}
@@ -20,3 +21,4 @@ sylius_admin_partial_customer_show:
         _sylius:
             template: $template
             vars: $vars
+            permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/order.yml
@@ -8,6 +8,7 @@ sylius_admin_partial_order_latest:
                 method: findLatest
                 arguments: [$count]
             template: $template
+            permission: true
 
 sylius_admin_partial_order_latest_in_channel:
     path: /latest/{channelCode}/{count}
@@ -21,3 +22,4 @@ sylius_admin_partial_order_latest_in_channel:
                     count: $count
                     channel: expr:notFoundOnNull(service('sylius.repository.channel').findOneByCode($channelCode))
             template: $template
+            permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/product.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/product.yml
@@ -9,3 +9,4 @@ sylius_admin_partial_product_show:
         _sylius:
             template: $template
             vars: $vars
+            permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/promotion.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/promotion.yml
@@ -9,3 +9,4 @@ sylius_admin_partial_promotion_show:
         _sylius:
             template: $template
             vars: $vars
+            permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/shipment.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/shipment.yml
@@ -14,6 +14,7 @@ sylius_admin_partial_shipment_ship:
                 graph: sylius_shipment
                 transition: ship
             section: admin
+            permission: true
             template: "@SyliusAdmin/Shipment/Partial/_ship.html.twig"
             form: Sylius\Bundle\ShippingBundle\Form\Type\ShipmentShipType
             vars:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/taxon.yml
@@ -10,6 +10,7 @@ sylius_admin_partial_taxon_tree:
             template: $template
             repository:
                 method: findRootNodes
+            permission: true
 
 sylius_admin_partial_taxon_show:
     path: /{id}
@@ -19,3 +20,4 @@ sylius_admin_partial_taxon_show:
         _sylius:
             template: $template
             vars: $vars
+            permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product.yml
@@ -6,6 +6,7 @@ sylius_admin_product:
         except: ['show', 'index']
         redirect: update
         grid: sylius_admin_product
+        permission: true
         vars:
             all:
                 subheader: sylius.ui.manage_your_product_catalog
@@ -22,6 +23,7 @@ sylius_admin_product_index:
         _controller: sylius.controller.product:indexAction
         _sylius:
             section: admin
+            permission: true
             grid: sylius_admin_product
             template: SyliusAdminBundle:Product:index.html.twig
             vars:
@@ -35,6 +37,7 @@ sylius_admin_product_per_taxon_index:
         _controller: sylius.controller.product:indexAction
         _sylius:
             section: admin
+            permission: true
             grid: sylius_admin_product_from_taxon
             template: SyliusAdminBundle:Product:index.html.twig
             vars:
@@ -48,6 +51,7 @@ sylius_admin_product_create:
         _controller: sylius.controller.product:createAction
         _sylius:
             section: admin
+            permission: true
             template: SyliusAdminBundle:Crud:create.html.twig
             redirect: sylius_admin_product_update
             vars:
@@ -64,6 +68,7 @@ sylius_admin_product_create_simple:
         _controller: sylius.controller.product:createAction
         _sylius:
             section: admin
+            permission: true
             factory:
                 method: createWithVariant
             template: SyliusAdminBundle:Crud:create.html.twig

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_association_type.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_association_type.yml
@@ -2,6 +2,7 @@ sylius_admin_product_association_type:
     resource: |
         alias: sylius.product_association_type
         section: admin
+        permission: true
         templates: SyliusAdminBundle:Crud
         except: ['show']
         redirect: update

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_review.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_review.yml
@@ -2,6 +2,7 @@ sylius_admin_product_review:
     resource: |
         alias: sylius.product_review
         section: admin
+        permission: true
         templates: SyliusAdminBundle:Crud
         except: ['show', 'create']
         redirect: update
@@ -21,6 +22,7 @@ sylius_admin_product_review_accept:
     defaults:
         _controller: sylius.controller.product_review:applyStateMachineTransitionAction
         _sylius:
+            permission: true
             state_machine:
                 graph: sylius_product_review
                 transition: accept
@@ -33,6 +35,7 @@ sylius_admin_product_review_reject:
     defaults:
         _controller: sylius.controller.product_review:applyStateMachineTransitionAction
         _sylius:
+            permission: true
             state_machine:
                 graph: sylius_product_review
                 transition: reject

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_variant.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_variant.yml
@@ -93,6 +93,7 @@ sylius_admin_product_variant_generate:
         _sylius:
             template: "@SyliusAdmin/ProductVariant/generate.html.twig"
             section: admin
+            permission: true
             redirect:
                 route: sylius_admin_product_variant_index
                 parameters: { productId: $productId }

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shipping_method.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shipping_method.yml
@@ -23,6 +23,7 @@ sylius_admin_shipping_method_archive:
         _controller: sylius.controller.shipping_method:updateAction
         _sylius:
             section: admin
+            permission: true
             template: '@SyliusUi/Grid/Action/archive.html.twig'
             form:
                 type: Sylius\Bundle\ResourceBundle\Form\Type\ArchivableType

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/taxon.yml
@@ -28,6 +28,7 @@ sylius_admin_taxon_create_for_parent:
         _controller: sylius.controller.taxon:createAction
         _sylius:
             section: admin
+            permission: true
             template: 'SyliusAdminBundle:Taxon:create.html.twig'
             redirect: sylius_admin_taxon_update
             factory:


### PR DESCRIPTION
While implementing the `Sylius\Bundle\ResourceBundle\Controller\AuthorizationCheckerInterface` we found out that many routes from the admin bundle miss the `permission` flag and so the authorization check is never called for these routes ([see source](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php#L484)). This is kind of security issue when implementing privileges separation for different roles of admins.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |
