### PR TITLE
add sylius version to the footer in admin

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
@@ -39,8 +39,9 @@
     {{ sonata_block_render_event('sylius.admin.layout.sidebar_down') }}
 {% endblock %}
 
-{% block footer %}
-    {{ 'sylius.ui.powered_by'|trans }} <a href="http://sylius.org" target="_blank">Sylius</a>.
+{% block post_content %}
+    <div class="ui divider"></div>
+    {{ 'sylius.ui.powered_by'|trans }} <a href="http://sylius.org" target="_blank">Sylius v{{ sylius_meta.version }}</a>
 {% endblock %}
 
 {% block javascripts %}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -93,6 +93,8 @@ twig:
     exception_controller: "FOS\\RestBundle\\Controller\\ExceptionController::showAction"
     globals:
         sylius: "@sylius.context.shopper"
+        sylius_meta:
+            version: !php/const:Sylius\Bundle\CoreBundle\Application\Kernel::VERSION
 
 sonata_block:
     blocks:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | yes |
| BC breaks?      | yes |
| Related tickets | fixes #8679  |
| License         | MIT |

It seems the version was missing from admin due to a bug in a twig file - the footer block in admin got renamed post_content at some point in history. 

On top of fixing this bug, I added a new constant in the kernel class, APP_NAME with the default value being "Sylius". In case at a later point someone decides to craft a forked version of Sylius called "Supercharged Sylius" and it needs to brag about the name. Before hand, Sylius was hardcoded in the twig template. 

I have declared both Sylius\Bundle\CoreBundle\Application\Kernel::VERSION and Sylius\Bundle\CoreBundle\Application\Kernel::APP_NAME as twig global variables and used them to be in the twig layout template for admin. 

I consider this useful when debugging a Sylius application over the phone with a non-technical person. First question I would ask is: what version of Sylius do you run? 

Also, I find it a good reason to brag about: look, I'm running Sylius 1.0.0!