### PR TITLE
Product Reviews does not exist on product

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/ProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ProductFixture.php
@@ -44,7 +44,6 @@ class ProductFixture extends AbstractResourceFixture
                 ->arrayNode('taxons')->prototype('scalar')->end()->end()
                 ->arrayNode('channels')->prototype('scalar')->end()->end()
                 ->arrayNode('product_attributes')->prototype('scalar')->end()->end()
-                ->arrayNode('product_reviews')->prototype('scalar')->end()->end()
                 ->arrayNode('product_options')->prototype('scalar')->end()->end()
                 ->arrayNode('images')->prototype('scalar')->end()->end()
                 ->booleanNode('shipping_required')->end()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #8403 |
| License         | MIT |


If you're generating products with the Sylius Fixtures Bundle you'll run into trouble with `product_reviews`. Sylius will let you know that they don't exist. Removing `product_reviews` as an option resolves the issue.
```[Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException]
  The option "product_reviews" does not exist. Defined options are: "channels", "code", "description", "enabled", "images", "main_taxon", "name", "product_attri
  butes", "product_options", "shipping_required", "short_description", "taxons", "variant_selection_method".```