### PR TITLE
Run security:check to actively check issues in Composer dependencies

### DIFF
--- a/etc/travis/suites/application/script.sh
+++ b/etc/travis/suites/application/script.sh
@@ -5,6 +5,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../bash/common.lib.s
 code=0
 commands=(
     validate-composer
+    validate-composer-security
     validate-behat-features
     validate-doctrine-schema
     validate-twig

--- a/etc/travis/suites/application/script/validate-composer-security
+++ b/etc/travis/suites/application/script/validate-composer-security
@@ -3,4 +3,4 @@
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../../bash/common.lib.sh"
 
 print_header "Validating (Composer package security)" "Sylius"
-run_command "bin/console security:check"
+run_command "bin/console security:check --end-point=http://security.sensiolabs.org/check_lock"

--- a/etc/travis/suites/application/script/validate-composer-security
+++ b/etc/travis/suites/application/script/validate-composer-security
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../../bash/common.lib.sh"
+
+print_header "Validating (Composer package security)" "Sylius"
+run_command "bin/console security:check"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Not sure 1.0 is good here, but let's first see if it works on Travis. Next to validating Composer, Yarn, etc, it might also be good to check dependencies for known security issues. Currently there is nothing, but it's good to keep it automated I think.