### PR TITLE
[Documentation] Non-existent action used

### DIFF
--- a/docs/cookbook/checkout.rst
+++ b/docs/cookbook/checkout.rst
@@ -243,7 +243,7 @@ to the ``app/Resources/SyliusShopBundle/config/routing/checkout.yml`` file.
         path: /complete
         methods: [GET, PUT]
         defaults:
-            _controller: sylius.controller.order:completeAction
+            _controller: sylius.controller.order:updateAction
             _sylius:
                 event: complete
                 flash: false


### PR DESCRIPTION
There is no any ```completeAction``` in source file (ShopBundle/Resources/config/routing/checkout.yml) 
Also there is no such action in ```OrderController``` or its ancestors, so it cause error

| Q               | A
| --------------- | ---
| Bug fix?        | yes |
| New feature?    | no |
| BC breaks?      | no |
| Related tickets | - |
| License         | MIT |
