### PR TITLE
[Docs] Tune default Platform.sh docs based on project in production

### DIFF
--- a/docs/cookbook/platform-sh.rst
+++ b/docs/cookbook/platform-sh.rst
@@ -125,6 +125,7 @@ This is how this file should look like for Sylius (tuned version of the default 
             php bin/console --env=prod --no-debug --ansi cache:clear --no-warmup
             php bin/console --env=prod --no-debug --ansi cache:warmup
             php bin/console --env=prod --no-debug --ansi assets:install
+            # Next command is only needed if you are using themes
             php bin/console --env=prod --no-debug --ansi theme:assets:install
             yarn install
             GULP_ENV=prod yarn run gulp
@@ -153,7 +154,7 @@ This file will load ``mysql`` and ``redis`` on your Platform.sh server.
 
     # .platform/services.yaml
     mysql:
-        type: mysql:10.0
+        type: mysql
         disk: 1024
 
     redis:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #8124 |
| License         | MIT |

As requested by @CoderMaggie, some additional information on the Platform.sh docs based on findings in a project running Platform.sh in production.