### PR TITLE
[ReviewBundle] Recalculate subject rating on review post create event

### DIFF
--- a/src/Sylius/Bundle/ReviewBundle/DependencyInjection/SyliusReviewExtension.php
+++ b/src/Sylius/Bundle/ReviewBundle/DependencyInjection/SyliusReviewExtension.php
@@ -79,9 +79,15 @@ final class SyliusReviewExtension extends AbstractResourceExtension
             ]);
 
             $reviewChangeListener->addTag('kernel.event_listener', [
+                'event' => sprintf('sylius.%s_review.post_create', $reviewSubject),
+                'method' => 'recalculateSubjectRating',
+            ]);
+
+            $reviewChangeListener->addTag('kernel.event_listener', [
                 'event' => sprintf('sylius.%s_review.post_update', $reviewSubject),
                 'method' => 'recalculateSubjectRating',
             ]);
+
             $reviewChangeListener->addTag('kernel.event_listener', [
                 'event' => sprintf('sylius.%s_review.post_delete', $reviewSubject),
                 'method' => 'recalculateSubjectRating',

--- a/src/Sylius/Bundle/ReviewBundle/DependencyInjection/SyliusReviewExtension.php
+++ b/src/Sylius/Bundle/ReviewBundle/DependencyInjection/SyliusReviewExtension.php
@@ -78,20 +78,17 @@ final class SyliusReviewExtension extends AbstractResourceExtension
                 new Reference(sprintf('sylius.%s_review.average_rating_updater', $reviewSubject)),
             ]);
 
-            $reviewChangeListener->addTag('kernel.event_listener', [
-                'event' => sprintf('sylius.%s_review.post_create', $reviewSubject),
-                'method' => 'recalculateSubjectRating',
-            ]);
-
-            $reviewChangeListener->addTag('kernel.event_listener', [
-                'event' => sprintf('sylius.%s_review.post_update', $reviewSubject),
-                'method' => 'recalculateSubjectRating',
-            ]);
-
-            $reviewChangeListener->addTag('kernel.event_listener', [
-                'event' => sprintf('sylius.%s_review.post_delete', $reviewSubject),
-                'method' => 'recalculateSubjectRating',
-            ]);
+            $reviewChangeListener
+                ->addTag('doctrine.event_listener', [
+                    'event' => 'postPersist',
+                ])
+                ->addTag('doctrine.event_listener', [
+                    'event' => 'postUpdate',
+                ])
+                ->addTag('doctrine.event_listener', [
+                    'event' => 'postDelete',
+                ])
+            ;
 
             $container->addDefinitions([
                 sprintf('sylius.%s_review.average_rating_updater', $reviewSubject) => new Definition(AverageRatingUpdater::class, [

--- a/src/Sylius/Bundle/ReviewBundle/DependencyInjection/SyliusReviewExtension.php
+++ b/src/Sylius/Bundle/ReviewBundle/DependencyInjection/SyliusReviewExtension.php
@@ -86,7 +86,7 @@ final class SyliusReviewExtension extends AbstractResourceExtension
                     'event' => 'postUpdate',
                 ])
                 ->addTag('doctrine.event_listener', [
-                    'event' => 'postDelete',
+                    'event' => 'postRemove',
                 ])
             ;
 

--- a/src/Sylius/Bundle/ReviewBundle/EventListener/ReviewChangeListener.php
+++ b/src/Sylius/Bundle/ReviewBundle/EventListener/ReviewChangeListener.php
@@ -71,8 +71,6 @@ final class ReviewChangeListener
             return;
         }
 
-        if (ReviewInterface::STATUS_ACCEPTED === $subject->getStatus()) {
-            $this->averageRatingUpdater->update($subject->getReviewSubject());
-        }
+        $this->averageRatingUpdater->update($subject->getReviewSubject());
     }
 }

--- a/src/Sylius/Bundle/ReviewBundle/EventListener/ReviewChangeListener.php
+++ b/src/Sylius/Bundle/ReviewBundle/EventListener/ReviewChangeListener.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ReviewBundle\EventListener;
 
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use Sylius\Bundle\ReviewBundle\Updater\ReviewableRatingUpdaterInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 use Sylius\Component\Review\Model\ReviewInterface;
-use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * @author Mateusz Zalewski <mateusz.zalewski@lakion.com>
@@ -37,13 +37,30 @@ final class ReviewChangeListener
     }
 
     /**
-     * @param GenericEvent $event
+     * @param LifecycleEventArgs $args
      */
-    public function recalculateSubjectRating(GenericEvent $event): void
+    public function postPersist(LifecycleEventArgs $args)
     {
-        $subject = $event->getSubject();
+        $this->recalculateSubjectRating($args);
+    }
+
+    /**
+     * @param LifecycleEventArgs $args
+     */
+    public function postUpdate(LifecycleEventArgs $args)
+    {
+        $this->recalculateSubjectRating($args);
+    }
+
+    /**
+     * @param LifecycleEventArgs $args
+     */
+    public function recalculateSubjectRating(LifecycleEventArgs $args): void
+    {
+        $subject = $args->getObject();
+
         if (!$subject instanceof ReviewInterface) {
-            throw new UnexpectedTypeException($subject, ReviewInterface::class);
+            return;
         }
 
         if (ReviewInterface::STATUS_ACCEPTED === $subject->getStatus()) {

--- a/src/Sylius/Bundle/ReviewBundle/EventListener/ReviewChangeListener.php
+++ b/src/Sylius/Bundle/ReviewBundle/EventListener/ReviewChangeListener.php
@@ -55,6 +55,14 @@ final class ReviewChangeListener
     /**
      * @param LifecycleEventArgs $args
      */
+    public function postRemove(LifecycleEventArgs $args)
+    {
+        $this->recalculateSubjectRating($args);
+    }
+
+    /**
+     * @param LifecycleEventArgs $args
+     */
     public function recalculateSubjectRating(LifecycleEventArgs $args): void
     {
         $subject = $args->getObject();

--- a/src/Sylius/Bundle/ReviewBundle/spec/EventListener/ReviewChangeListenerSpec.php
+++ b/src/Sylius/Bundle/ReviewBundle/spec/EventListener/ReviewChangeListenerSpec.php
@@ -47,26 +47,6 @@ final class ReviewChangeListenerSpec extends ObjectBehavior
         $this->recalculateSubjectRating($event);
     }
 
-    function it_does_nothing_if_review_was_new($averageRatingUpdater, LifecycleEventArgs $event, ReviewInterface $review): void
-    {
-        $event->getObject()->willReturn($review);
-        $review->getStatus()->willReturn(ReviewInterface::STATUS_NEW);
-
-        $averageRatingUpdater->update(Argument::type(ReviewableInterface::class))->shouldNotBeCalled();
-
-        $this->recalculateSubjectRating($event);
-    }
-
-    function it_does_nothing_if_review_was_rejected($averageRatingUpdater, LifecycleEventArgs $event, ReviewInterface $review): void
-    {
-        $event->getObject()->willReturn($review);
-        $review->getStatus()->willReturn(ReviewInterface::STATUS_REJECTED);
-
-        $averageRatingUpdater->update(Argument::type(ReviewableInterface::class))->shouldNotBeCalled();
-
-        $this->recalculateSubjectRating($event);
-    }
-
     function it_does_nothing_if_event_subject_is_not_review_object($averageRatingUpdater, LifecycleEventArgs $event): void
     {
         $event->getObject()->willReturn('badObject');

--- a/src/Sylius/Bundle/ReviewBundle/spec/EventListener/ReviewChangeListenerSpec.php
+++ b/src/Sylius/Bundle/ReviewBundle/spec/EventListener/ReviewChangeListenerSpec.php
@@ -39,7 +39,6 @@ final class ReviewChangeListenerSpec extends ObjectBehavior
         ReviewableInterface $reviewSubject
     ): void {
         $event->getObject()->willReturn($review);
-        $review->getStatus()->willReturn(ReviewInterface::STATUS_ACCEPTED);
         $review->getReviewSubject()->willReturn($reviewSubject);
 
         $averageRatingUpdater->update($reviewSubject)->shouldBeCalled();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | kind of |
| New feature?    | kind of  |
| BC breaks?      | no |
| Related tickets |  |
| License         | MIT |

In case you handle your reviews without moderation (directly with accepted status), you need your subject would be recalculate on post create event. You also need this feature if you handle ratings without title and comment.