### PR TITLE
Fix events on product listings, resources.data should be used

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_main.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_main.html.twig
@@ -1,18 +1,18 @@
 {% import '@SyliusUi/Macro/messages.html.twig' as messages %}
 {% import '@SyliusUi/Macro/pagination.html.twig' as pagination %}
 
-{{ sonata_block_render_event('sylius.shop.product.index.before_search', {'products': products}) }}
+{{ sonata_block_render_event('sylius.shop.product.index.before_search', {'products': resources.data}) }}
 
 {% include '@SyliusShop/Product/Index/_search.html.twig' %}
 
-{{ sonata_block_render_event('sylius.shop.product.index.after_search', {'products': products}) }}
+{{ sonata_block_render_event('sylius.shop.product.index.after_search', {'products': resources.data}) }}
 
 {% include '@SyliusShop/Product/Index/_pagination.html.twig' %}
 {% include '@SyliusShop/Product/Index/_sorting.html.twig' %}
 
 <div class="ui clearing hidden divider"></div>
 
-{{ sonata_block_render_event('sylius.shop.product.index.before_list', {'products': products}) }}
+{{ sonata_block_render_event('sylius.shop.product.index.before_list', {'products': resources.data}) }}
 
 {% if resources.data|length > 0 %}
     <div class="ui three column stackable grid" id="products">
@@ -24,7 +24,7 @@
     </div>
     <div class="ui hidden divider"></div>
 
-    {{ sonata_block_render_event('sylius.shop.product.index.before_pagination', {'products': products}) }}
+    {{ sonata_block_render_event('sylius.shop.product.index.before_pagination', {'products': resources.data}) }}
 
     {{ pagination.simple(resources.data) }}
 {% else %}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |

In the product list, the events get supplied a `products` var, which is empty. The products are actually in `resources.data`, which therefore should be supplied to the events.