### PR TITLE
Require PHP ^7.2 in Sylius ^1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,41 +12,6 @@ env:
 matrix:
     include:
         -
-            php: 7.1
-            env:
-                - SYLIUS_SUITE="application"
-                - SYMFONY_VERSION="3.4.*"
-            services:
-                - memcached
-        -
-            if: type IN (cron, api) OR tag IS present
-            php: 7.1
-            env:
-                - SYLIUS_SUITE="application"
-                - SYMFONY_VERSION="4.1.*"
-            services:
-                - memcached
-        -
-            php: 7.1
-            env:
-                - SYLIUS_SUITE="docs packages"
-                - SYMFONY_VERSION="3.4.*"
-            addons:
-                apt:
-                    packages:
-                        - parallel
-        -
-            if: type IN (cron, api) OR tag IS present
-            php: 7.1
-            env:
-                - SYLIUS_SUITE="docs packages"
-                - SYMFONY_VERSION="4.1.*"
-            addons:
-                apt:
-                    packages:
-                        - parallel
-        -
-            if: type IN (cron, api) OR tag IS present
             php: 7.2
             env:
                 - SYLIUS_SUITE="application"
@@ -61,7 +26,6 @@ matrix:
             services:
                 - memcached
         -
-            if: type IN (cron, api) OR tag IS present
             php: 7.2
             env:
                 - SYLIUS_SUITE="packages"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "ext-exif": "*",
         "ext-fileinfo": "*",

--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/addressing": "^1.2",

--- a/src/Sylius/Bundle/AdminApiBundle/composer.json
+++ b/src/Sylius/Bundle/AdminApiBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "friendsofsymfony/oauth-server-bundle": "^1.6",
         "sylius/core-bundle": "^1.2",

--- a/src/Sylius/Bundle/AdminBundle/composer.json
+++ b/src/Sylius/Bundle/AdminBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sonata-project/intl-bundle": "^2.2",
         "sylius/core-bundle": "^1.2",

--- a/src/Sylius/Bundle/AttributeBundle/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "ramsey/uuid": "^3.7",
         "sonata-project/intl-bundle": "^2.2",

--- a/src/Sylius/Bundle/ChannelBundle/composer.json
+++ b/src/Sylius/Bundle/ChannelBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/channel": "^1.2",
         "sylius/resource-bundle": "^1.2",

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "fzaninotto/faker": "^1.6",
         "jms/serializer-bundle": "^2.0",

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/currency": "^1.2",
         "sylius/resource-bundle": "^1.2",

--- a/src/Sylius/Bundle/CustomerBundle/composer.json
+++ b/src/Sylius/Bundle/CustomerBundle/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "doctrine/orm": "^2.5",
         "sylius/customer": "^1.2",

--- a/src/Sylius/Bundle/FixturesBundle/composer.json
+++ b/src/Sylius/Bundle/FixturesBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "doctrine/data-fixtures": "^1.2",
         "monolog/monolog": "^1.8",

--- a/src/Sylius/Bundle/GridBundle/composer.json
+++ b/src/Sylius/Bundle/GridBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/grid": "^1.2",
         "symfony/form": "^3.4|^4.1",

--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/inventory": "^1.2",
         "sylius/resource-bundle": "^1.2",

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/locale": "^1.2",
         "sylius/resource-bundle": "^1.2",

--- a/src/Sylius/Bundle/MailerBundle/composer.json
+++ b/src/Sylius/Bundle/MailerBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/mailer": "^1.2",
         "symfony/framework-bundle": "^3.4|^4.1"

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/resource-bundle": "^1.2",
         "symfony/framework-bundle": "^3.4|^4.1",

--- a/src/Sylius/Bundle/OrderBundle/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/money-bundle": "^1.2",

--- a/src/Sylius/Bundle/PaymentBundle/composer.json
+++ b/src/Sylius/Bundle/PaymentBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/payment": "^1.2",
         "sylius/resource-bundle": "^1.2",

--- a/src/Sylius/Bundle/PayumBundle/composer.json
+++ b/src/Sylius/Bundle/PayumBundle/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "payum/payum": "^1.4",
         "payum/payum-bundle": "^2.2",

--- a/src/Sylius/Bundle/ProductBundle/composer.json
+++ b/src/Sylius/Bundle/ProductBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/attribute-bundle": "^1.2",

--- a/src/Sylius/Bundle/PromotionBundle/composer.json
+++ b/src/Sylius/Bundle/PromotionBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/money-bundle": "^1.2",

--- a/src/Sylius/Bundle/ResourceBundle/composer.json
+++ b/src/Sylius/Bundle/ResourceBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "doctrine/doctrine-bundle": "^1.6",
         "friendsofsymfony/rest-bundle": "^2.1",

--- a/src/Sylius/Bundle/ReviewBundle/composer.json
+++ b/src/Sylius/Bundle/ReviewBundle/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/mailer-bundle": "^1.2",

--- a/src/Sylius/Bundle/ShippingBundle/composer.json
+++ b/src/Sylius/Bundle/ShippingBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/money-bundle": "^1.2",

--- a/src/Sylius/Bundle/ShopBundle/composer.json
+++ b/src/Sylius/Bundle/ShopBundle/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sonata-project/intl-bundle": "^2.2",
         "sylius/core-bundle": "^1.2",

--- a/src/Sylius/Bundle/TaxationBundle/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/registry": "^1.2",

--- a/src/Sylius/Bundle/TaxonomyBundle/composer.json
+++ b/src/Sylius/Bundle/TaxonomyBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/resource-bundle": "^1.2",

--- a/src/Sylius/Bundle/ThemeBundle/composer.json
+++ b/src/Sylius/Bundle/ThemeBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "doctrine/common": "^2.5",
         "symfony/symfony": "^3.4|^4.1",

--- a/src/Sylius/Bundle/UiBundle/composer.json
+++ b/src/Sylius/Bundle/UiBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "doctrine/collections": "^1.3",
         "knplabs/knp-menu-bundle": "^2.1",

--- a/src/Sylius/Bundle/UserBundle/composer.json
+++ b/src/Sylius/Bundle/UserBundle/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "doctrine/orm": "^2.5",
         "sylius/mailer-bundle": "^1.2",

--- a/src/Sylius/Component/Addressing/composer.json
+++ b/src/Sylius/Component/Addressing/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/registry": "^1.2",
         "sylius/resource": "^1.2",

--- a/src/Sylius/Component/Attribute/composer.json
+++ b/src/Sylius/Component/Attribute/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "doctrine/collections": "^1.3",
         "sylius/registry": "^1.2",

--- a/src/Sylius/Component/Channel/composer.json
+++ b/src/Sylius/Component/Channel/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/resource": "^1.2",
         "symfony/form": "^3.4|^4.1",

--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "knplabs/gaufrette": "^0.5",
         "payum/payum": "^1.3",

--- a/src/Sylius/Component/Currency/composer.json
+++ b/src/Sylius/Component/Currency/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/resource": "^1.2",
         "symfony/intl": "^3.4|^4.1",

--- a/src/Sylius/Component/Customer/composer.json
+++ b/src/Sylius/Component/Customer/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "doctrine/collections": "^1.3",
         "sylius/resource": "^1.0"

--- a/src/Sylius/Component/Grid/composer.json
+++ b/src/Sylius/Component/Grid/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/registry": "^1.2",
         "webmozart/assert": "^1.1"

--- a/src/Sylius/Component/Inventory/composer.json
+++ b/src/Sylius/Component/Inventory/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/resource": "^1.2",
         "webmozart/assert": "^1.0"

--- a/src/Sylius/Component/Locale/composer.json
+++ b/src/Sylius/Component/Locale/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/resource": "^1.2",
         "symfony/intl": "^3.4|^4.1",

--- a/src/Sylius/Component/Mailer/composer.json
+++ b/src/Sylius/Component/Mailer/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "webmozart/assert": "^1.0"
     },

--- a/src/Sylius/Component/Order/composer.json
+++ b/src/Sylius/Component/Order/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "webmozart/assert": "^1.1",
         "sylius/resource": "^1.2",

--- a/src/Sylius/Component/Payment/composer.json
+++ b/src/Sylius/Component/Payment/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/registry": "^1.2",
         "sylius/resource": "^1.0"

--- a/src/Sylius/Component/Product/composer.json
+++ b/src/Sylius/Component/Product/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "behat/transliterator": "^1.1",
         "sylius/attribute": "^1.2",

--- a/src/Sylius/Component/Promotion/composer.json
+++ b/src/Sylius/Component/Promotion/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "doctrine/orm": "^2.5",
         "sylius/registry": "^1.2",

--- a/src/Sylius/Component/Registry/composer.json
+++ b/src/Sylius/Component/Registry/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "webmozart/assert": "^1.0",
         "zendframework/zend-stdlib": "^3.1"

--- a/src/Sylius/Component/Resource/composer.json
+++ b/src/Sylius/Component/Resource/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "doctrine/common": "^2.6",
         "gedmo/doctrine-extensions": "^2.4",

--- a/src/Sylius/Component/Review/composer.json
+++ b/src/Sylius/Component/Review/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/resource": "^1.2",
         "doctrine/collections": "^1.3"

--- a/src/Sylius/Component/Shipping/composer.json
+++ b/src/Sylius/Component/Shipping/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/resource": "^1.2",
         "sylius/registry": "^1.2",

--- a/src/Sylius/Component/Taxation/composer.json
+++ b/src/Sylius/Component/Taxation/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "sylius/registry": "^1.2",
         "sylius/resource": "^1.0"

--- a/src/Sylius/Component/Taxonomy/composer.json
+++ b/src/Sylius/Component/Taxonomy/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "behat/transliterator": "^1.1",
         "sylius/resource": "^1.2",

--- a/src/Sylius/Component/User/composer.json
+++ b/src/Sylius/Component/User/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
 
         "doctrine/collections": "^1.1",
         "sylius/resource": "^1.2",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Sylius v1.3.0 will be released in late September, PHP 7.1 active support ends on 1st December and PHP 7.3 is about to come near the end of this year too.
