### PR TITLE
[ThemeBundle] Fix support for custom Twig namespaces

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Templating/TemplateNameParser.php
+++ b/src/Sylius/Bundle/ThemeBundle/Templating/TemplateNameParser.php
@@ -76,7 +76,7 @@ final class TemplateNameParser implements TemplateNameParserInterface
             try {
                 $this->kernel->getBundle($template->get('bundle'));
             } catch (\Exception $e) {
-                throw new \InvalidArgumentException(sprintf('Template name "%s" is not valid.', $name), 0, $e);
+                return $this->decoratedParser->parse($name);
             }
         }
 

--- a/src/Sylius/Bundle/ThemeBundle/spec/Templating/TemplateNameParserSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/Templating/TemplateNameParserSpec.php
@@ -63,11 +63,16 @@ final class TemplateNameParserSpec extends ObjectBehavior
         $this->parse('@Acme/Nested/Directory/app.html.twig')->shouldBeLike(new TemplateReference('AcmeBundle', 'Nested/Directory', 'app', 'html', 'twig'));
     }
 
-    function it_throws_an_exception_if_namespaced_path_references_not_existing_bundle(KernelInterface $kernel)
-    {
-        $kernel->getBundle('AcmeBundle')->willThrow(\Exception::class);
+    function it_delegates_custom_namespace_to_decorated_parser(
+        KernelInterface $kernel,
+        TemplateNameParserInterface $decoratedParser,
+        TemplateReferenceInterface $templateReference
+    ) {
+        $kernel->getBundle('myBundle')->willThrow(\Exception::class);
 
-        $this->shouldThrow(\InvalidArgumentException::class)->during('parse', ['@Acme/app.html.twig']);
+        $decoratedParser->parse('@my/custom/namespace.html.twig')->willReturn($templateReference);
+
+        $this->parse('@my/custom/namespace.html.twig')->shouldReturn($templateReference);
     }
 
     function it_generates_template_references_from_root_namespaced_paths()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #8189 |
| License         | MIT |

Fixes support for custom Twig namespaces (http://symfony.com/doc/current/templating/namespaced_paths.html#registering-your-own-namespaces)

I don't know if this should be done this way, but the patch works fine.