### PR TITLE
Remove min length validator from Customer Email (fixes #8363)

### DIFF
--- a/src/Sylius/Bundle/CustomerBundle/Resources/config/validation/Customer.xml
+++ b/src/Sylius/Bundle/CustomerBundle/Resources/config/validation/Customer.xml
@@ -60,8 +60,6 @@
                 </option>
             </constraint>
             <constraint name="Length">
-                <option name="min">2</option>
-                <option name="minMessage">sylius.customer.email.min</option>
                 <option name="max">254</option>
                 <option name="maxMessage">sylius.customer.email.max</option>
                 <option name="groups">

--- a/src/Sylius/Bundle/CustomerBundle/Resources/translations/validators.en.yml
+++ b/src/Sylius/Bundle/CustomerBundle/Resources/translations/validators.en.yml
@@ -13,7 +13,6 @@ sylius:
         email:
             already_used: This email is already used, please login or use forgotten password.
             max: Email must not be longer than {{ limit }} characters.
-            min: Email must be at least {{ limit }} characters long.
             not_blank: Please enter your email.
             invalid: This email is invalid.
             unique: This email is already used.


### PR DESCRIPTION
The email validator already checks for a minimum length.

| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #8363 |
| License         | MIT |
