### PR TITLE
[docs] fix server:start command

### DIFF
--- a/docs/book/installation/installation.rst
+++ b/docs/book/installation/installation.rst
@@ -81,14 +81,14 @@ Accessing the Shop
 .. tip::
 
     We strongly recommend using the Symfony built-in web server by running the
-    ``php bin/console server:start 127.0.0.1:8000``
+    ``php bin/console server:start --docroot=web 127.0.0.1:8000``
     command and then accessing ``http://127.0.0.1:8000`` in your web browser to see the shop.
 
 .. note::
 
     The localhost's 8000 port may be already occupied by some other process.
     If so you should try other ports, like for instance:
-    ``php bin/console server:start 127.0.0.1:8081``
+    ``php bin/console server:start --docroot=web 127.0.0.1:8081``
     Want to know more about using a built-in server, see `here <http://symfony.com/doc/current/cookbook/web_server/built_in.html>`_.
 
 You can log in as an administrator, with the credentials you have provided during the installation process.


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #9455
| License         | MIT

With Symfony 4 `--docroot=web` need to be added to server:start command

https://github.com/Sylius/Sylius/issues/9455
