### PR TITLE
Restrict packages to use Symfony's DI in ^3.2 version for tests

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -30,6 +30,7 @@
     "require-dev": {
         "doctrine/orm": "~2.5.0",
         "phpspec/phpspec": "^4.0",
+        "symfony/dependency-injection": "^3.2",
         "symfony/form": "^3.2",
         "symfony/validator": "^3.2",
         "phpunit/phpunit": "^5.6",

--- a/src/Sylius/Bundle/AdminApiBundle/composer.json
+++ b/src/Sylius/Bundle/AdminApiBundle/composer.json
@@ -32,6 +32,7 @@
         "doctrine/orm": "~2.5.0",
         "phpspec/phpspec": "^4.0",
         "phpunit/phpunit": "^5.6",
+        "symfony/dependency-injection": "^3.2",
         "twig/twig": "^2.0"
     },
     "config": {

--- a/src/Sylius/Bundle/AdminBundle/composer.json
+++ b/src/Sylius/Bundle/AdminBundle/composer.json
@@ -29,7 +29,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.6",
-        "phpspec/phpspec": "^4.0"
+        "phpspec/phpspec": "^4.0",
+        "symfony/dependency-injection": "^3.2"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Sylius/Bundle/AttributeBundle/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/composer.json
@@ -32,6 +32,7 @@
         "doctrine/orm": "~2.5.0",
         "phpspec/phpspec": "^4.0",
         "phpunit/phpunit": "^5.6",
+        "symfony/dependency-injection": "^3.2",
         "symfony/form": "^3.2",
         "symfony/browser-kit": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",

--- a/src/Sylius/Bundle/ChannelBundle/composer.json
+++ b/src/Sylius/Bundle/ChannelBundle/composer.json
@@ -32,6 +32,7 @@
         "phpunit/phpunit": "^5.6",
         "twig/twig": "^2.0",
         "doctrine/orm": "~2.5.0",
+        "symfony/dependency-injection": "^3.2",
         "symfony/form": "^3.2",
         "symfony/browser-kit": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -58,7 +58,8 @@
         "matthiasnoback/symfony-config-test": "^2.0",
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "phpspec/phpspec": "^4.0",
-        "phpunit/phpunit": "^5.6"
+        "phpunit/phpunit": "^5.6",
+        "symfony/dependency-injection": "^3.2"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -32,6 +32,7 @@
         "phpspec/phpspec": "^4.0",
         "phpunit/phpunit": "^5.6",
         "twig/twig": "^2.0",
+        "symfony/dependency-injection": "^3.2",
         "symfony/form": "^3.2",
         "symfony/browser-kit": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",

--- a/src/Sylius/Bundle/CustomerBundle/composer.json
+++ b/src/Sylius/Bundle/CustomerBundle/composer.json
@@ -43,6 +43,7 @@
     "require-dev": {
         "phpspec/phpspec": "^4.0",
         "phpunit/phpunit": "^5.6",
+        "symfony/dependency-injection": "^3.2",
         "symfony/form": "^3.2",
         "symfony/browser-kit": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",

--- a/src/Sylius/Bundle/FixturesBundle/composer.json
+++ b/src/Sylius/Bundle/FixturesBundle/composer.json
@@ -38,6 +38,7 @@
         "phpunit/phpunit": "^5.6",
         "twig/twig": "^2.0",
         "symfony/browser-kit": "^3.2",
+        "symfony/dependency-injection": "^3.2",
         "symfony/templating": "^3.2",
         "symfony/translation": "^3.2",
         "symfony/twig-bundle": "^3.2",

--- a/src/Sylius/Bundle/GridBundle/composer.json
+++ b/src/Sylius/Bundle/GridBundle/composer.json
@@ -42,6 +42,7 @@
         "phpunit/phpunit": "^5.6",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "symfony/browser-kit": "^3.2",
+        "symfony/dependency-injection": "^3.2",
         "symfony/proxy-manager-bridge": "^3.3",
         "symfony/security-csrf": "^3.2",
         "symfony/twig-bundle": "^3.2",

--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -34,6 +34,7 @@
         "phpunit/phpunit": "^5.6",
         "twig/twig": "^2.0",
         "symfony/browser-kit": "^3.2",
+        "symfony/dependency-injection": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0"
     },

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -34,6 +34,7 @@
         "twig/twig": "^2.0",
         "ocramius/proxy-manager": "^2.0",
         "symfony/browser-kit": "^3.2",
+        "symfony/dependency-injection": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0"
     },

--- a/src/Sylius/Bundle/MailerBundle/composer.json
+++ b/src/Sylius/Bundle/MailerBundle/composer.json
@@ -35,6 +35,7 @@
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "swiftmailer/swiftmailer": "^6.0",
         "symfony/browser-kit": "^3.2",
+        "symfony/dependency-injection": "^3.2",
         "symfony/form": "^3.2",
         "symfony/proxy-manager-bridge": "^3.3",
         "symfony/security-csrf": "^3.2",

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -36,6 +36,7 @@
         "sylius/currency-bundle": "^1.0",
         "symfony/form": "^3.2",
         "symfony/browser-kit": "^3.2",
+        "symfony/dependency-injection": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0"
     },

--- a/src/Sylius/Bundle/OrderBundle/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/composer.json
@@ -34,6 +34,7 @@
         "phpspec/phpspec": "^4.0",
         "phpunit/phpunit": "^5.6",
         "symfony/browser-kit": "^3.2",
+        "symfony/dependency-injection": "^3.2",
         "symfony/form": "^3.2",
         "symfony/validator": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",

--- a/src/Sylius/Bundle/PaymentBundle/composer.json
+++ b/src/Sylius/Bundle/PaymentBundle/composer.json
@@ -32,6 +32,7 @@
         "sylius/locale-bundle": "^1.0",
         "phpunit/phpunit": "^5.6",
         "symfony/browser-kit": "^3.2",
+        "symfony/dependency-injection": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0"
     },

--- a/src/Sylius/Bundle/PayumBundle/composer.json
+++ b/src/Sylius/Bundle/PayumBundle/composer.json
@@ -36,7 +36,8 @@
         "sylius/resource-bundle": "^1.0"
     },
     "require-dev": {
-        "phpspec/phpspec": "^4.0"
+        "phpspec/phpspec": "^4.0",
+        "symfony/dependency-injection": "^3.2"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Sylius/Bundle/ProductBundle/composer.json
+++ b/src/Sylius/Bundle/ProductBundle/composer.json
@@ -36,6 +36,7 @@
         "symfony/form": "^3.2",
         "symfony/validator": "^3.2",
         "symfony/browser-kit": "^3.2",
+        "symfony/dependency-injection": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0"
     },

--- a/src/Sylius/Bundle/PromotionBundle/composer.json
+++ b/src/Sylius/Bundle/PromotionBundle/composer.json
@@ -37,6 +37,7 @@
         "symfony/form": "^3.2",
         "symfony/validator": "^3.2",
         "symfony/browser-kit": "^3.2",
+        "symfony/dependency-injection": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0"
     },

--- a/src/Sylius/Bundle/ResourceBundle/composer.json
+++ b/src/Sylius/Bundle/ResourceBundle/composer.json
@@ -55,6 +55,7 @@
         "sensio/generator-bundle": "^3.1",
         "sylius/grid-bundle": "^1.0",
         "sylius/locale": "^1.0",
+        "symfony/dependency-injection": "^3.2",
         "twig/twig": "^2.0"
     },
     "suggest": {

--- a/src/Sylius/Bundle/ReviewBundle/composer.json
+++ b/src/Sylius/Bundle/ReviewBundle/composer.json
@@ -47,6 +47,7 @@
         "symfony/form": "^3.2",
         "symfony/validator": "^3.2",
         "symfony/browser-kit": "^3.2",
+        "symfony/dependency-injection": "^3.2",
         "symfony/security-bundle": "^3.2",
         "symfony/swiftmailer-bundle": "^3.0",
         "incenteev/composer-parameter-handler": "~2.0",

--- a/src/Sylius/Bundle/ShippingBundle/composer.json
+++ b/src/Sylius/Bundle/ShippingBundle/composer.json
@@ -35,6 +35,7 @@
         "symfony/form": "^3.2",
         "symfony/validator": "^3.2",
         "symfony/browser-kit": "^3.2",
+        "symfony/dependency-injection": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0"
     },

--- a/src/Sylius/Bundle/ShopBundle/composer.json
+++ b/src/Sylius/Bundle/ShopBundle/composer.json
@@ -31,7 +31,8 @@
         "matthiasnoback/symfony-config-test": "^2.0",
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "phpunit/phpunit": "^5.6",
-        "phpspec/phpspec": "^4.0"
+        "phpspec/phpspec": "^4.0",
+        "symfony/dependency-injection": "^3.2"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/Sylius/Bundle/TaxationBundle/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/composer.json
@@ -34,6 +34,7 @@
         "phpunit/phpunit": "^5.6",
         "symfony/form": "^3.2",
         "symfony/browser-kit": "^3.2",
+        "symfony/dependency-injection": "^3.2",
         "incenteev/composer-parameter-handler": "~2.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0"
     },

--- a/src/Sylius/Bundle/TaxonomyBundle/composer.json
+++ b/src/Sylius/Bundle/TaxonomyBundle/composer.json
@@ -31,6 +31,7 @@
         "doctrine/orm": "~2.5.0",
         "phpspec/phpspec": "^4.0",
         "phpunit/phpunit": "^5.6",
+        "symfony/dependency-injection": "^3.2",
         "incenteev/composer-parameter-handler": "^2.1"
     },
     "config": {

--- a/src/Sylius/Bundle/ThemeBundle/composer.json
+++ b/src/Sylius/Bundle/ThemeBundle/composer.json
@@ -34,6 +34,7 @@
         "phpunit/phpunit": "^5.6",
         "sylius/registry": "^1.0",
         "twig/twig": "^2.0",
+        "symfony/dependency-injection": "^3.2",
         "symfony/twig-bundle": "^3.2"
     },
     "config": {

--- a/src/Sylius/Bundle/UiBundle/composer.json
+++ b/src/Sylius/Bundle/UiBundle/composer.json
@@ -31,6 +31,7 @@
     },
     "require-dev": {
         "phpspec/phpspec": "^4.0",
+        "symfony/dependency-injection": "^3.2",
         "symfony/form": "^3.2",
         "twig/twig": "^2.0"
     },

--- a/src/Sylius/Bundle/UserBundle/composer.json
+++ b/src/Sylius/Bundle/UserBundle/composer.json
@@ -45,6 +45,7 @@
         "hwi/oauth-bundle": "^0.5",
         "phpspec/phpspec": "^4.0",
         "phpunit/phpunit": "^5.6",
+        "symfony/dependency-injection": "^3.2",
         "symfony/security-bundle": "^3.2",
         "symfony/swiftmailer-bundle": "^3.0",
         "incenteev/composer-parameter-handler": "~2.0"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

We're fetching all services to smoke test whether they are properly wired and Symfony in 4.0 marks all services as private by default, so it's breaking the build. This PR is rather a fast workaround than the proper solution, but it'll do fine for now (and we'll be able to merge other PRs).

<!--
 - Bug fixes must be submitted against the 1.0 branch
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
