### PR TITLE
[Addressing] Use UniqueWithinCollectionConstraint instead UniqueEntity for members validation

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/validation/Zone.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/validation/Zone.xml
@@ -48,13 +48,17 @@
                 <option name="groups">sylius</option>
             </constraint>
         </property>
-        <property name="members">
+        <getter property="members">
+            <constraint name="Sylius\Bundle\ResourceBundle\Validator\Constraints\UniqueWithinCollectionConstraint">
+                <option name="message">sylius.zone_member.unique</option>
+                <option name="groups">sylius</option>
+            </constraint>
             <constraint name="Valid" />
             <constraint name="Count">
                 <option name="min">1</option>
                 <option name="minMessage">sylius.zone.members.min_count</option>
                 <option name="groups">sylius</option>
             </constraint>
-        </property>
+        </getter>
     </class>
 </constraint-mapping>

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/validation/ZoneMember.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/validation/ZoneMember.xml
@@ -13,15 +13,6 @@
 
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
     <class name="Sylius\Component\Addressing\Model\ZoneMember">
-        <constraint name="Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity">
-            <option name="fields">
-                <value>code</value>
-                <value>belongsTo</value>
-            </option>
-            <option name="errorPath">code</option>
-            <option name="message">sylius.zone_member.unique</option>
-            <option name="groups">sylius</option>
-        </constraint>
         <property name="code">
             <constraint name="NotBlank">
                 <option name="message">sylius.zone_member.code.not_blank</option>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #3886 |
| License         | MIT |

Fixes Mysql Error Integrity constraint violation: 1062 when creating a new zone with duplicate zone members