### PR TITLE
Documentation - Use nullable return type

### DIFF
--- a/docs/customization/model.rst
+++ b/docs/customization/model.rst
@@ -59,9 +59,9 @@ Assuming that you would want to add another field on the model - for instance a 
         private $flag;
 
         /**
-         * @return bool
+         * @return bool|null
          */
-        public function getFlag(): bool
+        public function getFlag(): ?bool
         {
             return $this->flag;
         }


### PR DESCRIPTION
In doctrine config the field flag is defined as nullable, so we should use nullable type in getter.

| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT