### PR TITLE
[AdminApi] Fix nullable ClientInterface return type in admin api

### DIFF
--- a/src/Sylius/Bundle/AdminApiBundle/Model/ClientManager.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Model/ClientManager.php
@@ -24,7 +24,7 @@ class ClientManager extends BaseClientManager
     /**
      * {@inheritdoc}
      */
-    public function findClientByPublicId($publicId): ClientInterface
+    public function findClientByPublicId($publicId): ?ClientInterface
     {
         return $this->findClientBy(['randomId' => $publicId]);
     }

--- a/src/Sylius/Bundle/AdminApiBundle/spec/Model/ClientManagerSpec.php
+++ b/src/Sylius/Bundle/AdminApiBundle/spec/Model/ClientManagerSpec.php
@@ -44,4 +44,11 @@ final class ClientManagerSpec extends ObjectBehavior
 
         $this->findClientByPublicId('random_string')->shouldReturn($client);
     }
+
+    function it_returns_null_if_client_does_not_exist($repository): void
+    {
+        $repository->findOneBy(['randomId' => 'random_string'])->willReturn(null);
+
+        $this->findClientByPublicId('random_string')->shouldReturn(null);
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #8673
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.0 branch
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->

The underlying `findOneBy` may return null, the docblock seems to be
wrong. The null value will be handled correctly in the `AuthorizeController`.