### PR TITLE
Base URL support in ThemeBundle (fixes #8278)

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Asset/Package/UrlPackage.php
+++ b/src/Sylius/Bundle/ThemeBundle/Asset/Package/UrlPackage.php
@@ -8,6 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\ThemeBundle\Asset\Package;
@@ -63,7 +64,7 @@ class UrlPackage extends BaseUrlPackage
         parent::__construct($baseUrls, $versionStrategy, $context);
 
         if (!is_array($baseUrls)) {
-            $baseUrls = (array)$baseUrls;
+            $baseUrls = (array) $baseUrls;
         }
 
         foreach ($baseUrls as $baseUrl) {
@@ -112,10 +113,10 @@ class UrlPackage extends BaseUrlPackage
     }
 
     /**
-     * @param $urls
+     * @param array $urls
      * @return array
      */
-    private function getSslUrls($urls): array
+    private function getSslUrls(array $urls): array
     {
         $sslUrls = [];
 

--- a/src/Sylius/Bundle/ThemeBundle/Asset/Package/UrlPackage.php
+++ b/src/Sylius/Bundle/ThemeBundle/Asset/Package/UrlPackage.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ThemeBundle\Asset\Package;
+
+use Sylius\Bundle\ThemeBundle\Asset\PathResolverInterface;
+use Sylius\Bundle\ThemeBundle\Context\ThemeContextInterface;
+use Symfony\Component\Asset\Context\ContextInterface;
+use Symfony\Component\Asset\Exception\InvalidArgumentException;
+use Symfony\Component\Asset\UrlPackage as BaseUrlPackage;
+use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
+
+/**
+ * @see BaseUrlPackage
+ *
+ * @author Stefan Doorn <stefan@efectos.nl>
+ */
+class UrlPackage extends BaseUrlPackage
+{
+    /**
+     * @var array
+     */
+    private $baseUrls = [];
+
+    /**
+     * @var UrlPackage
+     */
+    private $sslPackage;
+
+    /**
+     * @var ThemeContextInterface
+     */
+    protected $themeContext;
+
+    /**
+     * @var PathResolverInterface
+     */
+    protected $pathResolver;
+
+    /**
+     * @param string|array $baseUrls Base asset URLs
+     * @param VersionStrategyInterface $versionStrategy The version strategy
+     * @param ThemeContextInterface $themeContext
+     * @param PathResolverInterface $pathResolver
+     * @param ContextInterface|null $context Context
+     */
+    public function __construct(
+        $baseUrls,
+        VersionStrategyInterface $versionStrategy,
+        ThemeContextInterface $themeContext,
+        PathResolverInterface $pathResolver,
+        ?ContextInterface $context = null
+    ) {
+        parent::__construct($baseUrls, $versionStrategy, $context);
+
+        if (!is_array($baseUrls)) {
+            $baseUrls = (array)$baseUrls;
+        }
+
+        foreach ($baseUrls as $baseUrl) {
+            $this->baseUrls[] = rtrim($baseUrl, '/');
+        }
+
+        $sslUrls = $this->getSslUrls($baseUrls);
+
+        if ($sslUrls && $baseUrls !== $sslUrls) {
+            $this->sslPackage = new self($sslUrls, $versionStrategy, $themeContext, $pathResolver);
+        }
+
+        $this->themeContext = $themeContext;
+        $this->pathResolver = $pathResolver;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUrl($path): string
+    {
+        if ($this->isAbsoluteUrl($path)) {
+            return $path;
+        }
+
+        if (null !== $this->sslPackage && $this->getContext()->isSecure()) {
+            return $this->sslPackage->getUrl($path);
+        }
+
+        $theme = $this->themeContext->getTheme();
+        if (null !== $theme) {
+            $path = $this->pathResolver->resolve($path, $theme);
+        }
+
+        $url = $this->getVersionStrategy()->applyVersion($path);
+
+        if ($this->isAbsoluteUrl($url)) {
+            return $url;
+        }
+
+        if ($url && '/' != $url[0]) {
+            $url = '/' . $url;
+        }
+
+        return $this->getBaseUrl($path) . $url;
+    }
+
+    /**
+     * @param $urls
+     * @return array
+     */
+    private function getSslUrls($urls): array
+    {
+        $sslUrls = [];
+
+        foreach ($urls as $url) {
+            if ('https://' === substr($url, 0, 8) || '//' === substr($url, 0, 2)) {
+                $sslUrls[] = $url;
+            } elseif ('http://' !== substr($url, 0, 7)) {
+                throw new InvalidArgumentException(sprintf('"%s" is not a valid URL', $url));
+            }
+        }
+
+        return $sslUrls;
+    }
+}

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/assets.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/assets.xml
@@ -35,5 +35,13 @@
             <argument type="service" id="sylius.theme.asset.path_resolver" />
             <argument type="service" id="assets.context" />
         </service>
+
+        <service id="assets.url_package" class="Sylius\Bundle\ThemeBundle\Asset\Package\UrlPackage" abstract="true">
+            <argument /> <!-- base URLs -->
+            <argument /> <!-- version strategy -->
+            <argument type="service" id="sylius.context.theme" />
+            <argument type="service" id="sylius.theme.asset.path_resolver" />
+            <argument type="service" id="assets.context" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ThemeBundle/spec/Asset/Package/UrlPackageSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/Asset/Package/UrlPackageSpec.php
@@ -18,6 +18,7 @@ use Sylius\Bundle\ThemeBundle\Asset\PathResolverInterface;
 use Sylius\Bundle\ThemeBundle\Context\ThemeContextInterface;
 use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
 use Symfony\Component\Asset\PackageInterface;
+use Symfony\Component\Asset\UrlPackage;
 use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
 
 /**
@@ -39,12 +40,16 @@ final class UrlPackageSpec extends ObjectBehavior
         $this->shouldImplement(PackageInterface::class);
     }
 
+    function it_extends_symfony_url_package(): void
+    {
+        $this->shouldImplement(UrlPackage::class);
+    }
+
     function it_returns_vanilla_url_if_there_are_no_active_themes_and_with_base_url(
         VersionStrategyInterface $versionStrategy,
         ThemeContextInterface $themeContext,
         PathResolverInterface $urlResolver
-    ): void
-    {
+    ): void {
         $this->beConstructedWith('https://cdn-url.com/', $versionStrategy, $themeContext, $urlResolver);
 
         $url = 'bundles/sample/asset.js';

--- a/src/Sylius/Bundle/ThemeBundle/spec/Asset/Package/UrlPackageSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/Asset/Package/UrlPackageSpec.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ThemeBundle\Asset\Package;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ThemeBundle\Asset\PathResolverInterface;
+use Sylius\Bundle\ThemeBundle\Context\ThemeContextInterface;
+use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;
+use Symfony\Component\Asset\PackageInterface;
+use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
+
+/**
+ * @author Kamil Kokot <kamil@kokot.me>
+ * @author Stefan Doorn <stefan@efectos.nl>
+ */
+final class UrlPackageSpec extends ObjectBehavior
+{
+    function let(
+        VersionStrategyInterface $versionStrategy,
+        ThemeContextInterface $themeContext,
+        PathResolverInterface $urlResolver
+    ): void {
+        $this->beConstructedWith(['https://cdn-url.com/'], $versionStrategy, $themeContext, $urlResolver);
+    }
+
+    function it_implements_package_interface(): void
+    {
+        $this->shouldImplement(PackageInterface::class);
+    }
+
+    function it_returns_vanilla_url_if_there_are_no_active_themes_and_with_base_url(
+        VersionStrategyInterface $versionStrategy,
+        ThemeContextInterface $themeContext,
+        PathResolverInterface $urlResolver
+    ): void
+    {
+        $this->beConstructedWith('https://cdn-url.com/', $versionStrategy, $themeContext, $urlResolver);
+
+        $url = 'bundles/sample/asset.js';
+        $versionedPath = 'bundles/sample/asset.js?v=42';
+
+        $themeContext->getTheme()->shouldBeCalled()->willReturn(null);
+        $versionStrategy->applyVersion($url)->shouldBeCalled()->willReturn($versionedPath);
+
+        $this->getUrl($url)->shouldReturn('https://cdn-url.com/' . $versionedPath);
+    }
+
+    function it_returns_modified_url_if_there_is_active_theme_and_with_base_url(
+        ThemeContextInterface $themeContext,
+        VersionStrategyInterface $versionStrategy,
+        PathResolverInterface $urlResolver,
+        ThemeInterface $theme
+    ): void {
+        $url = 'bundles/sample/asset.js';
+        $themedPath = 'bundles/theme/foo/bar/sample/asset.js';
+        $versionedThemedPath = 'bundles/theme/foo/bar/sample/asset.js?v=42';
+
+        $themeContext->getTheme()->shouldBeCalled()->willReturn($theme);
+        $urlResolver->resolve($url, $theme)->shouldBeCalled()->willReturn($themedPath);
+        $versionStrategy->applyVersion($themedPath)->shouldBeCalled()->willReturn($versionedThemedPath);
+
+        $this->getUrl($url)->shouldReturn('https://cdn-url.com/' . $versionedThemedPath);
+    }
+
+    function it_returns_url_without_changes_if_it_is_absolute(): void
+    {
+        $this->getUrl('//localhost/asset.js')->shouldReturn('//localhost/asset.js');
+        $this->getUrl('https://localhost/asset.js')->shouldReturn('https://localhost/asset.js');
+    }
+
+    function it_does_prepend_it_with_base_url_if_modified_url_is_an_absolute_one(
+        ThemeContextInterface $themeContext,
+        VersionStrategyInterface $versionStrategy,
+        PathResolverInterface $urlResolver,
+        ThemeInterface $theme
+    ): void {
+        $url = 'bundles/sample/asset.js';
+        $themedPath = 'bundles/theme/foo/bar/sample/asset.js';
+        $versionedThemedPath = 'https://cdn-url.com/bundles/theme/foo/bar/sample/asset.js?v=42';
+
+        $themeContext->getTheme()->shouldBeCalled()->willReturn($theme);
+        $urlResolver->resolve($url, $theme)->shouldBeCalled()->willReturn($themedPath);
+        $versionStrategy->applyVersion($themedPath)->shouldBeCalled()->willReturn($versionedThemedPath);
+
+        $this->getUrl($url)->shouldReturn($versionedThemedPath);
+    }
+
+    function it_does_not_prepend_it_with_base_url_if_modified_url_is_an_absolute_url(
+        ThemeContextInterface $themeContext,
+        VersionStrategyInterface $versionStrategy,
+        PathResolverInterface $urlResolver,
+        ThemeInterface $theme
+    ): void {
+        $url = 'bundles/sample/asset.js';
+        $themedPath = 'bundles/theme/foo/bar/sample/asset.js';
+        $versionedThemedPath = 'https://bundles/theme/foo/bar/sample/asset.js?v=42';
+
+        $themeContext->getTheme()->shouldBeCalled()->willReturn($theme);
+        $urlResolver->resolve($url, $theme)->shouldBeCalled()->willReturn($themedPath);
+        $versionStrategy->applyVersion($themedPath)->shouldBeCalled()->willReturn($versionedThemedPath);
+
+        $this->getUrl($url)->shouldReturn($versionedThemedPath);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | yes |
| BC breaks?      | no |
| Related tickets | fixes #8278 |
| License         | MIT |

Overrides Symfony's UrlPackage to allow theme bundle to handle different base URL's. Allows users that use themes, also to use CDN base URL's for assets.