### PR TITLE
Add PaymentMethod::instructions option to fixtures

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PaymentMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PaymentMethodExampleFactory.php
@@ -93,6 +93,7 @@ class PaymentMethodExampleFactory extends AbstractExampleFactory implements Exam
 
             $paymentMethod->setName($options['name']);
             $paymentMethod->setDescription($options['description']);
+            $paymentMethod->setInstructions($options['instructions']);
         }
 
         foreach ($options['channels'] as $channel) {
@@ -117,6 +118,8 @@ class PaymentMethodExampleFactory extends AbstractExampleFactory implements Exam
             ->setDefault('description', function (Options $options): string {
                 return $this->faker->sentence();
             })
+            ->setDefault('instructions', null)
+            ->setAllowedTypes('instructions', ['null', 'string'])
             ->setDefault('gatewayName', 'Offline')
             ->setDefault('gatewayFactory', 'offline')
             ->setDefault('gatewayConfig', [])

--- a/src/Sylius/Bundle/CoreBundle/Fixture/PaymentMethodFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/PaymentMethodFixture.php
@@ -35,6 +35,7 @@ class PaymentMethodFixture extends AbstractResourceFixture
                 ->scalarNode('code')->cannotBeEmpty()->end()
                 ->scalarNode('name')->cannotBeEmpty()->end()
                 ->scalarNode('description')->cannotBeEmpty()->end()
+                ->scalarNode('instructions')->end()
                 ->scalarNode('gatewayName')->cannotBeEmpty()->end()
                 ->scalarNode('gatewayFactory')->cannotBeEmpty()->end()
                 ->arrayNode('gatewayConfig')->prototype('variable')->end()->end()

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/PaymentMethodFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/PaymentMethodFixtureTest.php
@@ -75,6 +75,43 @@ final class PaymentMethodFixtureTest extends TestCase
     /**
      * @test
      */
+    public function payment_method_instructions_configuration_must_by_string(): void
+    {
+        $this->assertConfigurationIsValid([['custom' => [['instructions' => 'test']]]], 'custom.*.instructions');
+        $this->assertConfigurationIsInvalid([['custom' => [['instructions' => ['test']]]]], 'Invalid type for path "payment_method.custom.0.instructions". Expected scalar, but got array');
+    }
+
+    /**
+     * @test
+     */
+    public function payment_method_instructions_configuration_can_be_null(): void
+    {
+        $this->assertConfigurationIsValid([['custom' => [['instructions' => null]]]], 'custom.*.instructions');
+    }
+
+    /**
+     * @test
+     */
+    public function payment_method_instructions_configuration_default_null(): void
+    {
+        $this->assertProcessedConfigurationEquals(
+            [['custom' => [[]]]],
+            ['custom' => [[]]],
+            'custom.*.instructions'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function payment_method_instructions_configuration_is_optional(): void
+    {
+        $this->assertConfigurationIsValid([['custom' => [[]]]], 'custom.*.instructions');
+    }
+
+    /**
+     * @test
+     */
     public function payment_method_gateway_configuration_must_by_array(): void
     {
         $this->assertConfigurationIsValid([['custom' => [['gatewayConfig' => ['username' => 'USERNAME']]]]], 'custom.*.gatewayConfig');


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Not a real bug, but just a missing option. Default is still `null`, so it doesn't confuse as it's an optional text.
