### PR TITLE
Fix JS error when autocomplete field is empty

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-auto-complete.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-auto-complete.js
@@ -52,7 +52,7 @@
                         }
                     });
 
-                    if (0 < autocompleteValue.split(',').length) {
+                    if (0 < autocompleteValue.split(',').filter(String).length) {
                         var menuElement = element.find('div.menu');
 
                         menuElement.api({
@@ -60,7 +60,7 @@
                             method: 'GET',
                             url: loadForEditUrl,
                             beforeSend: function (settings) {
-                                settings.data[choiceValue] = autocompleteValue.split(',');
+                                settings.data[choiceValue] = autocompleteValue.split(',').filter(String);
 
                                 return settings;
                             },
@@ -75,7 +75,7 @@
                     }
 
                     window.setTimeout(function () {
-                        element.dropdown('set selected', element.find('input.autocomplete').val().split(','));
+                        element.dropdown('set selected', element.find('input.autocomplete').val().split(',').filter(String));
                     }, 5000);
                 });
             }

--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-product-auto-complete.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-product-auto-complete.js
@@ -13,7 +13,7 @@
     $.fn.extend({
         productAutoComplete: function () {
             $(this).each(function() {
-                $(this).dropdown('set selected', $(this).find('input[name*="[associations]"]').val().split(','));
+                $(this).dropdown('set selected', $(this).find('input[name*="[associations]"]').val().split(',').filter(String));
             });
 
             $(this).dropdown({
@@ -49,7 +49,7 @@
                 },
                 onAdd: function(addedValue, addedText, $addedChoice) {
                     var inputAssociation = $addedChoice.parents('.product-select').find('input[name*="[associations]"]');
-                    var associatedProductCodes = 0 < inputAssociation.val().length ? inputAssociation.val().split(',') : [];
+                    var associatedProductCodes = 0 < inputAssociation.val().length ? inputAssociation.val().split(',').filter(String) : [];
 
                     associatedProductCodes.push(addedValue);
                     $.unique(associatedProductCodes.sort());
@@ -58,7 +58,7 @@
                 },
                 onRemove: function(removedValue, removedText, $removedChoice) {
                     var inputAssociation = $removedChoice.parents('.product-select').find('input[name*="[associations]"]');
-                    var associatedProductCodes = 0 < inputAssociation.val().length ? inputAssociation.val().split(',') : [];
+                    var associatedProductCodes = 0 < inputAssociation.val().length ? inputAssociation.val().split(',').filter(String) : [];
 
                     associatedProductCodes.splice($.inArray(removedValue, associatedProductCodes), 1);
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

We should be good to go for browser compatibility because `Array.prototype.filter()` has been supported since IE 9: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter#Browser_compatibility and jQuery 3.x (which we're using) only supports IE 9+: https://jquery.com/browser-support/