### PR TITLE
Propagation of GetResponseForExceptionEvent stopped after onResourceDelete() method execution

### DIFF
--- a/src/Sylius/Bundle/AdminApiBundle/Tests/Event/GetResponseForExceptionEventPropagationTest.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Tests/Event/GetResponseForExceptionEventPropagationTest.php
@@ -51,8 +51,6 @@ final class GetResponseForExceptionEventPropagationTest extends KernelTestCase
 
         $this->container = new ContainerBuilder();
 
-        $this->container->setParameter('resource', null);
-
         $this->container->autowire('file_locator', FileLocator::class);
         $this->container->autowire('xml_file_loader', XmlFileLoader::class);
         $this->container->autowire('event_dispatcher', EventDispatcher::class);
@@ -65,7 +63,7 @@ final class GetResponseForExceptionEventPropagationTest extends KernelTestCase
         $this->container
             ->autowire('app.test_exception_listener', TestResourceDeleteSubscriber::class)
             ->addTag('kernel.event_subscriber', array('event' => 'kernel.exception'))
-            ->addTag('priority', array(244));
+            ->addTag('priority', array(0));
         ;
 
         $this->container->compile();

--- a/src/Sylius/Bundle/AdminApiBundle/Tests/Event/GetResponseForExceptionEventPropagationTest.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Tests/Event/GetResponseForExceptionEventPropagationTest.php
@@ -13,12 +13,28 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminApiBundle\Tests\Event;
 
+use Doctrine\DBAL\Driver\DriverException;
+use Doctrine\DBAL\Driver\PDOException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Sylius\Bundle\AdminBundle\EventListener\ResourceDeleteSubscriber;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Router;
 
 final class GetResponseForExceptionEventPropagationTest extends KernelTestCase
 {
@@ -34,17 +50,28 @@ final class GetResponseForExceptionEventPropagationTest extends KernelTestCase
         static::bootKernel();
 
         $this->container = new ContainerBuilder();
-        $this->container->autowire('event_dispatcher', 'Symfony\Component\EventDispatcher\EventDispatcher');
 
-        $this->container->autowire('app.test_exception_listener', 'Sylius\Bundle\AdminApiBundle\Tests\Event\ResourceDeleteSubscriber');
+        $this->container->setParameter('resource', null);
 
+        $this->container->autowire('file_locator', FileLocator::class);
+        $this->container->autowire('xml_file_loader', XmlFileLoader::class);
+        $this->container->autowire('event_dispatcher', EventDispatcher::class);
+        $this->container->autowire('app.url_generator', Router::class)->setArgument(1, null);
+        $this->container->setDefinition('session', new Definition(Session::class, [new MockArraySessionStorage()]));
         $this->container
-            ->autowire('app.exception_listener', 'Sylius\Bundle\AdminApiBundle\Tests\Event\ResourceDeleteSubscriber')
+            ->autowire('app.exception_listener', ResourceDeleteSubscriber::class)
+            ->addTag('kernel.event_subscriber', array('event' => 'kernel.exception'))
+            ->addTag('priority', array(255));
+        $this->container
+            ->autowire('app.test_exception_listener', TestResourceDeleteSubscriber::class)
             ->addTag('kernel.event_subscriber', array('event' => 'kernel.exception'))
             ->addTag('priority', array(-255));
         ;
 
+        $this->container->compile();
         $this->eventDispatcher = $this->container->get('event_dispatcher');
+        $this->eventDispatcher->addSubscriber($this->container->get('app.exception_listener'));
+        $this->eventDispatcher->addSubscriber($this->container->get('app.test_exception_listener'));
     }
 
     /**
@@ -52,14 +79,29 @@ final class GetResponseForExceptionEventPropagationTest extends KernelTestCase
      */
     public function get_response_for_exception_event_propagation_stopped_test(): void
     {
-        $this->eventDispatcher->dispatch('kernel.exception');
+        $request = new Request();
+        $request->setFormat('html', '');
+        $request->setMethod(Request::METHOD_DELETE);
+        $request->attributes = new ParameterBag(['_route' => 'sylius', '_controller' => '', '_sylius' => ['section' => 'admin']]);
+
+        $event = new GetResponseForExceptionEvent(
+            new \AppKernel("test", 0),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            new ForeignKeyConstraintViolationException(
+                "",
+                new PDOException(new \PDOException())))
+        ;
+        $request->headers->set('referer', 'localhost');
+
+        $this->eventDispatcher->dispatch('kernel.exception', $event);
 
         $testEventListener = $this->container->get('app.test_exception_listener');
         self::assertEquals(0, $testEventListener->getEventsCaught());
     }
 }
 
-final class ResourceDeleteSubscriber implements EventSubscriberInterface
+final class TestResourceDeleteSubscriber implements EventSubscriberInterface
 {
     private $eventsCaught = 0;
 

--- a/src/Sylius/Bundle/AdminApiBundle/Tests/Event/GetResponseForExceptionEventPropagationTest.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Tests/Event/GetResponseForExceptionEventPropagationTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminApiBundle\Tests\Event;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class GetResponseForExceptionEventPropagationTest extends KernelTestCase
+{
+    /** @var Container */
+    private $container;
+
+    /** @var EventDispatcher */
+    private $eventDispatcher;
+
+    public function setUp()
+    {
+        parent::setUp();
+        static::bootKernel();
+
+        $this->container = new ContainerBuilder();
+        $this->container->autowire('event_dispatcher', 'Symfony\Component\EventDispatcher\EventDispatcher');
+
+        $this->container->autowire('app.test_exception_listener', 'Sylius\Bundle\AdminApiBundle\Tests\Event\ResourceDeleteSubscriber');
+
+        $this->container
+            ->autowire('app.exception_listener', 'Sylius\Bundle\AdminApiBundle\Tests\Event\ResourceDeleteSubscriber')
+            ->addTag('kernel.event_subscriber', array('event' => 'kernel.exception'))
+            ->addTag('priority', array(-255));
+        ;
+
+        $this->eventDispatcher = $this->container->get('event_dispatcher');
+    }
+
+    /**
+     * @test
+     */
+    public function get_response_for_exception_event_propagation_stopped_test(): void
+    {
+        $this->eventDispatcher->dispatch('kernel.exception');
+
+        $testEventListener = $this->container->get('app.test_exception_listener');
+        self::assertEquals(0, $testEventListener->getEventsCaught());
+    }
+}
+
+final class ResourceDeleteSubscriber implements EventSubscriberInterface
+{
+    private $eventsCaught = 0;
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::EXCEPTION => 'onResourceDelete',
+        ];
+    }
+
+    /**
+     * @return int
+     */
+    public function getEventsCaught(): int
+    {
+        return $this->eventsCaught;
+    }
+
+    public function onResourceDelete()
+    {
+        $this->eventsCaught++;
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
+++ b/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
@@ -92,13 +92,14 @@ final class ResourceDeleteSubscriber implements EventSubscriberInterface
         ]);
 
         $referrer = $eventRequest->headers->get('referer');
-        if (null !== $referrer) {
-            $event->setResponse(new RedirectResponse($referrer));
 
-            return;
-        }
+        $url = null === $referrer ?
+            $this->createRedirectResponse($originalRoute, ResourceActions::INDEX) :
+            new RedirectResponse($referrer)
+        ;
 
-        $event->setResponse($this->createRedirectResponse($originalRoute, ResourceActions::INDEX));
+        $event->setResponse($url);
+        $event->stopPropagation();
     }
 
     /**

--- a/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
+++ b/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
@@ -93,12 +93,12 @@ final class ResourceDeleteSubscriber implements EventSubscriberInterface
 
         $referrer = $eventRequest->headers->get('referer');
 
-        $url = null === $referrer ?
+        $response = (null === $referrer) ?
             $this->createRedirectResponse($originalRoute, ResourceActions::INDEX) :
             new RedirectResponse($referrer)
         ;
 
-        $event->setResponse($url);
+        $event->setResponse($response);
         $event->stopPropagation();
     }
 

--- a/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
+++ b/src/Sylius/Bundle/AdminBundle/EventListener/ResourceDeleteSubscriber.php
@@ -99,7 +99,6 @@ final class ResourceDeleteSubscriber implements EventSubscriberInterface
         ;
 
         $event->setResponse($response);
-        $event->stopPropagation();
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/9320
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.0 or 1.1 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
