### PR TITLE
[Shipment] Shipment amount was not updated after decreasing item quantity

### DIFF
--- a/features/shipping/applying_shipping_fee/applying_correct_shipping_fee_on_order.feature
+++ b/features/shipping/applying_shipping_fee/applying_correct_shipping_fee_on_order.feature
@@ -9,6 +9,7 @@ Feature: Apply correct shipping fee on order
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And the store has "DHL" shipping method with "$10.00" fee
         And the store has "FedEx" shipping method with "$30.00" fee
+        And the store has "UPS" shipping method with "$5.00" fee per unit for "United States" channel
         And I am a logged in customer
 
     @ui
@@ -25,3 +26,11 @@ Feature: Apply correct shipping fee on order
         When I change shipping method to "FedEx"
         Then my cart total should be "$130.00"
         And my cart shipping total should be "$30.00"
+
+    @ui
+    Scenario: Changing per unit shipping fee after decreasing quantity of item
+        Given I have 2 products "PHP T-Shirt" in the cart
+        And I chose "UPS" shipping method
+        When I change "PHP T-Shirt" quantity to 1
+        Then my cart total should be "$105.00"
+        And my cart shipping total should be "$5.00"

--- a/src/Sylius/Behat/Context/Setup/ShippingContext.php
+++ b/src/Sylius/Behat/Context/Setup/ShippingContext.php
@@ -276,18 +276,26 @@ final class ShippingContext implements Context
     }
 
     /**
+     * @Given /^the store has "([^"]+)" shipping method with ("[^"]+") fee per unit for ("[^"]+" channel)$/
      * @Given /^the store has "([^"]+)" shipping method with ("[^"]+") fee per unit for ("[^"]+" channel) and ("[^"]+") for ("[^"]+" channel)$/
      */
     public function storeHasShippingMethodWithFeePerUnitForChannels(
         $shippingMethodName,
         $firstFee,
         ChannelInterface $firstChannel,
-        $secondFee,
-        ChannelInterface $secondChannel
+        $secondFee = null,
+        ChannelInterface $secondChannel = null
     ) {
         $configuration = [];
+        $channels = [];
+
         $configuration[$firstChannel->getCode()] = ['amount' => $firstFee];
-        $configuration[$secondChannel->getCode()] = ['amount' => $secondFee];
+        $channels[] = $firstChannel;
+
+        if (null !== $secondFee) {
+            $configuration[$secondChannel->getCode()] = ['amount' => $secondFee];
+            $channels[] = $secondChannel;
+        }
 
         $this->saveShippingMethod($this->shippingMethodExampleFactory->create([
             'name' => $shippingMethodName,
@@ -297,7 +305,7 @@ final class ShippingContext implements Context
                 'type' => DefaultCalculators::PER_UNIT_RATE,
                 'configuration' => $configuration,
             ],
-            'channels' => [$firstChannel, $secondChannel],
+            'channels' => $channels,
         ]));
     }
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_fee.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/shipping/applying_shipping_fee.yml
@@ -7,12 +7,13 @@ default:
             contexts_services:
                 - sylius.behat.context.hook.doctrine_orm
 
+                - sylius.behat.context.transform.channel
                 - sylius.behat.context.transform.country
-                - sylius.behat.context.transform.zone
                 - sylius.behat.context.transform.lexical
                 - sylius.behat.context.transform.product
-                - sylius.behat.context.transform.tax_category
                 - sylius.behat.context.transform.shipping_method
+                - sylius.behat.context.transform.tax_category
+                - sylius.behat.context.transform.zone
 
                 - sylius.behat.context.transform.shared_storage
 

--- a/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
@@ -69,6 +69,10 @@ final class OrderShipmentProcessor implements OrderProcessorInterface
             return;
         }
 
+        foreach ($shipment->getUnits() as $unit) {
+            $shipment->removeUnit($unit);
+        }
+
         foreach ($order->getItemUnits() as $itemUnit) {
             if (null === $itemUnit->getShipment()) {
                 $shipment->addUnit($itemUnit);

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentProcessorSpec.php
@@ -65,6 +65,8 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
 
         $shipment->setOrder($order)->shouldBeCalled();
         $shipment->setMethod($defaultShippingMethod)->shouldBeCalled();
+
+        $shipment->getUnits()->willReturn([]);
         $shipment->addUnit($itemUnit1)->shouldBeCalled();
         $shipment->addUnit($itemUnit2)->shouldBeCalled();
 
@@ -88,6 +90,32 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         $order->getShipments()->willReturn($shipments);
 
         $itemUnit->getShipment()->willReturn($shipment);
+
+        $shipment->getUnits()->willReturn([]);
+        $shipment->addUnit($itemUnitWithoutShipment)->shouldBeCalled();
+        $shipment->addUnit($itemUnit)->shouldNotBeCalled();
+
+        $this->process($order);
+    }
+
+    function it_removes_units_before_adding_new_ones(
+        OrderInterface $order,
+        ShipmentInterface $shipment,
+        Collection $shipments,
+        OrderItemUnitInterface $itemUnit,
+        OrderItemUnitInterface $itemUnitWithoutShipment
+    ) {
+        $shipments->first()->willReturn($shipment);
+
+        $order->isEmpty()->willReturn(false);
+        $order->hasShipments()->willReturn(true);
+        $order->getItemUnits()->willReturn([$itemUnit, $itemUnitWithoutShipment]);
+        $order->getShipments()->willReturn($shipments);
+
+        $itemUnit->getShipment()->willReturn($shipment);
+
+        $shipment->getUnits()->willReturn([$itemUnit]);
+        $shipment->removeUnit($itemUnit)->shouldBeCalled();
 
         $shipment->addUnit($itemUnitWithoutShipment)->shouldBeCalled();
         $shipment->addUnit($itemUnit)->shouldNotBeCalled();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | |
| License         | MIT |

Steps to reproduce:

1. Create shipping method with `per_unit_rate` calculator
2. Add some product to cart with quantity bigger than 1
3. Go to checkout and select shipping method created in *1.*
4. Go back to cart an decrease quantity of added order item
5. Cry a lot, as shipping fee is as big as it was before.

This is just a hotfix, to be 100% that proper units are added for the only one shipment. We should definitely think about some more sophisticated solution.