### PR TITLE
Allow filterable resource routes

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Routing/Configuration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Routing/Configuration.php
@@ -37,6 +37,7 @@ final class Configuration implements ConfigurationInterface
                     ->prototype('scalar')
                     ->end()
                 ->end()
+                ->booleanNode('filterable')->end()
                 ->variableNode('form')->cannotBeEmpty()->end()
                 ->scalarNode('serialization_version')->cannotBeEmpty()->end()
                 ->scalarNode('section')->cannotBeEmpty()->end()

--- a/src/Sylius/Bundle/ResourceBundle/Routing/ResourceLoader.php
+++ b/src/Sylius/Bundle/ResourceBundle/Routing/ResourceLoader.php
@@ -169,6 +169,9 @@ final class ResourceLoader implements LoaderInterface
         if (!empty($configuration['criteria'])) {
             $defaults['_sylius']['criteria'] = $configuration['criteria'];
         }
+        if (array_key_exists('filterable', $configuration)) {
+            $defaults['_sylius']['filterable'] = $configuration['filterable'];
+        }
         if (isset($configuration['templates']) && in_array($actionName, ['show', 'index', 'create', 'update'], true)) {
             $defaults['_sylius']['template'] = sprintf('%s:%s.html.twig', $configuration['templates'], $actionName);
         }

--- a/src/Sylius/Bundle/ResourceBundle/spec/Routing/ResourceLoaderSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Routing/ResourceLoaderSpec.php
@@ -237,6 +237,7 @@ alias: sylius.product_option
 identifier: code
 criteria: 
     code: \$code
+filterable: true
 EOT;
 
         $showDefaults = [
@@ -246,6 +247,7 @@ EOT;
                 'criteria' => [
                     'code' => '$code',
                 ],
+                'filterable' => true,
             ],
         ];
         $routeFactory->createRoute('/product-options/{code}', $showDefaults, [], [], '', [], ['GET'])->willReturn($showRoute);
@@ -257,7 +259,8 @@ EOT;
                 'permission' => false,
                 'criteria' => [
                     'code' => '$code',
-                ]
+                ],
+                'filterable' => true,
             ],
         ];
         $routeFactory->createRoute('/product-options/', $indexDefaults, [], [], '', [], ['GET'])->willReturn($indexRoute);
@@ -269,7 +272,8 @@ EOT;
                 'permission' => false,
                 'criteria' => [
                     'code' => '$code',
-                ]
+                ],
+                'filterable' => true,
             ],
         ];
         $routeFactory->createRoute('/product-options/new', $createDefaults, [], [], '', [], ['GET', 'POST'])->willReturn($createRoute);
@@ -282,6 +286,7 @@ EOT;
                 'criteria' => [
                     'code' => '$code',
                 ],
+                'filterable' => true,
             ],
         ];
         $routeFactory->createRoute('/product-options/{code}/edit', $updateDefaults, [], [], '', [], ['GET', 'PUT', 'PATCH'])->willReturn($updateRoute);
@@ -294,6 +299,7 @@ EOT;
                 'criteria' => [
                     'code' => '$code',
                 ],
+                'filterable' => true,
             ],
         ];
         $routeFactory->createRoute('/product-options/{code}', $deleteDefaults, [], [], '', [], ['DELETE'])->willReturn($deleteRoute);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

This adds the `filterable` option to the ResourceLoader, allowing to specify filterable routes without having to manaually redeclare the `index` route.