### PR TITLE
Clean the not Fulfilled Table before each collection

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Installer/Checker/SyliusRequirementsChecker.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Checker/SyliusRequirementsChecker.php
@@ -48,13 +48,12 @@ final class SyliusRequirementsChecker implements RequirementsCheckerInterface
      */
     public function check(InputInterface $input, OutputInterface $output): bool
     {
-        $notFulfilledTable = new TableRenderer($output);
-        $notFulfilledTable->setHeaders(['Requirement', 'Status']);
-
         $helpTable = new TableRenderer($output);
         $helpTable->setHeaders(['Issue', 'Recommendation']);
 
         foreach ($this->syliusRequirements as $collection) {
+            $notFulfilledTable = new TableRenderer($output);
+            $notFulfilledTable->setHeaders(['Requirement', 'Status']);
             $this->checkRequirementsInCollection($collection, $notFulfilledTable, $helpTable, $input->getOption('verbose'));
         }
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | not realy
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

Hey ya, 

During the installation, when any requirements collection fails it would print out the entire not-fulfilled table of the previous component aswell. This PR introduces a table per collection. As a result this:
```
PHP version and settings
+-------------------------+----------+
| Requirement             | Status   |
+-------------------------+----------+
| timezone                | ERROR!   |
| Recommended PHP version | WARNING! |
| detect_unicode          | WARNING! |
| session.auto_start      | WARNING! |
+-------------------------+----------+
extensions
+-------------------------+----------+
| Requirement             | Status   |
+-------------------------+----------+
| timezone                | ERROR!   |
| Recommended PHP version | WARNING! |
| detect_unicode          | WARNING! |
| session.auto_start      | WARNING! |
| JSON                    | ERROR!   |
| Session                 | ERROR!   |
| Ctype                   | ERROR!   |
| Tokenizer               | ERROR!   |
| SimpleXML               | ERROR!   |
| APC                     | ERROR!   |
| PCRE                    | ERROR!   |
| PHP-XML                 | WARNING! |
| Multibyte String        | WARNING! |
| Iconv                   | WARNING! |
| Exif                    | ERROR!   |
| Intl                    | ERROR!   |
| Fileinfo                | ERROR!   |
| Accelerator             | WARNING! |
| PDO                     | WARNING! |
| GD                      | ERROR!   |
| ICU                     | WARNING! |
+-------------------------+----------+
file system
+-------------------------+----------+
| Requirement             | Status   |
+-------------------------+----------+
| timezone                | ERROR!   |
| Recommended PHP version | WARNING! |
| detect_unicode          | WARNING! |
| session.auto_start      | WARNING! |
| JSON                    | ERROR!   |
| Session                 | ERROR!   |
| Ctype                   | ERROR!   |
| Tokenizer               | ERROR!   |
| SimpleXML               | ERROR!   |
| APC                     | ERROR!   |
| PCRE                    | ERROR!   |
| PHP-XML                 | WARNING! |
| Multibyte String        | WARNING! |
| Iconv                   | WARNING! |
| Exif                    | ERROR!   |
| Intl                    | ERROR!   |
| Fileinfo                | ERROR!   |
| Accelerator             | WARNING! |
| PDO                     | WARNING! |
| GD                      | ERROR!   |
| ICU                     | WARNING! |
| vendors                 | ERROR!   |
| cache                   | ERROR!   |
| logs                    | ERROR!   |
+-------------------------+----------+
```

Will be replaced by this:
```
PHP version and settings
+-------------------------+----------+
| Requirement             | Status   |
+-------------------------+----------+
| timezone                | ERROR!   |
| Recommended PHP version | WARNING! |
| detect_unicode          | WARNING! |
| session.auto_start      | WARNING! |
+-------------------------+----------+
extensions
+------------------+----------+
| Requirement      | Status   |
+------------------+----------+
| JSON             | ERROR!   |
| Session          | ERROR!   |
| Ctype            | ERROR!   |
| Tokenizer        | ERROR!   |
| SimpleXML        | ERROR!   |
| APC              | ERROR!   |
| PCRE             | ERROR!   |
| PHP-XML          | WARNING! |
| Multibyte String | WARNING! |
| Iconv            | WARNING! |
| Exif             | ERROR!   |
| Intl             | ERROR!   |
| Fileinfo         | ERROR!   |
| Accelerator      | WARNING! |
| PDO              | WARNING! |
| GD               | ERROR!   |
| ICU              | WARNING! |
+------------------+----------+
file system
+-------------+--------+
| Requirement | Status |
+-------------+--------+
| vendors     | ERROR! |
| cache       | ERROR! |
| logs        | ERROR! |
+-------------+--------+
```
The helptable functionality remains untouched.