### PR TITLE
Add required parameters to the Route generation

### DIFF
--- a/docs/components_and_bundles/bundles/SyliusGridBundle/custom_action.rst
+++ b/docs/components_and_bundles/bundles/SyliusGridBundle/custom_action.rst
@@ -11,7 +11,7 @@ In the template we will specify the button's icon to be ``mail`` and its colour 
 
     {% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
 
-    {% set path = options.link.url|default(path(options.link.route)) %}
+    {% set path = options.link.url|default(path(options.link.route, options.link.parameters)) %}
 
     {{ buttons.default(path, action.label, null, 'mail', 'purple') }}
 


### PR DESCRIPTION
According to the documentation we link to a specific supplier contact. In the custom action {% set path = ... %} the additional id parameter is missing. 
<cite>An exception has been thrown during the rendering of a template ("Some mandatory parameters are missing ("id") to generate a URL for route "app_admin_supplier_show".").</cite>

| Q               | A
| --------------- | -----
| Branch?         | 1.0, 1.1 or master <!-- see the comment below -->
| Bug fix?        | no/yes
| New feature?    | no/yes
| BC breaks?      | no/yes
| Deprecations?   | no/yes <!-- don't forget to update UPGRADE-*.md file -->
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.0 or 1.1 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
