### PR TITLE
[Addressing]  Fix default validation groups of AddressType

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/AddressType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/AddressType.php
@@ -87,7 +87,7 @@ final class AddressType extends AbstractResourceType
             ->setDefaults([
                 'validation_groups' => function (Options $options) {
                     if ($options['shippable']) {
-                        $this->validationGroups[] = 'shippable';
+                        return array_merge($this->validationGroups, ['shippable']);
                     }
 
                     return $this->validationGroups;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT

Once the `$options['shippable']` is true, 'shippable' validation group is added persistently to the form type default validation groups and used subsequently despite the `$options['shippable']` value.
In case of `\Sylius\Bundle\CoreBundle\Form\Type\Checkout\AddressType` which has 2 fields of that type, both of them will have validation groups including `shippable`, even if the 2nd one (`billingAddress`) does not have `'shippable' => true` option.
Moreover, in case of more than 1 field with `'shippable' => true`, validation groups will contain an entry of `shippable` group per field.
