### PR TITLE
Remove Symfony Version from README.md

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/README.md
+++ b/src/Sylius/Bundle/ThemeBundle/README.md
@@ -1,7 +1,7 @@
 SyliusThemeBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusThemeBundle.png?branch=master)](http://travis-ci.org/Sylius/SyliusThemeBundle)
 ==================
 
-Theme management for [**Symfony2**](http://symfony.com).
+Theme management for [**Symfony**](http://symfony.com).
 
 Sylius
 ------


### PR DESCRIPTION
Since it is usable in 3.x and 4.x too, this info was wrong.

| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes - only docs
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT
