### PR TITLE
Do not instantiate abstract class

### DIFF
--- a/src/Sylius/Bundle/MoneyBundle/Twig/FormatMoneyExtension.php
+++ b/src/Sylius/Bundle/MoneyBundle/Twig/FormatMoneyExtension.php
@@ -36,7 +36,7 @@ final class FormatMoneyExtension extends \Twig_Extension
     public function getFilters(): array
     {
         return [
-            new \Twig_Filter('sylius_format_money', [$this->helper, 'formatAmount']),
+            new \Twig_SimpleFilter('sylius_format_money', [$this->helper, 'formatAmount']),
         ];
     }
 }


### PR DESCRIPTION
... as Twig_Filter is deprecated in `1.x` and `Twig_Filter` class was removed in Twig `2.0`.

We get this error on Twig 1.35.0 , so as Sylius is on Twig 2.0 and that deprecation was removed, I'm not sure how it's possible that this didn't crash tests before. See https://github.com/twigphp/Twig/blob/1.x/lib/Twig/Filter.php

This means that all Sylius' users that use `Twig <2.x` can't use Sylius, so it's safest to use `SimpleFilter` for now. Also see https://github.com/twigphp/Twig/blob/2.x/lib/Twig/SimpleFilter.php

| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT