### PR TITLE
Sortable fields not working when sortable: true

### DIFF
--- a/src/Sylius/Component/Grid/Definition/ArrayToDefinitionConverter.php
+++ b/src/Sylius/Component/Grid/Definition/ArrayToDefinitionConverter.php
@@ -92,7 +92,12 @@ final class ArrayToDefinitionConverter implements ArrayToDefinitionConverterInte
             $field->setEnabled($configuration['enabled']);
         }
         if (array_key_exists('sortable', $configuration)) {
-            $field->setSortable($configuration['sortable']);
+            $sortable = $configuration['sortable'];
+            if ($sortable === true || $sortable === null) {
+                $sortable = $name;
+            }
+
+            $field->setSortable($sortable);
         }
         if (array_key_exists('position', $configuration)) {
             $field->setPosition($configuration['position']);

--- a/src/Sylius/Component/Grid/Definition/Field.php
+++ b/src/Sylius/Component/Grid/Definition/Field.php
@@ -150,11 +150,11 @@ class Field
     }
 
     /**
-     * @param string|null $sortable
+     * @param string $sortable
      */
     public function setSortable($sortable)
     {
-        $this->sortable = $sortable ?: $this->name;
+        $this->sortable = $sortable;
     }
 
     /**

--- a/src/Sylius/Component/Grid/spec/Definition/ArrayToDefinitionConverterSpec.php
+++ b/src/Sylius/Component/Grid/spec/Definition/ArrayToDefinitionConverterSpec.php
@@ -65,6 +65,30 @@ final class ArrayToDefinitionConverterSpec extends ObjectBehavior
 
         $grid->addField($codeField);
 
+        $enabledField = Field::fromNameAndType('enabled', 'boolean');
+        $enabledField->setLabel('Enabled');
+        $enabledField->setPath('method.enabled');
+        $enabledField->setSortable('enabled');
+
+        $grid->addField($enabledField);
+
+        $statusField = Field::fromNameAndType('status', 'string');
+        $statusField->setLabel('Status');
+        $statusField->setSortable('status');
+
+        $grid->addField($statusField);
+
+        $nameField = Field::fromNameAndType('name', 'string');
+        $nameField->setLabel('Name');
+        $nameField->setSortable('name');
+
+        $grid->addField($nameField);
+
+        $titleField = Field::fromNameAndType('title', 'string');
+        $titleField->setLabel('Title');
+
+        $grid->addField($titleField);
+
         $viewAction = Action::fromNameAndType('view', 'link');
         $viewAction->setLabel('Display Tax Category');
         $viewAction->setOptions(['foo' => 'bar']);
@@ -101,6 +125,27 @@ final class ArrayToDefinitionConverterSpec extends ObjectBehavior
                     'options' => [
                         'template' => 'bar.html.twig'
                     ],
+                ],
+                'enabled' => [
+                    'type' => 'boolean',
+                    'label' => 'Enabled',
+                    'path' => 'method.enabled',
+                    'sortable' => true,
+                ],
+                'status' => [
+                    'type' => 'string',
+                    'label' => 'Status',
+                    'sortable' => true,
+                ],
+                'name' => [
+                    'type' => 'string',
+                    'label' => 'Name',
+                    'sortable' => null,
+                ],
+                'title' => [
+                    'type' => 'string',
+                    'label' => 'Title',
+                    'sortable' => false,
                 ],
             ],
             'filters' => [

--- a/src/Sylius/Component/Grid/spec/Definition/FieldSpec.php
+++ b/src/Sylius/Component/Grid/spec/Definition/FieldSpec.php
@@ -79,7 +79,7 @@ final class FieldSpec extends ObjectBehavior
     {
         $this->getSortable()->shouldReturn(null);
 
-        $this->setSortable(null);
+        $this->setSortable('enabled');
         $this->getSortable()->shouldReturn('enabled');
     }
 


### PR DESCRIPTION
This properly fix the sortable fields. As it is right now it's not possible to specify that a field is sortable exactly as the docs states:
[SyliusGridBundle Docs](http://docs.sylius.org/en/latest/bundles/SyliusGridBundle/configuration.html
)

`sortable: true
`

It only allows you to specify the field name otherwise a doctrine exception is thrown because `true` is used as field name.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |
