### PR TITLE
Add a requirements for the minimal memory_limit setting when installing

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Installer/Requirement/SettingsRequirements.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Requirement/SettingsRequirements.php
@@ -53,7 +53,8 @@ final class SettingsRequirements extends RequirementCollection
                 $this->hasSufficientMemory(),
                 false,
                 $translator->trans('sylius.installer.settings.memory_limit.help', [])
-            ));
+            ))
+        ;
     }
 
     /**
@@ -92,12 +93,13 @@ final class SettingsRequirements extends RequirementCollection
      * @see https://github.com/composer/composer/blob/master/bin/composer#L26
      *
      * @param $value
+     *
      * @return int
      */
-    private function getMemoryInBytes($value)
+    private function getMemoryInBytes($value): int
     {
         $unit = strtolower(substr($value, -1, 1));
-        $value = (int)$value;
+        $value = (int) $value;
         switch ($unit) {
             case 'g':
                 $value *= 1024;
@@ -108,6 +110,7 @@ final class SettingsRequirements extends RequirementCollection
             case 'k':
                 $value *= 1024;
         }
+
         return $value;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
@@ -202,6 +202,9 @@ sylius:
                 help: Timezone %timezone% is deprecated. Fix your php.ini file (list of deprecated timezones http://php.net/manual/en/timezones.others.php).
             version: PHP version
             version_recommended: Recommended PHP version
+            memory_limit:
+                header: low memory_limit
+                help: Consider using php -d memory_limit=-1 to prevent issues with memory while installing.
 
     payum_gateway:
         cash_on_delivery: Cash on delivery


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | None
| License         | MIT

Hi! :raising_hand_man: 

When installing Sylius for the first time I got presented with an
```
[Symfony\Component\Debug\Exception\OutOfMemoryException]                                 
  Error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 32768 bytes)
```
This PR should warn the user upfront when installing Sylius about any minimal memory requirements.
I'd love to hear your thoughts about this PR. I've just started my Sylius journey so I'm not that familair with the conventions yet. For example: Should we enforce a new memory_limit if `ini_set` is available?
