### PR TITLE
Add event before / after product box on product listing

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/_box.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/_box.html.twig
@@ -1,5 +1,7 @@
 {% import "@SyliusShop/Common/Macro/money.html.twig" as money %}
 
+{{ sonata_block_render_event('sylius.shop.product.index.before_box', {'product': product}) }}
+
 <div class="ui fluid card">
     <a href="{{ path('sylius_shop_product_show', {'slug': product.slug, '_locale': product.translation.locale}) }}" class="blurring dimmable image">
         <div class="ui dimmer">
@@ -18,3 +20,5 @@
         {% endif %}
     </div>
 </div>
+
+{{ sonata_block_render_event('sylius.shop.product.index.after_box', {'product': product}) }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | yes |
| BC breaks?      | no|
| License         | MIT |

Add the ability to hook into a product listing before and after each product box.