### PR TITLE
Fix exception controller config

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -51,7 +51,7 @@ swiftmailer:
     password: "%mailer_password%"
 
 fos_rest:
-    exception: ~
+    exception: true
     view:
         formats:
             json: true

--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -9,5 +9,9 @@ _profiler:
     resource: "@WebProfilerBundle/Resources/config/routing/profiler.xml"
     prefix:   /_profiler
 
+_errors:
+    resource: '@TwigBundle/Resources/config/routing/errors.xml'
+    prefix: /_error
+
 _main:
     resource: routing.yml

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -90,7 +90,6 @@ stof_doctrine_extensions:
 twig:
     debug: "%kernel.debug%"
     strict_variables: "%kernel.debug%"
-    exception_controller: "FOS\\RestBundle\\Controller\\ExceptionController::showAction"
     globals:
         sylius: "@sylius.context.shopper"
         sylius_base_locale: "%locale%"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

The exception controller was configured incorrectly. You can easily tell by going to http://localhost/app_dev.php/_error/404.html