### PR TITLE
Add mailer_port to mailer configuration parameters

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -46,6 +46,7 @@ swiftmailer:
     host: "%mailer_host%"
     username: "%mailer_user%"
     password: "%mailer_password%"
+    port: "%mailer_port%"
 
 # Temporary fix to disable aliasing @serializer service to JMS variant
 # TODO: Remove when upgrading to JMS Serializer Bundle 2.0

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -12,6 +12,7 @@ parameters:
     mailer_host: 127.0.0.1
     mailer_user: ~
     mailer_password: ~
+    mailer_port: ~
 
     secret: EDITME
     locale: en_US


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets |  |
| License         | MIT |

It is a parameter needed to configure any mailer, would be handy to have it :)