### PR TITLE
Allow multiple Accept headers in request configuration

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfigurationFactory.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfigurationFactory.php
@@ -76,12 +76,18 @@ final class RequestConfigurationFactory implements RequestConfigurationFactoryIn
     {
         $parameters = [];
 
-        if (preg_match(self::API_VERSION_REGEXP, (string) $request->headers->get(self::API_VERSION_HEADER), $matches)) {
-            $parameters['serialization_version'] = $matches['version'];
+        $apiVersionHeaders = $request->headers->get(self::API_VERSION_HEADER, null, false);
+        foreach ($apiVersionHeaders as $apiVersionHeader) {
+            if (preg_match(self::API_VERSION_REGEXP, $apiVersionHeader, $matches)) {
+                $parameters['serialization_version'] = $matches['version'];
+            }
         }
 
-        if (preg_match(self::API_GROUPS_REGEXP, (string) $request->headers->get(self::API_GROUPS_HEADER), $matches)) {
-            $parameters['serialization_groups'] = array_map('trim', explode(',', $matches['groups']));
+        $apiGroupsHeaders = $request->headers->get(self::API_GROUPS_HEADER, null, false);
+        foreach ($apiGroupsHeaders as $apiGroupsHeader) {
+            if (preg_match(self::API_GROUPS_REGEXP, $apiGroupsHeader, $matches)) {
+                $parameters['serialization_groups'] = array_map('trim', explode(',', $matches['groups']));
+            }
         }
 
         return array_merge($request->attributes->get('_sylius', []), $parameters);

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationFactorySpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationFactorySpec.php
@@ -53,7 +53,7 @@ final class RequestConfigurationFactorySpec extends ObjectBehavior
         $request->headers = $headersBag;
         $request->attributes = $attributesBag;
 
-        $headersBag->get('Accept')->willReturn(null);
+        $headersBag->get('Accept', null, false)->willReturn([]);
 
         $attributesBag->get('_sylius', [])->willReturn(['template' => ':Product:show.html.twig']);
         $parametersParser
@@ -74,9 +74,97 @@ final class RequestConfigurationFactorySpec extends ObjectBehavior
         $request->headers = $headersBag;
         $request->attributes = $attributesBag;
 
+        $headersBag->get('Accept', null, false)->willReturn([]);
+
         $attributesBag->get('_sylius', [])->willReturn(['template' => ':Product:list.html.twig']);
         $parametersParser
             ->parseRequestValues(['template' => ':Product:list.html.twig'], $request)
+            ->willReturn(['template' => ':Product:list.html.twig'])
+        ;
+
+        $this->create($metadata, $request)->isSortable()->shouldReturn(false);
+    }
+
+    function it_creates_configuration_for_serialization_group_from_single_header(
+        ParametersParserInterface $parametersParser,
+        MetadataInterface $metadata,
+        Request $request,
+        ParameterBag $headersBag,
+        ParameterBag $attributesBag
+    ) {
+        $request->headers = $headersBag;
+        $request->attributes = $attributesBag;
+
+        $headersBag->get('Accept', null, false)->willReturn(['groups=Default,Detailed']);
+
+        $attributesBag->get('_sylius', [])->willReturn([]);
+        $parametersParser
+            ->parseRequestValues(['serialization_groups' => ['Default', 'Detailed']], $request)
+            ->willReturn(['template' => ':Product:list.html.twig'])
+        ;
+
+        $this->create($metadata, $request)->isSortable()->shouldReturn(false);
+    }
+
+    function it_creates_configuration_for_serialization_group_from_multiple_headers(
+        ParametersParserInterface $parametersParser,
+        MetadataInterface $metadata,
+        Request $request,
+        ParameterBag $headersBag,
+        ParameterBag $attributesBag
+    ) {
+        $request->headers = $headersBag;
+        $request->attributes = $attributesBag;
+
+        $headersBag->get('Accept', null, false)->willReturn(['application/json', 'groups=Default,Detailed']);
+
+        $attributesBag->get('_sylius', [])->willReturn([]);
+        $parametersParser
+            ->parseRequestValues(['serialization_groups' => ['Default', 'Detailed']], $request)
+            ->willReturn(['template' => ':Product:list.html.twig'])
+        ;
+
+        $this->create($metadata, $request)->isSortable()->shouldReturn(false);
+    }
+
+    function it_creates_configuration_for_serialization_version_from_single_header(
+        ParametersParserInterface $parametersParser,
+        MetadataInterface $metadata,
+        Request $request,
+        ParameterBag $headersBag,
+        ParameterBag $attributesBag
+    ) {
+        $request->headers = $headersBag;
+        $request->attributes = $attributesBag;
+
+        $headersBag->get('Accept', null, false)->willReturn(['version=1.0.0']);
+
+        $attributesBag->get('_sylius', [])->willReturn([]);
+
+        $parametersParser
+            ->parseRequestValues(['serialization_version' => '1.0.0'], $request)
+            ->willReturn(['template' => ':Product:list.html.twig'])
+        ;
+
+        $this->create($metadata, $request)->isSortable()->shouldReturn(false);
+    }
+
+    function it_creates_configuration_for_serialization_version_from_multiple_headers(
+        ParametersParserInterface $parametersParser,
+        MetadataInterface $metadata,
+        Request $request,
+        ParameterBag $headersBag,
+        ParameterBag $attributesBag
+    ) {
+        $request->headers = $headersBag;
+        $request->attributes = $attributesBag;
+
+        $headersBag->get('Accept', null, false)->willReturn(['application/xml', 'version=1.0.0']);
+
+        $attributesBag->get('_sylius', [])->willReturn([]);
+
+        $parametersParser
+            ->parseRequestValues(['serialization_version' => '1.0.0'], $request)
             ->willReturn(['template' => ':Product:list.html.twig'])
         ;
 
@@ -94,6 +182,8 @@ final class RequestConfigurationFactorySpec extends ObjectBehavior
 
         $request->headers = $headersBag;
         $request->attributes = $attributesBag;
+
+        $headersBag->get('Accept', null, false)->willReturn([]);
 
         $attributesBag->get('_sylius', [])->willReturn(['template' => ':Product:list.html.twig']);
 


### PR DESCRIPTION
By fetching all request headers of a given key instead of the first one only (which is the default of Symfonys headers `get`), configuring a request is possible event if two `Accept` headers are sent.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |
