### PR TITLE
Check if image exists before trying to delete it

### DIFF
--- a/src/Sylius/Component/Core/Uploader/ImageUploader.php
+++ b/src/Sylius/Component/Core/Uploader/ImageUploader.php
@@ -38,7 +38,7 @@ class ImageUploader implements ImageUploaderInterface
             return;
         }
 
-        if (null !== $image->getPath()) {
+        if (null !== $image->getPath() && $this->has($image->getPath())) {
             $this->remove($image->getPath());
         }
 
@@ -76,5 +76,15 @@ class ImageUploader implements ImageUploaderInterface
             substr($path, 2, 2),
             substr($path, 4)
         );
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return bool
+     */
+    private function has($path)
+    {
+        return $this->filesystem->has($path);
     }
 }


### PR DESCRIPTION
Fixes an issue when source image was deleted on existing image in the database and uploading a new one would result in error because there is nothing to delete

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | fixes #8236 |
| License         | MIT |
