### PR TITLE
[ResourceBundle] make sylius.translatable_entity_locale_assigner public

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/services/integrations/translation.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/services/integrations/translation.xml
@@ -31,7 +31,7 @@
             <tag name="form.type" />
         </service>
 
-        <service id="sylius.translatable_entity_locale_assigner" class="Sylius\Component\Resource\Translation\TranslatableEntityLocaleAssigner">
+        <service id="sylius.translatable_entity_locale_assigner" class="Sylius\Component\Resource\Translation\TranslatableEntityLocaleAssigner" public="true">
             <argument type="service" id="sylius.translation_locale_provider" />
         </service>
     </services>


### PR DESCRIPTION
make `sylius.translatable_entity_locale_assigner` public as is it retreived from the container by `ORMTranslatableListener`, trigging a deprecation warning in symfony 3.4.

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

unsure if this is a bug fix. shall i raise target 1.0?
