### PR TITLE
[Behat] Remove some unused methods in Behat pages

### DIFF
--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
@@ -205,21 +205,6 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
     /**
      * {@inheritdoc}
      */
-    public function specifyPriceForChannelAndCurrency($price, ChannelInterface $channel, CurrencyInterface $currency)
-    {
-        $calculatorElement = $this->getElement('calculator');
-        $calculatorElement
-            ->waitFor(5, function () use ($channel, $currency) {
-                return $this->getElement('calculator')->hasField(sprintf('%s %s', $channel->getName(), $currency->getCode()));
-            })
-        ;
-
-        $calculatorElement->fillField(sprintf('%s %s', $channel->getName(), $currency->getCode()), $price);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function activateLanguageTab($locale)
     {
         if (!$this->getDriver() instanceof Selenium2Driver) {
@@ -279,7 +264,6 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
             'attribute_delete_button' => '.tab[data-tab="%localeCode%"] .attribute .label:contains("%attributeName%") ~ button',
             'attribute_value' => '.tab[data-tab="%localeCode%"] .attribute .label:contains("%attributeName%") ~ input',
             'attributes_choice' => '#sylius_product_attribute_choice',
-            'calculator' => '#sylius_calculator_container',
             'channel_checkbox' => '.checkbox:contains("%channelName%") input',
             'channel_pricings' => '#sylius_product_variant_channelPricings',
             'code' => '#sylius_product_code',

--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPageInterface.php
@@ -43,13 +43,6 @@ interface CreateSimpleProductPageInterface extends BaseCreatePageInterface
     public function checkChannel($channelName);
 
     /**
-     * @param int $price
-     * @param ChannelInterface $channel
-     * @param CurrencyInterface $currency
-     */
-    public function specifyPriceForChannelAndCurrency($price, ChannelInterface $channel, CurrencyInterface $currency);
-
-    /**
      * @param string $code
      */
     public function specifyCode($code);

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/CreatePage.php
@@ -88,21 +88,6 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     /**
      * {@inheritdoc}
      */
-    public function specifyPriceForChannelAndCurrency($price, ChannelInterface $channel, CurrencyInterface $currency)
-    {
-        $calculatorElement = $this->getElement('calculator');
-        $calculatorElement
-            ->waitFor(5, function () use ($channel, $currency) {
-                return $this->getElement('calculator')->hasField(sprintf('%s %s', $channel->getName(), $currency->getCode()));
-            })
-        ;
-
-        $calculatorElement->fillField(sprintf('%s %s', $channel->getName(), $currency->getCode()), $price);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getValidationMessageForForm()
     {
         $formElement = $this->getDocument()->find('css', 'form[name="sylius_product_variant"]');
@@ -154,7 +139,6 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     protected function getDefinedElements()
     {
         return array_merge(parent::getDefinedElements(), [
-            'calculator' => '#sylius_calculator_container',
             'code' => '#sylius_product_variant_code',
             'depth' => '#sylius_product_variant_depth',
             'form' => 'form[name="sylius_product_variant"]',

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/CreatePageInterface.php
@@ -67,13 +67,6 @@ interface CreatePageInterface extends BaseCreatePageInterface
     public function choosePricingCalculator($name);
 
     /**
-     * @param int $price
-     * @param ChannelInterface $channel
-     * @param CurrencyInterface $currency
-     */
-    public function specifyPriceForChannelAndCurrency($price, ChannelInterface $channel, CurrencyInterface $currency);
-
-    /**
      * @return string
      */
     public function getValidationMessageForForm();


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I think that even the implementation was broken (with `#sylius_calculator_container` which does not exits).
