### PR TITLE
[Theme] Working with json manifest file version strategy

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Asset/Package/PathPackage.php
+++ b/src/Sylius/Bundle/ThemeBundle/Asset/Package/PathPackage.php
@@ -57,6 +57,8 @@ class PathPackage extends BasePathPackage
      */
     public function getUrl($path)
     {
+        $path = $this->getVersionStrategy()->applyVersion($path);
+
         if ($this->isAbsoluteUrl($path)) {
             return $path;
         }
@@ -66,6 +68,6 @@ class PathPackage extends BasePathPackage
             $path = $this->pathResolver->resolve($path, $theme);
         }
 
-        return $this->getBasePath().ltrim($this->getVersionStrategy()->applyVersion($path), '/');
+        return $this->getBasePath().ltrim($path, '/');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -
| License       | MIT

While I was trying to add the promising Webpack Encore tool to my sylius app, I stumbled across some issue. When the assets are served from the webpack dev server it’s more convenient to use the json manifest file version strategy to not change the path manually when switching from dev to production. The problem is, when an asset is served from  "http://localhost:8080/build" for exemple, the getUrl method of the PathPackage class won’t detect that it’s an absolute path and returns a relative path like "/http://localhost:8080/build". The solution I found is to apply the version strategy to $path and then check if it’s an absolute url. Maybe it’s not a good solution for every cases, so let me know what you think about it !