### PR TITLE
Exclude the web/media directory from firewall restrict list.

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -4,7 +4,7 @@
 parameters:
     sylius.security.admin_regex: "^/admin"
     sylius.security.api_regex: "^/api"
-    sylius.security.shop_regex: "^/(?!admin|api/.*|api$)[^/]++"
+    sylius.security.shop_regex: "^/(?!admin|api/.*|api$|media/.*)[^/]++"
 
 security:
     providers:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT

This change fixes the "... locale is unavailable in this channel" exception when loading product images in some condition.

Suppose client's browser locale is en_US, while the store's locale is zh_CN, this bug would prevent any product images from being loaded because the "NonChannelLocaleListener" class wrongly breaks the requests.

So the fix is to exclude the "/media" path from shop firewall match pattern. 
