### PR TITLE
Check for input minimum length on customer existence check in checkout

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/app.js
@@ -31,8 +31,14 @@
             throttle: 1500,
 
             beforeSend: function (settings) {
+                var email = $('#sylius_checkout_address_customer_email').val();
+
+                if (email.length < 3) {
+                    return false;
+                }
+
                 settings.data = {
-                    email: $('#sylius_checkout_address_customer_email').val()
+                    email: email
                 };
 
                 return settings;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no|
| BC breaks?      | no|
| License         | MIT |

Based on Customer validation an email should be between 2 - 254 characters. I noticed in my 404 logs that sometimes this request is fired without any information in it (empty). That will for sure return no valid customer and it's ineffecient.

Based on https://semantic-ui.com/behaviors/api.html#/usage ('Cancelling requests') this adjustment should prohibit this call when nothing (or something too long) is entered. It could be extended to check for email validatity, but that's always an hard issue. 