### PR TITLE
[Admin][DX] Improved attributes extensibility

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributeValues.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributeValues.html.twig
@@ -9,12 +9,12 @@
                 {{ _self.textField(form, count, id, subject, metadata.applicationName) }}
             {% endif %}
             <input type="hidden"
-                   name="sylius_product[attributes][{{ count }}][attribute]"
-                   id="sylius_product_attributes_{{ count }}_attribute"
+                   name="sylius_{{ subject }}[attributes][{{ count }}][attribute]"
+                   id="sylius_{{ subject }}_attributes_{{ count }}_attribute"
                    value="{{ code }}"/>
             <input type="hidden"
-                   name="sylius_product[attributes][{{ count }}][localeCode]"
-                   id="sylius_product_attributes_{{ count }}_localeCode"
+                   name="sylius_{{ subject }}[attributes][{{ count }}][localeCode]"
+                   id="sylius_{{ subject }}_attributes_{{ count }}_localeCode"
                    value="{{ localeCode }}"/>
             {% set count = count + 1 %}
         </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributeValues.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributeValues.html.twig
@@ -9,12 +9,12 @@
                 {{ _self.textField(form, count, id, subject, metadata.applicationName) }}
             {% endif %}
             <input type="hidden"
-                   name="sylius_{{ subject }}[attributes][{{ count }}][attribute]"
-                   id="sylius_{{ subject }}_attributes_{{ count }}_attribute"
+                   name="{{ metadata.applicationName }}_{{ subject }}[attributes][{{ count }}][attribute]"
+                   id="{{ metadata.applicationName }}_{{ subject }}_attributes_{{ count }}_attribute"
                    value="{{ code }}"/>
             <input type="hidden"
-                   name="sylius_{{ subject }}[attributes][{{ count }}][localeCode]"
-                   id="sylius_{{ subject }}_attributes_{{ count }}_localeCode"
+                   name="{{ metadata.applicationName }}_{{ subject }}[attributes][{{ count }}][localeCode]"
+                   id="{{ metadata.applicationName }}_{{ subject }}_attributes_{{ count }}_localeCode"
                    value="{{ localeCode }}"/>
             {% set count = count + 1 %}
         </div>


### PR DESCRIPTION
By not hard coding application name and subject.

Makes it possible to re-use attributeValues.html.twig for attributes for
your custom models (and Sylius default models).

| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | fixes https://sylius-devs.slack.com/files/sweoggy/F5T2DSDS8/Untitled.php |
| License         | MIT |
