### PR TITLE
[Documentation][Email] SenderInterface->send requires Array of Emails

### DIFF
--- a/docs/cookbook/custom-email.rst
+++ b/docs/cookbook/custom-email.rst
@@ -127,7 +127,7 @@ To achieve that you will need to:
                     continue;
                 }
                 foreach($admins as $admin) {
-                    $this->emailSender->send('out_of_stock', $admin->getEmail(), ['variant' => $variant]);
+                    $this->emailSender->send('out_of_stock', [$admin->getEmail()], ['variant' => $variant]);
                 }
             }
         }


### PR DESCRIPTION
The Senderinterface requires the email addresses as an Array. Bug in sample code

| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | none |
| License         | MIT |
