### PR TITLE
Improve use of Semantic's cards in frontend

### DIFF
--- a/src/Sylius/Behat/Page/Shop/Product/IndexPage.php
+++ b/src/Sylius/Behat/Page/Shop/Product/IndexPage.php
@@ -32,7 +32,7 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
     {
         $productsList = $this->getDocument()->find('css', '#products');
 
-        $products = $productsList->findAll('css', '.column > .card');
+        $products = $productsList->findAll('css', '.card');
 
         return count($products);
     }
@@ -44,7 +44,7 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
     {
         $productsList = $this->getDocument()->find('css', '#products');
 
-        return $productsList->find('css', '.column:first-child .content > a')->getText();
+        return $productsList->find('css', '.card:first-child .content > a')->getText();
     }
 
     /**
@@ -54,7 +54,7 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
     {
         $productsList = $this->getDocument()->find('css', '#products');
 
-        return $productsList->find('css', '.column:last-child .content > a')->getText();
+        return $productsList->find('css', '.card:last-child .content > a')->getText();
     }
 
     /**
@@ -119,7 +119,7 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
     public function hasProductsInOrder(array $productNames)
     {
         $productsList = $this->getDocument()->find('css', '#products');
-        $products = $productsList->findAll('css', '.column  .content > .sylius-product-name');
+        $products = $productsList->findAll('css', '.card  .content > .sylius-product-name');
 
         foreach ($productNames as $key => $value) {
             if ($products[$key]->getText() !== $value) {

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_main.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_main.html.twig
@@ -15,11 +15,9 @@
 {{ sonata_block_render_event('sylius.shop.product.index.before_list', {'products': resources.data}) }}
 
 {% if resources.data|length > 0 %}
-    <div class="ui three column stackable grid" id="products">
+    <div class="ui three cards" id="products">
         {% for product in resources.data %}
-            <div class="column">
-                {% include '@SyliusShop/Product/_box.html.twig' %}
-            </div>
+            {% include '@SyliusShop/Product/_box.html.twig' %}
         {% endfor %}
     </div>
     <div class="ui hidden divider"></div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/_horizontalList.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/_horizontalList.html.twig
@@ -1,13 +1,5 @@
-<div class="ui four column stackable grid">
-    <div class="row">
-        {% for product in products %}
-            <div class="column">
-                {% include '@SyliusShop/Product/_box.html.twig' %}
-            </div>
-    {% if 0 == loop.index % 4 %}
-    </div>
-    <div class="row">
-    {% endif %}
-        {% endfor %}
-    </div>
+<div class="ui four doubling cards">
+    {% for product in products %}
+        {% include '@SyliusShop/Product/_box.html.twig' %}
+    {% endfor %}
 </div>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

This is a small improvement to how Semantic UI's cards are rendered with the ShopBundle's default layouts.  Right now they're used within `.ui.grid` containers, but a `.ui.cards` container can also be used as a grid and handles rendering a little better overall (especially with ensuring the cards are equal heights, see below screenshots).

Current demo homepage:
![screen shot 2018-06-12 at 9 22 51 am](https://user-images.githubusercontent.com/368545/41296628-f915e54a-6e22-11e8-9e89-7cbc0d9273e1.png)

Homepage with patch:
![screen shot 2018-06-12 at 9 23 29 am](https://user-images.githubusercontent.com/368545/41296647-036f0760-6e23-11e8-96e6-0216a80cba8c.png)
