### PR TITLE
[Adjustment] Inject adjustment types that shall be cleared

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/order_processing.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/order_processing.xml
@@ -14,6 +14,14 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sylius.order_processing.order_adjustments_clearer" class="Sylius\Component\Core\OrderProcessing\OrderAdjustmentsClearer">
+            <argument type="collection">
+                <argument type="constant">Sylius\Component\Core\Model\AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT</argument>
+                <argument type="constant">Sylius\Component\Core\Model\AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT</argument>
+                <argument type="constant">Sylius\Component\Core\Model\AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT</argument>
+                <argument type="constant">Sylius\Component\Core\Model\AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT</argument>
+                <argument type="constant">Sylius\Component\Core\Model\AdjustmentInterface::SHIPPING_ADJUSTMENT</argument>
+                <argument type="constant">Sylius\Component\Core\Model\AdjustmentInterface::TAX_ADJUSTMENT</argument>
+            </argument>
             <tag name="sylius.order_processor" priority="60"/>
         </service>
 

--- a/src/Sylius/Component/Core/OrderProcessing/OrderAdjustmentsClearer.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderAdjustmentsClearer.php
@@ -22,20 +22,19 @@ final class OrderAdjustmentsClearer implements OrderProcessorInterface
     /**
      * @var array
      */
-    private static $adjustmentsToRemove = [
-        AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT,
-        AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT,
-        AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT,
-        AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT,
-        AdjustmentInterface::TAX_ADJUSTMENT,
-    ];
+    private $adjustmentsToRemove;
+
+    public function __construct(array $adjustmentsToRemove = [])
+    {
+        $this->adjustmentsToRemove = $adjustmentsToRemove;
+    }
 
     /**
      * {@inheritdoc}
      */
     public function process(OrderInterface $order): void
     {
-        foreach (self::$adjustmentsToRemove as $type) {
+        foreach ($this->adjustmentsToRemove as $type) {
             $order->removeAdjustmentsRecursively($type);
         }
     }

--- a/src/Sylius/Component/Core/OrderProcessing/OrderAdjustmentsClearer.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderAdjustmentsClearer.php
@@ -26,6 +26,21 @@ final class OrderAdjustmentsClearer implements OrderProcessorInterface
 
     public function __construct(array $adjustmentsToRemove = [])
     {
+        if (0 === func_num_args()) {
+            @trigger_error(
+                'Not passing adjustments types explicitly is deprecated since 1.2 and will be prohibited in 2.0',
+                E_USER_DEPRECATED
+            );
+
+            $adjustmentsToRemove = [
+                AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT,
+                AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT,
+                AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT,
+                AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT,
+                AdjustmentInterface::TAX_ADJUSTMENT,
+            ];
+        }
+
         $this->adjustmentsToRemove = $adjustmentsToRemove;
     }
 

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderAdjustmentsClearerSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderAdjustmentsClearerSpec.php
@@ -20,6 +20,17 @@ use Sylius\Component\Order\Processor\OrderProcessorInterface;
 
 final class OrderAdjustmentsClearerSpec extends ObjectBehavior
 {
+    function let()
+    {
+        $this->beConstructedWith([
+            AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT,
+            AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT,
+            AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT,
+            AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT,
+            AdjustmentInterface::TAX_ADJUSTMENT,
+        ]);
+    }
+    
     function it_is_an_order_processor(): void
     {
         $this->shouldImplement(OrderProcessorInterface::class);

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderAdjustmentsClearerSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderAdjustmentsClearerSpec.php
@@ -20,29 +20,31 @@ use Sylius\Component\Order\Processor\OrderProcessorInterface;
 
 final class OrderAdjustmentsClearerSpec extends ObjectBehavior
 {
-    function let()
-    {
-        $this->beConstructedWith([
-            AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT,
-            AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT,
-            AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT,
-            AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT,
-            AdjustmentInterface::TAX_ADJUSTMENT,
-        ]);
-    }
-    
     function it_is_an_order_processor(): void
     {
         $this->shouldImplement(OrderProcessorInterface::class);
     }
 
-    function it_removes_adjustments_from_order_recursively(OrderInterface $order): void
+    function it_removes_adjustments_with_default_types_from_order_recursively(OrderInterface $order): void
     {
         $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT)->shouldBeCalled();
         $order->removeAdjustmentsRecursively(AdjustmentInterface::TAX_ADJUSTMENT)->shouldBeCalled();
+
+        $this->process($order);
+    }
+
+    function it_removes_adjustments_with_specified_types_from_order_recursively(OrderInterface $order): void
+    {
+        $this->beConstructedWith([
+            AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT,
+            AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT,
+        ]);
+
+        $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT)->shouldBeCalled();
+        $order->removeAdjustmentsRecursively(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT)->shouldBeCalled();
 
         $this->process($order);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Due to the fact, that cleared adjustments types has been set as static array, after adding new adjustment type (that is also processed during checkout), it was necessary to implement whole new class (with very similar/the same implementation, but different static array) and override the service definition. With this change, only definition overriding is needed.