### PR TITLE
the name of file was wrong in docu

### DIFF
--- a/docs/cookbook/shop/custom-redirect-after-cart-add-action.rst
+++ b/docs/cookbook/shop/custom-redirect-after-cart-add-action.rst
@@ -1,7 +1,7 @@
 How to change a redirect after the add to cart action?
 ======================================================
 
-Currently **Sylius** by default is using route definition and **sylus-add-to-cart.js** script to handle redirect after successful add to cart action.
+Currently **Sylius** by default is using route definition and **sylius-add-to-cart.js** script to handle redirect after successful add to cart action.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
the name of sylius-add-to-cart.js file was misspelled.

| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | there is not any
| License         | MIT
