### PR TITLE
[ResourceBundle] Add the controller tag

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
@@ -91,6 +91,7 @@ abstract class AbstractDriver implements DriverInterface
                 new Reference('sylius.resource_controller.resource_delete_handler'),
             ])
             ->addMethodCall('setContainer', [new Reference('service_container')])
+            ->addTag('controller.service_arguments')
         ;
 
         $container->setDefinition($metadata->getServiceId('controller'), $definition);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | ~
| License         | MIT

Resource controllers have the tag missing. This does not allow having dependencies injected into actions.
