### PR TITLE
[Behat] Change how Page objects wait/check for disappearing element

### DIFF
--- a/src/Sylius/Behat/Page/Admin/Product/IndexPerTaxonPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPerTaxonPage.php
@@ -53,7 +53,7 @@ class IndexPerTaxonPage extends CrudIndexPage implements IndexPerTaxonPageInterf
         $this->getElement('save_configuration_button')->press();
 
         $this->getDocument()->waitFor(5, function () {
-            return false === $this->getElement('save_configuration_button')->hasClass('loading');
+            return null === $this->getElement('save_configuration_button')->find('css', '.loading');
         });
     }
 

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/IndexPage.php
@@ -61,7 +61,7 @@ final class IndexPage extends BaseIndexPage implements IndexPageInterface
         $this->getElement('save_configuration_button')->press();
 
         $this->getDocument()->waitFor(5, function () {
-            return false === $this->getElement('save_configuration_button')->hasClass('loading');
+            return null === $this->getElement('save_configuration_button')->find('css', '.loading');
         });
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | None |
| License         | MIT |

At present a few steps in Behat scenarios are somewhat unstable - they sometimes pass and sometimes fail due to a race condition. `And I save my new configuration` in  [`features/product/managing_products/sorting_products_within_a_taxon_by_position.feature` ](https://github.com/Sylius/Sylius/blob/de21554/features/product/managing_products/sorting_products_within_a_taxon_by_position.feature#L34) is one particular instance.

The issue seems to arise from the fact, that `waitFor` condition is checking if a particular element has a particular class (`.loading`), but the check internally is two steps: 1) find the element 2) check if it has the class. However if the page is reloaded (or DOM updated for that matter) between steps 1 and 2, selenium / WebDriver / ChromeDriver throws an exception: `stale element reference: element is not attached to the page document`

The general approach to check if the element has a class works fine when waiting for an element to appear, but is not suitable in the cases when element can disappear.

This change replaces check with an atomic one, which checks if the element with a given class exists at all - which in case of disappearing element is a valid condition to check.