### PR TITLE
Example did not work for me.

### DIFF
--- a/docs/bundles/SyliusShippingBundle/resolving_available_methods.rst
+++ b/docs/bundles/SyliusShippingBundle/resolving_available_methods.rst
@@ -52,7 +52,7 @@ It supports two special options, required ``subject`` and optional ``criteria``.
         {
             $shipment = $this->get('sylius.repository.shipment')->find(5);
 
-            $form = $this->get('form.factory')->create('sylius_shipping_method_choice', array('subject' => $shipment));
+            $form = $this->get('form.factory')->create(ShippingMethodChoiceType::class, null, array('subject' => $shipment));
         }
     }
 


### PR DESCRIPTION
I was no able to load form type using the code from the example, it was possible to load it only with ShippingMethodChoiceType::class and null as a second arg.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #X, partially #Y, mentioned in #Z |
| License         | MIT |
