### PR TITLE
[ResourceBundle] Redirect using url from resource method.

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/RedirectHandlerInterface.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/RedirectHandlerInterface.php
@@ -36,12 +36,13 @@ interface RedirectHandlerInterface
 
     /**
      * @param RequestConfiguration $configuration
-     * @param string               $route
-     * @param array                $parameters
+     * @param string $route
+     * @param array $parameters
+     * @param ResourceInterface|null $resource
      *
      * @return Response
      */
-    public function redirectToRoute(RequestConfiguration $configuration, string $route, array $parameters = []): Response;
+    public function redirectToRoute(RequestConfiguration $configuration, string $route, array $parameters = [], ?ResourceInterface $resource = null): Response;
 
     /**
      * @param RequestConfiguration $configuration

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/RedirectHandlerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/RedirectHandlerSpec.php
@@ -125,4 +125,36 @@ final class RedirectHandlerSpec extends ObjectBehavior
 
         $this->redirect($configuration, 'http://myurl.com')->shouldHaveType(Response::class);
     }
+
+    function it_redirects_from_resource_field(RequestConfiguration $configuration): void
+    {
+        $this
+            ->redirectToRoute($configuration, 'resource.returnUrl', [], $this->getResourceWithReturnUrl())
+            ->shouldHaveType(RedirectResponse::class)
+        ;
+    }
+
+    function it_will_throw_when_resource_field_is_empty(RequestConfiguration $configuration): void
+    {
+        $this
+            ->shouldThrow(RouteNotFoundException::class)
+            ->duringRedirectToRoute($configuration, 'resource.returnUrl', [], $this->getResourceWithEmptyReturnUrl())
+        ;
+    }
+
+    private function getResourceWithReturnUrl()
+    {
+        return new class implements ResourceInterface {
+            public function getId() { return 1; }
+            public function getReturnUrl() { return 'http://myurl.com'; }
+        };
+    }
+
+    private function getResourceWithEmptyReturnUrl()
+    {
+        return new class implements ResourceInterface {
+            public function getId() { return 1; }
+            public function getReturnUrl() { return null; }
+        };
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | ~
| License         | MIT

This PR provide Url to redirect from the resource it's self.

```yaml
some_route:
    path: /path
    defaults:
        _controller: app.controller.resource:xxxAction
        _sylius:
            flash: false
            redirect: resource.returnUri
```

PS. I have no idea to mock `resource.returnUri` in spec.
