### PR TITLE
Fixes history issue when adding to cart

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-add-to-cart.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-add-to-cart.js
@@ -29,7 +29,7 @@
                 },
                 onSuccess: function (response) {
                     validationElement.addClass('hidden');
-                    window.location.replace(redirectUrl);
+                    window.location.href = redirectUrl;
                 },
                 onFailure: function (response) {
                     validationElement.removeClass('hidden');


### PR DESCRIPTION
Use window.location.href instead of window.location.replace() to keep previous location in history and expected behavior for web browser's back-button

See https://stackoverflow.com/questions/503093/how-to-redirect-to-another-webpage

| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | not sure
| Deprecations?   | no
| Related tickets | 
| License         | MIT