### PR TITLE
Fixed Product->hasAttribute function

### DIFF
--- a/src/Sylius/Component/Product/Model/Product.php
+++ b/src/Sylius/Component/Product/Model/Product.php
@@ -248,7 +248,13 @@ class Product implements ProductInterface
      */
     public function hasAttribute(AttributeValueInterface $attribute): bool
     {
-        return $this->attributes->contains($attribute);
+        foreach ($this->attributes as $value){
+            if ($value->getCode() === $attribute->getCode()){
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Sylius/Component/Product/spec/Model/ProductSpec.php
+++ b/src/Sylius/Component/Product/spec/Model/ProductSpec.php
@@ -90,6 +90,7 @@ final class ProductSpec extends ObjectBehavior
 
     function it_adds_attribute(ProductAttributeValueInterface $attribute): void
     {
+        $attribute->getCode()->shouldBeCalled();
         $attribute->setProduct($this)->shouldBeCalled();
 
         $this->addAttribute($attribute);
@@ -98,6 +99,7 @@ final class ProductSpec extends ObjectBehavior
 
     function it_removes_attribute(ProductAttributeValueInterface $attribute): void
     {
+        $attribute->getCode()->shouldBeCalled();
         $attribute->setProduct($this)->shouldBeCalled();
 
         $this->addAttribute($attribute);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0 or master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update UPGRADE-*.md file -->
| Related tickets | none
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.0 branch
 - Features and deprecations must be submitted against the master branch
-->
**Before:** The Product `hasAttribute` function takes in an attribute and checks if it is inside the `attributes` member (an array). For this it uses the `in_array` function which needs equality between these objects. If however the parameter attribute that it is checking against is not yet saved in the database and therefore has no id, the attributes are not considered equal.

**After**: Now the attributes are considered equal if they have the same attribute code. This is a property that is kept unique by the database so there will be no two attributes that are different but share the same attribute code.