### PR TITLE
Use generic names for data-* properties in sylius-lazy-choice-tree.js

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-lazy-choice-tree.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-lazy-choice-tree.js
@@ -67,7 +67,7 @@ $.fn.extend({
       if (!isLeafLoaded(parentCode)) {
         expandButton.api({
           on: 'now',
-          url: tree.data('taxon-leafs-url'),
+          url: tree.data('tree-leafs-url') || tree.data('taxon-leafs-url'),
           method: 'GET',
           cache: false,
           data: {
@@ -153,7 +153,7 @@ $.fn.extend({
     tree.api({
       on: 'now',
       method: 'GET',
-      url: tree.data('taxon-root-nodes-url'),
+      url: tree.data('tree-root-nodes-url') || tree.data('taxon-root-nodes-url'),
       cache: false,
       beforeSend(settings) {
         loader.addClass('active');

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_taxonomy.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_taxonomy.html.twig
@@ -4,8 +4,8 @@
 
     <h4>{{ 'sylius.ui.product_taxon'|trans }}</h4>
     <div id="sylius-product-taxonomy-tree"
-         data-taxon-root-nodes-url="{{ path('sylius_admin_ajax_taxon_root_nodes') }}"
-         data-taxon-leafs-url="{{ path('sylius_admin_ajax_taxon_leafs') }}"
+         data-tree-root-nodes-url="{{ path('sylius_admin_ajax_taxon_root_nodes') }}"
+         data-tree-leafs-url="{{ path('sylius_admin_ajax_taxon_leafs') }}"
     >
         {{ form_widget(form.productTaxons) }}
         <div class="ui inverted dimmer">


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes?
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

It could be used for more than taxons, so the name of the data-* properties should not include "taxon".