### PR TITLE
[AdminBundle] Specify default _format in individual AJAX routes

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing.yml
@@ -5,8 +5,6 @@ sylius_admin_partial:
 sylius_admin_ajax:
     resource: "@SyliusAdminBundle/Resources/config/routing/ajax.yml"
     prefix: /ajax
-    defaults:
-        _format: json
 
 sylius_admin_dashboard:
     path: /

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax.yml
@@ -25,3 +25,4 @@ sylius_admin_ajax_get_version:
     path: /get-version
     defaults:
         _controller: sylius.controller.admin.notification:getVersionAction
+        _format: json

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product.yml
@@ -3,12 +3,14 @@ sylius_admin_ajax_generate_product_slug:
     methods: [GET]
     defaults:
         _controller: sylius.controller.product_slug:generateAction
+        _format: json
 
 sylius_admin_ajax_product_by_name_phrase:
     path: /search
     methods: [GET]
     defaults:
         _controller: sylius.controller.product:indexAction
+        _format: json
         _sylius:
             serialization_groups: [Autocomplete]
             permission: true
@@ -23,6 +25,7 @@ sylius_admin_ajax_product_by_code:
     methods: [GET]
     defaults:
         _controller: sylius.controller.product:indexAction
+        _format: json
         _sylius:
             serialization_groups: [Autocomplete]
             permission: true
@@ -35,6 +38,7 @@ sylius_admin_ajax_product_index:
     methods: [GET]
     defaults:
         _controller: sylius.controller.product:indexAction
+        _format: json
         _sylius:
             permission: true
             grid: sylius_admin_product

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product_taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product_taxon.yml
@@ -3,5 +3,6 @@ sylius_admin_ajax_product_taxons_update_position:
     methods: [PUT]
     defaults:
         _controller: sylius.controller.product_taxon:updatePositionsAction
+        _format: json
         _sylius:
             permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product_variant.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product_variant.yml
@@ -3,6 +3,7 @@ sylius_admin_ajax_product_variants_update_position:
     methods: [PUT]
     defaults:
         _controller: sylius.controller.product_variant:updatePositionsAction
+        _format: json
         _sylius:
             permission: true
 
@@ -11,6 +12,7 @@ sylius_admin_ajax_product_variants_by_phrase:
     methods: [GET]
     defaults:
         _controller: sylius.controller.product_variant:indexAction
+        _format: json
         _sylius:
             serialization_groups: [Autocomplete]
             permission: true
@@ -26,6 +28,7 @@ sylius_admin_ajax_product_variants_by_codes:
     methods: [GET]
     defaults:
         _controller: sylius.controller.product_variant:indexAction
+        _format: json
         _sylius:
             serialization_groups: [Autocomplete]
             permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/taxon.yml
@@ -3,6 +3,7 @@ sylius_admin_ajax_taxon_root_nodes:
     methods: [GET]
     defaults:
         _controller: sylius.controller.taxon:indexAction
+        _format: json
         _sylius:
             serialization_groups: [Autocomplete]
             permission: true
@@ -14,6 +15,7 @@ sylius_admin_ajax_taxon_leafs:
     methods: [GET]
     defaults:
         _controller: sylius.controller.taxon:indexAction
+        _format: json
         _sylius:
             serialization_groups: [Autocomplete]
             permission: true
@@ -27,6 +29,7 @@ sylius_admin_ajax_taxon_by_code:
     methods: [GET]
     defaults:
         _controller: sylius.controller.taxon:indexAction
+        _format: json
         _sylius:
             serialization_groups: [Autocomplete]
             permission: true
@@ -39,6 +42,7 @@ sylius_admin_ajax_taxon_by_name_phrase:
     methods: [GET]
     defaults:
         _controller: sylius.controller.taxon:indexAction
+        _format: json
         _sylius:
             serialization_groups: [Autocomplete]
             permission: true
@@ -52,12 +56,14 @@ sylius_admin_ajax_generate_taxon_slug:
     methods: [GET]
     defaults:
         _controller: sylius.controller.taxon_slug:generateAction
+        _format: json
 
 sylius_admin_ajax_taxon_move:
     path: /{id}/move
     methods: [PUT]
     defaults:
         _controller: sylius.controller.taxon:updateAction
+        _format: json
         _sylius:
             permission: true
             form: Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonPositionType


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | kind of? (configuration)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

Specify default `_format` in individual AJAX routes. If it is set at a higher level, it can never be overridden per route. See https://github.com/symfony/symfony/issues/10779

This fixes `sylius_admin_ajax_render_province_form`.