### PR TITLE
[UI] Show filter label when form type is defined

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Filter/string.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Filter/string.html.twig
@@ -3,4 +3,4 @@
 {% if form.type is defined %}
 {{ form_row(form.type, {'label': filter.label}) }}
 {% endif %}
-{{ form_row(form.value, {'label': form.type is defined ? '' : false}) }}
+{{ form_row(form.value, {'label': form.type is defined ? '' : filter.label}) }}


### PR DESCRIPTION
Fix empty label when `form_options: { type }` is 'string'.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |




How to reproduce:
in `sylius_grid_mymodel.yml` specify form_options to avoid matching type dropdown:

```
year:
  type: string
  form_options:
    type: contains
```

And field label disappear:
![schermata 2017-07-06 alle 19 16 16](https://user-images.githubusercontent.com/1499063/27923713-9d9ae940-627f-11e7-80b2-4022bba58fbb.png)
