### PR TITLE
Mention ^PHP7.1 requirement when installing Sylius (closes 8765)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Documentation
 
 Documentation is available at [docs.sylius.org](http://docs.sylius.org).
 
+Requirements
+------------
+
+Read about the Sylius system requirements in detail [here](http://docs.sylius.org/en/latest/book/installation/requirements.html).
+
 Installation
 ------------
 
@@ -45,6 +50,8 @@ $ php bin/console sylius:install
 $ yarn install && yarn run gulp
 $ php bin/console server:start
 ```
+
+> Note: make sure to use PHP ^7.1. Using an older PHP version will result in installing an older version of Sylius.
 
 Then open `http://localhost:8000/` in your web browser to enjoy your Sylius shop in a development environment.
 

--- a/docs/book/installation/installation.rst
+++ b/docs/book/installation/installation.rst
@@ -30,6 +30,10 @@ To create a new project using Sylius Standard Edition, run this command:
 
     $ composer create-project sylius/sylius-standard acme
 
+.. note::
+
+    Make sure to use PHP ^7.1. Using an older PHP version will result in installing an older version of Sylius.
+
 This will create a new Symfony project in ``acme`` directory. When all the
 dependencies are installed, you'll be asked to fill the ``parameters.yml``
 file via interactive script. Please follow the steps. After everything is in


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #8765
| License         | MIT

Mention about PHP ^7.1 not to confuse people installing older Sylius versions.