### PR TITLE
Change "Support Request" label to "Help Wanted"

### DIFF
--- a/docs/contributing/organization/vision-and-strategy.rst
+++ b/docs/contributing/organization/vision-and-strategy.rst
@@ -37,11 +37,11 @@ Labels (Issue Types)
 * **Enhancement** - Minor issues and PRs improving the current solutions (optimizations, typo fixes, etc.).
 * **Environment** - Environment (OS, databases, libraries, etc.) specific issues.
 * **Feature** - New feature proposals.
+* **Help Wanted** - Issues needing help and clarification.
 * **Maintenance** - Travis configurations, READMEs, releases, etc.
 * **Potential Bug** - Bug reports, should become a *Bug* after confirming it.
 * **RFC** - Discussions about potential changes or new features.
 * **Shop** - ShopBundle related issues and PRs.
-* **Support Request** - Issues needing help and clarification.
 * **Symfony 4.0** - Symfony 4.0 related issues and PRs.
 * **UX** - Issues and PRs aimed at improving User eXperience.
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

GitHub has introduced a native support for issues labeled with `Help Wanted` (so that their count can bed displayed near repository summary etc.).

<!--
 - Bug fixes must be submitted against the 1.0 branch
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
