### PR TITLE
[Documentation] Add more rules to the contribution guide + Fix CMS cookbook

### DIFF
--- a/docs/contributing/documentation/standards.rst
+++ b/docs/contributing/documentation/standards.rst
@@ -131,7 +131,10 @@ Language Standards
 
     The Vitamins are in my Fresh California Raisins
 
-* Do not use `Serial (Oxford) Commas`_;
+* Please use appropriate, informative, rather formal language;
+* Do not place any kind of advertisements in the documentation;
+* The documentation should be neutral, without judgements, opinions. Make sure you do not favor anyone,
+  our community is great as a whole, there is no need to point who is better than the rest of us;
 * You should use a form of *you* instead of *we* (i.e. avoid the first person
   point of view: use the second instead);
 * When referencing a hypothetical person, such as "a user with a session cookie", gender-neutral

--- a/docs/cookbook/shop/cms.rst
+++ b/docs/cookbook/shop/cms.rst
@@ -12,8 +12,8 @@ Content management in Sylius
 ----------------------------
 
 Sylius standard app does not come with a content management system. Our community has taken care of it.
-As Sylius does have an awesome dev oriented plugin environment, developers from `BitBag <https://bitbag.shop>`_ decided to develop
-their flexible CMS module. You can find it on `their GitHub <https://github.com/BitBagCommerce/SyliusCmsPlugin>`_.
+As Sylius does have a convenient dev oriented plugin environment, the developers from `BitBag <https://bitbag.shop>`_ decided to develop
+their flexible CMS module. You can find it `here <https://github.com/BitBagCommerce/SyliusCmsPlugin>`_.
 
 .. tip::
 
@@ -28,12 +28,12 @@ Inside the plugin, you will find:
 * Sections which you can use to create a blog, customer information, etc.
 * FAQ module
 
-What is the most awesome thing about this plugin is that you can customize it for your specific needs like you do with each :doc:`Sylius model </customization/model>`.
+A very handy feature of this plugin is that you can customize it for your specific needs like you do with each :doc:`Sylius model </customization/model>`.
 
 Installation & usage
 --------------------
 
-Find out more about how to install the plugin on `GitHub <https://github.com/BitBagCommerce/SyliusCmsPlugin>`_.
+Find out more about how to install the plugin on `GitHub <https://github.com/BitBagCommerce/SyliusCmsPlugin>`_ in the README file.
 
 Learn more
 ----------

--- a/docs/cookbook/shop/map.rst.inc
+++ b/docs/cookbook/shop/map.rst.inc
@@ -5,3 +5,4 @@
 * :doc:`/cookbook/shop/taxons-menu`
 * :doc:`/cookbook/shop/embedding-products`
 * :doc:`/cookbook/shop/disabling-localised-urls`
+* :doc:`/cookbook/shop/cms`


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Doc fix?        | yes
| New docs?    | yes
| Related tickets | fixes #9155 as it was missing inclusion in .rst file
| License         | MIT

Added some statements regarding the neutrality of Sylius Documentation to the contribution guide.
