### PR TITLE
[AttributeBundle] Fixing composer.json for ramsey/uuid

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": "^7.1",
 
+        "ramsey/uuid": "^3.7",
         "sonata-project/intl-bundle": "^2.2",
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/attribute": "^1.0",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

We use AttributeBundle as a standalone and since this commit https://github.com/Sylius/Sylius/commit/59b13758876f4a2ae519f97e5fac481c6154df90 we have issue about a missing lib ramsey/uuid.
I just added in the composer.json of the AttributeBundle

The lib is used in src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeChoicesCollectionType.php

<!--
 - Bug fixes must be submitted against the 1.0 or 1.1 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
