### PR TITLE
[Shipping] Make shipping method category requirements translatable

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -243,6 +243,9 @@
     * `ShipmentUnitInterface::setShipment`
     * `ShipmentMethodInterface::setCategory`
     
+* static `getCategoryRequirementLabels` method was removed from `ShippingMethod`
+* `getCategoryRequirementLabel` method was removed from `ShippingMethodInterface`
+
 ### Taxation / TaxationBundle
 
 * The following methods does not longer have a default null argument and requires one to be explicitly passed:

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodType.php
@@ -20,6 +20,7 @@ use Sylius\Bundle\ResourceBundle\Form\Type\ResourceTranslationsType;
 use Sylius\Component\Registry\ServiceRegistryInterface;
 use Sylius\Component\Shipping\Calculator\CalculatorInterface;
 use Sylius\Component\Shipping\Model\ShippingMethod;
+use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -93,7 +94,11 @@ final class ShippingMethodType extends AbstractResourceType
                 'label' => 'sylius.form.shipping_method.category',
             ])
             ->add('categoryRequirement', ChoiceType::class, [
-                'choices' => array_flip(ShippingMethod::getCategoryRequirementLabels()),
+                'choices' => [
+                    'sylius.form.shipping_method.match_none_category_requirement' => ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_NONE,
+                    'sylius.form.shipping_method.match_any_category_requirement' => ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_ANY,
+                    'sylius.form.shipping_method.match_all_category_requirement' => ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_ALL,
+                ],
                 'multiple' => false,
                 'expanded' => true,
                 'label' => 'sylius.form.shipping_method.category_requirement',

--- a/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
@@ -36,7 +36,10 @@ sylius:
             configuration: Configuration
             description: Description
             enabled: Enabled
+            match_all_category_requirement: All units has to match the method category
+            match_any_category_requirement: At least 1 unit has to match the method category
+            match_none_category_requirement: None of the units have to match the method category
             name: Name
+            position: Position
             tax_category: Tax category
             translations: Translations
-            position: Position

--- a/src/Sylius/Component/Shipping/Model/ShippingMethod.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethod.php
@@ -154,14 +154,6 @@ class ShippingMethod implements ShippingMethodInterface
     /**
      * {@inheritdoc}
      */
-    public function getCategoryRequirementLabel(): string
-    {
-        return self::getCategoryRequirementLabels()[$this->categoryRequirement];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getName(): ?string
     {
         return $this->getTranslation()->getName();
@@ -221,18 +213,6 @@ class ShippingMethod implements ShippingMethodInterface
     public function setConfiguration(array $configuration): void
     {
         $this->configuration = $configuration;
-    }
-
-    /**
-     * @return array
-     */
-    public static function getCategoryRequirementLabels(): array
-    {
-        return [
-            ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_NONE => 'None of the units have to match the method category',
-            ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_ANY => 'At least 1 unit has to match the method category',
-            ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_ALL => 'All units has to match the method category',
-        ];
     }
 
     /**

--- a/src/Sylius/Component/Shipping/Model/ShippingMethodInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethodInterface.php
@@ -75,11 +75,6 @@ interface ShippingMethodInterface extends
     /**
      * @return string
      */
-    public function getCategoryRequirementLabel(): string;
-
-    /**
-     * @return string
-     */
     public function getCalculator(): ?string;
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | yes |
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/8360 |
| License         | MIT |

I was not sure what to do with `getCategoryRequirementLabel` method, as it uses the static method that would couple component with translations keys... but now there is no easy way to display shipping method category requirement... but we don't display it anywhere 😄  🎪 
