### PR TITLE
Exception while apply refund transition

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
+++ b/src/Sylius/Bundle/ResourceBundle/Controller/ResourceController.php
@@ -543,7 +543,7 @@ class ResourceController extends Controller
         $this->isGrantedOr403($configuration, ResourceActions::UPDATE);
         $resource = $this->findOr404($configuration);
 
-        if ($configuration->isCsrfProtectionEnabled() && !$this->isCsrfTokenValid($resource->getId(), $request->request->get('_csrf_token'))) {
+        if ($configuration->isCsrfProtectionEnabled() && !$this->isCsrfTokenValid((string) $resource->getId(), $request->request->get('_csrf_token'))) {
             throw new HttpException(Response::HTTP_FORBIDDEN, 'Invalid CSRF token.');
         }
 


### PR DESCRIPTION
Admin refund action throws exception 
"Argument 1 passed to Symfony\Bundle\FrameworkBundle\Controller\Controller::isCsrfTokenValid() must be of the type string, integer given"

| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update UPGRADE-*.md file -->
| Related tickets | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.0 or 1.1 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
