### PR TITLE
Add more accurate select jQuery selector

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-variants-prices.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-variants-prices.js
@@ -25,7 +25,7 @@ function handleProductOptionsChange() {
     $('[name*="sylius_add_to_cart[cartItem][variant]"]').on('change', function() {
         var $selector = '';
 
-        $('#sylius-product-adding-to-cart select').each(function() {
+        $('#sylius-product-adding-to-cart select[data-option]').each(function() {
             var option = $(this).find('option:selected').val();
             $selector += '[data-' + $(this).attr('data-option') + '="' + option + '"]';
         });


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0 or master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #8734
| License         | MIT

Add more accurate select jQuery selector for custom select appended in the add to cart form.