### PR TITLE
[Addressing] Use typehints introduced by PHP 7+

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,14 @@
 
 * `ZoneMatcher` has been made final, use decoration instead of extending it.
 
+* The following methods does not longer have a default null argument and requires one to be explicitly passed:
+  
+  * `AddressInterface::setCountryCode`
+  * `AddressInterface::setProviceCode`
+  * `AddressInterface::setProviceName`
+  * `ProvinceInterface::setCountry`
+  * `ZoneMemberInterface::setBelongsTo`
+
 ### Order / OrderBundle
 
 * In order to be compatibile with Doctrine ORM 2.6+ and be more consistent 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,10 @@
 
 ## Packages:
 
+### Addressing / AddressingBundle
+
+* `ZoneMatcher` has been made final, use decoration instead of extending it.
+
 ### Order / OrderBundle
 
 * In order to be compatibile with Doctrine ORM 2.6+ and be more consistent 

--- a/app/TestAppKernel.php
+++ b/app/TestAppKernel.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 require_once __DIR__.'/AppKernel.php';
 
+use ProxyManager\Proxy\VirtualProxyInterface;
 use PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -59,6 +60,10 @@ class TestAppKernel extends AppKernel
             }
 
             $serviceReflection = new \ReflectionObject($service);
+
+            if ($serviceReflection->implementsInterface(VirtualProxyInterface::class)) {
+                continue;
+            }
 
             $servicePropertiesReflections = $serviceReflection->getProperties();
             $servicePropertiesDefaultValues = $serviceReflection->getDefaultProperties();

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "knplabs/knp-gaufrette-bundle": "^0.3",
         "knplabs/knp-menu-bundle": "^2.1",
         "liip/imagine-bundle": "^1.6",
-        "ocramius/proxy-manager": "^1.0",
+        "ocramius/proxy-manager": "^2.1",
         "payum/payum": "^1.4",
         "payum/payum-bundle": "^2.2",
         "php-http/guzzle6-adapter": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec06964f359cf72f544233d76e84ae5d",
+    "content-hash": "52a6a5e21da6d75a5295fcb904940661",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -2920,39 +2920,93 @@
             "time": "2017-06-19T01:22:40+00:00"
         },
         {
-            "name": "ocramius/proxy-manager",
-            "version": "1.0.2",
+            "name": "ocramius/package-versions",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Ocramius/ProxyManager.git",
-                "reference": "57e9272ec0e8deccf09421596e0e2252df440e11"
+                "url": "https://github.com/Ocramius/PackageVersions.git",
+                "reference": "51e867c70f0799790b3e82276875414ce13daaca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/57e9272ec0e8deccf09421596e0e2252df440e11",
-                "reference": "57e9272ec0e8deccf09421596e0e2252df440e11",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/51e867c70f0799790b3e82276875414ce13daaca",
+                "reference": "51e867c70f0799790b3e82276875414ce13daaca",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "zendframework/zend-code": ">2.2.5,<3.0"
+                "composer-plugin-api": "^1.0",
+                "php": "~7.0"
             },
             "require-dev": {
+                "composer/composer": "^1.3",
+                "ext-zip": "*",
+                "phpunit/phpunit": "^5.4.7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "time": "2016-12-30T09:49:15+00:00"
+        },
+        {
+            "name": "ocramius/proxy-manager",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/ProxyManager.git",
+                "reference": "e18ac876b2e4819c76349de8f78ccc8ef1554cd7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/e18ac876b2e4819c76349de8f78ccc8ef1554cd7",
+                "reference": "e18ac876b2e4819c76349de8f78ccc8ef1554cd7",
+                "shasum": ""
+            },
+            "require": {
+                "ocramius/package-versions": "^1.1.1",
+                "php": "^7.1.0",
+                "zendframework/zend-code": "^3.1.0"
+            },
+            "require-dev": {
+                "couscous/couscous": "^1.5.2",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "1.5.*"
+                "humbug/humbug": "dev-master@DEV",
+                "nikic/php-parser": "^3.0.4",
+                "phpbench/phpbench": "^0.12.2",
+                "phpstan/phpstan": "^0.6.4",
+                "phpunit/phpunit": "^5.6.4",
+                "phpunit/phpunit-mock-objects": "^3.4.1",
+                "squizlabs/php_codesniffer": "^2.7.0"
             },
             "suggest": {
                 "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects",
                 "zendframework/zend-json": "To have the JsonRpc adapter (Remote Object feature)",
                 "zendframework/zend-soap": "To have the Soap adapter (Remote Object feature)",
-                "zendframework/zend-stdlib": "To use the hydrator proxy",
                 "zendframework/zend-xmlrpc": "To have the XmlRpc adapter (Remote Object feature)"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -2968,7 +3022,7 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "http://ocramius.github.io/"
                 }
             ],
             "description": "A library providing utilities to generate, instantiate and generally operate with Object Proxies",
@@ -2980,7 +3034,7 @@
                 "proxy pattern",
                 "service proxies"
             ],
-            "time": "2015-08-09T04:28:19+00:00"
+            "time": "2017-05-04T11:12:50+00:00"
         },
         {
             "name": "pagerfanta/pagerfanta",
@@ -5829,26 +5883,27 @@
         },
         {
             "name": "zendframework/zend-code",
-            "version": "2.6.3",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-code.git",
-                "reference": "95033f061b083e16cdee60530ec260d7d628b887"
+                "reference": "02944646c109fa53b6b6ab8b5269bb080fcdf5b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/95033f061b083e16cdee60530ec260d7d628b887",
-                "reference": "95033f061b083e16cdee60530ec260d7d628b887",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/02944646c109fa53b6b6ab8b5269bb080fcdf5b4",
+                "reference": "02944646c109fa53b6b6ab8b5269bb080fcdf5b4",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || 7.0.0 - 7.0.4 || ^7.0.6",
+                "php": "^7.1",
                 "zendframework/zend-eventmanager": "^2.6 || ^3.0"
             },
             "require-dev": {
                 "doctrine/annotations": "~1.0",
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "^4.8.21",
+                "ext-phar": "*",
+                "phpunit/phpunit": "^6.2.3",
+                "zendframework/zend-coding-standard": "^1.0.0",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "suggest": {
@@ -5858,8 +5913,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev",
-                    "dev-develop": "2.7-dev"
+                    "dev-master": "3.2-dev",
+                    "dev-develop": "3.3-dev"
                 }
             },
             "autoload": {
@@ -5877,7 +5932,7 @@
                 "code",
                 "zf2"
             ],
-            "time": "2016-04-20T17:26:42+00:00"
+            "time": "2017-07-23T13:06:00+00:00"
         },
         {
             "name": "zendframework/zend-eventmanager",

--- a/src/Sylius/Bundle/AddressingBundle/Controller/ProvinceController.php
+++ b/src/Sylius/Bundle/AddressingBundle/Controller/ProvinceController.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
@@ -32,12 +33,12 @@ class ProvinceController extends ResourceController
     /**
      * @param Request $request
      *
-     * @return JsonResponse
+     * @return Response
      *
      * @throws AccessDeniedException
      * @throws NotFoundHttpException
      */
-    public function choiceOrTextFieldFormAction(Request $request)
+    public function choiceOrTextFieldFormAction(Request $request): Response
     {
         $configuration = $this->requestConfigurationFactory->create($this->metadata, $request);
 
@@ -86,7 +87,7 @@ class ProvinceController extends ResourceController
      *
      * @return FormInterface
      */
-    protected function createProvinceChoiceForm(CountryInterface $country)
+    protected function createProvinceChoiceForm(CountryInterface $country): FormInterface
     {
         return $this->get('form.factory')->createNamed('sylius_address_province', ProvinceCodeChoiceType::class, null, [
             'country' => $country,
@@ -98,7 +99,7 @@ class ProvinceController extends ResourceController
     /**
      * @return FormInterface
      */
-    protected function createProvinceTextForm()
+    protected function createProvinceTextForm(): FormInterface
     {
         return $this->get('form.factory')->createNamed('sylius_address_province', TextType::class, null, [
             'required' => false,

--- a/src/Sylius/Bundle/AddressingBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/AddressingBundle/DependencyInjection/Configuration.php
@@ -48,7 +48,7 @@ final class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('sylius_addressing');
@@ -70,7 +70,7 @@ final class Configuration implements ConfigurationInterface
     /**
      * @param ArrayNodeDefinition $node
      */
-    private function addResourcesSection(ArrayNodeDefinition $node)
+    private function addResourcesSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()
@@ -186,7 +186,7 @@ final class Configuration implements ConfigurationInterface
     /**
      * @param ArrayNodeDefinition $node
      */
-    private function addScopesSection(ArrayNodeDefinition $node)
+    private function addScopesSection(ArrayNodeDefinition $node): void
     {
         $node
             ->children()

--- a/src/Sylius/Bundle/AddressingBundle/DependencyInjection/SyliusAddressingExtension.php
+++ b/src/Sylius/Bundle/AddressingBundle/DependencyInjection/SyliusAddressingExtension.php
@@ -29,7 +29,7 @@ final class SyliusAddressingExtension extends AbstractResourceExtension
     /**
      * {@inheritdoc}
      */
-    public function load(array $config, ContainerBuilder $container)
+    public function load(array $config, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration($this->getConfiguration([], $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/src/Sylius/Bundle/AddressingBundle/Form/EventListener/BuildAddressFormSubscriber.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/EventListener/BuildAddressFormSubscriber.php
@@ -56,7 +56,7 @@ final class BuildAddressFormSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FormEvents::PRE_SET_DATA => 'preSetData',
@@ -67,7 +67,7 @@ final class BuildAddressFormSubscriber implements EventSubscriberInterface
     /**
      * @param FormEvent $event
      */
-    public function preSetData(FormEvent $event)
+    public function preSetData(FormEvent $event): void
     {
         /* @var AddressInterface $address */
         $address = $event->getData();
@@ -100,7 +100,7 @@ final class BuildAddressFormSubscriber implements EventSubscriberInterface
     /**
      * @param FormEvent $event
      */
-    public function preSubmit(FormEvent $event)
+    public function preSubmit(FormEvent $event): void
     {
         $data = $event->getData();
         if (!is_array($data) || !array_key_exists('countryCode', $data)) {
@@ -134,7 +134,7 @@ final class BuildAddressFormSubscriber implements EventSubscriberInterface
      *
      * @return FormInterface
      */
-    private function createProvinceCodeChoiceForm(CountryInterface $country, $provinceCode = null)
+    private function createProvinceCodeChoiceForm(CountryInterface $country, ?string $provinceCode = null): FormInterface
     {
         return $this->formFactory->createNamed('provinceCode', ProvinceCodeChoiceType::class, $provinceCode, [
             'country' => $country,
@@ -149,7 +149,7 @@ final class BuildAddressFormSubscriber implements EventSubscriberInterface
      *
      * @return FormInterface
      */
-    private function createProvinceNameTextForm($provinceName = null)
+    private function createProvinceNameTextForm(?string $provinceName = null): FormInterface
     {
         return $this->formFactory->createNamed('provinceName', TextType::class, $provinceName, [
             'required' => false,

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/AddressType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/AddressType.php
@@ -35,7 +35,7 @@ final class AddressType extends AbstractResourceType
      * @param string[] $validationGroups
      * @param EventSubscriberInterface $buildAddressFormSubscriber
      */
-    public function __construct($dataClass, array $validationGroups, EventSubscriberInterface $buildAddressFormSubscriber)
+    public function __construct(string $dataClass, array $validationGroups, EventSubscriberInterface $buildAddressFormSubscriber)
     {
         parent::__construct($dataClass, $validationGroups);
 
@@ -45,7 +45,7 @@ final class AddressType extends AbstractResourceType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('firstName', TextType::class, [
@@ -82,7 +82,7 @@ final class AddressType extends AbstractResourceType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         parent::configureOptions($resolver);
 
@@ -104,7 +104,7 @@ final class AddressType extends AbstractResourceType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sylius_address';
     }

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AddressingBundle\Form\Type;
 
+use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -40,19 +41,19 @@ final class CountryChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
-                'choices' => function (Options $options) {
+                'choices' => function (Options $options): iterable {
                     if (null === $options['enabled']) {
                         $countries = $this->countryRepository->findAll();
                     } else {
                         $countries = $this->countryRepository->findBy(['enabled' => $options['enabled']]);
                     }
 
-                    usort($countries, function ($a, $b) {
-                        return $a->getName() < $b->getName() ? -1 : 1;
+                    usort($countries, function (CountryInterface $a, CountryInterface $b): int {
+                        return $a->getName() <=> $b->getName();
                     });
 
                     return $countries;
@@ -70,7 +71,7 @@ final class CountryChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): string
     {
         return ChoiceType::class;
     }
@@ -78,7 +79,7 @@ final class CountryChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sylius_country_choice';
     }

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryCodeChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryCodeChoiceType.php
@@ -40,7 +40,7 @@ final class CountryCodeChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addModelTransformer(new ReversedTransformer(new ResourceToIdentifierTransformer($this->countryRepository, 'code')));
     }
@@ -48,7 +48,7 @@ final class CountryCodeChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): string
     {
         return CountryChoiceType::class;
     }
@@ -56,7 +56,7 @@ final class CountryCodeChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sylius_country_code_choice';
     }

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryType.php
@@ -28,7 +28,7 @@ final class CountryType extends AbstractResourceType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->addEventSubscriber(new AddCodeFormSubscriber(\Symfony\Component\Form\Extension\Core\Type\CountryType::class))
@@ -45,7 +45,7 @@ final class CountryType extends AbstractResourceType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sylius_country';
     }

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceChoiceType.php
@@ -41,10 +41,10 @@ final class ProvinceChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'choices' => function (Options $options) {
+            'choices' => function (Options $options): iterable {
                 if (null === $options['country']) {
                     return $this->provinceRepository->findAll();
                 }
@@ -64,7 +64,7 @@ final class ProvinceChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): string
     {
         return ChoiceType::class;
     }
@@ -72,7 +72,7 @@ final class ProvinceChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sylius_province_choice';
     }

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceCodeChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceCodeChoiceType.php
@@ -40,7 +40,7 @@ final class ProvinceCodeChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addModelTransformer(new ReversedTransformer(new ResourceToIdentifierTransformer($this->provinceRepository, 'code')));
     }
@@ -48,7 +48,7 @@ final class ProvinceCodeChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): string
     {
         return ProvinceChoiceType::class;
     }
@@ -56,7 +56,7 @@ final class ProvinceCodeChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sylius_province_code_choice';
     }

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ProvinceType.php
@@ -26,7 +26,7 @@ final class ProvinceType extends AbstractResourceType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->addEventSubscriber(new AddCodeFormSubscriber())
@@ -43,7 +43,7 @@ final class ProvinceType extends AbstractResourceType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sylius_province';
     }

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneChoiceType.php
@@ -40,10 +40,10 @@ final class ZoneChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'choices' => function (Options $options) {
+            'choices' => function (Options $options): iterable {
                 return $this->zoneRepository->findAll();
             },
             'choice_value' => 'code',
@@ -57,7 +57,7 @@ final class ZoneChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): string
     {
         return ChoiceType::class;
     }
@@ -65,7 +65,7 @@ final class ZoneChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sylius_zone_choice';
     }

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneCodeChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneCodeChoiceType.php
@@ -43,7 +43,7 @@ final class ZoneCodeChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addModelTransformer(new ReversedTransformer(new ResourceToIdentifierTransformer($this->zoneRepository, 'code')));
     }
@@ -51,12 +51,12 @@ final class ZoneCodeChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
                 'choice_filter' => null,
-                'choices' => function (Options $options) {
+                'choices' => function (Options $options): iterable {
                     $zones =  $this->zoneRepository->findAll();
                     if ($options['choice_filter']) {
                         $zones = array_filter($zones, $options['choice_filter']);
@@ -75,7 +75,7 @@ final class ZoneCodeChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): string
     {
         return ChoiceType::class;
     }
@@ -83,7 +83,7 @@ final class ZoneCodeChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sylius_zone_code_choice';
     }

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneMemberType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneMemberType.php
@@ -25,7 +25,7 @@ final class ZoneMemberType extends AbstractResourceType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('code', $options['entry_type'], array_merge($options['entry_options'], ['required' => true]));
     }
@@ -33,7 +33,7 @@ final class ZoneMemberType extends AbstractResourceType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired('entry_type')
@@ -48,7 +48,7 @@ final class ZoneMemberType extends AbstractResourceType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sylius_zone_member';
     }

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneType.php
@@ -40,7 +40,7 @@ final class ZoneType extends AbstractResourceType
      * @param string[] $validationGroups
      * @param string[] $scopeChoices
      */
-    public function __construct($dataClass, array $validationGroups, array $scopeChoices = [])
+    public function __construct(string $dataClass, array $validationGroups, array $scopeChoices = [])
     {
         parent::__construct($dataClass, $validationGroups);
 
@@ -50,7 +50,7 @@ final class ZoneType extends AbstractResourceType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->addEventSubscriber(new AddCodeFormSubscriber())
@@ -73,7 +73,7 @@ final class ZoneType extends AbstractResourceType
             ;
         }
 
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
             /** @var ZoneInterface $zone */
             $zone = $event->getData();
 
@@ -83,7 +83,7 @@ final class ZoneType extends AbstractResourceType
             ];
 
             if ($zone->getType() === ZoneInterface::TYPE_ZONE) {
-                $entryOptions['entry_options']['choice_filter'] = function(ZoneInterface $subZone) use ($zone){
+                $entryOptions['entry_options']['choice_filter'] = function (ZoneInterface $subZone) use ($zone): bool {
                     return $zone->getId() !== $subZone->getId();
                 };
             }
@@ -103,7 +103,7 @@ final class ZoneType extends AbstractResourceType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sylius_zone';
     }
@@ -113,7 +113,7 @@ final class ZoneType extends AbstractResourceType
      *
      * @return string
      */
-    private function getZoneMemberEntryType($zoneMemberType)
+    private function getZoneMemberEntryType(string $zoneMemberType): string
     {
         $zoneMemberEntryTypes = [
             ZoneInterface::TYPE_COUNTRY => CountryCodeChoiceType::class,
@@ -129,7 +129,7 @@ final class ZoneType extends AbstractResourceType
      *
      * @return array
      */
-    private function getZoneMemberEntryOptions($zoneMemberType)
+    private function getZoneMemberEntryOptions(string $zoneMemberType): array
     {
         $zoneMemberEntryOptions = [
             ZoneInterface::TYPE_COUNTRY => ['label' => 'sylius.form.zone.types.country'],

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneTypeChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneTypeChoiceType.php
@@ -26,7 +26,7 @@ final class ZoneTypeChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([
@@ -43,7 +43,7 @@ final class ZoneTypeChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): string
     {
         return ChoiceType::class;
     }
@@ -51,7 +51,7 @@ final class ZoneTypeChoiceType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'sylius_zone_type_choice';
     }

--- a/src/Sylius/Bundle/AddressingBundle/SyliusAddressingBundle.php
+++ b/src/Sylius/Bundle/AddressingBundle/SyliusAddressingBundle.php
@@ -25,7 +25,7 @@ final class SyliusAddressingBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    public function getSupportedDrivers()
+    public function getSupportedDrivers(): array
     {
         return [
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,
@@ -35,7 +35,7 @@ final class SyliusAddressingBundle extends AbstractResourceBundle
     /**
      * {@inheritdoc}
      */
-    protected function getModelNamespace()
+    protected function getModelNamespace(): string
     {
         return 'Sylius\Component\Addressing\Model';
     }

--- a/src/Sylius/Bundle/AddressingBundle/Twig/CountryNameExtension.php
+++ b/src/Sylius/Bundle/AddressingBundle/Twig/CountryNameExtension.php
@@ -24,7 +24,7 @@ class CountryNameExtension extends \Twig_Extension
     /**
      * {@inheritdoc}
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new \Twig_SimpleFilter('sylius_country_name', [$this, 'translateCountryIsoCode']),
@@ -33,11 +33,11 @@ class CountryNameExtension extends \Twig_Extension
 
     /**
      * @param mixed  $country
-     * @param string $locale
+     * @param string|null $locale
      *
      * @return string
      */
-    public function translateCountryIsoCode($country, $locale = null)
+    public function translateCountryIsoCode($country, ?string $locale = null): string
     {
         if ($country instanceof CountryInterface) {
             return Intl::getRegionBundle()->getCountryName($country->getCode(), $locale);

--- a/src/Sylius/Bundle/AddressingBundle/Twig/ProvinceNamingExtension.php
+++ b/src/Sylius/Bundle/AddressingBundle/Twig/ProvinceNamingExtension.php
@@ -37,7 +37,7 @@ class ProvinceNamingExtension extends \Twig_Extension
     /**
      * {@inheritdoc}
      */
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new \Twig_SimpleFilter('sylius_province_name', [$this->provinceNamingProvider, 'getName']),

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraint.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraint.php
@@ -30,7 +30,7 @@ class ProvinceAddressConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function getTargets()
+    public function getTargets(): string
     {
         return self::CLASS_CONSTRAINT;
     }
@@ -38,7 +38,7 @@ class ProvinceAddressConstraint extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'sylius_province_address_validator';
     }

--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraintValidator.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ProvinceAddressConstraintValidator.php
@@ -46,7 +46,7 @@ class ProvinceAddressConstraintValidator extends ConstraintValidator
     /**
      * {@inheritdoc}
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$value instanceof AddressInterface) {
             throw new \InvalidArgumentException(
@@ -72,7 +72,7 @@ class ProvinceAddressConstraintValidator extends ConstraintValidator
      *
      * @return bool
      */
-    protected function isProvinceValid(AddressInterface $address)
+    protected function isProvinceValid(AddressInterface $address): bool
     {
         $countryCode = $address->getCountryCode();
         if (null === $country = $this->countryRepository->findOneBy(['code' => $countryCode])) {

--- a/src/Sylius/Bundle/AddressingBundle/spec/Form/EventListener/BuildAddressFormSubscriberSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/Form/EventListener/BuildAddressFormSubscriberSpec.php
@@ -33,22 +33,22 @@ use Symfony\Component\Form\FormInterface;
  */
 final class BuildAddressFormSubscriberSpec extends ObjectBehavior
 {
-    function let(RepositoryInterface $countryRepository, FormFactoryInterface $formFactory)
+    function let(RepositoryInterface $countryRepository, FormFactoryInterface $formFactory): void
     {
         $this->beConstructedWith($countryRepository, $formFactory);
     }
 
-    function it_is_initializable()
+    function it_is_initializable(): void
     {
         $this->shouldHaveType(BuildAddressFormSubscriber::class);
     }
 
-    function it_is_a_subscriber()
+    function it_is_a_subscriber(): void
     {
         $this->shouldImplement(EventSubscriberInterface::class);
     }
 
-    function it_subscribes_to_event()
+    function it_subscribes_to_event(): void
     {
         $this::getSubscribedEvents()->shouldReturn([
             FormEvents::PRE_SET_DATA => 'preSetData',
@@ -64,7 +64,7 @@ final class BuildAddressFormSubscriberSpec extends ObjectBehavior
         AddressInterface $address,
         CountryInterface $country,
         RepositoryInterface $countryRepository
-    ) {
+    ): void {
         $event->getData()->willReturn($address);
         $event->getForm()->willReturn($form);
 
@@ -91,7 +91,7 @@ final class BuildAddressFormSubscriberSpec extends ObjectBehavior
         AddressInterface $address,
         CountryInterface $country,
         RepositoryInterface $countryRepository
-    ) {
+    ): void {
         $event->getData()->willReturn($address);
         $event->getForm()->willReturn($form);
 
@@ -117,7 +117,7 @@ final class BuildAddressFormSubscriberSpec extends ObjectBehavior
         FormInterface $form,
         FormInterface $provinceForm,
         CountryInterface $country
-    ) {
+    ): void {
         $event->getForm()->willReturn($form);
         $event->getData()->willReturn([
             'countryCode' => 'FR',
@@ -142,7 +142,7 @@ final class BuildAddressFormSubscriberSpec extends ObjectBehavior
         FormInterface $provinceForm,
         CountryInterface $country,
         RepositoryInterface $countryRepository
-    ) {
+    ): void {
         $event->getData()->willReturn([
             'countryCode' => 'US',
         ]);

--- a/src/Sylius/Bundle/AddressingBundle/spec/Twig/CountryNameExtensionSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/Twig/CountryNameExtensionSpec.php
@@ -22,24 +22,24 @@ use Sylius\Component\Addressing\Model\CountryInterface;
  */
 final class CountryNameExtensionSpec extends ObjectBehavior
 {
-    function it_is_a_twig_extension()
+    function it_is_a_twig_extension(): void
     {
         $this->shouldHaveType(\Twig_Extension::class);
     }
 
-    function it_translates_country_iso_code_into_name()
+    function it_translates_country_iso_code_into_name(): void
     {
         $this->translateCountryIsoCode('IE')->shouldReturn('Ireland');
     }
 
-    function it_translates_country_into_name(CountryInterface $country)
+    function it_translates_country_into_name(CountryInterface $country): void
     {
         $country->getCode()->willReturn('IE');
 
         $this->translateCountryIsoCode($country)->shouldReturn('Ireland');
     }
 
-    function it_translates_country_code_to_name_according_to_locale()
+    function it_translates_country_code_to_name_according_to_locale(): void
     {
         $this->translateCountryIsoCode('IE', 'es')->shouldReturn('Irlanda');
     }

--- a/src/Sylius/Bundle/AddressingBundle/spec/Validator/Constraints/ProvinceAddressConstraintSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/Validator/Constraints/ProvinceAddressConstraintSpec.php
@@ -21,17 +21,17 @@ use Sylius\Bundle\AddressingBundle\Validator\Constraints\ProvinceAddressConstrai
  */
 final class ProvinceAddressConstraintSpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    function it_is_initializable(): void
     {
         $this->shouldHaveType(ProvinceAddressConstraint::class);
     }
 
-    function it_has_targets()
+    function it_has_targets(): void
     {
         $this->getTargets()->shouldReturn('class');
     }
 
-    function it_is_validated_by()
+    function it_is_validated_by(): void
     {
         $this->validatedBy()->shouldReturn('sylius_province_address_validator');
     }

--- a/src/Sylius/Bundle/AddressingBundle/spec/Validator/Constraints/ProvinceAddressConstraintValidatorSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/Validator/Constraints/ProvinceAddressConstraintValidatorSpec.php
@@ -30,17 +30,17 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  */
 final class ProvinceAddressConstraintValidatorSpec extends ObjectBehavior
 {
-    function let(RepositoryInterface $countryRepository, RepositoryInterface $provinceRepository)
+    function let(RepositoryInterface $countryRepository, RepositoryInterface $provinceRepository): void
     {
         $this->beConstructedWith($countryRepository, $provinceRepository);
     }
 
-    function it_is_initializable()
+    function it_is_initializable(): void
     {
         $this->shouldHaveType(ProvinceAddressConstraintValidator::class);
     }
 
-    function it_throws_exception_if_the_value_is_not_an_address(Constraint $constraint)
+    function it_throws_exception_if_the_value_is_not_an_address(Constraint $constraint): void
     {
         $this->shouldThrow(\InvalidArgumentException::class)->during('validate', [
             '',
@@ -52,7 +52,7 @@ final class ProvinceAddressConstraintValidatorSpec extends ObjectBehavior
         AddressInterface $address,
         ProvinceAddressConstraint $constraint,
         ExecutionContextInterface $context
-    ) {
+    ): void {
         $this->initialize($context);
 
         $context->getPropertyPath()->willReturn('property_path');
@@ -71,7 +71,7 @@ final class ProvinceAddressConstraintValidatorSpec extends ObjectBehavior
         ProvinceAddressConstraint $constraint,
         ExecutionContextInterface $context,
         RepositoryInterface $countryRepository
-    ) {
+    ): void {
         $country->getCode()->willReturn('IE');
         $address->getCountryCode()->willReturn('IE');
         $countryRepository->findOneBy(['code' => 'IE'])->willReturn($country);
@@ -98,7 +98,7 @@ final class ProvinceAddressConstraintValidatorSpec extends ObjectBehavior
         ExecutionContextInterface $context,
         RepositoryInterface $countryRepository,
         RepositoryInterface $provinceRepository
-    ) {
+    ): void {
         $country->getCode()->willReturn('US');
         $address->getCountryCode()->willReturn('US');
         $countryRepository->findOneBy(['code' => 'US'])->willReturn($country);
@@ -130,7 +130,7 @@ final class ProvinceAddressConstraintValidatorSpec extends ObjectBehavior
         ExecutionContextInterface $context,
         RepositoryInterface $countryRepository,
         RepositoryInterface $provinceRepository
-    ) {
+    ): void {
         $country->getCode()->willReturn('US');
         $address->getCountryCode()->willReturn('US');
         $countryRepository->findOneBy(['code' => 'US'])->willReturn($country);

--- a/src/Sylius/Bundle/AddressingBundle/test/src/Tests/SyliusAddressingBundleTest.php
+++ b/src/Sylius/Bundle/AddressingBundle/test/src/Tests/SyliusAddressingBundleTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AddressingBundle\Tests;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -24,14 +25,14 @@ class SyliusAddressingBundleTest extends WebTestCase
     /**
      * @test
      */
-    public function its_services_are_initializable()
+    public function its_services_are_initializable(): void
     {
-        /** @var ContainerInterface $container */
+        /** @var ContainerBuilder $container */
         $container = self::createClient()->getContainer();
 
         $services = $container->getServiceIds();
 
-        $services = array_filter($services, function ($serviceId) {
+        $services = array_filter($services, function (string $serviceId): bool {
             return 0 === strpos($serviceId, 'sylius.');
         });
 

--- a/src/Sylius/Component/Addressing/Comparator/AddressComparator.php
+++ b/src/Sylius/Component/Addressing/Comparator/AddressComparator.php
@@ -23,7 +23,7 @@ final class AddressComparator implements AddressComparatorInterface
     /**
      * {@inheritdoc}
      */
-    public function equal(AddressInterface $firstAddress, AddressInterface $secondAddress)
+    public function equal(AddressInterface $firstAddress, AddressInterface $secondAddress): bool
     {
         return $this->normalizeAddress($firstAddress) === $this->normalizeAddress($secondAddress);
     }
@@ -33,7 +33,7 @@ final class AddressComparator implements AddressComparatorInterface
      *
      * @return array
      */
-    private function normalizeAddress(AddressInterface $address)
+    private function normalizeAddress(AddressInterface $address): array
     {
         return array_map(function ($value) {
             return strtolower(trim((string) $value));

--- a/src/Sylius/Component/Addressing/Comparator/AddressComparatorInterface.php
+++ b/src/Sylius/Component/Addressing/Comparator/AddressComparatorInterface.php
@@ -26,5 +26,5 @@ interface AddressComparatorInterface
      *
      * @return bool
      */
-    public function equal(AddressInterface $firstAddress, AddressInterface $secondAddress);
+    public function equal(AddressInterface $firstAddress, AddressInterface $secondAddress): bool;
 }

--- a/src/Sylius/Component/Addressing/Converter/CountryNameConverter.php
+++ b/src/Sylius/Component/Addressing/Converter/CountryNameConverter.php
@@ -23,7 +23,7 @@ final class CountryNameConverter implements CountryNameConverterInterface
     /**
      * {@inheritdoc}
      */
-    public function convertToCode($name, $locale = 'en')
+    public function convertToCode(string $name, string $locale = 'en'): string
     {
         $names = Intl::getRegionBundle()->getCountryNames($locale);
         $countryCode = array_search($name, $names, true);

--- a/src/Sylius/Component/Addressing/Converter/CountryNameConverterInterface.php
+++ b/src/Sylius/Component/Addressing/Converter/CountryNameConverterInterface.php
@@ -26,5 +26,5 @@ interface CountryNameConverterInterface
      *
      * @throws \InvalidArgumentException
      */
-    public function convertToCode($name, $locale = 'en');
+    public function convertToCode(string $name, string $locale = 'en'): string;
 }

--- a/src/Sylius/Component/Addressing/Factory/ZoneFactory.php
+++ b/src/Sylius/Component/Addressing/Factory/ZoneFactory.php
@@ -44,7 +44,7 @@ final class ZoneFactory implements ZoneFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createNew()
+    public function createNew(): ZoneInterface
     {
         return $this->factory->createNew();
     }
@@ -52,7 +52,7 @@ final class ZoneFactory implements ZoneFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createTyped($type)
+    public function createTyped(string $type): ZoneInterface
     {
         /* @var ZoneInterface $zone */
         $zone = $this->createNew();
@@ -64,7 +64,7 @@ final class ZoneFactory implements ZoneFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createWithMembers(array $membersCodes)
+    public function createWithMembers(array $membersCodes): ZoneInterface
     {
         /* @var ZoneInterface $zone */
         $zone = $this->createNew();

--- a/src/Sylius/Component/Addressing/Factory/ZoneFactoryInterface.php
+++ b/src/Sylius/Component/Addressing/Factory/ZoneFactoryInterface.php
@@ -26,12 +26,12 @@ interface ZoneFactoryInterface extends FactoryInterface
      *
      * @return ZoneInterface
      */
-    public function createTyped($type);
+    public function createTyped(string $type): ZoneInterface;
 
     /**
      * @param array $membersCodes
      *
      * @return ZoneInterface
      */
-    public function createWithMembers(array $membersCodes);
+    public function createWithMembers(array $membersCodes): ZoneInterface;
 }

--- a/src/Sylius/Component/Addressing/Matcher/ZoneMatcher.php
+++ b/src/Sylius/Component/Addressing/Matcher/ZoneMatcher.php
@@ -24,17 +24,17 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
  * @author Jan Góralski <jan.goralski@lakion.com>
  */
-class ZoneMatcher implements ZoneMatcherInterface
+final class ZoneMatcher implements ZoneMatcherInterface
 {
     /**
      * @var RepositoryInterface
      */
-    protected $zoneRepository;
+    private $zoneRepository;
 
     /**
      * @var array
      */
-    protected $priorities = [
+    private const PRIORITIES = [
         ZoneInterface::TYPE_PROVINCE,
         ZoneInterface::TYPE_COUNTRY,
         ZoneInterface::TYPE_ZONE,
@@ -51,7 +51,7 @@ class ZoneMatcher implements ZoneMatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function match(AddressInterface $address, $scope = null)
+    public function match(AddressInterface $address, ?string $scope = null): ?ZoneInterface
     {
         $zones = [];
 
@@ -62,7 +62,7 @@ class ZoneMatcher implements ZoneMatcherInterface
             }
         }
 
-        foreach ($this->priorities as $priority) {
+        foreach (static::PRIORITIES as $priority) {
             if (isset($zones[$priority])) {
                 return $zones[$priority];
             }
@@ -74,7 +74,7 @@ class ZoneMatcher implements ZoneMatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function matchAll(AddressInterface $address, $scope = null)
+    public function matchAll(AddressInterface $address, ?string $scope = null): array
     {
         $zones = [];
 
@@ -93,7 +93,7 @@ class ZoneMatcher implements ZoneMatcherInterface
      *
      * @return bool
      */
-    protected function addressBelongsToZone(AddressInterface $address, ZoneInterface $zone)
+    private function addressBelongsToZone(AddressInterface $address, ZoneInterface $zone): bool
     {
         foreach ($zone->getMembers() as $member) {
             if ($this->addressBelongsToZoneMember($address, $member)) {
@@ -112,7 +112,7 @@ class ZoneMatcher implements ZoneMatcherInterface
      *
      * @throws \InvalidArgumentException
      */
-    protected function addressBelongsToZoneMember(AddressInterface $address, ZoneMemberInterface $member)
+    private function addressBelongsToZoneMember(AddressInterface $address, ZoneMemberInterface $member): bool
     {
         switch ($type = $member->getBelongsTo()->getType()) {
             case ZoneInterface::TYPE_PROVINCE:
@@ -124,7 +124,7 @@ class ZoneMatcher implements ZoneMatcherInterface
             case ZoneInterface::TYPE_ZONE:
                 $zone = $this->getZoneByCode($member->getCode());
 
-                return $this->addressBelongsToZone($address, $zone);
+                return null !== $zone && $this->addressBelongsToZone($address, $zone);
 
             default:
                 throw new \InvalidArgumentException(sprintf('Unexpected zone type "%s".', $type));
@@ -136,7 +136,7 @@ class ZoneMatcher implements ZoneMatcherInterface
      *
      * @return array
      */
-    protected function getZones($scope = null)
+    private function getZones(?string $scope = null): array
     {
         if (null === $scope) {
             return $this->zoneRepository->findAll();
@@ -148,9 +148,9 @@ class ZoneMatcher implements ZoneMatcherInterface
     /**
      * @param string $code
      *
-     * @return ZoneInterface
+     * @return ZoneInterface|null
      */
-    protected function getZoneByCode($code)
+    private function getZoneByCode(string $code): ?ZoneInterface
     {
         return $this->zoneRepository->findOneBy(['code' => $code]);
     }

--- a/src/Sylius/Component/Addressing/Matcher/ZoneMatcherInterface.php
+++ b/src/Sylius/Component/Addressing/Matcher/ZoneMatcherInterface.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Addressing\Matcher;
 
-use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Addressing\Model\AddressInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 
@@ -31,7 +30,7 @@ interface ZoneMatcherInterface
      *
      * @return ZoneInterface|null
      */
-    public function match(AddressInterface $address, $scope = null);
+    public function match(AddressInterface $address, ?string $scope = null): ?ZoneInterface;
 
     /**
      * Returns all matching zones for given address.
@@ -39,7 +38,7 @@ interface ZoneMatcherInterface
      * @param AddressInterface $address
      * @param string|null      $scope
      *
-     * @return Collection|ZoneInterface[]
+     * @return array|ZoneInterface[]
      */
-    public function matchAll(AddressInterface $address, $scope = null);
+    public function matchAll(AddressInterface $address, ?string $scope = null): array;
 }

--- a/src/Sylius/Component/Addressing/Model/Address.php
+++ b/src/Sylius/Component/Addressing/Model/Address.php
@@ -173,7 +173,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function setCountryCode(?string $countryCode = null): void
+    public function setCountryCode(?string $countryCode): void
     {
         if (null === $countryCode) {
             $this->provinceCode = null;
@@ -193,7 +193,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function setProvinceCode(?string $provinceCode = null): void
+    public function setProvinceCode(?string $provinceCode): void
     {
         if (null === $this->countryCode) {
             return;
@@ -213,7 +213,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function setProvinceName(?string $provinceName = null): void
+    public function setProvinceName(?string $provinceName): void
     {
         $this->provinceName = $provinceName;
     }

--- a/src/Sylius/Component/Addressing/Model/Address.php
+++ b/src/Sylius/Component/Addressing/Model/Address.php
@@ -28,52 +28,52 @@ class Address implements AddressInterface
     protected $id;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $firstName;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $lastName;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $phoneNumber;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $company;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $countryCode;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $provinceCode;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $provinceName;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $street;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $city;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $postcode;
 
@@ -93,7 +93,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function getFirstName()
+    public function getFirstName(): ?string
     {
         return $this->firstName;
     }
@@ -101,7 +101,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function setFirstName($firstName)
+    public function setFirstName(?string $firstName): void
     {
         $this->firstName = $firstName;
     }
@@ -109,7 +109,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function getLastName()
+    public function getLastName(): ?string
     {
         return $this->lastName;
     }
@@ -117,7 +117,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function setLastName($lastName)
+    public function setLastName(?string $lastName): void
     {
         $this->lastName = $lastName;
     }
@@ -125,7 +125,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function getFullName()
+    public function getFullName(): string
     {
         return trim(sprintf('%s %s', $this->firstName, $this->lastName));
     }
@@ -133,7 +133,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function getPhoneNumber()
+    public function getPhoneNumber(): ?string
     {
         return $this->phoneNumber;
     }
@@ -141,7 +141,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function setPhoneNumber($phoneNumber)
+    public function setPhoneNumber(?string $phoneNumber): void
     {
         $this->phoneNumber = $phoneNumber;
     }
@@ -149,7 +149,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function getCompany()
+    public function getCompany(): ?string
     {
         return $this->company;
     }
@@ -157,7 +157,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function setCompany($company)
+    public function setCompany(?string $company): void
     {
         $this->company = $company;
     }
@@ -165,7 +165,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function getCountryCode()
+    public function getCountryCode(): ?string
     {
         return $this->countryCode;
     }
@@ -173,7 +173,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function setCountryCode($countryCode = null)
+    public function setCountryCode(?string $countryCode = null): void
     {
         if (null === $countryCode) {
             $this->provinceCode = null;
@@ -185,7 +185,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function getProvinceCode()
+    public function getProvinceCode(): ?string
     {
         return $this->provinceCode;
     }
@@ -193,7 +193,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function setProvinceCode($provinceCode = null)
+    public function setProvinceCode(?string $provinceCode = null): void
     {
         if (null === $this->countryCode) {
             return;
@@ -205,7 +205,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function getProvinceName()
+    public function getProvinceName(): ?string
     {
         return $this->provinceName;
     }
@@ -213,7 +213,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function setProvinceName($provinceName = null)
+    public function setProvinceName(?string $provinceName = null): void
     {
         $this->provinceName = $provinceName;
     }
@@ -221,7 +221,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function getStreet()
+    public function getStreet(): ?string
     {
         return $this->street;
     }
@@ -229,7 +229,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function setStreet($street)
+    public function setStreet(?string $street): void
     {
         $this->street = $street;
     }
@@ -237,7 +237,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function getCity()
+    public function getCity(): ?string
     {
         return $this->city;
     }
@@ -245,7 +245,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function setCity($city)
+    public function setCity(?string $city): void
     {
         $this->city = $city;
     }
@@ -253,7 +253,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function getPostcode()
+    public function getPostcode(): ?string
     {
         return $this->postcode;
     }
@@ -261,7 +261,7 @@ class Address implements AddressInterface
     /**
      * {@inheritdoc}
      */
-    public function setPostcode($postcode)
+    public function setPostcode(?string $postcode): void
     {
         $this->postcode = $postcode;
     }

--- a/src/Sylius/Component/Addressing/Model/AddressInterface.php
+++ b/src/Sylius/Component/Addressing/Model/AddressInterface.php
@@ -22,107 +22,107 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
 interface AddressInterface extends TimestampableInterface, ResourceInterface
 {
     /**
-     * @return string
+     * @return string|null
      */
-    public function getFirstName();
+    public function getFirstName(): ?string;
 
     /**
-     * @param string $firstName
+     * @param string|null $firstName
      */
-    public function setFirstName($firstName);
+    public function setFirstName(?string $firstName): void;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getLastName();
+    public function getLastName(): ?string;
 
     /**
-     * @param string $lastName
+     * @param string|null $lastName
      */
-    public function setLastName($lastName);
+    public function setLastName(?string $lastName): void;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getFullName();
+    public function getFullName(): ?string;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getPhoneNumber();
+    public function getPhoneNumber(): ?string;
 
     /**
-     * @param string $phoneNumber
+     * @param string|null $phoneNumber
      */
-    public function setPhoneNumber($phoneNumber);
+    public function setPhoneNumber(?string $phoneNumber): void;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getCompany();
+    public function getCompany(): ?string;
 
     /**
-     * @param string $company
+     * @param string|null $company
      */
-    public function setCompany($company);
+    public function setCompany(?string $company): void;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getCountryCode();
+    public function getCountryCode(): ?string;
 
     /**
-     * @param string $countryCode
+     * @param string|null $countryCode
      */
-    public function setCountryCode($countryCode = null);
+    public function setCountryCode(?string $countryCode = null): void;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getProvinceCode();
+    public function getProvinceCode(): ?string;
 
     /**
-     * @param string $provinceCode
+     * @param string|null $provinceCode
      */
-    public function setProvinceCode($provinceCode = null);
+    public function setProvinceCode(?string $provinceCode = null): void;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getProvinceName();
+    public function getProvinceName(): ?string;
 
     /**
-     * @param string $provinceName
+     * @param string|null $provinceName
      */
-    public function setProvinceName($provinceName = null);
+    public function setProvinceName(?string $provinceName = null): void;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getStreet();
+    public function getStreet(): ?string;
 
     /**
-     * @param string $street
+     * @param string|null $street
      */
-    public function setStreet($street);
+    public function setStreet(?string $street): void;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getCity();
+    public function getCity(): ?string;
 
     /**
-     * @param string $city
+     * @param string|null $city
      */
-    public function setCity($city);
+    public function setCity(?string $city): void;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getPostcode();
+    public function getPostcode(): ?string;
 
     /**
-     * @param string $postcode
+     * @param string|null $postcode
      */
-    public function setPostcode($postcode);
+    public function setPostcode(?string $postcode): void;
 }

--- a/src/Sylius/Component/Addressing/Model/AddressInterface.php
+++ b/src/Sylius/Component/Addressing/Model/AddressInterface.php
@@ -74,7 +74,7 @@ interface AddressInterface extends TimestampableInterface, ResourceInterface
     /**
      * @param string|null $countryCode
      */
-    public function setCountryCode(?string $countryCode = null): void;
+    public function setCountryCode(?string $countryCode): void;
 
     /**
      * @return string|null
@@ -84,7 +84,7 @@ interface AddressInterface extends TimestampableInterface, ResourceInterface
     /**
      * @param string|null $provinceCode
      */
-    public function setProvinceCode(?string $provinceCode = null): void;
+    public function setProvinceCode(?string $provinceCode): void;
 
     /**
      * @return string|null
@@ -94,7 +94,7 @@ interface AddressInterface extends TimestampableInterface, ResourceInterface
     /**
      * @param string|null $provinceName
      */
-    public function setProvinceName(?string $provinceName = null): void;
+    public function setProvinceName(?string $provinceName): void;
 
     /**
      * @return string|null

--- a/src/Sylius/Component/Addressing/Model/Country.php
+++ b/src/Sylius/Component/Addressing/Model/Country.php
@@ -35,7 +35,7 @@ class Country implements CountryInterface
     /**
      * Country code ISO 3166-1 alpha-2.
      *
-     * @var string
+     * @var string|null
      */
     protected $code;
 
@@ -52,9 +52,9 @@ class Country implements CountryInterface
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
-        return $this->getName() ?: $this->getCode();
+        return (string) ($this->getName() ?? $this->getCode());
     }
 
     /**
@@ -68,7 +68,7 @@ class Country implements CountryInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -76,7 +76,7 @@ class Country implements CountryInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }
@@ -84,7 +84,7 @@ class Country implements CountryInterface
     /**
      * {@inheritdoc}
      */
-    public function getName($locale = null)
+    public function getName(?string $locale = null): ?string
     {
         return Intl::getRegionBundle()->getCountryName($this->code, $locale);
     }
@@ -92,7 +92,7 @@ class Country implements CountryInterface
     /**
      * {@inheritdoc}
      */
-    public function getProvinces()
+    public function getProvinces(): Collection
     {
         return $this->provinces;
     }
@@ -100,7 +100,7 @@ class Country implements CountryInterface
     /**
      * {@inheritdoc}
      */
-    public function hasProvinces()
+    public function hasProvinces(): bool
     {
         return !$this->provinces->isEmpty();
     }
@@ -108,7 +108,7 @@ class Country implements CountryInterface
     /**
      * {@inheritdoc}
      */
-    public function addProvince(ProvinceInterface $province)
+    public function addProvince(ProvinceInterface $province): void
     {
         if (!$this->hasProvince($province)) {
             $this->provinces->add($province);
@@ -119,7 +119,7 @@ class Country implements CountryInterface
     /**
      * {@inheritdoc}
      */
-    public function removeProvince(ProvinceInterface $province)
+    public function removeProvince(ProvinceInterface $province): void
     {
         if ($this->hasProvince($province)) {
             $this->provinces->removeElement($province);
@@ -130,7 +130,7 @@ class Country implements CountryInterface
     /**
      * {@inheritdoc}
      */
-    public function hasProvince(ProvinceInterface $province)
+    public function hasProvince(ProvinceInterface $province): bool
     {
         return $this->provinces->contains($province);
     }

--- a/src/Sylius/Component/Addressing/Model/CountryInterface.php
+++ b/src/Sylius/Component/Addressing/Model/CountryInterface.php
@@ -30,32 +30,32 @@ interface CountryInterface extends ToggleableInterface, ResourceInterface, CodeA
      *
      * @return string|null
      */
-    public function getName($locale = null);
+    public function getName(?string $locale = null): ?string;
 
     /**
      * @return Collection|ProvinceInterface[]
      */
-    public function getProvinces();
+    public function getProvinces(): Collection;
 
     /**
      * @return bool
      */
-    public function hasProvinces();
+    public function hasProvinces(): bool;
 
     /**
      * @param ProvinceInterface $province
      */
-    public function addProvince(ProvinceInterface $province);
+    public function addProvince(ProvinceInterface $province): void;
 
     /**
      * @param ProvinceInterface $province
      */
-    public function removeProvince(ProvinceInterface $province);
+    public function removeProvince(ProvinceInterface $province): void;
 
     /**
      * @param ProvinceInterface $province
      *
      * @return bool
      */
-    public function hasProvince(ProvinceInterface $province);
+    public function hasProvince(ProvinceInterface $province): bool;
 }

--- a/src/Sylius/Component/Addressing/Model/Province.php
+++ b/src/Sylius/Component/Addressing/Model/Province.php
@@ -118,7 +118,7 @@ class Province implements ProvinceInterface
     /**
      * {@inheritdoc}
      */
-    public function setCountry(?CountryInterface $country = null): void
+    public function setCountry(?CountryInterface $country): void
     {
         $this->country = $country;
     }

--- a/src/Sylius/Component/Addressing/Model/Province.php
+++ b/src/Sylius/Component/Addressing/Model/Province.php
@@ -24,31 +24,31 @@ class Province implements ProvinceInterface
     protected $id;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $code;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $name;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $abbreviation;
 
     /**
-     * @var CountryInterface
+     * @var CountryInterface|null
      */
     protected $country;
 
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
-        return $this->getName();
+        return (string) $this->getName();
     }
 
     /**
@@ -62,7 +62,7 @@ class Province implements ProvinceInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -70,7 +70,7 @@ class Province implements ProvinceInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }
@@ -78,7 +78,7 @@ class Province implements ProvinceInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -86,7 +86,7 @@ class Province implements ProvinceInterface
     /**
      * {@inheritdoc}
      */
-    public function setName($name)
+    public function setName(?string $name): void
     {
         $this->name = $name;
     }
@@ -94,7 +94,7 @@ class Province implements ProvinceInterface
     /**
      * {@inheritdoc}
      */
-    public function getAbbreviation()
+    public function getAbbreviation(): ?string
     {
         return $this->abbreviation;
     }
@@ -102,7 +102,7 @@ class Province implements ProvinceInterface
     /**
      * {@inheritdoc}
      */
-    public function setAbbreviation($abbreviation)
+    public function setAbbreviation(?string $abbreviation): void
     {
         $this->abbreviation = $abbreviation;
     }
@@ -110,7 +110,7 @@ class Province implements ProvinceInterface
     /**
      * {@inheritdoc}
      */
-    public function getCountry()
+    public function getCountry(): ?CountryInterface
     {
         return $this->country;
     }
@@ -118,7 +118,7 @@ class Province implements ProvinceInterface
     /**
      * {@inheritdoc}
      */
-    public function setCountry(CountryInterface $country = null)
+    public function setCountry(?CountryInterface $country = null): void
     {
         $this->country = $country;
     }

--- a/src/Sylius/Component/Addressing/Model/ProvinceInterface.php
+++ b/src/Sylius/Component/Addressing/Model/ProvinceInterface.php
@@ -22,32 +22,32 @@ use Sylius\Component\Resource\Model\ResourceInterface;
 interface ProvinceInterface extends ResourceInterface, CodeAwareInterface
 {
     /**
-     * @return string
+     * @return string|null
      */
-    public function getName();
+    public function getName(): ?string;
 
     /**
-     * @param string $name
+     * @param string|null $name
      */
-    public function setName($name);
+    public function setName(?string $name): void;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getAbbreviation();
+    public function getAbbreviation(): ?string;
 
     /**
-     * @param string $abbreviation
+     * @param string|null $abbreviation
      */
-    public function setAbbreviation($abbreviation);
+    public function setAbbreviation(?string $abbreviation): void;
 
     /**
-     * @return CountryInterface
+     * @return CountryInterface|null
      */
-    public function getCountry();
+    public function getCountry(): ?CountryInterface;
 
     /**
      * @param CountryInterface $country
      */
-    public function setCountry(CountryInterface $country = null);
+    public function setCountry(?CountryInterface $country = null): void;
 }

--- a/src/Sylius/Component/Addressing/Model/ProvinceInterface.php
+++ b/src/Sylius/Component/Addressing/Model/ProvinceInterface.php
@@ -49,5 +49,5 @@ interface ProvinceInterface extends ResourceInterface, CodeAwareInterface
     /**
      * @param CountryInterface $country
      */
-    public function setCountry(?CountryInterface $country = null): void;
+    public function setCountry(?CountryInterface $country): void;
 }

--- a/src/Sylius/Component/Addressing/Model/Zone.php
+++ b/src/Sylius/Component/Addressing/Model/Zone.php
@@ -28,22 +28,22 @@ class Zone implements ZoneInterface
     protected $id;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $code;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $name;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $type;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $scope = Scope::ALL;
 
@@ -60,15 +60,15 @@ class Zone implements ZoneInterface
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
-        return $this->getName();
+        return (string) $this->getName();
     }
 
     /**
      * {@inheritdoc}
      */
-    public static function getTypes()
+    public static function getTypes(): array
     {
         return [self::TYPE_COUNTRY, self::TYPE_PROVINCE, self::TYPE_ZONE];
     }
@@ -84,7 +84,7 @@ class Zone implements ZoneInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -92,7 +92,7 @@ class Zone implements ZoneInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }
@@ -100,7 +100,7 @@ class Zone implements ZoneInterface
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -108,7 +108,7 @@ class Zone implements ZoneInterface
     /**
      * {@inheritdoc}
      */
-    public function setName($name)
+    public function setName(?string $name): void
     {
         $this->name = $name;
     }
@@ -116,7 +116,7 @@ class Zone implements ZoneInterface
     /**
      * {@inheritdoc}
      */
-    public function getType()
+    public function getType(): ?string
     {
         return $this->type;
     }
@@ -126,9 +126,9 @@ class Zone implements ZoneInterface
      *
      * @throws \InvalidArgumentException
      */
-    public function setType($type)
+    public function setType(?string $type): void
     {
-        if (!in_array($type, self::getTypes())) {
+        if (!in_array($type, static::getTypes(), true)) {
             throw new \InvalidArgumentException('Wrong zone type supplied.');
         }
 
@@ -138,7 +138,7 @@ class Zone implements ZoneInterface
     /**
      * {@inheritdoc}
      */
-    public function getScope()
+    public function getScope(): ?string
     {
         return $this->scope;
     }
@@ -146,7 +146,7 @@ class Zone implements ZoneInterface
     /**
      * {@inheritdoc}
      */
-    public function setScope($scope)
+    public function setScope(?string $scope): void
     {
         $this->scope = $scope;
     }
@@ -154,7 +154,7 @@ class Zone implements ZoneInterface
     /**
      * {@inheritdoc}
      */
-    public function getMembers()
+    public function getMembers(): Collection
     {
         return $this->members;
     }
@@ -162,7 +162,7 @@ class Zone implements ZoneInterface
     /**
      * {@inheritdoc}
      */
-    public function hasMembers()
+    public function hasMembers(): bool
     {
         return !$this->members->isEmpty();
     }
@@ -170,7 +170,7 @@ class Zone implements ZoneInterface
     /**
      * {@inheritdoc}
      */
-    public function addMember(ZoneMemberInterface $member)
+    public function addMember(ZoneMemberInterface $member): void
     {
         if (!$this->hasMember($member)) {
             $this->members->add($member);
@@ -181,7 +181,7 @@ class Zone implements ZoneInterface
     /**
      * {@inheritdoc}
      */
-    public function removeMember(ZoneMemberInterface $member)
+    public function removeMember(ZoneMemberInterface $member): void
     {
         if ($this->hasMember($member)) {
             $this->members->removeElement($member);
@@ -192,7 +192,7 @@ class Zone implements ZoneInterface
     /**
      * {@inheritdoc}
      */
-    public function hasMember(ZoneMemberInterface $member)
+    public function hasMember(ZoneMemberInterface $member): bool
     {
         return $this->members->contains($member);
     }

--- a/src/Sylius/Component/Addressing/Model/ZoneInterface.php
+++ b/src/Sylius/Component/Addressing/Model/ZoneInterface.php
@@ -30,62 +30,62 @@ interface ZoneInterface extends ResourceInterface, CodeAwareInterface
     /**
      * @return string[]
      */
-    public static function getTypes();
+    public static function getTypes(): array;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getName();
+    public function getName(): ?string;
 
     /**
-     * @param string $name
+     * @param string|null $name
      */
-    public function setName($name);
+    public function setName(?string $name): void;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getType();
+    public function getType(): ?string;
 
     /**
-     * @param string $type
+     * @param string|null $type
      */
-    public function setType($type);
+    public function setType(?string $type): void;
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getScope();
+    public function getScope(): ?string;
 
     /**
-     * @param string $scope
+     * @param string|null $scope
      */
-    public function setScope($scope);
+    public function setScope(?string $scope): void;
 
     /**
      * @return Collection|ZoneMemberInterface[]
      */
-    public function getMembers();
+    public function getMembers(): Collection;
 
     /**
      * @return bool
      */
-    public function hasMembers();
+    public function hasMembers(): bool;
 
     /**
      * @param ZoneMemberInterface $member
      */
-    public function addMember(ZoneMemberInterface $member);
+    public function addMember(ZoneMemberInterface $member): void;
 
     /**
      * @param ZoneMemberInterface $member
      */
-    public function removeMember(ZoneMemberInterface $member);
+    public function removeMember(ZoneMemberInterface $member): void;
 
     /**
      * @param ZoneMemberInterface $member
      *
      * @return bool
      */
-    public function hasMember(ZoneMemberInterface $member);
+    public function hasMember(ZoneMemberInterface $member): bool;
 }

--- a/src/Sylius/Component/Addressing/Model/ZoneMember.php
+++ b/src/Sylius/Component/Addressing/Model/ZoneMember.php
@@ -69,7 +69,7 @@ class ZoneMember implements ZoneMemberInterface
     /**
      * {@inheritdoc}
      */
-    public function setBelongsTo(?ZoneInterface $belongsTo = null): void
+    public function setBelongsTo(?ZoneInterface $belongsTo): void
     {
         $this->belongsTo = $belongsTo;
     }

--- a/src/Sylius/Component/Addressing/Model/ZoneMember.php
+++ b/src/Sylius/Component/Addressing/Model/ZoneMember.php
@@ -25,12 +25,12 @@ class ZoneMember implements ZoneMemberInterface
     protected $id;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $code;
 
     /**
-     * @var ZoneInterface
+     * @var ZoneInterface|null
      */
     protected $belongsTo;
 
@@ -45,7 +45,7 @@ class ZoneMember implements ZoneMemberInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -53,7 +53,7 @@ class ZoneMember implements ZoneMemberInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }
@@ -61,7 +61,7 @@ class ZoneMember implements ZoneMemberInterface
     /**
      * {@inheritdoc}
      */
-    public function getBelongsTo()
+    public function getBelongsTo(): ?ZoneInterface
     {
         return $this->belongsTo;
     }
@@ -69,7 +69,7 @@ class ZoneMember implements ZoneMemberInterface
     /**
      * {@inheritdoc}
      */
-    public function setBelongsTo(ZoneInterface $belongsTo = null)
+    public function setBelongsTo(?ZoneInterface $belongsTo = null): void
     {
         $this->belongsTo = $belongsTo;
     }

--- a/src/Sylius/Component/Addressing/Model/ZoneMemberInterface.php
+++ b/src/Sylius/Component/Addressing/Model/ZoneMemberInterface.php
@@ -22,12 +22,12 @@ use Sylius\Component\Resource\Model\ResourceInterface;
 interface ZoneMemberInterface extends ResourceInterface, CodeAwareInterface
 {
     /**
-     * @return ZoneInterface
+     * @return ZoneInterface|null
      */
-    public function getBelongsTo();
+    public function getBelongsTo(): ?ZoneInterface;
 
     /**
-     * @param ZoneInterface $belongsTo
+     * @param ZoneInterface|null $belongsTo
      */
-    public function setBelongsTo(ZoneInterface $belongsTo = null);
+    public function setBelongsTo(?ZoneInterface $belongsTo = null): void;
 }

--- a/src/Sylius/Component/Addressing/Model/ZoneMemberInterface.php
+++ b/src/Sylius/Component/Addressing/Model/ZoneMemberInterface.php
@@ -29,5 +29,5 @@ interface ZoneMemberInterface extends ResourceInterface, CodeAwareInterface
     /**
      * @param ZoneInterface|null $belongsTo
      */
-    public function setBelongsTo(?ZoneInterface $belongsTo = null): void;
+    public function setBelongsTo(?ZoneInterface $belongsTo): void;
 }

--- a/src/Sylius/Component/Addressing/Provider/ProvinceNamingProvider.php
+++ b/src/Sylius/Component/Addressing/Provider/ProvinceNamingProvider.php
@@ -39,7 +39,7 @@ class ProvinceNamingProvider implements ProvinceNamingProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getName(AddressInterface $address)
+    public function getName(AddressInterface $address): string
     {
         if (null !== $address->getProvinceName()) {
             return $address->getProvinceName();
@@ -58,7 +58,7 @@ class ProvinceNamingProvider implements ProvinceNamingProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function getAbbreviation(AddressInterface $address)
+    public function getAbbreviation(AddressInterface $address): string
     {
         if (null !== $address->getProvinceName()) {
             return $address->getProvinceName();

--- a/src/Sylius/Component/Addressing/Provider/ProvinceNamingProviderInterface.php
+++ b/src/Sylius/Component/Addressing/Provider/ProvinceNamingProviderInterface.php
@@ -26,12 +26,12 @@ interface ProvinceNamingProviderInterface
      *
      * @return string
      */
-    public function getName(AddressInterface $address);
+    public function getName(AddressInterface $address): string;
 
     /**
      * @param AddressInterface $address
      *
      * @return string
      */
-    public function getAbbreviation(AddressInterface $address);
+    public function getAbbreviation(AddressInterface $address): string;
 }

--- a/src/Sylius/Component/Addressing/spec/Comparator/AddressComparatorSpec.php
+++ b/src/Sylius/Component/Addressing/spec/Comparator/AddressComparatorSpec.php
@@ -23,17 +23,17 @@ use Sylius\Component\Addressing\Model\AddressInterface;
  */
 final class AddressComparatorSpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    function it_is_initializable(): void
     {
         $this->shouldHaveType(AddressComparator::class);
     }
 
-    function it_implements_address_comparator_interface()
+    function it_implements_address_comparator_interface(): void
     {
         $this->shouldImplement(AddressComparatorInterface::class);
     }
 
-    function it_returns_false_if_addresses_differ(AddressInterface $firstAddress, AddressInterface $secondAddress)
+    function it_returns_false_if_addresses_differ(AddressInterface $firstAddress, AddressInterface $secondAddress): void
     {
         $firstAddress->getCity()->willReturn('Stoke-On-Trent');
         $firstAddress->getStreet()->willReturn('Villiers St');
@@ -60,7 +60,7 @@ final class AddressComparatorSpec extends ObjectBehavior
         $this->equal($firstAddress, $secondAddress)->shouldReturn(false);
     }
 
-    function it_returns_true_when_addresses_are_the_same(AddressInterface $address)
+    function it_returns_true_when_addresses_are_the_same(AddressInterface $address): void
     {
         $address->getCity()->willReturn('Toowoomba');
         $address->getStreet()->willReturn('Ryans Dr');
@@ -76,7 +76,7 @@ final class AddressComparatorSpec extends ObjectBehavior
         $this->equal($address, $address)->shouldReturn(true);
     }
 
-    function it_ignores_leading_and_trailing_spaces_or_letter_cases(AddressInterface $firstAddress, AddressInterface $secondAddress)
+    function it_ignores_leading_and_trailing_spaces_or_letter_cases(AddressInterface $firstAddress, AddressInterface $secondAddress): void
     {
         $firstAddress->getCity()->willReturn('TOOWOOMBA');
         $firstAddress->getStreet()->willReturn('Ryans Dr     ');

--- a/src/Sylius/Component/Addressing/spec/Converter/CountryNameConverterSpec.php
+++ b/src/Sylius/Component/Addressing/spec/Converter/CountryNameConverterSpec.php
@@ -22,31 +22,31 @@ use Sylius\Component\Addressing\Converter\CountryNameConverterInterface;
  */
 final class CountryNameConverterSpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    function it_is_initializable(): void
     {
         $this->shouldHaveType(CountryNameConverter::class);
     }
 
-    function it_implements_country_name_to_code_converter_interface()
+    function it_implements_country_name_to_code_converter_interface(): void
     {
         $this->shouldImplement(CountryNameConverterInterface::class);
     }
 
-    function it_converts_english_country_name_to_codes_by_default()
+    function it_converts_english_country_name_to_codes_by_default(): void
     {
         $this->convertToCode('Australia')->shouldReturn('AU');
         $this->convertToCode('China')->shouldReturn('CN');
         $this->convertToCode('France')->shouldReturn('FR');
     }
 
-    function it_converts_country_name_to_codes_for_given_locale()
+    function it_converts_country_name_to_codes_for_given_locale(): void
     {
         $this->convertToCode('Niemcy', 'pl')->shouldReturn('DE');
         $this->convertToCode('Chine', 'fr')->shouldReturn('CN');
         $this->convertToCode('Francia', 'es')->shouldReturn('FR');
     }
 
-    function it_throws_an_exception_if_country_name_cannot_be_converted_to_code()
+    function it_throws_an_exception_if_country_name_cannot_be_converted_to_code(): void
     {
         $this->shouldThrow(\InvalidArgumentException::class)->during('convertToCode', ['Atlantis']);
     }

--- a/src/Sylius/Component/Addressing/spec/Factory/ZoneFactorySpec.php
+++ b/src/Sylius/Component/Addressing/spec/Factory/ZoneFactorySpec.php
@@ -25,27 +25,27 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
  */
 final class ZoneFactorySpec extends ObjectBehavior
 {
-    function let(FactoryInterface $factory, FactoryInterface $zoneMemberFactory)
+    function let(FactoryInterface $factory, FactoryInterface $zoneMemberFactory): void
     {
         $this->beConstructedWith($factory, $zoneMemberFactory);
     }
 
-    function it_is_initializable()
+    function it_is_initializable(): void
     {
         $this->shouldHaveType(ZoneFactory::class);
     }
 
-    function it_implements_factory_interface()
+    function it_implements_factory_interface(): void
     {
         $this->shouldImplement(FactoryInterface::class);
     }
 
-    function it_implements_zone_factory_interface()
+    function it_implements_zone_factory_interface(): void
     {
         $this->shouldImplement(ZoneFactoryInterface::class);
     }
 
-    function it_creates_zone_with_type(FactoryInterface $factory, ZoneInterface $zone)
+    function it_creates_zone_with_type(FactoryInterface $factory, ZoneInterface $zone): void
     {
         $factory->createNew()->willReturn($zone);
         $zone->setType('country')->shouldBeCalled();
@@ -59,7 +59,7 @@ final class ZoneFactorySpec extends ObjectBehavior
         ZoneInterface $zone,
         ZoneMemberInterface $zoneMember1,
         ZoneMemberInterface $zoneMember2
-    ) {
+    ): void {
         $factory->createNew()->willReturn($zone);
         $zoneMemberFactory->createNew()->willReturn($zoneMember1, $zoneMember2);
 

--- a/src/Sylius/Component/Addressing/spec/Matcher/ZoneMatcherSpec.php
+++ b/src/Sylius/Component/Addressing/spec/Matcher/ZoneMatcherSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Component\Addressing\Matcher;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Addressing\Matcher\ZoneMatcher;
 use Sylius\Component\Addressing\Matcher\ZoneMatcherInterface;
@@ -30,22 +31,17 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
  */
 final class ZoneMatcherSpec extends ObjectBehavior
 {
-    function let(RepositoryInterface $repository)
+    function let(RepositoryInterface $repository): void
     {
         $this->beConstructedWith($repository);
     }
 
-    function it_is_initializable()
-    {
-        $this->shouldHaveType(ZoneMatcher::class);
-    }
-
-    function it_implements_zone_matcher_interface()
+    function it_implements_zone_matcher_interface(): void
     {
         $this->shouldImplement(ZoneMatcherInterface::class);
     }
 
-    function it_returns_null_if_there_are_no_zones(RepositoryInterface $repository, AddressInterface $address)
+    function it_returns_null_if_there_are_no_zones(RepositoryInterface $repository, AddressInterface $address): void
     {
         $repository->findAll()->willReturn([]);
         $this->match($address)->shouldReturn(null);
@@ -57,14 +53,14 @@ final class ZoneMatcherSpec extends ObjectBehavior
         AddressInterface $address,
         ZoneMemberInterface $memberProvince,
         ZoneInterface $zone
-    ) {
+    ): void {
         $province->getCode()->willReturn('DU');
         $repository->findAll()->willReturn([$zone]);
         $address->getProvinceCode()->willReturn('DU');
         $memberProvince->getCode()->willReturn('DU');
 
         $zone->getType()->willReturn(ZoneInterface::TYPE_PROVINCE);
-        $zone->getMembers()->willReturn([$memberProvince]);
+        $zone->getMembers()->willReturn(new ArrayCollection([$memberProvince->getWrappedObject()]));
         $memberProvince->getBelongsTo()->willReturn($zone);
 
         $this->match($address)->shouldReturn($zone);
@@ -76,13 +72,13 @@ final class ZoneMatcherSpec extends ObjectBehavior
         AddressInterface $address,
         ZoneMemberInterface $memberProvince,
         ZoneInterface $zone
-    ) {
+    ): void {
         $repository->findBy(['scope' => ['shipping', 'all']])->shouldBeCalled()->willReturn([$zone]);
         $province->getCode()->willReturn('TX');
         $address->getProvinceCode()->willReturn('TX');
         $memberProvince->getCode()->willReturn('TX');
         $zone->getType()->willReturn(ZoneInterface::TYPE_PROVINCE);
-        $zone->getMembers()->willReturn([$memberProvince]);
+        $zone->getMembers()->willReturn(new ArrayCollection([$memberProvince->getWrappedObject()]));
         $memberProvince->getBelongsTo()->willReturn($zone);
 
         $this->match($address, 'shipping')->shouldReturn($zone);
@@ -94,13 +90,13 @@ final class ZoneMatcherSpec extends ObjectBehavior
         AddressInterface $address,
         ZoneMemberInterface $memberCountry,
         ZoneInterface $zone
-    ) {
+    ): void {
         $repository->findAll()->willReturn([$zone]);
         $country->getCode()->willReturn('IE');
         $address->getCountryCode()->willReturn('IE');
         $memberCountry->getCode()->willReturn('IE');
         $zone->getType()->willReturn(ZoneInterface::TYPE_COUNTRY);
-        $zone->getMembers()->willReturn([$memberCountry]);
+        $zone->getMembers()->willReturn(new ArrayCollection([$memberCountry->getWrappedObject()]));
         $memberCountry->getBelongsTo()->willReturn($zone);
 
         $this->match($address)->shouldReturn($zone);
@@ -112,13 +108,13 @@ final class ZoneMatcherSpec extends ObjectBehavior
         AddressInterface $address,
         ZoneMemberInterface $memberCountry,
         ZoneInterface $zone
-    ) {
+    ): void {
         $repository->findBy(['scope' => ['shipping', 'all']])->willReturn([$zone]);
         $country->getCode()->willReturn('IE');
         $address->getCountryCode()->willReturn('IE');
         $memberCountry->getCode()->willReturn('IE');
         $zone->getType()->willReturn(ZoneInterface::TYPE_COUNTRY);
-        $zone->getMembers()->willReturn([$memberCountry]);
+        $zone->getMembers()->willReturn(new ArrayCollection([$memberCountry->getWrappedObject()]));
         $memberCountry->getBelongsTo()->willReturn($zone);
 
         $this->match($address, 'shipping')->shouldReturn($zone);
@@ -132,16 +128,16 @@ final class ZoneMatcherSpec extends ObjectBehavior
         ZoneMemberInterface $memberZone,
         ZoneInterface $subZone,
         ZoneInterface $rootZone
-    ) {
+    ): void {
         $country->getCode()->willReturn('IE');
 
         $address->getCountryCode()->willReturn('IE');
         $memberCountry->getCode()->willReturn('IE');
-        $subZone->getMembers()->willReturn([$memberCountry]);
+        $subZone->getMembers()->willReturn(new ArrayCollection([$memberCountry->getWrappedObject()]));
         $subZone->getType()->willReturn(ZoneInterface::TYPE_COUNTRY);
         $subZone->getCode()->willReturn('Ireland');
         $memberZone->getCode()->willReturn('Ireland');
-        $rootZone->getMembers()->willReturn([$memberZone]);
+        $rootZone->getMembers()->willReturn(new ArrayCollection([$memberZone->getWrappedObject()]));
         $rootZone->getType()->willReturn(ZoneInterface::TYPE_ZONE);
 
         $memberCountry->getBelongsTo()->willReturn($subZone);
@@ -160,17 +156,17 @@ final class ZoneMatcherSpec extends ObjectBehavior
         ZoneMemberInterface $memberZone,
         ZoneInterface $subZone,
         ZoneInterface $rootZone
-    ) {
+    ): void {
         $country->getCode()->willReturn('IE');
         $address->getCountryCode()->willReturn('IE');
 
         $memberCountry->getCode()->willReturn('IE');
-        $subZone->getMembers()->willReturn([$memberCountry]);
+        $subZone->getMembers()->willReturn(new ArrayCollection([$memberCountry->getWrappedObject()]));
         $subZone->getType()->willReturn(ZoneInterface::TYPE_COUNTRY);
         $subZone->getCode()->willReturn('Ireland');
         $memberZone->getCode()->willReturn('Ireland');
 
-        $rootZone->getMembers()->willReturn([$memberZone]);
+        $rootZone->getMembers()->willReturn(new ArrayCollection([$memberZone->getWrappedObject()]));
         $rootZone->getType()->willReturn(ZoneInterface::TYPE_ZONE);
 
         $memberCountry->getBelongsTo()->willReturn($subZone);
@@ -190,7 +186,7 @@ final class ZoneMatcherSpec extends ObjectBehavior
         ZoneMemberInterface $memberProvince,
         ZoneInterface $zoneCountry,
         ZoneInterface $zoneProvince
-    ) {
+    ): void {
         $province->getCode()->willReturn('DU');
         $country->getCode()->willReturn('IE');
 
@@ -200,9 +196,9 @@ final class ZoneMatcherSpec extends ObjectBehavior
         $memberCountry->getCode()->willReturn('IE');
         $memberProvince->getCode()->willReturn('DU');
 
-        $zoneProvince->getMembers()->willReturn([$memberProvince]);
+        $zoneProvince->getMembers()->willReturn(new ArrayCollection([$memberProvince->getWrappedObject()]));
         $zoneProvince->getType()->willReturn(ZoneInterface::TYPE_PROVINCE);
-        $zoneCountry->getMembers()->willReturn([$memberCountry]);
+        $zoneCountry->getMembers()->willReturn(new ArrayCollection([$memberCountry->getWrappedObject()]));
         $zoneCountry->getType()->willReturn(ZoneInterface::TYPE_COUNTRY);
 
         $repository->findAll()->willReturn([$zoneCountry, $zoneProvince]);
@@ -219,17 +215,17 @@ final class ZoneMatcherSpec extends ObjectBehavior
         ZoneMemberInterface $memberProvince,
         ZoneInterface $zoneCountry,
         ZoneInterface $zoneProvince
-    ) {
+    ): void {
         $address->getCountryCode()->willReturn('IE');
         $memberCountry->getCode()->willReturn('IE');
 
         $address->getProvinceCode()->willReturn('DU');
         $memberProvince->getCode()->willReturn('DU');
 
-        $zoneCountry->getMembers()->willReturn([$memberCountry]);
+        $zoneCountry->getMembers()->willReturn(new ArrayCollection([$memberCountry->getWrappedObject()]));
         $zoneCountry->getType()->willReturn(ZoneInterface::TYPE_COUNTRY);
 
-        $zoneProvince->getMembers()->willReturn([$memberProvince]);
+        $zoneProvince->getMembers()->willReturn(new ArrayCollection([$memberProvince->getWrappedObject()]));
         $zoneProvince->getType()->willReturn(ZoneInterface::TYPE_PROVINCE);
 
         $repository->findBy(['scope' => ['shipping', 'all']])->willReturn([$zoneCountry, $zoneProvince]);
@@ -248,7 +244,7 @@ final class ZoneMatcherSpec extends ObjectBehavior
         ZoneInterface $zoneProvince,
         ZoneInterface $zoneCountry,
         ZoneInterface $zoneZone
-    ) {
+    ): void {
         $repository->findAll()->willReturn([$zoneProvince, $zoneCountry, $zoneZone]);
 
         $address->getProvinceCode()->willReturn('TX');
@@ -256,19 +252,19 @@ final class ZoneMatcherSpec extends ObjectBehavior
 
         $memberProvince->getBelongsTo()->willReturn($zoneProvince);
         $zoneProvince->getType()->willReturn(ZoneInterface::TYPE_PROVINCE);
-        $zoneProvince->getMembers()->willReturn([$memberProvince]);
+        $zoneProvince->getMembers()->willReturn(new ArrayCollection([$memberProvince->getWrappedObject()]));
 
         $address->getCountryCode()->willReturn('US');
         $memberCountry->getCode()->willReturn('US');
 
         $zoneCountry->getType()->willReturn(ZoneInterface::TYPE_COUNTRY);
-        $zoneCountry->getMembers()->willReturn([$memberCountry]);
+        $zoneCountry->getMembers()->willReturn(new ArrayCollection([$memberCountry->getWrappedObject()]));
         $zoneCountry->getCode()->willReturn('USA');
         $memberCountry->getBelongsTo()->willReturn($zoneCountry);
 
         $memberZone->getCode()->willReturn('USA');
         $zoneZone->getType()->willReturn(ZoneInterface::TYPE_ZONE);
-        $zoneZone->getMembers()->willReturn([$memberZone]);
+        $zoneZone->getMembers()->willReturn(new ArrayCollection([$memberZone->getWrappedObject()]));
         $memberZone->getBelongsTo()->willReturn($zoneZone);
 
         $repository->findOneBy(['code' => 'USA'])->willReturn($zoneCountry);
@@ -281,14 +277,14 @@ final class ZoneMatcherSpec extends ObjectBehavior
         AddressInterface $address,
         ZoneMemberInterface $memberCountry,
         ZoneInterface $zoneCountry
-    ) {
+    ): void {
         $repository->findBy(['scope' => ['shipping', 'all']])->willReturn([$zoneCountry]);
 
         $address->getCountryCode()->willReturn('US');
 
         $memberCountry->getCode()->willReturn('US');
         $zoneCountry->getType()->willReturn(ZoneInterface::TYPE_COUNTRY);
-        $zoneCountry->getMembers()->willReturn([$memberCountry]);
+        $zoneCountry->getMembers()->willReturn(new ArrayCollection([$memberCountry->getWrappedObject()]));
         $memberCountry->getBelongsTo()->willReturn($zoneCountry);
 
         $this->matchAll($address, 'shipping')->shouldReturn([$zoneCountry]);

--- a/src/Sylius/Component/Addressing/spec/Model/AddressSpec.php
+++ b/src/Sylius/Component/Addressing/spec/Model/AddressSpec.php
@@ -22,44 +22,44 @@ use Sylius\Component\Addressing\Model\AddressInterface;
  */
 final class AddressSpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    function it_is_initializable(): void
     {
         $this->shouldHaveType(Address::class);
     }
 
-    function it_implements_Sylius_address_interface()
+    function it_implements_Sylius_address_interface(): void
     {
         $this->shouldImplement(AddressInterface::class);
     }
 
-    function it_has_no_id_by_default()
+    function it_has_no_id_by_default(): void
     {
         $this->getId()->shouldReturn(null);
     }
 
-    function it_has_no_first_name_by_default()
+    function it_has_no_first_name_by_default(): void
     {
         $this->getFirstName()->shouldReturn(null);
     }
 
-    function its_first_name_is_mutable()
+    function its_first_name_is_mutable(): void
     {
         $this->setFirstName('John');
         $this->getFirstName()->shouldReturn('John');
     }
 
-    function it_has_no_last_name_by_default()
+    function it_has_no_last_name_by_default(): void
     {
         $this->getLastName()->shouldReturn(null);
     }
 
-    function its_last_name_is_mutable()
+    function its_last_name_is_mutable(): void
     {
         $this->setLastName('Doe');
         $this->getLastName()->shouldReturn('Doe');
     }
 
-    function it_returns_correct_full_name()
+    function it_returns_correct_full_name(): void
     {
         $this->setFirstName('John');
         $this->setLastName('Doe');
@@ -67,29 +67,29 @@ final class AddressSpec extends ObjectBehavior
         $this->getFullName()->shouldReturn('John Doe');
     }
 
-    function it_has_no_phone_number_by_default()
+    function it_has_no_phone_number_by_default(): void
     {
         $this->getPhoneNumber()->shouldReturn(null);
     }
 
-    function its_phone_number_is_mutable()
+    function its_phone_number_is_mutable(): void
     {
         $this->setPhoneNumber('+48555123456');
         $this->getPhoneNumber()->shouldReturn('+48555123456');
     }
 
-    function it_has_no_country_by_default()
+    function it_has_no_country_by_default(): void
     {
         $this->getCountryCode()->shouldReturn(null);
     }
 
-    function its_country_code_is_mutable()
+    function its_country_code_is_mutable(): void
     {
         $this->setCountryCode('IE');
         $this->getCountryCode()->shouldReturn('IE');
     }
 
-    function it_allows_to_unset_the_country_code()
+    function it_allows_to_unset_the_country_code(): void
     {
         $this->setCountryCode('IE');
         $this->getCountryCode()->shouldReturn('IE');
@@ -98,7 +98,7 @@ final class AddressSpec extends ObjectBehavior
         $this->getCountryCode()->shouldReturn(null);
     }
 
-    function it_unsets_the_province_code_when_erasing_country_code()
+    function it_unsets_the_province_code_when_erasing_country_code(): void
     {
         $this->setCountryCode('IE');
         $this->setProvinceCode('DU');
@@ -109,19 +109,19 @@ final class AddressSpec extends ObjectBehavior
         $this->getProvinceCode()->shouldReturn(null);
     }
 
-    function it_has_no_province_code_by_default()
+    function it_has_no_province_code_by_default(): void
     {
         $this->getProvinceCode()->shouldReturn(null);
     }
 
-    function it_ignores_province_code_when_there_is_no_country_code()
+    function it_ignores_province_code_when_there_is_no_country_code(): void
     {
         $this->setCountryCode(null);
         $this->setProvinceCode('DU');
         $this->getProvinceCode()->shouldReturn(null);
     }
 
-    function its_province_code_is_mutable()
+    function its_province_code_is_mutable(): void
     {
         $this->setCountryCode('IE');
 
@@ -129,67 +129,67 @@ final class AddressSpec extends ObjectBehavior
         $this->getProvinceCode()->shouldReturn('DU');
     }
 
-    function it_has_no_province_name_by_default()
+    function it_has_no_province_name_by_default(): void
     {
         $this->getProvinceName()->shouldReturn(null);
     }
 
-    function its_province_name_is_mutable()
+    function its_province_name_is_mutable(): void
     {
         $this->setProvinceName('Utah');
         $this->getProvinceName()->shouldReturn('Utah');
     }
 
-    function it_has_no_company_by_default()
+    function it_has_no_company_by_default(): void
     {
         $this->getCompany()->shouldReturn(null);
     }
 
-    function its_company_is_mutable()
+    function its_company_is_mutable(): void
     {
         $this->setCompany('Foo Ltd.');
         $this->getCompany()->shouldReturn('Foo Ltd.');
     }
 
-    function it_has_no_street_by_default()
+    function it_has_no_street_by_default(): void
     {
         $this->getStreet()->shouldReturn(null);
     }
 
-    function its_street_is_mutable()
+    function its_street_is_mutable(): void
     {
         $this->setStreet('Foo Street 3/44');
         $this->getStreet()->shouldReturn('Foo Street 3/44');
     }
 
-    function it_has_no_city_by_default()
+    function it_has_no_city_by_default(): void
     {
         $this->getCity()->shouldReturn(null);
     }
 
-    function its_city_is_mutable()
+    function its_city_is_mutable(): void
     {
         $this->setCity('New York');
         $this->getCity()->shouldReturn('New York');
     }
 
-    function it_has_no_postcode_by_default()
+    function it_has_no_postcode_by_default(): void
     {
         $this->getPostcode()->shouldReturn(null);
     }
 
-    function its_postcode_is_mutable()
+    function its_postcode_is_mutable(): void
     {
         $this->setPostcode('24154');
         $this->getPostcode()->shouldReturn('24154');
     }
 
-    function its_creation_time_is_initialized_by_default()
+    function its_creation_time_is_initialized_by_default(): void
     {
         $this->getCreatedAt()->shouldHaveType(\DateTime::class);
     }
 
-    function its_last_update_time_is_undefined_by_default()
+    function its_last_update_time_is_undefined_by_default(): void
     {
         $this->getUpdatedAt()->shouldReturn(null);
     }

--- a/src/Sylius/Component/Addressing/spec/Model/CountrySpec.php
+++ b/src/Sylius/Component/Addressing/spec/Model/CountrySpec.php
@@ -28,65 +28,65 @@ use Sylius\Component\Resource\Model\ToggleableInterface;
  */
 final class CountrySpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    function it_is_initializable(): void
     {
         $this->shouldHaveType(Country::class);
     }
 
-    function it_implements_Sylius_country_interface()
+    function it_implements_Sylius_country_interface(): void
     {
         $this->shouldImplement(CountryInterface::class);
     }
 
-    function it_is_toggleable()
+    function it_is_toggleable(): void
     {
         $this->shouldImplement(ToggleableInterface::class);
     }
 
-    function it_implements_code_aware_interface()
+    function it_implements_code_aware_interface(): void
     {
         $this->shouldImplement(CodeAwareInterface::class);
     }
 
-    function it_has_no_id_by_default()
+    function it_has_no_id_by_default(): void
     {
         $this->getId()->shouldReturn(null);
     }
 
-    function it_returns_name_when_converted_to_string()
+    function it_returns_name_when_converted_to_string(): void
     {
         $this->setCode('VE');
         $this->__toString()->shouldReturn('Venezuela');
     }
 
-    function it_has_no_code_by_default()
+    function it_has_no_code_by_default(): void
     {
         $this->getCode()->shouldReturn(null);
     }
 
-    function its_code_is_mutable()
+    function its_code_is_mutable(): void
     {
         $this->setCode('MX');
         $this->getCode()->shouldReturn('MX');
     }
 
-    function it_initializes_provinces_collection_by_default()
+    function it_initializes_provinces_collection_by_default(): void
     {
         $this->getProvinces()->shouldHaveType(Collection::class);
     }
 
-    function it_has_no_provinces_by_default()
+    function it_has_no_provinces_by_default(): void
     {
         $this->hasProvinces()->shouldReturn(false);
     }
 
-    function it_adds_province(ProvinceInterface $province)
+    function it_adds_province(ProvinceInterface $province): void
     {
         $this->addProvince($province);
         $this->hasProvince($province)->shouldReturn(true);
     }
 
-    function it_removes_province(ProvinceInterface $province)
+    function it_removes_province(ProvinceInterface $province): void
     {
         $this->addProvince($province);
         $this->hasProvince($province)->shouldReturn(true);
@@ -95,13 +95,13 @@ final class CountrySpec extends ObjectBehavior
         $this->hasProvince($province)->shouldReturn(false);
     }
 
-    function it_sets_country_on_added_province(ProvinceInterface $province)
+    function it_sets_country_on_added_province(ProvinceInterface $province): void
     {
         $province->setCountry($this)->shouldBeCalled();
         $this->addProvince($province);
     }
 
-    function it_unsets_country_on_removed_province(ProvinceInterface $province)
+    function it_unsets_country_on_removed_province(ProvinceInterface $province): void
     {
         $this->addProvince($province);
         $this->hasProvince($province)->shouldReturn(true);
@@ -111,18 +111,18 @@ final class CountrySpec extends ObjectBehavior
         $this->removeProvince($province);
     }
 
-    function it_is_enabled_by_default()
+    function it_is_enabled_by_default(): void
     {
         $this->isEnabled()->shouldReturn(true);
     }
 
-    function it_can_be_disabled()
+    function it_can_be_disabled(): void
     {
         $this->disable();
         $this->isEnabled()->shouldReturn(false);
     }
 
-    function it_can_be_enabled()
+    function it_can_be_enabled(): void
     {
         $this->disable();
         $this->isEnabled()->shouldReturn(false);
@@ -131,7 +131,7 @@ final class CountrySpec extends ObjectBehavior
         $this->isEnabled()->shouldReturn(true);
     }
 
-    function it_can_set_enabled_value()
+    function it_can_set_enabled_value(): void
     {
         $this->setEnabled(false);
         $this->isEnabled()->shouldReturn(false);

--- a/src/Sylius/Component/Addressing/spec/Model/ProvinceSpec.php
+++ b/src/Sylius/Component/Addressing/spec/Model/ProvinceSpec.php
@@ -24,65 +24,65 @@ use Sylius\Component\Resource\Model\CodeAwareInterface;
  */
 final class ProvinceSpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    function it_is_initializable(): void
     {
         $this->shouldHaveType(Province::class);
     }
 
-    function it_implements_Sylius_country_province_interface()
+    function it_implements_Sylius_country_province_interface(): void
     {
         $this->shouldImplement(ProvinceInterface::class);
     }
 
-    function it_implements_code_aware_interface()
+    function it_implements_code_aware_interface(): void
     {
         $this->shouldImplement(CodeAwareInterface::class);
     }
 
-    function it_has_no_id_by_default()
+    function it_has_no_id_by_default(): void
     {
         $this->getId()->shouldReturn(null);
     }
 
-    function it_has_no_code_by_default()
+    function it_has_no_code_by_default(): void
     {
         $this->getCode()->shouldReturn(null);
     }
 
-    function its_code_is_mutable()
+    function its_code_is_mutable(): void
     {
         $this->setCode('US-TX');
         $this->getCode()->shouldReturn('US-TX');
     }
 
-    function it_has_no_name_by_default()
+    function it_has_no_name_by_default(): void
     {
         $this->getName()->shouldReturn(null);
     }
 
-    function its_name_is_mutable()
+    function its_name_is_mutable(): void
     {
         $this->setName('Texas');
         $this->getName()->shouldReturn('Texas');
     }
 
-    function it_has_no_abbreviation_by_default()
+    function it_has_no_abbreviation_by_default(): void
     {
         $this->getAbbreviation()->shouldReturn(null);
     }
 
-    function its_abbreviation_is_mutable()
+    function its_abbreviation_is_mutable(): void
     {
         $this->setAbbreviation('TEX');
         $this->getAbbreviation()->shouldReturn('TEX');
     }
 
-    function it_does_not_belong_to_country_by_default()
+    function it_does_not_belong_to_country_by_default(): void
     {
         $this->getCountry()->shouldReturn(null);
     }
 
-    function it_allows_to_attach_itself_to_a_country(CountryInterface $country)
+    function it_allows_to_attach_itself_to_a_country(CountryInterface $country): void
     {
         $this->setCountry($country);
         $this->getCountry()->shouldReturn($country);

--- a/src/Sylius/Component/Addressing/spec/Model/ZoneMemberSpec.php
+++ b/src/Sylius/Component/Addressing/spec/Model/ZoneMemberSpec.php
@@ -24,38 +24,38 @@ use Sylius\Component\Addressing\Model\ZoneMemberInterface;
  */
 final class ZoneMemberSpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    function it_is_initializable(): void
     {
         $this->shouldHaveType(ZoneMember::class);
     }
 
-    function it_implements_zone_member_interface()
+    function it_implements_zone_member_interface(): void
     {
         $this->shouldImplement(ZoneMemberInterface::class);
     }
 
-    function it_has_no_id_by_default()
+    function it_has_no_id_by_default(): void
     {
         $this->getId()->shouldReturn(null);
     }
 
-    function it_has_no_code_by_default()
+    function it_has_no_code_by_default(): void
     {
         $this->getCode()->shouldReturn(null);
     }
 
-    function its_code_is_mutable()
+    function its_code_is_mutable(): void
     {
         $this->setCode('IE');
         $this->getCode()->shouldReturn('IE');
     }
 
-    function it_doesnt_belong_to_any_zone_by_default()
+    function it_doesnt_belong_to_any_zone_by_default(): void
     {
         $this->getBelongsTo()->shouldReturn(null);
     }
 
-    function it_can_belong_to_a_zone(ZoneInterface $zone)
+    function it_can_belong_to_a_zone(ZoneInterface $zone): void
     {
         $this->setBelongsTo($zone);
         $this->getBelongsTo()->shouldReturn($zone);

--- a/src/Sylius/Component/Addressing/spec/Model/ZoneSpec.php
+++ b/src/Sylius/Component/Addressing/spec/Model/ZoneSpec.php
@@ -26,61 +26,61 @@ use Sylius\Component\Addressing\Model\ZoneMemberInterface;
  */
 final class ZoneSpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    function it_is_initializable(): void
     {
         $this->shouldHaveType(Zone::class);
     }
 
-    function it_implements_Sylius_zone_interface()
+    function it_implements_Sylius_zone_interface(): void
     {
         $this->shouldImplement(ZoneInterface::class);
     }
 
-    function it_has_no_id_by_default()
+    function it_has_no_id_by_default(): void
     {
         $this->getId()->shouldReturn(null);
     }
 
-    function it_has_no_name_by_default()
+    function it_has_no_name_by_default(): void
     {
         $this->getName()->shouldReturn(null);
     }
 
-    function its_name_is_mutable()
+    function its_name_is_mutable(): void
     {
         $this->setName('Yugoslavia');
         $this->getName()->shouldReturn('Yugoslavia');
     }
 
-    function it_has_no_type_by_default()
+    function it_has_no_type_by_default(): void
     {
         $this->getType()->shouldReturn(null);
     }
 
-    function its_type_is_mutable()
+    function its_type_is_mutable(): void
     {
         $this->setType('country');
         $this->getType()->shouldReturn('country');
     }
 
-    function it_initializes_members_collection_by_default()
+    function it_initializes_members_collection_by_default(): void
     {
         $this->getMembers()->shouldHaveType(Collection::class);
     }
 
-    function it_has_no_members_by_default()
+    function it_has_no_members_by_default(): void
     {
         $this->hasMembers()->shouldReturn(false);
     }
 
-    function it_adds_member(ZoneMemberInterface $member)
+    function it_adds_member(ZoneMemberInterface $member): void
     {
         $this->addMember($member);
         $this->hasMembers()->shouldReturn(true);
         $this->hasMember($member)->shouldReturn(true);
     }
 
-    function it_removes_member(ZoneMemberInterface $member)
+    function it_removes_member(ZoneMemberInterface $member): void
     {
         $this->addMember($member);
         $this->hasMember($member)->shouldReturn(true);
@@ -89,12 +89,12 @@ final class ZoneSpec extends ObjectBehavior
         $this->hasMember($member)->shouldReturn(false);
     }
 
-    function it_has_scope_all_by_default()
+    function it_has_scope_all_by_default(): void
     {
         $this->getScope()->shouldReturn(Scope::ALL);
     }
 
-    function its_scope_is_mutable()
+    function its_scope_is_mutable(): void
     {
         $this->setScope('shipping');
         $this->getScope()->shouldReturn('shipping');

--- a/src/Sylius/Component/Addressing/spec/Provider/ProvinceNamingProviderSpec.php
+++ b/src/Sylius/Component/Addressing/spec/Provider/ProvinceNamingProviderSpec.php
@@ -26,17 +26,17 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
  */
 final class ProvinceNamingProviderSpec extends ObjectBehavior
 {
-    function let(RepositoryInterface $provinceRepository)
+    function let(RepositoryInterface $provinceRepository): void
     {
         $this->beConstructedWith($provinceRepository);
     }
 
-    function it_is_initializable()
+    function it_is_initializable(): void
     {
         $this->shouldHaveType(ProvinceNamingProvider::class);
     }
 
-    function it_implements_province_name_provider_interface()
+    function it_implements_province_name_provider_interface(): void
     {
         $this->shouldHaveType(ProvinceNamingProviderInterface::class);
     }
@@ -44,7 +44,7 @@ final class ProvinceNamingProviderSpec extends ObjectBehavior
     function it_throws_invalid_argument_exception_when_province_with_given_code_is_not_found(
         RepositoryInterface $provinceRepository,
         AddressInterface $address
-    ) {
+    ): void {
         $address->getProvinceName()->willReturn(null);
         $address->getProvinceCode()->willReturn('ZZ-TOP');
         $provinceRepository->findOneBy(['code' => 'ZZ-TOP'])->willReturn(null);
@@ -57,7 +57,7 @@ final class ProvinceNamingProviderSpec extends ObjectBehavior
         RepositoryInterface $provinceRepository,
         ProvinceInterface $province,
         AddressInterface $address
-    ) {
+    ): void {
         $address->getProvinceCode()->willReturn('IE-UL');
         $address->getProvinceName()->willReturn(null);
         $provinceRepository->findOneBy(['code' => 'IE-UL'])->willReturn($province);
@@ -66,14 +66,14 @@ final class ProvinceNamingProviderSpec extends ObjectBehavior
         $this->getName($address)->shouldReturn('Ulster');
     }
 
-    function it_gets_province_name_form_address(AddressInterface $address)
+    function it_gets_province_name_form_address(AddressInterface $address): void
     {
         $address->getProvinceName()->willReturn('Ulster');
 
         $this->getName($address)->shouldReturn('Ulster');
     }
 
-    function it_returns_nothing_if_province_name_and_code_are_not_given_in_an_address(AddressInterface $address)
+    function it_returns_nothing_if_province_name_and_code_are_not_given_in_an_address(AddressInterface $address): void
     {
         $address->getProvinceCode()->willReturn(null);
         $address->getProvinceName()->willReturn(null);
@@ -87,7 +87,7 @@ final class ProvinceNamingProviderSpec extends ObjectBehavior
         RepositoryInterface $provinceRepository,
         ProvinceInterface $province,
         AddressInterface $address
-    ) {
+    ): void {
         $address->getProvinceName()->willReturn(null);
         $address->getProvinceCode()->willReturn('IE-UL');
         $provinceRepository->findOneBy(['code' => 'IE-UL'])->willReturn($province);
@@ -100,7 +100,7 @@ final class ProvinceNamingProviderSpec extends ObjectBehavior
         RepositoryInterface $provinceRepository,
         ProvinceInterface $province,
         AddressInterface $address
-    ) {
+    ): void {
         $address->getProvinceName()->willReturn(null);
         $address->getProvinceCode()->willReturn('IE-UL');
         $provinceRepository->findOneBy(['code' => 'IE-UL'])->willReturn($province);
@@ -110,7 +110,7 @@ final class ProvinceNamingProviderSpec extends ObjectBehavior
         $this->getAbbreviation($address)->shouldReturn('Ulster');
     }
 
-    function it_gets_province_name_form_address_if_its_abbreviation_is_not_set(AddressInterface $address)
+    function it_gets_province_name_form_address_if_its_abbreviation_is_not_set(AddressInterface $address): void
     {
         $address->getProvinceName()->willReturn('Ulster');
 

--- a/src/Sylius/Component/Attribute/Model/Attribute.php
+++ b/src/Sylius/Component/Attribute/Model/Attribute.php
@@ -87,7 +87,7 @@ class Attribute implements AttributeInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -95,7 +95,7 @@ class Attribute implements AttributeInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Channel/Model/Channel.php
+++ b/src/Sylius/Component/Channel/Model/Channel.php
@@ -77,7 +77,7 @@ class Channel implements ChannelInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -85,7 +85,7 @@ class Channel implements ChannelInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Currency/Model/Currency.php
+++ b/src/Sylius/Component/Currency/Model/Currency.php
@@ -65,7 +65,7 @@ class Currency implements CurrencyInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -73,7 +73,7 @@ class Currency implements CurrencyInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Customer/Model/CustomerGroup.php
+++ b/src/Sylius/Component/Customer/Model/CustomerGroup.php
@@ -53,7 +53,7 @@ class CustomerGroup implements CustomerGroupInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -61,7 +61,7 @@ class CustomerGroup implements CustomerGroupInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Locale/Model/Locale.php
+++ b/src/Sylius/Component/Locale/Model/Locale.php
@@ -57,7 +57,7 @@ class Locale implements LocaleInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -65,7 +65,7 @@ class Locale implements LocaleInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Payment/Model/PaymentMethod.php
+++ b/src/Sylius/Component/Payment/Model/PaymentMethod.php
@@ -73,7 +73,7 @@ class PaymentMethod implements PaymentMethodInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -81,7 +81,7 @@ class PaymentMethod implements PaymentMethodInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Product/Model/Product.php
+++ b/src/Sylius/Component/Product/Model/Product.php
@@ -92,7 +92,7 @@ class Product implements ProductInterface
     /**
      * @return string
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -100,7 +100,7 @@ class Product implements ProductInterface
     /**
      * @param string $code
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Product/Model/ProductAssociationType.php
+++ b/src/Sylius/Component/Product/Model/ProductAssociationType.php
@@ -69,7 +69,7 @@ class ProductAssociationType implements ProductAssociationTypeInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -77,7 +77,7 @@ class ProductAssociationType implements ProductAssociationTypeInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Product/Model/ProductOption.php
+++ b/src/Sylius/Component/Product/Model/ProductOption.php
@@ -76,7 +76,7 @@ class ProductOption implements ProductOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -84,7 +84,7 @@ class ProductOption implements ProductOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Product/Model/ProductOptionValue.php
+++ b/src/Sylius/Component/Product/Model/ProductOptionValue.php
@@ -64,7 +64,7 @@ class ProductOptionValue implements ProductOptionValueInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -72,7 +72,7 @@ class ProductOptionValue implements ProductOptionValueInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Product/Model/ProductVariant.php
+++ b/src/Sylius/Component/Product/Model/ProductVariant.php
@@ -72,7 +72,7 @@ class ProductVariant implements ProductVariantInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -80,7 +80,7 @@ class ProductVariant implements ProductVariantInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Promotion/Model/Promotion.php
+++ b/src/Sylius/Component/Promotion/Model/Promotion.php
@@ -118,7 +118,7 @@ class Promotion implements PromotionInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -126,7 +126,7 @@ class Promotion implements PromotionInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Promotion/Model/PromotionCoupon.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionCoupon.php
@@ -63,7 +63,7 @@ class PromotionCoupon implements PromotionCouponInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -71,7 +71,7 @@ class PromotionCoupon implements PromotionCouponInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Resource/Model/CodeAwareInterface.php
+++ b/src/Sylius/Component/Resource/Model/CodeAwareInterface.php
@@ -19,12 +19,12 @@ namespace Sylius\Component\Resource\Model;
 interface CodeAwareInterface
 {
     /**
-     * @return string
+     * @return string|null
      */
-    public function getCode();
+    public function getCode(): ?string;
 
     /**
-     * @param string $code
+     * @param string|null $code
      */
-    public function setCode($code);
+    public function setCode(?string $code): void;
 }

--- a/src/Sylius/Component/Shipping/Model/ShippingCategory.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingCategory.php
@@ -66,7 +66,7 @@ class ShippingCategory implements ShippingCategoryInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -74,7 +74,7 @@ class ShippingCategory implements ShippingCategoryInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Shipping/Model/ShippingMethod.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethod.php
@@ -90,7 +90,7 @@ class ShippingMethod implements ShippingMethodInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -98,7 +98,7 @@ class ShippingMethod implements ShippingMethodInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Taxation/Model/TaxCategory.php
+++ b/src/Sylius/Component/Taxation/Model/TaxCategory.php
@@ -73,7 +73,7 @@ class TaxCategory implements TaxCategoryInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -81,7 +81,7 @@ class TaxCategory implements TaxCategoryInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Taxation/Model/TaxRate.php
+++ b/src/Sylius/Component/Taxation/Model/TaxRate.php
@@ -73,7 +73,7 @@ class TaxRate implements TaxRateInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -81,7 +81,7 @@ class TaxRate implements TaxRateInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }

--- a/src/Sylius/Component/Taxonomy/Model/Taxon.php
+++ b/src/Sylius/Component/Taxonomy/Model/Taxon.php
@@ -98,7 +98,7 @@ class Taxon implements TaxonInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -106,7 +106,7 @@ class Taxon implements TaxonInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode(?string $code): void
     {
         $this->code = $code;
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets | related to #8114 |
| License         | MIT |

*Introducing visual debt to Sylius...*

### Pros
 - ensuring correctness of existing docblock (ex. `ZoneMatcherInterface::matchAll` had `Collection` return docblock while it was returning an array and service using it in CoreBundle was expecting an array too)
 - removing possibility of weird method calls like `$province->setCountry();` and replacing them with explicit `$province->setCountry(null);`
 - easier maintenance
 - preventing weird type-related bugs, like using a boolean as a string etc.

### Cons
 - BC breaks - related to method signatures, customised code which implements an interface / extends a class from Sylius will need an update (which should be just copy-paste)