### PR TITLE
fix BC break caused by security fix for CVE-2017-16790

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Sylius/Bundle/ResourceBundle/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\RequestHandlerInterface;
 use Symfony\Component\Form\Util\ServerParams;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\File\File;
 
 /**
  * Does not compare the form's method with the request's method.
@@ -106,5 +107,10 @@ final class HttpFoundationRequestHandler implements RequestHandlerInterface
         }
 
         $form->submit($data, 'PATCH' !== $method);
+    }
+
+    public function isFileUpload($data)
+    {
+        return $data instanceof File;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://symfony.com/blog/cve-2017-16790-ensure-that-submitted-data-are-uploaded-files
| License         | MIT