### PR TITLE
[Resource] Allows to set redirect parameters when using sylius.resource and a custom criteria

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfiguration.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfiguration.php
@@ -250,9 +250,31 @@ class RequestConfiguration
         }
 
         $parameters = isset($redirect['parameters']) ? $redirect['parameters'] : [];
+        $parameters = $this->addExtraRedirectParameters($parameters);
 
         if (null !== $resource) {
             $parameters = $this->parseResourceValues($parameters, $resource);
+        }
+
+        return $parameters;
+    }
+
+    /**
+     * @param array $parameters
+     *
+     * @return array
+     */
+    private function addExtraRedirectParameters($parameters)
+    {
+        $vars = $this->getVars();
+        $accessor = PropertyAccess::createPropertyAccessor();
+
+        if ($accessor->isReadable($vars, '[redirect][parameters]')) {
+            $extraParameters = $accessor->getValue($vars, '[redirect][parameters]');
+
+            if (is_array($extraParameters)) {
+                $parameters = array_merge($parameters, $extraParameters);
+            }
         }
 
         return $parameters;

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationSpec.php
@@ -193,6 +193,9 @@ final class RequestConfigurationSpec extends ObjectBehavior
 
     function it_returns_array_as_redirect_parameters(Parameters $parameters)
     {
+        $parameters->get('vars', [])->willReturn([]);
+        $this->getVars()->shouldReturn([]);
+
         $parameters->get('redirect')->willReturn(null);
         $this->getRedirectParameters()->shouldReturn([]);
 
@@ -206,8 +209,19 @@ final class RequestConfigurationSpec extends ObjectBehavior
         $this->getRedirectParameters()->shouldReturn(['myParameter']);
 
         $parameters->get('redirect')->willReturn(['parameters' => ['myParameter']]);
-
         $this->getRedirectParameters('resource')->shouldReturn(['myParameter']);
+
+        $invalidExtraParameters = ['redirect' => ['parameters' => 'myValue']];
+        $parameters->get('vars', [])->willReturn($invalidExtraParameters);
+        $this->getVars()->shouldReturn($invalidExtraParameters);
+        $parameters->get('redirect')->willReturn(['parameters' => ['myParameter']]);
+        $this->getRedirectParameters('resource')->shouldReturn(['myParameter']);
+
+        $validExtraParameters = ['redirect' => ['parameters' => ['myExtraParameter']]];
+        $parameters->get('vars', [])->willReturn($validExtraParameters);
+        $this->getVars()->shouldReturn($validExtraParameters);
+        $parameters->get('redirect')->willReturn(['parameters' => ['myParameter']]);
+        $this->getRedirectParameters('resource')->shouldReturn(['myParameter', 'myExtraParameter']);
     }
 
     function it_checks_if_limit_is_enabled(Parameters $parameters)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | #8382 |
| License         | MIT |

This PR allows to set redirect parameters when using sylius.resource and a custom criteria. For example:

```
app_document:
    prefix: /customers/{customerId}/
    resource: |
        alias: app.document
        section: ...
        templates: ...
        redirect: index
        grid: app_document
        form:
            type: ...
        criteria:
            customer: $customerId
        vars:
            all:
                redirect:
                    parameters:
                        customerId: $customerId
    type: sylius.resource
```
