### PR TITLE
Use %kernel.project_dir% instead of %kernel.root_dir%

### DIFF
--- a/UPGRADE-1.2.md
+++ b/UPGRADE-1.2.md
@@ -3,6 +3,9 @@
 * __BC BREAK:__ `Sylius\Bundle\UserBundle\Controller\UserController`'s method `addFlash` has been renamed to
   `addTranslatedFlash` with added scalar typehints for compatibility with both Symfony 3.4 and Symfony 4.0.
 
+* `Sylius\Bundle\CoreBundle\Installer\Requirement\FilesystemRequirements::__construct` deprecates passing
+  `string $rootDir` as a second argument, remove it from your calls to be compatible with 2.0 release.
+
 * The deprecated form mapping feature in SonataCoreBundle has been disabled in the app configuration included from SyliusCoreBundle.
   If you depend on the feature in your application, you will need to make the necessary changes. Refer to
   https://github.com/sonata-project/SonataCoreBundle/pull/462 for more information. 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -17,7 +17,7 @@ framework:
     translator: { fallbacks: ["%locale%", "en"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
         strict_requirements: "%kernel.debug%"
     form: true
     csrf_protection: true
@@ -39,7 +39,7 @@ doctrine:
         charset: UTF8
 
 doctrine_migrations:
-    dir_name: "%kernel.root_dir%/migrations"
+    dir_name: "%kernel.project_dir%/app/migrations"
     namespace: Sylius\Migrations
     table_name: sylius_migrations
     name: Sylius Migrations

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -5,7 +5,7 @@ imports:
     - { resource: "config.yml" }
 
 framework:
-    router: { resource: "%kernel.root_dir%/config/routing_dev.yml" }
+    router: { resource: "%kernel.project_dir%/app/config/routing_dev.yml" }
     profiler: { only_exceptions: false }
 
 doctrine:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -6,7 +6,7 @@ parameters:
     database_user: "%env(SYLIUS_DATABASE_USER)%"
     database_password: "%env(SYLIUS_DATABASE_PASSWORD)%"
     # You should uncomment this if you want use pdo_sqlite.
-    # database_path: "%kernel.root_dir%/data.db3"
+    # database_path: "%kernel.project_dir%/data.db3"
 
     mailer_transport: "%env(SYLIUS_MAILER_TRANSPORT)%"
     mailer_host: "%env(SYLIUS_MAILER_HOST)%"

--- a/docs/components_and_bundles/bundles/SyliusThemeBundle/configuration_sources/filesystem.rst
+++ b/docs/components_and_bundles/bundles/SyliusThemeBundle/configuration_sources/filesystem.rst
@@ -3,7 +3,7 @@ Filesystem configuration source
 
 **Filesystem** configuration source loads theme definitions from files placed under specified directories.
 
-By default it seeks for ``composer.json`` files that exists under ``%kernel.root_dir%/themes`` directory, which
+By default it seeks for ``composer.json`` files that exists under ``%kernel.project_dir%/app/themes`` directory, which
 usually is resolved to ``app/themes``.
 
 Configuration reference
@@ -18,7 +18,7 @@ Configuration reference
                 filename: composer.json
                 scan_depth: null
                 directories:
-                    - "%kernel.root_dir%/themes"
+                    - "%kernel.project_dir%/app/themes"
 
 .. note::
     Like every other source, ``filesystem`` is disabled if not specified otherwise. To enable it and use

--- a/docs/cookbook/configuration/extending-bundles-other-em.rst
+++ b/docs/cookbook/configuration/extending-bundles-other-em.rst
@@ -15,15 +15,15 @@ Installing the SyliusBundles
 - Install SyliusAddressingBundle
 
 .. tip::
-    
+
     Read more about how to install SyliusCustomerBundle :doc:`here </components_and_bundles/bundles/SyliusCustomerBundle/installation>`.
 
 .. tip::
-    
+
     Read more about how to install SyliusUserBundle :doc:`here </components_and_bundles/bundles/SyliusUserBundle/installation>`.
 
 .. tip::
-    
+
     Read more about how to install SyliusAddressingBundle :doc:`here </components_and_bundles/bundles/SyliusAddressingBundle/installation>`.
 
 Extending the SyliusBundles
@@ -36,7 +36,7 @@ Extending the SyliusBundles
 - Generate AddressingBundle
 
 .. tip::
-    
+
     Read more about how to generate your own Symfony's bundle `here <https://symfony.com/doc/current/bundles/SensioGeneratorBundle/commands/generate_bundle.html>`_.
 
 2. Extending the Sylius's bundles:
@@ -135,7 +135,7 @@ Extending the SyliusBundles
     }
 
 .. code-block:: yaml
-    
+
     # src/CustomerBundle/Resources/config/config.yml
 
     sylius_customer:
@@ -202,7 +202,7 @@ Extending the SyliusBundles
     }
 
 .. code-block:: yaml
-    
+
     # src/UserBundle/Resources/config/config.yml
 
     sylius_user:
@@ -299,7 +299,7 @@ Extending the SyliusBundles
     }
 
 .. code-block:: yaml
-    
+
     # src/AddressingBundle/Resources/config/config.yml
 
     sylius_addressing:
@@ -354,7 +354,7 @@ Extending the SyliusBundles
 4. Import our new config files to the global config
 
 .. code-block:: yaml
-    
+
     # app/config/config.yml
 
     imports:
@@ -365,7 +365,7 @@ Extending the SyliusBundles
 5. Add the proper ORM mapping in the global config
 
 .. code-block:: yaml
-    
+
     # app/config/config.yml
 
     # Doctrine Configuration
@@ -388,19 +388,19 @@ Extending the SyliusBundles
                     mappings:
                         SyliusCustomerBundle:
                             type: xml
-                            dir: "%kernel.root_dir%/../vendor/sylius/customer-bundle/Resources/config/doctrine/model"
+                            dir: "%kernel.project_dir%/vendor/sylius/customer-bundle/Resources/config/doctrine/model"
                             prefix: Sylius\Component\Customer\Model
                             is_bundle: false
                         CustomerBundle: ~
                         SyliusUserBundle:
                             type: xml
-                            dir: "%kernel.root_dir%/../vendor/sylius/user-bundle/Resources/config/doctrine/model"
+                            dir: "%kernel.project_dir%/vendor/sylius/user-bundle/Resources/config/doctrine/model"
                             prefix: Sylius\Component\User\Model
                             is_bundle: false
                         UserBundle: ~
                         SyliusAddressingBundle:
                             type: xml
-                            dir: "%kernel.root_dir%/../vendor/sylius/addressing-bundle/Resources/config/doctrine/model"
+                            dir: "%kernel.project_dir%/vendor/sylius/addressing-bundle/Resources/config/doctrine/model"
                             prefix: Sylius\Component\Addressing\Model
                             is_bundle: false
                         AddressingBundle: ~
@@ -546,13 +546,13 @@ As the Sylius's models which hold the declaration and the mapping of the relatio
 
         /**
         * Get customer
-        * @return  
+        * @return
         */
         public function getCustomer()
         {
             return $this->customer;
         }
-        
+
         /**
         * Set customer
         * @return $this
@@ -629,7 +629,7 @@ As the Sylius's models which hold the declaration and the mapping of the relatio
                 cascade: ["all"]
 
 .. code-block:: yaml
-    
+
     # src/UserBundle/Resources/config/doctrine/ShopUser.orm.yml
 
     UserBundle\Entity\ShopUser:
@@ -646,7 +646,7 @@ As the Sylius's models which hold the declaration and the mapping of the relatio
                 cascade: ["persist"]
 
 .. code-block:: yaml
-    
+
     # src/AddressingBundle/Resources/config/doctrine/Address.orm.yml
 
     AddressingBundle\Entity\Address:
@@ -690,8 +690,8 @@ It should returns:
 
 .. code-block:: bash
 
-    [Doctrine\Common\Persistence\Mapping\MappingException]                                                     
-    The class 'UserBundle\Entity\ShopUser' was not found in the chain configured namespaces AppBundle\Entity, Sylius\Component\Customer\Model, Sylius\Component\User\Model, Sylius\Component\Ad  
+    [Doctrine\Common\Persistence\Mapping\MappingException]
+    The class 'UserBundle\Entity\ShopUser' was not found in the chain configured namespaces AppBundle\Entity, Sylius\Component\Customer\Model, Sylius\Component\User\Model, Sylius\Component\Ad
     dressing\Model
 
 This seems to be a "known issue" related to the shema-tool CLI command, as obviously this command uses all the metadata collected across all mapping drivers.

--- a/src/Sylius/Bundle/AddressingBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/AddressingBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/AddressingBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/AddressingBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/AddressingBundle/test/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/AttributeBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/AttributeBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/AttributeBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/AttributeBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/AttributeBundle/test/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/ChannelBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/ChannelBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/ChannelBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/ChannelBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/ChannelBundle/test/composer.json
+++ b/src/Sylius/Bundle/ChannelBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallAssetsCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallAssetsCommand.php
@@ -44,9 +44,9 @@ EOT
         ));
 
         try {
-            $rootDir = $this->getContainer()->getParameter('kernel.root_dir') . '/../';
-            $this->ensureDirectoryExistsAndIsWritable($rootDir . self::WEB_ASSETS_DIRECTORY, $output);
-            $this->ensureDirectoryExistsAndIsWritable($rootDir . self::WEB_BUNDLES_DIRECTORY, $output);
+            $projectDir = $this->getContainer()->getParameter('kernel.project_dir');
+            $this->ensureDirectoryExistsAndIsWritable($projectDir . self::WEB_ASSETS_DIRECTORY, $output);
+            $this->ensureDirectoryExistsAndIsWritable($projectDir . self::WEB_BUNDLES_DIRECTORY, $output);
         } catch (\RuntimeException $exception) {
             $output->writeln($exception->getMessage());
 
@@ -54,7 +54,7 @@ EOT
         }
 
         $commands = [
-            'assets:install',
+            'assets:install' => ['web'],
         ];
 
         $this->runCommands($commands, $output);

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
@@ -60,9 +60,9 @@ EOT
         }
 
         try {
-            $rootDir = $this->getContainer()->getParameter('kernel.root_dir') . '/../';
-            $this->ensureDirectoryExistsAndIsWritable($rootDir . self::WEB_MEDIA_DIRECTORY, $output);
-            $this->ensureDirectoryExistsAndIsWritable($rootDir . self::WEB_MEDIA_IMAGE_DIRECTORY, $output);
+            $projectDir = $this->getContainer()->getParameter('kernel.project_dir');
+            $this->ensureDirectoryExistsAndIsWritable($projectDir . self::WEB_MEDIA_DIRECTORY, $output);
+            $this->ensureDirectoryExistsAndIsWritable($projectDir . self::WEB_MEDIA_IMAGE_DIRECTORY, $output);
         } catch (\RuntimeException $exception) {
             $outputStyle->writeln($exception->getMessage());
 

--- a/src/Sylius/Bundle/CoreBundle/Installer/Requirement/FilesystemRequirements.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Requirement/FilesystemRequirements.php
@@ -19,19 +19,21 @@ final class FilesystemRequirements extends RequirementCollection
 {
     /**
      * @param TranslatorInterface $translator
-     * @param string $root
      * @param string $cacheDir
-     * @param string $logDir
+     * @param string $logsDir
+     * @param string $rootDir Deprecated.
      */
-    public function __construct(TranslatorInterface $translator, string $root, string $cacheDir, string $logDir)
+    public function __construct(TranslatorInterface $translator, string $cacheDir, string $logsDir, string $rootDir = null)
     {
         parent::__construct($translator->trans('sylius.installer.filesystem.header', []));
 
+        if (func_num_args() >= 4) {
+            @trigger_error('Passing root directory to "%s" constructor as a second argument is deprecated since 1.2 and this argument will be removed in 2.0.', E_USER_DEPRECATED);
+
+            [$rootDir, $cacheDir, $logsDir] = [$cacheDir, $logsDir, $rootDir];
+        }
+
         $this
-            ->add(new Requirement(
-                $translator->trans('sylius.installer.filesystem.vendors', []),
-                is_dir($root . '/../vendor')
-            ))
             ->add(new Requirement(
                 $translator->trans('sylius.installer.filesystem.cache.header', []),
                 is_writable($cacheDir),
@@ -40,9 +42,9 @@ final class FilesystemRequirements extends RequirementCollection
             ))
             ->add(new Requirement(
                 $translator->trans('sylius.installer.filesystem.logs.header', []),
-                is_writable($logDir),
+                is_writable($logsDir),
                 true,
-                $translator->trans('sylius.installer.filesystem.logs.help', ['%path%' => $logDir])
+                $translator->trans('sylius.installer.filesystem.logs.help', ['%path%' => $logsDir])
             ))
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Installer/Requirement/FilesystemRequirements.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Requirement/FilesystemRequirements.php
@@ -28,7 +28,11 @@ final class FilesystemRequirements extends RequirementCollection
         parent::__construct($translator->trans('sylius.installer.filesystem.header', []));
 
         if (func_num_args() >= 4) {
-            @trigger_error('Passing root directory to "%s" constructor as a second argument is deprecated since 1.2 and this argument will be removed in 2.0.', E_USER_DEPRECATED);
+            @trigger_error(sprintf(
+                'Passing root directory to "%s" constructor as the second argument is deprecated since 1.2 ' .
+                'and this argument will be removed in 2.0.',
+                self::class
+            ), E_USER_DEPRECATED);
 
             [$rootDir, $cacheDir, $logsDir] = [$cacheDir, $logsDir, $rootDir];
         }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -38,7 +38,7 @@ knp_gaufrette:
     adapters:
         sylius_image:
             local:
-                directory: "%kernel.root_dir%/../web/media/image"
+                directory: "%kernel.project_dir%/web/media/image"
                 create: true
     filesystems:
         sylius_image:
@@ -48,7 +48,7 @@ liip_imagine:
     loaders:
         default:
             filesystem:
-                data_root: "%kernel.root_dir%/../web/media/image"
+                data_root: "%kernel.project_dir%/web/media/image"
     filter_sets:
         sylius_small:
             filters:

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer_requirements.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer_requirements.xml
@@ -30,7 +30,6 @@
                 <argument type="service">
                     <service class="Sylius\Bundle\CoreBundle\Installer\Requirement\FilesystemRequirements">
                         <argument type="service" id="translator" />
-                        <argument>%kernel.root_dir%</argument>
                         <argument>%kernel.cache_dir%</argument>
                         <argument>%kernel.logs_dir%</argument>
                     </service>

--- a/src/Sylius/Bundle/CurrencyBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/CurrencyBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/CurrencyBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/CurrencyBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/CurrencyBundle/test/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/CustomerBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/CustomerBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/CustomerBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/CustomerBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/CustomerBundle/test/composer.json
+++ b/src/Sylius/Bundle/CustomerBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/FixturesBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/FixturesBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     csrf_protection: true
     templating:
         engines: ['twig']

--- a/src/Sylius/Bundle/FixturesBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/FixturesBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/FixturesBundle/test/composer.json
+++ b/src/Sylius/Bundle/FixturesBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/GridBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/GridBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/GridBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/GridBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/GridBundle/test/composer.json
+++ b/src/Sylius/Bundle/GridBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/InventoryBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/InventoryBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/InventoryBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/InventoryBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/InventoryBundle/test/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/LocaleBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/LocaleBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/LocaleBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/LocaleBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/LocaleBundle/test/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/MailerBundle/test/composer.json
+++ b/src/Sylius/Bundle/MailerBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/MoneyBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/MoneyBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/MoneyBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/MoneyBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/MoneyBundle/test/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/OrderBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/OrderBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/OrderBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/OrderBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/OrderBundle/test/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/PaymentBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/PaymentBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/PaymentBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/PaymentBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/PaymentBundle/test/composer.json
+++ b/src/Sylius/Bundle/PaymentBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/ProductBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/ProductBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/ProductBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/ProductBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/ProductBundle/test/composer.json
+++ b/src/Sylius/Bundle/ProductBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/PromotionBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/PromotionBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/PromotionBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/PromotionBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/PromotionBundle/test/composer.json
+++ b/src/Sylius/Bundle/PromotionBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/ResourceBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/ResourceBundle/test/app/config/config.yml
@@ -7,7 +7,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/ResourceBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/ResourceBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/ResourceBundle/test/composer.json
+++ b/src/Sylius/Bundle/ResourceBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/ReviewBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/ReviewBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/ReviewBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/ReviewBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/ReviewBundle/test/composer.json
+++ b/src/Sylius/Bundle/ReviewBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/ShippingBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/ShippingBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/ShippingBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/ShippingBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/ShippingBundle/test/composer.json
+++ b/src/Sylius/Bundle/ShippingBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/TaxationBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/TaxationBundle/test/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/TaxationBundle/test/app/config/parameters.yml
+++ b/src/Sylius/Bundle/TaxationBundle/test/app/config/parameters.yml
@@ -1,6 +1,6 @@
 parameters:
     database_driver: pdo_sqlite
-    database_path: "%kernel.root_dir%/db.sql"
+    database_path: "%kernel.project_dir%/app/db.sql"
 
     locale: en_US
     secret: "Three can keep a secret, if two of them are dead."

--- a/src/Sylius/Bundle/TaxationBundle/test/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/test/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/TaxonomyBundle/Tests/Functional/app/config/config.yml
+++ b/src/Sylius/Bundle/TaxonomyBundle/Tests/Functional/app/config/config.yml
@@ -10,7 +10,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/TaxonomyBundle/Tests/Functional/composer.json
+++ b/src/Sylius/Bundle/TaxonomyBundle/Tests/Functional/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/ThemeBundle/Configuration/Filesystem/FilesystemConfigurationSourceFactory.php
+++ b/src/Sylius/Bundle/ThemeBundle/Configuration/Filesystem/FilesystemConfigurationSourceFactory.php
@@ -33,7 +33,7 @@ final class FilesystemConfigurationSourceFactory implements ConfigurationSourceF
                     ->scalarNode('filename')->defaultValue('composer.json')->cannotBeEmpty()->end()
                     ->integerNode('scan_depth')->info('Restrict depth to scan for configuration file inside theme folder')->defaultNull()->end()
                     ->arrayNode('directories')
-                        ->defaultValue(['%kernel.root_dir%/themes'])
+                        ->defaultValue(['%kernel.project_dir%/app/themes'])
                         ->requiresAtLeastOneElement()
                         ->performNoDeepMerging()
                         ->prototype('scalar')

--- a/src/Sylius/Bundle/ThemeBundle/Tests/DependencyInjection/FilesystemSource/ConfigurationTest.php
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/DependencyInjection/FilesystemSource/ConfigurationTest.php
@@ -33,7 +33,7 @@ final class ConfigurationTest extends TestCase
                 ['sources' => ['filesystem' => null]],
             ],
             ['sources' => ['filesystem' => [
-                'directories' => ['%kernel.root_dir%/themes'],
+                'directories' => ['%kernel.project_dir%/app/themes'],
                 'filename' => 'composer.json',
                 'enabled' => true,
                 'scan_depth' => null,
@@ -52,7 +52,7 @@ final class ConfigurationTest extends TestCase
                 ['sources' => ['filesystem' => ['scan_depth' => 1]]],
             ],
             ['sources' => ['filesystem' => [
-                'directories' => ['%kernel.root_dir%/themes'],
+                'directories' => ['%kernel.project_dir%/app/themes'],
                 'filename' => 'composer.json',
                 'enabled' => true,
                 'scan_depth' => 1,

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/config/config.yml
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/config/config.yml
@@ -6,7 +6,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:
@@ -27,4 +27,4 @@ sylius_theme:
         filesystem:
             scan_depth: 1
             directories:
-                - "%kernel.root_dir%/../../Fixtures/themes"
+                - "%kernel.project_dir%/../Fixtures/themes"

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/composer.json
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}

--- a/src/Sylius/Bundle/UserBundle/Tests/Functional/app/config/config.yml
+++ b/src/Sylius/Bundle/UserBundle/Tests/Functional/app/config/config.yml
@@ -10,7 +10,7 @@ framework:
     translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
-        resource: "%kernel.root_dir%/config/routing.yml"
+        resource: "%kernel.project_dir%/app/config/routing.yml"
     form: ~
     csrf_protection: true
     templating:

--- a/src/Sylius/Bundle/UserBundle/Tests/Functional/composer.json
+++ b/src/Sylius/Bundle/UserBundle/Tests/Functional/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "example/test-application"
+}


### PR DESCRIPTION
`%kernel.root_dir%` is deprecated in Symfony 3.4 and removed from Symfony 4.0+.