### PR TITLE
[Documentation] Update Disabling Order Confirmation email cookbook

### DIFF
--- a/docs/cookbook/disabling-order-confirmation-email.rst
+++ b/docs/cookbook/disabling-order-confirmation-email.rst
@@ -73,20 +73,6 @@ The above compiler pass needs to be added to your bundle in the ``AppBundle/AppB
 
 That's it, we have removed the definition of the listner that is responsible for sending the order confirmation email.
 
-Overriding service definition
------------------------------
-
-If you'd like to change the logic, and for instance send a confirmation email not after the order complete, but after the payment is complete
-then you just need to override the service definition, and change the event to which the listener is attached.
-
-.. code-block:: yaml
-
-    services:
-        sylius.listener.order_complete:
-            class: Sylius\Bundle\ShopBundle\EventListener\OrderCompleteListener
-            tags:
-                - { name: kernel.event_listener, event: sylius.order.payment.post_complete, method: sendConfirmationEmail }
-
 Learn more
 ----------
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Doc fix?        | ~yes |
| New docs?    | no :( |
| Related tickets | fixes #8395, at least in the docs there will be no more confusion |
| License         | MIT |

Currently the `sylius.order.payment.post/pre_complete` events are not available.
And the `sylius.payment.post/pre_complete` events cannot be used in the `sylius.listener.order_complete` as they contain Payment object not Order.