### PR TITLE
Remove 'bulk actions' from GridBundle feature list

### DIFF
--- a/docs/bundles/SyliusGridBundle/index.rst
+++ b/docs/bundles/SyliusGridBundle/index.rst
@@ -9,7 +9,6 @@ Some of the features worth mentioning:
 * Supports different data sources: Doctrine ORM/ODM, native SQL query.
 * Rich filter functionality, easy to define your own filter type with flexible form
 * Each column type is configurable and you can create your own
-* Bulk actions
 * Automatic sorting
 
 .. toctree::


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | no|
| BC breaks?      | no|
| License         | MIT |

The GridBundle states it supports bulk actions on the feature overview. I'm quite sure it doesn't at the moment (although it would be a great feature to have). Probably better to remove it from the docs, as this shows up on the first Google result when searching for 'Sylius bulk action'.