### PR TITLE
[Behat] Add a less strict alternative to SymfonyPage::verifyUrl

### DIFF
--- a/src/Sylius/Behat/Page/SymfonyPage.php
+++ b/src/Sylius/Behat/Page/SymfonyPage.php
@@ -87,6 +87,63 @@ abstract class SymfonyPage extends Page implements SymfonyPageInterface
     }
 
     /**
+     * @param array $requiredUrlParameters
+     * @throws UnexpectedPageException
+     */
+    protected function verifyRoute(array $requiredUrlParameters = [])
+    {
+        $url = $this->getDriver()->getCurrentUrl();
+        $path = parse_url($url)['path'];
+
+        $path = preg_replace('#^/app(_dev|_test|_test_cached)?\.php/#', '/', $path);
+        $matchedRoute = $this->router->match($path);
+
+        $this->verifyRouteName($matchedRoute, $url);
+        $this->verifyRouteParameters($requiredUrlParameters, $matchedRoute);
+    }
+
+
+    /**
+     * @param array $matchedRoute
+     * @param string $url
+     * @throws UnexpectedPageException
+     */
+    private function verifyRouteName(array $matchedRoute, string $url)
+    {
+        if ($matchedRoute['_route'] !== $this->getRouteName()) {
+            throw new UnexpectedPageException(
+                sprintf(
+                    "Matched route '%s' does not match the expected route '%s' for URL '%s'",
+                    $matchedRoute['_route'],
+                    $this->getRouteName(),
+                    $url
+                )
+            );
+        }
+    }
+
+    /**
+     * @param array $requiredUrlParameters
+     * @param array $matchedRoute
+     * @throws UnexpectedPageException
+     */
+    private function verifyRouteParameters(array $requiredUrlParameters, array $matchedRoute)
+    {
+        foreach ($requiredUrlParameters as $key => $value) {
+            if (!isset($matchedRoute[$key]) || $matchedRoute[$key] != $value) {
+                throw new UnexpectedPageException(
+                    sprintf(
+                        "Matched route does not match the expected parameter '%s'='%s' (%s found)",
+                        $key,
+                        $value,
+                        $matchedRoute[$key] ?? 'null'
+                    )
+                );
+            }
+        }
+    }
+
+    /**
      * @param NodeElement $modalContainer
      * @param string $appearClass
      *

--- a/src/Sylius/Behat/Page/SymfonyPage.php
+++ b/src/Sylius/Behat/Page/SymfonyPage.php
@@ -88,9 +88,10 @@ abstract class SymfonyPage extends Page implements SymfonyPageInterface
 
     /**
      * @param array $requiredUrlParameters
+     *
      * @throws UnexpectedPageException
      */
-    protected function verifyRoute(array $requiredUrlParameters = [])
+    public function verifyRoute(array $requiredUrlParameters = [])
     {
         $url = $this->getDriver()->getCurrentUrl();
         $path = parse_url($url)['path'];
@@ -106,6 +107,7 @@ abstract class SymfonyPage extends Page implements SymfonyPageInterface
     /**
      * @param array $matchedRoute
      * @param string $url
+     *
      * @throws UnexpectedPageException
      */
     private function verifyRouteName(array $matchedRoute, string $url)
@@ -125,12 +127,13 @@ abstract class SymfonyPage extends Page implements SymfonyPageInterface
     /**
      * @param array $requiredUrlParameters
      * @param array $matchedRoute
+     *
      * @throws UnexpectedPageException
      */
     private function verifyRouteParameters(array $requiredUrlParameters, array $matchedRoute)
     {
         foreach ($requiredUrlParameters as $key => $value) {
-            if (!isset($matchedRoute[$key]) || $matchedRoute[$key] != $value) {
+            if (!isset($matchedRoute[$key]) || $matchedRoute[$key] !== $value) {
                 throw new UnexpectedPageException(
                     sprintf(
                         "Matched route does not match the expected parameter '%s'='%s' (%s found)",

--- a/src/Sylius/Behat/Page/SymfonyPageInterface.php
+++ b/src/Sylius/Behat/Page/SymfonyPageInterface.php
@@ -22,4 +22,11 @@ interface SymfonyPageInterface extends PageInterface
      * @return string
      */
     public function getRouteName();
+
+    /**
+     * @param array $requiredUrlParameters
+     *
+     * @throws UnexpectedPageException
+     */
+    public function verifyRoute(array $requiredUrlParameters = []);
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

The problem at hand was that when verifying if the current url belongs to the page object it expects the URL to match perfectly, but in case of `CRUD/UpdatePage` this is not always desired, as it requires ID of the resource to be passed in order to generate the full expected URL. But in some cases the ID is not relevant and I would be happy for it to match any URL that is for an UpdatePage of my resource.

For this reason, I have added a new method `verifyRoute()` which will validate if the matched route has the same name as expected and validates any parameters that you explicitly provide (any other parameters that exist in the matched route but not provided by you will be ignored and accepted)

This means that if you wish to match an exact URL with exact parameters, you can still achieve that. But in case when you don't care for parameters, you can pass none and only route will be checked.

Feedback very welcome