### PR TITLE
Improved parse alias exception message

### DIFF
--- a/src/Sylius/Component/Resource/Metadata/Metadata.php
+++ b/src/Sylius/Component/Resource/Metadata/Metadata.php
@@ -199,7 +199,7 @@ final class Metadata implements MetadataInterface
     private static function parseAlias(string $alias): array
     {
         if (false === strpos($alias, '.')) {
-            throw new \InvalidArgumentException('Invalid alias supplied, it should conform to the following format "<applicationName>.<name>".');
+            throw new \InvalidArgumentException('Invalid alias ' . $alias . ' supplied, it should conform to the following format "<applicationName>.<name>".');
         }
 
         return explode('.', $alias);

--- a/src/Sylius/Component/Resource/Metadata/Metadata.php
+++ b/src/Sylius/Component/Resource/Metadata/Metadata.php
@@ -199,7 +199,7 @@ final class Metadata implements MetadataInterface
     private static function parseAlias(string $alias): array
     {
         if (false === strpos($alias, '.')) {
-            throw new \InvalidArgumentException('Invalid alias ' . $alias . ' supplied, it should conform to the following format "<applicationName>.<name>".');
+            throw new \InvalidArgumentException(sprintf('Invalid alias "%s" supplied, it should conform to the following format "<applicationName>.<name>".', $alias));
         }
 
         return explode('.', $alias);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

Small contribution to make the exception thrown in the Metadata resource more explanatory. When an Exception is thrown: "Invalid alias", the alias is now included in the Exception message, which makes debugging much easier.
