### PR TITLE
Make afterUrl nullable

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Model/PaymentSecurityToken.php
+++ b/src/Sylius/Bundle/PayumBundle/Model/PaymentSecurityToken.php
@@ -69,7 +69,7 @@ class PaymentSecurityToken implements ResourceInterface, TokenInterface
     /**
      * {@inheritdoc}
      *
-     * @return IdentityInterface|null
+     * @return IdentityInterface
      */
     public function getDetails()
     {
@@ -111,7 +111,7 @@ class PaymentSecurityToken implements ResourceInterface, TokenInterface
     /**
      * {@inheritdoc}
      */
-    public function getAfterUrl(): string
+    public function getAfterUrl(): ?string
     {
         return $this->afterUrl;
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| License         | MIT |

Just ran into this issue using an offline payment method.

```
Type error: Return value of Sylius\Bundle\PayumBundle\Model\PaymentSecurityToken::getAfterUrl() must be of the type string, null returned
```

The used gateway = 'offline', so it's the Sylius internal one. Ran into it as in the resulting controller I'm doing some logging, which requested the afterUrl. Looking at the class code, it makes sense that it could return `null`, without the user having any other option finding out whether it is set at all (no other way to test this). 