### PR TITLE
[Documentation] Use SyliusElasticSearchPlugin repository in docs

### DIFF
--- a/docs/book/products/search.rst
+++ b/docs/book/products/search.rst
@@ -47,15 +47,15 @@ ElasticSearch
 When the grids filtering is not enough for you, and your needs are more complex you should go for the
 `ElasticSearch <https://www.elastic.co/products/elasticsearch>`_ integration.
 
-There is the `Lakion/SyliusElasticSearchBundle <https://github.com/Lakion/SyliusElasticSearchBundle>`_ integration extension,
+There is the `Sylius/SyliusElasticSearchPlugin <https://github.com/Sylius/SyliusElasticSearchPlugin>`_ integration extension,
 which you can use to extend Sylius functionalities with ElasticSearch.
 
-All you have to do is require the bundle in your project via composer, install the ElasticSearch server, and configure ElasticSearch
-in your application. Everything is well described in the Lakion/SyliusElasticSearchBundle's readme.
+All you have to do is require the plugin in your project via composer, install the ElasticSearch server, and configure ElasticSearch
+in your application. Everything is well described in the Sylius/SyliusElasticSearchPlugin's readme.
 
 Learn more
 ----------
 
-* `SyliusElasticSearchBundle <https://github.com/Lakion/SyliusElasticSearchBundle>`_
+* `SyliusElasticSearchPlugin <https://github.com/Sylius/SyliusElasticSearchPlugin>`_
 * :doc:`Grid Bundle documentation </components_and_bundles/bundles/SyliusGridBundle/index>`
 * :doc:`Grid Component documentation </components_and_bundles/components/Grid/index>`

--- a/docs/components_and_bundles/bundles/SyliusResourceBundle/index.rst
+++ b/docs/components_and_bundles/bundles/SyliusResourceBundle/index.rst
@@ -15,7 +15,7 @@ So far we support:
 * Doctrine MongoDB ODM
 * Doctrine PHPCR ODM
 * InMemory
-* ElasticSearch (via an `extension <https://github.com/Lakion/SyliusElasticSearchBundle>`_)
+* ElasticSearch (via an `extension <https://github.com/Sylius/SyliusElasticSearchPlugin>`_)
 
 .. toctree::
    :numbered:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
or master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT

You already have fork https://github.com/Lakion/SyliusElasticSearchBundle, but in docs only links on original repository.
I try fix it.

<!--
 - Bug fixes must be submitted against the 1.0 branch
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
