### PR TITLE
Make images removal tests great again

### DIFF
--- a/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPage.php
@@ -572,6 +572,10 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
 
     private function saveImageUrlForType(string $type, string $imageUrl): void
     {
+        if (false !== strpos($imageUrl, 'data:image/jpeg')) {
+            return;
+        }
+
         $this->imageUrls[$type] = $imageUrl;
     }
 }

--- a/src/Sylius/Behat/Page/Admin/Taxon/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Taxon/UpdatePage.php
@@ -350,6 +350,10 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 
     private function saveImageUrlForType(string $type, string $imageUrl): void
     {
+        if (false !== strpos($imageUrl, 'data:image/jpeg')) {
+            return;
+        }
+
         $this->imageUrls[$type] = $imageUrl;
     }
 }


### PR DESCRIPTION
There were lots of failures because the saved image URL was a data URI.