### PR TITLE
Handle exceptions thrown while deleting a resource

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\ResourceBundle\Controller;
 use Doctrine\Common\Persistence\ObjectManager;
 use FOS\RestBundle\View\View;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
+use Sylius\Component\Resource\Exception\DeleteHandlingException;
 use Sylius\Component\Resource\Exception\UpdateHandlingException;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Resource\Metadata\MetadataInterface;
@@ -413,7 +414,23 @@ class ResourceController extends Controller
             return $this->redirectHandler->redirectToIndex($configuration, $resource);
         }
 
-        $this->repository->remove($resource);
+        try {
+            $this->repository->remove($resource);
+        } catch (\Exception $exception) {
+            $exception = new DeleteHandlingException('Ups, something went wrong, please try again.', 'something_went_wrong_error', 500, 0, $exception);
+
+            if (!$configuration->isHtmlRequest()) {
+                return $this->viewHandler->handle(
+                    $configuration,
+                    View::create(null, $exception->getApiResponseCode())
+                );
+            }
+
+            $this->flashHelper->addErrorFlash($configuration, $exception->getFlash());
+
+            return $this->redirectHandler->redirectToReferer($configuration);
+        }
+
         $this->eventDispatcher->dispatchPostEvent(ResourceActions::DELETE, $configuration, $resource);
 
         if (!$configuration->isHtmlRequest()) {

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
@@ -33,6 +33,7 @@ use Sylius\Bundle\ResourceBundle\Controller\SingleResourceProviderInterface;
 use Sylius\Bundle\ResourceBundle\Controller\StateMachineInterface;
 use Sylius\Bundle\ResourceBundle\Controller\ViewHandlerInterface;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
+use Sylius\Component\Resource\Exception\DeleteHandlingException;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Resource\Metadata\MetadataInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
@@ -1393,6 +1394,56 @@ final class ResourceControllerSpec extends ObjectBehavior
         $redirectHandler->redirectToIndex($configuration, $resource)->shouldNotBeCalled();
 
         $this->deleteAction($request)->shouldReturn($redirectResponse);
+    }
+
+    function it_does_not_correctly_delete_a_resource_and_returns_500_for_not_html_response(
+        MetadataInterface $metadata,
+        RequestConfigurationFactoryInterface $requestConfigurationFactory,
+        RequestConfiguration $configuration,
+        AuthorizationCheckerInterface $authorizationChecker,
+        ViewHandlerInterface $viewHandler,
+        RepositoryInterface $repository,
+        SingleResourceProviderInterface $singleResourceProvider,
+        ResourceInterface $resource,
+        EventDispatcherInterface $eventDispatcher,
+        CsrfTokenManagerInterface $csrfTokenManager,
+        ContainerInterface $container,
+        ResourceControllerEvent $event,
+        Request $request,
+        Response $response
+    ): void {
+        $metadata->getApplicationName()->willReturn('sylius');
+        $metadata->getName()->willReturn('product');
+
+        $requestConfigurationFactory->create($metadata, $request)->willReturn($configuration);
+        $configuration->hasPermission()->willReturn(true);
+        $configuration->getPermission(ResourceActions::DELETE)->willReturn('sylius.product.delete');
+        $request->request = new ParameterBag(['_csrf_token' => 'xyz']);
+
+        $container->has('security.csrf.token_manager')->willReturn(true);
+        $container->get('security.csrf.token_manager')->willReturn($csrfTokenManager);
+        $csrfTokenManager->isTokenValid(new CsrfToken(1, 'xyz'))->willReturn(true);
+
+        $authorizationChecker->isGranted($configuration, 'sylius.product.delete')->willReturn(true);
+        $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
+        $resource->getId()->willReturn(1);
+
+        $configuration->isHtmlRequest()->willReturn(false);
+        $configuration->isCsrfProtectionEnabled()->willReturn(true);
+
+        $eventDispatcher->dispatchPreEvent(ResourceActions::DELETE, $configuration, $resource)->willReturn($event);
+        $event->isStopped()->willReturn(false);
+
+        $repository->remove($resource)->shouldBeCalled();
+        $repository->remove($resource)->willThrow(new DeleteHandlingException());
+
+        $eventDispatcher->dispatchPostEvent(ResourceActions::DELETE, $configuration, $resource)->shouldNotBeCalled();
+
+        $expectedView = View::create(null, 500);
+
+        $viewHandler->handle($configuration, Argument::that($this->getViewComparingCallback($expectedView)))->willReturn($response);
+
+        $this->deleteAction($request)->shouldReturn($response);
     }
 
     function it_deletes_a_resource_and_returns_204_for_non_html_requests(

--- a/src/Sylius/Component/Resource/Exception/DeleteHandlingException.php
+++ b/src/Sylius/Component/Resource/Exception/DeleteHandlingException.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Resource\Exception;
+
+/**
+ * This exception is thrown when something goes wrong during the deletion of a
+ * resource.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+class DeleteHandlingException extends UpdateHandlingException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(
+        string $message = 'Ups, something went wrong, please try again.',
+        string $flash = 'something_went_wrong_error',
+        int $apiResponseCode = 500,
+        int $code = 0,
+        ?\Exception $previous = null
+    ) {
+        parent::__construct($message, $flash, $apiResponseCode, $code, $previous);
+    }
+}

--- a/src/Sylius/Component/Resource/spec/Exception/DeleteHandlingExceptionSpec.php
+++ b/src/Sylius/Component/Resource/spec/Exception/DeleteHandlingExceptionSpec.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Resource\Exception;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Resource\Exception\DeleteHandlingException;
+
+/**
+ * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
+ */
+final class DeleteHandlingExceptionSpec extends ObjectBehavior
+{
+    function it_extends_an_exception(): void
+    {
+        $this->shouldHaveType(\Exception::class);
+    }
+
+    function it_has_a_message(): void
+    {
+        $this->getMessage()->shouldReturn('Ups, something went wrong, please try again.');
+    }
+
+    function it_has_a_flash(): void
+    {
+        $this->getFlash()->shouldReturn('something_went_wrong_error');
+    }
+
+    function it_has_an_api_response_code(): void
+    {
+        $this->getApiResponseCode()->shouldReturn(500);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Related tickets | fixes #7948
| License         | MIT

The aim of this PR is to handle all exceptions that can be thrown during the deletion of a resource (think for example if a `ON DELETE` constraint fails). It would be great if we could introduce a `ResourceDeleteHandler` class to let users customize how they want to delete a resource, but it would introduce a BC break because it should be a new service injected in the constructor of the controller. Also, I think that the repository should not contain a `remove` method and instead we should follow the Doctrine way that uses the `EntityManager::delete` method.