### PR TITLE
Field used for label does not exist

### DIFF
--- a/src/Sylius/Bundle/CustomerBundle/Form/Type/CustomerChoiceType.php
+++ b/src/Sylius/Bundle/CustomerBundle/Form/Type/CustomerChoiceType.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CustomerBundle\Form\Type;
 
+use Sylius\Component\Customer\Model\CustomerInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Bridge\Doctrine\Form\DataTransformer\CollectionToArrayTransformer;
 use Symfony\Component\Form\AbstractType;
@@ -56,7 +57,7 @@ final class CustomerChoiceType extends AbstractType
                 return $this->customerRepository->findAll();
             },
             'choice_value' => 'email',
-            'choice_label' => function (Customer $customer) {
+            'choice_label' => function (CustomerInterface $customer): string {
                 return sprintf('%s (%s)', $customer->getFullName(), $customer->getEmail());
             },
             'choice_translation_domain' => false,

--- a/src/Sylius/Bundle/CustomerBundle/Form/Type/CustomerChoiceType.php
+++ b/src/Sylius/Bundle/CustomerBundle/Form/Type/CustomerChoiceType.php
@@ -56,7 +56,9 @@ final class CustomerChoiceType extends AbstractType
                 return $this->customerRepository->findAll();
             },
             'choice_value' => 'email',
-            'choice_label' => 'name',
+            'choice_label' => function (Customer $customer) {
+                return sprintf('%s (%s)', $customer->getFullName(), $customer->getEmail());
+            },
             'choice_translation_domain' => false,
         ]);
     }


### PR DESCRIPTION
Change 'choice_label' to use a closure that renders customers full name and e-mail.
Nor field `name`, nor method `getName` exist in Customer entity
Should go to 1.0, 1.1 and master

| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | None
| License         | MIT