### PR TITLE
Make Travis tests more reliable

### DIFF
--- a/src/Sylius/Behat/Resources/config/profiles/default.yml
+++ b/src/Sylius/Behat/Resources/config/profiles/default.yml
@@ -29,6 +29,7 @@ default:
                             browserName: chrome
                             browser: chrome
                             version: ""
+                            marionette: null # https://github.com/Behat/MinkExtension/pull/311
                             chrome:
                                 switches:
                                     - "start-fullscreen"


### PR DESCRIPTION
Without `marionette: null`, MinkExtension in v2.3.0 runs Firefox instead of Chrome.