### PR TITLE
Remove sylius.theme.templating.name_parser decorator

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/templating.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/templating.xml
@@ -27,11 +27,6 @@
             <argument type="service" id="kernel" />
         </service>
 
-        <service id="sylius.theme.templating.name_parser" class="Sylius\Bundle\ThemeBundle\Templating\TemplateNameParser" decorates="templating.name_parser" decoration-priority="256" public="false">
-            <argument type="service" id="sylius.theme.templating.name_parser.inner" />
-            <argument type="service" id="kernel" />
-        </service>
-
         <service id="sylius.theme.templating.cache" class="Doctrine\Common\Cache\ArrayCache" />
 
         <service id="sylius.theme.templating.locator" class="Sylius\Bundle\ThemeBundle\Templating\Locator\TemplateLocator" public="false">


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no (must be done in 1.2)
| Related tickets | fixes #7491, #8929
| License         | MIT

Let's try @emodric's solution in https://github.com/Sylius/Sylius/issues/8929#issuecomment-363372536