### PR TITLE
Fix removal of cart payments in OrderPaymentProcessor

### DIFF
--- a/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPaymentProcessor.php
@@ -59,7 +59,11 @@ final class OrderPaymentProcessor implements OrderProcessorInterface
         }
 
         if (0 === $order->getTotal()) {
-            foreach ($order->getPayments(OrderPaymentStates::STATE_CART) as $payment) {
+            $removablePayments = $order->getPayments()->filter(function (PaymentInterface $payment): bool {
+                return $payment->getState() === OrderPaymentStates::STATE_CART;
+            });
+
+            foreach ($removablePayments as $payment) {
                 $order->removePayment($payment);
             }
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

The `Order::getPayments` method does not accept a `$state` property to filter payments so it would always remove all payments that are attached to it