### PR TITLE
Take shop firewallname in services from container parameter

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -128,7 +128,7 @@
 
         <service id="sylius.security.user_impersonator" class="Sylius\Bundle\CoreBundle\Security\UserImpersonator" public="false">
             <argument type="service" id="session" />
-            <argument type="string">shop</argument>
+            <argument type="string">%sylius_shop.firewall_context_name%</argument>
         </service>
 
         <service id="sylius.calculator.product_variant_price" class="Sylius\Component\Core\Calculator\ProductVariantPriceCalculator" />

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/integrations/locale/url.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/integrations/locale/url.xml
@@ -21,7 +21,7 @@
             <argument type="service" id="sylius.locale_provider" />
             <argument type="service" id="security.firewall.map" />
             <argument type="collection">
-                <argument type="string">shop</argument>
+                <argument type="string">%sylius_shop.firewall_context_name%</argument>
             </argument>
             <tag name="kernel.event_listener" event="kernel.request" method="restrictRequestLocale" priority="10"/>
         </service>


### PR DESCRIPTION
Since now we have the option to configure the shop firewall name, chage it to be able to impersonate

| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | #8210  |
| License         | MIT |
