### PR TITLE
[Documentation] [Order] Fixes in Order component documentation: typo in models.rst and wording in processors.rst

### DIFF
--- a/docs/components_and_bundles/components/Order/models.rst
+++ b/docs/components_and_bundles/components/Order/models.rst
@@ -18,7 +18,7 @@ Orders have the following properties:
 +--------------------------+---------------------------------------------+
 | number                   | Number is human-friendly identifier         |
 +--------------------------+---------------------------------------------+
-| notes                    | Additional inforamtion about order          |
+| notes                    | Additional information about order          |
 +--------------------------+---------------------------------------------+
 | items                    | Collection of items                         |
 +--------------------------+---------------------------------------------+

--- a/docs/components_and_bundles/components/Order/processors.rst
+++ b/docs/components_and_bundles/components/Order/processors.rst
@@ -1,7 +1,7 @@
 Processors
 ==========
 
-Order processors are responsible of manipulating the orders to apply different predefined adjustments or other modifications based on order state.
+Order processors are responsible for manipulating the orders to apply different predefined adjustments or other modifications based on order state.
 
 .. _component_order_processors_order-processor-interface:
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT
