### PR TITLE
[Documentation][MailerBundle] Clean installation part

### DIFF
--- a/docs/components_and_bundles/bundles/SyliusMailerBundle/installation.rst
+++ b/docs/components_and_bundles/bundles/SyliusMailerBundle/installation.rst
@@ -22,9 +22,6 @@ Adding required bundles to the kernel
 
 You need to enable the bundle inside the kernel.
 
-If you're not using any other Sylius bundles, you will also need to add `SyliusResourceBundle` and its dependencies to kernel.
-Don't worry, everything was automatically installed via Composer.
-
 .. code-block:: php
 
     <?php
@@ -41,16 +38,9 @@ Don't worry, everything was automatically installed via Composer.
             new WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
 
             new Sylius\Bundle\MailerBundle\SyliusMailerBundle(),
-            new Sylius\Bundle\ResourceBundle\SyliusResourceBundle(),
-
-            // Other bundles...
-            new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
         );
     }
 
-.. note::
-
-    Please register the bundle before *DoctrineBundle*. This is important as we use listeners which have to be processed first.
 
 Container configuration
 -----------------------
@@ -63,27 +53,5 @@ Put this configuration inside your ``app/config/config.yml``.
         sender:
             name: My website
             address: no-reply@my-website.com
-
-And configure doctrine extensions which are used by the bundle.
-
-.. code-block:: yaml
-
-    stof_doctrine_extensions:
-        orm:
-            default:
-                timestampable: true
-
-Updating database schema
-------------------------
-
-Run the following command.
-
-.. code-block:: bash
-
-    $ php bin/console doctrine:schema:update --force
-
-.. warning::
-
-    This should be done only in **dev** environment! We recommend using Doctrine migrations, to safely update your schema.
 
 Congratulations! The bundle is now installed and ready to use.


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

The mailer bundle don't need doctrine.

There is also a lot of unused dependencies in the require-dev part of the composer.json file of the bundle. Tests also register useless bundles (such as doctrine). Should I create another PR to clean both composer.json & tests?