### PR TITLE
[Grid] allow configuring inclusiveness of to and from date filters

### DIFF
--- a/src/Sylius/Component/Grid/Filter/DateFilter.php
+++ b/src/Sylius/Component/Grid/Filter/DateFilter.php
@@ -20,6 +20,8 @@ use Sylius\Component\Grid\Filtering\FilterInterface;
 final class DateFilter implements FilterInterface
 {
     const NAME = 'date';
+    const DEFAULT_INCLUSIVE_FROM = true;
+    const DEFAULT_INCLUSIVE_TO = false;
 
     /**
      * {@inheritdoc}
@@ -28,17 +30,40 @@ final class DateFilter implements FilterInterface
     {
         $expressionBuilder = $dataSource->getExpressionBuilder();
 
-        $field = isset($options['field']) ? $options['field'] : $name;
+        $field = $this->getOption($options, 'field', $name);
 
         $from = $this->getDateTime($data['from']);
         if (null !== $from) {
-            $expressionBuilder->greaterThanOrEqual($field, $from);
+            $inclusive = (bool)$this->getOption($options, 'inclusive_from', self::DEFAULT_INCLUSIVE_FROM);
+            if (true === $inclusive) {
+                $expressionBuilder->greaterThanOrEqual($field, $from);
+            } else {
+                $expressionBuilder->greaterThan($field, $from);
+            }
         }
 
         $to = $this->getDateTime($data['to']);
         if (null !== $to) {
-            $expressionBuilder->lessThan($field, $to);
+            $inclusive = (bool)$this->getOption($options, 'inclusive_to', self::DEFAULT_INCLUSIVE_TO);
+            if (true === $inclusive) {
+                $expressionBuilder->lessThanOrEqual($field, $to);
+            } else {
+                $expressionBuilder->lessThan($field, $to);
+            }
         }
+    }
+
+
+    /**
+     * @param array $options
+     * @param string $name
+     * @param null|mixed $default
+     *
+     * @return null|mixed
+     */
+    private function getOption(array $options, $name, $default = null)
+    {
+        return isset($options[$name]) ? $options[$name] : $default;
     }
 
     /**

--- a/src/Sylius/Component/Grid/spec/Filter/DateFilterSpec.php
+++ b/src/Sylius/Component/Grid/spec/Filter/DateFilterSpec.php
@@ -60,6 +60,34 @@ final class DateFilterSpec extends ObjectBehavior
         );
     }
 
+    function it_filters_date_from_not_inclusive(
+        DataSourceInterface $dataSource,
+        ExpressionBuilderInterface $expressionBuilder
+    ) {
+        $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
+
+        $expressionBuilder
+            ->greaterThan('checkoutCompletedAt', '2016-12-05 08:00')
+            ->shouldBeCalled()
+        ;
+
+        $this->apply(
+            $dataSource,
+            'checkoutCompletedAt',
+            [
+                'from' => [
+                    'date' => '2016-12-05',
+                    'time' => '08:00',
+                ],
+                'to' => [
+                    'date' => '',
+                    'time' => '',
+                ]
+            ],
+            ['inclusive_from' => false]
+        );
+    }
+
     function it_filters_date_from_without_time(
         DataSourceInterface $dataSource,
         ExpressionBuilderInterface $expressionBuilder
@@ -113,6 +141,34 @@ final class DateFilterSpec extends ObjectBehavior
                 ]
             ],
             []
+        );
+    }
+
+    function it_filters_date_to_inclusive(
+        DataSourceInterface $dataSource,
+        ExpressionBuilderInterface $expressionBuilder
+    ) {
+        $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
+
+        $expressionBuilder
+            ->lessThanOrEqual('checkoutCompletedAt', '2016-12-06 08:00')
+            ->shouldBeCalled()
+        ;
+
+        $this->apply(
+            $dataSource,
+            'checkoutCompletedAt',
+            [
+                'from' => [
+                    'date' => '',
+                    'time' => '',
+                ],
+                'to' => [
+                    'date' => '2016-12-06',
+                    'time' => '08:00',
+                ]
+            ],
+            ['inclusive_to' => true]
         );
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no|
| Related tickets |  |
| License         | MIT |

There seems to have been some arbitrary decision made that the DateFilter should have inclusive from, but exclusive to. 
I've made these configurable.
Defaults reflect the current code, so no BC break.
