### PR TITLE
[Documentation] Clarification of how to install assets in a new theme

### DIFF
--- a/docs/book/themes/themes.rst
+++ b/docs/book/themes/themes.rst
@@ -62,7 +62,24 @@ Let it be ``CrimsonTheme/`` for instance.
        }
    }
 
-3. Customize a template:
+3. Install theme assets
+
+Theme assets are installed by running the ``sylius:theme:assets:install`` command, which is supplementary for and should be used after ``assets:install``.
+
+.. code-block:: bash
+
+   bin/console sylius:theme:assets:install
+
+The command run with ``--symlink`` or ``--relative`` parameters creates symlinks for every installed asset file,
+not for entire asset directory (eg. if ``AcmeBundle/Resources/public/asset.js`` exists, it creates symlink ``web/bundles/acme/asset.js``
+leading to ``AcmeBundle/Resources/public/asset.js`` instead of symlink ``web/bundles/acme/`` leading to ``AcmeBundle/Resources/public/``).
+When you create a new asset or delete an existing one, it is required to rerun this command to apply changes (just as the hard copy option works).
+
+.. note::
+
+   Whenever you install a new bundle with assets you will need to run ``sylius:theme:assets:install`` again to make sure they are accessible in your theme.
+
+4. Customize a template:
 
 In order to customize the login view you should take the content of ``@SyliusShopBundle/views/login.html.twig`` file
 and paste it to your theme directory: ``app/themes/CrimsonTheme/SyliusShopBundle/views/login.html.twig``
@@ -98,14 +115,14 @@ Let's remove the registration column in this example:
 
    Learn more about customizing templates :doc:`here </customization/template>`.
 
-4. Choose your new theme on the channel:
+5. Choose your new theme on the channel:
 
 In the administration panel go to channels and change the theme of your desired channel to ``Crimson Theme``.
 
 .. image:: ../../_images/channel_theme.png
    :align: center
 
-5. If changes are not yet visible, clear the cache:
+6. If changes are not yet visible, clear the cache:
 
 .. code-block:: bash
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |  mentioned in #8789 
| License         | MIT

Added step 3 in the guide. This is mainly taken from [here](http://docs.sylius.org/en/latest/components_and_bundles/bundles/SyliusThemeBundle/important_changes.html#assets) but when you are reading this page on how to create a theme, you don't know to find that page. One option was to link to that, but as that page is about changes, it seems to make more sense to put it into the core documentation. Merging it in to this page will prevent developers from struggling (as I did) to find out why the issues in ticket #8789 are happening.

I've renamed later steps to accommodate the insertion of step 3.

Probably at some point, the original mention [here](http://docs.sylius.org/en/latest/components_and_bundles/bundles/SyliusThemeBundle/important_changes.html#assets) should be removed.

Thanks to @stefandoorn for help.