### PR TITLE
[HOTFIX] Missing configuration for channel in sonata

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -102,6 +102,7 @@ sonata_block:
                 address: ~
                 addresses: ~
                 cart: ~
+                channel: ~
                 customer: ~
                 form: ~
                 order: ~


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Right now usage of `sylius.admin.dashboard.after_content` Sonata block bundle will result in following message:

<img width="772" alt="screen shot 2018-04-17 at 14 12 38" src="https://user-images.githubusercontent.com/6213903/38869017-8290e8b6-4249-11e8-9f9e-4b492789f4fe.png">

which is result of:
<img width="1067" alt="screen shot 2018-04-17 at 14 12 46" src="https://user-images.githubusercontent.com/6213903/38869030-8d27493c-4249-11e8-9c68-b4d3fe91ed09.png">

Maybe we should test blocks somehow but right now I do not have time to figure it our :( 