### PR TITLE
[ResourceBundle] Return event response if exists before deleting resource

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -405,6 +405,10 @@ class ResourceController extends Controller
         if ($event->isStopped()) {
             $this->flashHelper->addFlashFromEvent($configuration, $event);
 
+            if ($event->hasResponse()) {
+                return $event->getResponse();
+            }
+
             return $this->redirectHandler->redirectToIndex($configuration, $resource);
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

Return event response so it's possible to return a different template with a list of relations (as example) before deleting the resource.