### PR TITLE
Make accordion in select attribute values great again

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
@@ -73,5 +73,11 @@
 
         $(document).previewUploadedImage('#sylius_product_images');
         $(document).previewUploadedImage('#sylius_taxon_images');
+
+        $('body').on('DOMNodeInserted', '[data-form-collection="item"]', function() {
+            if ($(this).find('.accordion').length > 0) {
+                $(this).find('.accordion').accordion();
+            }
+        });
     });
 })(jQuery);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/8900
| License         | MIT

For sure it's not the best solution from the js point of view, but it works :)
The problem was that newly added select attribute values has translation accordion inside which needs to be triggered to make them work.