### PR TITLE
Add reset method to DataCollectors, needed for SF4 compat

### DIFF
--- a/src/Sylius/Bundle/ChannelBundle/Collector/ChannelCollector.php
+++ b/src/Sylius/Bundle/ChannelBundle/Collector/ChannelCollector.php
@@ -85,6 +85,14 @@ final class ChannelCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
+    public function reset(): void
+    {
+        $this->data['channel'] = null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getName(): string
     {
         return 'sylius.channel_collector';

--- a/src/Sylius/Bundle/CoreBundle/Collector/SyliusCollector.php
+++ b/src/Sylius/Bundle/CoreBundle/Collector/SyliusCollector.php
@@ -133,6 +133,16 @@ final class SyliusCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
+    public function reset(): void
+    {
+        $this->data['base_currency_code'] = null;
+        $this->data['currency_code'] = null;
+        $this->data['locale_code'] = null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getName(): string
     {
         return 'sylius_core';

--- a/src/Sylius/Bundle/ThemeBundle/Collector/ThemeCollector.php
+++ b/src/Sylius/Bundle/ThemeBundle/Collector/ThemeCollector.php
@@ -98,6 +98,16 @@ final class ThemeCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
+    public function reset(): void
+    {
+        $this->data['used_theme'] = null;
+        $this->data['used_themes'] = [];
+        $this->data['themes'] = [];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getName(): string
     {
         return 'sylius_theme';


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.0 or 1.1 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->

This one fixes a deprecation messages:

```
User Deprecated: Implementing "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface" without the "reset()" method is deprecated since Symfony 3.4 and will be unsupported in 4.0 for class "Sylius\Bundle\ChannelBundle\Collector\ChannelCollector".

User Deprecated: Implementing "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface" without the "reset()" method is deprecated since Symfony 3.4 and will be unsupported in 4.0 for class "Sylius\Bundle\ThemeBundle\Collector\ThemeCollector".

User Deprecated: Implementing "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface" without the "reset()" method is deprecated since Symfony 3.4 and will be unsupported in 4.0 for class "Sylius\Bundle\CoreBundle\Collector\SyliusCollector".
```

Not sure what branch should I submit this to. Tell me if I have to rebase on another one. Initially open to 1.1 because I get the deprecation message there (Symfony 3.4).