### PR TITLE
Force Travis to use Ubuntu Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: precise
+
 env:
     global:
         - SYLIUS_CACHE_DIR=$HOME/.sylius-cache


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

Trusty was automatically enabled for our builds causing fails, until #8327 or #8293 is merged we should stay on Precise.