### PR TITLE
[Documentation][Resource] Fix the form options configuration in docs

### DIFF
--- a/docs/bundles/SyliusResourceBundle/create_resource.rst
+++ b/docs/bundles/SyliusResourceBundle/create_resource.rst
@@ -88,7 +88,8 @@ Below you can see the usage for specifying custom options, in this case, ``valid
             _sylius:
                 form:
                     type: app_book_custom
-                    validation_groups: [sylius, my_custom_group]
+                    options:
+                        validation_groups: [sylius, my_custom_group]
 
 Using Custom Factory Method
 ---------------------------

--- a/docs/bundles/SyliusResourceBundle/update_resource.rst
+++ b/docs/bundles/SyliusResourceBundle/update_resource.rst
@@ -84,7 +84,8 @@ Below you can see how to specify custom options, in this case, ``validation_grou
             _sylius:
                 form:
                     type: app_book_custom
-                    validation_groups: [sylius, my_custom_group]
+                    options:
+                        validation_groups: [sylius, my_custom_group]
 
 Overriding the Criteria
 -----------------------


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | / |
| License         | MIT |

I believe this is an error in the docs. The `validation_groups` (and other form options) need to be defined under a key `options` instead of directly under `form`.

(See: https://github.com/Sylius/Sylius/blob/v1.0.0-beta.2/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfiguration.php#L149)


