### PR TITLE
Update _details.html.twig

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/_details.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/_details.html.twig
@@ -2,7 +2,7 @@
     {{ sonata_block_render_event('sylius.shop.product.show.tab_details', {'product': product}) }}
 
     {% if product.description is not empty %}
-        {{ product.description }}
+        {{ product.description | nl2br }}
     {% else %}
         {{ 'sylius.ui.no_description'|trans }}.
     {% endif %}


### PR DESCRIPTION
convert newlines in product description to breaklines.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #8338 |
| License         | MIT |
