### PR TITLE
[Travis] Update Yarn to stable 1.2.1, use Node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
             php: 7.1
             env:
                 - SYLIUS_SUITE="application"
-                - TRAVIS_NODE_VERSION="7.5"
+                - TRAVIS_NODE_VERSION="6.11"
             services:
                 - memcached
         -
@@ -22,7 +22,7 @@ matrix:
             php: 7.2
             env:
                 - SYLIUS_SUITE="application"
-                - TRAVIS_NODE_VERSION="7.5"
+                - TRAVIS_NODE_VERSION="6.11"
             services:
                 - memcached
         -

--- a/etc/travis/suites/application/before_install.sh
+++ b/etc/travis/suites/application/before_install.sh
@@ -15,4 +15,4 @@ run_command "rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/
 run_command "sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg"
 run_command "echo \"deb http://dl.yarnpkg.com/debian/ stable main\" | sudo tee /etc/apt/sources.list.d/yarn.list"
 run_command "sudo apt-get update -qq"
-run_command "sudo apt-get install -y -qq yarn=0.21.3-1"
+run_command "sudo apt-get install -y -qq yarn=1.2.1-1"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

This also uses LTS Node v6 since v7 is not officially supported:
```
yarn install v1.2.1
warning You are using Node "7.5.0" which is not supported and may encounter bugs or unexpected behavior. Yarn supports the following semver range: "^4.8.0 || ^5.7.0 || ^6.2.2 || ^8.0.0"
```

To use Node v8, we'd need either Trusty (which causes some problems as you know) or upgrade gcc ourselves, but I'd just wait and see if Trusty works in the near future.