### PR TITLE
Fix: Old interface names used in product documentation

### DIFF
--- a/docs/book/products/products.rst
+++ b/docs/book/products/products.rst
@@ -120,7 +120,7 @@ Firstly let's learn how to prepare an exemplary Option and its values.
 
 .. code-block:: php
 
-     /* @var $option OptionInterface */
+     /* @var $option ProductOptionInterface */
      $option = $this->get('sylius.factory.product_option')->createNew();
      $option->setCode('t_shirt_color');
      $option->setName('T-Shirt Color');
@@ -133,7 +133,7 @@ Firstly let's learn how to prepare an exemplary Option and its values.
      ];
 
      foreach ($valuesData as $code => $values) {
-         /* @var OptionValueInterface $optionValue */
+         /* @var ProductOptionValueInterface $optionValue */
          $optionValue = $this->get('sylius.factory.product_option_value')->createNew();
 
          $optionValue->setCode($code);
@@ -152,7 +152,7 @@ After you have an Option created and you keep it as ``$option`` variable let's a
      $product->addOption($option);
 
      // Having option of a product you can generate variants. Sylius has a service for that operation.
-     /** @var VariantGeneratorInterface $variantGenerator */
+     /** @var ProductVariantGeneratorInterface $variantGenerator */
      $variantGenerator = $this->get('sylius.generator.product_variant');
 
      $variantGenerator->generate($product);

--- a/docs/book/products/products.rst
+++ b/docs/book/products/products.rst
@@ -120,7 +120,7 @@ Firstly let's learn how to prepare an exemplary Option and its values.
 
 .. code-block:: php
 
-     /* @var $option ProductOptionInterface */
+     /** @var ProductOptionInterface $option */
      $option = $this->get('sylius.factory.product_option')->createNew();
      $option->setCode('t_shirt_color');
      $option->setName('T-Shirt Color');
@@ -133,7 +133,7 @@ Firstly let's learn how to prepare an exemplary Option and its values.
      ];
 
      foreach ($valuesData as $code => $values) {
-         /* @var ProductOptionValueInterface $optionValue */
+         /** @var ProductOptionValueInterface $optionValue */
          $optionValue = $this->get('sylius.factory.product_option_value')->createNew();
 
          $optionValue->setCode($code);


### PR DESCRIPTION
…4234008d0881a1d6a92cf5

| Q               | A
| --------------- | -----
| Branch?         | master
| Doc fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

Some interfaces in the product documentation no longer exist in the Sylius project.
They have been prefixed with Product in commit:
https://github.com/Sylius/Sylius/commit/14b7e412321a55c50b4234008d0881a1d6a92cf5
