### PR TITLE
[Resource] Allow parsing variable in yaml to int/float/double

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ParametersParser.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ParametersParser.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\ResourceBundle\Controller;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Request;
+use Webmozart\Assert\Assert;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
@@ -75,6 +76,16 @@ final class ParametersParser implements ParametersParserInterface
 
         if (0 === strpos($parameter, 'expr:')) {
             return $this->parseRequestValueExpression(substr($parameter, 5), $request);
+        }
+
+        if (0 === strpos($parameter, '!!')) {
+            $parameter = explode(' ', $parameter);
+
+            $parser = trim($parameter[0], '!').'val';
+
+            Assert::oneOf($parser, ['intval', 'floatval', 'doubleval'], 'Variable can be parsed only to int, float or double.');
+
+            return $parser($request->get(substr($parameter[1], 1)));
         }
 
         return $parameter;

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ParametersParserSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ParametersParserSpec.php
@@ -69,6 +69,50 @@ final class ParametersParserSpec extends ObjectBehavior
         ;
     }
 
+    function it_parser_string_parameter_and_change_its_type_to_int(): void
+    {
+        $request = new Request();
+        $request->request->set('int', '5');
+
+        $this
+            ->parseRequestValues(['nested' => ['int' => '!!int $int']], $request)
+            ->shouldReturn(['nested' => ['int' => 5]])
+        ;
+    }
+
+    function it_parser_string_parameter_and_change_its_type_to_float(): void
+    {
+        $request = new Request();
+        $request->request->set('float', '5.4');
+
+        $this
+            ->parseRequestValues(['nested' => ['float' => '!!float $float']], $request)
+            ->shouldReturn(['nested' => ['float' => 5.4]])
+        ;
+    }
+
+    function it_parser_string_parameter_and_change_its_type_to_double(): void
+    {
+        $request = new Request();
+        $request->request->set('double', '5.4');
+
+        $this
+            ->parseRequestValues(['nested' => ['double' => '!!double $double']], $request)
+            ->shouldReturn(['nested' => ['double' => 5.4]])
+        ;
+    }
+
+    function it_throws_exception_if_string_parameter_is_going_to_be_parsed_to_invalid_type()
+    {
+        $request = new Request();
+        $request->request->set('int', 5);
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('parseRequestValues', [['nested' => ['int' => '!!invalid $int']], $request])
+        ;
+    }
+
     function it_parses_expressions(): void
     {
         $request = new Request();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | discovered in in https://github.com/Sylius/Sylius/pull/8478 |
| License         | MIT |

While working on introducing strict scalar types in *Core*, I've realized we can have some problems with them while using parameters passed with [yml routing configuration](https://github.com/Sylius/Sylius/blob/7c13a247355d42d07a4e8cb360bbac709d706528/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/product.yml#L16). Yaml itself supports explicit typing (https://symfony.com/doc/current/components/yaml/yaml_format.html#explicit-typing), however it does not work for variables which are always passed as a string.

I think we can use the same syntax in our resource routing to make it possible (for now only for `int`, `float` and `double`).