### PR TITLE
[Resource] Make sure Sylius resources services are public

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
@@ -107,6 +107,7 @@ abstract class AbstractDriver implements DriverInterface
         $modelClass = $metadata->getClass('model');
 
         $definition = new Definition($factoryClass);
+        $definition->setPublic(true);
 
         $definitionArgs = [$modelClass];
         if (in_array(TranslatableFactoryInterface::class, class_implements($factoryClass), true)) {

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/AbstractDoctrineDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/AbstractDoctrineDriver.php
@@ -46,7 +46,7 @@ abstract class AbstractDoctrineDriver extends AbstractDriver
     {
         $container->setAlias(
             $metadata->getServiceId('manager'),
-            new Alias($this->getManagerServiceId($metadata))
+            new Alias($this->getManagerServiceId($metadata), true)
         );
     }
 

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineORMDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineORMDriver.php
@@ -51,6 +51,7 @@ final class DoctrineORMDriver extends AbstractDoctrineDriver
             new Reference($metadata->getServiceId('manager')),
             $this->getClassMetadataDefinition($metadata),
         ]);
+        $definition->setPublic(true);
 
         $container->setDefinition($metadata->getServiceId('repository'), $definition);
     }

--- a/src/Sylius/Bundle/ResourceBundle/Tests/Resource/ResourceServicesTest.php
+++ b/src/Sylius/Bundle/ResourceBundle/Tests/Resource/ResourceServicesTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Tests\Resource;
+namespace Sylius\Bundle\ResourceBundle\Tests\Resource;
 
 use Doctrine\ORM\EntityManager;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
@@ -28,16 +28,16 @@ final class ResourceServicesTest extends WebTestCase
     {
         $client = parent::createClient();
 
-        $productRepository = $client->getContainer()->get('sylius.repository.product');
+        $productRepository = $client->getContainer()->get('app.repository.book');
         $this->assertTrue($productRepository instanceof RepositoryInterface);
 
-        $productRepository = $client->getContainer()->get('sylius.manager.customer');
+        $productRepository = $client->getContainer()->get('app.manager.book');
         $this->assertTrue($productRepository instanceof EntityManager);
 
-        $productRepository = $client->getContainer()->get('sylius.controller.shipping_method');
+        $productRepository = $client->getContainer()->get('app.controller.book');
         $this->assertTrue($productRepository instanceof ResourceController);
 
-        $productRepository = $client->getContainer()->get('sylius.factory.promotion');
+        $productRepository = $client->getContainer()->get('app.factory.book');
         $this->assertTrue($productRepository instanceof FactoryInterface);
     }
 }

--- a/tests/Resource/ResourceServicesTest.php
+++ b/tests/Resource/ResourceServicesTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Resource;
+
+use Doctrine\ORM\EntityManager;
+use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class ResourceServicesTest extends WebTestCase
+{
+    /**
+     * @test
+     */
+    public function it_allows_to_access_resource_services_from_container(): void
+    {
+        $client = parent::createClient();
+
+        $productRepository = $client->getContainer()->get('sylius.repository.product');
+        $this->assertTrue($productRepository instanceof RepositoryInterface);
+
+        $productRepository = $client->getContainer()->get('sylius.manager.customer');
+        $this->assertTrue($productRepository instanceof EntityManager);
+
+        $productRepository = $client->getContainer()->get('sylius.controller.shipping_method');
+        $this->assertTrue($productRepository instanceof ResourceController);
+
+        $productRepository = $client->getContainer()->get('sylius.factory.promotion');
+        $this->assertTrue($productRepository instanceof FactoryInterface);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Since Symfony 3.4 services are made private by default. Getting them from the container explicitly is now deprecated, but not possible in Symfony 4 (which we're heading to).