### PR TITLE
[Maintenance] Make all constants public

### DIFF
--- a/src/Sylius/Behat/Page/Admin/Order/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/UpdatePage.php
@@ -23,8 +23,8 @@ use Sylius\Component\Addressing\Model\AddressInterface;
  */
 class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
-    const TYPE_BILLING = 'billing';
-    const TYPE_SHIPPING = 'shipping';
+    public const TYPE_BILLING = 'billing';
+    public const TYPE_SHIPPING = 'shipping';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
@@ -28,8 +28,8 @@ use Webmozart\Assert\Assert;
  */
 class AddressPage extends SymfonyPage implements AddressPageInterface
 {
-    const TYPE_BILLING = 'billing';
-    const TYPE_SHIPPING = 'shipping';
+    public const TYPE_BILLING = 'billing';
+    public const TYPE_SHIPPING = 'shipping';
 
     /**
      * @var AddressFactoryInterface

--- a/src/Sylius/Bundle/AdminBundle/Menu/CustomerShowMenuBuilder.php
+++ b/src/Sylius/Bundle/AdminBundle/Menu/CustomerShowMenuBuilder.php
@@ -25,7 +25,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 final class CustomerShowMenuBuilder
 {
-    const EVENT_NAME = 'sylius.menu.admin.customer.show';
+    public const EVENT_NAME = 'sylius.menu.admin.customer.show';
 
     /**
      * @var FactoryInterface

--- a/src/Sylius/Bundle/AdminBundle/Menu/MainMenuBuilder.php
+++ b/src/Sylius/Bundle/AdminBundle/Menu/MainMenuBuilder.php
@@ -23,7 +23,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 final class MainMenuBuilder
 {
-    const EVENT_NAME = 'sylius.menu.admin.main';
+    public const EVENT_NAME = 'sylius.menu.admin.main';
 
     /**
      * @var FactoryInterface

--- a/src/Sylius/Bundle/AdminBundle/Menu/OrderShowMenuBuilder.php
+++ b/src/Sylius/Bundle/AdminBundle/Menu/OrderShowMenuBuilder.php
@@ -25,7 +25,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 final class OrderShowMenuBuilder
 {
-    const EVENT_NAME = 'sylius.menu.admin.order.show';
+    public const EVENT_NAME = 'sylius.menu.admin.order.show';
 
     /**
      * @var FactoryInterface

--- a/src/Sylius/Bundle/AdminBundle/Menu/ProductFormMenuBuilder.php
+++ b/src/Sylius/Bundle/AdminBundle/Menu/ProductFormMenuBuilder.php
@@ -24,7 +24,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 final class ProductFormMenuBuilder
 {
-    const EVENT_NAME = 'sylius.menu.admin.product.form';
+    public const EVENT_NAME = 'sylius.menu.admin.product.form';
 
     /**
      * @var FactoryInterface

--- a/src/Sylius/Bundle/AdminBundle/Menu/ProductVariantFormMenuBuilder.php
+++ b/src/Sylius/Bundle/AdminBundle/Menu/ProductVariantFormMenuBuilder.php
@@ -24,7 +24,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 final class ProductVariantFormMenuBuilder
 {
-    const EVENT_NAME = 'sylius.menu.admin.product_variant.form';
+    public const EVENT_NAME = 'sylius.menu.admin.product_variant.form';
 
     /**
      * @var FactoryInterface

--- a/src/Sylius/Bundle/CoreBundle/Application/Kernel.php
+++ b/src/Sylius/Bundle/CoreBundle/Application/Kernel.php
@@ -33,12 +33,12 @@ use Symfony\Component\HttpKernel\Kernel as HttpKernel;
  */
 class Kernel extends HttpKernel
 {
-    const VERSION = '1.0.0-beta.3';
-    const VERSION_ID = '10000';
-    const MAJOR_VERSION = '1';
-    const MINOR_VERSION = '0';
-    const RELEASE_VERSION = '0';
-    const EXTRA_VERSION = 'beta.3';
+    public const VERSION = '1.0.0-beta.3';
+    public const VERSION_ID = '10000';
+    public const MAJOR_VERSION = '1';
+    public const MINOR_VERSION = '0';
+    public const RELEASE_VERSION = '0';
+    public const EXTRA_VERSION = 'beta.3';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/CoreBundle/Command/AbstractInstallCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/AbstractInstallCommand.php
@@ -22,10 +22,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class AbstractInstallCommand extends ContainerAwareCommand
 {
-    const WEB_ASSETS_DIRECTORY = 'web/assets/';
-    const WEB_BUNDLES_DIRECTORY = 'web/bundles/';
-    const WEB_MEDIA_DIRECTORY = 'web/media/';
-    const WEB_MEDIA_IMAGE_DIRECTORY = 'web/media/image/';
+    public const WEB_ASSETS_DIRECTORY = 'web/assets/';
+    public const WEB_BUNDLES_DIRECTORY = 'web/bundles/';
+    public const WEB_MEDIA_DIRECTORY = 'web/media/';
+    public const WEB_MEDIA_IMAGE_DIRECTORY = 'web/media/image/';
 
     /**
      * @var CommandExecutor

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PaymentMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PaymentMethodExampleFactory.php
@@ -29,7 +29,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class PaymentMethodExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
-    const DEFAULT_LOCALE = 'en_US';
+    public const DEFAULT_LOCALE = 'en_US';
 
     /**
      * @var PaymentMethodFactoryInterface

--- a/src/Sylius/Bundle/CoreBundle/Installer/Requirement/SettingsRequirements.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Requirement/SettingsRequirements.php
@@ -17,7 +17,7 @@ use Symfony\Component\Translation\TranslatorInterface;
 
 final class SettingsRequirements extends RequirementCollection
 {
-    const RECOMMENDED_PHP_VERSION = '7.0';
+    public const RECOMMENDED_PHP_VERSION = '7.0';
 
     /**
      * @param TranslatorInterface $translator

--- a/src/Sylius/Bundle/CoreBundle/Mailer/Emails.php
+++ b/src/Sylius/Bundle/CoreBundle/Mailer/Emails.php
@@ -18,10 +18,10 @@ namespace Sylius\Bundle\CoreBundle\Mailer;
  */
 final class Emails
 {
-    const CONTACT_REQUEST = 'contact_request';
-    const ORDER_CONFIRMATION = 'order_confirmation';
-    const SHIPMENT_CONFIRMATION = 'shipment_confirmation';
-    const USER_REGISTRATION = 'user_registration';
+    public const CONTACT_REQUEST = 'contact_request';
+    public const ORDER_CONFIRMATION = 'order_confirmation';
+    public const SHIPMENT_CONFIRMATION = 'shipment_confirmation';
+    public const USER_REGISTRATION = 'user_registration';
 
     private function __construct()
     {

--- a/src/Sylius/Bundle/GridBundle/Doctrine/DBAL/Driver.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/DBAL/Driver.php
@@ -22,7 +22,7 @@ use Sylius\Component\Grid\Parameters;
  */
 final class Driver implements DriverInterface
 {
-    const NAME = 'doctrine/dbal';
+    public const NAME = 'doctrine/dbal';
 
     /**
      * @var Connection

--- a/src/Sylius/Bundle/GridBundle/Doctrine/ORM/Driver.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/ORM/Driver.php
@@ -22,7 +22,7 @@ use Sylius\Component\Grid\Parameters;
  */
 final class Driver implements DriverInterface
 {
-    const NAME = 'doctrine/orm';
+    public const NAME = 'doctrine/orm';
 
     /**
      * @var ManagerRegistry

--- a/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/Driver.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/Driver.php
@@ -22,12 +22,12 @@ final class Driver implements DriverInterface
     /**
      * Driver name
      */
-    const NAME = 'doctrine/phpcr-odm';
+    public const NAME = 'doctrine/phpcr-odm';
 
     /**
      * Alias to use to reference fields from the data source class.
      */
-    const QB_SOURCE_ALIAS = 'o';
+    public const QB_SOURCE_ALIAS = 'o';
 
     /**
      * @var DocumentManagerInterface

--- a/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/ExtraComparison.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/ExtraComparison.php
@@ -19,9 +19,9 @@ namespace Sylius\Bundle\GridBundle\Doctrine\PHPCRODM;
  */
 final class ExtraComparison
 {
-    const NOT_CONTAINS = 'NOT_CONTAINS';
-    const IS_NULL = 'IS_NULL';
-    const IS_NOT_NULL = 'IS_NOT_NULL';
+    public const NOT_CONTAINS = 'NOT_CONTAINS';
+    public const IS_NULL = 'IS_NULL';
+    public const IS_NOT_NULL = 'IS_NOT_NULL';
 
     private function __construct()
     {

--- a/src/Sylius/Bundle/GridBundle/SyliusGridBundle.php
+++ b/src/Sylius/Bundle/GridBundle/SyliusGridBundle.php
@@ -24,8 +24,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 final class SyliusGridBundle extends Bundle
 {
-    const DRIVER_DOCTRINE_ORM = 'doctrine/orm';
-    const DRIVER_DOCTRINE_PHPCR_ODM = 'doctrine/phpcr-odm';
+    public const DRIVER_DOCTRINE_ORM = 'doctrine/orm';
+    public const DRIVER_DOCTRINE_PHPCR_ODM = 'doctrine/phpcr-odm';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/OrderBundle/SyliusExpiredCartsEvents.php
+++ b/src/Sylius/Bundle/OrderBundle/SyliusExpiredCartsEvents.php
@@ -15,8 +15,8 @@ namespace Sylius\Bundle\OrderBundle;
 
 final class SyliusExpiredCartsEvents
 {
-    const PRE_REMOVE = 'sylius.carts.pre_remove';
-    const POST_REMOVE = 'sylius.carts.post_remove';
+    public const PRE_REMOVE = 'sylius.carts.pre_remove';
+    public const POST_REMOVE = 'sylius.carts.post_remove';
 
     private function __construct()
     {

--- a/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfigurationFactory.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfigurationFactory.php
@@ -21,11 +21,11 @@ use Symfony\Component\HttpFoundation\Request;
  */
 final class RequestConfigurationFactory implements RequestConfigurationFactoryInterface
 {
-    const API_VERSION_HEADER = 'Accept';
-    const API_GROUPS_HEADER = 'Accept';
+    public const API_VERSION_HEADER = 'Accept';
+    public const API_GROUPS_HEADER = 'Accept';
 
-    const API_VERSION_REGEXP = '/(v|version)=(?P<version>[0-9\.]+)/i';
-    const API_GROUPS_REGEXP = '/(g|groups)=(?P<groups>[a-z,_\s]+)/i';
+    public const API_VERSION_REGEXP = '/(v|version)=(?P<version>[0-9\.]+)/i';
+    public const API_GROUPS_REGEXP = '/(g|groups)=(?P<groups>[a-z,_\s]+)/i';
 
     /**
      * @var ParametersParserInterface

--- a/src/Sylius/Bundle/ResourceBundle/Event/ResourceControllerEvent.php
+++ b/src/Sylius/Bundle/ResourceBundle/Event/ResourceControllerEvent.php
@@ -21,10 +21,10 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ResourceControllerEvent extends GenericEvent
 {
-    const TYPE_ERROR = 'error';
-    const TYPE_WARNING = 'warning';
-    const TYPE_INFO = 'info';
-    const TYPE_SUCCESS = 'success';
+    public const TYPE_ERROR = 'error';
+    public const TYPE_WARNING = 'warning';
+    public const TYPE_INFO = 'info';
+    public const TYPE_SUCCESS = 'success';
 
     /**
      * @var string

--- a/src/Sylius/Bundle/ResourceBundle/ResourceBundleInterface.php
+++ b/src/Sylius/Bundle/ResourceBundle/ResourceBundleInterface.php
@@ -18,9 +18,9 @@ namespace Sylius\Bundle\ResourceBundle;
  */
 interface ResourceBundleInterface
 {
-    const MAPPING_XML = 'xml';
-    const MAPPING_YAML = 'yaml';
-    const MAPPING_ANNOTATION = 'annotation';
+    public const MAPPING_XML = 'xml';
+    public const MAPPING_YAML = 'yaml';
+    public const MAPPING_ANNOTATION = 'annotation';
 
     /**
      * Returns a vector of supported drivers.

--- a/src/Sylius/Bundle/ResourceBundle/SyliusResourceBundle.php
+++ b/src/Sylius/Bundle/ResourceBundle/SyliusResourceBundle.php
@@ -25,9 +25,9 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 final class SyliusResourceBundle extends Bundle
 {
-    const DRIVER_DOCTRINE_ORM = 'doctrine/orm';
-    const DRIVER_DOCTRINE_MONGODB_ODM = 'doctrine/mongodb-odm';
-    const DRIVER_DOCTRINE_PHPCR_ODM = 'doctrine/phpcr-odm';
+    public const DRIVER_DOCTRINE_ORM = 'doctrine/orm';
+    public const DRIVER_DOCTRINE_MONGODB_ODM = 'doctrine/mongodb-odm';
+    public const DRIVER_DOCTRINE_PHPCR_ODM = 'doctrine/phpcr-odm';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Bundle/ShopBundle/Menu/AccountMenuBuilder.php
+++ b/src/Sylius/Bundle/ShopBundle/Menu/AccountMenuBuilder.php
@@ -23,7 +23,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 final class AccountMenuBuilder
 {
-    const EVENT_NAME = 'sylius.menu.shop.account';
+    public const EVENT_NAME = 'sylius.menu.shop.account';
 
     /**
      * @var FactoryInterface

--- a/src/Sylius/Bundle/ThemeBundle/Asset/Installer/AssetsInstallerInterface.php
+++ b/src/Sylius/Bundle/ThemeBundle/Asset/Installer/AssetsInstallerInterface.php
@@ -27,7 +27,7 @@ interface AssetsInstallerInterface
      * @see AssetsInstallerInterface::installBundleAssets()
      * @see AssetsInstallerInterface::installDirAssets()
      */
-    const HARD_COPY = 0;
+    public const HARD_COPY = 0;
 
     /**
      * Constant used as parameter and returned in installAssets() methods.
@@ -36,7 +36,7 @@ interface AssetsInstallerInterface
      * @see AssetsInstallerInterface::installBundleAssets()
      * @see AssetsInstallerInterface::installDirAssets()
      */
-    const SYMLINK = 1;
+    public const SYMLINK = 1;
 
     /**
      * Constant used as parameter and returned in installAssets() methods.
@@ -45,7 +45,7 @@ interface AssetsInstallerInterface
      * @see AssetsInstallerInterface::installBundleAssets()
      * @see AssetsInstallerInterface::installDirAssets()
      */
-    const RELATIVE_SYMLINK = 2;
+    public const RELATIVE_SYMLINK = 2;
 
     /**
      * @param string $targetDir

--- a/src/Sylius/Bundle/UserBundle/Mailer/Emails.php
+++ b/src/Sylius/Bundle/UserBundle/Mailer/Emails.php
@@ -18,7 +18,7 @@ namespace Sylius\Bundle\UserBundle\Mailer;
  */
 class Emails
 {
-    const RESET_PASSWORD_TOKEN = 'reset_password_token';
-    const RESET_PASSWORD_PIN = 'reset_password_pin';
-    const EMAIL_VERIFICATION_TOKEN = 'verification_token';
+    public const RESET_PASSWORD_TOKEN = 'reset_password_token';
+    public const RESET_PASSWORD_PIN = 'reset_password_pin';
+    public const EMAIL_VERIFICATION_TOKEN = 'verification_token';
 }

--- a/src/Sylius/Bundle/UserBundle/UserEvents.php
+++ b/src/Sylius/Bundle/UserBundle/UserEvents.php
@@ -15,23 +15,23 @@ namespace Sylius\Bundle\UserBundle;
 
 final class UserEvents
 {
-    const REQUEST_RESET_PASSWORD_TOKEN = 'sylius.user.password_reset.request.token';
+    public const REQUEST_RESET_PASSWORD_TOKEN = 'sylius.user.password_reset.request.token';
 
-    const REQUEST_RESET_PASSWORD_PIN = 'sylius.user.password_reset.request.pin';
+    public const REQUEST_RESET_PASSWORD_PIN = 'sylius.user.password_reset.request.pin';
 
-    const REQUEST_VERIFICATION_TOKEN = 'sylius.user.email_verification.token';
+    public const REQUEST_VERIFICATION_TOKEN = 'sylius.user.email_verification.token';
 
-    const PRE_EMAIL_VERIFICATION = 'sylius.user.pre_email_verification';
-    const POST_EMAIL_VERIFICATION = 'sylius.user.post_email_verification';
+    public const PRE_EMAIL_VERIFICATION = 'sylius.user.pre_email_verification';
+    public const POST_EMAIL_VERIFICATION = 'sylius.user.post_email_verification';
 
-    const PRE_PASSWORD_RESET = 'sylius.user.pre_password_reset';
-    const POST_PASSWORD_RESET = 'sylius.user.post_password_reset';
+    public const PRE_PASSWORD_RESET = 'sylius.user.pre_password_reset';
+    public const POST_PASSWORD_RESET = 'sylius.user.post_password_reset';
 
-    const PRE_PASSWORD_CHANGE = 'sylius.user.pre_password_change';
-    const POST_PASSWORD_CHANGE = 'sylius.user.post_password_change';
+    public const PRE_PASSWORD_CHANGE = 'sylius.user.pre_password_change';
+    public const POST_PASSWORD_CHANGE = 'sylius.user.post_password_change';
 
     /**
      * Occurs when the user is logged in programmatically.
      */
-    const SECURITY_IMPLICIT_LOGIN = 'sylius.user.security.implicit_login';
+    public const SECURITY_IMPLICIT_LOGIN = 'sylius.user.security.implicit_login';
 }

--- a/src/Sylius/Component/Addressing/Model/Scope.php
+++ b/src/Sylius/Component/Addressing/Model/Scope.php
@@ -18,7 +18,7 @@ namespace Sylius\Component\Addressing\Model;
  */
 final class Scope
 {
-    const ALL = 'all';
+    public const ALL = 'all';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Addressing/Model/ZoneInterface.php
+++ b/src/Sylius/Component/Addressing/Model/ZoneInterface.php
@@ -23,9 +23,9 @@ use Sylius\Component\Resource\Model\ResourceInterface;
  */
 interface ZoneInterface extends ResourceInterface, CodeAwareInterface
 {
-    const TYPE_COUNTRY = 'country';
-    const TYPE_PROVINCE = 'province';
-    const TYPE_ZONE = 'zone';
+    public const TYPE_COUNTRY = 'country';
+    public const TYPE_PROVINCE = 'province';
+    public const TYPE_ZONE = 'zone';
 
     /**
      * @return string[]

--- a/src/Sylius/Component/Attribute/AttributeType/CheckboxAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/CheckboxAttributeType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  */
 final class CheckboxAttributeType implements AttributeTypeInterface
 {
-    const TYPE = 'checkbox';
+    public const TYPE = 'checkbox';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Attribute/AttributeType/DateAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/DateAttributeType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  */
 final class DateAttributeType implements AttributeTypeInterface
 {
-    const TYPE = 'date';
+    public const TYPE = 'date';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Attribute/AttributeType/DatetimeAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/DatetimeAttributeType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  */
 final class DatetimeAttributeType implements AttributeTypeInterface
 {
-    const TYPE = 'datetime';
+    public const TYPE = 'datetime';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Attribute/AttributeType/IntegerAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/IntegerAttributeType.php
@@ -23,7 +23,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  */
 final class IntegerAttributeType implements AttributeTypeInterface
 {
-    const TYPE = 'integer';
+    public const TYPE = 'integer';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Attribute/AttributeType/PercentAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/PercentAttributeType.php
@@ -23,7 +23,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  */
 final class PercentAttributeType implements AttributeTypeInterface
 {
-    const TYPE = 'percent';
+    public const TYPE = 'percent';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Attribute/AttributeType/SelectAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/SelectAttributeType.php
@@ -26,7 +26,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  */
 class SelectAttributeType implements AttributeTypeInterface
 {
-    const TYPE = 'select';
+    public const TYPE = 'select';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Attribute/AttributeType/TextAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/TextAttributeType.php
@@ -25,7 +25,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  */
 final class TextAttributeType implements AttributeTypeInterface
 {
-    const TYPE = 'text';
+    public const TYPE = 'text';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Attribute/AttributeType/TextareaAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/TextareaAttributeType.php
@@ -23,7 +23,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  */
 final class TextareaAttributeType implements AttributeTypeInterface
 {
-    const TYPE = 'textarea';
+    public const TYPE = 'textarea';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Attribute/Model/AttributeValueInterface.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeValueInterface.php
@@ -20,13 +20,13 @@ use Sylius\Component\Resource\Model\ResourceInterface;
  */
 interface AttributeValueInterface extends ResourceInterface
 {
-    const STORAGE_BOOLEAN = 'boolean';
-    const STORAGE_DATE = 'date';
-    const STORAGE_DATETIME = 'datetime';
-    const STORAGE_FLOAT = 'float';
-    const STORAGE_INTEGER = 'integer';
-    const STORAGE_JSON = 'json';
-    const STORAGE_TEXT = 'text';
+    public const STORAGE_BOOLEAN = 'boolean';
+    public const STORAGE_DATE = 'date';
+    public const STORAGE_DATETIME = 'datetime';
+    public const STORAGE_FLOAT = 'float';
+    public const STORAGE_INTEGER = 'integer';
+    public const STORAGE_JSON = 'json';
+    public const STORAGE_TEXT = 'text';
 
     /**
      * @return AttributeSubjectInterface

--- a/src/Sylius/Component/Core/Model/AdjustmentInterface.php
+++ b/src/Sylius/Component/Core/Model/AdjustmentInterface.php
@@ -17,10 +17,10 @@ use Sylius\Component\Order\Model\AdjustmentInterface as BaseAdjustmentInterface;
 
 interface AdjustmentInterface extends BaseAdjustmentInterface
 {
-    const ORDER_ITEM_PROMOTION_ADJUSTMENT = 'order_item_promotion';
-    const ORDER_PROMOTION_ADJUSTMENT = 'order_promotion';
-    const ORDER_SHIPPING_PROMOTION_ADJUSTMENT = 'order_shipping_promotion';
-    const ORDER_UNIT_PROMOTION_ADJUSTMENT = 'order_unit_promotion';
-    const SHIPPING_ADJUSTMENT = 'shipping';
-    const TAX_ADJUSTMENT = 'tax';
+    public const ORDER_ITEM_PROMOTION_ADJUSTMENT = 'order_item_promotion';
+    public const ORDER_PROMOTION_ADJUSTMENT = 'order_promotion';
+    public const ORDER_SHIPPING_PROMOTION_ADJUSTMENT = 'order_shipping_promotion';
+    public const ORDER_UNIT_PROMOTION_ADJUSTMENT = 'order_unit_promotion';
+    public const SHIPPING_ADJUSTMENT = 'shipping';
+    public const TAX_ADJUSTMENT = 'tax';
 }

--- a/src/Sylius/Component/Core/Model/AdminUserInterface.php
+++ b/src/Sylius/Component/Core/Model/AdminUserInterface.php
@@ -20,7 +20,7 @@ use Sylius\Component\User\Model\UserInterface as BaseUserInterface;
  */
 interface AdminUserInterface extends BaseUserInterface
 {
-    const DEFAULT_ADMIN_ROLE = 'ROLE_ADMINISTRATION_ACCESS';
+    public const DEFAULT_ADMIN_ROLE = 'ROLE_ADMINISTRATION_ACCESS';
 
     /**
      * @return string

--- a/src/Sylius/Component/Core/Model/ProductInterface.php
+++ b/src/Sylius/Component/Core/Model/ProductInterface.php
@@ -37,8 +37,8 @@ interface ProductInterface extends
      * 2) Match  - Each product option is displayed as select field.
      *             User selects the values and we match them to variant.
      */
-    const VARIANT_SELECTION_CHOICE = 'choice';
-    const VARIANT_SELECTION_MATCH = 'match';
+    public const VARIANT_SELECTION_CHOICE = 'choice';
+    public const VARIANT_SELECTION_MATCH = 'match';
 
     /**
      * @return string

--- a/src/Sylius/Component/Core/Model/Scope.php
+++ b/src/Sylius/Component/Core/Model/Scope.php
@@ -18,8 +18,8 @@ namespace Sylius\Component\Core\Model;
  */
 final class Scope
 {
-    const SHIPPING = 'shipping';
-    const TAX = 'tax';
+    public const SHIPPING = 'shipping';
+    public const TAX = 'tax';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Core/OrderCheckoutStates.php
+++ b/src/Sylius/Component/Core/OrderCheckoutStates.php
@@ -18,12 +18,12 @@ namespace Sylius\Component\Core;
  */
 final class OrderCheckoutStates
 {
-    const STATE_ADDRESSED = 'addressed';
-    const STATE_CART = 'cart';
-    const STATE_COMPLETED = 'completed';
-    const STATE_PAYMENT_SELECTED = 'payment_selected';
-    const STATE_PAYMENT_SKIPPED = 'payment_skipped';
-    const STATE_SHIPPING_SELECTED = 'shipping_selected';
+    public const STATE_ADDRESSED = 'addressed';
+    public const STATE_CART = 'cart';
+    public const STATE_COMPLETED = 'completed';
+    public const STATE_PAYMENT_SELECTED = 'payment_selected';
+    public const STATE_PAYMENT_SKIPPED = 'payment_skipped';
+    public const STATE_SHIPPING_SELECTED = 'shipping_selected';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Core/OrderCheckoutTransitions.php
+++ b/src/Sylius/Component/Core/OrderCheckoutTransitions.php
@@ -18,14 +18,14 @@ namespace Sylius\Component\Core;
  */
 final class OrderCheckoutTransitions
 {
-    const GRAPH = 'sylius_order_checkout';
+    public const GRAPH = 'sylius_order_checkout';
 
-    const TRANSITION_ADDRESS = 'address';
-    const TRANSITION_COMPLETE = 'complete';
-    const TRANSITION_SELECT_PAYMENT = 'select_payment';
-    const TRANSITION_SELECT_SHIPPING = 'select_shipping';
-    const TRANSITION_SKIP_PAYMENT = 'skip_payment';
-    const TRANSITION_SKIP_SHIPPING = 'skip_shipping';
+    public const TRANSITION_ADDRESS = 'address';
+    public const TRANSITION_COMPLETE = 'complete';
+    public const TRANSITION_SELECT_PAYMENT = 'select_payment';
+    public const TRANSITION_SELECT_SHIPPING = 'select_shipping';
+    public const TRANSITION_SKIP_PAYMENT = 'skip_payment';
+    public const TRANSITION_SKIP_SHIPPING = 'skip_shipping';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Core/OrderPaymentStates.php
+++ b/src/Sylius/Component/Core/OrderPaymentStates.php
@@ -18,13 +18,13 @@ namespace Sylius\Component\Core;
  */
 final class OrderPaymentStates
 {
-    const STATE_CART = 'cart';
-    const STATE_AWAITING_PAYMENT = 'awaiting_payment';
-    const STATE_PARTIALLY_PAID = 'partially_paid';
-    const STATE_CANCELLED = 'cancelled';
-    const STATE_PAID = 'paid';
-    const STATE_PARTIALLY_REFUNDED = 'partially_refunded';
-    const STATE_REFUNDED = 'refunded';
+    public const STATE_CART = 'cart';
+    public const STATE_AWAITING_PAYMENT = 'awaiting_payment';
+    public const STATE_PARTIALLY_PAID = 'partially_paid';
+    public const STATE_CANCELLED = 'cancelled';
+    public const STATE_PAID = 'paid';
+    public const STATE_PARTIALLY_REFUNDED = 'partially_refunded';
+    public const STATE_REFUNDED = 'refunded';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Core/OrderPaymentTransitions.php
+++ b/src/Sylius/Component/Core/OrderPaymentTransitions.php
@@ -18,14 +18,14 @@ namespace Sylius\Component\Core;
  */
 final class OrderPaymentTransitions
 {
-    const GRAPH = 'sylius_order_payment';
+    public const GRAPH = 'sylius_order_payment';
 
-    const TRANSITION_REQUEST_PAYMENT = 'request_payment';
-    const TRANSITION_PARTIALLY_PAY = 'partially_pay';
-    const TRANSITION_CANCEL = 'cancel';
-    const TRANSITION_PAY = 'pay';
-    const TRANSITION_PARTIALLY_REFUND = 'partially_refund';
-    const TRANSITION_REFUND = 'refund';
+    public const TRANSITION_REQUEST_PAYMENT = 'request_payment';
+    public const TRANSITION_PARTIALLY_PAY = 'partially_pay';
+    public const TRANSITION_CANCEL = 'cancel';
+    public const TRANSITION_PAY = 'pay';
+    public const TRANSITION_PARTIALLY_REFUND = 'partially_refund';
+    public const TRANSITION_REFUND = 'refund';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Core/OrderShippingStates.php
+++ b/src/Sylius/Component/Core/OrderShippingStates.php
@@ -18,11 +18,11 @@ namespace Sylius\Component\Core;
  */
 final class OrderShippingStates
 {
-    const STATE_CART = 'cart';
-    const STATE_READY = 'ready';
-    const STATE_CANCELLED = 'cancelled';
-    const STATE_PARTIALLY_SHIPPED = 'partially_shipped';
-    const STATE_SHIPPED = 'shipped';
+    public const STATE_CART = 'cart';
+    public const STATE_READY = 'ready';
+    public const STATE_CANCELLED = 'cancelled';
+    public const STATE_PARTIALLY_SHIPPED = 'partially_shipped';
+    public const STATE_SHIPPED = 'shipped';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Core/OrderShippingTransitions.php
+++ b/src/Sylius/Component/Core/OrderShippingTransitions.php
@@ -18,12 +18,12 @@ namespace Sylius\Component\Core;
  */
 final class OrderShippingTransitions
 {
-    const GRAPH = 'sylius_order_shipping';
+    public const GRAPH = 'sylius_order_shipping';
 
-    const TRANSITION_REQUEST_SHIPPING = 'request_shipping';
-    const TRANSITION_PARTIALLY_SHIP = 'partially_ship';
-    const TRANSITION_SHIP = 'ship';
-    const TRANSITION_CANCEL = 'cancel';
+    public const TRANSITION_REQUEST_SHIPPING = 'request_shipping';
+    public const TRANSITION_PARTIALLY_SHIP = 'partially_ship';
+    public const TRANSITION_SHIP = 'ship';
+    public const TRANSITION_CANCEL = 'cancel';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Core/ProductReviewTransitions.php
+++ b/src/Sylius/Component/Core/ProductReviewTransitions.php
@@ -18,8 +18,8 @@ namespace Sylius\Component\Core;
  */
 class ProductReviewTransitions
 {
-    const GRAPH = 'sylius_product_review';
+    public const GRAPH = 'sylius_product_review';
 
-    const TRANSITION_ACCEPT = 'accept';
-    const TRANSITION_REJECT = 'reject';
+    public const TRANSITION_ACCEPT = 'accept';
+    public const TRANSITION_REJECT = 'reject';
 }

--- a/src/Sylius/Component/Core/Promotion/Action/FixedDiscountPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/FixedDiscountPromotionActionCommand.php
@@ -27,7 +27,7 @@ use Webmozart\Assert\Assert;
  */
 final class FixedDiscountPromotionActionCommand extends DiscountPromotionActionCommand
 {
-    const TYPE = 'order_fixed_discount';
+    public const TYPE = 'order_fixed_discount';
 
     /**
      * @var ProportionalIntegerDistributorInterface

--- a/src/Sylius/Component/Core/Promotion/Action/PercentageDiscountPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/PercentageDiscountPromotionActionCommand.php
@@ -27,7 +27,7 @@ use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
  */
 final class PercentageDiscountPromotionActionCommand extends DiscountPromotionActionCommand implements PromotionActionCommandInterface
 {
-    const TYPE = 'order_percentage_discount';
+    public const TYPE = 'order_percentage_discount';
 
     /**
      * @var ProportionalIntegerDistributorInterface

--- a/src/Sylius/Component/Core/Promotion/Action/ShippingPercentageDiscountPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/ShippingPercentageDiscountPromotionActionCommand.php
@@ -27,7 +27,7 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
  */
 final class ShippingPercentageDiscountPromotionActionCommand implements PromotionActionCommandInterface
 {
-    const TYPE = 'shipping_percentage_discount';
+    public const TYPE = 'shipping_percentage_discount';
 
     /**
      * @var FactoryInterface

--- a/src/Sylius/Component/Core/Promotion/Action/UnitFixedDiscountPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/UnitFixedDiscountPromotionActionCommand.php
@@ -27,7 +27,7 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
  */
 final class UnitFixedDiscountPromotionActionCommand extends UnitDiscountPromotionActionCommand
 {
-    const TYPE = 'unit_fixed_discount';
+    public const TYPE = 'unit_fixed_discount';
 
     /**
      * @var FilterInterface

--- a/src/Sylius/Component/Core/Promotion/Action/UnitPercentageDiscountPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/UnitPercentageDiscountPromotionActionCommand.php
@@ -26,7 +26,7 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
  */
 final class UnitPercentageDiscountPromotionActionCommand extends UnitDiscountPromotionActionCommand
 {
-    const TYPE = 'unit_percentage_discount';
+    public const TYPE = 'unit_percentage_discount';
 
     /**
      * @var FilterInterface

--- a/src/Sylius/Component/Core/Promotion/Checker/Rule/ContainsProductRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Rule/ContainsProductRuleChecker.php
@@ -26,7 +26,7 @@ use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
  */
 final class ContainsProductRuleChecker implements RuleCheckerInterface
 {
-    const TYPE = 'contains_product';
+    public const TYPE = 'contains_product';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Core/Promotion/Checker/Rule/CustomerGroupRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Rule/CustomerGroupRuleChecker.php
@@ -24,7 +24,7 @@ use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
  */
 class CustomerGroupRuleChecker implements RuleCheckerInterface
 {
-    const TYPE = 'customer_group';
+    public const TYPE = 'customer_group';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Core/Promotion/Checker/Rule/HasTaxonRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Rule/HasTaxonRuleChecker.php
@@ -25,7 +25,7 @@ use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
  */
 final class HasTaxonRuleChecker implements RuleCheckerInterface
 {
-    const TYPE = 'has_taxon';
+    public const TYPE = 'has_taxon';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Core/Promotion/Checker/Rule/NthOrderRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Rule/NthOrderRuleChecker.php
@@ -25,7 +25,7 @@ use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
  */
 final class NthOrderRuleChecker implements RuleCheckerInterface
 {
-    const TYPE = 'nth_order';
+    public const TYPE = 'nth_order';
 
     /**
      * @var OrderRepositoryInterface

--- a/src/Sylius/Component/Core/Promotion/Checker/Rule/ShippingCountryRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Rule/ShippingCountryRuleChecker.php
@@ -25,7 +25,7 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
  */
 final class ShippingCountryRuleChecker implements RuleCheckerInterface
 {
-    const TYPE = 'shipping_country';
+    public const TYPE = 'shipping_country';
 
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Component/Core/Promotion/Checker/Rule/TotalOfItemsFromTaxonRuleChecker.php
+++ b/src/Sylius/Component/Core/Promotion/Checker/Rule/TotalOfItemsFromTaxonRuleChecker.php
@@ -25,7 +25,7 @@ use Webmozart\Assert\Assert;
  */
 final class TotalOfItemsFromTaxonRuleChecker implements RuleCheckerInterface
 {
-    const TYPE = 'total_of_items_from_taxon';
+    public const TYPE = 'total_of_items_from_taxon';
 
     /**
      * @var TaxonRepositoryInterface

--- a/src/Sylius/Component/Core/SyliusLocaleEvents.php
+++ b/src/Sylius/Component/Core/SyliusLocaleEvents.php
@@ -18,7 +18,7 @@ namespace Sylius\Component\Core;
  */
 final class SyliusLocaleEvents
 {
-    const CODE_CHANGED = 'sylius.locale.code_changed';
+    public const CODE_CHANGED = 'sylius.locale.code_changed';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Core/Test/Services/DefaultChannelFactory.php
+++ b/src/Sylius/Component/Core/Test/Services/DefaultChannelFactory.php
@@ -25,9 +25,9 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
  */
 final class DefaultChannelFactory implements DefaultChannelFactoryInterface
 {
-    const DEFAULT_CHANNEL_NAME = 'Default';
-    const DEFAULT_CHANNEL_CODE = 'DEFAULT';
-    const DEFAULT_CHANNEL_CURRENCY = 'USD';
+    public const DEFAULT_CHANNEL_NAME = 'Default';
+    public const DEFAULT_CHANNEL_CODE = 'DEFAULT';
+    public const DEFAULT_CHANNEL_CURRENCY = 'USD';
 
     /**
      * @var ChannelFactoryInterface

--- a/src/Sylius/Component/Core/Test/Services/DefaultUnitedStatesChannelFactory.php
+++ b/src/Sylius/Component/Core/Test/Services/DefaultUnitedStatesChannelFactory.php
@@ -28,12 +28,12 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
  */
 final class DefaultUnitedStatesChannelFactory implements DefaultChannelFactoryInterface
 {
-    const DEFAULT_CHANNEL_CODE = 'WEB-US';
-    const DEFAULT_COUNTRY_CODE = 'US';
-    const DEFAULT_ZONE_CODE = 'US';
-    const DEFAULT_CURRENCY_CODE = 'USD';
-    const DEFAULT_ZONE_NAME = 'United States';
-    const DEFAULT_CHANNEL_NAME = 'United States';
+    public const DEFAULT_CHANNEL_CODE = 'WEB-US';
+    public const DEFAULT_COUNTRY_CODE = 'US';
+    public const DEFAULT_ZONE_CODE = 'US';
+    public const DEFAULT_CURRENCY_CODE = 'USD';
+    public const DEFAULT_ZONE_NAME = 'United States';
+    public const DEFAULT_CHANNEL_NAME = 'United States';
 
     /**
      * @var RepositoryInterface

--- a/src/Sylius/Component/Customer/Model/CustomerInterface.php
+++ b/src/Sylius/Component/Customer/Model/CustomerInterface.php
@@ -21,9 +21,9 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  */
 interface CustomerInterface extends TimestampableInterface, ResourceInterface
 {
-    const UNKNOWN_GENDER = 'u';
-    const MALE_GENDER = 'm';
-    const FEMALE_GENDER = 'f';
+    public const UNKNOWN_GENDER = 'u';
+    public const MALE_GENDER = 'm';
+    public const FEMALE_GENDER = 'f';
 
     /**
      * @return string

--- a/src/Sylius/Component/Grid/Data/DataSourceInterface.php
+++ b/src/Sylius/Component/Grid/Data/DataSourceInterface.php
@@ -20,8 +20,8 @@ use Sylius\Component\Grid\Parameters;
  */
 interface DataSourceInterface
 {
-    const CONDITION_AND = 'and';
-    const CONDITION_OR  = 'or';
+    public const CONDITION_AND = 'and';
+    public const CONDITION_OR  = 'or';
 
     /**
      * @param mixed $expression

--- a/src/Sylius/Component/Grid/Definition/ArrayToDefinitionConverter.php
+++ b/src/Sylius/Component/Grid/Definition/ArrayToDefinitionConverter.php
@@ -21,7 +21,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 final class ArrayToDefinitionConverter implements ArrayToDefinitionConverterInterface
 {
-    const EVENT_NAME = 'sylius.grid.%s';
+    public const EVENT_NAME = 'sylius.grid.%s';
 
     /**
      * @var EventDispatcherInterface

--- a/src/Sylius/Component/Grid/Filter/BooleanFilter.php
+++ b/src/Sylius/Component/Grid/Filter/BooleanFilter.php
@@ -21,8 +21,8 @@ use Sylius\Component\Grid\Filtering\FilterInterface;
  */
 final class BooleanFilter implements FilterInterface
 {
-    const TRUE  = 'true';
-    const FALSE = 'false';
+    public const TRUE  = 'true';
+    public const FALSE = 'false';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Grid/Filter/DateFilter.php
+++ b/src/Sylius/Component/Grid/Filter/DateFilter.php
@@ -21,9 +21,9 @@ use Sylius\Component\Grid\Filtering\FilterInterface;
  */
 final class DateFilter implements FilterInterface
 {
-    const NAME = 'date';
-    const DEFAULT_INCLUSIVE_FROM = true;
-    const DEFAULT_INCLUSIVE_TO = false;
+    public const NAME = 'date';
+    public const DEFAULT_INCLUSIVE_FROM = true;
+    public const DEFAULT_INCLUSIVE_TO = false;
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Grid/Filter/ExistsFilter.php
+++ b/src/Sylius/Component/Grid/Filter/ExistsFilter.php
@@ -21,8 +21,8 @@ use Sylius\Component\Grid\Filtering\FilterInterface;
  */
 final class ExistsFilter implements FilterInterface
 {
-    const TRUE = true;
-    const FALSE = false;
+    public const TRUE = true;
+    public const FALSE = false;
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Grid/Filter/MoneyFilter.php
+++ b/src/Sylius/Component/Grid/Filter/MoneyFilter.php
@@ -21,7 +21,7 @@ use Sylius\Component\Grid\Filtering\FilterInterface;
  */
 final class MoneyFilter implements FilterInterface
 {
-    const DEFAULT_SCALE = 2;
+    public const DEFAULT_SCALE = 2;
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Grid/Filter/StringFilter.php
+++ b/src/Sylius/Component/Grid/Filter/StringFilter.php
@@ -22,18 +22,18 @@ use Sylius\Component\Grid\Filtering\FilterInterface;
  */
 final class StringFilter implements FilterInterface
 {
-    const NAME = 'string';
+    public const NAME = 'string';
 
-    const TYPE_EQUAL = 'equal';
-    const TYPE_NOT_EQUAL = 'not_equal';
-    const TYPE_EMPTY = 'empty';
-    const TYPE_NOT_EMPTY = 'not_empty';
-    const TYPE_CONTAINS = 'contains';
-    const TYPE_NOT_CONTAINS = 'not_contains';
-    const TYPE_STARTS_WITH = 'starts_with';
-    const TYPE_ENDS_WITH = 'ends_with';
-    const TYPE_IN = 'in';
-    const TYPE_NOT_IN = 'not_in';
+    public const TYPE_EQUAL = 'equal';
+    public const TYPE_NOT_EQUAL = 'not_equal';
+    public const TYPE_EMPTY = 'empty';
+    public const TYPE_NOT_EMPTY = 'not_empty';
+    public const TYPE_CONTAINS = 'contains';
+    public const TYPE_NOT_CONTAINS = 'not_contains';
+    public const TYPE_STARTS_WITH = 'starts_with';
+    public const TYPE_ENDS_WITH = 'ends_with';
+    public const TYPE_IN = 'in';
+    public const TYPE_NOT_IN = 'not_in';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Mailer/SyliusMailerEvents.php
+++ b/src/Sylius/Component/Mailer/SyliusMailerEvents.php
@@ -18,7 +18,7 @@ namespace Sylius\Component\Mailer;
  */
 class SyliusMailerEvents
 {
-    const EMAIL_PRE_RENDER = 'sylius.email_rendered';
-    const EMAIL_PRE_SEND = 'sylius.email_send.pre_send';
-    const EMAIL_POST_SEND = 'sylius.email_send.post_send';
+    public const EMAIL_PRE_RENDER = 'sylius.email_rendered';
+    public const EMAIL_PRE_SEND = 'sylius.email_send.pre_send';
+    public const EMAIL_POST_SEND = 'sylius.email_send.post_send';
 }

--- a/src/Sylius/Component/Order/CartActions.php
+++ b/src/Sylius/Component/Order/CartActions.php
@@ -18,8 +18,8 @@ namespace Sylius\Component\Order;
  */
 final class CartActions
 {
-    const ADD = 'add';
-    const REMOVE = 'remove';
+    public const ADD = 'add';
+    public const REMOVE = 'remove';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Order/Model/OrderInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderInterface.php
@@ -22,10 +22,10 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  */
 interface OrderInterface extends AdjustableInterface, ResourceInterface, TimestampableInterface
 {
-    const STATE_CART = 'cart';
-    const STATE_NEW = 'new';
-    const STATE_CANCELLED = 'cancelled';
-    const STATE_FULFILLED = 'fulfilled';
+    public const STATE_CART = 'cart';
+    public const STATE_NEW = 'new';
+    public const STATE_CANCELLED = 'cancelled';
+    public const STATE_FULFILLED = 'fulfilled';
 
     /**
      * @return \DateTime

--- a/src/Sylius/Component/Order/OrderTransitions.php
+++ b/src/Sylius/Component/Order/OrderTransitions.php
@@ -15,11 +15,11 @@ namespace Sylius\Component\Order;
 
 final class OrderTransitions
 {
-    const GRAPH = 'sylius_order';
+    public const GRAPH = 'sylius_order';
 
-    const TRANSITION_CREATE = 'create';
-    const TRANSITION_CANCEL = 'cancel';
-    const TRANSITION_FULFILL = 'fulfill';
+    public const TRANSITION_CREATE = 'create';
+    public const TRANSITION_CANCEL = 'cancel';
+    public const TRANSITION_FULFILL = 'fulfill';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Order/SyliusCartEvents.php
+++ b/src/Sylius/Component/Order/SyliusCartEvents.php
@@ -15,7 +15,7 @@ namespace Sylius\Component\Order;
 
 final class SyliusCartEvents
 {
-    const CART_CHANGE = 'sylius.cart_change';
+    public const CART_CHANGE = 'sylius.cart_change';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Payment/Model/PaymentInterface.php
+++ b/src/Sylius/Component/Payment/Model/PaymentInterface.php
@@ -21,14 +21,14 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  */
 interface PaymentInterface extends TimestampableInterface, ResourceInterface
 {
-    const STATE_CART = 'cart';
-    const STATE_NEW = 'new';
-    const STATE_PROCESSING = 'processing';
-    const STATE_COMPLETED = 'completed';
-    const STATE_FAILED = 'failed';
-    const STATE_CANCELLED = 'cancelled';
-    const STATE_REFUNDED = 'refunded';
-    const STATE_UNKNOWN = 'unknown';
+    public const STATE_CART = 'cart';
+    public const STATE_NEW = 'new';
+    public const STATE_PROCESSING = 'processing';
+    public const STATE_COMPLETED = 'completed';
+    public const STATE_FAILED = 'failed';
+    public const STATE_CANCELLED = 'cancelled';
+    public const STATE_REFUNDED = 'refunded';
+    public const STATE_UNKNOWN = 'unknown';
 
     /**
      * @return PaymentMethodInterface

--- a/src/Sylius/Component/Payment/PaymentTransitions.php
+++ b/src/Sylius/Component/Payment/PaymentTransitions.php
@@ -18,15 +18,15 @@ namespace Sylius\Component\Payment;
  */
 final class PaymentTransitions
 {
-    const GRAPH = 'sylius_payment';
+    public const GRAPH = 'sylius_payment';
 
-    const TRANSITION_CREATE = 'create';
-    const TRANSITION_PROCESS = 'process';
-    const TRANSITION_COMPLETE = 'complete';
-    const TRANSITION_FAIL = 'fail';
-    const TRANSITION_CANCEL = 'cancel';
-    const TRANSITION_REFUND = 'refund';
-    const TRANSITION_VOID = 'void';
+    public const TRANSITION_CREATE = 'create';
+    public const TRANSITION_PROCESS = 'process';
+    public const TRANSITION_COMPLETE = 'complete';
+    public const TRANSITION_FAIL = 'fail';
+    public const TRANSITION_CANCEL = 'cancel';
+    public const TRANSITION_REFUND = 'refund';
+    public const TRANSITION_VOID = 'void';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Promotion/Checker/Rule/CartQuantityRuleChecker.php
+++ b/src/Sylius/Component/Promotion/Checker/Rule/CartQuantityRuleChecker.php
@@ -21,7 +21,7 @@ use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
  */
 final class CartQuantityRuleChecker implements RuleCheckerInterface
 {
-    const TYPE = 'cart_quantity';
+    public const TYPE = 'cart_quantity';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Promotion/Checker/Rule/ItemTotalRuleChecker.php
+++ b/src/Sylius/Component/Promotion/Checker/Rule/ItemTotalRuleChecker.php
@@ -20,7 +20,7 @@ use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
  */
 final class ItemTotalRuleChecker implements RuleCheckerInterface
 {
-    const TYPE = 'item_total';
+    public const TYPE = 'item_total';
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Component/Resource/Repository/RepositoryInterface.php
+++ b/src/Sylius/Component/Resource/Repository/RepositoryInterface.php
@@ -22,8 +22,8 @@ use Sylius\Component\Resource\Model\ResourceInterface;
  */
 interface RepositoryInterface extends ObjectRepository
 {
-    const ORDER_ASCENDING = 'ASC';
-    const ORDER_DESCENDING = 'DESC';
+    public const ORDER_ASCENDING = 'ASC';
+    public const ORDER_DESCENDING = 'DESC';
 
     /**
      * @param array $criteria

--- a/src/Sylius/Component/Resource/ResourceActions.php
+++ b/src/Sylius/Component/Resource/ResourceActions.php
@@ -18,11 +18,11 @@ namespace Sylius\Component\Resource;
  */
 final class ResourceActions
 {
-    const SHOW = 'show';
-    const INDEX = 'index';
-    const CREATE = 'create';
-    const UPDATE = 'update';
-    const DELETE = 'delete';
+    public const SHOW = 'show';
+    public const INDEX = 'index';
+    public const CREATE = 'create';
+    public const UPDATE = 'update';
+    public const DELETE = 'delete';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Review/Model/ReviewInterface.php
+++ b/src/Sylius/Component/Review/Model/ReviewInterface.php
@@ -22,9 +22,9 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  */
 interface ReviewInterface extends TimestampableInterface, ResourceInterface
 {
-    const STATUS_NEW = 'new';
-    const STATUS_ACCEPTED = 'accepted';
-    const STATUS_REJECTED = 'rejected';
+    public const STATUS_NEW = 'new';
+    public const STATUS_ACCEPTED = 'accepted';
+    public const STATUS_REJECTED = 'rejected';
 
     /**
      * @return string

--- a/src/Sylius/Component/Shipping/Calculator/DefaultCalculators.php
+++ b/src/Sylius/Component/Shipping/Calculator/DefaultCalculators.php
@@ -21,12 +21,12 @@ final class DefaultCalculators
     /**
      * Flat rate per shipment calculator.
      */
-    const FLAT_RATE = 'flat_rate';
+    public const FLAT_RATE = 'flat_rate';
 
     /**
      * Fixed price per unit calculator.
      */
-    const PER_UNIT_RATE = 'per_unit_rate';
+    public const PER_UNIT_RATE = 'per_unit_rate';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Shipping/Model/ShipmentInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShipmentInterface.php
@@ -22,10 +22,10 @@ use Sylius\Component\Resource\Model\TimestampableInterface;
  */
 interface ShipmentInterface extends ResourceInterface, ShippingSubjectInterface, TimestampableInterface
 {
-    const STATE_CART = 'cart';
-    const STATE_READY = 'ready';
-    const STATE_SHIPPED = 'shipped';
-    const STATE_CANCELLED = 'cancelled';
+    public const STATE_CART = 'cart';
+    public const STATE_READY = 'ready';
+    public const STATE_SHIPPED = 'shipped';
+    public const STATE_CANCELLED = 'cancelled';
 
     /**
      * @return string

--- a/src/Sylius/Component/Shipping/Model/ShippingMethodInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethodInterface.php
@@ -31,9 +31,9 @@ interface ShippingMethodInterface extends
     ToggleableInterface,
     TranslatableInterface
 {
-    const CATEGORY_REQUIREMENT_MATCH_NONE = 0;
-    const CATEGORY_REQUIREMENT_MATCH_ANY = 1;
-    const CATEGORY_REQUIREMENT_MATCH_ALL = 2;
+    public const CATEGORY_REQUIREMENT_MATCH_NONE = 0;
+    public const CATEGORY_REQUIREMENT_MATCH_ANY = 1;
+    public const CATEGORY_REQUIREMENT_MATCH_ALL = 2;
 
     /**
      * @return int

--- a/src/Sylius/Component/Shipping/ShipmentTransitions.php
+++ b/src/Sylius/Component/Shipping/ShipmentTransitions.php
@@ -18,11 +18,11 @@ namespace Sylius\Component\Shipping;
  */
 final class ShipmentTransitions
 {
-    const GRAPH = 'sylius_shipment';
+    public const GRAPH = 'sylius_shipment';
 
-    const TRANSITION_CREATE = 'create';
-    const TRANSITION_SHIP = 'ship';
-    const TRANSITION_CANCEL = 'cancel';
+    public const TRANSITION_CREATE = 'create';
+    public const TRANSITION_SHIP = 'ship';
+    public const TRANSITION_CANCEL = 'cancel';
 
     private function __construct()
     {

--- a/src/Sylius/Component/Shipping/ShipmentUnitTransitions.php
+++ b/src/Sylius/Component/Shipping/ShipmentUnitTransitions.php
@@ -15,9 +15,9 @@ namespace Sylius\Component\Shipping;
 
 class ShipmentUnitTransitions
 {
-    const GRAPH = 'sylius_shipment_unit';
+    public const GRAPH = 'sylius_shipment_unit';
 
-    const SYLIUS_CREATE = 'create';
-    const SYLIUS_SHIP = 'ship';
-    const SYLIUS_CANCEL = 'cancel';
+    public const SYLIUS_CREATE = 'create';
+    public const SYLIUS_SHIP = 'ship';
+    public const SYLIUS_CANCEL = 'cancel';
 }

--- a/src/Sylius/Component/User/Model/UserInterface.php
+++ b/src/Sylius/Component/User/Model/UserInterface.php
@@ -32,7 +32,7 @@ interface UserInterface extends
     TimestampableInterface,
     ToggleableInterface
 {
-    const DEFAULT_ROLE = 'ROLE_USER';
+    public const DEFAULT_ROLE = 'ROLE_USER';
 
     /**
      * @return string

--- a/src/Sylius/Component/User/Security/UserPbkdf2PasswordEncoder.php
+++ b/src/Sylius/Component/User/Security/UserPbkdf2PasswordEncoder.php
@@ -32,7 +32,7 @@ use Webmozart\Assert\Assert;
  */
 final class UserPbkdf2PasswordEncoder implements UserPasswordEncoderInterface
 {
-    const MAX_PASSWORD_LENGTH = 4096;
+    public const MAX_PASSWORD_LENGTH = 4096;
 
     /**
      * @var string


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | |
| License         | MIT |

Since php7.1 we are allowed to declare visibility of constants. Since all of them are public right now I suggest making it explicit and coherent with the regular variables. 