### PR TITLE
Fix DocumentRepository not compatible with Interface

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Doctrine/ODM/PHPCR/DocumentRepository.php
+++ b/src/Sylius/Bundle/ResourceBundle/Doctrine/ODM/PHPCR/DocumentRepository.php
@@ -31,7 +31,7 @@ class DocumentRepository extends BaseDocumentRepository implements RepositoryInt
     /**
      * {@inheritdoc}
      */
-    public function createPaginator(array $criteria = [], array $sorting = [])
+    public function createPaginator(array $criteria = [], array $sorting = []): iterable
     {
         $queryBuilder = $this->getCollectionQueryBuilder();
 
@@ -44,7 +44,7 @@ class DocumentRepository extends BaseDocumentRepository implements RepositoryInt
     /**
      * {@inheritdoc}
      */
-    public function add(ResourceInterface $resource)
+    public function add(ResourceInterface $resource): void
     {
         $this->dm->persist($resource);
         $this->dm->flush();
@@ -53,7 +53,7 @@ class DocumentRepository extends BaseDocumentRepository implements RepositoryInt
     /**
      * {@inheritdoc}
      */
-    public function remove(ResourceInterface $resource)
+    public function remove(ResourceInterface $resource): void
     {
         if (null !== $this->find($resource->getId())) {
             $this->dm->remove($resource);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes |
| New feature?    | no|
| BC breaks?      | no|
| License         | MIT |

Fixes the following error I ran in after upgrading to `dev-master` today:

```
Compile Error: Declaration of Sylius\Bundle\ResourceBundle\Doctrine\ODM\PHPCR\DocumentRepository::createPaginator(array $criteria = Array, array $sorting = Array) must be compatible with Sylius\Component\Resource\Repository\RepositoryInterface::createPaginator(array $criteria = Array, array $sorting = Array): iterable
```

Probably because I'm using the Lakion CmsPlugin, which uses PHPCR. 