### PR TITLE
Fixed: Breadcrumbs links for Taxon and Product views

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_breadcrumb.html.twig
@@ -6,7 +6,7 @@
         {% set ancestors = taxon.ancestors|reverse %}
 
         {% for ancestor in ancestors %}
-            {% if ancestor.root %}
+            {% if ancestor.isRoot() %}
                 <div class="section">{{ ancestor.name }}</div>
             {% else %}
                 <a href="{{ path('sylius_shop_product_index', {'slug': ancestor.slug, '_locale': ancestor.translation.locale}) }}" class="section">{{ ancestor.name }}</a>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_breadcrumb.html.twig
@@ -4,7 +4,7 @@
     <a href="{{ path('sylius_shop_homepage') }}" class="section">{{ 'sylius.ui.home'|trans }}</a>
     <div class="divider"> / </div>
     {% for ancestor in ancestors %}
-        {% if ancestor.root %}
+        {% if ancestor.isRoot() %}
             <div class="section">{{ ancestor.name }}</div>
         {% else %}
             <a href="{{ path('sylius_shop_product_index', {'slug': ancestor.slug, '_locale': ancestor.translation.locale}) }}" class="section">{{ ancestor.name }}</a>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT

Issue: As far as there are `isRoot()` and `getRoot()` functions exists at `Taxon.php`, referring to `root` at Twig template (meaning `isRoot`) causing not expected behavior and all breadcrumbs become text rather than links (as far as `getRoot` actually called and it always `true`). 

PR fixing this issue.