### PR TITLE
[Fix][OAuth] Attach existing non-registered customer

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
@@ -142,7 +142,7 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
         /** @var SyliusUserInterface $user */
         $user = $this->userFactory->createNew();
 
-        $customer = $this->customerRepository->findOneBy(['emailCanonical' => $response->getEmail()]);
+        $customer = $this->customerRepository->findOneBy(['emailCanonical' => strtolower($response->getEmail())]);
 
         if (null === $customer) {
             /** @var CustomerInterface $customer */
@@ -158,17 +158,16 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
 
         if (null !== $name = $response->getFirstName()) {
             $customer->setFirstName($name);
-        } else {
-            if (null !== $realName = $response->getRealName()) {
+        } elseif (null !== $realName = $response->getRealName()) {
                 $customer->setFirstName($realName);
-            }
         }
+
         if (null !== $lastName = $response->getLastName()) {
             $customer->setLastName($lastName);
-        } else {
-            if (!$user->getUsername()) {
-                $user->setUsername($response->getEmail() ?: $response->getNickname());
-            }
+        }
+
+        if (!$user->getUsername()) {
+            $user->setUsername($response->getEmail() ?: $response->getNickname());
         }
 
         // set random password to prevent issue with not nullable field & potential security hole

--- a/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
@@ -142,10 +142,12 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
         /** @var SyliusUserInterface $user */
         $user = $this->userFactory->createNew();
 
-        $customer = $this->customerRepository->findOneBy(['emailCanonical' => strtolower($response->getEmail())]);
+        $canonicalEmail = $this->canonicalizer->canonicalize($response->getEmail());
+
+        /** @var CustomerInterface $customer */
+        $customer = $this->customerRepository->findOneBy(['emailCanonical' => $canonicalEmail]);
 
         if (null === $customer) {
-            /** @var CustomerInterface $customer */
             $customer = $this->customerFactory->createNew();
         }
 
@@ -159,7 +161,7 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
         if (null !== $name = $response->getFirstName()) {
             $customer->setFirstName($name);
         } elseif (null !== $realName = $response->getRealName()) {
-                $customer->setFirstName($realName);
+            $customer->setFirstName($realName);
         }
 
         if (null !== $lastName = $response->getLastName()) {

--- a/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
@@ -18,6 +18,7 @@ use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthAwareUserProviderInterface;
 use Sylius\Bundle\UserBundle\Provider\UsernameOrEmailProvider as BaseUserProvider;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\ShopUserInterface as SyliusUserInterface;
+use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\User\Canonicalizer\CanonicalizerInterface;
@@ -60,6 +61,11 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
     private $userManager;
 
     /**
+     * @var CustomerRepositoryInterface
+     */
+    private $customerRepository;
+
+    /**
      * @param string $supportedUserClass
      * @param FactoryInterface $customerFactory
      * @param FactoryInterface $userFactory
@@ -68,6 +74,7 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
      * @param RepositoryInterface $oauthRepository
      * @param ObjectManager $userManager
      * @param CanonicalizerInterface $canonicalizer
+     * @param CustomerRepositoryInterface $customerRepository
      */
     public function __construct(
         $supportedUserClass,
@@ -77,7 +84,8 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
         FactoryInterface $oauthFactory,
         RepositoryInterface $oauthRepository,
         ObjectManager $userManager,
-        CanonicalizerInterface $canonicalizer
+        CanonicalizerInterface $canonicalizer,
+        CustomerRepositoryInterface $customerRepository
     ) {
         parent::__construct($supportedUserClass, $userRepository, $canonicalizer);
 
@@ -86,6 +94,7 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
         $this->oauthRepository = $oauthRepository;
         $this->userFactory = $userFactory;
         $this->userManager = $userManager;
+        $this->customerRepository = $customerRepository;
     }
 
     /**
@@ -132,8 +141,14 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
     {
         /** @var SyliusUserInterface $user */
         $user = $this->userFactory->createNew();
-        /** @var CustomerInterface $customer */
-        $customer = $this->customerFactory->createNew();
+
+        $customer = $this->customerRepository->findOneBy(['emailCanonical' => $response->getEmail()]);
+
+        if (null === $customer) {
+            /** @var CustomerInterface $customer */
+            $customer = $this->customerFactory->createNew();
+        }
+
         $user->setCustomer($customer);
 
         // set default values taken from OAuth sign-in provider account
@@ -141,12 +156,19 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
             $customer->setEmail($email);
         }
 
-        if (null !== $realName = $response->getRealName()) {
-            $customer->setFirstName($realName);
+        if (null !== $name = $response->getFirstName()) {
+            $customer->setFirstName($name);
+        } else {
+            if (null !== $realName = $response->getRealName()) {
+                $customer->setFirstName($realName);
+            }
         }
-
-        if (!$user->getUsername()) {
-            $user->setUsername($response->getEmail() ?: $response->getNickname());
+        if (null !== $lastName = $response->getLastName()) {
+            $customer->setLastName($lastName);
+        } else {
+            if (!$user->getUsername()) {
+                $user->setUsername($response->getEmail() ?: $response->getNickname());
+            }
         }
 
         // set random password to prevent issue with not nullable field & potential security hole

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/integrations/hwi_oauth.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/integrations/hwi_oauth.xml
@@ -22,6 +22,7 @@
             <argument type="service" id="sylius.repository.oauth_user" />
             <argument type="service" id="sylius.manager.shop_user" />
             <argument type="service" id="sylius.canonicalizer" />
+            <argument type="service" id="sylius.repository.customer" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets |    |
| License         | MIT |

Check if customer with provided email already exists before trying to create one - fixes a UniqueConstraint violation error and is in line with default direct registration logic.
Also tries to read First name and Last name from OAuth provided data first and then reverts back to the default behaviour of reading "Real name" for first name and nickname/email for last name