### PR TITLE
Add missing translations for French in admin product menu.

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.fr.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.fr.yml
@@ -775,6 +775,7 @@ sylius:
         taxation_categories: 'Catégories de taxes'
         taxation_settings: 'Configuration des taxes'
         taxes: 'Taxes'
+        taxonomy: 'Taxonomie'
         taxons: 'Taxons'
         terms_and_conditions: 'Conditions générales de vente'
         text: 'Texte'


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | None
| License         | MIT

In the admin product, there is a missing message for taxonomy in French locale.
The message is present in english.

I hope it will help french users :)
