### PR TITLE
Moved IE css polyfills

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
@@ -13,6 +13,11 @@
     {% endblock %}
 
     {% block stylesheets %}
+        <!--[if lt IE 9]>
+        <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+        <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+        <![endif]-->
+
         {% include '@SyliusUi/_stylesheets.html.twig' with {'path': 'assets/shop/css/style.css'} %}
 
         {{ sonata_block_render_event('sylius.shop.layout.stylesheets') }}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Layout/centered.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Layout/centered.html.twig
@@ -13,6 +13,10 @@
     {% endblock %}
 
     {% block stylesheets %}
+        <!--[if lt IE 9]>
+        <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+        <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+        <![endif]-->
     {% endblock %}
 </head>
 <body class="centered">

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Layout/sidebar.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Layout/sidebar.html.twig
@@ -13,6 +13,10 @@
     {% endblock %}
 
     {% block stylesheets %}
+        <!--[if lt IE 9]>
+        <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+        <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+        <![endif]-->
     {% endblock %}
 </head>
 

--- a/src/Sylius/Bundle/UiBundle/Resources/views/_stylesheets.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/_stylesheets.html.twig
@@ -1,6 +1,1 @@
 <link rel="stylesheet" href="{{ asset(path) }}">
-
-<!--[if lt IE 9]>
-<script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
-<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-<![endif]-->


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT

If there are more styles included through `@SyliusUi/_stylesheets.html.twig` (for example bootstrap from cdn) it causes duplicate includes of IE 9 polyfills.