### PR TITLE
Fix a TypeError on admin login page.

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-notification.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-notification.js
@@ -72,7 +72,7 @@
                     url: notificationMenu.attr('data-url'),
                     accept: "application/json",
                     success: function (data) {
-                        if (undefined !== data && data.version !== retrieve(LAST_SYLIUS_VERSION)) {
+                        if (undefined !== data && undefined !== data.version && data.version !== retrieve(LAST_SYLIUS_VERSION)) {
                             store(LAST_SYLIUS_VERSION, data.version.toString());
                         }
                     },


### PR DESCRIPTION
On admin login page, sylius-notifications.js tries to use toString() on an undefined variable, this fix adds a check before the call to prevent javascript from throwing TypeError.

This bug is present in 1.1 but variable has a different name: data in 1.1 and response in 1.2.

| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | None
| License         | MIT
