### PR TITLE
Make AddressLogEntry entity extendable

### DIFF
--- a/src/Sylius/Component/Addressing/Model/AddressLogEntry.php
+++ b/src/Sylius/Component/Addressing/Model/AddressLogEntry.php
@@ -18,6 +18,6 @@ use Sylius\Component\Resource\Model\ResourceLogEntry;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-final class AddressLogEntry extends ResourceLogEntry
+class AddressLogEntry extends ResourceLogEntry
 {
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |

According to the [docs](https://doctrine-orm.readthedocs.io/projects/doctrine-orm/en/latest/tutorials/getting-started.html#what-are-entities):
> An entity class must not be final or contain final methods.