### PR TITLE
[Core] Control Order's payment and shipping state

### DIFF
--- a/features/checkout/skipping_payment_step_when_order_total_is_zero_after_applying_coupon.feature
+++ b/features/checkout/skipping_payment_step_when_order_total_is_zero_after_applying_coupon.feature
@@ -1,0 +1,27 @@
+@checkout
+Feature: Skipping payment selection when order total is zero after applying coupon
+    In order to not select payment method when it is unnecessary
+    As a Customer
+    I want to be redirect directly to order summary page after shipping selection
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "PHP T-Shirt" priced at "$10.00"
+        And the store ships everywhere for free
+        And the store has "SHL" shipping method with "$5.00" fee
+        And the store has promotion "Holiday promotion" with coupon "HOLIDAYPROMO"
+        And the promotion gives "$10.00" discount to every order with quantity at least 1
+        And the store allows paying offline
+        And I am a logged in customer
+
+    @ui
+    Scenario: Seeing order summary after shipping selection when order total is zero
+        Given I have product "PHP T-Shirt" in the cart
+        And I use coupon with code "HOLIDAYPROMO"
+        And I am at the checkout addressing step
+        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I complete the addressing step
+        And I select "Free" shipping method
+        And I complete the shipping step
+        Then I should be on the checkout summary step
+        And I should not see any information about payment method

--- a/features/checkout/skipping_payment_step_when_order_total_is_zero_after_applying_coupon.feature
+++ b/features/checkout/skipping_payment_step_when_order_total_is_zero_after_applying_coupon.feature
@@ -1,8 +1,8 @@
 @checkout
 Feature: Skipping payment selection when order total is zero after applying coupon
-    In order to not select payment method when it is unnecessary
+    In order not to select payment method when it is unnecessary
     As a Customer
-    I want to be redirect directly to order summary page after shipping selection
+    I want to be redirected directly to order summary page after shipping selection when my order total is zero
 
     Background:
         Given the store operates on a single channel in "United States"

--- a/features/order/managing_orders/seeing_order_payment_state_as_completed_if_free_order_coupon_was_applied.feature
+++ b/features/order/managing_orders/seeing_order_payment_state_as_completed_if_free_order_coupon_was_applied.feature
@@ -1,0 +1,24 @@
+@managing_orders
+Feature: Seeing payment state as paid after checkout steps if order total is zero
+    In order to know that the payment is always paid if order total is zero
+    As an Administrator
+    I want to be able to see payment state as paid
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Angel T-Shirt" priced at "$10.00"
+        And the store ships everywhere for free
+        And the store allows paying offline
+        And the store has promotion "Holiday promotion" with coupon "HOLIDAYPROMO"
+        And the promotion gives "$10.00" discount to every order with quantity at least 1
+        And there is a customer "lucy@teamlucifer.com" that placed an order "#00000666"
+        And the customer bought a single "Angel T-Shirt"
+        And the customer used coupon "HOLIDAYPROMO"
+        And the customer "Lucifer Morningstar" addressed it to "Seaside Fwy", "90802" "Los Angeles" in the "United States" with identical billing address
+        And the customer chose "Free" shipping method
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Seeing payment state as paid on orders list
+        When I browse orders
+        Then the order "#00000666" should have order payment state "Paid"

--- a/features/order/managing_orders/seeing_order_payment_state_as_completed_if_free_order_coupon_was_applied.feature
+++ b/features/order/managing_orders/seeing_order_payment_state_as_completed_if_free_order_coupon_was_applied.feature
@@ -2,7 +2,7 @@
 Feature: Seeing payment state as paid after checkout steps if order total is zero
     In order to know that the payment is always paid if order total is zero
     As an Administrator
-    I want to be able to see payment state as paid
+    I want to be able to see payment state as paid when order total was zero
 
     Background:
         Given the store operates on a single channel in "United States"

--- a/features/order/managing_orders/seeing_order_payment_state_as_completed_if_order_total_is_zero.feature
+++ b/features/order/managing_orders/seeing_order_payment_state_as_completed_if_order_total_is_zero.feature
@@ -1,8 +1,8 @@
 @managing_orders
 Feature: Seeing payment state as paid after checkout steps if order total is zero
-    In order to know that the payment is always paid if order total is zero
+    In order to have coherent payment states of all orders
     As an Administrator
-    I want to be able to see payment state as paid
+    I want orders with no unpaid payments to have payment state paid
 
     Background:
         Given the store operates on a single channel in "United States"

--- a/features/order/managing_orders/seeing_order_shipment_state_as_shipped_if_there_is_not_shipments_to_deliver.feature
+++ b/features/order/managing_orders/seeing_order_shipment_state_as_shipped_if_there_is_not_shipments_to_deliver.feature
@@ -1,0 +1,28 @@
+@managing_orders
+Feature: Seeing shipping states of an order as shipped if there is no shipments to deliver
+    In order to get to know the state of shipping for order without shipments
+    As an Administrator
+    I want to be able to see shipping states
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a "Guards! Guards!" configurable product
+        And this product has "Guards! Guards! - ebook" variant priced at "$12.55" which does not require shipping
+        And the store ships everywhere for free
+        And the store allows paying with "Cash on Delivery"
+        And there is a customer "lucy@teamlucifer.com" that placed an order "#00000666"
+        And the customer bought a single "Guards! Guards! - ebook" variant of product "Guards! Guards!"
+        And the customer "Lucifer Morningstar" addressed it to "Seaside Fwy", "90802" "Los Angeles" in the "United States" with identical billing address
+        And the customer chose "Cash on Delivery" payment
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Seeing shipping state as shipped on orders list
+        When I browse orders
+        Then the order "#00000666" should have order shipping state "Shipped"
+
+    @ui
+    Scenario: Seeing shipping state as shipped on order's summary
+        When I view the summary of the order "#00000666"
+        Then it should have order's shipping state "Shipped"
+        And I should not see information about shipments

--- a/features/order/managing_orders/seeing_order_shipment_state_as_shipped_if_there_is_not_shipments_to_deliver.feature
+++ b/features/order/managing_orders/seeing_order_shipment_state_as_shipped_if_there_is_not_shipments_to_deliver.feature
@@ -1,8 +1,8 @@
 @managing_orders
-Feature: Seeing shipping states of an order as shipped if there is no shipments to deliver
-    In order to get to know the state of shipping for order without shipments
+Feature: Seeing shipping states of an order as shipped if there are no shipments to deliver
+    In order to have coherent shipping states of all orders
     As an Administrator
-    I want to be able to see shipping states
+    I want orders with no undelivered shipments to have shipping state shipped
 
     Background:
         Given the store operates on a single channel in "United States"

--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -283,6 +283,24 @@ final class OrderContext implements Context
     }
 
     /**
+     * @Given /^the customer chose ("[^"]+" payment)$/
+     */
+    public function theCustomerChosePayment(PaymentMethodInterface $paymentMethod)
+    {
+        /** @var OrderInterface $order */
+        $order = $this->sharedStorage->get('order');
+
+        foreach ($order->getPayments() as $payment) {
+            $payment->setMethod($paymentMethod);
+        }
+
+        $this->applyTransitionOnOrderCheckout($order, OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT);
+        $this->applyTransitionOnOrderCheckout($order, OrderCheckoutTransitions::TRANSITION_COMPLETE);
+
+        $this->objectManager->flush();
+    }
+
+    /**
      * @Given the customer bought a single :product
      * @Given I bought a single :product
      */

--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -934,8 +934,7 @@ final class OrderContext implements Context
         int $productCount,
         ProductInterface $product,
         bool $isFulfilled = false
-    ): void
-    {
+    ): void {
         for ($i = 0; $i < $orderCount; $i++) {
             $order = $this->createOrder($customer, uniqid('#'), $channel);
 
@@ -943,12 +942,14 @@ final class OrderContext implements Context
                 $order,
                 $channel,
                 $this->variantResolver->getVariant($product),
-                (int)$productCount
+                (int) $productCount
             );
 
             $order->setState($isFulfilled ? OrderInterface::STATE_FULFILLED : OrderInterface::STATE_NEW);
 
             $this->objectManager->persist($order);
         }
+
+        $this->objectManager->flush();
     }
 }

--- a/src/Sylius/Behat/Context/Transform/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Transform/PromotionContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Transform;
 
 use Behat\Behat\Context\Context;
+use Sylius\Component\Promotion\Repository\PromotionCouponRepositoryInterface;
 use Sylius\Component\Promotion\Repository\PromotionRepositoryInterface;
 use Webmozart\Assert\Assert;
 
@@ -28,12 +29,16 @@ final class PromotionContext implements Context
     private $promotionRepository;
 
     /**
-     * @param PromotionRepositoryInterface $promotionRepository
+     * @var PromotionCouponRepositoryInterface
      */
+    private $promotionCouponRepository;
+
     public function __construct(
-        PromotionRepositoryInterface $promotionRepository
+        PromotionRepositoryInterface $promotionRepository,
+        PromotionCouponRepositoryInterface $promotionCouponRepository
     ) {
         $this->promotionRepository = $promotionRepository;
+        $this->promotionCouponRepository = $promotionCouponRepository;
     }
 
     /**
@@ -51,5 +56,22 @@ final class PromotionContext implements Context
         );
 
         return $promotion;
+    }
+
+    /**
+     * @Transform /^coupon "([^"]+)"$/
+     * @Transform /^"([^"]+)" coupon$/
+     * @Transform :coupon
+     */
+    public function getPromotionCouponByCode($promotionCouponCode)
+    {
+        $promotionCoupon = $this->promotionCouponRepository->findOneBy(['code' => $promotionCouponCode]);
+
+        Assert::notNull(
+            $promotionCoupon,
+            sprintf('Promotion coupon with code "%s" does not exist', $promotionCouponCode)
+        );
+
+        return $promotionCoupon;
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -500,6 +500,14 @@ final class ManagingOrdersContext implements Context
     }
 
     /**
+     * @Then it should have order's shipping state :orderShippingState
+     */
+    public function itShouldHaveOrderShippingState($orderShippingState)
+    {
+        Assert::same($this->showPage->getShippingState(), $orderShippingState);
+    }
+
+    /**
      * @Then it's payment state should be refunded
      */
     public function orderPaymentStateShouldBeRefunded()
@@ -651,6 +659,14 @@ final class ManagingOrdersContext implements Context
     public function theOrderShouldHavePaymentState(OrderInterface $order, $orderPaymentState)
     {
         Assert::true($this->indexPage->isSingleResourceOnPage(['paymentState' => $orderPaymentState]));
+    }
+
+    /**
+     * @Then the order :order should have order shipping state :orderPaymentState
+     */
+    public function theOrderShouldHaveShippingState(OrderInterface $order, $orderPaymentState)
+    {
+        Assert::true($this->indexPage->isSingleResourceOnPage(['shippingState' => $orderPaymentState]));
     }
 
     /**
@@ -824,6 +840,14 @@ final class ManagingOrdersContext implements Context
     public function iShouldNotSeeInformationAboutPayments()
     {
         Assert::same($this->showPage->getPaymentsCount(), 0);
+    }
+
+    /**
+     * @Then I should not see information about shipments
+     */
+    public function iShouldNotSeeInformationAboutShipments()
+    {
+        Assert::same($this->showPage->getShipmentsCount(), 0);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -662,19 +662,12 @@ final class ManagingOrdersContext implements Context
     }
 
     /**
-     * @Then the order :order should have order shipping state :orderPaymentState
-     */
-    public function theOrderShouldHaveShippingState(OrderInterface $order, $orderPaymentState)
-    {
-        Assert::true($this->indexPage->isSingleResourceOnPage(['shippingState' => $orderPaymentState]));
-    }
-
-    /**
+     * @Then the order :order should have order shipping state :orderShippingState
      * @Then /^(this order) should have order shipping state "([^"]+)"$/
      */
-    public function theOrderShouldHaveShipmentState(OrderInterface $order, $orderShipmentState)
+    public function theOrderShouldHaveShippingState(OrderInterface $order, $orderShippingState)
     {
-        Assert::true($this->indexPage->isSingleResourceOnPage(['shippingState' => $orderShipmentState]));
+        Assert::true($this->indexPage->isSingleResourceOnPage(['shippingState' => $orderShippingState]));
     }
 
     /**

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Admin\Order;
 
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
 use Sylius\Behat\Page\SymfonyPage;
 use Sylius\Behat\Service\Accessor\TableAccessorInterface;
@@ -329,9 +330,27 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
      */
     public function getPaymentsCount()
     {
-        $payments = $this->getElement('payments')->findAll('css', '.item');
+        try {
+            $payments = $this->getElement('payments')->findAll('css', '.item');
+        } catch (ElementNotFoundException $exception) {
+            return 0;
+        }
 
         return count($payments);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getShipmentsCount()
+    {
+        try {
+            $shipments = $this->getElement('shipments')->findAll('css', '.item');
+        } catch (ElementNotFoundException $exception) {
+            return 0;
+        }
+
+        return count($shipments);
     }
 
     /**
@@ -356,6 +375,14 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
     public function getPaymentState()
     {
         return $this->getElement('order_payment_state')->getText();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getShippingState()
+    {
+        return $this->getElement('order_shipping_state')->getText();
     }
 
     public function cancelOrder()
@@ -451,6 +478,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
             'items_total' => '#items-total',
             'order_notes' => '#sylius-order-notes',
             'order_payment_state' => '#payment-state > span',
+            'order_shipping_state' => '#shipping-state > span',
             'order_state' => '#sylius-order-state',
             'payments' => '#sylius-payments',
             'promotion_discounts' => '#promotion-discounts',

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
@@ -342,7 +342,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
     /**
      * {@inheritdoc}
      */
-    public function getShipmentsCount()
+    public function getShipmentsCount(): int
     {
         try {
             $shipments = $this->getElement('shipments')->findAll('css', '.item');

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
@@ -229,6 +229,11 @@ interface ShowPageInterface extends SymfonyPageInterface
     public function getPaymentsCount();
 
     /**
+     * @return int
+     */
+    public function getShipmentsCount();
+
+    /**
      * @return bool
      */
     public function hasCancelButton();
@@ -242,6 +247,11 @@ interface ShowPageInterface extends SymfonyPageInterface
      * @return string
      */
     public function getPaymentState();
+
+    /**
+     * @return string
+     */
+    public function getShippingState();
 
     public function cancelOrder();
 

--- a/src/Sylius/Behat/Resources/config/services/contexts/transform.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/transform.xml
@@ -107,6 +107,7 @@
 
         <service id="sylius.behat.context.transform.promotion" class="Sylius\Behat\Context\Transform\PromotionContext">
             <argument type="service" id="__symfony__.sylius.repository.promotion" />
+            <argument type="service" id="__symfony__.sylius.repository.promotion_coupon" />
             <tag name="fob.context_service" />
         </service>
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/order/managing_orders.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/order/managing_orders.yml
@@ -36,6 +36,7 @@ default:
                 - sylius.behat.context.transform.payment
                 - sylius.behat.context.transform.product
                 - sylius.behat.context.transform.product_variant
+                - sylius.behat.context.transform.promotion
                 - sylius.behat.context.transform.shipping_method
                 - sylius.behat.context.transform.tax_category
                 - sylius.behat.context.transform.taxon

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_payments.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_payments.html.twig
@@ -1,9 +1,11 @@
 <div class="ui segment" id="payment-state">
     {% include '@SyliusAdmin/Order/Label/PaymentState/' ~ order.paymentState ~ '.html.twig' with { 'value': 'sylius.ui.' ~ order.paymentState, 'attached': true } %}
-    <h3 class="ui dividing header">{{ 'sylius.ui.payments'|trans }}</h3>
-    <div class="ui relaxed divided list" id="sylius-payments">
-        {% for payment in order.payments %}
-            {% include '@SyliusAdmin/Order/Show/_payment.html.twig' %}
-        {% endfor %}
-    </div>
+    {% if order.hasPayments %}
+        <h3 class="ui dividing header">{{ 'sylius.ui.payments'|trans }}</h3>
+        <div class="ui relaxed divided list" id="sylius-payments">
+            {% for payment in order.payments %}
+                {% include '@SyliusAdmin/Order/Show/_payment.html.twig' %}
+            {% endfor %}
+        </div>
+    {% endif %}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_shipments.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_shipments.html.twig
@@ -1,9 +1,11 @@
-<div class="ui segment">
+<div class="ui segment" id="shipping-state">
     {% include '@SyliusAdmin/Order/Label/ShippingState/' ~ order.shippingState ~ '.html.twig' with { 'value': 'sylius.ui.' ~ order.shippingState, 'attached': true } %}
-    <h3 class="ui dividing header" id="shipping-state">{{ 'sylius.ui.shipments'|trans }}</h3>
-    <div class="ui relaxed divided list" id="sylius-shipments">
-        {% for shipment in order.shipments %}
-            {% include '@SyliusAdmin/Order/Show/_shipment.html.twig' %}
-        {% endfor %}
-    </div>
+    {% if order.hasShipments %}
+        <h3 class="ui dividing header" id="shipping-state">{{ 'sylius.ui.shipments'|trans }}</h3>
+        <div class="ui relaxed divided list" id="sylius-shipments">
+            {% for shipment in order.shipments %}
+                {% include '@SyliusAdmin/Order/Show/_shipment.html.twig' %}
+            {% endfor %}
+        </div>
+    {% endif %}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/show.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/show.html.twig
@@ -46,9 +46,7 @@
         {{ sonata_block_render_event('sylius.admin.order.show.before_payments', {'resource': resource}) }}
 
         {% include '@SyliusAdmin/Order/Show/_payments.html.twig' %}
-        {% if order.hasShipments %}
-            {% include '@SyliusAdmin/Order/Show/_shipments.html.twig' %}
-        {% endif %}
+        {% include '@SyliusAdmin/Order/Show/_shipments.html.twig' %}
 
         {{ sonata_block_render_event('sylius.admin.order.show.after_shipments', {'resource': resource}) }}
     </div>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order_checkout.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order_checkout.yml
@@ -55,3 +55,7 @@ winzou_state_machine:
                     do: ["@sylius.state_resolver.order_checkout", "resolve"]
                     args: ["object"]
                     priority: 1
+                sylius_control_payment_state:
+                    on: ["complete"]
+                    do: ["@sylius.state_resolver.order_payment", "resolve"]
+                    args: ["object"]

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order_checkout.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order_checkout.yml
@@ -59,3 +59,7 @@ winzou_state_machine:
                     on: ["complete"]
                     do: ["@sylius.state_resolver.order_payment", "resolve"]
                     args: ["object"]
+                sylius_control_shipping_state:
+                    on: ["complete"]
+                    do: ["@sylius.state_resolver.order_shipping", "resolve"]
+                    args: ["object"]

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\OrderProcessing;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Core\OrderPaymentStates;
 use Sylius\Component\Core\Payment\Exception\NotProvidedOrderPaymentException;
 use Sylius\Component\Core\Payment\Provider\OrderPaymentProviderInterface;
 use Sylius\Component\Order\Model\OrderInterface as BaseOrderInterface;
@@ -63,6 +65,10 @@ final class OrderPaymentProcessor implements OrderProcessorInterface
         }
 
         if (0 === $order->getTotal()) {
+            foreach ($order->getPayments(OrderPaymentStates::STATE_CART) as $payment) {
+                $order->removePayment($payment);
+            }
+
             return;
         }
 

--- a/src/Sylius/Component/Core/StateResolver/OrderPaymentStateResolver.php
+++ b/src/Sylius/Component/Core/StateResolver/OrderPaymentStateResolver.php
@@ -94,7 +94,10 @@ final class OrderPaymentStateResolver implements StateResolverInterface
             $completedPaymentTotal += $payment->getAmount();
         }
 
-        if (0 < $completedPayments->count() && $completedPaymentTotal >= $order->getTotal()) {
+        if (
+            (0 < $completedPayments->count() && $completedPaymentTotal >= $order->getTotal()) ||
+            $order->getPayments()->isEmpty()
+        ) {
             return OrderPaymentTransitions::TRANSITION_PAY;
         }
 

--- a/src/Sylius/Component/Core/spec/StateResolver/OrderPaymentStateResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/StateResolver/OrderPaymentStateResolverSpec.php
@@ -109,7 +109,7 @@ final class OrderPaymentStateResolverSpec extends ObjectBehavior
         $this->resolve($order);
     }
 
-    function it_marks_an_order_as_paid_if_it_does_not_have_any_payment(
+    function it_marks_an_order_as_paid_if_it_does_not_have_any_payments(
         FactoryInterface $stateMachineFactory,
         StateMachineInterface $stateMachine,
         OrderInterface $order

--- a/src/Sylius/Component/Core/spec/StateResolver/OrderPaymentStateResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/StateResolver/OrderPaymentStateResolverSpec.php
@@ -109,6 +109,21 @@ final class OrderPaymentStateResolverSpec extends ObjectBehavior
         $this->resolve($order);
     }
 
+    function it_marks_an_order_as_paid_if_it_does_not_have_any_payment(
+        FactoryInterface $stateMachineFactory,
+        StateMachineInterface $stateMachine,
+        OrderInterface $order
+    ) {
+        $order->getPayments()->willReturn(new ArrayCollection([]));
+        $order->getTotal()->willReturn(0);
+
+        $stateMachineFactory->get($order, OrderPaymentTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->can(OrderPaymentTransitions::TRANSITION_PAY)->willReturn(true);
+        $stateMachine->apply(OrderPaymentTransitions::TRANSITION_PAY)->shouldBeCalled();
+
+        $this->resolve($order);
+    }
+
     function it_marks_an_order_as_paid_if_fully_paid_even_if_previous_payment_was_failed(
         FactoryInterface $stateMachineFactory,
         StateMachineInterface $stateMachine,

--- a/src/Sylius/Component/Core/spec/StateResolver/OrderShippingStateResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/StateResolver/OrderShippingStateResolverSpec.php
@@ -62,7 +62,7 @@ final class OrderShippingStateResolverSpec extends ObjectBehavior
         $this->resolve($order);
     }
 
-    function it_marks_an_order_as_shipped_if_there_is_no_shipments_to_deliver(
+    function it_marks_an_order_as_shipped_if_there_are_no_shipments_to_deliver(
         FactoryInterface $stateMachineFactory,
         OrderInterface $order,
         StateMachineInterface $orderStateMachine

--- a/src/Sylius/Component/Core/spec/StateResolver/OrderShippingStateResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/StateResolver/OrderShippingStateResolverSpec.php
@@ -62,6 +62,20 @@ final class OrderShippingStateResolverSpec extends ObjectBehavior
         $this->resolve($order);
     }
 
+    function it_marks_an_order_as_shipped_if_there_is_no_shipments_to_deliver(
+        FactoryInterface $stateMachineFactory,
+        OrderInterface $order,
+        StateMachineInterface $orderStateMachine
+    ): void {
+        $order->getShipments()->willReturn(new ArrayCollection());
+        $order->getShippingState()->willReturn(OrderShippingStates::STATE_READY);
+        $stateMachineFactory->get($order, OrderShippingTransitions::GRAPH)->willReturn($orderStateMachine);
+
+        $orderStateMachine->apply(OrderShippingTransitions::TRANSITION_SHIP)->shouldBeCalled();
+
+        $this->resolve($order);
+    }
+
     function it_marks_an_order_as_partially_shipped_if_some_shipments_are_delivered(
         FactoryInterface $stateMachineFactory,
         OrderInterface $order,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | https://github.com/Sylius/Sylius/issues/7952, https://github.com/Sylius/Sylius/issues/7943  |
| License         | MIT |

Big thanks for @Persata and @bruno-ds for pointing this out!

For now, if there is no shipment to deliver we mark order as `shipped` and if there is no payment we make order `paid`. We can of course introduce some new states but I think it's not crucial for 1.0.0.
