### PR TITLE
Validate API url with pattern ^/api/.* not just ^/api

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -549,7 +549,7 @@ fos_rest:
             - { path: "^/(?!admin|api)[^/]++/verify", role: IS_AUTHENTICATED_ANONYMOUSLY }
 
             - { path: "^/admin", role: ROLE_ADMINISTRATION_ACCESS }
-            - { path: "^/api", role: ROLE_API_ACCESS }
+            - { path: "^/api/.*", role: ROLE_API_ACCESS }
             - { path: "^/(?!admin|api)[^/]++/account", role: ROLE_USER }
   ```
 ### Database Migrations
@@ -565,4 +565,3 @@ fos_rest:
 ### Behat
 
 * `Sylius\Behat\Page\Admin\Crud\IndexPage`, `Sylius\Behat\Page\Admin\Crud\CreatePage`, `Sylius\Behat\Page\Admin\Crud\UpdatePage` now accepts route name instead of resource name.
-

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -56,5 +56,5 @@ fos_rest:
         empty_content: 204
     format_listener:
         rules:
-            - { path: '^/api', priorities: ['json', 'xml'], fallback_format: json, prefer_extension: true }
+            - { path: '^/api/.*', priorities: ['json', 'xml'], fallback_format: json, prefer_extension: true }
             - { path: '^/', stop: true }

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -4,7 +4,7 @@
 parameters:
     sylius.security.admin_regex: "^/admin"
     sylius.security.api_regex: "^/api"
-    sylius.security.shop_regex: "^/(?!admin|api)[^/]++"
+    sylius.security.shop_regex: "^/(?!admin|api/.*|api$)[^/]++"
 
 security:
     providers:
@@ -46,7 +46,7 @@ security:
             security: false
 
         api:
-            pattern: "%sylius.security.api_regex%"
+            pattern: "%sylius.security.api_regex%/.*"
             fos_oauth:  true
             stateless:  true
             anonymous:  true
@@ -98,5 +98,5 @@ security:
         - { path: "%sylius.security.shop_regex%/verify", role: IS_AUTHENTICATED_ANONYMOUSLY }
 
         - { path: "%sylius.security.admin_regex%", role: ROLE_ADMINISTRATION_ACCESS }
-        - { path: "%sylius.security.api_regex%", role: ROLE_API_ACCESS }
+        - { path: "%sylius.security.api_regex%/.*", role: ROLE_API_ACCESS }
         - { path: "%sylius.security.shop_regex%/account", role: ROLE_USER }


### PR DESCRIPTION
Now if we want to have url which starts with `/api` we have access denied exception due to /api firewall. Also where is similar issue with FOS FormatListener, etc.

Before 

| url | http code |
|---|----|
| /api/something | 401 |
| /apiary | 401 |

After

| url | http code |
|---|----|
| /api/something | 401 |
| /apiary | 200 |