### PR TITLE
Adds locale bundle to list of bundles

### DIFF
--- a/docs/bundles/SyliusProductBundle/installation.rst
+++ b/docs/bundles/SyliusProductBundle/installation.rst
@@ -42,6 +42,7 @@ Don't worry, everything was automatically installed via Composer.
             new Sylius\Bundle\ProductBundle\SyliusProductBundle(),
             new Sylius\Bundle\AttributeBundle\SyliusAttributeBundle(),
             new Sylius\Bundle\ResourceBundle\SyliusResourceBundle(),
+            new Sylius\Bundle\LocaleBundle\SyliusLocaleBundle(),
 
             // Other bundles...
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),


### PR DESCRIPTION
It seems that the locale bundle is a dependency of the product bundle, and hence also needs to be registered with the kernel.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |
