### PR TITLE
Missing 'required' class added

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Form/_address.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Form/_address.html.twig
@@ -7,7 +7,7 @@
 
 {% include '@SyliusShop/Common/Form/_countryCode.html.twig' with {'form': form.countryCode} %}
 
-<div class="province-container field" data-url="{{ path('sylius_shop_ajax_render_province_form') }}">
+<div class="province-container required field" data-url="{{ path('sylius_shop_ajax_render_province_form') }}">
     {% if form.provinceCode is defined %}
         {{ form_row(form.provinceCode, {'attr': {'class': 'ui dropdown'}}) }}
     {% elseif form.provinceName is defined %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Province field was not displayed as mandatory during the checkout, even thought it's required.
