### PR TITLE
Allow specific override of flash messages for Admin and Shop.

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/_flashes.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/_flashes.html.twig
@@ -1,0 +1,1 @@
+{% include '@SyliusUi/_flashes.html.twig' %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
@@ -8,6 +8,10 @@
     {{ sonata_block_render_event('sylius.admin.layout.stylesheets') }}
 {% endblock %}
 
+{% block flash_messages %}
+    {% include '@SyliusAdmin/_flashes.html.twig' %}
+{% endblock %}
+
 {% block topbar %}
     <a class="icon item" id="sidebar-toggle" title="{{ 'sylius.ui.toggle_sidebar'|trans }}">
         <i class="sidebar icon"></i>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/complete.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/complete.html.twig
@@ -12,7 +12,7 @@
 
         {{ sonata_block_render_event('sylius.shop.checkout.complete.after_content_header', {'order': order}) }}
 
-        {% include 'SyliusUiBundle::_flashes.html.twig' %}
+        {% include '@SyliusShop/_flashes.html.twig' %}
 
         {{ form_start(form, {'action': path('sylius_shop_checkout_complete'), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate'}}) }}
             {{ form_errors(form) }}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/_flashes.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/_flashes.html.twig
@@ -1,0 +1,1 @@
+{% include '@SyliusUi/_flashes.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
@@ -50,7 +50,7 @@
             </header>
         {% endblock %}
 
-        {% include '@SyliusUi/_flashes.html.twig' %}
+        {% include '@SyliusShop/_flashes.html.twig' %}
 
         {{ sonata_block_render_event('sylius.shop.layout.before_content') }}
 

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Layout/sidebar.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Layout/sidebar.html.twig
@@ -28,7 +28,9 @@
 <div class="pusher">
     <div class="full height" id="wrapper">
         <div id="content">
-            {% include '@SyliusUi/_flashes.html.twig' %}
+            {% block flash_messages %}
+                {% include '@SyliusUi/_flashes.html.twig' %}
+            {% endblock %}
 
             {% block pre_content %}
             {% endblock %}


### PR DESCRIPTION
_flashes.html.twig are now two different file to allow override.

Ref. #9032 @pamil 

| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #9032 
| License         | MIT
