### PR TITLE
[Locale] get translation for country name

### DIFF
--- a/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
@@ -51,6 +51,7 @@
 
         <service id="sylius.templating.helper.locale" class="Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelper">
             <argument type="service" id="sylius.locale_converter" />
+            <argument>%sylius_locale.locale%</argument>
             <tag name="templating.helper" alias="sylius_locale" />
         </service>
 

--- a/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
+++ b/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
@@ -27,19 +27,30 @@ final class LocaleHelper extends Helper implements LocaleHelperInterface
     private $localeConverter;
 
     /**
-     * @param LocaleConverterInterface $localeConverter
+     * @var string
      */
-    public function __construct(LocaleConverterInterface $localeConverter)
+    private $defaultLocale;
+
+    /**
+     * @param LocaleConverterInterface $localeConverter
+     * @param string $defaultLocale
+     */
+    public function __construct(LocaleConverterInterface $localeConverter, string $defaultLocale)
     {
         $this->localeConverter = $localeConverter;
+        $this->defaultLocale = $defaultLocale;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function convertCodeToName(string $localeCode): ?string
+    public function convertCodeToName(string $localeCode, ?string $locale = null): ?string
     {
-        return $this->localeConverter->convertCodeToName($localeCode);
+        if (null === $locale) {
+            $locale = $this->defaultLocale;
+        }
+
+        return $this->localeConverter->convertCodeToName($localeCode, $locale);
     }
 
     /**

--- a/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelperInterface.php
+++ b/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelperInterface.php
@@ -22,8 +22,9 @@ interface LocaleHelperInterface extends HelperInterface
 {
     /**
      * @param string $localeCode
+     * @param string $locale
      *
      * @return string|null
      */
-    public function convertCodeToName(string $localeCode): ?string;
+    public function convertCodeToName(string $localeCode, ?string $locale): ?string;
 }

--- a/src/Sylius/Bundle/LocaleBundle/spec/Templating/Helper/LocaleHelperSpec.php
+++ b/src/Sylius/Bundle/LocaleBundle/spec/Templating/Helper/LocaleHelperSpec.php
@@ -25,7 +25,7 @@ final class LocaleHelperSpec extends ObjectBehavior
 {
     function let(LocaleConverterInterface $localeConverter): void
     {
-        $this->beConstructedWith($localeConverter);
+        $this->beConstructedWith($localeConverter, 'en');
     }
 
     function it_is_a_helper(): void
@@ -38,11 +38,18 @@ final class LocaleHelperSpec extends ObjectBehavior
         $this->shouldImplement(LocaleHelperInterface::class);
     }
 
-    function it_converts_locales_code_to_name(LocaleConverterInterface $localeConverter): void
+    function it_converts_locales_code_to_name_with_default_locale(LocaleConverterInterface $localeConverter): void
     {
-        $localeConverter->convertCodeToName('fr_FR')->willReturn('French (France)');
+        $localeConverter->convertCodeToName('fr_FR', 'en')->willReturn('French (France)');
 
         $this->convertCodeToName('fr_FR')->shouldReturn('French (France)');
+    }
+
+    function it_converts_locales_code_to_name_with_provided_locale(LocaleConverterInterface $localeConverter): void
+    {
+        $localeConverter->convertCodeToName('fr_FR', 'en')->willReturn('French (France)');
+
+        $this->convertCodeToName('fr_FR', 'en')->shouldReturn('French (France)');
     }
 
     function it_has_a_name(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

I added a second argument $local in LocalHelper, just like in the LocalConverter, in order to get the country name translated. So the twig filter would now look like:

`{{ locale|sylius_locale_name(app.request.locale) }}`

