### PR TITLE
[Core][Payum] Set default gateway name in gateway config

### DIFF
--- a/src/Sylius/Component/Core/Factory/PaymentMethodFactory.php
+++ b/src/Sylius/Component/Core/Factory/PaymentMethodFactory.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Factory;
 
+use Payum\Core\Model\GatewayConfigInterface;
 use Sylius\Component\Core\Model\PaymentMethodInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 
@@ -54,8 +55,10 @@ final class PaymentMethodFactory implements PaymentMethodFactoryInterface
      */
     public function createWithGateway(string $gatewayFactory): PaymentMethodInterface
     {
+        /** @var GatewayConfigInterface $gatewayConfig */
         $gatewayConfig = $this->gatewayConfigFactory->createNew();
         $gatewayConfig->setFactoryName($gatewayFactory);
+        $gatewayConfig->setGatewayName(ucfirst($gatewayFactory));
 
         /** @var PaymentMethodInterface $paymentMethod */
         $paymentMethod = $this->decoratedFactory->createNew();

--- a/src/Sylius/Component/Core/spec/Factory/PaymentMethodFactorySpec.php
+++ b/src/Sylius/Component/Core/spec/Factory/PaymentMethodFactorySpec.php
@@ -42,6 +42,7 @@ final class PaymentMethodFactorySpec extends ObjectBehavior
     ): void {
         $gatewayConfigFactory->createNew()->willReturn($gatewayConfig);
         $gatewayConfig->setFactoryName('offline')->shouldBeCalled();
+        $gatewayConfig->setGatewayName('Offline')->shouldBeCalled();
 
         $decoratedFactory->createNew()->willReturn($paymentMethod);
         $paymentMethod->setGatewayConfig($gatewayConfig)->shouldBeCalled();


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Without this fix, when creating payment method programatically, it was required to fetch gateway config from payment method, and set it's gateway name manually to prevent doctrine error (gateway name cannot be null).

```
$paymentMethod = $this->paymentMethodFactory->createWithGateway('offline');
$gatewayConfig = $paymentMethod->getGatewayConfig();
$gatewayConfig->setGatewayName('Offline');
$paymentMethod->setGatewayConfig($gatewayConfig);
```

The other idea is to modify `createWithGateway` method to get `?string $gatewayName` as second argument, and `ucfirst($gatewayFactory)` as default value, wdyt?