### PR TITLE
Quote usage of !!int  to remove deprecation warning

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/customer.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/customer.yml
@@ -10,7 +10,7 @@ sylius_admin_partial_customer_latest:
             repository:
                 method: findLatest
                 arguments:
-                    - !!int $count
+                    - '!!int $count'
             template: $template
             permission: true
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/order.yml
@@ -7,7 +7,7 @@ sylius_admin_partial_order_latest:
             repository:
                 method: findLatest
                 arguments:
-                    - !!int $count
+                    - '!!int $count'
             template: $template
             permission: true
 
@@ -20,7 +20,7 @@ sylius_admin_partial_order_latest_in_channel:
             repository:
                 method: findLatestInChannel
                 arguments:
-                    count: !!int $count
+                    count: '!!int $count'
                     channel: expr:notFoundOnNull(service('sylius.repository.channel').findOneByCode($channelCode))
             template: $template
             permission: true

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/product.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/product.yml
@@ -13,7 +13,7 @@ sylius_shop_partial_product_index_latest:
                 arguments:
                     - "expr:service('sylius.context.channel').getChannel()"
                     - "expr:service('sylius.context.locale').getLocaleCode()"
-                    - !!int $count
+                    - '!!int $count'
 
 sylius_shop_partial_product_show_by_slug:
     path: /{slug}

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/product_review.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/product_review.yml
@@ -12,5 +12,5 @@ sylius_shop_partial_product_review_latest:
                 method: findLatestByProductId
                 arguments:
                     - $productId
-                    - !!int $count
+                    - '!!int $count'
         count: 3


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Removes some Symfony deprecation warnings.
