### PR TITLE
Implement Twig_ExistsLoaderInterface to keep compatibility with Symfony's WebProfilerBundle (Fix #8392)

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Twig/ThemeFilesystemLoader.php
+++ b/src/Sylius/Bundle/ThemeBundle/Twig/ThemeFilesystemLoader.php
@@ -20,7 +20,7 @@ use Symfony\Component\Templating\TemplateReferenceInterface;
 /**
  * @author Kamil Kokot <kamil@kokot.me>
  */
-final class ThemeFilesystemLoader implements \Twig_LoaderInterface
+final class ThemeFilesystemLoader implements \Twig_LoaderInterface, \Twig_ExistsLoaderInterface
 {
     /**
      * @var \Twig_LoaderInterface


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #8392 |
| License         | MIT |

Since Symfony's WebProfilerBundle still requires implementing interfaces required in Twig 1.x, this adds back the implementation of `Twig_ExistsLoaderInterface` to the `ThemeFilesystemLoader` to satisfy the problematic class' requirements in the least disruptive way.