### PR TITLE
Adds slug requirement for product creation

### DIFF
--- a/docs/book/products/products.rst
+++ b/docs/book/products/products.rst
@@ -24,12 +24,13 @@ Before we learn how to create products that can be sold, let's see how to create
      /** @var ProductInterface $product */
      $product = $productFactory->createNew();
 
-Creating an empty product is not enough to save it in the database. It needs to have a ``name`` and ``code``.
+Creating an empty product is not enough to save it in the database. It needs to have a ``name``, a ``code`` and a ``slug``.
 
 .. code-block:: php
 
      $product->setName('T-Shirt');
      $product->setCode('00001');
+     $product->setSlug('t-shirt');
 
      /** @var RepositoryInterface $productRepository */
      $productRepository = $this->get('sylius.repository.product');


### PR DESCRIPTION
When attempting to create product without setting the slug, I get an MySQL error saying that column slug can not be null. Setting the slug persists the product. Please ensure that my proposed change is valid.

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |
