### PR TITLE
[Grid] to and from are not required in grid date filter

### DIFF
--- a/src/Sylius/Component/Grid/Filter/DateFilter.php
+++ b/src/Sylius/Component/Grid/Filter/DateFilter.php
@@ -32,7 +32,7 @@ final class DateFilter implements FilterInterface
 
         $field = $this->getOption($options, 'field', $name);
 
-        $from = $this->getDateTime($data['from']);
+        $from = isset($data['from']) ? $this->getDateTime($data['from']) : null;
         if (null !== $from) {
             $inclusive = (bool)$this->getOption($options, 'inclusive_from', self::DEFAULT_INCLUSIVE_FROM);
             if (true === $inclusive) {
@@ -42,7 +42,7 @@ final class DateFilter implements FilterInterface
             }
         }
 
-        $to = $this->getDateTime($data['to']);
+        $to = isset($data['to']) ? $this->getDateTime($data['to']) : null;
         if (null !== $to) {
             $inclusive = (bool)$this->getOption($options, 'inclusive_to', self::DEFAULT_INCLUSIVE_TO);
             if (true === $inclusive) {

--- a/src/Sylius/Component/Grid/spec/Filter/DateFilterSpec.php
+++ b/src/Sylius/Component/Grid/spec/Filter/DateFilterSpec.php
@@ -50,10 +50,6 @@ final class DateFilterSpec extends ObjectBehavior
                 'from' => [
                     'date' => '2016-12-05',
                     'time' => '08:00',
-                ],
-                'to' => [
-                    'date' => '',
-                    'time' => '',
                 ]
             ],
             []
@@ -131,10 +127,6 @@ final class DateFilterSpec extends ObjectBehavior
             $dataSource,
             'checkoutCompletedAt',
             [
-                'from' => [
-                    'date' => '',
-                    'time' => '',
-                ],
                 'to' => [
                     'date' => '2016-12-06',
                     'time' => '08:00',
@@ -187,10 +179,6 @@ final class DateFilterSpec extends ObjectBehavior
             $dataSource,
             'checkoutCompletedAt',
             [
-                'from' => [
-                    'date' => '',
-                    'time' => '',
-                ],
                 'to' => [
                     'date' => '2016-12-06',
                     'time' => '',


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes |
| New feature?    | no|
| BC breaks?      | no|
| Related tickets |  |
| License         | MIT |

As per the form type: https://github.com/Sylius/Sylius/blob/a912a695563d853a86e4bd2b2fafef1cd6b75a15/src/Sylius/Bundle/GridBundle/Form/Type/Filter/DateFilterType.php#L30-L46

`to` and `from` are not required, and not providing them cause an `Undefined index` error.
