### PR TITLE
Remove final from controllers extending ResourceController (fixes #8563)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -70,10 +70,6 @@
     * `HandleException`
     * `IntegerDistributor`
     * `MissingChannelConfigurationException`
-    * `OrderController`
-    * `PaymentMethodController`
-    * `ProductTaxonController`
-    * `ProductVariantController`
     * `PromotionActionFactory`
     * `PromotionRuleFactory`
     * `ReviewerReviewsRemover`
@@ -137,7 +133,6 @@
 
 ### Product / ProductBundle
 
-* `ProductAttributeController` has been made final, use decoration instead of extending it.
 * `ProductVariantCombination` has been made final, use decoration instead of extending it.
 * `ProductVariantCombinationValidator` has been made final, use decoration instead of extending it.
 * The following methods does not longer have a default null argument and requires one to be explicitly passed:

--- a/src/Sylius/Bundle/CoreBundle/Controller/OrderController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/OrderController.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Webmozart\Assert\Assert;
 
-final class OrderController extends BaseOrderController
+class OrderController extends BaseOrderController
 {
     /**
      * @param Request $request

--- a/src/Sylius/Bundle/CoreBundle/Controller/PaymentMethodController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/PaymentMethodController.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-final class PaymentMethodController extends ResourceController
+class PaymentMethodController extends ResourceController
 {
     /**
      * @param Request $request

--- a/src/Sylius/Bundle/CoreBundle/Controller/ProductTaxonController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/ProductTaxonController.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 /**
  * @author Anna Walasek <anna.walasek@lakion.com>
  */
-final class ProductTaxonController extends ResourceController
+class ProductTaxonController extends ResourceController
 {
     /**
      * @param Request $request

--- a/src/Sylius/Bundle/CoreBundle/Controller/ProductVariantController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/ProductVariantController.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 /**
  * @author Grzegorz Sadowski <grzegorz.sadowski@lakion.com>
  */
-final class ProductVariantController extends ResourceController
+class ProductVariantController extends ResourceController
 {
     /**
      * @param Request $request

--- a/src/Sylius/Bundle/ProductBundle/Controller/ProductAttributeController.php
+++ b/src/Sylius/Bundle/ProductBundle/Controller/ProductAttributeController.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
  */
-final class ProductAttributeController extends ResourceController
+class ProductAttributeController extends ResourceController
 {
     /**
      * @param Request $request


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | no|
| BC breaks?      | no|
| Related tickets | fixes #8563 |
| License         | MIT |

In case it's decided that controllers extending `ResourceController` should not be `final`, then here is the PR to fix that.