### PR TITLE
[Attribute] Fixing null default DateTime on AttributeValue

### DIFF
--- a/src/Sylius/Component/Attribute/Model/AttributeValue.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeValue.php
@@ -11,6 +11,8 @@
 
 namespace Sylius\Component\Attribute\Model;
 
+use Sylius\Component\Attribute\AttributeType\DateAttributeType;
+use Sylius\Component\Attribute\AttributeType\DatetimeAttributeType;
 use Webmozart\Assert\Assert;
 
 /**
@@ -154,6 +156,9 @@ class AttributeValue implements AttributeValueInterface
         $this->assertAttributeIsSet();
 
         $setter = 'set' . $this->attribute->getStorageType();
+        if(($this->attribute->getStorageType() == DatetimeAttributeType::TYPE or $this->attribute->getStorageType() == DateAttributeType::TYPE) and $value === null){
+            $value = new \DateTime();
+        }
 
         $this->$setter($value);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |

When using the standalone ProductBundle their is an issue with AttributeValue, when i try to create this entity to add it to a Product their is an issue saying : 

> Catchable Fatal Error: Argument 1 passed to Sylius\Component\Attribute\Model\AttributeValue::setDate() must be an instance of DateTime, null given, called in /var/www/vendor/sylius/attribute/Model/AttributeValue.php on line 163 and defined

I added a condition to check if a date or a datetime attibute have a null value.

Thanks for your awsome job.