### PR TITLE
Tweak search for province container to be a bit more flexible

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-province-field.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-province-field.js
@@ -16,7 +16,7 @@
 
             countrySelect.on('change', function(event) {
                 var select = $(event.currentTarget);
-                var provinceContainer = select.parents('.field').next('div.province-container');
+                var provinceContainer = select.parents('.field').siblings('div.province-container');
 
                 var provinceSelectFieldName = select.attr('name').replace('country', 'province');
                 var provinceInputFieldName = select.attr('name').replace('countryCode', 'provinceName');


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | N/A |
| License         | MIT |

If you make a change to the order of an address form's fields that results in the province container not being immediately after the country field, the JS which handles loading up the correct province input for the country can fail out because the province container won't be correctly selected therefore the URL for the AJAX request won't be grabbed.  This changes the jQuery method from `.next()` to `.siblings()` so that the `provinceField` function will try to find the province container as any sibling to the country field's wrapping div (using a checkout form as an example, this would now scan for the province container as any direct descendent of the `sylius-shipping-address` div basically).