### PR TITLE
[Documentation] Remove outdated exchange rate info from Order docs

### DIFF
--- a/docs/book/orders/orders.rst
+++ b/docs/book/orders/orders.rst
@@ -10,8 +10,8 @@ It represents an order that can be either placed or in progress (cart).
 **Order** holds a collection of **OrderItem** instances, which represent products from the shop,
 as its physical copies, with chosen variants and quantities.
 
-Each Order is **assigned to the channel** in which it has been created. Moreover the **language** the customer was using
-and the **currency with its exchange rate** at the moment of creation are saved.
+Each Order is **assigned to the channel** in which it has been created as well as the **language** the customer was using
+while placing the order. The order currency code will be the base currency of the current channel by default.
 
 How to create an Order programmatically?
 ----------------------------------------


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update UPGRADE-*.md file -->
| Related tickets | -
| License         | MIT

As mentioned in https://github.com/Sylius/Sylius/pull/6901#commitcomment-21147273 this confused me quite a bit before I found this.

Feel free to suggest sth. different
