### PR TITLE
ensure we return null rather than void in SyliusPluginTrait::getContainerExtension

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Application/SyliusPluginTrait.php
+++ b/src/Sylius/Bundle/CoreBundle/Application/SyliusPluginTrait.php
@@ -65,9 +65,7 @@ trait SyliusPluginTrait
             }
         }
 
-        if ($this->containerExtension) {
-            return $this->containerExtension;
-        }
+        return $this->containerExtension ?: null;
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

I am not entirely sure what is going on here.
It seems for one that when I implemented a proper Di extension in FOSSyliusImportExportPlugin I suddenly ended up with 
```
  [Payum\Core\Exception\InvalidArgumentException]
  The storage factory with such name filesystem already registered
```

Which in turn seems to be caused by suddenly `\Payum\Bundle\PayumBundle\PayumBundle::build` being called twice.

Messing around I eventually ended up at:
```
PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Type error: Return value of FriendsOfSylius\SyliusImportExportPlugin\FOSSyliusImportExportPlugin::getContainerExtension() must implement interface Symfony\Component\DependencyInjection\Extension\ExtensionInterface or be null, none returned in /Users/lsmith/htdocs/SyliusImportExportPlugin/vendor/sylius/sylius/src/Sylius/Bundle/CoreBundle/Application/SyliusPluginTrait.php:71
```

Which led me to this PR and which magically fixed all the issues I had once I removed all my debug code.