### PR TITLE
Ensure that DatabaseSetupCommandsProvider::getDatabaseName() returns a string.

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Installer/Provider/DatabaseSetupCommandsProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Provider/DatabaseSetupCommandsProvider.php
@@ -153,7 +153,7 @@ final class DatabaseSetupCommandsProvider implements DatabaseSetupCommandsProvid
      */
     private function getDatabaseName(): string
     {
-        return $this->getEntityManager()->getConnection()->getDatabase();
+        return (string) $this->getEntityManager()->getConnection()->getDatabase();
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0+
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

`$connection->getDatabase()` returns null in case the database name has not being specified ( example : using sqlite )  
