### PR TITLE
Remove RFC label from stalebot's whitelist

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,7 +3,6 @@ daysUntilClose: 7
 exemptLabels:
   - Bug
   - Critical
-  - RFC
 staleLabel: Stale
 markComment: >
   This issue has been automatically marked as stale because it has not had any


### PR DESCRIPTION
RFCs without any activity in last three months are really unlikely to be noticed again.
The comment stalebot makes a week before closing an issue might be used as a reminder instead.