### PR TITLE
[Shipping][OrderProcessing] Default shipping method fixes

### DIFF
--- a/features/checkout/shipping_order/seeing_default_shipping_method_selected_based_on_shipping_address.feature
+++ b/features/checkout/shipping_order/seeing_default_shipping_method_selected_based_on_shipping_address.feature
@@ -1,0 +1,41 @@
+@checkout
+Feature: Seeing shipping methods which category is same as category of all my units
+    In order to select correct shipping method for my order
+    As a Customer
+    I want to be able to choose only shipping methods that match shipping category of all my items
+
+    Background:
+        Given the store operates on a channel named "Web"
+        And the store has a product "Star Trek Ship" priced at "$19.99"
+        And the store ships to "United Kingdom"
+        And the store ships to "United States"
+        And the store has a zone "United Kingdom" with code "UK"
+        And this zone has the "United Kingdom" country member
+        And the store has a zone "United States" with code "US"
+        And this zone has the "United States" country member
+        And the store has "DHL" shipping method with "$10.00" fee within the "US" zone
+        And the store has "FedEx" shipping method with "$20.00" fee within the "UK" zone
+        And I am a logged in customer
+
+    @ui
+    Scenario: Seeing default shipping method selected based on country from shipping address
+        Given I have product "Star Trek Ship" in the cart
+        When I am at the checkout addressing step
+        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I complete the addressing step
+        Then I should be on the checkout shipping step
+        And I should see selected "DHL" shipping method
+        And I should not see "FedEx" shipping method
+
+    @ui
+    Scenario: Seeing default shipping method selected based on country from shipping address after readdressing
+        Given I have product "Star Trek Ship" in the cart
+        When I am at the checkout addressing step
+        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I complete the addressing step
+        And I decide to change my address
+        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United Kingdom" for "Jon Snow"
+        And I complete the addressing step
+        Then I should be on the checkout shipping step
+        And I should see selected "FedEx" shipping method
+        And I should not see "DHL" shipping method

--- a/features/checkout/shipping_order/seeing_default_shipping_method_selected_based_on_shipping_address.feature
+++ b/features/checkout/shipping_order/seeing_default_shipping_method_selected_based_on_shipping_address.feature
@@ -1,5 +1,5 @@
 @checkout
-Feature: Seeing shipping methods which category is same as category of all my units
+Feature: Seeing default shipping method selected based on shipping address
     In order to select correct shipping method for my order
     As a Customer
     I want to be able to choose only shipping methods that match shipping category of all my items

--- a/features/checkout/shipping_order/seeing_default_shipping_method_selected_based_on_shipping_address.feature
+++ b/features/checkout/shipping_order/seeing_default_shipping_method_selected_based_on_shipping_address.feature
@@ -20,8 +20,8 @@ Feature: Seeing shipping methods which category is same as category of all my un
     @ui
     Scenario: Seeing default shipping method selected based on country from shipping address
         Given I have product "Star Trek Ship" in the cart
-        When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I am at the checkout addressing step
+        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
         And I should see selected "DHL" shipping method
@@ -30,8 +30,8 @@ Feature: Seeing shipping methods which category is same as category of all my un
     @ui
     Scenario: Seeing default shipping method selected based on country from shipping address after readdressing
         Given I have product "Star Trek Ship" in the cart
-        When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I am at the checkout addressing step
+        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I decide to change my address
         And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United Kingdom" for "Jon Snow"

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutShippingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutShippingContext.php
@@ -192,6 +192,14 @@ final class CheckoutShippingContext implements Context
     }
 
     /**
+     * @Then I should see selected :shippingMethodName shipping method
+     */
+    public function iShouldSeeSelectedShippingMethod($shippingMethodName)
+    {
+        Assert::same($this->selectShippingPage->getSelectedShippingMethodName(), $shippingMethodName);
+    }
+
+    /**
      * @Then I should not see :shippingMethodName shipping method
      */
     public function iShouldNotSeeShippingMethod($shippingMethodName)

--- a/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPage.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Shop\Checkout;
 
 use Behat\Mink\Driver\Selenium2Driver;
+use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Sylius\Behat\Page\SymfonyPage;
 
@@ -56,6 +57,24 @@ class SelectShippingPage extends SymfonyPage implements SelectShippingPageInterf
 
         return $shippingMethods;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSelectedShippingMethodName(): ?string
+    {
+        $shippingMethods = $this->getSession()->getPage()->findAll('css', '#sylius-shipping-methods .item');
+
+        /** @var NodeElement $shippingMethod */
+        foreach ($shippingMethods as $shippingMethod) {
+            if (null !== $shippingMethod->find('css', 'input:checked')) {
+                return $shippingMethod->find('css', '.content label')->getText();
+            }
+        }
+
+        return null;
+    }
+
 
     /**
      * {@inheritdoc}

--- a/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPageInterface.php
@@ -28,6 +28,11 @@ interface SelectShippingPageInterface extends SymfonyPageInterface
     public function getShippingMethods();
 
     /**
+     * @return string|null
+     */
+    public function getSelectedShippingMethodName(): ?string;
+
+    /**
      * @return bool
      */
     public function hasNoShippingMethodsMessage();

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -70,6 +70,7 @@
         </service>
         <service id="sylius.shipping_method_resolver.default" class="Sylius\Component\Core\Resolver\DefaultShippingMethodResolver">
             <argument type="service" id="sylius.repository.shipping_method" />
+            <argument type="service" id="sylius.zone_matcher" />
         </service>
         <service id="sylius.updater.order.exchange_rate" class="Sylius\Component\Core\Updater\OrderExchangeRateUpdater">
             <argument type="service" id="sylius.repository.currency" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/order_processing.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/order_processing.xml
@@ -29,6 +29,7 @@
 
         <service id="sylius.order_processing.order_shipment_processor" class="Sylius\Component\Core\OrderProcessing\OrderShipmentProcessor">
             <argument type="service" id="sylius.shipping_method_resolver.default" />
+            <argument type="service" id="sylius.shipping_methods_resolver" />
             <argument type="service" id="sylius.factory.shipment" />
             <tag name="sylius.order_processor" priority="50"/>
         </service>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/order_processing.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/order_processing.xml
@@ -29,8 +29,8 @@
 
         <service id="sylius.order_processing.order_shipment_processor" class="Sylius\Component\Core\OrderProcessing\OrderShipmentProcessor">
             <argument type="service" id="sylius.shipping_method_resolver.default" />
-            <argument type="service" id="sylius.shipping_methods_resolver" />
             <argument type="service" id="sylius.factory.shipment" />
+            <argument type="service" id="sylius.shipping_methods_resolver" />
             <tag name="sylius.order_processor" priority="50"/>
         </service>
 

--- a/src/Sylius/Component/Core/Resolver/DefaultShippingMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/DefaultShippingMethodResolver.php
@@ -33,20 +33,27 @@ class DefaultShippingMethodResolver implements DefaultShippingMethodResolverInte
     private $shippingMethodRepository;
 
     /**
-     * @var ZoneMatcherInterface
+     * @var ZoneMatcherInterface|null
      */
     private $zoneMatcher;
 
     /**
      * @param ShippingMethodRepositoryInterface $shippingMethodRepository
-     * @param ZoneMatcherInterface $zoneMatcher
+     * @param ZoneMatcherInterface|null $zoneMatcher
      */
     public function __construct(
         ShippingMethodRepositoryInterface $shippingMethodRepository,
-        ZoneMatcherInterface $zoneMatcher
+        ?ZoneMatcherInterface $zoneMatcher = null
     ) {
         $this->shippingMethodRepository = $shippingMethodRepository;
         $this->zoneMatcher = $zoneMatcher;
+
+        if (1 === func_num_args() || null === $zoneMatcher) {
+            @trigger_error(
+                'Not passing ZoneMatcherInterface explicitly is deprecated since 1.2 and will be prohibited in 2.0',
+                E_USER_DEPRECATED
+            );
+        }
     }
 
     /**
@@ -76,11 +83,11 @@ class DefaultShippingMethodResolver implements DefaultShippingMethodResolverInte
      * @param ChannelInterface $channel
      * @param AddressInterface|null $address
      *
-     * @return array
+     * @return array|ShippingMethodInterface[]
      */
     private function getShippingMethods(ChannelInterface $channel, ?AddressInterface $address): array
     {
-        if (null === $address) {
+        if (null === $address || null === $this->zoneMatcher) {
             return $this->shippingMethodRepository->findEnabledForChannel($channel);
         }
 

--- a/src/Sylius/Component/Core/Resolver/DefaultShippingMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/DefaultShippingMethodResolver.php
@@ -72,6 +72,12 @@ class DefaultShippingMethodResolver implements DefaultShippingMethodResolverInte
         return $shippingMethods[0];
     }
 
+    /**
+     * @param ChannelInterface $channel
+     * @param AddressInterface|null $address
+     *
+     * @return array
+     */
     private function getShippingMethods(ChannelInterface $channel, ?AddressInterface $address): array
     {
         if (null === $address) {

--- a/src/Sylius/Component/Core/spec/Resolver/DefaultShippingMethodResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/Resolver/DefaultShippingMethodResolverSpec.php
@@ -65,6 +65,30 @@ final class DefaultShippingMethodResolverSpec extends ObjectBehavior
         $this->getDefaultShippingMethod($shipment)->shouldReturn($firstShippingMethod);
     }
 
+    function it_returns_first_enabled_shipping_method_from_shipment_order_channel_if_zone_matcher_is_not_used(
+        AddressInterface $shippingAddress,
+        ChannelInterface $channel,
+        OrderInterface $order,
+        ShipmentInterface $shipment,
+        ShippingMethodInterface $firstShippingMethod,
+        ShippingMethodInterface $secondShippingMethod,
+        ShippingMethodRepositoryInterface $shippingMethodRepository
+    ): void {
+        $this->beConstructedWith($shippingMethodRepository);
+
+        $shipment->getOrder()->willReturn($order);
+
+        $order->getChannel()->willReturn($channel);
+        $order->getShippingAddress()->willReturn($shippingAddress);
+
+        $shippingMethodRepository
+            ->findEnabledForChannel($channel)
+            ->willReturn([$firstShippingMethod, $secondShippingMethod])
+        ;
+
+        $this->getDefaultShippingMethod($shipment)->shouldReturn($firstShippingMethod);
+    }
+
     function it_returns_first_enabled_shipping_method_matched_by_order_channel_and_shipping_address_zone(
         AddressInterface $shippingAddress,
         ChannelInterface $channel,

--- a/src/Sylius/Component/Core/spec/Resolver/DefaultShippingMethodResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/Resolver/DefaultShippingMethodResolverSpec.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 namespace spec\Sylius\Component\Core\Resolver;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Addressing\Matcher\ZoneMatcherInterface;
+use Sylius\Component\Addressing\Model\ZoneInterface;
+use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
@@ -25,9 +29,11 @@ use Sylius\Component\Shipping\Resolver\DefaultShippingMethodResolverInterface;
 
 final class DefaultShippingMethodResolverSpec extends ObjectBehavior
 {
-    function let(ShippingMethodRepositoryInterface $shippingMethodRepository): void
-    {
-        $this->beConstructedWith($shippingMethodRepository);
+    function let(
+        ShippingMethodRepositoryInterface $shippingMethodRepository,
+        ZoneMatcherInterface $zoneMatcher
+    ): void {
+        $this->beConstructedWith($shippingMethodRepository, $zoneMatcher);
     }
 
     function it_implements_a_default_shipping_method_resolver_interface(): void
@@ -35,16 +41,21 @@ final class DefaultShippingMethodResolverSpec extends ObjectBehavior
         $this->shouldImplement(DefaultShippingMethodResolverInterface::class);
     }
 
-    function it_returns_first_enabled_shipping_method_from_shipment_order_channel_as_default(
+    function it_returns_first_enabled_shipping_method_from_shipment_order_channel_if_there_is_not_shipping_address(
         ChannelInterface $channel,
         OrderInterface $order,
         ShipmentInterface $shipment,
         ShippingMethodInterface $firstShippingMethod,
         ShippingMethodInterface $secondShippingMethod,
-        ShippingMethodRepositoryInterface $shippingMethodRepository
+        ShippingMethodRepositoryInterface $shippingMethodRepository,
+        ZoneMatcherInterface $zoneMatcher
     ): void {
         $shipment->getOrder()->willReturn($order);
+
         $order->getChannel()->willReturn($channel);
+        $order->getShippingAddress()->willReturn(null);
+
+        $zoneMatcher->matchAll(Argument::any())->shouldNotBeCalled();
 
         $shippingMethodRepository
             ->findEnabledForChannel($channel)
@@ -54,17 +65,54 @@ final class DefaultShippingMethodResolverSpec extends ObjectBehavior
         $this->getDefaultShippingMethod($shipment)->shouldReturn($firstShippingMethod);
     }
 
-    function it_throws_an_exception_if_there_is_no_enabled_shipping_methods(
-        ShippingMethodRepositoryInterface $shippingMethodRepository,
-        ShipmentInterface $shipment,
+    function it_returns_first_enabled_shipping_method_matched_by_order_channel_and_shipping_address_zone(
+        AddressInterface $shippingAddress,
         ChannelInterface $channel,
-        OrderInterface $order
+        OrderInterface $order,
+        ShipmentInterface $shipment,
+        ShippingMethodInterface $firstShippingMethod,
+        ShippingMethodInterface $secondShippingMethod,
+        ShippingMethodRepositoryInterface $shippingMethodRepository,
+        ZoneInterface $firstZone,
+        ZoneInterface $secondZone,
+        ZoneMatcherInterface $zoneMatcher
     ): void {
         $shipment->getOrder()->willReturn($order);
+
         $order->getChannel()->willReturn($channel);
+        $order->getShippingAddress()->willReturn($shippingAddress);
+
+        $zoneMatcher->matchAll($shippingAddress)->willReturn([$firstZone, $secondZone]);
 
         $shippingMethodRepository
-            ->findEnabledForChannel($channel)->willReturn([]);
+            ->findEnabledForZonesAndChannel([$firstZone, $secondZone], $channel)
+            ->willReturn([$firstShippingMethod, $secondShippingMethod])
+        ;
+
+        $this->getDefaultShippingMethod($shipment)->shouldReturn($firstShippingMethod);
+    }
+
+    function it_throws_an_exception_if_there_is_no_enabled_shipping_methods_for_order_channel_and_zones(
+        AddressInterface $shippingAddress,
+        ChannelInterface $channel,
+        OrderInterface $order,
+        ShipmentInterface $shipment,
+        ShippingMethodRepositoryInterface $shippingMethodRepository,
+        ZoneInterface $firstZone,
+        ZoneInterface $secondZone,
+        ZoneMatcherInterface $zoneMatcher
+    ): void {
+        $shipment->getOrder()->willReturn($order);
+
+        $order->getChannel()->willReturn($channel);
+        $order->getShippingAddress()->willReturn($shippingAddress);
+
+        $zoneMatcher->matchAll($shippingAddress)->willReturn([$firstZone, $secondZone]);
+
+        $shippingMethodRepository
+            ->findEnabledForZonesAndChannel([$firstZone, $secondZone], $channel)
+            ->willReturn([])
+        ;
 
         $this
             ->shouldThrow(UnresolvedDefaultShippingMethodException::class)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/7965 |
| License         | MIT |
 
Two bugs where involved in this issue:
1. `DefaultShippingMethodResolver` where returning only enabled shipping methods for channel, without considering their eligibility for proper zone.
2. When the shipment was already set on `Order` it was taken confidently, without checking does it's method is eligible for current state of the order.

It was especially frustrating when shipping step was skipped.

Current solution is not perfect (even more complexity in `OrderShipmentProcessor`) but better than not working at all 😄  🐃 