### PR TITLE
Fixed missing orderby in product variants

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Product.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/Product.orm.xml
@@ -30,6 +30,9 @@
             <cascade>
                 <cascade-all />
             </cascade>
+            <order-by>
+                <order-by-field name="position" direction="ASC" />
+            </order-by>
         </one-to-many>
 
         <many-to-many field="options" target-entity="Sylius\Component\Product\Model\ProductOptionInterface">


### PR DESCRIPTION
Can set the product variants position in admin but no effect in public product page.

| Q               | A
| --------------- | -----
| Branch?         | 1.0, 1.1 or master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.0 or 1.1 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
