### PR TITLE
Add events before and after taxon header

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_header.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_header.html.twig
@@ -1,6 +1,10 @@
 {% include '@SyliusShop/Taxon/_breadcrumb.html.twig' %}
 
+{{ sonata_block_render_event('sylius.shop.taxon.header.before', {'taxon': taxon}) }}
+
 <h1 class="ui monster section dividing header">
     {{ taxon.name }}
     <div class="sub header">{{ taxon.description }}</div>
 </h1>
+
+{{ sonata_block_render_event('sylius.shop.taxon.header.after', {'taxon': taxon}) }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | yes |
| BC breaks?      | yes |
| License         | MIT |

Can be used e.g. to add tracking based on Taxon name (e.g. Enhanced Ecommerce).