### PR TITLE
[Documentation] Fixed Docblock in Taxon document

### DIFF
--- a/docs/book/products/taxons.rst
+++ b/docs/book/products/taxons.rst
@@ -64,7 +64,7 @@ Finally **the parent taxon** has to be added to the system using a repository, a
 
 .. code-block:: php
 
-     /** @var TaxonRepositoryInterface $taxonsRepository */
+     /** @var TaxonRepositoryInterface $taxonRepository */
      $taxonRepository = $this->get('sylius.repository.taxon');
 
      $taxonRepository->add($taxon);


### PR DESCRIPTION
I copied that part and wondered why my IDE wasn't suggesting methods.
Turned out, that the variable was once named $taxonsRepository instead of the singular one.

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

