### PR TITLE
[Documentation][GridBundle]Wrong definition of sortable attribute

### DIFF
--- a/docs/components_and_bundles/bundles/SyliusGridBundle/configuration.rst
+++ b/docs/components_and_bundles/bundles/SyliusGridBundle/configuration.rst
@@ -20,8 +20,8 @@ Here you will find all configuration options of ``sylius_grid``.
                         type: twig # Type of field
                         label: Name # Label
                         path: . # dot means a whole object
-                        sortable: true
-                        position: 100
+                        sortable: ~ | field path
+                        position: 100
                         options:
                             template: :Grid/Column:_name.html.twig # Only twig column
                             vars:


### PR DESCRIPTION
sortable: true --> translates to o.1 in the SQL query
sortable: ~ --> translates to o.attribute in SQL query
sortable: path.to.my.subentity.prop --> translates to o.subentity.prop

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes none
| License         | MIT