### PR TITLE
Remove instances of loop.index0

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_items.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_items.html.twig
@@ -16,8 +16,8 @@
             </tr>
             </thead>
             <tbody>
-                {% for index,item in cart.items %}
-                    {% include '@SyliusShop/Cart/Summary/_item.html.twig' with {'item': item, 'form': form.items[index]} %}
+                {% for key, item in cart.items %}
+                    {% include '@SyliusShop/Cart/Summary/_item.html.twig' with {'item': item, 'form': form.items[key]} %}
                 {% endfor %}
             </tbody>
         </table>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_items.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/Summary/_items.html.twig
@@ -16,8 +16,8 @@
             </tr>
             </thead>
             <tbody>
-                {% for item in cart.items %}
-                    {% include '@SyliusShop/Cart/Summary/_item.html.twig' with {'item': item, 'form': form.items[loop.index0]} %}
+                {% for index,item in cart.items %}
+                    {% include '@SyliusShop/Cart/Summary/_item.html.twig' with {'item': item, 'form': form.items[index]} %}
                 {% endfor %}
             </tbody>
         </table>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_payment.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_payment.html.twig
@@ -3,8 +3,8 @@
     <div class="ui fluid stackable items">
         {{ form_errors(form.method) }}
 
-        {% for index,choice_form in form.method %}
-            {% include '@SyliusShop/Checkout/SelectPayment/_choice.html.twig' with {'form': choice_form, 'method': form.method.vars.choices[index].data} %}
+        {% for key, choice_form in form.method %}
+            {% include '@SyliusShop/Checkout/SelectPayment/_choice.html.twig' with {'form': choice_form, 'method': form.method.vars.choices[key].data} %}
         {% else %}
             {% include '@SyliusShop/Checkout/SelectPayment/_unavailable.html.twig' %}
         {% endfor %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_payment.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_payment.html.twig
@@ -3,8 +3,8 @@
     <div class="ui fluid stackable items">
         {{ form_errors(form.method) }}
 
-        {% for choice_form in form.method %}
-            {% include '@SyliusShop/Checkout/SelectPayment/_choice.html.twig' with {'form': choice_form, 'method': form.method.vars.choices[loop.index0].data} %}
+        {% for index,choice_form in form.method %}
+            {% include '@SyliusShop/Checkout/SelectPayment/_choice.html.twig' with {'form': choice_form, 'method': form.method.vars.choices[index].data} %}
         {% else %}
             {% include '@SyliusShop/Checkout/SelectPayment/_unavailable.html.twig' %}
         {% endfor %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_form.html.twig
@@ -1,6 +1,6 @@
 <div class="ui unmargined segments">
-    {% for index,shipment in order.shipments %}
-        {% include '@SyliusShop/Checkout/SelectShipping/_shipment.html.twig' with {'form': form.shipments[index]} %}
+    {% for key, shipment in order.shipments %}
+        {% include '@SyliusShop/Checkout/SelectShipping/_shipment.html.twig' with {'form': form.shipments[key]} %}
     {% else %}
         {% include '@SyliusShop/Checkout/SelectShipping/_unavailable.html.twig' %}
     {% endfor %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_form.html.twig
@@ -1,6 +1,6 @@
 <div class="ui unmargined segments">
-    {% for shipment in order.shipments %}
-        {% include '@SyliusShop/Checkout/SelectShipping/_shipment.html.twig' with {'form': form.shipments[loop.index0]} %}
+    {% for index,shipment in order.shipments %}
+        {% include '@SyliusShop/Checkout/SelectShipping/_shipment.html.twig' with {'form': form.shipments[index]} %}
     {% else %}
         {% include '@SyliusShop/Checkout/SelectShipping/_unavailable.html.twig' %}
     {% endfor %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_shipment.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_shipment.html.twig
@@ -3,9 +3,9 @@
     <div class="ui fluid stackable items">
         {{ form_errors(form.method) }}
 
-        {% for index,choice_form in form.method %}
+        {% for key, choice_form in form.method %}
             {% set fee = form.method.vars.shipping_costs[choice_form.vars.value] %}
-            {% set method = form.method.vars.choices[index].data %}
+            {% set method = form.method.vars.choices[key].data %}
             {% include '@SyliusShop/Checkout/SelectShipping/_choice.html.twig' with {'form': choice_form, 'method': method, 'fee': fee} %}
         {% else %}
             {% include '@SyliusShop/Checkout/SelectShipping/_unavailable.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_shipment.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_shipment.html.twig
@@ -3,9 +3,9 @@
     <div class="ui fluid stackable items">
         {{ form_errors(form.method) }}
 
-        {% for choice_form in form.method %}
+        {% for index,choice_form in form.method %}
             {% set fee = form.method.vars.shipping_costs[choice_form.vars.value] %}
-            {% set method = form.method.vars.choices[loop.index0].data %}
+            {% set method = form.method.vars.choices[index].data %}
             {% include '@SyliusShop/Checkout/SelectShipping/_choice.html.twig' with {'form': choice_form, 'method': method, 'fee': fee} %}
         {% else %}
             {% include '@SyliusShop/Checkout/SelectShipping/_unavailable.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_variants.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_variants.html.twig
@@ -9,7 +9,7 @@
     </tr>
     </thead>
     <tbody>
-    {% for index,variant in product.variants %}
+    {% for key, variant in product.variants %}
         <tr>
             <td>
                 {{ variant.name }}
@@ -25,7 +25,7 @@
             </td>
             <td class="sylius-product-variant-price">{{ money.calculatePrice(variant) }}</td>
             <td class="right aligned">
-                {{ form_widget(form.cartItem.variant[index], {'label': false}) }}
+                {{ form_widget(form.cartItem.variant[key], {'label': false}) }}
             </td>
         </tr>
     {% endfor %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_variants.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_variants.html.twig
@@ -9,7 +9,7 @@
     </tr>
     </thead>
     <tbody>
-    {% for variant in product.variants %}
+    {% for index,variant in product.variants %}
         <tr>
             <td>
                 {{ variant.name }}
@@ -25,7 +25,7 @@
             </td>
             <td class="sylius-product-variant-price">{{ money.calculatePrice(variant) }}</td>
             <td class="right aligned">
-                {{ form_widget(form.cartItem.variant[loop.index0], {'label': false}) }}
+                {{ form_widget(form.cartItem.variant[index], {'label': false}) }}
             </td>
         </tr>
     {% endfor %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

When using Sylius with [PHP-PM](https://github.com/php-pm/php-pm), it cannot be guaranteed that the elements of an ArrayCollection will have continuous indexes (for example if you add two items to the cart, then remove one then add a third one the final items collection will have indexes 0 and 2). This sometimes breaks Sylius in Twig templates where loop.index0 is used because it may not match the current item index.

This PR fixes the issue by using the actual index within the loop instead of loop.index0.