### PR TITLE
[Documentation][Product] Fix some typos

### DIFF
--- a/docs/components/Product/basic_usage.rst
+++ b/docs/components/Product/basic_usage.rst
@@ -22,6 +22,7 @@ Product attributes management
    <?php
 
    use Sylius\Component\Product\Model\Attribute;
+   use Sylius\Component\Product\Model\AttributeValue;
    use Doctrine\Common\Collections\ArrayCollection;
 
    $attribute = new Attribute();
@@ -67,7 +68,7 @@ Product variants management
 
    <?php
 
-   use Sylius\Component\Product\Model\ProductVariant;
+   use Sylius\Component\Product\Model\Variant;
 
    $variant = new Variant();
    $availableVariant = new Variant();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | none |
| License         | MIT |

This fixes partially. If you copy the code from [Product attributes management](http://docs.sylius.org/en/latest/components/Product/basic_usage.html#product-attributes-management) , it throws

```
PHP Fatal error:  Uncaught RuntimeException: No locale has been set and current locale is undefined. in /home/hari/experiments/php/sylius/product/vendor/sylius/resource/Model/TranslatableTrait.php:126
Stack trace:
```

The problem is locale not set for Translation. Want to look into it regarding how to fix the same..