### PR TITLE
fix a jasvacript error: double #id in province validation on checkout…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.php_cs.cache
+/.phpintel
 
 /app/config/parameters.yml
 /app/config/*.local.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /.php_cs.cache
 /.phpintel
+*.sublime-project
+*.sublime-workspace
+
+
 
 /app/config/parameters.yml
 /app/config/*.local.yml

--- a/src/Sylius/Bundle/ShopBundle/EmailManager/OrderEmailManager.php
+++ b/src/Sylius/Bundle/ShopBundle/EmailManager/OrderEmailManager.php
@@ -37,6 +37,13 @@ final class OrderEmailManager implements OrderEmailManagerInterface
      */
     public function sendConfirmationEmail(OrderInterface $order): void
     {
+        // send copy to contact email
+        $channel = $order->getChannel();
+        $contact_email = $channel->getContactEmail();
+        if (!empty($contact_email)) {
+            $this->emailSender->send(Emails::ORDER_CONFIRMATION, [$contact_email], ['order' => $order]);
+        }
+
         $this->emailSender->send(Emails::ORDER_CONFIRMATION, [$order->getCustomer()->getEmail()], ['order' => $order]);
     }
 }

--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-province-field.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-province-field.js
@@ -29,7 +29,12 @@
                     return;
                 }
 
-                $.get(provinceContainer.attr('data-url'), {countryCode: $(this).val()}, function (response) {
+                var addressType= $(this).closest('div[id$="-address"]').attr('id');
+        
+                $.get(provinceContainer.attr('data-url'), {
+                    countryCode: $(this).val(),
+                    type: addressType
+                }, function (response) {
                     if (!response.content) {
                         provinceContainer.fadeOut('slow', function () {
                             provinceContainer.html('');


### PR DESCRIPTION
…/address
------
I found the error in checkout/address when I was trying to do an event.preventDefault () to validate a field before submit
------
| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no/yes
| Deprecations?   | no/yes <!-- don't forget to update UPGRADE-*.md file -->
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.0 branch
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
