### PR TITLE
remove "or" from ui because it breaks with foreign translations

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/generate.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/generate.html.twig
@@ -25,7 +25,6 @@
     <div class="ui basic segment">
         <div class="ui buttons">
             <button class="ui labeled icon primary button" type="submit"><i class="random icon"></i>{{- 'sylius.ui.generate'|trans -}}</button>
-            <div class="or" data-text="{{ 'sylius.ui.or'|trans }}"></div>
             {% include '@SyliusUi/Form/Buttons/_cancel.html.twig' with {'path': path(configuration.getRouteName('index'), {'productId': product.id})} %}
         </div>
     </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/generate.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/generate.html.twig
@@ -25,7 +25,6 @@
     <div class="ui basic segment">
         <div class="ui buttons">
             <button class="ui labeled icon primary button" type="submit"><i class="random icon"></i>{{- 'sylius.ui.generate'|trans -}}</button>
-            <div class="or" data-text="{{ 'sylius.ui.or'|trans }}"></div>
             {% include '@SyliusUi/Form/Buttons/_cancel.html.twig' with {'path': path(configuration.getRouteName('index'), {'promotionId': promotion.id})} %}
         </div>
     </div>

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/Buttons/_create.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/Buttons/_create.html.twig
@@ -1,7 +1,6 @@
 <div class="ui basic segment">
     <div class="ui buttons">
         <button class="ui labeled icon primary button" type="submit"><i class="plus icon"></i>{{- 'sylius.ui.create'|trans -}}</button>
-        <div class="or" data-text="{{ 'sylius.ui.or'|trans }}"></div>
         {% include '@SyliusUi/Form/Buttons/_cancel.html.twig' with {'path': paths.cancel|default(null)} %}
     </div>
 </div>

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/Buttons/_update.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/Buttons/_update.html.twig
@@ -1,7 +1,6 @@
 <div class="ui basic segment">
     <div class="ui buttons">
         <button class="ui labeled icon primary button" type="submit" id="sylius_save_changes_button"><i class="save icon"></i> {{ 'sylius.ui.save_changes'|trans }}</button>
-        <div class="or" data-text="{{ 'sylius.ui.or'|trans }}"></div>
         {% include '@SyliusUi/Form/Buttons/_cancel.html.twig' with {'path': paths.cancel|default(null)} %}
     </div>
 </div>


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no|
| BC breaks?      | no |
| Related tickets | fixes #7580 |
| License         | MIT |

# Preview

Before:

![1992009c-f944-11e6-9a72-db8c0215ed0c](https://user-images.githubusercontent.com/1016798/28524852-79b336b6-7082-11e7-854d-91d624716d2f.png)

After:

![bildschirmfoto 2017-07-24 um 15 13 08](https://user-images.githubusercontent.com/1016798/28524890-a018f03e-7082-11e7-970f-6f42e176525f.png)

# Questions
It does not seem like the translation is used in any other place.
Should i remove it from the translations (which would be a very minor BC-Break, if anyone uses this key for anything else)
If I should remove it: where do i remove it? Only in the english language files or everywhere?
(Sorry, I don't know how the auto-update from crowdin works)
