### PR TITLE
Fix the translation of registration form for zh_CN.

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Resources/translations/messages.zh_CN.yml
+++ b/src/Sylius/Bundle/UserBundle/Resources/translations/messages.zh_CN.yml
@@ -8,7 +8,7 @@ sylius:
             enabled: 已启用
             password:
                 label: 密码
-                confirmation: 验证码
+                confirmation: 确认密码
             remember_me: 记住我
             shipping_address: 送货地址
             username: 用户名


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

Fix the translation of "confirmation" for zh_CN. The previous translation "验证码" is quite misleading, which usually used in the sms confirmation for example.
