### PR TITLE
Fix wrong use statement for ProductInterface

### DIFF
--- a/docs/customization/factory.rst
+++ b/docs/customization/factory.rst
@@ -41,7 +41,7 @@ Take its interface (``Sylius\Component\Product\Factory\ProductFactoryInterface``
 
     namespace AppBundle\Factory;
 
-    use Sylius\Component\Core\Model\ProductInterface;
+    use Sylius\Component\Product\Model\ProductInterface;
     use Sylius\Component\Product\Factory\ProductFactoryInterface;
 
     class ProductFactory implements ProductFactoryInterface


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

After the question at https://stackoverflow.com/questions/47135122/error-following-sylius-customizing-factories-guide-examples, it seems the `use` statement shown in the example is wrong when checking it agains the 1.0 code base.