### PR TITLE
Fix wrong type for "images" option in ProductFixture

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/BookProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/BookProductFixture.php
@@ -141,8 +141,14 @@ class BookProductFixture extends AbstractFixture
                     'book_genre' => $this->faker->randomElements(array_keys($bookGenres), $this->faker->numberBetween(1, count($bookGenres))),
                 ],
                 'images' => [
-                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'books.jpg'), 'main'],
-                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'books.jpg'), 'thumbnail'],
+                    [
+                        'path' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 'books.jpg'),
+                        'type' => 'main',
+                    ],
+                    [
+                        'path' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 'books.jpg'),
+                        'type' => 'thumbnail',
+                    ],
                 ],
             ];
         }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
@@ -359,13 +359,21 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
     private function createImages(ProductInterface $product, array $options): void
     {
         foreach ($options['images'] as $image) {
-            $imagePath = array_shift($image);
+            // BC, to be deprecated in 1.3 and removed in 2.0
+            if (!array_key_exists('path', $image)) {
+                $imagePath = array_shift($image);
+                $imageType = array_pop($image);
+            } else {
+                $imagePath = $image['path'];
+                $imageType = $image['type'] ?? null;
+            }
+
             $uploadedImage = new UploadedFile($imagePath, basename($imagePath));
 
             /** @var ImageInterface $productImage */
             $productImage = $this->productImageFactory->createNew();
             $productImage->setFile($uploadedImage);
-            $productImage->setType(end($image) ?: null);
+            $productImage->setType($imageType);
 
             $this->imageUploader->upload($productImage);
 

--- a/src/Sylius/Bundle/CoreBundle/Fixture/MugProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/MugProductFixture.php
@@ -152,8 +152,14 @@ class MugProductFixture extends AbstractFixture
                 ],
                 'product_options' => ['mug_type'],
                 'images' => [
-                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'mugs.jpg'), 'main'],
-                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'mugs.jpg'), 'thumbnail'],
+                    [
+                        'path' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 'mugs.jpg'),
+                        'type' => 'main',
+                    ],
+                    [
+                        'path' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 'mugs.jpg'),
+                        'type' => 'thumbnail',
+                    ],
                 ],
             ];
         }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/ProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ProductFixture.php
@@ -42,7 +42,7 @@ class ProductFixture extends AbstractResourceFixture
                 ->arrayNode('channels')->scalarPrototype()->end()->end()
                 ->arrayNode('product_attributes')->scalarPrototype()->end()->end()
                 ->arrayNode('product_options')->scalarPrototype()->end()->end()
-                ->arrayNode('images')->scalarPrototype()->end()->end()
+                ->arrayNode('images')->variablePrototype()->end()->end()
                 ->booleanNode('shipping_required')->end()
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/StickerProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/StickerProductFixture.php
@@ -134,8 +134,14 @@ class StickerProductFixture extends AbstractFixture
                 ],
                 'product_options' => ['sticker_size'],
                 'images' => [
-                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'stickers.jpg'), 'main'],
-                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 'stickers.jpg'), 'thumbnail'],
+                    [
+                        'path' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 'stickers.jpg'),
+                        'type' => 'main',
+                    ],
+                    [
+                        'path' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 'stickers.jpg'),
+                        'type' => 'thumbnail',
+                    ],
                 ],
             ];
         }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/TshirtProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/TshirtProductFixture.php
@@ -160,8 +160,14 @@ class TshirtProductFixture extends AbstractFixture
                 ],
                 'product_options' => ['t_shirt_color', 't_shirt_size'],
                 'images' => [
-                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 't-shirts.jpg'), 'main'],
-                    [sprintf('%s/../Resources/fixtures/%s', __DIR__, 't-shirts.jpg'), 'thumbnail'],
+                    [
+                        'path' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 't-shirts.jpg'),
+                        'type' => 'main',
+                    ],
+                    [
+                        'path' => sprintf('%s/../Resources/fixtures/%s', __DIR__, 't-shirts.jpg'),
+                        'type' => 'thumbnail',
+                    ],
                 ],
             ];
         }

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductFixtureTest.php
@@ -117,7 +117,7 @@ final class ProductFixtureTest extends TestCase
      */
     public function product_images_are_optional(): void
     {
-        $this->assertConfigurationIsValid([['custom' => [['images' => ['../image/path1.jpg', '../image/path2.jpg']]]]], 'custom.*.images');
+        $this->assertConfigurationIsValid([['custom' => [['images' => [['path' => '../image/path1.jpg', 'type' => 'main'], ['path' => '../image/path2.jpg', 'type' => 'thumbnail']]]]]], 'custom.*.images');
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

It wasn't actually working with `ProductExampleFactory`, but the tests don't catch it.