### PR TITLE
Fix UI form add button issue collection in a collection

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-form-collection.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-form-collection.js
@@ -25,7 +25,7 @@
 
         this.$element.on(
             'click',
-            '[data-form-collection="add"]:first',
+            '[data-form-collection="add"]:last',
             $.proxy(this.addItem, this)
         );
 


### PR DESCRIPTION
If you have a collection in a collection in an admin form for example, it should take the last add button not the first.
If you take the first, it will take the first of the first embedded collection if you have one (not the right one).

| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update UPGRADE-*.md file -->
| License         | MIT
