### PR TITLE
Fix wrong target-entity in exchange-rate entity

### DIFF
--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/doctrine/model/ExchangeRate.orm.xml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/doctrine/model/ExchangeRate.orm.xml
@@ -34,10 +34,10 @@
             <gedmo:timestampable on="update"/>
         </field>
 
-        <many-to-one field="sourceCurrency" target-entity="Sylius\Component\Currency\Model\Currency">
+        <many-to-one field="sourceCurrency" target-entity="Sylius\Component\Currency\Model\CurrencyInterface">
             <join-column name="source_currency" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
         </many-to-one>
-        <many-to-one field="targetCurrency" target-entity="Sylius\Component\Currency\Model\Currency">
+        <many-to-one field="targetCurrency" target-entity="Sylius\Component\Currency\Model\CurrencyInterface">
             <join-column name="target_currency" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
         </many-to-one>
     </mapped-superclass>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

This fixes an error that surfaces when trying to extend the `Currency` entity: due to the wrong mapping, it's not actually possible to extend the `Currency` entity.

I'm not sure how to reliably test this, apart from looking at all 97 `target-entity` attributes and ensuring they point to interfaces (except a Payum `GatewayConfig` that doesn't have an interface).