### PR TITLE
[Docs] Corrections on OrderItemQuantityModifier

### DIFF
--- a/docs/components_and_bundles/bundles/SyliusOrderBundle/services.rst
+++ b/docs/components_and_bundles/bundles/SyliusOrderBundle/services.rst
@@ -56,18 +56,18 @@ that needs to be done. This service handles this task, adding and removing prope
    $orderItemQuantityModifier = $this->get('sylius.order_item_quantity_modifier');
 
    $orderItem = $orderItemFactory->createNew();
-   $orderItem->getQuantity(); // default quantity of order item is "0"
+   $orderItem->getQuantity(); // default quantity of order item is 0
 
    $orderItem->setUnitPrice(1000);
 
    $orderItemQuantityModifier->modify($orderItem, 4);
 
    $orderItem->getQuantity(); // after using modifier, quantity is as expected
-   $orderItem->getTotal();    // item's total is sum of all units' total (units has been created by modifier)
+   $orderItem->getTotal();    // item's total is sum of all units' total (units have been created by modifier)
 
    $orderItemQuantityModifier->modify($orderItem, 2);
 
    // OrderItemQuantityModifier can also reduce item's quantity and remove unnecessary units
 
-   $orderItem->getQuantity(); // "2"
-   $orderItem->getTotal();    // 4000
+   $orderItem->getQuantity(); // 2
+   $orderItem->getTotal();    // 2000


### PR DESCRIPTION
`$orderItem->getTotal();` should be 2 * 1000 = 2000
Changed the `"0"` and `"2"` because getQuantity() returns an integer.
