### PR TITLE
Make sure controller services are public

### DIFF
--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/services/controller.xml
@@ -13,17 +13,17 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylius.controller.show_available_payment_methods" class="Sylius\Bundle\AdminApiBundle\Controller\ShowAvailablePaymentMethodsController">
+        <service id="sylius.controller.show_available_payment_methods" class="Sylius\Bundle\AdminApiBundle\Controller\ShowAvailablePaymentMethodsController" public="true">
             <argument type="service" id="sm.factory" />
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="sylius.payment_methods_resolver" />
             <argument type="service" id="fos_rest.view_handler" />
         </service>
-        <service id="sylius.controller.update_product_taxon_position" class="Sylius\Bundle\AdminApiBundle\Controller\ProductTaxonPositionController">
+        <service id="sylius.controller.update_product_taxon_position" class="Sylius\Bundle\AdminApiBundle\Controller\ProductTaxonPositionController" public="true">
             <argument type="service" id="sylius.repository.product_taxon" />
             <argument type="service" id="doctrine.orm.entity_manager" />
         </service>
-        <service id="sylius.controller.show_available_shipping_methods" class="Sylius\Bundle\AdminApiBundle\Controller\ShowAvailableShippingMethodsController">
+        <service id="sylius.controller.show_available_shipping_methods" class="Sylius\Bundle\AdminApiBundle\Controller\ShowAvailableShippingMethodsController" public="true">
             <argument type="service" id="sm.factory" />
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="sylius.shipping_methods_resolver" />

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
@@ -17,20 +17,20 @@
     </parameters>
 
     <services>
-        <service id="sylius.controller.admin.dashboard" class="Sylius\Bundle\AdminBundle\Controller\DashboardController">
+        <service id="sylius.controller.admin.dashboard" class="Sylius\Bundle\AdminBundle\Controller\DashboardController" public="true">
             <argument type="service" id="sylius.dashboard.statistics_provider" />
             <argument type="service" id="sylius.repository.channel" />
             <argument type="service" id="templating" />
             <argument type="service" id="router" />
         </service>
 
-        <service id="sylius.controller.customer_statistics" class="Sylius\Bundle\AdminBundle\Controller\CustomerStatisticsController">
+        <service id="sylius.controller.customer_statistics" class="Sylius\Bundle\AdminBundle\Controller\CustomerStatisticsController" public="true">
             <argument type='service' id="sylius.customer_statistics_provider" />
             <argument type='service' id="sylius.repository.customer" />
             <argument type='service' id="templating" />
         </service>
 
-        <service id="sylius.controller.admin.notification" class="Sylius\Bundle\AdminBundle\Controller\NotificationController">
+        <service id="sylius.controller.admin.notification" class="Sylius\Bundle\AdminBundle\Controller\NotificationController" public="true">
             <argument type="service" id="sylius.http_client" />
             <argument type="service" id="sylius.http_message_factory" />
             <argument type="string">%sylius.admin.notification.uri%</argument>

--- a/src/Sylius/Bundle/PayumBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/config/services/controller.xml
@@ -4,7 +4,7 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylius.controller.payum" class="Sylius\Bundle\PayumBundle\Controller\PayumController">
+        <service id="sylius.controller.payum" class="Sylius\Bundle\PayumBundle\Controller\PayumController" public="true">
             <argument type="service" id="payum" />
             <argument type="service" id="sylius.repository.order" />
             <argument type="expression">service('sylius.resource_registry').get('sylius.order')</argument>

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/controller.xml
@@ -13,7 +13,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylius.controller.shop.contact" class="Sylius\Bundle\ShopBundle\Controller\ContactController">
+        <service id="sylius.controller.shop.contact" class="Sylius\Bundle\ShopBundle\Controller\ContactController" public="true">
             <argument type="service" id="router" />
             <argument type="service" id="form.factory" />
             <argument type="service" id="templating" />
@@ -22,25 +22,25 @@
             <argument type="service" id="sylius.email_manager.contact" />
         </service>
 
-        <service id="sylius.controller.shop.homepage" class="Sylius\Bundle\ShopBundle\Controller\HomepageController">
+        <service id="sylius.controller.shop.homepage" class="Sylius\Bundle\ShopBundle\Controller\HomepageController" public="true">
             <argument type="service" id="templating" />
         </service>
 
-        <service id="sylius.controller.shop.currency_switch" class="Sylius\Bundle\ShopBundle\Controller\CurrencySwitchController">
+        <service id="sylius.controller.shop.currency_switch" class="Sylius\Bundle\ShopBundle\Controller\CurrencySwitchController" public="true">
             <argument type="service" id="templating" />
             <argument type="service" id="sylius.context.currency" />
             <argument type="service" id="sylius.storage.currency" />
             <argument type="service" id="sylius.context.channel" />
         </service>
 
-        <service id="sylius.controller.shop.locale_switch" class="Sylius\Bundle\ShopBundle\Controller\LocaleSwitchController">
+        <service id="sylius.controller.shop.locale_switch" class="Sylius\Bundle\ShopBundle\Controller\LocaleSwitchController" public="true">
             <argument type="service" id="templating" />
             <argument type="service" id="sylius.context.locale" />
             <argument type="service" id="sylius.locale_provider" />
             <argument type="service" id="sylius.shop.locale_switcher" />
         </service>
 
-        <service id="sylius.controller.shop.security_widget" class="Sylius\Bundle\ShopBundle\Controller\SecurityWidgetController">
+        <service id="sylius.controller.shop.security_widget" class="Sylius\Bundle\ShopBundle\Controller\SecurityWidgetController" public="true">
             <argument type="service" id="templating" />
         </service>
     </services>

--- a/src/Sylius/Bundle/UiBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/UiBundle/Resources/config/services/controller.xml
@@ -13,7 +13,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sylius.controller.security" class="Sylius\Bundle\UiBundle\Controller\SecurityController">
+        <service id="sylius.controller.security" class="Sylius\Bundle\UiBundle\Controller\SecurityController" public="true">
             <argument type="service" id="security.authentication_utils" />
             <argument type="service" id="form.factory" />
             <argument type="service" id="templating" />


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0 (it's harmless to explicitly declare controller services as public)
| Bug fix?        | no (but it removes deprecation messages since Symfony 3.4)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

Services are private by default since Symfony 3.4 (see https://symfony.com/blog/new-in-symfony-3-4-services-are-private-by-default)