### PR TITLE
Prevent the kernel response listener for cart from continuing when the session is not actually started.

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/EventListener/SessionCartSubscriber.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/SessionCartSubscriber.php
@@ -61,6 +61,11 @@ final class SessionCartSubscriber implements EventSubscriberInterface
             return;
         }
 
+        $session = $event->getRequest()->getSession();
+        if ($session && !$session->isStarted()) {
+            return;
+        }
+
         try {
             $cart = $this->cartContext->getCart();
         } catch (CartNotFoundException $exception) {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

Prevent the kernel response listener for cart from continuing when the session is not actually started. Otherwise the next `cartContext->getCart()` method call would open a session with no sense.

A problem caused by this issue is that the following cache-control header being sent to client anyway: (because a session is started, the Symfony session listener would set that header)
> cache-control:max-age=0, must-revalidate, private

For landing pages without cart, or some shop API calls need to be cached from the CDN layer, we don't want the above cache-control header being set.

BTW, by fixing the issue and installing friendsofsymfony/http-cache-bundle I managed to enable the CDN cache for some shop API calls. Otherwise, the http-cache-bundle would work as expected.
