### PR TITLE
[ResourceBundle] make controller public by default

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
@@ -70,6 +70,7 @@ abstract class AbstractDriver implements DriverInterface
     {
         $definition = new Definition($metadata->getClass('controller'));
         $definition
+            ->setPublic(true)
             ->setArguments([
                 $this->getMetadataDefinition($metadata),
                 new Reference('sylius.resource_controller.request_configuration_factory'),


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

unsure if this is a bug fix. shall i raise target 1.0?

Symfony's `ContainerControllerResolver` is is triggering a deprecation warning on when retrieving controllers from the container because they are private by default. They should be public.
```
The "..." service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead.
```
