### PR TITLE
[Docs] Update all occurrences of .dev to .test

### DIFF
--- a/docs/api/authorization.rst
+++ b/docs/api/authorization.rst
@@ -5,7 +5,7 @@ Authorization
 =============
 
 This part of documentation is about authorization to Sylius platform through API. In order to check this configuration,
-please set up your local copy of Sylius platform and change *sylius.dev*  to your address.
+please set up your local copy of Sylius platform and change *sylius.test*  to your address.
 
 OAuth2
 ------
@@ -76,7 +76,7 @@ Example
 
 .. code-block:: bash
 
-    curl http://sylius.dev/api/oauth/v2/token \
+    curl http://sylius.test/api/oauth/v2/token \
         -d "client_id"=demo_client \
         -d "client_secret"=secret_demo_client \
         -d "grant_type"=password \
@@ -117,7 +117,7 @@ Example
 
 .. code-block:: bash
 
-    curl http://sylius.dev/api/v1/users/
+    curl http://sylius.test/api/v1/users/
         -H "Authorization: Bearer NzFiYTM4ZTEwMjcwZTcyZWIzZTA0NmY3NjE3MTIyMjM1Y2NlMmNlNWEyMTAzY2UzYmY0YWIxYmUzNTkyMDcyNQ"
 
 .. note::
@@ -153,7 +153,7 @@ Example
 
 .. code-block:: bash
 
-    curl http://sylius.dev/api/oauth/v2/token \
+    curl http://sylius.test/api/oauth/v2/token \
         -d "client_id"=demo_client \
         -d "client_secret"=secret_demo_client \
         -d "grant_type"=refresh_token \

--- a/docs/api/provinces.rst
+++ b/docs/api/provinces.rst
@@ -127,7 +127,7 @@ Example
 
 .. code-block:: bash
 
-    $ curl http://sylius.dev/api/v1/countries/PL/provinces/PL-MZ \
+    $ curl http://sylius.test/api/v1/countries/PL/provinces/PL-MZ \
         -H "Authorization: Bearer SampleToken" \
         -H "Accept: application/json" \
         -X DELETE

--- a/docs/book/installation/vagrant_installation.rst
+++ b/docs/book/installation/vagrant_installation.rst
@@ -38,14 +38,14 @@ How to install Sylius using Vagrant?
     $ cd sylius
     $ vagrant up
 
-4. Add an entry for sylius.dev to the ``etc/hosts`` file:
+4. Add an entry for sylius.test to the ``etc/hosts`` file:
 
 .. code-block:: bash
 
     # etc/hosts
-    10.0.0.200      sylius.dev www.sylius.dev
+    10.0.0.200      sylius.test www.sylius.test
 
-From now on you will be able to access running Sylius application at ``http://sylius.dev/app_dev.php``.
+From now on you will be able to access running Sylius application at ``http://sylius.test/app_dev.php``.
 
 .. _Composer: http://packagist.org
 .. _`Composer installed globally`: http://getcomposer.org/doc/00-intro.md#globally


### PR DESCRIPTION
New preloaded `.dev` gTLD HSTS causing issues for some web browsers in development env.
https://chromium-review.googlesource.com/c/chromium/src/+/669923

It seems to be generally accepted to switch to `.test` instead.
https://tools.ietf.org/html/rfc2606

More info: https://ma.ttias.be/chrome-force-dev-domains-https-via-preloaded-hsts/

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no?
| New feature?    | no?
| BC breaks?      | yes? no?
| Deprecations?   | yes? no? <!-- don't forget to update UPGRADE-*.md file -->
| Related tickets | sylius/Vagrant#16
| License         | MIT

