### PR TITLE
Allowing fields comparison in grid filters

### DIFF
--- a/src/Sylius/Bundle/GridBundle/Doctrine/DBAL/ExpressionBuilder.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/DBAL/ExpressionBuilder.php
@@ -78,6 +78,22 @@ final class ExpressionBuilder implements ExpressionBuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function fieldsEquals(string $field, string $secondField)
+    {
+        return $this->queryBuilder->expr()->eq($field, $secondField);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fieldsNotEquals(string $field, string $secondField)
+    {
+        return $this->queryBuilder->expr()->neq($field, $secondField);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function lessThan(string $field, $value)
     {
         $this->queryBuilder->andWhere($field . ' < :' . $field)->setParameter($field, $value);

--- a/src/Sylius/Bundle/GridBundle/Doctrine/ORM/ExpressionBuilder.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/ORM/ExpressionBuilder.php
@@ -81,6 +81,22 @@ final class ExpressionBuilder implements ExpressionBuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function fieldsEquals(string $field, string $secondField)
+    {
+        return $this->queryBuilder->expr()->eq($this->getFieldName($field), $this->getFieldName($secondField));
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function fieldsNotEquals(string $field, string $secondField)
+    {
+        return $this->queryBuilder->expr()->neq($this->getFieldName($field), $this->getFieldName($secondField));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function lessThan(string $field, $value)
     {
         $parameterName = $this->getParameterName($field);

--- a/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/ExpressionBuilder.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/ExpressionBuilder.php
@@ -97,7 +97,7 @@ final class ExpressionBuilder implements ExpressionBuilderInterface
     public function fieldsNotEquals(string $field, string $secondField)
     {
         //TODO: I don't know PHPCRODM, so not sure if simply doing this will work.
-        return $this->expressionBuilder->neq($field, $value);
+        return $this->expressionBuilder->neq($field, $secondField);
     }
 
     /**

--- a/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/ExpressionBuilder.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/PHPCRODM/ExpressionBuilder.php
@@ -85,6 +85,24 @@ final class ExpressionBuilder implements ExpressionBuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function fieldsEquals(string $field, string $secondField)
+    {
+        //TODO: I don't know PHPCRODM, so not sure if simply doing this will work.
+        return $this->expressionBuilder->eq($field, $secondField);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fieldsNotEquals(string $field, string $secondField)
+    {
+        //TODO: I don't know PHPCRODM, so not sure if simply doing this will work.
+        return $this->expressionBuilder->neq($field, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function lessThan(string $field, $value)
     {
         return $this->expressionBuilder->lt($field, $value);

--- a/src/Sylius/Bundle/ResourceBundle/Grid/Parser/OptionsParser.php
+++ b/src/Sylius/Bundle/ResourceBundle/Grid/Parser/OptionsParser.php
@@ -89,6 +89,10 @@ final class OptionsParser implements OptionsParserInterface
             return $this->parseOptionResourceField(substr($parameter, 9), $data);
         }
 
+        if (0 === strpos($parameter, 'resource[')) {
+            return $this->parseOptionResourceField(substr($parameter, 8), $data);
+        }
+
         return $parameter;
     }
 

--- a/src/Sylius/Bundle/ResourceBundle/spec/Grid/Parser/OptionsParserSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Grid/Parser/OptionsParserSpec.php
@@ -89,4 +89,26 @@ final class OptionsParserSpec extends ObjectBehavior
             ->shouldReturn(['id' => 21])
         ;
     }
+
+    function it_parses_options_with_array(
+        PropertyAccessorInterface $propertyAccessor,
+        Request $request,
+        ResourceInterface $data
+    ): void {
+        $arrayData = [
+            0 => $data,
+            'name' => 'An awesome name',
+        ];
+        $propertyAccessor->getValue($arrayData, '[0].id')->willReturn(21);
+        $propertyAccessor->getValue($arrayData, 'name')->willReturn('An awesome name');
+
+        $this
+            ->parseOptions(['name' => 'resource.name'], $request, $arrayData)
+            ->shouldReturn(['name' => 'An awesome name'])
+        ;
+        $this
+            ->parseOptions(['id' => 'resource[0].id'], $request, $arrayData)
+            ->shouldReturn(['id' => 21])
+        ;
+    }
 }

--- a/src/Sylius/Component/Grid/Data/ExpressionBuilderInterface.php
+++ b/src/Sylius/Component/Grid/Data/ExpressionBuilderInterface.php
@@ -56,6 +56,22 @@ interface ExpressionBuilderInterface
 
     /**
      * @param string $field
+     * @param string $secondField
+     *
+     * @return mixed
+     */
+    public function fieldsEquals(string $field, string $secondField);
+
+    /**
+     * @param string $field
+     * @param string $secondField
+     *
+     * @return mixed
+     */
+    public function fieldsNotEquals(string $field, string $secondField);
+
+    /**
+     * @param string $field
      * @param mixed $value
      *
      * @return mixed


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Adding a support to fields comparison. So we can filter for example an entity related to an other one.
There is still the PHPCRODM to verify (marked as TODO: ) since I don't know if that works

@pamil @CoderMaggie  : I believe it's the right branch this time (master for features :) )