### PR TITLE
[Core] Removed WebServerBundle from prod env

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,22 @@
 
 * `\DateTimeInterface` is used for typehints instead of `\DateTime` to allow for compatibility with `\DateTimeImmutable`.
   Do not rely on mutable behaviour and set changes directly on the model.
+  
+* `WebServerBundle` which is used to run PHP's internal web server is no longer loaded in the production environment.
+   You can re-add the bundle if you need to by adding the following code to your AppKernel.php:
+  ```php
+  public function registerBundles()
+  {
+        // Other registrered bundles
+    
+	    if (in_array($this->getEnvironment(), ['prod']))
+        {
+            $bundles[] = new \Symfony\Bundle\WebServerBundle\WebServerBundle();
+        }
+
+        return array_merge(parent::registerBundles(), $bundles);
+  }
+  ```
 
 ## Packages:
 

--- a/src/Sylius/Bundle/CoreBundle/Application/Kernel.php
+++ b/src/Sylius/Bundle/CoreBundle/Application/Kernel.php
@@ -99,15 +99,15 @@ class Kernel extends HttpKernel
             new \Sylius\Bundle\ThemeBundle\SyliusThemeBundle(), // must be added after FrameworkBundle
         ];
 
-        // Symfony 3.3 moved server:* commands to another bundle
-        if (class_exists(\Symfony\Bundle\WebServerBundle\WebServerBundle::class)) {
-            $bundles[] = new \Symfony\Bundle\WebServerBundle\WebServerBundle();
-        }
-
         if (in_array($this->getEnvironment(), ['dev', 'test', 'test_cached'], true)) {
             $bundles[] = new \Symfony\Bundle\DebugBundle\DebugBundle();
             $bundles[] = new \Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new \Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
+            
+            // Symfony 3.3 moved server:* commands to another bundle
+            if (class_exists(\Symfony\Bundle\WebServerBundle\WebServerBundle::class)) {
+                $bundles[] = new \Symfony\Bundle\WebServerBundle\WebServerBundle();
+            }
         }
 
         return $bundles;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets | N/A |
| License         | MIT |

[No one](http://symfony.com/doc/current/setup/web_server_configuration.html) should be using the internal web server in a production environment anyway. Makes the Kernel a tiny bit slimmer and promotes good practises (it always possible to re-add the bundle if needed).
