### PR TITLE
[Core] Fix customer order addresses saver

### DIFF
--- a/src/Sylius/Component/Core/Customer/CustomerOrderAddressesSaver.php
+++ b/src/Sylius/Component/Core/Customer/CustomerOrderAddressesSaver.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Customer;
 
+use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 
@@ -42,10 +43,18 @@ final class CustomerOrderAddressesSaver implements OrderAddressesSaverInterface
             return;
         }
 
-        $shippingAddress = $order->getShippingAddress();
-        $billingAddress = $order->getBillingAddress();
+        $this->addAddress($customer, $order->getBillingAddress());
+        $this->addAddress($customer, $order->getShippingAddress());
+    }
 
-        $this->addressAdder->add($customer, clone $billingAddress);
-        $this->addressAdder->add($customer, clone $shippingAddress);
+    /**
+     * @param CustomerInterface $customer
+     * @param AddressInterface|null $address
+     */
+    private function addAddress(CustomerInterface $customer, ?AddressInterface $address): void
+    {
+        if (null !== $address) {
+            $this->addressAdder->add($customer, clone $address);
+        }
     }
 }

--- a/src/Sylius/Component/Core/spec/Customer/CustomerOrderAddressesSaverSpec.php
+++ b/src/Sylius/Component/Core/spec/Customer/CustomerOrderAddressesSaverSpec.php
@@ -67,4 +67,22 @@ final class CustomerOrderAddressesSaverSpec extends ObjectBehavior
 
         $this->saveAddresses($order);
     }
+
+    function it_does_not_save_empty_addresses(
+        CustomerAddressAdderInterface $addressAdder,
+        OrderInterface $order,
+        CustomerInterface $customer,
+        ShopUserInterface $user
+    ): void {
+        $order->getCustomer()->willReturn($customer);
+        $customer->getUser()->willReturn($user);
+
+        $order->getShippingAddress()->willReturn(null);
+        $order->getBillingAddress()->willReturn(null);
+
+        $addressAdder->add($customer, Argument::any())->shouldNotBeCalled();
+        $addressAdder->add($customer, Argument::any())->shouldNotBeCalled();
+
+        $this->saveAddresses($order);
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Because both `shippingAddress` and `billingAddress` can be returned `null`.