### PR TITLE
Fix wrong Balrog of Morgoth name

### DIFF
--- a/docs/api/admin_users.rst
+++ b/docs/api/admin_users.rst
@@ -109,7 +109,7 @@ Exemplary Response
     {
         "id": 7,
         "username": "Balrog",
-        "usernameCanonical": "barlog",
+        "usernameCanonical": "balrog",
         "roles": [
             "ROLE_ADMINISTRATION_ACCESS"
         ],
@@ -219,7 +219,7 @@ Exemplary Response
     {
         "id": 9,
         "username": "Balrog",
-        "usernameCanonical": "barlog",
+        "usernameCanonical": "balrog",
         "roles": [
             "ROLE_ADMINISTRATION_ACCESS"
         ],
@@ -278,7 +278,7 @@ Exemplary Response
     {
         "id": 9,
         "username": "Balrog",
-        "usernameCanonical": "barlog",
+        "usernameCanonical": "balrog",
         "roles": [
             "ROLE_ADMINISTRATION_ACCESS"
         ],

--- a/tests/Controller/AdminUserApiTest.php
+++ b/tests/Controller/AdminUserApiTest.php
@@ -70,7 +70,7 @@ class AdminUserApiTest extends JsonApiTestCase
         $data =
 <<<EOT
         {
-            "username": "Barlog",
+            "username": "Balrog",
             "email": "teamEvil@middleearth.com",
             "plainPassword": "youShallNotPass",
             "localeCode": "en_US"

--- a/tests/Responses/Expected/admin_user/create_response.json
+++ b/tests/Responses/Expected/admin_user/create_response.json
@@ -1,7 +1,7 @@
 {
     "id": @integer@,
-    "username": "Barlog",
-    "usernameCanonical": "barlog",
+    "username": "Balrog",
+    "usernameCanonical": "balrog",
     "roles": [
         "ROLE_ADMINISTRATION_ACCESS"
     ],


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

It was quite frustrating to see such a big disrespect for this awesome creature :/
http://lotr.wikia.com/wiki/Balrog
To be precisely, we should refer to a specific Balrog's name ([Durin's Bane](http://lotr.wikia.com/wiki/Durin%27s_Bane) in this case), but it can be a little bit confusing, so it's good as it is right now :)

![zrzut ekranu 2018-03-16 o 11 51 45](https://user-images.githubusercontent.com/6212718/37517012-6f285752-2910-11e8-904b-dfdc18e1e806.png)
