### PR TITLE
Make Stalebot less annoying

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,6 +3,7 @@ daysUntilClose: 7
 exemptLabels:
   - Bug
   - Critical
+  - Do not stale
 staleLabel: Stale
 markComment: >
   This issue has been automatically marked as stale because it has not had any


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

Stalebot is a great tool, that helps a lot with some old, deprecated issues and pull requests. However, sometimes it's quite frustrating when we have the issue that needs to be kept open, but currently, there is no time or possibility to process it (2 examples from the recent past: https://github.com/Sylius/Sylius/issues/6580, https://github.com/Sylius/Sylius/issues/5846). 
I propose to introduce a new label, that would be used in such situations. I don't know is it the best option (even the label name is a neologism, I think 😄), but could be good enough to try. The only thing we must keep in mind is not to abuse this label, so we don't wake up with dozens of "unstaleable"  issues at some point of the time.

I would love to read community's opinion about this proposal (and label name as well) :)