### PR TITLE
[Behat][AddressBook] Added missing assertion

### DIFF
--- a/features/account/customer_account/address_book/editing_address.feature
+++ b/features/account/customer_account/address_book/editing_address.feature
@@ -49,7 +49,7 @@ Feature: Making changes in existing addresses
         And I save my changed address
         Then I should be notified that the address has been successfully updated
         And I should still have a single address in my address book
-        And it should contain "Australia"
+        And it should contain "AUSTRALIA"
         And it should contain "Queensland"
 
     @ui @javascript

--- a/src/Sylius/Behat/Context/Ui/Shop/AddressBookContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/AddressBookContext.php
@@ -224,7 +224,7 @@ final class AddressBookContext implements Context
     {
         $fullName = $this->sharedStorage->get('full_name');
 
-        $this->addressBookIndexPage->addressOfContains($fullName, $value);
+        Assert::true($this->addressBookIndexPage->addressOfContains($fullName, $value));
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | none |
| License         | MIT |

Assertion for containing a string in an address was missing which caused the step `it should contain` to always pass.