### PR TITLE
Allow parent class type in ServiceRegistry

### DIFF
--- a/src/Sylius/Component/Registry/ServiceRegistry.php
+++ b/src/Sylius/Component/Registry/ServiceRegistry.php
@@ -26,11 +26,11 @@ class ServiceRegistry implements ServiceRegistryInterface
     private $services = [];
 
     /**
-     * Interface which is required by all services.
+     * Interface or parent class which is required by all services.
      *
      * @var string
      */
-    private $interface;
+    private $className;
 
     /**
      * Human readable context for these services, e.g. "grid field"
@@ -40,12 +40,12 @@ class ServiceRegistry implements ServiceRegistryInterface
     private $context;
 
     /**
-     * @param string $interface
+     * @param string $className
      * @param string $context
      */
-    public function __construct(string $interface, string $context = 'service')
+    public function __construct(string $className, string $context = 'service')
     {
-        $this->interface = $interface;
+        $this->className = $className;
         $this->context = $context;
     }
 
@@ -70,9 +70,9 @@ class ServiceRegistry implements ServiceRegistryInterface
             throw new \InvalidArgumentException(sprintf('%s needs to be an object, %s given.', ucfirst($this->context), gettype($service)));
         }
 
-        if (!in_array($this->interface, class_implements($service), true)) {
+        if (!$service instanceof $this->className) {
             throw new \InvalidArgumentException(
-                sprintf('%s needs to implement "%s", "%s" given.', ucfirst($this->context), $this->interface, get_class($service))
+                sprintf('%s needs to be of type "%s", "%s" given.', ucfirst($this->context), $this->className, get_class($service))
             );
         }
 

--- a/src/Sylius/Component/Registry/spec/ServiceRegistrySpec.php
+++ b/src/Sylius/Component/Registry/spec/ServiceRegistrySpec.php
@@ -16,6 +16,7 @@ namespace spec\Sylius\Component\Registry;
 require_once __DIR__.'/Fixture/SampleServiceInterface.php';
 
 use PhpSpec\ObjectBehavior;
+use spec\Sylius\Component\Registry\Fixture\AbstractSampleService;
 use spec\Sylius\Component\Registry\Fixture\SampleServiceInterface;
 use Sylius\Component\Registry\ExistingServiceException;
 use Sylius\Component\Registry\NonExistingServiceException;
@@ -42,7 +43,7 @@ final class ServiceRegistrySpec extends ObjectBehavior
         $this->all()->shouldReturn([]);
     }
 
-    function it_registers_service_with_given_type(SampleServiceInterface $service): void
+    function it_registers_service_with_given_interface(SampleServiceInterface $service): void
     {
         $this->has('test')->shouldReturn(false);
         $this->register('test', $service);
@@ -51,8 +52,29 @@ final class ServiceRegistrySpec extends ObjectBehavior
         $this->get('test')->shouldReturn($service);
     }
 
-    function it_throws_exception_when_trying_to_register_service_with_taken_type(SampleServiceInterface $service): void
+    function it_registers_service_with_given_parent_class(\stdClass $service): void
     {
+        $this->beConstructedWith(\stdClass::class);
+        $this->has('test')->shouldReturn(false);
+        $this->register('test', $service);
+
+        $this->has('test')->shouldReturn(true);
+        $this->get('test')->shouldReturn($service);
+    }
+
+    function it_throws_exception_when_trying_to_register_service_with_taken_interface(SampleServiceInterface $service): void
+    {
+        $this->register('test', $service);
+
+        $this
+            ->shouldThrow(ExistingServiceException::class)
+            ->duringRegister('test', $service)
+        ;
+    }
+
+    function it_throws_exception_when_trying_to_register_service_with_taken_parent_class(\stdClass $service): void
+    {
+        $this->beConstructedWith(\stdClass::class);
         $this->register('test', $service);
 
         $this
@@ -70,7 +92,7 @@ final class ServiceRegistrySpec extends ObjectBehavior
         ;
     }
 
-    function it_unregisters_service_with_given_type(SampleServiceInterface $service): void
+    function it_unregisters_service_with_given_interface(SampleServiceInterface $service): void
     {
         $this->register('foo', $service);
         $this->has('foo')->shouldReturn(true);
@@ -79,8 +101,25 @@ final class ServiceRegistrySpec extends ObjectBehavior
         $this->has('foo')->shouldReturn(false);
     }
 
-    function it_retrieves_registered_service_by_type(SampleServiceInterface $service): void
+    function it_unregisters_service_with_given_parent_class(\stdClass $service): void
     {
+        $this->beConstructedWith(\stdClass::class);
+        $this->register('foo', $service);
+        $this->has('foo')->shouldReturn(true);
+
+        $this->unregister('foo');
+        $this->has('foo')->shouldReturn(false);
+    }
+
+    function it_retrieves_registered_service_by_interface(SampleServiceInterface $service): void
+    {
+        $this->register('test', $service);
+        $this->get('test')->shouldReturn($service);
+    }
+
+    function it_retrieves_registered_service_by_parent_class(\stdClass $service): void
+    {
+        $this->beConstructedWith(\stdClass::class);
         $this->register('test', $service);
         $this->get('test')->shouldReturn($service);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | none |
| License         | MIT |

Hello there,

[Sylius Registry](http://docs.sylius.org/en/latest/components/Registry/basic_usage.html) is a very useful standalone component that allow to locate services that share the same type.

This is a common need in many PHP projects, however the current implementation limits the type checking to services that share the same `interface`.

Some PHP projects or libraries rely on abstract classes instead of interfaces and type comparing with `instanceof` work as well. 

The aim of this PR is to use the `is_a()` function instead of `class_implements()` - thus we could register services sharing the same `class` as well as services sharing the same `interface`.

A simple example:
```php
$serviceRegistry = new ServiceRegistry('PDO', 'connection');
$serviceRegistry->register('master', new PDO('mysql:host=10.0.1.1', 'foo', 'bar'));
$serviceRegistry->register('slave', new PDO('mysql:host=10.0.1.2', 'foo', 'bar'));
```

Thank you,
Ben