### PR TITLE
Fixed pluralize bug for ru locale.

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Resources/translations/messages.ru.yml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/translations/messages.ru.yml
@@ -20,4 +20,4 @@ sylius:
         stripe_checkout: Stripe checkout
     payum_action:
         payment:
-            description: 'Оплата содержит %items% элемент в общей сложности %total% | Оплата содержит %items% элементы в общей сложности %total%'
+            description: 'Оплата содержит %items% элемент в общей сложности %total% | Оплата содержит %items% элемента в общей сложности %total%' | Оплата содержит %items% элементов в общей сложности %total%'

--- a/src/Sylius/Bundle/PayumBundle/Resources/translations/messages.ru.yml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/translations/messages.ru.yml
@@ -1,5 +1,5 @@
 # This file is part of the Sylius package.
-# (c) Paweł Jędrzejewski
+# (c) Pawel Jedrzejewski
 
 sylius:
     form:
@@ -20,4 +20,4 @@ sylius:
         stripe_checkout: Stripe checkout
     payum_action:
         payment:
-            description: 'Оплата содержит %items% элемент в общей сложности %total% | Оплата содержит %items% элемента в общей сложности %total%' | Оплата содержит %items% элементов в общей сложности %total%'
+            description: 'Оплата содержит %items% элемент в общей сложности %total% | Оплата содержит %items% элемента в общей сложности %total% | Оплата содержит %items% элементов в общей сложности %total%'


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT


For the Russian translation, pluralizing the message requires 3 alternatives (does not as in English).
If specify 2 alternatives the system gives an error 'Unable to choose a translation for XXX. Double check that this translation has the correct plural options'.
