### PR TITLE
Revert "Changed CustomerChoiceType for a ResourceToIdentifierTransformer in OrderType of SyliusAdminApiBundle"

### DIFF
--- a/src/Sylius/Bundle/AdminApiBundle/Form/Type/OrderType.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Form/Type/OrderType.php
@@ -14,13 +14,13 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminApiBundle\Form\Type;
 
 use Sylius\Bundle\ChannelBundle\Form\Type\ChannelChoiceType;
+use Sylius\Bundle\CustomerBundle\Form\Type\CustomerChoiceType;
 use Sylius\Bundle\LocaleBundle\Form\Type\LocaleChoiceType;
 use Sylius\Bundle\ResourceBundle\Form\DataTransformer\ResourceToIdentifierTransformer;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -38,21 +38,15 @@ final class OrderType extends AbstractResourceType
     private $localeRepository;
 
     /**
-     * @var RepositoryInterface
-     */
-    private $customerRepository;
-
-    /**
      * {@inheritdoc}
      *
      * @param RepositoryInterface $localeRepository
      */
-    public function __construct(string $dataClass, array $validationGroups = [], RepositoryInterface $localeRepository, RepositoryInterface $customerRepository)
+    public function __construct(string $dataClass, array $validationGroups = [], RepositoryInterface $localeRepository)
     {
         parent::__construct($dataClass, $validationGroups);
 
         $this->localeRepository = $localeRepository;
-        $this->customerRepository = $customerRepository;
     }
 
     /**
@@ -61,7 +55,7 @@ final class OrderType extends AbstractResourceType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('customer', TextType::class, [
+            ->add('customer', CustomerChoiceType::class, [
                 'constraints' => [
                     new NotBlank(['groups' => ['sylius']]),
                 ],
@@ -86,10 +80,6 @@ final class OrderType extends AbstractResourceType
                 }
             })
         ;
-
-        $builder->get('customer')->addModelTransformer(
-            new ResourceToIdentifierTransformer($this->customerRepository, 'email')
-        );
 
         $builder->get('localeCode')->addModelTransformer(
             new ReversedTransformer(new ResourceToIdentifierTransformer($this->localeRepository, 'code'))

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/services/form.xml
@@ -36,7 +36,6 @@
             <argument>%sylius.model.order.class%</argument>
             <argument>%sylius.form.type.api_order.validation_groups%</argument>
             <argument type="service" id="sylius.repository.locale" />
-            <argument type="service" id="sylius.repository.customer" />
             <tag name="form.type" />
         </service>
 


### PR DESCRIPTION
Reverts #8778.

Replacing `CustomerChoiceType` with `TextType` looks like a BC break - behaviour would change if anyone has relied on form type being `CustomerChoiceType` and therefore extended it by a type extension. Moreover, it feels like it does not feel right semantically.

In order to improve performance we should use a choice loader inside our choice types. Since patch release will be out today (or at last tomorrow), reverting it and coming up with more backward compatible yet performant solution later seems like the best decision.