### PR TITLE
Try to auto-detect a bundle's model namespace by default

### DIFF
--- a/src/Sylius/Bundle/AdminApiBundle/SyliusAdminApiBundle.php
+++ b/src/Sylius/Bundle/AdminApiBundle/SyliusAdminApiBundle.php
@@ -27,12 +27,4 @@ final class SyliusAdminApiBundle extends AbstractResourceBundle
             SyliusResourceBundle::DRIVER_DOCTRINE_ORM,
         ];
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getModelNamespace(): string
-    {
-        return 'Sylius\Bundle\AdminApiBundle\Model';
-    }
 }

--- a/src/Sylius/Bundle/PayumBundle/SyliusPayumBundle.php
+++ b/src/Sylius/Bundle/PayumBundle/SyliusPayumBundle.php
@@ -39,12 +39,4 @@ final class SyliusPayumBundle extends AbstractResourceBundle
 
         $container->addCompilerPass(new RegisterGatewayConfigTypePass());
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getModelNamespace(): string
-    {
-        return 'Sylius\Bundle\PayumBundle\Model';
-    }
 }

--- a/src/Sylius/Bundle/ResourceBundle/AbstractResourceBundle.php
+++ b/src/Sylius/Bundle/ResourceBundle/AbstractResourceBundle.php
@@ -99,7 +99,7 @@ abstract class AbstractResourceBundle extends Bundle implements ResourceBundleIn
      */
     protected function getModelNamespace(): ?string
     {
-        return null;
+        return (new \ReflectionClass($this))->getNamespaceName().'\\Model';
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

The `AbstractResourceBundle` right now requires that bundles/plugins define a model namespace.  Following conventions in core, by default this is presumably `<BundleNamespace>\Model`.  So instead of forcing child classes to define this we can make an assumption by default as a small DX improvement.

For the most part this doesn't impact core as most bundles are using component models (except for the two changed here).  But this can impact the plugin ecosystem and local app development by requiring one less method to set up.