### PR TITLE
Fixed Customer API docs with invalid "groups" parameter

### DIFF
--- a/docs/api/customers.rst
+++ b/docs/api/customers.rst
@@ -53,7 +53,7 @@ If you request for a more detailed data, you will receive an object with followi
 +-------------------------+-------------------------------------------+
 | birthday                | Customers birthday                        |
 +-------------------------+-------------------------------------------+
-| groups                  | Array of groups customer belongs to       |
+| group                   | Customer group code                       |
 +-------------------------+-------------------------------------------+
 
 .. note::
@@ -81,7 +81,7 @@ Definition
 +--------------------------+----------------+------------------------------------------------------------------------------------------------------+
 | lastName                 | request        | Customer's last name                                                                                 |
 +--------------------------+----------------+------------------------------------------------------------------------------------------------------+
-| groups                   | request        | *(optional)* Array of groups customer belongs to                                                     |
+| group                   | request        | *(optional)* Customer group code                                                                      |
 +--------------------------+----------------+------------------------------------------------------------------------------------------------------+
 | gender                   | request        | Customer's gender                                                                                    |
 +--------------------------+----------------+------------------------------------------------------------------------------------------------------+
@@ -139,9 +139,7 @@ Exemplary Response
         "firstName":"John",
         "lastName":"Diggle",
         "gender":"m",
-        "group":[
-
-        ]
+        "group":{}
     }
 
 If you try to create a customer without email or gender, you will receive a ``400 Bad Request`` error.
@@ -244,9 +242,7 @@ Exemplary Response
         "firstName":"Levi",
         "lastName":"Friesen",
         "gender":"u",
-        "group":[
-
-        ]
+        "group":{}
     }
 
 Collection of Customers
@@ -428,7 +424,7 @@ Definition
 +--------------------------+----------------+------------------------------------------------------------------------------+
 | lastName                 | request        | Customers last name                                                          |
 +--------------------------+----------------+------------------------------------------------------------------------------+
-| groups                   | request        | *(optional)* Array of groups customer belongs to                             |
+| group                    | request        | *(optional)* Customer group code                                             |
 +--------------------------+----------------+------------------------------------------------------------------------------+
 | gender                   | request        | Customers gender                                                             |
 +--------------------------+----------------+------------------------------------------------------------------------------+
@@ -534,7 +530,7 @@ Definition
 +--------------------------+----------------+--------------------------------------------------+
 | lastName                 | request        | *(optional)* Customers last name                 |
 +--------------------------+----------------+--------------------------------------------------+
-| groups                   | request        | *(optional)* Array of groups customer belongs to |
+| group                    | request        | *(optional)* Customer group code                 |
 +--------------------------+----------------+--------------------------------------------------+
 | gender                   | request        | *(optional)* Customers gender                    |
 +--------------------------+----------------+--------------------------------------------------+


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0 (affects all)
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT

According to the Customer API docs, "groups" fields is expected to be an array while it has a 1 to N relationship in DB, and it does not work if an array is passed.

