### PR TITLE
[PaymentMethod] Minor gateway fixes

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/payment_method.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/payment_method.yml
@@ -26,10 +26,12 @@ sylius_grid:
                     label: sylius.ui.name
                     sortable: translation.name
                 gateway:
-                    type: string
-                    path: gatewayConfig.gatewayName
+                    type: twig
+                    path: gatewayConfig.factoryName
                     label: sylius.ui.gateway
-                    sortable: gatewayConfig.gatewayName
+                    sortable: gatewayConfig.factoryName
+                    options:
+                        template: "@SyliusUi/Grid/Field/humanized.html.twig"
                 enabled:
                     type: twig
                     label: sylius.ui.enabled

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/PaymentMethodTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/PaymentMethodTypeExtension.php
@@ -53,10 +53,8 @@ final class PaymentMethodTypeExtension extends AbstractTypeExtension
                 }
 
                 $gatewayConfig = $paymentMethod->getGatewayConfig();
-                if (null === $gatewayConfig->getGatewayName()) {
-                    $gatewayConfig->setGatewayName(StringInflector::nameToLowercaseCode(
-                        $paymentMethod->getName() ?? $paymentMethod->getCode())
-                    );
+                if (null === $gatewayConfig->getGatewayName() && null !== $paymentMethod->getCode()) {
+                    $gatewayConfig->setGatewayName(StringInflector::nameToLowercaseCode($paymentMethod->getCode()));
                 }
             })
         ;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes #8060 |
| License         | MIT |

Changes:
- display gateway as gateway factory name in payment methods grid
- set gateway name as a payment method code which is unique instead of payment method name 