### PR TITLE
[Grid] Filtering orders bug

### DIFF
--- a/features/order/managing_orders/filtering_orders_by_date.feature
+++ b/features/order/managing_orders/filtering_orders_by_date.feature
@@ -7,15 +7,15 @@ Feature: Filtering orders
     Background:
         Given the store operates on a single channel in "United States"
         And the store has customer "Mike Ross" with email "ross@teammike.com"
-        And this customer has placed an order "#00000001" at "2016-12-04 08:00:00"
-        And this customer has also placed an order "#00000002" at "2016-12-05 09:00:00"
-        And this customer has also placed an order "#00000003" at "2016-12-06 10:00:00"
+        And this customer has placed an order "#00000001" at "2016-12-04 08:00"
+        And this customer has also placed an order "#00000002" at "2016-12-05 09:00"
+        And this customer has also placed an order "#00000003" at "2016-12-06 10:00"
         And I am logged in as an administrator
 
     @ui
     Scenario: Filtering orders by date from
         When I browse orders
-        And I specify filter date from as "2016-12-05 08:30:00"
+        And I specify filter date from as "2016-12-05 08:30"
         And I filter
         Then I should see 2 orders in the list
         And I should see an order with "#00000002" number
@@ -25,7 +25,7 @@ Feature: Filtering orders
     @ui
     Scenario: Filtering orders by date to
         When I browse orders
-        And I specify filter date to as "2016-12-05 09:30:00"
+        And I specify filter date to as "2016-12-05 09:30"
         And I filter
         Then I should see 2 orders in the list
         And I should see an order with "#00000001" number
@@ -35,8 +35,8 @@ Feature: Filtering orders
     @ui
     Scenario: Filtering orders by date from to
         When I browse orders
-        And I specify filter date from as "2016-12-05 08:30:00"
-        And I specify filter date to as "2016-12-05 09:30:00"
+        And I specify filter date from as "2016-12-05 08:30"
+        And I specify filter date to as "2016-12-05 09:30"
         And I filter
         Then I should see a single order in the list
         And I should see an order with "#00000002" number
@@ -53,3 +53,17 @@ Feature: Filtering orders
         And I should see an order with "#00000002" number
         And I should see an order with "#00000003" number
         But I should not see an order with "#00000001" number
+
+    @ui
+    Scenario: Filtering orders placed at midnight or just before midnight
+        Given this customer has placed an order "#00000004" at "2016-12-10 00:00"
+        And this customer has also placed an order "#00000005" at "2016-12-11 23:59"
+        And this customer has also placed an order "#00000006" at "2016-12-12 00:00"
+        When I browse orders
+        And I specify filter date from as "2016-12-10"
+        And I specify filter date to as "2016-12-11"
+        And I filter
+        Then I should see 2 orders in the list
+        And I should see an order with "#00000004" number
+        And I should see an order with "#00000005" number
+        But I should not see an order with "#00000006" number

--- a/features/order/managing_orders/filtering_orders_by_date.feature
+++ b/features/order/managing_orders/filtering_orders_by_date.feature
@@ -7,9 +7,9 @@ Feature: Filtering orders
     Background:
         Given the store operates on a single channel in "United States"
         And the store has customer "Mike Ross" with email "ross@teammike.com"
-        And this customer has placed an order "#00000001" at "2016-12-05 08:00:00"
+        And this customer has placed an order "#00000001" at "2016-12-04 08:00:00"
         And this customer has also placed an order "#00000002" at "2016-12-05 09:00:00"
-        And this customer has also placed an order "#00000003" at "2016-12-05 10:00:00"
+        And this customer has also placed an order "#00000003" at "2016-12-06 10:00:00"
         And I am logged in as an administrator
 
     @ui
@@ -42,3 +42,14 @@ Feature: Filtering orders
         And I should see an order with "#00000002" number
         But I should not see an order with "#00000001" number
         And I should not see an order with "#00000003" number
+
+    @ui
+    Scenario: Filtering orders by date from without time
+        When I browse orders
+        And I specify filter date from as "2016-12-05"
+        And I specify filter date to as "2016-12-06"
+        And I filter
+        Then I should see 2 orders in the list
+        And I should see an order with "#00000002" number
+        And I should see an order with "#00000003" number
+        But I should not see an order with "#00000001" number

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -164,7 +164,7 @@ final class ManagingOrdersContext implements Context
      */
     public function iSpecifyFilterDateFromAs($dateTime)
     {
-        $this->indexPage->specifyFilterDateFrom(new \DateTime($dateTime));
+        $this->indexPage->specifyFilterDateFrom($dateTime);
     }
 
     /**
@@ -172,7 +172,7 @@ final class ManagingOrdersContext implements Context
      */
     public function iSpecifyFilterDateToAs($dateTime)
     {
-        $this->indexPage->specifyFilterDateTo(new \DateTime($dateTime));
+        $this->indexPage->specifyFilterDateTo($dateTime);
     }
 
     /**

--- a/src/Sylius/Behat/Page/Admin/Order/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/IndexPage.php
@@ -20,23 +20,23 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
     /**
      * {@inheritdoc}
      */
-    public function specifyFilterDateFrom(\DateTimeInterface $dateTime)
+    public function specifyFilterDateFrom(string $dateTime)
     {
-        $timestamp = $dateTime->getTimestamp();
+        $dateAndTime = explode(' ', $dateTime);
 
-        $this->getDocument()->fillField('criteria_date_from_date', date('Y-m-d', $timestamp));
-        $this->getDocument()->fillField('criteria_date_from_time', date('H:i', $timestamp));
+        $this->getDocument()->fillField('criteria_date_from_date', $dateAndTime[0]);
+        $this->getDocument()->fillField('criteria_date_from_time', $dateAndTime[1] ?? '');
     }
 
     /**
      * {@inheritdoc}
      */
-    public function specifyFilterDateTo(\DateTimeInterface $dateTime)
+    public function specifyFilterDateTo(string $dateTime)
     {
-        $timestamp = $dateTime->getTimestamp();
+        $dateAndTime = explode(' ', $dateTime);
 
-        $this->getDocument()->fillField('criteria_date_to_date', date('Y-m-d', $timestamp));
-        $this->getDocument()->fillField('criteria_date_to_time', date('H:i', $timestamp));
+        $this->getDocument()->fillField('criteria_date_to_date', $dateAndTime[0]);
+        $this->getDocument()->fillField('criteria_date_to_time', $dateAndTime[1] ?? '');
     }
 
     /**

--- a/src/Sylius/Behat/Page/Admin/Order/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Order/IndexPageInterface.php
@@ -18,14 +18,14 @@ use Sylius\Behat\Page\Admin\Crud\IndexPageInterface as BaseIndexPageInterface;
 interface IndexPageInterface extends BaseIndexPageInterface
 {
     /**
-     * @param \DateTimeInterface $dateTime
+     * @param string $dateTime
      */
-    public function specifyFilterDateFrom(\DateTimeInterface $dateTime);
+    public function specifyFilterDateFrom(string $dateTime);
 
     /**
-     * @param \DateTimeInterface $dateTime
+     * @param string $dateTime
      */
-    public function specifyFilterDateTo(\DateTimeInterface $dateTime);
+    public function specifyFilterDateTo(string $dateTime);
 
     /**
      * @param string $channelName

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/order.yml
@@ -85,6 +85,7 @@ sylius_grid:
                     label: sylius.ui.date
                     options:
                         field: checkoutCompletedAt
+                        inclusive_to: true
                 channel:
                     type: entity
                     label: sylius.ui.channel

--- a/src/Sylius/Bundle/GridBundle/Form/DataTransformer/DateTimeFilterTransformer.php
+++ b/src/Sylius/Bundle/GridBundle/Form/DataTransformer/DateTimeFilterTransformer.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\GridBundle\Form\DataTransformer;
+
+use Symfony\Component\Form\DataTransformerInterface;
+use Webmozart\Assert\Assert;
+
+final class DateTimeFilterTransformer implements DataTransformerInterface
+{
+    private static $defaultTime = [
+        'from' => ['hour' => '00', 'minute' => '00'],
+        'to' => ['hour' => '23', 'minute' => '59'],
+    ];
+
+    /** @var string */
+    private $type;
+
+    public function __construct(string $type)
+    {
+        Assert::oneOf($type, array_keys(static::$defaultTime));
+
+        $this->type = $type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($value): array
+    {
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reverseTransform($value): array
+    {
+        if (!$value['date']['year']) {
+            return $value;
+        }
+
+        $value['time']['hour'] = $value['time']['hour'] === '' ? static::$defaultTime[$this->type]['hour'] : $value['time']['hour'];
+        $value['time']['minute'] = $value['time']['minute'] === '' ? static::$defaultTime[$this->type]['minute'] : $value['time']['minute'];
+
+        return $value;
+    }
+}

--- a/src/Sylius/Bundle/GridBundle/Form/Type/Filter/DateFilterType.php
+++ b/src/Sylius/Bundle/GridBundle/Form/Type/Filter/DateFilterType.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\GridBundle\Form\Type\Filter;
 
+use Sylius\Bundle\GridBundle\Form\DataTransformer\DateTimeFilterTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -39,6 +40,9 @@ final class DateFilterType extends AbstractType
                 'required' => false,
             ])
         ;
+
+        $builder->get('from')->addViewTransformer(new DateTimeFilterTransformer('from'));
+        $builder->get('to')->addViewTransformer(new DateTimeFilterTransformer('to'));
     }
 
     /**

--- a/src/Sylius/Component/Grid/Filter/DateFilter.php
+++ b/src/Sylius/Component/Grid/Filter/DateFilter.php
@@ -31,7 +31,7 @@ final class DateFilter implements FilterInterface
 
         $field = (string) $this->getOption($options, 'field', $name);
 
-        $from = isset($data['from']) ? $this->getDateTime($data['from']) : null;
+        $from = isset($data['from']) ? $this->getDateTime($data['from'], '00:00') : null;
         if (null !== $from) {
             $inclusive = (bool) $this->getOption($options, 'inclusive_from', self::DEFAULT_INCLUSIVE_FROM);
             if (true === $inclusive) {
@@ -41,7 +41,7 @@ final class DateFilter implements FilterInterface
             }
         }
 
-        $to = isset($data['to']) ? $this->getDateTime($data['to']) : null;
+        $to = isset($data['to']) ? $this->getDateTime($data['to'], '23:59') : null;
         if (null !== $to) {
             $inclusive = (bool) $this->getOption($options, 'inclusive_to', self::DEFAULT_INCLUSIVE_TO);
             if (true === $inclusive) {
@@ -66,17 +66,18 @@ final class DateFilter implements FilterInterface
 
     /**
      * @param string[] $data
+     * @param string $defaultTime
      *
      * @return string|null
      */
-    private function getDateTime(array $data): ?string
+    private function getDateTime(array $data, string $defaultTime): ?string
     {
         if (empty($data['date'])) {
             return null;
         }
 
         if (empty($data['time'])) {
-            return $data['date'];
+            $data['time'] = $defaultTime;
         }
 
         return $data['date'] . ' ' . $data['time'];

--- a/src/Sylius/Component/Grid/spec/Filter/DateFilterSpec.php
+++ b/src/Sylius/Component/Grid/spec/Filter/DateFilterSpec.php
@@ -77,14 +77,14 @@ final class DateFilterSpec extends ObjectBehavior
         );
     }
 
-    function it_filters_date_from_without_time(
+    function it_filters_date_from_with_default_time(
         DataSourceInterface $dataSource,
         ExpressionBuilderInterface $expressionBuilder
     ): void {
         $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
 
         $expressionBuilder
-            ->greaterThanOrEqual('checkoutCompletedAt', '2016-12-05')
+            ->greaterThanOrEqual('checkoutCompletedAt', '2016-12-05 00:00')
             ->shouldBeCalled()
         ;
 
@@ -157,14 +157,14 @@ final class DateFilterSpec extends ObjectBehavior
         );
     }
 
-    function it_filters_date_to_without_time(
+    function it_filters_date_to_with_default_time(
         DataSourceInterface $dataSource,
         ExpressionBuilderInterface $expressionBuilder
     ): void {
         $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
 
         $expressionBuilder
-            ->lessThan('checkoutCompletedAt', '2016-12-06')
+            ->lessThan('checkoutCompletedAt', '2016-12-06 23:59')
             ->shouldBeCalled()
         ;
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Fixes https://twitter.com/nickchambers/status/977964619787587585
| License         | MIT

Bug was reporter on Twitter 🐦 by Nick Chambers. I'm not 100% sure about this approach, as it requires providing default time in both form type and filter itself. Nevertheless, it works nice (as shown in scenario). I assume that proposed approach (`00:00` as default time for *from* and `23:59` as default time for *to*) should be appropriate for most cases :) 