### PR TITLE
Restrict scanning for composer.json in themes to certain directory depth (optional)

### DIFF
--- a/UPGRADE-1.0.md
+++ b/UPGRADE-1.0.md
@@ -1,3 +1,10 @@
+# UPGRADE FROM 1.0.7 to 1.0.8
+
+* Scanning for `composer.json` file inside themes directories is recursive by default, which can result in slow performance
+  when e.g. a `node_modules` folder is present inside a theme folder. Supply the optional `scan_depth` (integer) setting
+  to the `sylius_theme` configuration to restrict scanning for the theme configuration file to a specific depth inside
+  the specified theme directories.
+
 # UPGRADE FROM 1.0.1 to 1.0.2
 
 * `Sylius\Bundle\AdminApiBundle\Model\ClientManager`'s `findClientByPublicId($publicId): ClientInterface` signature

--- a/UPGRADE-1.0.md
+++ b/UPGRADE-1.0.md
@@ -1,10 +1,3 @@
-# UPGRADE FROM 1.0.7 to 1.0.8
-
-* Scanning for `composer.json` file inside themes directories is recursive by default, which can result in slow performance
-  when e.g. a `node_modules` folder is present inside a theme folder. Supply the optional `scan_depth` (integer) setting
-  to the `sylius_theme` configuration to restrict scanning for the theme configuration file to a specific depth inside
-  the specified theme directories.
-
 # UPGRADE FROM 1.0.1 to 1.0.2
 
 * `Sylius\Bundle\AdminApiBundle\Model\ClientManager`'s `findClientByPublicId($publicId): ClientInterface` signature

--- a/UPGRADE-1.1.md
+++ b/UPGRADE-1.1.md
@@ -1,1 +1,7 @@
 # UPGRADE FROM 1.0 to 1.1
+
+* Scanning for `composer.json` file inside themes directories is recursive by default, which can result in slow performance
+  when e.g. a `node_modules` folder is present inside a theme folder. Supply the optional `scan_depth` (integer) setting
+  to the `sylius_theme` configuration to restrict scanning for the theme configuration file to a specific depth inside
+  the specified theme directories.
+  

--- a/docs/components_and_bundles/bundles/SyliusThemeBundle/configuration_sources/filesystem.rst
+++ b/docs/components_and_bundles/bundles/SyliusThemeBundle/configuration_sources/filesystem.rst
@@ -16,6 +16,7 @@ Configuration reference
             filesystem:
                 enabled: false
                 filename: composer.json
+                scan_depth: null
                 directories:
                     - "%kernel.root_dir%/themes"
 
@@ -28,3 +29,10 @@ Configuration reference
         sylius_theme:
             sources:
                 filesystem: ~
+
+.. tip::
+
+    Scanning for the configuration file inside themes directories is recursive with unlimited directory depth by default,
+    which can result in slow performance when a lot of files are placed inside themes (e.g. a `node_modules` folder).
+    Define the optional `scan_depth` (integer) setting to the configuration to restrict scanning for the theme configuration
+    file to a specific depth.

--- a/src/Sylius/Bundle/ThemeBundle/Configuration/Filesystem/FilesystemConfigurationSourceFactory.php
+++ b/src/Sylius/Bundle/ThemeBundle/Configuration/Filesystem/FilesystemConfigurationSourceFactory.php
@@ -31,6 +31,7 @@ final class FilesystemConfigurationSourceFactory implements ConfigurationSourceF
             ->fixXmlConfig('directory', 'directories')
                 ->children()
                     ->scalarNode('filename')->defaultValue('composer.json')->cannotBeEmpty()->end()
+                    ->integerNode('scan_depth')->info('Restrict depth to scan for configuration file inside theme folder')->defaultNull()->end()
                     ->arrayNode('directories')
                         ->defaultValue(['%kernel.root_dir%/themes'])
                         ->requiresAtLeastOneElement()
@@ -48,6 +49,7 @@ final class FilesystemConfigurationSourceFactory implements ConfigurationSourceF
         $recursiveFileLocator = new Definition(RecursiveFileLocator::class, [
             new Reference('sylius.theme.finder_factory'),
             $config['directories'],
+            $config['scan_depth']
         ]);
 
         $configurationLoader = new Definition(ProcessingConfigurationLoader::class, [

--- a/src/Sylius/Bundle/ThemeBundle/Locator/RecursiveFileLocator.php
+++ b/src/Sylius/Bundle/ThemeBundle/Locator/RecursiveFileLocator.php
@@ -29,13 +29,20 @@ final class RecursiveFileLocator implements FileLocatorInterface
     private $paths;
 
     /**
+     * @var int
+     */
+    private $depth;
+
+    /**
      * @param FinderFactoryInterface $finderFactory
      * @param array|string[] $paths An array of paths where to look for resources
+     * @param int|null $depth Restrict depth to search for configuration file inside theme folder
      */
-    public function __construct(FinderFactoryInterface $finderFactory, array $paths)
+    public function __construct(FinderFactoryInterface $finderFactory, array $paths, ?int $depth = null)
     {
         $this->finderFactory = $finderFactory;
         $this->paths = $paths;
+        $this->depth = $depth;
     }
 
     /**
@@ -67,6 +74,11 @@ final class RecursiveFileLocator implements FileLocatorInterface
         foreach ($this->paths as $path) {
             try {
                 $finder = $this->finderFactory->create();
+
+                if ($this->depth !== null) {
+                    $finder->depth(sprintf('<= %d', $this->depth));
+                }
+
                 $finder
                     ->files()
                     ->name($name)

--- a/src/Sylius/Bundle/ThemeBundle/Tests/DependencyInjection/FilesystemSource/ConfigurationTest.php
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/DependencyInjection/FilesystemSource/ConfigurationTest.php
@@ -35,6 +35,26 @@ final class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'directories' => ['%kernel.root_dir%/themes'],
                 'filename' => 'composer.json',
                 'enabled' => true,
+                'scan_depth' => null,
+            ]]],
+            'sources'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_an_integer_for_scan_depth(): void
+    {
+        $this->assertProcessedConfigurationEquals(
+            [
+                ['sources' => ['filesystem' => ['scan_depth' => 1]]],
+            ],
+            ['sources' => ['filesystem' => [
+                'directories' => ['%kernel.root_dir%/themes'],
+                'filename' => 'composer.json',
+                'enabled' => true,
+                'scan_depth' => 1,
             ]]],
             'sources'
         );
@@ -53,6 +73,7 @@ final class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'directories' => ['/custom/path', '/custom/path2'],
                 'filename' => 'composer.json',
                 'enabled' => true,
+                'scan_depth' => null,
             ]]],
             'sources.filesystem'
         );
@@ -72,6 +93,7 @@ final class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'directories' => ['/last/custom/path'],
                 'filename' => 'composer.json',
                 'enabled' => true,
+                'scan_depth' => null,
             ]]],
             'sources.filesystem'
         );
@@ -85,6 +107,19 @@ final class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertPartialConfigurationIsInvalid(
             [
                 ['directories' => '/string/not/array'],
+            ],
+            'sources.filesystem'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_is_invalid_to_pass_a_string_as_scan_depth(): void
+    {
+        $this->assertPartialConfigurationIsInvalid(
+            [
+                ['sources' => ['filesystem' => ['directories' => ['/custom/path', '/custom/path2'], 'scan_depth' => 'test']]],
             ],
             'sources.filesystem'
         );

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/TestBundle/public/theme_asset.txt
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/TestBundle/public/theme_asset.txt
@@ -1,0 +1,1 @@
+This should not be overridden by first theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/TestBundle/translations/messages.en.yml
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/TestBundle/translations/messages.en.yml
@@ -1,0 +1,5 @@
+test:
+  theme_bundle: 'That should not be overridden by first test theme.'
+  theme: 'That should not be overridden by first test theme.'
+  parent_theme_bundle: 'PARENT_THEME/BUNDLE_NAME/translations'
+  parent_theme: 'PARENT_THEME/BUNDLE_NAME/translations'

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/TestBundle/views/Templating/bothThemesTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/TestBundle/views/Templating/bothThemesTemplate.txt.twig
@@ -1,0 +1,1 @@
+TestBundle:Templating:bothThemesTemplate.txt.twig|sylius/third-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/TestBundle/views/Templating/lastThemeTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/TestBundle/views/Templating/lastThemeTemplate.txt.twig
@@ -1,0 +1,1 @@
+TestBundle:Templating:lastThemeTemplate.txt.twig|sylius/third-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/composer.json
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "sylius/third-test-theme",
+    "extra": {
+        "sylius-theme": {
+            "title": "Sylius Third Theme",
+            "parents": [
+                "sylius/first-test-theme"
+            ]
+        }
+    }
+}

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/translations/messages.en.yml
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/translations/messages.en.yml
@@ -1,0 +1,3 @@
+test:
+  theme: 'That should not be overridden by first test theme.'
+  parent_theme: 'PARENT_THEME/translations'

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/views/Templating/bothThemesTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/views/Templating/bothThemesTemplate.txt.twig
@@ -1,0 +1,1 @@
+:Templating:bothThemesTemplate.txt.twig|sylius/third-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/views/Templating/lastThemeTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/views/Templating/lastThemeTemplate.txt.twig
@@ -1,0 +1,1 @@
+:Templating:lastThemeTemplate.txt.twig|sylius/third-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/config/config.yml
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/config/config.yml
@@ -25,5 +25,6 @@ twig:
 sylius_theme:
     sources:
         filesystem:
+            scan_depth: 1
             directories:
                 - "%kernel.root_dir%/../../Fixtures/themes"

--- a/src/Sylius/Bundle/ThemeBundle/spec/Locator/RecursiveFileLocatorSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/Locator/RecursiveFileLocatorSpec.php
@@ -76,6 +76,33 @@ final class RecursiveFileLocatorSpec extends ObjectBehavior
         ]);
     }
 
+    function it_searches_for_files_at_a_maximum_depth(
+        FinderFactoryInterface $finderFactory,
+        Finder $finder,
+        SplFileInfo $firstSplFileInfo,
+        SplFileInfo $secondSplFileInfo
+    ): void {
+        $this->beConstructedWith($finderFactory, ['/search/path/'], 1);
+        $finderFactory->create()->willReturn($finder);
+
+        $finder->depth('<= 1')->shouldBeCalled()->willReturn($finder);
+        $finder->name('readme.md')->shouldBeCalled()->willReturn($finder);
+        $finder->in('/search/path/')->shouldBeCalled()->willReturn($finder);
+        $finder->ignoreUnreadableDirs()->shouldBeCalled()->willReturn($finder);
+        $finder->files()->shouldBeCalled()->willReturn($finder);
+
+        $finder->getIterator()->willReturn(new \ArrayIterator([
+            $secondSplFileInfo->getWrappedObject(),
+        ]));
+
+        $firstSplFileInfo->getPathname()->willReturn('/search/path/nested1/leveldeeper/readme.md');
+        $secondSplFileInfo->getPathname()->willReturn('/search/path/nested2/readme.md');
+
+        $this->locateFilesNamed('readme.md')->shouldReturn([
+            '/search/path/nested2/readme.md',
+        ]);
+    }
+
     function it_throws_an_exception_if_searching_for_file_with_empty_name(): void
     {
         $this->shouldThrow(\InvalidArgumentException::class)->during('locateFileNamed', ['']);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in #9008
| License         | MIT
  