### PR TITLE
[MailerBundle] Fix compatibility for Swiftmailer v6

### DIFF
--- a/src/Sylius/Bundle/MailerBundle/Sender/Adapter/SwiftMailerAdapter.php
+++ b/src/Sylius/Bundle/MailerBundle/Sender/Adapter/SwiftMailerAdapter.php
@@ -50,7 +50,7 @@ class SwiftMailerAdapter extends AbstractAdapter
         array $data,
         array $attachments = []
     ) {
-        $message = \Swift_Message::newInstance()
+        $message = (new \Swift_Message())
             ->setSubject($renderedEmail->getSubject())
             ->setFrom([$senderAddress => $senderName])
             ->setTo($recipients)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

In Swiftmailer v6 the `newInstance()` methods were removed.
This change makes the MailerBundle compatible with both Swiftmailer v5 and v6 👍
