### PR TITLE
Fix invalid YAML tag syntax

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -95,7 +95,7 @@ twig:
         sylius: "@sylius.context.shopper"
         sylius_base_locale: "%locale%"
         sylius_meta:
-            version: !php/const:Sylius\Bundle\CoreBundle\Application\Kernel::VERSION
+            version: !php/const Sylius\Bundle\CoreBundle\Application\Kernel::VERSION
 
 sonata_block:
     blocks:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | maybe? (to me invalid YAML syntax could be considered a bug)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

1.1 because it requires Symfony 3.4

Symfony introduced invalid YAML syntax but they've since fixed it. This removes a deprecation message. See https://github.com/symfony/symfony/pull/22913