### PR TITLE
[Behat] Handle multiple notifications in NotificationChecker

### DIFF
--- a/src/Sylius/Behat/Exception/NotificationExpectationMismatchException.php
+++ b/src/Sylius/Behat/Exception/NotificationExpectationMismatchException.php
@@ -20,17 +20,13 @@ final class NotificationExpectationMismatchException extends \RuntimeException
     public function __construct(
         NotificationType $expectedType,
         $expectedMessage,
-        NotificationType $actualType,
-        $actualMessage,
         $code = 0,
         \Exception $previous = null
     ) {
         $message = sprintf(
-            "Expected *%s* notification with a \"%s\" message was not found.\n *%s* notification with a \"%s\" message has been found.",
+            "Expected *%s* notification with a \"%s\" message was not found",
             $expectedType,
-            $expectedMessage,
-            $actualType,
-            $actualMessage
+            $expectedMessage
         );
 
         parent::__construct($message, $code, $previous);

--- a/src/Sylius/Behat/Service/Accessor/NotificationAccessor.php
+++ b/src/Sylius/Behat/Service/Accessor/NotificationAccessor.php
@@ -13,10 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Service\Accessor;
 
-use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
-use Sylius\Behat\NotificationType;
 
 final class NotificationAccessor implements NotificationAccessorInterface
 {
@@ -25,9 +23,6 @@ final class NotificationAccessor implements NotificationAccessorInterface
      */
     private $session;
 
-    /**
-     * @param Session $session
-     */
     public function __construct(Session $session)
     {
         $this->session = $session;
@@ -36,40 +31,14 @@ final class NotificationAccessor implements NotificationAccessorInterface
     /**
      * {@inheritdoc}
      */
-    public function getMessage()
+    public function getMessageElements(): array
     {
-        return $this->getMessageElement()->getText();
-    }
+        $messageElements = $this->session->getPage()->findAll('css', '.sylius-flash-message');
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        if ($this->getMessageElement()->hasClass('positive')) {
-            return NotificationType::success();
-        }
-
-        if ($this->getMessageElement()->hasClass('negative')) {
-            return NotificationType::failure();
-        }
-
-        throw new \RuntimeException('Cannot resolve notification type');
-    }
-
-    /**
-     * @return NodeElement
-     *
-     * @throws ElementNotFoundException
-     */
-    private function getMessageElement()
-    {
-        $messageElement = $this->session->getPage()->find('css', '.sylius-flash-message');
-
-        if (null === $messageElement) {
+        if (empty($messageElements)) {
             throw new ElementNotFoundException($this->session->getDriver(), 'message element', 'css', '.sylius-flash-message');
         }
 
-        return $messageElement;
+        return $messageElements;
     }
 }

--- a/src/Sylius/Behat/Service/Accessor/NotificationAccessorInterface.php
+++ b/src/Sylius/Behat/Service/Accessor/NotificationAccessorInterface.php
@@ -13,17 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Service\Accessor;
 
-use Sylius\Behat\NotificationType;
+use Behat\Mink\Element\NodeElement;
 
 interface NotificationAccessorInterface
 {
     /**
-     * @return string
+     * @return array|NodeElement[]
      */
-    public function getMessage();
-
-    /**
-     * @return NotificationType
-     */
-    public function getType();
+    public function getMessageElements(): array;
 }

--- a/src/Sylius/Behat/Service/NotificationChecker.php
+++ b/src/Sylius/Behat/Service/NotificationChecker.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Service;
 use Sylius\Behat\Exception\NotificationExpectationMismatchException;
 use Sylius\Behat\NotificationType;
 use Sylius\Behat\Service\Accessor\NotificationAccessorInterface;
+use Webmozart\Assert\Assert;
 
 final class NotificationChecker implements NotificationCheckerInterface
 {
@@ -35,37 +36,17 @@ final class NotificationChecker implements NotificationCheckerInterface
     /**
      * {@inheritdoc}
      */
-    public function checkNotification($message, NotificationType $type)
+    public function checkNotification(string $message, NotificationType $type): void
     {
-        if ($this->hasType($type) && $this->hasMessage($message)) {
-            return;
+        foreach ($this->notificationAccessor->getMessageElements() as $messageElement) {
+            if (
+                false !== strpos($messageElement->getText(), $message) &&
+                $messageElement->hasClass($type->__toString() === 'success' ? 'positive' : 'negative')
+            ) {
+                return;
+            }
         }
 
-        throw new NotificationExpectationMismatchException(
-            $type,
-            $message,
-            $this->notificationAccessor->getType(),
-            $this->notificationAccessor->getMessage()
-        );
-    }
-
-    /**
-     * @param NotificationType $type
-     *
-     * @return bool
-     */
-    private function hasType(NotificationType $type)
-    {
-        return $type === $this->notificationAccessor->getType();
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return bool
-     */
-    private function hasMessage($message)
-    {
-        return false !== strpos($this->notificationAccessor->getMessage(), $message);
+        throw new NotificationExpectationMismatchException($type, $message);
     }
 }

--- a/src/Sylius/Behat/Service/NotificationCheckerInterface.php
+++ b/src/Sylius/Behat/Service/NotificationCheckerInterface.php
@@ -19,10 +19,7 @@ use Sylius\Behat\NotificationType;
 interface NotificationCheckerInterface
 {
     /**
-     * @param string $message
-     * @param NotificationType $type
-     *
      * @throws NotificationExpectationMismatchException
      */
-    public function checkNotification($message, NotificationType $type);
+    public function checkNotification(string $message, NotificationType $type): void;
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

With previous implementation, `NotificationAccessor` was always returning the first found flash message, which was a little bit uncomfortable. New implementation should work like a charm, and make this service more reusable.