### PR TITLE
[Bug][Admin] Avoid deleting Product Variant when removing the associa…

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductVariant.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ProductVariant.orm.xml
@@ -49,7 +49,7 @@
             mapped-by="productVariants"
         >
             <cascade>
-                <cascade-all/>
+                <cascade-persist/>
             </cascade>
         </many-to-many>
     </mapped-superclass>


### PR DESCRIPTION
…tion between product image & variant (admin Product media form)

| Q               | A
| --------------- | -----
| Branch?         | 1.0 or 
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

On product admin form, we can now associate product variants to product images.
But removing the association removes also the product variant.
