### PR TITLE
[ResourceBundle] Possibility to force your own response for non html requests when event stopped

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -472,11 +472,7 @@ class ResourceController extends Controller
         $event = $this->eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource);
 
         if ($event->isStopped()) {
-            if ($event->hasResponse()) {
-                $response = $event->getResponse();
-            }
-
-            if(!$configuration->isHtmlRequest() && !isset($response)) {
+            if (!$configuration->isHtmlRequest() && !$event->hasResponse()) {
                 throw new HttpException($event->getErrorCode(), $event->getMessage());
             }
 
@@ -484,8 +480,8 @@ class ResourceController extends Controller
                 $this->flashHelper->addFlashFromEvent($configuration, $event);
             }
 
-            if(isset($response)) {
-                return $response;
+            if ($event->hasResponse()) {
+                return $event->getResponse();
             }
 
             return $this->redirectHandler->redirectToResource($configuration, $resource);

--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -471,14 +471,21 @@ class ResourceController extends Controller
 
         $event = $this->eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource);
 
-        if ($event->isStopped() && !$configuration->isHtmlRequest()) {
-            throw new HttpException($event->getErrorCode(), $event->getMessage());
-        }
         if ($event->isStopped()) {
-            $this->flashHelper->addFlashFromEvent($configuration, $event);
-
             if ($event->hasResponse()) {
-                return $event->getResponse();
+                $response = $event->getResponse();
+            }
+
+            if(!$configuration->isHtmlRequest() && !isset($response)) {
+                throw new HttpException($event->getErrorCode(), $event->getMessage());
+            }
+
+            if ($configuration->isHtmlRequest()) {
+                $this->flashHelper->addFlashFromEvent($configuration, $event);
+            }
+
+            if(isset($response)) {
+                return $response;
             }
 
             return $this->redirectHandler->redirectToResource($configuration, $resource);

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
@@ -2166,6 +2166,8 @@ final class ResourceControllerSpec extends ObjectBehavior
 
         $eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource)->willReturn($event);
         $event->isStopped()->willReturn(true);
+        $event->hasResponse()->willReturn(false);
+        $event->getResponse()->shouldNotBeCalled();
         $event->getMessage()->willReturn('Cannot approve this product.');
         $event->getErrorCode()->willReturn(500);
 

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
@@ -2220,7 +2220,6 @@ final class ResourceControllerSpec extends ObjectBehavior
 
         $eventDispatcher->dispatchPostEvent(ResourceActions::UPDATE, $configuration, $resource)->shouldNotBeCalled();
         $flashHelper->addSuccessFlash($configuration, ResourceActions::UPDATE, $resource)->shouldNotBeCalled();
-
         $flashHelper->addFlashFromEvent($configuration, $event)->shouldNotBeCalled();
 
         $event->hasResponse()->willReturn(true);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #8831
| License         | MIT

Aims to fix the possibility to force your own response for **non-html requests** by attaching it to a `ResourceActions::UPDATE` event.