### PR TITLE
Moved the shipping required check to the order model itself

### DIFF
--- a/src/Sylius/Component/Core/Checker/OrderShippingMethodSelectionRequirementChecker.php
+++ b/src/Sylius/Component/Core/Checker/OrderShippingMethodSelectionRequirementChecker.php
@@ -41,7 +41,7 @@ final class OrderShippingMethodSelectionRequirementChecker implements OrderShipp
      */
     public function isShippingMethodSelectionRequired(OrderInterface $order)
     {
-        if (!$this->ifItemsRequireShipping($order)) {
+        if (!$order->requiresShipping()) {
             return false;
         }
 
@@ -56,23 +56,6 @@ final class OrderShippingMethodSelectionRequirementChecker implements OrderShipp
         /** @var ShipmentInterface $shipment */
         foreach ($order->getShipments() as $shipment) {
             if (1 !== count($this->shippingMethodsResolver->getSupportedMethods($shipment))) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @param OrderInterface $order
-     *
-     * @return bool
-     */
-    private function ifItemsRequireShipping(OrderInterface $order)
-    {
-        /** @var OrderItemInterface $orderItem */
-        foreach ($order->getItems() as $orderItem) {
-            if ($orderItem->getVariant()->isShippingRequired()) {
                 return true;
             }
         }

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -318,6 +318,20 @@ class Order extends BaseOrder implements OrderInterface
     }
 
     /**
+     * @return bool
+     */
+    public function requiresShipping()
+    {
+        foreach ($this->getItems() as $orderItem) {
+            if ($orderItem->getVariant()->isShippingRequired()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getShipments()

--- a/src/Sylius/Component/Core/Model/OrderInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderInterface.php
@@ -92,6 +92,11 @@ interface OrderInterface extends
     public function getItemUnitsByVariant(ProductVariantInterface $variant);
 
     /**
+     * @return bool
+     */
+    public function requiresShipping();
+
+    /**
      * @return Collection|ShipmentInterface[]
      */
     public function getShipments();

--- a/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
@@ -57,7 +57,7 @@ final class OrderShipmentProcessor implements OrderProcessorInterface
         /** @var OrderInterface $order */
         Assert::isInstanceOf($order, OrderInterface::class);
 
-        if ($order->isEmpty() || !$this->ifItemsRequireShipping($order)) {
+        if ($order->isEmpty() || !$order->requiresShipping()) {
             $order->removeShipments();
 
             return;
@@ -103,21 +103,5 @@ final class OrderShipmentProcessor implements OrderProcessorInterface
         } catch (UnresolvedDefaultShippingMethodException $exception) {
             return null;
         }
-    }
-
-    /**
-     * @param OrderInterface $order
-     *
-     * @return bool
-     */
-    private function ifItemsRequireShipping(OrderInterface $order)
-    {
-        foreach ($order->getItems() as $orderItem) {
-            if ($orderItem->getVariant()->isShippingRequired()) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/Sylius/Component/Core/spec/Checker/OrderShippingMethodSelectionRequirementCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Checker/OrderShippingMethodSelectionRequirementCheckerSpec.php
@@ -45,21 +45,9 @@ final class OrderShippingMethodSelectionRequirementCheckerSpec extends ObjectBeh
     }
 
     function it_says_that_shipping_method_do_not_have_to_be_selected_if_none_of_variants_from_order_requires_shipping(
-        OrderInterface $order,
-        OrderItemInterface $firstItem,
-        OrderItemInterface $secondItem,
-        ProductVariantInterface $firstProductVariant,
-        ProductVariantInterface $secondProductVariant
+        OrderInterface $order
     ) {
-        $order->getItems()->willReturn([$firstItem, $secondItem]);
-
-        $firstItem->getVariant()->willReturn($firstProductVariant);
-        $secondItem->getVariant()->willReturn($secondProductVariant);
-
-        $firstProductVariant->isShippingRequired()->willReturn(false);
-        $secondProductVariant->isShippingRequired()->willReturn(false);
-
-        $order->hasShipments()->willReturn(false);
+        $order->requiresShipping()->willReturn(false);
 
         $this->isShippingMethodSelectionRequired($order)->shouldReturn(false);
     }
@@ -67,23 +55,13 @@ final class OrderShippingMethodSelectionRequirementCheckerSpec extends ObjectBeh
     function it_says_that_shipping_method_do_not_have_to_be_selected_if_order_variants_require_shipping_but_there_is_only_one_shipping_method_available(
         ChannelInterface $channel,
         OrderInterface $order,
-        OrderItemInterface $firstItem,
-        OrderItemInterface $secondItem,
-        ProductVariantInterface $firstProductVariant,
-        ProductVariantInterface $secondProductVariant,
         ShipmentInterface $shipment,
         ShippingMethodInterface $shippingMethod,
         ShippingMethodsResolverInterface $shippingMethodsResolver
     ) {
-        $order->getItems()->willReturn([$firstItem, $secondItem]);
-
-        $firstItem->getVariant()->willReturn($firstProductVariant);
-        $secondItem->getVariant()->willReturn($secondProductVariant);
-
-        $firstProductVariant->isShippingRequired()->willReturn(false);
-        $secondProductVariant->isShippingRequired()->willReturn(true);
-
         $order->hasShipments()->willReturn(true);
+
+        $order->requiresShipping()->willReturn(true);
 
         $order->getChannel()->willReturn($channel);
         $channel->isSkippingShippingStepAllowed()->willReturn(true);
@@ -92,23 +70,14 @@ final class OrderShippingMethodSelectionRequirementCheckerSpec extends ObjectBeh
 
         $shippingMethodsResolver->getSupportedMethods($shipment)->willReturn([$shippingMethod]);
 
+
         $this->isShippingMethodSelectionRequired($order)->shouldReturn(false);
     }
 
     function it_says_that_shipping_method_have_to_be_selected_if_order_variants_require_shipping_and_order_has_not_shipments_yet(
-        OrderInterface $order,
-        OrderItemInterface $firstItem,
-        OrderItemInterface $secondItem,
-        ProductVariantInterface $firstProductVariant,
-        ProductVariantInterface $secondProductVariant
+        OrderInterface $order
     ) {
-        $order->getItems()->willReturn([$firstItem, $secondItem]);
-
-        $firstItem->getVariant()->willReturn($firstProductVariant);
-        $secondItem->getVariant()->willReturn($secondProductVariant);
-
-        $firstProductVariant->isShippingRequired()->willReturn(false);
-        $secondProductVariant->isShippingRequired()->willReturn(true);
+        $order->requiresShipping()->willReturn(true);
 
         $order->hasShipments()->willReturn(false);
 
@@ -117,19 +86,9 @@ final class OrderShippingMethodSelectionRequirementCheckerSpec extends ObjectBeh
 
     function it_says_that_shipping_method_have_to_be_selected_if_order_variants_require_shipping_and_channel_does_not_allow_to_skip_shipping_step(
         ChannelInterface $channel,
-        OrderInterface $order,
-        OrderItemInterface $firstItem,
-        OrderItemInterface $secondItem,
-        ProductVariantInterface $firstProductVariant,
-        ProductVariantInterface $secondProductVariant
+        OrderInterface $order
     ) {
-        $order->getItems()->willReturn([$firstItem, $secondItem]);
-
-        $firstItem->getVariant()->willReturn($firstProductVariant);
-        $secondItem->getVariant()->willReturn($secondProductVariant);
-
-        $firstProductVariant->isShippingRequired()->willReturn(false);
-        $secondProductVariant->isShippingRequired()->willReturn(true);
+        $order->requiresShipping()->willReturn(true);
 
         $order->hasShipments()->willReturn(true);
 
@@ -142,22 +101,12 @@ final class OrderShippingMethodSelectionRequirementCheckerSpec extends ObjectBeh
     function it_says_that_shipping_method_have_to_be_selected_if_order_variants_require_shipping_and_there_is_more_than_one_shipping_method_available(
         ChannelInterface $channel,
         OrderInterface $order,
-        OrderItemInterface $firstItem,
-        OrderItemInterface $secondItem,
-        ProductVariantInterface $firstProductVariant,
-        ProductVariantInterface $secondProductVariant,
         ShipmentInterface $shipment,
         ShippingMethodInterface $firstShippingMethod,
         ShippingMethodInterface $secondShippingMethod,
         ShippingMethodsResolverInterface $shippingMethodsResolver
     ) {
-        $order->getItems()->willReturn([$firstItem, $secondItem]);
-
-        $firstItem->getVariant()->willReturn($firstProductVariant);
-        $secondItem->getVariant()->willReturn($secondProductVariant);
-
-        $firstProductVariant->isShippingRequired()->willReturn(false);
-        $secondProductVariant->isShippingRequired()->willReturn(true);
+        $order->requiresShipping()->willReturn(true);
 
         $order->hasShipments()->willReturn(true);
 

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderShipmentProcessorSpec.php
@@ -56,16 +56,13 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         OrderItemUnitInterface $itemUnit2,
         ShipmentInterface $shipment,
         ShippingMethodInterface $defaultShippingMethod,
-        OrderItemInterface $orderItem,
-        ProductVariantInterface $productVariant
+        OrderItemInterface $orderItem
     ) {
         $defaultShippingMethodResolver->getDefaultShippingMethod($shipment)->willReturn($defaultShippingMethod);
 
         $shipmentFactory->createNew()->willReturn($shipment);
 
-        $orderItem->getVariant()->willReturn($productVariant);
-
-        $productVariant->isShippingRequired()->willReturn(true);
+        $order->requiresShipping()->willReturn(true);
 
         $order->getItems()->willReturn([$orderItem]);
         $order->isEmpty()->willReturn(false);
@@ -97,7 +94,7 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
 
         $shipmentFactory->createNew()->willReturn($shipment);
 
-        $orderItem->getVariant()->willReturn($productVariant);
+        $order->requiresShipping()->willReturn(false);
 
         $productVariant->isShippingRequired()->willReturn(false);
 
@@ -123,7 +120,7 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
 
         $orderItem->getVariant()->willReturn($productVariant);
 
-        $productVariant->isShippingRequired()->willReturn(true);
+        $order->requiresShipping()->willReturn(true);
 
         $order->getItems()->willReturn([$orderItem]);
 
@@ -146,22 +143,16 @@ final class OrderShipmentProcessorSpec extends ObjectBehavior
         ShipmentInterface $shipment,
         Collection $shipments,
         OrderItemUnitInterface $itemUnit,
-        OrderItemUnitInterface $itemUnitWithoutShipment,
-        OrderItemInterface $orderItem,
-        ProductVariantInterface $productVariant
+        OrderItemUnitInterface $itemUnitWithoutShipment
     ) {
         $shipments->first()->willReturn($shipment);
+
+        $order->requiresShipping()->willReturn(true);
 
         $order->isEmpty()->willReturn(false);
         $order->hasShipments()->willReturn(true);
         $order->getItemUnits()->willReturn([$itemUnit, $itemUnitWithoutShipment]);
         $order->getShipments()->willReturn($shipments);
-
-        $productVariant->isShippingRequired()->willReturn(true);
-
-        $orderItem->getVariant()->willReturn($productVariant);
-
-        $order->getItems()->willReturn([$orderItem]);
 
         $itemUnit->getShipment()->willReturn($shipment);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | resolves #8380  |
| License         | MIT |

Hi,

As mentioned in #8380, I've moved the check for whether shipping is required onto the order model itself.

I've added it to the core `OrderInterface` since that's where the other shipping related method definitions exist, and also updated the PHPSpec tests to suit.

Let me know if there's any issues or anything I've missed!