### PR TITLE
Use \DateTimeInterface typehint instead of \DateTime

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,10 @@
 # UPGRADE FROM 1.0.0-beta.3 to 1.0.0
 
+## Application:
+
+* `\DateTimeInterface` is used for typehints instead of `\DateTime` to allow for compatibility with `\DateTimeImmutable`.
+  Do not rely on mutable behaviour and set changes directly on the model.
+
 ## Packages:
 
 ### Order / OrderBundle

--- a/src/Sylius/Behat/Context/Setup/CustomerContext.php
+++ b/src/Sylius/Behat/Context/Setup/CustomerContext.php
@@ -209,7 +209,7 @@ final class CustomerContext implements Context
      * @param string $email
      * @param string|null $firstName
      * @param string|null $lastName
-     * @param \DateTime|null $createdAt
+     * @param \DateTimeInterface|null $createdAt
      * @param string|null $phoneNumber
      *
      * @return CustomerInterface
@@ -218,7 +218,7 @@ final class CustomerContext implements Context
         $email,
         $firstName = null,
         $lastName = null,
-        \DateTime $createdAt = null,
+        \DateTimeInterface $createdAt = null,
         $phoneNumber = null
     ) {
         /** @var CustomerInterface $customer */

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionCouponsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionCouponsContext.php
@@ -137,7 +137,7 @@ final class ManagingPromotionCouponsContext implements Context
     /**
      * @When I make generated coupons valid until :date
      */
-    public function iMakeGeneratedCouponsValidUntil(\DateTime $date)
+    public function iMakeGeneratedCouponsValidUntil(\DateTimeInterface $date)
     {
         $this->generatePage->setExpiresAt($date);
     }
@@ -195,7 +195,7 @@ final class ManagingPromotionCouponsContext implements Context
     /**
      * @When I make it valid until :date
      */
-    public function iMakeItValidUntil(\DateTime $date)
+    public function iMakeItValidUntil(\DateTimeInterface $date)
     {
         $this->createPage->setExpiresAt($date);
     }
@@ -203,7 +203,7 @@ final class ManagingPromotionCouponsContext implements Context
     /**
      * @When I change expires date to :date
      */
-    public function iChangeExpiresDateTo(\DateTime $date)
+    public function iChangeExpiresDateTo(\DateTimeInterface $date)
     {
         $this->updatePage->setExpiresAt($date);
     }
@@ -265,7 +265,7 @@ final class ManagingPromotionCouponsContext implements Context
     /**
      * @Then this coupon should be valid until :date
      */
-    public function thisCouponShouldBeValidUntil(\DateTime $date)
+    public function thisCouponShouldBeValidUntil(\DateTimeInterface $date)
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['expiresAt' => date('d-m-Y', $date->getTimestamp())]));
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -473,7 +473,7 @@ final class ManagingPromotionsContext implements Context
     /**
      * @When I make it available from :startsDate to :endsDate
      */
-    public function iMakeItAvailableFromTo(\DateTime $startsDate, \DateTime $endsDate)
+    public function iMakeItAvailableFromTo(\DateTimeInterface $startsDate, \DateTimeInterface $endsDate)
     {
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
@@ -484,7 +484,7 @@ final class ManagingPromotionsContext implements Context
     /**
      * @Then the :promotion promotion should be available from :startsDate to :endsDate
      */
-    public function thePromotionShouldBeAvailableFromTo(PromotionInterface $promotion, \DateTime $startsDate, \DateTime $endsDate)
+    public function thePromotionShouldBeAvailableFromTo(PromotionInterface $promotion, \DateTimeInterface $startsDate, \DateTimeInterface $endsDate)
     {
         $this->iWantToModifyAPromotion($promotion);
 

--- a/src/Sylius/Behat/Page/Admin/Customer/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Customer/ShowPageInterface.php
@@ -47,7 +47,7 @@ interface ShowPageInterface extends PageInterface
     public function getCustomerName();
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getRegistrationDate();
 

--- a/src/Sylius/Behat/Page/Admin/Order/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/IndexPage.php
@@ -23,7 +23,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
     /**
      * {@inheritdoc}
      */
-    public function specifyFilterDateFrom(\DateTime $dateTime)
+    public function specifyFilterDateFrom(\DateTimeInterface $dateTime)
     {
         $timestamp = $dateTime->getTimestamp();
 
@@ -34,7 +34,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
     /**
      * {@inheritdoc}
      */
-    public function specifyFilterDateTo(\DateTime $dateTime)
+    public function specifyFilterDateTo(\DateTimeInterface $dateTime)
     {
         $timestamp = $dateTime->getTimestamp();
 

--- a/src/Sylius/Behat/Page/Admin/Order/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Order/IndexPageInterface.php
@@ -21,14 +21,14 @@ use Sylius\Behat\Page\Admin\Crud\IndexPageInterface as BaseIndexPageInterface;
 interface IndexPageInterface extends BaseIndexPageInterface
 {
     /**
-     * @param \DateTime $dateTime
+     * @param \DateTimeInterface $dateTime
      */
-    public function specifyFilterDateFrom(\DateTime $dateTime);
+    public function specifyFilterDateFrom(\DateTimeInterface $dateTime);
 
     /**
-     * @param \DateTime $dateTime
+     * @param \DateTimeInterface $dateTime
      */
-    public function specifyFilterDateTo(\DateTime $dateTime);
+    public function specifyFilterDateTo(\DateTimeInterface $dateTime);
 
     /**
      * @param string $channelName

--- a/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
@@ -161,7 +161,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     /**
      * {@inheritdoc}
      */
-    public function setStartsAt(\DateTime $dateTime)
+    public function setStartsAt(\DateTimeInterface $dateTime)
     {
         $timestamp = $dateTime->getTimestamp();
 
@@ -172,7 +172,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     /**
      * {@inheritdoc}
      */
-    public function setEndsAt(\DateTime $dateTime)
+    public function setEndsAt(\DateTimeInterface $dateTime)
     {
         $timestamp = $dateTime->getTimestamp();
 

--- a/src/Sylius/Behat/Page/Admin/Promotion/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/CreatePageInterface.php
@@ -104,14 +104,14 @@ interface CreatePageInterface extends BaseCreatePageInterface
     public function checkChannel($name);
 
     /**
-     * @param \DateTime $dateTime
+     * @param \DateTimeInterface $dateTime
      */
-    public function setStartsAt(\DateTime $dateTime);
+    public function setStartsAt(\DateTimeInterface $dateTime);
 
     /**
-     * @param \DateTime $dateTime
+     * @param \DateTimeInterface $dateTime
      */
-    public function setEndsAt(\DateTime $dateTime);
+    public function setEndsAt(\DateTimeInterface $dateTime);
 
     /**
      * @return string

--- a/src/Sylius/Behat/Page/Admin/Promotion/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/UpdatePage.php
@@ -78,7 +78,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     /**
      * {@inheritdoc}
      */
-    public function setStartsAt(\DateTime $dateTime)
+    public function setStartsAt(\DateTimeInterface $dateTime)
     {
         $timestamp = $dateTime->getTimestamp();
 
@@ -89,7 +89,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     /**
      * {@inheritdoc}
      */
-    public function setEndsAt(\DateTime $dateTime)
+    public function setEndsAt(\DateTimeInterface $dateTime)
     {
         $timestamp = $dateTime->getTimestamp();
 
@@ -100,7 +100,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     /**
      * {@inheritdoc}
      */
-    public function hasStartsAt(\DateTime $dateTime)
+    public function hasStartsAt(\DateTimeInterface $dateTime)
     {
         $timestamp = $dateTime->getTimestamp();
 
@@ -111,7 +111,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     /**
      * {@inheritdoc}
      */
-    public function hasEndsAt(\DateTime $dateTime)
+    public function hasEndsAt(\DateTimeInterface $dateTime)
     {
         $timestamp = $dateTime->getTimestamp();
 

--- a/src/Sylius/Behat/Page/Admin/Promotion/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/UpdatePageInterface.php
@@ -64,22 +64,22 @@ interface UpdatePageInterface extends BaseUpdatePageInterface
     public function checkChannel($name);
 
     /**
-     * @param \DateTime $dateTime
+     * @param \DateTimeInterface $dateTime
      */
-    public function setStartsAt(\DateTime $dateTime);
+    public function setStartsAt(\DateTimeInterface $dateTime);
 
     /**
-     * @param \DateTime $dateTime
+     * @param \DateTimeInterface $dateTime
      */
-    public function setEndsAt(\DateTime $dateTime);
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasStartsAt(\DateTime $dateTime);
+    public function setEndsAt(\DateTimeInterface $dateTime);
 
     /**
      * {@inheritdoc}
      */
-    public function hasEndsAt(\DateTime $dateTime);
+    public function hasStartsAt(\DateTimeInterface $dateTime);
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasEndsAt(\DateTimeInterface $dateTime);
 }

--- a/src/Sylius/Behat/Page/Admin/PromotionCoupon/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/PromotionCoupon/CreatePage.php
@@ -34,7 +34,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     /**
      * {@inheritdoc}
      */
-    public function setExpiresAt(\DateTime $date)
+    public function setExpiresAt(\DateTimeInterface $date)
     {
         $timestamp = $date->getTimestamp();
 

--- a/src/Sylius/Behat/Page/Admin/PromotionCoupon/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/PromotionCoupon/CreatePageInterface.php
@@ -26,9 +26,9 @@ interface CreatePageInterface extends BaseCreatePageInterface
     public function setCustomerUsageLimit($limit);
 
     /**
-     * @param \DateTime $date
+     * @param \DateTimeInterface $date
      */
-    public function setExpiresAt(\DateTime $date);
+    public function setExpiresAt(\DateTimeInterface $date);
 
     /**
      * @param string $code

--- a/src/Sylius/Behat/Page/Admin/PromotionCoupon/GeneratePage.php
+++ b/src/Sylius/Behat/Page/Admin/PromotionCoupon/GeneratePage.php
@@ -70,7 +70,7 @@ class GeneratePage extends SymfonyPage implements GeneratePageInterface
     /**
      * {@inheritdoc}
      */
-    public function setExpiresAt(\DateTime $date)
+    public function setExpiresAt(\DateTimeInterface $date)
     {
         $timestamp = $date->getTimestamp();
 

--- a/src/Sylius/Behat/Page/Admin/PromotionCoupon/GeneratePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/PromotionCoupon/GeneratePageInterface.php
@@ -54,9 +54,9 @@ interface GeneratePageInterface extends SymfonyPageInterface
     public function specifyCodeLength($codeLength);
 
     /**
-     * @param \DateTime $date
+     * @param \DateTimeInterface $date
      */
-    public function setExpiresAt(\DateTime $date);
+    public function setExpiresAt(\DateTimeInterface $date);
 
     /**
      * @param int $limit

--- a/src/Sylius/Behat/Page/Admin/PromotionCoupon/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/PromotionCoupon/UpdatePage.php
@@ -33,9 +33,9 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     }
 
     /**
-     * @param \DateTime $date
+     * @param \DateTimeInterface $date
      */
-    public function setExpiresAt(\DateTime $date)
+    public function setExpiresAt(\DateTimeInterface $date)
     {
         $timestamp = $date->getTimestamp();
 

--- a/src/Sylius/Behat/Page/Admin/PromotionCoupon/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/PromotionCoupon/UpdatePageInterface.php
@@ -31,9 +31,9 @@ interface UpdatePageInterface extends BaseUpdatePageInterface
     public function setCustomerUsageLimit($limit);
 
     /**
-     * @param \DateTime $date
+     * @param \DateTimeInterface $date
      */
-    public function setExpiresAt(\DateTime $date);
+    public function setExpiresAt(\DateTimeInterface $date);
 
     /**
      * @param int $limit

--- a/src/Sylius/Bundle/AdminApiBundle/Fixture/Factory/ApiAccessTokenExampleFactory.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Fixture/Factory/ApiAccessTokenExampleFactory.php
@@ -114,7 +114,7 @@ class ApiAccessTokenExampleFactory extends AbstractExampleFactory
             ->setAllowedTypes('client', ['string', ClientInterface::class, 'null'])
             ->setNormalizer('client', LazyOption::findOneBy($this->clientRepository, 'randomId'))
             ->setDefault('expires_at', null)
-            ->setAllowedTypes('expires_at', ['null', \DateTime::class])
+            ->setAllowedTypes('expires_at', ['null', \DateTimeInterface::class])
         ;
     }
 }

--- a/src/Sylius/Bundle/AttributeBundle/spec/Validator/Constraints/ValidAttributeValueValidatorSpec.php
+++ b/src/Sylius/Bundle/AttributeBundle/spec/Validator/Constraints/ValidAttributeValueValidatorSpec.php
@@ -69,7 +69,7 @@ final class ValidAttributeValueValidatorSpec extends ObjectBehavior
         ValidAttributeValue $attributeValueConstraint
     ) {
         $this
-            ->shouldThrow(new UnexpectedTypeException('\DateTime', AttributeValueInterface::class))
+            ->shouldThrow(new UnexpectedTypeException('\DateTimeInterface', AttributeValueInterface::class))
             ->during('validate', [$badObject, $attributeValueConstraint])
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -247,7 +247,7 @@ class OrderRepository extends BaseOrderRepository implements OrderRepositoryInte
     /**
      * {@inheritdoc}
      */
-    public function findOrdersUnpaidSince(\DateTime $terminalDate)
+    public function findOrdersUnpaidSince(\DateTimeInterface $terminalDate)
     {
         return $this->createQueryBuilder('o')
             ->where('o.checkoutState = :checkoutState')

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
@@ -169,7 +169,7 @@ class ShippingMethodExampleFactory extends AbstractExampleFactory implements Exa
             ->setAllowedTypes('channels', 'array')
             ->setNormalizer('channels', LazyOption::findBy($this->channelRepository, 'code'))
             ->setDefault('archived_at', null)
-            ->setAllowedTypes('archived_at', ['null', \DateTime::class])
+            ->setAllowedTypes('archived_at', ['null', \DateTimeInterface::class])
         ;
     }
 

--- a/src/Sylius/Bundle/CoreBundle/spec/Validator/Constraints/LocalesAwareValidAttributeValueValidatorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Validator/Constraints/LocalesAwareValidAttributeValueValidatorSpec.php
@@ -95,7 +95,7 @@ class LocalesAwareValidAttributeValueValidatorSpec extends ObjectBehavior
         ValidAttributeValue $attributeValueConstraint
     ) {
         $this
-            ->shouldThrow(new UnexpectedTypeException('\DateTime', AttributeValueInterface::class))
+            ->shouldThrow(new UnexpectedTypeException('\DateTimeInterface', AttributeValueInterface::class))
             ->during('validate', [$badObject, $attributeValueConstraint])
         ;
     }

--- a/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/OrderBundle/Doctrine/ORM/OrderRepository.php
@@ -114,7 +114,7 @@ class OrderRepository extends EntityRepository implements OrderRepositoryInterfa
     /**
      * {@inheritdoc}
      */
-    public function findCartsNotModifiedSince(\DateTime $terminalDate)
+    public function findCartsNotModifiedSince(\DateTimeInterface $terminalDate)
     {
         return $this->createQueryBuilder('o')
             ->andWhere('o.state = :state')

--- a/src/Sylius/Bundle/OrderBundle/spec/Remover/ExpiredCartsRemoverSpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Remover/ExpiredCartsRemoverSpec.php
@@ -50,7 +50,7 @@ final class ExpiredCartsRemoverSpec extends ObjectBehavior
         OrderInterface $firstCart,
         OrderInterface $secondCart
     ) {
-        $orderRepository->findCartsNotModifiedSince(Argument::type('\DateTime'))->willReturn([
+        $orderRepository->findCartsNotModifiedSince(Argument::type('\DateTimeInterface'))->willReturn([
             $firstCart,
             $secondCart
         ]);

--- a/src/Sylius/Bundle/PromotionBundle/Doctrine/ORM/PromotionRepository.php
+++ b/src/Sylius/Bundle/PromotionBundle/Doctrine/ORM/PromotionRepository.php
@@ -44,11 +44,11 @@ class PromotionRepository extends EntityRepository implements PromotionRepositor
 
     /**
      * @param QueryBuilder $queryBuilder
-     * @param \DateTime|null $date
+     * @param \DateTimeInterface|null $date
      *
      * @return QueryBuilder
      */
-    protected function filterByActive(QueryBuilder $queryBuilder, \DateTime $date = null)
+    protected function filterByActive(QueryBuilder $queryBuilder, \DateTimeInterface $date = null)
     {
         return $queryBuilder
             ->andWhere('o.startsAt IS NULL OR o.startsAt < :date')

--- a/src/Sylius/Bundle/UserBundle/spec/EventListener/UserLastLoginSubscriberSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/EventListener/UserLastLoginSubscriberSpec.php
@@ -59,7 +59,7 @@ final class UserLastLoginSubscriberSpec extends ObjectBehavior
         $event->getAuthenticationToken()->willReturn($token);
         $token->getUser()->willReturn($user);
 
-        $user->setLastLogin(Argument::type(\DateTime::class))->shouldBeCalled();
+        $user->setLastLogin(Argument::type(\DateTimeInterface::class))->shouldBeCalled();
 
         $userManager->persist($user)->shouldBeCalled();
         $userManager->flush()->shouldBeCalled();
@@ -74,7 +74,7 @@ final class UserLastLoginSubscriberSpec extends ObjectBehavior
     ) {
         $event->getUser()->willReturn($user);
 
-        $user->setLastLogin(Argument::type(\DateTime::class))->shouldBeCalled();
+        $user->setLastLogin(Argument::type(\DateTimeInterface::class))->shouldBeCalled();
 
         $userManager->persist($user)->shouldBeCalled();
         $userManager->flush()->shouldBeCalled();

--- a/src/Sylius/Component/Addressing/spec/Model/AddressSpec.php
+++ b/src/Sylius/Component/Addressing/spec/Model/AddressSpec.php
@@ -186,7 +186,7 @@ final class AddressSpec extends ObjectBehavior
 
     function its_creation_time_is_initialized_by_default()
     {
-        $this->getCreatedAt()->shouldHaveType(\DateTime::class);
+        $this->getCreatedAt()->shouldHaveType(\DateTimeInterface::class);
     }
 
     function its_last_update_time_is_undefined_by_default()

--- a/src/Sylius/Component/Attribute/Model/AttributeValue.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeValue.php
@@ -62,12 +62,12 @@ class AttributeValue implements AttributeValueInterface
     private $float;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     private $datetime;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     private $date;
 
@@ -255,7 +255,7 @@ class AttributeValue implements AttributeValueInterface
     }
 
     /**
-     * @return \DateTime|null
+     * @return \DateTimeInterface|null
      */
     protected function getDatetime()
     {
@@ -263,15 +263,15 @@ class AttributeValue implements AttributeValueInterface
     }
 
     /**
-     * @param \DateTime|null $datetime
+     * @param \DateTimeInterface|null $datetime
      */
-    protected function setDatetime(\DateTime $datetime = null)
+    protected function setDatetime(\DateTimeInterface $datetime = null)
     {
         $this->datetime = $datetime;
     }
 
     /**
-     * @return \DateTime|null
+     * @return \DateTimeInterface|null
      */
     protected function getDate()
     {
@@ -279,9 +279,9 @@ class AttributeValue implements AttributeValueInterface
     }
 
     /**
-     * @param \DateTime|null $date
+     * @param \DateTimeInterface|null $date
      */
-    protected function setDate(\DateTime $date = null)
+    protected function setDate(\DateTimeInterface $date = null)
     {
         $this->date = $date;
     }

--- a/src/Sylius/Component/Attribute/spec/Model/AttributeSpec.php
+++ b/src/Sylius/Component/Attribute/spec/Model/AttributeSpec.php
@@ -99,7 +99,7 @@ final class AttributeSpec extends ObjectBehavior
 
     function it_initializes_creation_date_by_default()
     {
-        $this->getCreatedAt()->shouldHaveType(\DateTime::class);
+        $this->getCreatedAt()->shouldHaveType(\DateTimeInterface::class);
     }
 
     function its_creation_date_is_mutable(\DateTime $date)

--- a/src/Sylius/Component/Channel/spec/Model/ChannelSpec.php
+++ b/src/Sylius/Component/Channel/spec/Model/ChannelSpec.php
@@ -80,7 +80,7 @@ final class ChannelSpec extends ObjectBehavior
 
     function it_initializes_creation_date_by_default()
     {
-        $this->getCreatedAt()->shouldHaveType(\DateTime::class);
+        $this->getCreatedAt()->shouldHaveType(\DateTimeInterface::class);
     }
 
     function its_creation_date_is_mutable(\DateTime $date)

--- a/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
+++ b/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
@@ -117,11 +117,11 @@ interface OrderRepositoryInterface extends BaseOrderRepositoryInterface
     public function findLatestInChannel($count, ChannelInterface $channel);
 
     /**
-     * @param \DateTime $terminalDate
+     * @param \DateTimeInterface $terminalDate
      *
      * @return OrderInterface[]
      */
-    public function findOrdersUnpaidSince(\DateTime $terminalDate);
+    public function findOrdersUnpaidSince(\DateTimeInterface $terminalDate);
 
     /**
      * @return OrderInterface|null

--- a/src/Sylius/Component/Core/spec/Test/Factory/TestPromotionFactorySpec.php
+++ b/src/Sylius/Component/Core/spec/Test/Factory/TestPromotionFactorySpec.php
@@ -46,8 +46,8 @@ final class TestPromotionFactorySpec extends ObjectBehavior
         $promotionFactory->createNew()->willReturn($promotion);
         $promotion->setName('Super promotion')->shouldBeCalled();
         $promotion->setCode('super_promotion')->shouldBeCalled();
-        $promotion->setStartsAt(Argument::type('\DateTime'))->shouldBeCalled();
-        $promotion->setEndsAt(Argument::type('\DateTime'))->shouldBeCalled();
+        $promotion->setStartsAt(Argument::type('\DateTimeInterface'))->shouldBeCalled();
+        $promotion->setEndsAt(Argument::type('\DateTimeInterface'))->shouldBeCalled();
 
         $this->create('Super promotion')->shouldReturn($promotion);
     }
@@ -60,8 +60,8 @@ final class TestPromotionFactorySpec extends ObjectBehavior
         $promotionFactory->createNew()->willReturn($promotion);
         $promotion->setName('Super promotion')->shouldBeCalled();
         $promotion->setCode('super_promotion')->shouldBeCalled();
-        $promotion->setStartsAt(Argument::type('\DateTime'))->shouldBeCalled();
-        $promotion->setEndsAt(Argument::type('\DateTime'))->shouldBeCalled();
+        $promotion->setStartsAt(Argument::type('\DateTimeInterface'))->shouldBeCalled();
+        $promotion->setEndsAt(Argument::type('\DateTimeInterface'))->shouldBeCalled();
         $promotion->addChannel($channel)->shouldBeCalled();
 
         $this->createForChannel('Super promotion', $channel)->shouldReturn($promotion);

--- a/src/Sylius/Component/Core/spec/Updater/UnpaidOrdersStateUpdaterSpec.php
+++ b/src/Sylius/Component/Core/spec/Updater/UnpaidOrdersStateUpdaterSpec.php
@@ -51,7 +51,7 @@ final class UnpaidOrdersStateUpdaterSpec extends ObjectBehavior
         StateMachineInterface $firstOrderStateMachine,
         StateMachineInterface $secondOrderStateMachine
     ) {
-        $orderRepository->findOrdersUnpaidSince(Argument::type(\DateTime::class))->willReturn([
+        $orderRepository->findOrdersUnpaidSince(Argument::type(\DateTimeInterface::class))->willReturn([
            $firstOrder,
            $secondOrder
         ]);

--- a/src/Sylius/Component/Currency/spec/Model/CurrencySpec.php
+++ b/src/Sylius/Component/Currency/spec/Model/CurrencySpec.php
@@ -48,7 +48,7 @@ final class CurrencySpec extends ObjectBehavior
 
     function it_initializes_creation_date_by_default()
     {
-        $this->getCreatedAt()->shouldHaveType(\DateTime::class);
+        $this->getCreatedAt()->shouldHaveType(\DateTimeInterface::class);
     }
 
     function its_creation_date_is_mutable(\DateTime $date)

--- a/src/Sylius/Component/Currency/spec/Model/ExchangeRateSpec.php
+++ b/src/Sylius/Component/Currency/spec/Model/ExchangeRateSpec.php
@@ -67,7 +67,7 @@ final class ExchangeRateSpec extends ObjectBehavior
 
     function it_initializes_creation_date_by_default()
     {
-        $this->getCreatedAt()->shouldHaveType(\DateTime::class);
+        $this->getCreatedAt()->shouldHaveType(\DateTimeInterface::class);
     }
 
     function its_creation_date_is_mutable(\DateTime $date)

--- a/src/Sylius/Component/Customer/Model/Customer.php
+++ b/src/Sylius/Component/Customer/Model/Customer.php
@@ -48,7 +48,7 @@ class Customer implements CustomerInterface
     protected $lastName;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $birthday;
 
@@ -176,7 +176,7 @@ class Customer implements CustomerInterface
     /**
      * {@inheritdoc}
      */
-    public function setBirthday(\DateTime $birthday = null)
+    public function setBirthday(\DateTimeInterface $birthday = null)
     {
         $this->birthday = $birthday;
     }

--- a/src/Sylius/Component/Customer/Model/CustomerInterface.php
+++ b/src/Sylius/Component/Customer/Model/CustomerInterface.php
@@ -73,14 +73,14 @@ interface CustomerInterface extends TimestampableInterface, ResourceInterface
     public function setLastName($lastName);
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getBirthday();
 
     /**
-     * @param  \DateTime $birthday
+     * @param  \DateTimeInterface $birthday
      */
-    public function setBirthday(\DateTime $birthday = null);
+    public function setBirthday(\DateTimeInterface $birthday = null);
 
     /**
      * @return string

--- a/src/Sylius/Component/Grid/FieldTypes/DatetimeFieldType.php
+++ b/src/Sylius/Component/Grid/FieldTypes/DatetimeFieldType.php
@@ -46,7 +46,7 @@ final class DatetimeFieldType implements FieldTypeInterface
             return null;
         }
 
-        Assert::isInstanceOf($value, \DateTime::class);
+        Assert::isInstanceOf($value, \DateTimeInterface::class);
 
         return $value->format($options['format']);
     }

--- a/src/Sylius/Component/Locale/spec/Model/LocaleSpec.php
+++ b/src/Sylius/Component/Locale/spec/Model/LocaleSpec.php
@@ -81,7 +81,7 @@ final class LocaleSpec extends ObjectBehavior
 
     function it_initializes_creation_date_by_default()
     {
-        $this->getCreatedAt()->shouldHaveType(\DateTime::class);
+        $this->getCreatedAt()->shouldHaveType(\DateTimeInterface::class);
     }
 
     function it_does_not_have_last_update_date_by_default()

--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -30,7 +30,7 @@ class Order implements OrderInterface
     protected $id;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $checkoutCompletedAt;
 
@@ -102,7 +102,7 @@ class Order implements OrderInterface
     /**
      * {@inheritdoc}
      */
-    public function setCheckoutCompletedAt(\DateTime $checkoutCompletedAt = null)
+    public function setCheckoutCompletedAt(\DateTimeInterface $checkoutCompletedAt = null)
     {
         $this->checkoutCompletedAt = $checkoutCompletedAt;
     }

--- a/src/Sylius/Component/Order/Model/OrderInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderInterface.php
@@ -28,14 +28,14 @@ interface OrderInterface extends AdjustableInterface, ResourceInterface, Timesta
     const STATE_FULFILLED = 'fulfilled';
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getCheckoutCompletedAt();
 
     /**
-     * @param null|\DateTime $checkoutCompletedAt
+     * @param null|\DateTimeInterface $checkoutCompletedAt
      */
-    public function setCheckoutCompletedAt(\DateTime $checkoutCompletedAt = null);
+    public function setCheckoutCompletedAt(\DateTimeInterface $checkoutCompletedAt = null);
 
     /**
      * @return bool

--- a/src/Sylius/Component/Order/Repository/OrderRepositoryInterface.php
+++ b/src/Sylius/Component/Order/Repository/OrderRepositoryInterface.php
@@ -55,11 +55,11 @@ interface OrderRepositoryInterface extends RepositoryInterface
     public function findCartById($id);
 
     /**
-     * @param \DateTime $terminalDate
+     * @param \DateTimeInterface $terminalDate
      *
      * @return OrderInterface[]
      */
-    public function findCartsNotModifiedSince(\DateTime $terminalDate);
+    public function findCartsNotModifiedSince(\DateTimeInterface $terminalDate);
 
     /**
      * @return \Doctrine\ORM\QueryBuilder

--- a/src/Sylius/Component/Order/spec/Model/AdjustmentSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/AdjustmentSpec.php
@@ -236,7 +236,7 @@ final class AdjustmentSpec extends ObjectBehavior
 
     function it_initializes_creation_date_by_default()
     {
-        $this->getCreatedAt()->shouldHaveType(\DateTime::class);
+        $this->getCreatedAt()->shouldHaveType(\DateTimeInterface::class);
     }
 
     function it_has_no_last_update_date_by_default()

--- a/src/Sylius/Component/Order/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderSpec.php
@@ -456,7 +456,7 @@ final class OrderSpec extends ObjectBehavior
 
     function it_initializes_creation_date_by_default()
     {
-        $this->getCreatedAt()->shouldHaveType(\DateTime::class);
+        $this->getCreatedAt()->shouldHaveType(\DateTimeInterface::class);
     }
 
     function it_has_no_last_update_date_by_default()

--- a/src/Sylius/Component/Payment/spec/Model/PaymentMethodSpec.php
+++ b/src/Sylius/Component/Payment/spec/Model/PaymentMethodSpec.php
@@ -118,7 +118,7 @@ final class PaymentMethodSpec extends ObjectBehavior
 
     function it_initializes_creation_date_by_default()
     {
-        $this->getCreatedAt()->shouldHaveType(\DateTime::class);
+        $this->getCreatedAt()->shouldHaveType(\DateTimeInterface::class);
     }
 
     function it_has_no_last_update_date_by_default()

--- a/src/Sylius/Component/Product/spec/Model/ProductSpec.php
+++ b/src/Sylius/Component/Product/spec/Model/ProductSpec.php
@@ -199,7 +199,7 @@ final class ProductSpec extends ObjectBehavior
 
     function it_initializes_creation_date_by_default()
     {
-        $this->getCreatedAt()->shouldHaveType(\DateTime::class);
+        $this->getCreatedAt()->shouldHaveType(\DateTimeInterface::class);
     }
 
     function its_creation_date_is_mutable(\DateTime $creationDate)

--- a/src/Sylius/Component/Promotion/Generator/PromotionCouponGeneratorInstruction.php
+++ b/src/Sylius/Component/Promotion/Generator/PromotionCouponGeneratorInstruction.php
@@ -28,7 +28,7 @@ final class PromotionCouponGeneratorInstruction implements PromotionCouponGenera
     private $codeLength = 6;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     private $expiresAt;
 
@@ -80,7 +80,7 @@ final class PromotionCouponGeneratorInstruction implements PromotionCouponGenera
     /**
      * {@inheritdoc}
      */
-    public function setExpiresAt(\DateTime $expiresAt = null)
+    public function setExpiresAt(\DateTimeInterface $expiresAt = null)
     {
         $this->expiresAt = $expiresAt;
     }

--- a/src/Sylius/Component/Promotion/Generator/PromotionCouponGeneratorInstructionInterface.php
+++ b/src/Sylius/Component/Promotion/Generator/PromotionCouponGeneratorInstructionInterface.php
@@ -39,14 +39,14 @@ interface PromotionCouponGeneratorInstructionInterface
     public function setCodeLength($codeLength);
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getExpiresAt();
 
     /**
-     * @param \DateTime $expiresAt
+     * @param \DateTimeInterface $expiresAt
      */
-    public function setExpiresAt(\DateTime $expiresAt = null);
+    public function setExpiresAt(\DateTimeInterface $expiresAt = null);
 
     /**
      * @return int

--- a/src/Sylius/Component/Promotion/Model/Promotion.php
+++ b/src/Sylius/Component/Promotion/Model/Promotion.php
@@ -69,12 +69,12 @@ class Promotion implements PromotionInterface
     protected $used = 0;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $startsAt;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $endsAt;
 
@@ -248,7 +248,7 @@ class Promotion implements PromotionInterface
     /**
      * {@inheritdoc}
      */
-    public function setStartsAt(\DateTime $startsAt = null)
+    public function setStartsAt(\DateTimeInterface $startsAt = null)
     {
         $this->startsAt = $startsAt;
     }
@@ -264,7 +264,7 @@ class Promotion implements PromotionInterface
     /**
      * {@inheritdoc}
      */
-    public function setEndsAt(\DateTime $endsAt = null)
+    public function setEndsAt(\DateTimeInterface $endsAt = null)
     {
         $this->endsAt = $endsAt;
     }

--- a/src/Sylius/Component/Promotion/Model/PromotionCoupon.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionCoupon.php
@@ -48,7 +48,7 @@ class PromotionCoupon implements PromotionCouponInterface
     protected $promotion;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $expiresAt;
 
@@ -145,7 +145,7 @@ class PromotionCoupon implements PromotionCouponInterface
     /**
      * {@inheritdoc}
      */
-    public function setExpiresAt(\DateTime $expiresAt = null)
+    public function setExpiresAt(\DateTimeInterface $expiresAt = null)
     {
         $this->expiresAt = $expiresAt;
     }

--- a/src/Sylius/Component/Promotion/Model/PromotionCouponInterface.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionCouponInterface.php
@@ -57,14 +57,14 @@ interface PromotionCouponInterface extends CodeAwareInterface, TimestampableInte
     public function setPromotion(PromotionInterface $promotion = null);
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getExpiresAt();
 
     /**
-     * @param \DateTime $expiresAt
+     * @param \DateTimeInterface $expiresAt
      */
-    public function setExpiresAt(\DateTime $expiresAt = null);
+    public function setExpiresAt(\DateTimeInterface $expiresAt = null);
 
     /**
      * @return bool

--- a/src/Sylius/Component/Promotion/Model/PromotionInterface.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionInterface.php
@@ -88,24 +88,24 @@ interface PromotionInterface extends CodeAwareInterface, TimestampableInterface,
     public function decrementUsed();
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getStartsAt();
 
     /**
-     * @param \DateTime $startsAt
+     * @param \DateTimeInterface $startsAt
      */
-    public function setStartsAt(\DateTime $startsAt = null);
+    public function setStartsAt(\DateTimeInterface $startsAt = null);
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getEndsAt();
 
     /**
-     * @param \DateTime $endsAt
+     * @param \DateTimeInterface $endsAt
      */
-    public function setEndsAt(\DateTime $endsAt = null);
+    public function setEndsAt(\DateTimeInterface $endsAt = null);
 
     /**
      * @return bool

--- a/src/Sylius/Component/Resource/Model/ArchivableInterface.php
+++ b/src/Sylius/Component/Resource/Model/ArchivableInterface.php
@@ -19,12 +19,12 @@ namespace Sylius\Component\Resource\Model;
 interface ArchivableInterface
 {
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getArchivedAt();
 
     /**
-     * @param \DateTime $archivedAt
+     * @param \DateTimeInterface $archivedAt
      */
-    public function setArchivedAt(\DateTime $archivedAt = null);
+    public function setArchivedAt(\DateTimeInterface $archivedAt = null);
 }

--- a/src/Sylius/Component/Resource/Model/ArchivableTrait.php
+++ b/src/Sylius/Component/Resource/Model/ArchivableTrait.php
@@ -21,12 +21,12 @@ namespace Sylius\Component\Resource\Model;
 trait ArchivableTrait
 {
     /**
-     * @var \DateTime|null
+     * @var \DateTimeInterface|null
      */
     protected $archivedAt;
 
     /**
-     * @return \DateTime|null
+     * @return \DateTimeInterface|null
      */
     public function getArchivedAt()
     {
@@ -34,9 +34,9 @@ trait ArchivableTrait
     }
 
     /**
-     * @param \DateTime|null $archivedAt
+     * @param \DateTimeInterface|null $archivedAt
      */
-    public function setArchivedAt(\DateTime $archivedAt = null)
+    public function setArchivedAt(\DateTimeInterface $archivedAt = null)
     {
         $this->archivedAt = $archivedAt;
     }

--- a/src/Sylius/Component/Resource/Model/TimestampableInterface.php
+++ b/src/Sylius/Component/Resource/Model/TimestampableInterface.php
@@ -19,22 +19,22 @@ namespace Sylius\Component\Resource\Model;
 interface TimestampableInterface
 {
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getCreatedAt();
 
     /**
-     * @param \DateTime $createdAt
+     * @param \DateTimeInterface $createdAt
      */
-    public function setCreatedAt(\DateTime $createdAt);
+    public function setCreatedAt(\DateTimeInterface $createdAt);
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getUpdatedAt();
 
     /**
-     * @param \DateTime $updatedAt
+     * @param \DateTimeInterface $updatedAt
      */
-    public function setUpdatedAt(\DateTime $updatedAt);
+    public function setUpdatedAt(\DateTimeInterface $updatedAt);
 }

--- a/src/Sylius/Component/Resource/Model/TimestampableTrait.php
+++ b/src/Sylius/Component/Resource/Model/TimestampableTrait.php
@@ -19,17 +19,17 @@ namespace Sylius\Component\Resource\Model;
 trait TimestampableTrait
 {
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $createdAt;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $updatedAt;
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getCreatedAt()
     {
@@ -37,15 +37,15 @@ trait TimestampableTrait
     }
 
     /**
-     * @param \DateTime $createdAt
+     * @param \DateTimeInterface $createdAt
      */
-    public function setCreatedAt(\DateTime $createdAt)
+    public function setCreatedAt(\DateTimeInterface $createdAt)
     {
         $this->createdAt = $createdAt;
     }
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getUpdatedAt()
     {
@@ -53,9 +53,9 @@ trait TimestampableTrait
     }
 
     /**
-     * @param \DateTime $updatedAt
+     * @param \DateTimeInterface $updatedAt
      */
-    public function setUpdatedAt(\DateTime $updatedAt)
+    public function setUpdatedAt(\DateTimeInterface $updatedAt)
     {
         $this->updatedAt = $updatedAt;
     }

--- a/src/Sylius/Component/Shipping/spec/Model/ShipmentUnitSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Model/ShipmentUnitSpec.php
@@ -72,7 +72,7 @@ final class ShipmentUnitSpec extends ObjectBehavior
 
     function it_initializes_creation_date_by_default()
     {
-        $this->getCreatedAt()->shouldHaveType(\DateTime::class);
+        $this->getCreatedAt()->shouldHaveType(\DateTimeInterface::class);
     }
 
     function its_creation_date_is_mutable()

--- a/src/Sylius/Component/Shipping/spec/Model/ShippingCategorySpec.php
+++ b/src/Sylius/Component/Shipping/spec/Model/ShippingCategorySpec.php
@@ -67,7 +67,7 @@ final class ShippingCategorySpec extends ObjectBehavior
 
     function it_initializes_creation_date_by_default()
     {
-        $this->getCreatedAt()->shouldHaveType(\DateTime::class);
+        $this->getCreatedAt()->shouldHaveType(\DateTimeInterface::class);
     }
 
     function its_creation_date_is_mutable()

--- a/src/Sylius/Component/Taxation/spec/Model/TaxCategorySpec.php
+++ b/src/Sylius/Component/Taxation/spec/Model/TaxCategorySpec.php
@@ -66,7 +66,7 @@ final class TaxCategorySpec extends ObjectBehavior
 
     function it_should_initialize_creation_date_by_default()
     {
-        $this->getCreatedAt()->shouldHaveType(\DateTime::class);
+        $this->getCreatedAt()->shouldHaveType(\DateTimeInterface::class);
     }
 
     function it_should_not_have_last_update_date_by_default()

--- a/src/Sylius/Component/Taxation/spec/Model/TaxRateSpec.php
+++ b/src/Sylius/Component/Taxation/spec/Model/TaxRateSpec.php
@@ -117,7 +117,7 @@ final class TaxRateSpec extends ObjectBehavior
 
     function it_should_initialize_creation_date_by_default()
     {
-        $this->getCreatedAt()->shouldHaveType(\DateTime::class);
+        $this->getCreatedAt()->shouldHaveType(\DateTimeInterface::class);
     }
 
     function it_should_not_have_last_update_date_by_default()

--- a/src/Sylius/Component/User/Model/User.php
+++ b/src/Sylius/Component/User/Model/User.php
@@ -66,7 +66,7 @@ class User implements UserInterface
     protected $plainPassword;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $lastLogin;
 
@@ -85,12 +85,12 @@ class User implements UserInterface
     protected $passwordResetToken;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $passwordRequestedAt;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $verifiedAt;
 
@@ -100,12 +100,12 @@ class User implements UserInterface
     protected $locked = false;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $expiresAt;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
     protected $credentialsExpireAt;
 
@@ -270,9 +270,9 @@ class User implements UserInterface
     }
 
     /**
-     * @param \DateTime $date
+     * @param \DateTimeInterface $date
      */
-    public function setExpiresAt(\DateTime $date = null)
+    public function setExpiresAt(\DateTimeInterface $date = null)
     {
         $this->expiresAt = $date;
     }
@@ -288,7 +288,7 @@ class User implements UserInterface
     /**
      * {@inheritdoc}
      */
-    public function setCredentialsExpireAt(\DateTime $date = null)
+    public function setCredentialsExpireAt(\DateTimeInterface $date = null)
     {
         $this->credentialsExpireAt = $date;
     }
@@ -304,7 +304,7 @@ class User implements UserInterface
     /**
      * {@inheritdoc}
      */
-    public function setLastLogin(\DateTime $time = null)
+    public function setLastLogin(\DateTimeInterface $time = null)
     {
         $this->lastLogin = $time;
     }
@@ -436,7 +436,7 @@ class User implements UserInterface
     /**
      * {@inheritdoc}
      */
-    public function setPasswordRequestedAt(\DateTime $date = null)
+    public function setPasswordRequestedAt(\DateTimeInterface $date = null)
     {
         $this->passwordRequestedAt = $date;
     }
@@ -460,7 +460,7 @@ class User implements UserInterface
     /**
      * {@inheritdoc}
      */
-    public function setVerifiedAt(\DateTime $verifiedAt = null)
+    public function setVerifiedAt(\DateTimeInterface $verifiedAt = null)
     {
         $this->verifiedAt = $verifiedAt;
     }
@@ -552,11 +552,11 @@ class User implements UserInterface
     }
 
     /**
-     * @param \DateTime $date
+     * @param \DateTimeInterface $date
      *
      * @return bool
      */
-    protected function hasExpired(\DateTime $date = null)
+    protected function hasExpired(\DateTimeInterface $date = null)
     {
         return null !== $date && new \DateTime() >= $date;
     }

--- a/src/Sylius/Component/User/Model/UserInterface.php
+++ b/src/Sylius/Component/User/Model/UserInterface.php
@@ -99,14 +99,14 @@ interface UserInterface extends
     public function setPasswordResetToken($passwordResetToken);
 
     /**
-     * @return \DateTime|null
+     * @return \DateTimeInterface|null
      */
     public function getPasswordRequestedAt();
 
     /**
-     * @param \DateTime|null $date
+     * @param \DateTimeInterface|null $date
      */
-    public function setPasswordRequestedAt(\DateTime $date = null);
+    public function setPasswordRequestedAt(\DateTimeInterface $date = null);
 
     /**
      * @param \DateInterval $ttl
@@ -121,29 +121,29 @@ interface UserInterface extends
     public function isVerified();
 
     /**
-     * @return \DateTime|null
+     * @return \DateTimeInterface|null
      */
     public function getVerifiedAt();
 
     /**
-     * @param \DateTime|null $verifiedAt
+     * @param \DateTimeInterface|null $verifiedAt
      */
-    public function setVerifiedAt(\DateTime $verifiedAt = null);
+    public function setVerifiedAt(\DateTimeInterface $verifiedAt = null);
 
     /**
-     * @param \DateTime|null $date
+     * @param \DateTimeInterface|null $date
      */
-    public function setCredentialsExpireAt(\DateTime $date = null);
+    public function setCredentialsExpireAt(\DateTimeInterface $date = null);
 
     /**
-     * @return \DateTime|null
+     * @return \DateTimeInterface|null
      */
     public function getLastLogin();
 
     /**
-     * @param \DateTime|null $time
+     * @param \DateTimeInterface|null $time
      */
-    public function setLastLogin(\DateTime $time = null);
+    public function setLastLogin(\DateTimeInterface $time = null);
 
     /**
      * Never use this to check if this user has access to anything!

--- a/tests/DataFixtures/ORM/resources/cart.yml
+++ b/tests/DataFixtures/ORM/resources/cart.yml
@@ -32,7 +32,7 @@ Sylius\Component\Core\Model\Customer:
         lastName: "Queen"
         email: "oliver.queen@star-city.com"
         emailCanonical: "oliver.queen@star-city.com"
-        birthday: "<date()>"
+        birthday: "<(new \\DateTime())>"
 
 Sylius\Component\Core\Model\Product:
     mug:
@@ -56,7 +56,7 @@ Sylius\Component\Core\Model\ProductVariant:
         product: "@mug"
         currentLocale: "en_US"
         currentTranslation: "@sw_mug_translation"
-        updatedAt: 2015-10-10
+        updatedAt: "<(new \\DateTime('2015-10-10'))>"
         optionValues: ["@mug-size-s"]
         channelPricings:
             WEB: "@sw_mug_web_channel_pricing"
@@ -65,7 +65,7 @@ Sylius\Component\Core\Model\ProductVariant:
         product: "@mug"
         currentLocale: "en_US"
         currentTranslation: "@hard_available_mug_translation"
-        updatedAt: 2015-10-05
+        updatedAt: "<(new \\DateTime('2015-10-05'))>"
         optionValues: ["@mug-size-l"]
         channelPricings:
             WEB: "@hard_available_mug_web_channel_pricing"

--- a/tests/DataFixtures/ORM/resources/cart_with_items.yml
+++ b/tests/DataFixtures/ORM/resources/cart_with_items.yml
@@ -53,7 +53,7 @@ Sylius\Component\Core\Model\Customer:
         lastName: "Queen"
         email: "oliver.queen@star-city.com"
         emailCanonical: "oliver.queen@star-city.com"
-        birthday: "<date()>"
+        birthday: "<(new \\DateTime())>"
 
 Sylius\Component\Core\Model\Product:
     mug:
@@ -76,7 +76,7 @@ Sylius\Component\Core\Model\ProductVariant:
         product: "@mug"
         currentLocale: "en_US"
         currentTranslation: "@sw_mug_translation"
-        updatedAt: 2015-10-10
+        updatedAt: "<(new \\DateTime('2015-10-10'))>"
         channelPricings:
             WEB: "@sw_mug_web_channel_pricing"
     mug_lotr:
@@ -84,7 +84,7 @@ Sylius\Component\Core\Model\ProductVariant:
         product: "@mug"
         currentLocale: "en_US"
         currentTranslation: "@lotr_mug_translation"
-        updatedAt: 2015-10-04
+        updatedAt: "<(new \\DateTime('2015-10-04'))>"
         channelPricings:
             WEB: "@lotr_mug_web_channel_pricing"
     mug_bb:
@@ -92,7 +92,7 @@ Sylius\Component\Core\Model\ProductVariant:
         product: "@mug"
         currentLocale: "en_US"
         currentTranslation: "@bb_mug_translation"
-        updatedAt: 2015-10-05
+        updatedAt: "<(new \\DateTime('2015-10-05'))>"
         channelPricings:
             WEB: "@bb_mug_web_channel_pricing"
     hard_available_mug:
@@ -100,7 +100,7 @@ Sylius\Component\Core\Model\ProductVariant:
         product: "@mug"
         currentLocale: "en_US"
         currentTranslation: "@hard_available_mug_translation"
-        updatedAt: 2015-10-05
+        updatedAt: "<(new \\DateTime('2015-10-05'))>"
         channelPricings:
             WEB: "@hard_available_mug_web_channel_pricing"
         tracked: true

--- a/tests/DataFixtures/ORM/resources/checkout.yml
+++ b/tests/DataFixtures/ORM/resources/checkout.yml
@@ -32,7 +32,7 @@ Sylius\Component\Core\Model\ProductVariant:
         product: "@mug"
         currentLocale: "en_US"
         currentTranslation: "@sw_mug_translation"
-        updatedAt: 2015-10-10
+        updatedAt: <(new DateTime('2015-10-10'))>
         channelPricings:
             CHANNEL: "@sw_mug_web_channel_pricing"
         taxCategory: "@taxable_goods"
@@ -41,7 +41,7 @@ Sylius\Component\Core\Model\ProductVariant:
         product: "@mug"
         currentLocale: "en_US"
         currentTranslation: "@hard_available_mug_translation"
-        updatedAt: 2015-10-05
+        updatedAt: <(new DateTime('2015-10-05'))>
         channelPricings:
             CHANNEL: "@hard_available_mug_web_channel_pricing"
         taxCategory: "@taxable_goods"
@@ -161,7 +161,7 @@ Sylius\Component\Core\Model\Customer:
         lastName: "Queen"
         email: "oliver.queen@star-city.com"
         emailCanonical: "oliver.queen@star-city.com"
-        birthday: <date()>
+        birthday: <(new \DateTime())>
 
 Sylius\Component\Taxation\Model\TaxCategory:
     taxable_goods:

--- a/tests/DataFixtures/ORM/resources/customers.yml
+++ b/tests/DataFixtures/ORM/resources/customers.yml
@@ -13,4 +13,4 @@ Sylius\Component\Core\Model\Customer:
         lastName: "Doe"
         email: "<current()>@doe.com"
         emailCanonical: "<current()>@doe.com"
-        birthday: "<date()>"
+        birthday: "<(new \\DateTime())>"

--- a/tests/DataFixtures/ORM/resources/order.yml
+++ b/tests/DataFixtures/ORM/resources/order.yml
@@ -32,4 +32,4 @@ Sylius\Component\Core\Model\Customer:
         lastName: Queen
         email: oliver.queen@star-city.com
         emailCanonical: oliver.queen@star-city.com
-        birthday: <date()>
+        birthday: <(new \DateTime())>

--- a/tests/DataFixtures/ORM/resources/promotion_coupons.yml
+++ b/tests/DataFixtures/ORM/resources/promotion_coupons.yml
@@ -8,4 +8,4 @@ Sylius\Component\Core\Model\PromotionCoupon:
         used: 3
         usageLimit: 4
         perCustomerUsageLimit: 1
-        expiresAt: <date()>
+        expiresAt: <(new \DateTime())>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | kind of |
| Related tickets | fixes #6465 |
| License         | MIT |

It makes possible to use `\DateTimeImmutable`. BC breaks only if userland code relies on `\DateTime` mutable behaviour (methods not included in `\DateTimeInterface`), like:

```php
$product->getUpdatedAt()->add(new \DateInterval('2 days'));
```