### PR TITLE
Fixed typo - use small case instead of uppercased

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.nl.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.nl.yml
@@ -488,7 +488,7 @@ sylius:
         new_admin_user: 'Nieuwe beheerder'
         new_channel: 'Nieuw kanaal'
         new_comment_posted_on_order: 'Nieuwe commentaar gepost op bestelling'
-        new_country: 'NIeuw land toevoegen'
+        new_country: 'Nieuw land toevoegen'
         new_coupon: 'Nieuwe coupon'
         new_currency: 'Nieuwe valuta'
         new_customer: 'Nieuwe klant'


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |

Changed uppercased letter to small cased letter