### PR TITLE
[Fixtures] Creating images from array for Taxons

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/BookProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/BookProductFixture.php
@@ -93,6 +93,10 @@ class BookProductFixture extends AbstractFixture
                     'name' => 'Books',
                 ],
             ],
+            'images' => [
+                [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'books.jpg'), 'main'],
+                [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'books.jpg'), 'thumbnail'],
+            ]
         ]]]);
 
         $bookGenres = [

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
@@ -14,12 +14,15 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Fixture\Factory;
 
 use Sylius\Component\Core\Formatter\StringInflector;
+use Sylius\Component\Core\Model\TaxonImageInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
+use Sylius\Component\Core\Uploader\ImageUploaderInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Taxonomy\Generator\TaxonSlugGeneratorInterface;
 use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -29,6 +32,11 @@ class TaxonExampleFactory extends AbstractExampleFactory implements ExampleFacto
      * @var FactoryInterface
      */
     private $taxonFactory;
+
+    /**
+     * @var FactoryInterface
+     */
+    private $taxonImageFactory;
 
     /**
      * @var TaxonRepositoryInterface
@@ -56,21 +64,32 @@ class TaxonExampleFactory extends AbstractExampleFactory implements ExampleFacto
     private $optionsResolver;
 
     /**
+     * @var ImageUploaderInterface
+     */
+    private $imageUploader;
+
+    /**
      * @param FactoryInterface $taxonFactory
+     * @param FactoryInterface $taxonImageFactory
      * @param TaxonRepositoryInterface $taxonRepository
      * @param RepositoryInterface $localeRepository
      * @param TaxonSlugGeneratorInterface $taxonSlugGenerator
+     * @param ImageUploaderInterface $imageUploader
      */
     public function __construct(
         FactoryInterface $taxonFactory,
+        FactoryInterface $taxonImageFactory,
         TaxonRepositoryInterface $taxonRepository,
         RepositoryInterface $localeRepository,
-        TaxonSlugGeneratorInterface $taxonSlugGenerator
+        TaxonSlugGeneratorInterface $taxonSlugGenerator,
+        ImageUploaderInterface $imageUploader
     ) {
         $this->taxonFactory = $taxonFactory;
+        $this->taxonImageFactory = $taxonImageFactory;
         $this->taxonRepository = $taxonRepository;
         $this->localeRepository = $localeRepository;
         $this->taxonSlugGenerator = $taxonSlugGenerator;
+        $this->imageUploader = $imageUploader;
 
         $this->faker = \Faker\Factory::create();
         $this->optionsResolver = new OptionsResolver();
@@ -107,6 +126,10 @@ class TaxonExampleFactory extends AbstractExampleFactory implements ExampleFacto
             $taxon->addChild($this->create($childOptions));
         }
 
+        foreach ($options['images'] as $imageOptions) {
+            $taxon->addImage($this->createImages($imageOptions));
+        }
+
         return $taxon;
     }
 
@@ -128,7 +151,28 @@ class TaxonExampleFactory extends AbstractExampleFactory implements ExampleFacto
             })
             ->setDefault('children', [])
             ->setAllowedTypes('children', ['array'])
+            ->setDefault('images', [])
+            ->setAllowedTypes('images', ['array'])
         ;
+    }
+
+    /**
+     * @param array $image
+     * @return TaxonImageInterface
+     */
+    private function createImages(array $image): TaxonImageInterface
+    {
+        $imagePath = array_shift($image);
+        $uploadedImage = new UploadedFile($imagePath, basename($imagePath));
+
+        /** @var TaxonImageInterface $taxonImage */
+        $taxonImage = $this->taxonImageFactory->createNew();
+        $taxonImage->setFile($uploadedImage);
+        $taxonImage->setType(end($image) ?: null);
+
+        $this->imageUploader->upload($taxonImage);
+
+        return $taxonImage;
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Fixture/TaxonFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/TaxonFixture.php
@@ -37,6 +37,7 @@ class TaxonFixture extends AbstractResourceFixture
                 ->scalarNode('slug')->cannotBeEmpty()->end()
                 ->scalarNode('description')->cannotBeEmpty()->end()
                 ->variableNode('children')->cannotBeEmpty()->defaultValue([])->end()
+                ->arrayNode('images')->prototype('scalar')->end()->end()
         ;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
@@ -110,9 +110,11 @@
 
         <service id="sylius.fixture.example_factory.taxon" class="Sylius\Bundle\CoreBundle\Fixture\Factory\TaxonExampleFactory">
             <argument type="service" id="sylius.factory.taxon" />
+            <argument type="service" id="sylius.factory.taxon_image" />
             <argument type="service" id="sylius.repository.taxon" />
             <argument type="service" id="sylius.repository.locale" />
             <argument type="service" id="sylius.generator.taxon_slug" />
+            <argument type="service" id="sylius.image_uploader" />
         </service>
 
         <service id="sylius.fixture.example_factory.product" class="Sylius\Bundle\CoreBundle\Fixture\Factory\ProductExampleFactory">

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/TaxonFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/TaxonFixtureTest.php
@@ -58,6 +58,17 @@ final class TaxonFixtureTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function taxon_images_is_optional(): void
+    {
+        $this->assertConfigurationIsValid(
+            [['custom' => [['images' => ['../image/path1.jpg', '../image/path2.jpg']]]]],
+            'custom.*.images'
+        );
+    }
+
+    /**
+     * @test
+     */
     public function taxon_children_are_optional(): void
     {
         $this->assertConfigurationIsValid([['custom' => [['children' => [['name' => 'foo']]]]]], 'custom.*.children');


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

From Fixtures level we are not able to add images to Taxons as we can in Products. This PR adds missing configuration 😉 