### PR TITLE
[ThemeBundle] Remove deprecated translator selector usage

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/translations.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/translations.xml
@@ -16,7 +16,7 @@
         <service id="sylius.theme.translation.translator" class="Sylius\Bundle\ThemeBundle\Translation\Translator" decorates="translator.default" decoration-priority="256" public="false">
             <argument type="service" id="sylius.theme.translation.loader_provider" />
             <argument type="service" id="sylius.theme.translation.resource_provider" />
-            <argument type="service" id="translator.selector" />
+            <argument type="service" id="translator.formatter" />
             <argument>%kernel.default_locale%</argument>
             <argument type="collection">
                 <argument key="cache_dir">%kernel.cache_dir%/translations</argument>

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Translation/TranslatorTest.php
@@ -17,9 +17,9 @@ use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\ThemeBundle\Translation\Provider\Loader\TranslatorLoaderProvider;
 use Sylius\Bundle\ThemeBundle\Translation\Provider\Resource\TranslatorResourceProvider;
 use Sylius\Bundle\ThemeBundle\Translation\Translator;
+use Symfony\Component\Translation\Formatter\MessageFormatterInterface;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\MessageCatalogue;
-use Symfony\Component\Translation\MessageSelector;
 
 /**
  * @see \Symfony\Component\Translation\Tests\TranslatorTest
@@ -363,8 +363,14 @@ final class TranslatorTest extends TestCase
     {
         $loaderProvider = new TranslatorLoaderProvider();
         $resourceProvider = new TranslatorResourceProvider();
-        $messageSelector = $this->getMockBuilder(MessageSelector::class)->getMock();
 
-        return new Translator($loaderProvider, $resourceProvider, $messageSelector, $locale, $options);
+        $messageFormatter = new class implements MessageFormatterInterface {
+            public function format($message, $locale, array $parameters = array())
+            {
+                return strtr($message, $parameters);
+            }
+        };
+
+        return new Translator($loaderProvider, $resourceProvider, $messageFormatter, $locale, $options);
     }
 }

--- a/src/Sylius/Bundle/ThemeBundle/Translation/Translator.php
+++ b/src/Sylius/Bundle/ThemeBundle/Translation/Translator.php
@@ -16,7 +16,7 @@ namespace Sylius\Bundle\ThemeBundle\Translation;
 use Sylius\Bundle\ThemeBundle\Translation\Provider\Loader\TranslatorLoaderProviderInterface;
 use Sylius\Bundle\ThemeBundle\Translation\Provider\Resource\TranslatorResourceProviderInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
-use Symfony\Component\Translation\MessageSelector;
+use Symfony\Component\Translation\Formatter\MessageFormatterInterface;
 use Symfony\Component\Translation\Translator as BaseTranslator;
 
 final class Translator extends BaseTranslator implements WarmableInterface
@@ -47,14 +47,14 @@ final class Translator extends BaseTranslator implements WarmableInterface
     /**
      * @param TranslatorLoaderProviderInterface $loaderProvider
      * @param TranslatorResourceProviderInterface $resourceProvider
-     * @param MessageSelector $messageSelector
+     * @param MessageFormatterInterface $messageFormatter
      * @param string $locale
      * @param array $options
      */
     public function __construct(
         TranslatorLoaderProviderInterface $loaderProvider,
         TranslatorResourceProviderInterface $resourceProvider,
-        MessageSelector $messageSelector,
+        MessageFormatterInterface $messageFormatter,
         string $locale,
         array $options = []
     ) {
@@ -68,7 +68,7 @@ final class Translator extends BaseTranslator implements WarmableInterface
             $this->addResources();
         }
 
-        parent::__construct($locale, $messageSelector, $this->options['cache_dir'], $this->options['debug']);
+        parent::__construct($locale, $messageFormatter, $this->options['cache_dir'], $this->options['debug']);
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | NA
| License         | MIT

>  Passing a "Symfony\Component\Translation\MessageSelector" instance into the "Symfony\Component\Translation\Translator::__construct" as a second argument is deprecated since Symfony 3.4 and will be removed in 4.0. Inject a "Symfony\Component\Translation\Formatter\MessageFormatterInterface" implementation instead.

See https://github.com/symfony/symfony/blob/b9a2e21326ad93aab1350e566afced701942ac6d/src/Symfony/Component/Translation/Translator.php#L90