### PR TITLE
[Grid] Default parameters for "default" grid action

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/default.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/default.html.twig
@@ -1,5 +1,5 @@
 {% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
 
-{% set path = options.link.url|default(path(options.link.route, options.link.parameters)) %}
+{% set path = options.link.url|default(path(options.link.route, options.link.parameters|default({}))) %}
 
 {{ buttons.default(path, action.label, null, action.icon) }}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

With previous implementation, it was required to pass `parameters` even if action route does not require any:

```yml
actions:
    main:
        destroy_ring:
            type: default
            options:
                link:
                    route: sylius_destroy_ring
                    parameters: {}
```

Now not passing `paremeters` does not result in twig error.


```yml
actions:
    main:
        destroy_ring:
            type: default
            options:
                link:
                    route: sylius_destroy_ring
```