### PR TITLE
[Documentation][SyliusGridBundle] fixing twig field type

### DIFF
--- a/docs/bundles/SyliusGridBundle/field_types.rst
+++ b/docs/bundles/SyliusGridBundle/field_types.rst
@@ -62,6 +62,12 @@ In the ``:Grid/Column:_prettyName.html.twig`` template, you just need to render 
 
 .. code-block:: twig
 
+    <strong>{{ data }}</strong>
+
+If you wish to render more complex grid fields just redefine the path of the field to root – ``path: .`` in the yaml and you can access all attributes of the object instance:
+
+.. code-block:: twig
+
     <strong>{{ data.name }}</strong>
     <p>{{ data.description|markdown }}</p>
 


### PR DESCRIPTION
The description was missing a hint how to get the single field data or
the whole instance data into the twig template and display it.
Otherwise the example will display an error.

| Q               | A
| --------------- | ---
| Bug fix?        | yes - documentation bug |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | none |
| License         | MIT |
