### PR TITLE
[UX][Admin] Changed admin titles to include Sylius as postfix

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/create.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/create.html.twig
@@ -5,7 +5,7 @@
 {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.new_'~metadata.name) %}
 {% set event_prefix = metadata.applicationName ~ '.admin.' ~ metadata.name ~ '.create' %}
 
-{% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
+{% block title %}{{ header|trans }} {{ parent() }}{% endblock %}
 
 {% form_theme form '@SyliusAdmin/Form/theme.html.twig' %}
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/index.html.twig
@@ -8,7 +8,7 @@
 
 {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
 
-{% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
+{% block title %}{{ header|trans }} {{ parent() }}{% endblock %}
 
 {% block content %}
 {{ sonata_block_render_event(event_prefix ~ '.before_header', {'resources': resources}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/update.html.twig
@@ -6,7 +6,7 @@
 {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.edit_'~metadata.name) %}
 {% set event_prefix = metadata.applicationName ~ '.admin.' ~ metadata.name ~ '.update' %}
 
-{% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
+{% block title %}{{ header|trans }} {{ parent() }}{% endblock %}
 
 {% form_theme form '@SyliusAdmin/Form/theme.html.twig' %}
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/show.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/show.html.twig
@@ -3,7 +3,7 @@
 {% import '@SyliusUi/Macro/labels.html.twig' as label %}
 {% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
 
-{% block title %}{{ parent() }} {{ 'sylius.ui.customer'|trans ~' '~ customer.email }}{% endblock %}
+{% block title %}{{ 'sylius.ui.customer'|trans ~' '~ customer.email }} {{ parent() }}{% endblock %}
 
 {% block content %}
     {{ sonata_block_render_event('sylius.admin.customer.show.before_header', {'resource': resource}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/index.html.twig
@@ -1,6 +1,6 @@
 {% extends 'SyliusAdminBundle::layout.html.twig' %}
 
-{% block title %}{{ parent() }}{{ 'sylius.ui.dashboard'|trans }}{% endblock %}
+{% block title %}{{ 'sylius.ui.dashboard'|trans }} {{ parent() }}{% endblock %}
 
 {% block content %}
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/history.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/history.html.twig
@@ -2,7 +2,7 @@
 
 {% import '@SyliusUi/Macro/labels.html.twig' as label %}
 
-{% block title %}{{ parent() }} {{ 'sylius.ui.order'|trans }} #{{ order.number }} - {{ 'sylius.ui.order_history'|trans }}{% endblock %}
+{% block title %}{{ 'sylius.ui.order'|trans }} #{{ order.number }} - {{ 'sylius.ui.order_history'|trans }} {{ parent() }}{% endblock %}
 
 {% block content %}
 {{ sonata_block_render_event('sylius.admin.order.history.before_header', {'resource': resource}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/show.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/show.html.twig
@@ -2,7 +2,7 @@
 
 {% import '@SyliusUi/Macro/labels.html.twig' as label %}
 
-{% block title %}{{ parent() }} {{ 'sylius.ui.order'|trans ~' #'~ order.number }}{% endblock %}
+{% block title %}{{ 'sylius.ui.order'|trans ~' #'~ order.number }} {{ parent() }}{% endblock %}
 
 {% set customer = order.customer %}
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/update.html.twig
@@ -3,7 +3,7 @@
 {% import 'SyliusUiBundle:Macro:headers.html.twig' as headers %}
 {% import 'SyliusUiBundle:Macro:buttons.html.twig' as buttons %}
 
-{% block title %}{{ parent() }} {{ 'sylius.ui.edit_order'|trans ~' #'~ order.number }}{% endblock %}
+{% block title %}{{ 'sylius.ui.edit_order'|trans ~' #'~ order.number }} {{ parent() }}{% endblock %}
 
 {% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/index.html.twig
@@ -7,7 +7,7 @@
 
 {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
 
-{% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
+{% block title %}{{ header|trans }} {{ parent() }}{% endblock %}
 
 {% block content %}
     {{ sonata_block_render_event('sylius.admin.product.index.before_header', {'resources': resources}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/generate.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/generate.html.twig
@@ -4,7 +4,7 @@
 
 {% set header = 'sylius.ui.generate_variants' %}
 
-{% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
+{% block title %}{{ header|trans }} {{ parent() }}{% endblock %}
 
 {% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/index.html.twig
@@ -7,7 +7,7 @@
 
 {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
 
-{% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
+{% block title %}{{ header|trans }} {{ parent() }}{% endblock %}
 
 {% block content %}
     {{ sonata_block_render_event('sylius.admin.product_variant.index.before_header', {'resources': resources}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/generate.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/generate.html.twig
@@ -4,7 +4,7 @@
 
 {% set header = 'sylius.ui.generate_coupons' %}
 
-{% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
+{% block title %}{{ header|trans }} {{ parent() }}{% endblock %}
 
 {% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/index.html.twig
@@ -7,7 +7,7 @@
 
 {% set header = configuration.vars.header|default(metadata.applicationName~'.ui.'~metadata.pluralName) %}
 
-{% block title %}{{ parent() }} {{ header|trans }}{% endblock %}
+{% block title %}{{ header|trans }} {{ parent() }}{% endblock %}
 
 {% block content %}
     {{ sonata_block_render_event('sylius.admin.promotion_coupon.index.before_header', {'resources': resources}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
@@ -1,6 +1,6 @@
 {% extends 'SyliusUiBundle:Layout:sidebar.html.twig' %}
 
-{% block title %}Sylius | {% endblock %}
+{% block title %} | Sylius{% endblock %}
 
 {% block stylesheets %}
     {% include 'SyliusUiBundle::_stylesheets.html.twig' with {'path': 'assets/admin/css/style.css'} %}


### PR DESCRIPTION
Instead of prefix, this is better UX. Knowing where you are in the admin
panel is more important to users than knowing what is powering it.

| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no (Well yes if someone relied on page titles...) |
| Related tickets |  |
| License         | MIT |
