### PR TITLE
[Resource] Fix deprecation referencing controllers with a single colon

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -22,7 +22,7 @@ sylius_shop_default_locale:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.shop.locale_switch:switchAction
+        _controller: sylius.controller.shop.locale_switch::switchAction
 
 _liip_imagine:
     resource: "@LiipImagineBundle/Resources/config/routing.yaml"

--- a/docs/book/architecture/resource_layer.rst
+++ b/docs/book/architecture/resource_layer.rst
@@ -161,7 +161,7 @@ Displaying a resource with a custom template and repository methods:
         path: /products/{slug}
         methods: [GET]
         defaults:
-            _controller: sylius.controller.product:showAction
+            _controller: sylius.controller.product::showAction
             _sylius:
                 template: AppStoreBundle:Product:show.html.twig # Use a custom template.
                 repository:
@@ -177,7 +177,7 @@ Creating a product using custom form and a redirection method:
         path: /my-stores/{store}/products/new
         methods: [GET, POST]
         defaults:
-            _controller: sylius.controller.product:createAction
+            _controller: sylius.controller.product::createAction
             _sylius:
                 form: AppStoreBundle/Form/Type/CustomFormType # Use this form type!
                 template: AppStoreBundle:Product:create.html.twig # Use a custom template.

--- a/docs/components_and_bundles/bundles/SyliusResourceBundle/create_resource.rst
+++ b/docs/components_and_bundles/bundles/SyliusResourceBundle/create_resource.rst
@@ -12,7 +12,7 @@ you should use the **createAction** of your **app.controller.book** service.
         path: /books/new
         methods: [GET, POST]
         defaults:
-            _controller: app.controller.book:createAction
+            _controller: app.controller.book::createAction
 
 Done! Now when you go to ``/books/new``, the ResourceController will use the factory (``app.factory.book``) to create a new book instance.
 Then it will try to create an ``app_book`` form, and set the newly created book as its data.
@@ -44,7 +44,7 @@ Just like for the **show** and **index** actions, you can customize the template
         path: /books/new
         methods: [GET, POST]
         defaults:
-            _controller: app.controller.book:createAction
+            _controller: app.controller.book::createAction
             _sylius:
                 template: Book/create.html.twig
 
@@ -64,7 +64,7 @@ __ http://symfony.com/doc/current/forms.html#building-the-form
         path: /books/new
         methods: [GET, POST]
         defaults:
-            _controller: app.controller.book:createAction
+            _controller: app.controller.book::createAction
             _sylius:
                 form: AppBundle\Form\BookType
 
@@ -84,7 +84,7 @@ Below you can see the usage for specifying custom options, in this case, ``valid
         path: /books/new
         methods: [GET, POST]
         defaults:
-            _controller: app.controller.book:createAction
+            _controller: app.controller.book::createAction
             _sylius:
                 form:
                     type: app_book_custom
@@ -105,7 +105,7 @@ To use a different method of your factory, you can simply configure the ``factor
         path: /books/new
         methods: [GET, POST]
         defaults:
-            _controller: app.controller.book:createAction
+            _controller: app.controller.book::createAction
             _sylius:
                 factory: createNewWithAuthor
 
@@ -119,7 +119,7 @@ Additionally, if you want to provide your custom method with arguments from the 
         path: /books/{author}/new
         methods: [GET, POST]
         defaults:
-            _controller: app.controller.book:createAction
+            _controller: app.controller.book::createAction
             _sylius:
                 factory:
                     method: createNewWithAuthor
@@ -140,7 +140,7 @@ If you would like to use your own service to create the resource, then try the f
         path: /{authorId}/books/new
         methods: [GET, POST]
         defaults:
-            _controller: app.controller.book:createAction
+            _controller: app.controller.book::createAction
             _sylius:
                 factory:
                     method: ["expr:service('app.factory.custom_book_factory')", "createNewByAuthorId"]
@@ -164,7 +164,7 @@ For example, to redirect to the index list after successfully creating a new res
         path: /books/new
         methods: [GET, POST]
         defaults:
-            _controller: app.controller.book:createAction
+            _controller: app.controller.book::createAction
             _sylius:
                 redirect: app_book_index
 
@@ -178,7 +178,7 @@ You can also perform more complex redirects, with parameters. For example:
         path: /genre/{genreId}/books/new
         methods: [GET, POST]
         defaults:
-            _controller: app.controller.book:createAction
+            _controller: app.controller.book::createAction
             _sylius:
                 redirect:
                     route: app_genre_show
@@ -194,7 +194,7 @@ In addition to the request parameters, you can access some of the newly created 
         path: /books/new
         methods: [GET, POST]
         defaults:
-            _controller: app.controller.book:createAction
+            _controller: app.controller.book::createAction
             _sylius:
                 redirect:
                     route: app_book_show
@@ -217,7 +217,7 @@ own action name.
         path: /customer/books/new
         methods: [GET, POST]
         defaults:
-            _controller: app.controller.book:createAction
+            _controller: app.controller.book::createAction
             _sylius:
                 event: customer_create
 
@@ -235,7 +235,7 @@ Configuration Reference
         path: /{genreName}/books/add
         methods: [GET, POST]
         defaults:
-            _controller: app.controller.book:createAction
+            _controller: app.controller.book::createAction
             _sylius:
                 template: Book/addToGenre.html.twig
                 form: app_new_book

--- a/docs/components_and_bundles/bundles/SyliusResourceBundle/delete_resource.rst
+++ b/docs/components_and_bundles/bundles/SyliusResourceBundle/delete_resource.rst
@@ -11,7 +11,7 @@ Deleting a resource is simple.
         path: /books/{id}
         methods: [DELETE]
         defaults:
-            _controller: app.controller.book:deleteAction
+            _controller: app.controller.book::deleteAction
 
 Calling an Action with DELETE method
 ------------------------------------
@@ -45,7 +45,7 @@ For example, if you want to delete a book that belongs to a particular genre, no
         path: /genre/{genreId}/books/{id}
         methods: [DELETE]
         defaults:
-            _controller: app.controller.book:deleteAction
+            _controller: app.controller.book::deleteAction
             _sylius:
                 criteria:
                     id: $id
@@ -66,7 +66,7 @@ By default the controller will redirect to the "index" route after successful ac
         path: /genre/{genreId}/books/{id}
         methods: [DELETE]
         defaults:
-            _controller: app.controller.book:deleteAction
+            _controller: app.controller.book::deleteAction
             _sylius:
                 redirect:
                     route: app_genre_show
@@ -88,7 +88,7 @@ However, you can customize the last part of the event, to provide your own actio
         path: /customer/book-delete/{id}
         methods: [DELETE]
         defaults:
-            _controller: app.controller.book:deleteAction
+            _controller: app.controller.book::deleteAction
             _sylius:
                 event: customer_delete
 
@@ -107,7 +107,7 @@ Configuration Reference
         path: /{genreName}/books/{id}/remove
         methods: [DELETE]
         defaults:
-            _controller: app.controller.book:deleteAction
+            _controller: app.controller.book::deleteAction
             _sylius:
                 event: book_delete
                 repository:

--- a/docs/components_and_bundles/bundles/SyliusResourceBundle/index_resources.rst
+++ b/docs/components_and_bundles/bundles/SyliusResourceBundle/index_resources.rst
@@ -12,7 +12,7 @@ In the default scenario, it will return an instance of paginator, with a list of
         path: /books
         methods: [GET]
         defaults:
-            _controller: app.controller.book:indexAction
+            _controller: app.controller.book::indexAction
 
 When you go to ``/books``, the ResourceController will use the repository (``app.repository.book``) to create a paginator.
 The default template will be rendered - ``App:Book:index.html.twig`` with the paginator as the ``books`` variable.
@@ -33,7 +33,7 @@ Just like for the **showAction**, you can override the default template and crit
         path: /books/disabled
         methods: [GET]
         defaults:
-            _controller: app.controller.book:indexAction
+            _controller: app.controller.book::indexAction
             _sylius:
                 criteria:
                     enabled: false
@@ -54,7 +54,7 @@ Except filtering, you can also sort Books.
         path: /books/top
         methods: [GET]
         defaults:
-            _controller: app.controller.book:indexAction
+            _controller: app.controller.book::indexAction
             _sylius:
                 sortable: true
                 sorting:
@@ -87,7 +87,7 @@ You can also control the "max per page" for paginator, using ``paginate`` parame
         path: /books/top
         methods: [GET]
         defaults:
-            _controller: app.controller.book:indexAction
+            _controller: app.controller.book::indexAction
             _sylius:
                 paginate: 5
                 sortable: true
@@ -110,7 +110,7 @@ Pagination is handy, but you do not always want to do it, you can disable pagina
         path: /books/top
         methods: [GET]
         defaults:
-            _controller: app.controller.book:indexAction
+            _controller: app.controller.book::indexAction
             _sylius:
                 paginate: false
                 limit: 3
@@ -132,7 +132,7 @@ Configuration Reference
         path: /{author}/books
         methods: [GET]
         defaults:
-            _controller: app.controller.book:indexAction
+            _controller: app.controller.book::indexAction
             _sylius:
                 template: Author/books.html.twig
                 repository:

--- a/docs/components_and_bundles/bundles/SyliusResourceBundle/show_resource.rst
+++ b/docs/components_and_bundles/bundles/SyliusResourceBundle/show_resource.rst
@@ -15,7 +15,7 @@ Let's assume that you have a ``app.book`` resource registered. To display a sing
         path: /books/{id}
         methods: [GET]
         defaults:
-            _controller: app.controller.book:showAction
+            _controller: app.controller.book::showAction
 
 Done! Now when you go to ``/books/3``, ResourceController will use the repository (``app.repository.book``) to find a Book with the given id (``3``).
 If the requested book resource does not exist, it will throw a ``404 Not Found`` exception.
@@ -36,7 +36,7 @@ Okay, but what if you want to display the same Book resource, but with a differe
         path: /admin/books/{id}
         methods: [GET]
         defaults:
-            _controller: app.controller.book:showAction
+            _controller: app.controller.book::showAction
             _sylius:
                 template: Admin/Book/show.html.twig
 
@@ -56,7 +56,7 @@ Displaying books by id can be boring... and let's say we do not want to allow vi
         path: /books/{title}
         methods: [GET]
         defaults:
-            _controller: app.controller.book:showAction
+            _controller: app.controller.book::showAction
             _sylius:
                 criteria:
                     title: $title
@@ -79,7 +79,7 @@ Creating yet another action to change the method called could be a solution but 
         path: /books/{author}
         methods: [GET]
         defaults:
-            _controller: app.controller.book:showAction
+            _controller: app.controller.book::showAction
             _sylius:
                 repository:
                     method: findOneNewestByAuthor
@@ -100,7 +100,7 @@ If you would like to use your own service to get the resource, then try the foll
         path: /books/{author}
         methods: [GET]
         defaults:
-            _controller: app.controller.book:showAction
+            _controller: app.controller.book::showAction
             _sylius:
                 repository:
                     method: ["expr:service('app.repository.custom_book_repository')", "findOneNewestByAuthor"]
@@ -120,7 +120,7 @@ Configuration Reference
         path: /books/{author}
         methods: [GET]
         defaults:
-            _controller: app.controller.book:showAction
+            _controller: app.controller.book::showAction
             _sylius:
                 template: Book/show.html.twig
                 repository:

--- a/docs/components_and_bundles/bundles/SyliusResourceBundle/update_resource.rst
+++ b/docs/components_and_bundles/bundles/SyliusResourceBundle/update_resource.rst
@@ -11,7 +11,7 @@ To display an edit form of a particular resource, change it or update it via API
         path: /books/{id}/edit
         methods: [GET, PUT]
         defaults:
-            _controller: app.controller.book:updateAction
+            _controller: app.controller.book::updateAction
 
 Done! Now when you go to ``/books/5/edit``, ResourceController will use the repository (``app.repository.book``) to find the book with id == **5**.
 If found it will create the ``app_book`` form, and set the existing book as data.
@@ -44,7 +44,7 @@ Just like for other actions, you can customize the template.
         path: /books/{id}/edit
         methods: [GET, PUT]
         defaults:
-            _controller: app.controller.book:updateAction
+            _controller: app.controller.book::updateAction
             _sylius:
                 template: Admin/Book/update.html.twig
 
@@ -61,7 +61,7 @@ Same way like for **createAction** you can override the default form.
         path: /books/{id}/edit
         methods: [GET, PUT]
         defaults:
-            _controller: app.controller.book:updateAction
+            _controller: app.controller.book::updateAction
             _sylius:
                 form: AppBundle\Form\BookType
 
@@ -80,7 +80,7 @@ Below you can see how to specify custom options, in this case, ``validation_grou
         path: /books/{id}/edit
         methods: [GET, PUT]
         defaults:
-            _controller: app.controller.book:updateAction
+            _controller: app.controller.book::updateAction
             _sylius:
                 form:
                     type: app_book_custom
@@ -100,7 +100,7 @@ By default, the **updateAction** will look for the resource by id. You can easil
         path: /books/{title}/edit
         methods: [GET, PUT]
         defaults:
-            _controller: app.controller.book:updateAction
+            _controller: app.controller.book::updateAction
             _sylius:
                 criteria: { title: $title }
 
@@ -117,7 +117,7 @@ By default the controller will try to get the id of resource and redirect to the
         path: /books/{id}/edit
         methods: [GET, PUT]
         defaults:
-            _controller: app.controller.book:updateAction
+            _controller: app.controller.book::updateAction
             _sylius:
                 redirect: app_book_index
 
@@ -131,7 +131,7 @@ You can also perform more complex redirects, with parameters. For example:
         path: /genre/{genreId}/books/{id}/edit
         methods: [GET, PUT]
         defaults:
-            _controller: app.controller.book:updateAction
+            _controller: app.controller.book::updateAction
             _sylius:
                 redirect:
                     route: app_genre_show
@@ -153,7 +153,7 @@ own action name.
         path: /customer/book-update/{id}
         methods: [GET, PUT]
         defaults:
-            _controller: app.controller.book:updateAction
+            _controller: app.controller.book::updateAction
             _sylius:
                 event: customer_update
 
@@ -175,7 +175,7 @@ Sylius, by default is returning the ``204 HTTP Code``, which indicates an empty 
         path: /books/{title}/edit
         methods: [GET, PUT]
         defaults:
-            _controller: app.controller.book:updateAction
+            _controller: app.controller.book::updateAction
             _sylius:
                 criteria: { title: $title }
                 return_content: true
@@ -196,7 +196,7 @@ Configuration Reference
         path: /genre/{genreId}/books/{title}/edit
         methods: [GET, PUT, PATCH]
         defaults:
-            _controller: app.controller.book:updateAction
+            _controller: app.controller.book::updateAction
             _sylius:
                 template: Book/editInGenre.html.twig
                 form: app_book_custom

--- a/docs/cookbook/shop/checkout.rst
+++ b/docs/cookbook/shop/checkout.rst
@@ -197,14 +197,14 @@ to the ``app/Resources/SyliusShopBundle/config/routing/checkout.yml`` file.
         path: /
         methods: [GET]
         defaults:
-            _controller: FrameworkBundle:Redirect:redirect
+            _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction
             route: sylius_shop_checkout_address
 
     sylius_shop_checkout_address:
         path: /address
         methods: [GET, PUT]
         defaults:
-            _controller: sylius.controller.order:updateAction
+            _controller: sylius.controller.order::updateAction
             _sylius:
                 event: address
                 flash: false
@@ -225,7 +225,7 @@ to the ``app/Resources/SyliusShopBundle/config/routing/checkout.yml`` file.
         path: /select-payment
         methods: [GET, PUT]
         defaults:
-            _controller: sylius.controller.order:updateAction
+            _controller: sylius.controller.order::updateAction
             _sylius:
                 event: payment
                 flash: false
@@ -243,7 +243,7 @@ to the ``app/Resources/SyliusShopBundle/config/routing/checkout.yml`` file.
         path: /complete
         methods: [GET, PUT]
         defaults:
-            _controller: sylius.controller.order:updateAction
+            _controller: sylius.controller.order::updateAction
             _sylius:
                 event: complete
                 flash: false

--- a/docs/cookbook/shop/custom-redirect-after-cart-add-action.rst
+++ b/docs/cookbook/shop/custom-redirect-after-cart-add-action.rst
@@ -9,7 +9,7 @@ Currently **Sylius** by default is using route definition and **sylius-add-to-ca
         path: /add-item
         methods: [GET]
         defaults:
-            _controller: sylius.controller.order_item:addAction
+            _controller: sylius.controller.order_item::addAction
             _sylius:
                 template: $template
                 factory:

--- a/docs/cookbook/shop/disabling-localised-urls.rst
+++ b/docs/cookbook/shop/disabling-localised-urls.rst
@@ -25,7 +25,7 @@ Replace:
         path: /
         methods: [GET]
         defaults:
-            _controller: sylius.controller.shop.locale_switch:switchAction
+            _controller: sylius.controller.shop.locale_switch::switchAction
 
 With:
 

--- a/docs/cookbook/shop/embedding-products.rst
+++ b/docs/cookbook/shop/embedding-products.rst
@@ -71,7 +71,7 @@ To be able to render a partial with the retrieved products configure routing for
         path: /latest/{code}/{count} # configure a new path that has all the needed variables
         methods: [GET]
         defaults:
-            _controller: sylius.controller.product:indexAction # you make a call on the Product Controller's index action
+            _controller: sylius.controller.product::indexAction # you make a call on the Product Controller's index action
             _sylius:
                 template: $template
                 repository:

--- a/docs/customization/factory.rst
+++ b/docs/customization/factory.rst
@@ -113,7 +113,7 @@ To actually use it overwrite ``sylius_admin_product_create_simple`` route like b
         path: /products/new/simple
         methods: [GET, POST]
         defaults:
-            _controller: sylius.controller.product:createAction
+            _controller: sylius.controller.product::createAction
             _sylius:
                 section: admin
                 factory:

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/adjustment.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/adjustment.yml
@@ -2,7 +2,7 @@ sylius_admin_api_adjustment_index:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.adjustment:indexAction
+        _controller: sylius.controller.adjustment::indexAction
         _sylius:
             serialization_version: $version
             repository:
@@ -14,7 +14,7 @@ sylius_admin_api_adjustment_create:
     path: /
     methods: [POST]
     defaults:
-        _controller: sylius.controller.adjustment:createAction
+        _controller: sylius.controller.adjustment::createAction
         _sylius:
             serialization_version: $version
 
@@ -22,7 +22,7 @@ sylius_admin_api_adjustment_update:
     path: /{id}
     methods: [PUT, PATCH]
     defaults:
-        _controller: sylius.controller.adjustment:updateAction
+        _controller: sylius.controller.adjustment::updateAction
         _sylius:
             serialization_version: $version
 
@@ -30,7 +30,7 @@ sylius_admin_api_adjustment_delete:
     path: /{id}
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.adjustment:deleteAction
+        _controller: sylius.controller.adjustment::deleteAction
         _sylius:
             serialization_version: $version
             filterable: true

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/cart.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/cart.yml
@@ -15,7 +15,7 @@ sylius_admin_api_cart_create:
     path: /
     methods: [POST]
     defaults:
-        _controller: sylius.controller.order:createAction
+        _controller: sylius.controller.order::createAction
         _sylius:
             serialization_version: $version
             form: Sylius\Bundle\AdminApiBundle\Form\Type\OrderType
@@ -25,7 +25,7 @@ sylius_admin_api_cart_update:
     path: /{id}
     methods: [PUT, PATCH]
     defaults:
-        _controller: sylius.controller.order:updateAction
+        _controller: sylius.controller.order::updateAction
         _sylius:
             serialization_version: $version
             form: Sylius\Bundle\AdminApiBundle\Form\Type\OrderPromotionCouponType
@@ -35,7 +35,7 @@ sylius_admin_api_cart_delete:
     path: /{id}
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.order:deleteAction
+        _controller: sylius.controller.order::deleteAction
         _format: json
         _sylius:
             serialization_version: $version
@@ -48,7 +48,7 @@ sylius_admin_api_cart_show:
     path: /{id}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:showAction
+        _controller: sylius.controller.order::showAction
         _sylius:
             serialization_version: $version
             repository:

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/cart_item.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/cart_item.yml
@@ -5,7 +5,7 @@ sylius_admin_api_cart_item_create:
     path: /items/
     methods: [POST]
     defaults:
-        _controller: sylius.controller.order_item:createAction
+        _controller: sylius.controller.order_item::createAction
         _sylius:
             serialization_version: $version
             form: Sylius\Bundle\AdminApiBundle\Form\Type\OrderItemType

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/checkout.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/checkout.yml
@@ -6,7 +6,7 @@ sylius_admin_api_checkout_show:
     path: /{id}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:showAction
+        _controller: sylius.controller.order::showAction
         _sylius:
             serialization_version: $version
             serialization_groups: [Detailed]
@@ -15,7 +15,7 @@ sylius_admin_api_checkout_addressing:
     path: /addressing/{orderId}
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.order:updateAction
+        _controller: sylius.controller.order::updateAction
         _sylius:
             serialization_version: $version
             form: Sylius\Bundle\AdminApiBundle\Form\Type\AddressType
@@ -30,13 +30,13 @@ sylius_admin_api_checkout_available_shipping_methods:
     path: /select-shipping/{orderId}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.show_available_shipping_methods:showAction
+        _controller: sylius.controller.show_available_shipping_methods::showAction
 
 sylius_admin_api_checkout_select_shipping:
     path: /select-shipping/{orderId}
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.order:updateAction
+        _controller: sylius.controller.order::updateAction
         _sylius:
             serialization_version: $version
             form: Sylius\Bundle\CoreBundle\Form\Type\Checkout\SelectShippingType
@@ -51,13 +51,13 @@ sylius_admin_api_checkout_available_payment_methods:
     path: /select-payment/{orderId}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.show_available_payment_methods:showAction
+        _controller: sylius.controller.show_available_payment_methods::showAction
 
 sylius_admin_api_checkout_select_payment:
     path: /select-payment/{orderId}
     methods: [PUT, PATCH]
     defaults:
-        _controller: sylius.controller.order:updateAction
+        _controller: sylius.controller.order::updateAction
         _sylius:
             serialization_version: $version
             form: Sylius\Bundle\CoreBundle\Form\Type\Checkout\SelectPaymentType
@@ -72,7 +72,7 @@ sylius_admin_api_checkout_complete:
     path: /complete/{orderId}
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.order:updateAction
+        _controller: sylius.controller.order::updateAction
         _sylius:
             serialization_version: $version
             form:

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/customer.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/customer.yml
@@ -5,7 +5,7 @@ sylius_admin_api_customer_index:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.customer:indexAction
+        _controller: sylius.controller.customer::indexAction
         _sylius:
             serialization_version: $version
             serialization_groups: [Default]
@@ -18,7 +18,7 @@ sylius_admin_api_customer_show:
     path: /{id}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.customer:showAction
+        _controller: sylius.controller.customer::showAction
         _sylius:
             serialization_version: $version
             serialization_groups: [Detailed]
@@ -27,7 +27,7 @@ sylius_admin_api_customer_create:
     path: /
     methods: [POST]
     defaults:
-        _controller: sylius.controller.customer:createAction
+        _controller: sylius.controller.customer::createAction
         _sylius:
             serialization_version: $version
             serialization_groups: [Detailed]
@@ -38,7 +38,7 @@ sylius_admin_api_customer_update:
     path: /{id}
     methods: [PUT, PATCH]
     defaults:
-        _controller: sylius.controller.customer:updateAction
+        _controller: sylius.controller.customer::updateAction
         _sylius:
             serialization_version: $version
             form:
@@ -48,7 +48,7 @@ sylius_admin_api_customer_delete:
     path: /{id}
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.customer:deleteAction
+        _controller: sylius.controller.customer::deleteAction
         _sylius:
             serialization_version: $version
             csrf_protection: false
@@ -57,7 +57,7 @@ sylius_admin_api_customer_order_index:
     path: /{id}/orders/
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:indexAction
+        _controller: sylius.controller.order::indexAction
         _sylius:
             serialization_version: $version
             paginate: $limit

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/exchange_rate.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/exchange_rate.yml
@@ -13,7 +13,7 @@ sylius_admin_api_exchange_rate_update:
     path: /exchange-rates/{sourceCurrencyCode}-{targetCurrencyCode}
     methods: [PUT, PATCH]
     defaults:
-        _controller: sylius.controller.exchange_rate:updateAction
+        _controller: sylius.controller.exchange_rate::updateAction
         _sylius:
             serialization_version: $version
             serialization_groups: [Default, Detailed]
@@ -25,7 +25,7 @@ sylius_admin_api_exchange_rate_delete:
     path: /exchange-rates/{sourceCurrencyCode}-{targetCurrencyCode}
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.exchange_rate:deleteAction
+        _controller: sylius.controller.exchange_rate::deleteAction
         _sylius:
             serialization_version: $version
             repository:
@@ -37,7 +37,7 @@ sylius_admin_api_exchange_rate_show:
     path: /exchange-rates/{sourceCurrencyCode}-{targetCurrencyCode}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.exchange_rate:showAction
+        _controller: sylius.controller.exchange_rate::showAction
         _sylius:
             serialization_version: $version
             serialization_groups: [Default, Detailed]

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/order.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/order.yml
@@ -14,7 +14,7 @@ sylius_admin_api_order_cancel:
     path: /orders/{id}/cancel
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.order:applyStateMachineTransitionAction
+        _controller: sylius.controller.order::applyStateMachineTransitionAction
         _sylius:
             section: admin_api
             state_machine:
@@ -27,7 +27,7 @@ sylius_admin_api_order_shipment_ship:
     path: /orders/{orderId}/shipments/{id}/ship
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.shipment:updateAction
+        _controller: sylius.controller.shipment::updateAction
         _sylius:
             event: ship
             repository:
@@ -45,7 +45,7 @@ sylius_admin_api_order_payment_complete:
     path: /orders/{orderId}/payments/{id}/complete
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.payment:applyStateMachineTransitionAction
+        _controller: sylius.controller.payment::applyStateMachineTransitionAction
         _sylius:
             event: complete
             repository:

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/product_attribute.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/product_attribute.yml
@@ -16,7 +16,7 @@ sylius_admin_api_product_attribute_create:
     path: /product-attributes/{type}
     methods: [POST]
     defaults:
-        _controller: sylius.controller.product_attribute:createAction
+        _controller: sylius.controller.product_attribute::createAction
         _sylius:
             serialization_version: $version
             factory:

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/product_review.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/product_review.yml
@@ -19,7 +19,7 @@ sylius_admin_api_product_review_create:
     path: /reviews/
     methods: [POST]
     defaults:
-        _controller: sylius.controller.product_review:createAction
+        _controller: sylius.controller.product_review::createAction
         _sylius:
             serialization_groups: [Default, Detailed]
             serialization_version: $version
@@ -34,7 +34,7 @@ sylius_admin_api_product_review_update:
     path: /reviews/{id}
     methods: [PUT, PATCH]
     defaults:
-        _controller: sylius.controller.product_review:updateAction
+        _controller: sylius.controller.product_review::updateAction
         _sylius:
             serialization_version: $version
             section: admin_api
@@ -47,7 +47,7 @@ sylius_admin_api_product_review_delete:
     path: /reviews/{id}
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.product_review:deleteAction
+        _controller: sylius.controller.product_review::deleteAction
         _sylius:
             serialization_version: $version
             section: admin_api
@@ -60,7 +60,7 @@ sylius_admin_api_product_review_show:
     path: /reviews/{id}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product_review:showAction
+        _controller: sylius.controller.product_review::showAction
         _sylius:
             serialization_version: $version
             section: admin_api
@@ -73,7 +73,7 @@ sylius_admin_api_product_review_accept:
     path: /reviews/{id}/accept
     methods: [POST, PUT, PATCH]
     defaults:
-        _controller: sylius.controller.product_review:applyStateMachineTransitionAction
+        _controller: sylius.controller.product_review::applyStateMachineTransitionAction
         _sylius:
             state_machine:
                 graph: sylius_product_review
@@ -84,7 +84,7 @@ sylius_admin_api_product_review_reject:
     path: /reviews/{id}/reject
     methods: [POST, PUT, PATCH]
     defaults:
-        _controller: sylius.controller.product_review:applyStateMachineTransitionAction
+        _controller: sylius.controller.product_review::applyStateMachineTransitionAction
         _sylius:
             state_machine:
                 graph: sylius_product_review

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/product_taxon_position.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/product_taxon_position.yml
@@ -2,6 +2,6 @@ sylius_admin_api_taxon_products_update_position:
     path: /taxons/{taxonCode}/products
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.update_product_taxon_position:updatePositionsAction
+        _controller: sylius.controller.update_product_taxon_position::updatePositionsAction
         _sylius:
             serialization_version: $version

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/product_variant.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/product_variant.yml
@@ -19,7 +19,7 @@ sylius_admin_api_product_variant_create:
     path: /variants/
     methods: [POST]
     defaults:
-        _controller: sylius.controller.product_variant:createAction
+        _controller: sylius.controller.product_variant::createAction
         _sylius:
             serialization_groups: [Default, Detailed]
             serialization_version: $version
@@ -34,7 +34,7 @@ sylius_admin_api_product_variant_update:
     path: /variants/{code}
     methods: [PUT, PATCH]
     defaults:
-        _controller: sylius.controller.product_variant:updateAction
+        _controller: sylius.controller.product_variant::updateAction
         _sylius:
             serialization_version: $version
             section: admin_api
@@ -47,7 +47,7 @@ sylius_admin_api_product_variant_delete:
     path: /variants/{code}
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.product_variant:deleteAction
+        _controller: sylius.controller.product_variant::deleteAction
         _sylius:
             serialization_version: $version
             section: admin_api
@@ -60,7 +60,7 @@ sylius_admin_api_product_variant_show:
     path: /variants/{code}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product_variant:showAction
+        _controller: sylius.controller.product_variant::showAction
         _sylius:
             serialization_version: $version
             section: admin_api

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/promotion_coupon.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/promotion_coupon.yml
@@ -5,7 +5,7 @@ sylius_admin_api_promotion_coupon_index:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.promotion_coupon:indexAction
+        _controller: sylius.controller.promotion_coupon::indexAction
         _sylius:
             serialization_version: $version
             serialization_groups: [Default]
@@ -18,7 +18,7 @@ sylius_admin_api_promotion_coupon_create:
     path: /
     methods: [POST]
     defaults:
-        _controller: sylius.controller.promotion_coupon:createAction
+        _controller: sylius.controller.promotion_coupon::createAction
         _sylius:
             serialization_version: $version
             section: admin_api
@@ -33,7 +33,7 @@ sylius_admin_api_promotion_coupon_update:
     path: /{code}
     methods: [PUT, PATCH]
     defaults:
-        _controller: sylius.controller.promotion_coupon:updateAction
+        _controller: sylius.controller.promotion_coupon::updateAction
         _sylius:
             serialization_version: $version
             section: admin_api
@@ -45,7 +45,7 @@ sylius_admin_api_promotion_coupon_show:
     path: /{code}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.promotion_coupon:showAction
+        _controller: sylius.controller.promotion_coupon::showAction
         _sylius:
             serialization_version: $version
             serialization_groups: [Default, Detailed]
@@ -58,7 +58,7 @@ sylius_admin_api_promotion_coupon_delete:
     path: /{code}
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.promotion_coupon:deleteAction
+        _controller: sylius.controller.promotion_coupon::deleteAction
         _sylius:
             serialization_version: $version
             section: admin_api

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/province.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/province.yml
@@ -5,7 +5,7 @@ sylius_admin_api_province_delete:
     path: /{code}
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.province:deleteAction
+        _controller: sylius.controller.province::deleteAction
         _sylius:
             serialization_version: $version
             criteria:
@@ -16,7 +16,7 @@ sylius_admin_api_province_show:
     path: /{code}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.province:showAction
+        _controller: sylius.controller.province::showAction
         _sylius:
             serialization_version: $version
             serialization_groups: [Detailed]

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/zone.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/zone.yml
@@ -16,7 +16,7 @@ sylius_admin_api_zone_create:
     path: /zones/{type}
     methods: [POST]
     defaults:
-        _controller: sylius.controller.zone:createAction
+        _controller: sylius.controller.zone::createAction
         _sylius:
             serialization_version: $version
             factory:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing.yml
@@ -9,12 +9,12 @@ sylius_admin_ajax:
 sylius_admin_dashboard:
     path: /
     defaults:
-        _controller: sylius.controller.admin.dashboard:indexAction
+        _controller: sylius.controller.admin.dashboard::indexAction
 
 sylius_admin_impersonate_user:
     path: /impersonate/{username}
     defaults:
-        _controller: 'sylius.controller.impersonate_user:impersonateAction'
+        _controller: 'sylius.controller.impersonate_user::impersonateAction'
         username: $username
 
 sylius_admin_admin_user:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax.yml
@@ -17,12 +17,12 @@ sylius_admin_ajax_product_variant:
 sylius_admin_ajax_render_province_form:
     path: /render-province-form
     defaults:
-        _controller: sylius.controller.province:choiceOrTextFieldFormAction
+        _controller: sylius.controller.province::choiceOrTextFieldFormAction
         _sylius:
             template: "@SyliusAdmin/Common/Form/_province.html.twig"
 
 sylius_admin_ajax_get_version:
     path: /get-version
     defaults:
-        _controller: sylius.controller.admin.notification:getVersionAction
+        _controller: sylius.controller.admin.notification::getVersionAction
         _format: json

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product.yml
@@ -2,14 +2,14 @@ sylius_admin_ajax_generate_product_slug:
     path: /generate-slug/
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product_slug:generateAction
+        _controller: sylius.controller.product_slug::generateAction
         _format: json
 
 sylius_admin_ajax_product_by_name_phrase:
     path: /search
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product:indexAction
+        _controller: sylius.controller.product::indexAction
         _format: json
         _sylius:
             serialization_groups: [Autocomplete]
@@ -24,7 +24,7 @@ sylius_admin_ajax_product_by_code:
     path: /code
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product:indexAction
+        _controller: sylius.controller.product::indexAction
         _format: json
         _sylius:
             serialization_groups: [Autocomplete]
@@ -37,7 +37,7 @@ sylius_admin_ajax_product_index:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product:indexAction
+        _controller: sylius.controller.product::indexAction
         _format: json
         _sylius:
             permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product_taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product_taxon.yml
@@ -2,7 +2,7 @@ sylius_admin_ajax_product_taxons_update_position:
     path: /update
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.product_taxon:updatePositionsAction
+        _controller: sylius.controller.product_taxon::updatePositionsAction
         _format: json
         _sylius:
             permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product_variant.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product_variant.yml
@@ -2,7 +2,7 @@ sylius_admin_ajax_product_variants_update_position:
     path: /update
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.product_variant:updatePositionsAction
+        _controller: sylius.controller.product_variant::updatePositionsAction
         _format: json
         _sylius:
             permission: true
@@ -11,7 +11,7 @@ sylius_admin_ajax_product_variants_by_phrase:
     path: /search
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product_variant:indexAction
+        _controller: sylius.controller.product_variant::indexAction
         _format: json
         _sylius:
             serialization_groups: [Autocomplete]
@@ -27,7 +27,7 @@ sylius_admin_ajax_product_variants_by_codes:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product_variant:indexAction
+        _controller: sylius.controller.product_variant::indexAction
         _format: json
         _sylius:
             serialization_groups: [Autocomplete]

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/taxon.yml
@@ -2,7 +2,7 @@ sylius_admin_ajax_taxon_root_nodes:
     path: /root-nodes
     methods: [GET]
     defaults:
-        _controller: sylius.controller.taxon:indexAction
+        _controller: sylius.controller.taxon::indexAction
         _format: json
         _sylius:
             serialization_groups: [Autocomplete]
@@ -14,7 +14,7 @@ sylius_admin_ajax_taxon_leafs:
     path: /leafs
     methods: [GET]
     defaults:
-        _controller: sylius.controller.taxon:indexAction
+        _controller: sylius.controller.taxon::indexAction
         _format: json
         _sylius:
             serialization_groups: [Autocomplete]
@@ -28,7 +28,7 @@ sylius_admin_ajax_taxon_by_code:
     path: /leaf
     methods: [GET]
     defaults:
-        _controller: sylius.controller.taxon:indexAction
+        _controller: sylius.controller.taxon::indexAction
         _format: json
         _sylius:
             serialization_groups: [Autocomplete]
@@ -41,7 +41,7 @@ sylius_admin_ajax_taxon_by_name_phrase:
     path: /search
     methods: [GET]
     defaults:
-        _controller: sylius.controller.taxon:indexAction
+        _controller: sylius.controller.taxon::indexAction
         _format: json
         _sylius:
             serialization_groups: [Autocomplete]
@@ -55,14 +55,14 @@ sylius_admin_ajax_generate_taxon_slug:
     path: /generate-slug/
     methods: [GET]
     defaults:
-        _controller: sylius.controller.taxon_slug:generateAction
+        _controller: sylius.controller.taxon_slug::generateAction
         _format: json
 
 sylius_admin_ajax_taxon_move:
     path: /{id}/move
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.taxon:updateAction
+        _controller: sylius.controller.taxon::updateAction
         _format: json
         _sylius:
             permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer.yml
@@ -19,7 +19,7 @@ sylius_admin_customer:
 sylius_admin_customer_show:
     path: /customers/{id}
     defaults:
-        _controller: sylius.controller.customer:showAction
+        _controller: sylius.controller.customer::showAction
         _sylius:
             section: admin
             template: SyliusAdminBundle:Customer:show.html.twig
@@ -29,7 +29,7 @@ sylius_admin_customer_order_index:
     path: /customers/{id}/orders
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:indexAction
+        _controller: sylius.controller.order::indexAction
         _sylius:
             section: admin
             permission: true
@@ -49,7 +49,7 @@ sylius_admin_customer_orders_statistics:
     path: /orders-statistics
     methods: [GET]
     defaults:
-        _controller: sylius.controller.customer_statistics:renderAction
+        _controller: sylius.controller.customer_statistics::renderAction
         _sylius:
             section: admin
             permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/inventory.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/inventory.yml
@@ -2,7 +2,7 @@ sylius_admin_inventory_index:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product_variant:indexAction
+        _controller: sylius.controller.product_variant::indexAction
         _sylius:
             template: "@SyliusAdmin/Crud/index.html.twig"
             grid: sylius_admin_inventory

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
@@ -17,7 +17,7 @@ sylius_admin_order_show:
     path: /orders/{id}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:showAction
+        _controller: sylius.controller.order::showAction
         _sylius:
             section: admin
             permission: true
@@ -27,7 +27,7 @@ sylius_admin_order_history:
     path: /orders/{id}/history
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:showAction
+        _controller: sylius.controller.order::showAction
         _sylius:
             section: admin
             permission: true
@@ -37,7 +37,7 @@ sylius_admin_order_update:
     path: /orders/{id}/edit
     methods: [GET, PUT]
     defaults:
-        _controller: sylius.controller.order:updateAction
+        _controller: sylius.controller.order::updateAction
         _sylius:
             section: admin
             permission: true
@@ -51,7 +51,7 @@ sylius_admin_order_cancel:
     path: /orders/{id}/cancel
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.order:applyStateMachineTransitionAction
+        _controller: sylius.controller.order::applyStateMachineTransitionAction
         _sylius:
             permission: true
             state_machine:
@@ -63,7 +63,7 @@ sylius_admin_order_payment_complete:
     path: /orders/{orderId}/payments/{id}/complete
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.payment:applyStateMachineTransitionAction
+        _controller: sylius.controller.payment::applyStateMachineTransitionAction
         _sylius:
             event: complete
             permission: true
@@ -81,7 +81,7 @@ sylius_admin_order_payment_refund:
     path: /orders/{orderId}/payments/{id}/refund
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.payment:applyStateMachineTransitionAction
+        _controller: sylius.controller.payment::applyStateMachineTransitionAction
         _sylius:
             permission: true
             repository:
@@ -99,7 +99,7 @@ sylius_admin_order_shipment_ship:
     path: /{id}/ship
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.shipment:updateAction
+        _controller: sylius.controller.shipment::updateAction
         _sylius:
             event: ship
             repository:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/address.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/address.yml
@@ -2,7 +2,7 @@ sylius_admin_partial_address_log_entry_index:
     path: /log-entry/{id}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.address_log_entry:indexAction
+        _controller: sylius.controller.address_log_entry::indexAction
         _sylius:
             template: "@SyliusUi/Grid/_history.html.twig"
             grid: sylius_admin_address_log_entry

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/channel.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/channel.yml
@@ -2,7 +2,7 @@ sylius_admin_partial_channel_index:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.channel:indexAction
+        _controller: sylius.controller.channel::indexAction
         _sylius:
             repository:
                 method: findAll

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/customer.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/customer.yml
@@ -5,7 +5,7 @@ sylius_admin_partial_customer_latest:
     path: /latest/{count}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.customer:indexAction
+        _controller: sylius.controller.customer::indexAction
         _sylius:
             repository:
                 method: findLatest
@@ -18,7 +18,7 @@ sylius_admin_partial_customer_show:
     path: /{id}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.customer:showAction
+        _controller: sylius.controller.customer::showAction
         _sylius:
             template: $template
             vars: $vars

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/order.yml
@@ -2,7 +2,7 @@ sylius_admin_partial_order_latest:
     path: /latest/{count}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:indexAction
+        _controller: sylius.controller.order::indexAction
         _sylius:
             repository:
                 method: findLatest
@@ -15,7 +15,7 @@ sylius_admin_partial_order_latest_in_channel:
     path: /latest/{channelCode}/{count}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:indexAction
+        _controller: sylius.controller.order::indexAction
         _sylius:
             repository:
                 method: findLatestInChannel

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/product.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/product.yml
@@ -5,7 +5,7 @@ sylius_admin_partial_product_show:
     path: /{id}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product:showAction
+        _controller: sylius.controller.product::showAction
         _sylius:
             template: $template
             vars: $vars

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/promotion.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/promotion.yml
@@ -5,7 +5,7 @@ sylius_admin_partial_promotion_show:
     path: /{id}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.promotion:showAction
+        _controller: sylius.controller.promotion::showAction
         _sylius:
             template: $template
             vars: $vars

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/shipment.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/shipment.yml
@@ -2,7 +2,7 @@ sylius_admin_partial_shipment_ship:
     path: /{id}/ship
     methods: [GET]
     defaults:
-        _controller: sylius.controller.shipment:updateAction
+        _controller: sylius.controller.shipment::updateAction
         _sylius:
             event: ship
             repository:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/partial/taxon.yml
@@ -5,7 +5,7 @@ sylius_admin_partial_taxon_tree:
     path: /tree
     methods: [GET]
     defaults:
-        _controller: sylius.controller.taxon:indexAction
+        _controller: sylius.controller.taxon::indexAction
         _sylius:
             template: $template
             repository:
@@ -16,7 +16,7 @@ sylius_admin_partial_taxon_show:
     path: /{id}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.taxon:showAction
+        _controller: sylius.controller.taxon::showAction
         _sylius:
             template: $template
             vars: $vars

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/payment_method.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/payment_method.yml
@@ -20,7 +20,7 @@ sylius_admin_payment_method_create:
     path: /payment-methods/new/{factory}
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.payment_method:createAction
+        _controller: sylius.controller.payment_method::createAction
         _sylius:
             section: admin
             factory:
@@ -42,5 +42,5 @@ sylius_admin_get_payment_gateways:
     path: /payment-gateways
     methods: [GET]
     defaults:
-        _controller: sylius.controller.payment_method:getPaymentGatewaysAction
+        _controller: sylius.controller.payment_method::getPaymentGatewaysAction
         template: SyliusAdminBundle:PaymentMethod/Gateways:paymentGateways.html.twig

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product.yml
@@ -20,7 +20,7 @@ sylius_admin_product_index:
     path: /products/
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product:indexAction
+        _controller: sylius.controller.product::indexAction
         _sylius:
             section: admin
             permission: true
@@ -34,7 +34,7 @@ sylius_admin_product_per_taxon_index:
     path: /products/taxon/{taxonId}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product:indexAction
+        _controller: sylius.controller.product::indexAction
         _sylius:
             section: admin
             permission: true
@@ -48,7 +48,7 @@ sylius_admin_product_create:
     path: /products/new
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.product:createAction
+        _controller: sylius.controller.product::createAction
         _sylius:
             section: admin
             permission: true
@@ -65,7 +65,7 @@ sylius_admin_product_create_simple:
     path: /products/new/simple
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.product:createAction
+        _controller: sylius.controller.product::createAction
         _sylius:
             section: admin
             permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_attribute.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_attribute.yml
@@ -20,7 +20,7 @@ sylius_admin_product_attribute_create:
     path: /product-attributes/{type}/new
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.product_attribute:createAction
+        _controller: sylius.controller.product_attribute::createAction
         _sylius:
             section: admin
             factory:
@@ -42,19 +42,19 @@ sylius_admin_get_attribute_types:
     path: /attribute-types
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product_attribute:getAttributeTypesAction
+        _controller: sylius.controller.product_attribute::getAttributeTypesAction
         template: SyliusAdminBundle:ProductAttribute/Types:attributeTypes.html.twig
 
 sylius_admin_get_product_attributes:
     path: /attributes
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product_attribute:renderAttributesAction
+        _controller: sylius.controller.product_attribute::renderAttributesAction
         template: SyliusAdminBundle:Product/Attribute:attributeChoice.html.twig
 
 sylius_admin_render_attribute_forms:
     path: /attribute-forms
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product_attribute:renderAttributeValueFormsAction
+        _controller: sylius.controller.product_attribute::renderAttributeValueFormsAction
         template: SyliusAdminBundle:Product/Attribute:attributeValues.html.twig

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_review.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_review.yml
@@ -20,7 +20,7 @@ sylius_admin_product_review_accept:
     path: /product-review/{id}/accept
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.product_review:applyStateMachineTransitionAction
+        _controller: sylius.controller.product_review::applyStateMachineTransitionAction
         _sylius:
             permission: true
             state_machine:
@@ -33,7 +33,7 @@ sylius_admin_product_review_reject:
     path: /product-review/{id}/reject
     methods: [PUT]
     defaults:
-        _controller: sylius.controller.product_review:applyStateMachineTransitionAction
+        _controller: sylius.controller.product_review::applyStateMachineTransitionAction
         _sylius:
             permission: true
             state_machine:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_variant.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_variant.yml
@@ -2,7 +2,7 @@ sylius_admin_product_variant_index:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product_variant:indexAction
+        _controller: sylius.controller.product_variant::indexAction
         _sylius:
             template: "@SyliusAdmin/ProductVariant/index.html.twig"
             grid: sylius_admin_product_variant
@@ -21,7 +21,7 @@ sylius_admin_product_variant_create:
     path: /new
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.product_variant:createAction
+        _controller: sylius.controller.product_variant::createAction
         _sylius:
             factory:
                 method: createForProduct
@@ -47,7 +47,7 @@ sylius_admin_product_variant_update:
     path: /{id}/edit
     methods: [GET, PUT]
     defaults:
-        _controller: sylius.controller.product_variant:updateAction
+        _controller: sylius.controller.product_variant::updateAction
         _sylius:
             template: "@SyliusAdmin/Crud/update.html.twig"
             grid: sylius_admin_product_variant
@@ -74,7 +74,7 @@ sylius_admin_product_variant_bulk_delete:
     path: /bulk-delete
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.product_variant:bulkDeleteAction
+        _controller: sylius.controller.product_variant::bulkDeleteAction
         _sylius:
             section: admin
             redirect: referer
@@ -87,7 +87,7 @@ sylius_admin_product_variant_delete:
     path: /{id}
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.product_variant:deleteAction
+        _controller: sylius.controller.product_variant::deleteAction
         _sylius:
             section: admin
             redirect: referer
@@ -102,7 +102,7 @@ sylius_admin_product_variant_generate:
     path: /generate
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.product:updateAction
+        _controller: sylius.controller.product::updateAction
         _sylius:
             template: "@SyliusAdmin/ProductVariant/generate.html.twig"
             section: admin

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/promotion_coupon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/promotion_coupon.yml
@@ -2,7 +2,7 @@ sylius_admin_promotion_coupon_index:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.promotion_coupon:indexAction
+        _controller: sylius.controller.promotion_coupon::indexAction
         _sylius:
             template: "@SyliusAdmin/PromotionCoupon/index.html.twig"
             grid: sylius_admin_promotion_coupon
@@ -21,7 +21,7 @@ sylius_admin_promotion_coupon_create:
     path: /new
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.promotion_coupon:createAction
+        _controller: sylius.controller.promotion_coupon::createAction
         _sylius:
             factory:
                 method: createForPromotion
@@ -47,7 +47,7 @@ sylius_admin_promotion_coupon_update:
     path: /{id}/edit
     methods: [GET, PUT]
     defaults:
-        _controller: sylius.controller.promotion_coupon:updateAction
+        _controller: sylius.controller.promotion_coupon::updateAction
         _sylius:
             template: "@SyliusAdmin/Crud/update.html.twig"
             grid: sylius_admin_promotion_coupon
@@ -70,7 +70,7 @@ sylius_admin_promotion_coupon_generate:
     path: /generate
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.promotion_coupon:generateAction
+        _controller: sylius.controller.promotion_coupon::generateAction
         _sylius:
             template: "@SyliusAdmin/PromotionCoupon/generate.html.twig"
             section: admin
@@ -83,7 +83,7 @@ sylius_admin_promotion_coupon_bulk_delete:
     path: /bulk-delete
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.promotion_coupon:bulkDeleteAction
+        _controller: sylius.controller.promotion_coupon::bulkDeleteAction
         _sylius:
             section: admin
             redirect: referer
@@ -97,7 +97,7 @@ sylius_admin_promotion_coupon_delete:
     path: /{id}
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.promotion_coupon:deleteAction
+        _controller: sylius.controller.promotion_coupon::deleteAction
         _sylius:
             section: admin
             redirect: referer

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/security.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/security.yml
@@ -2,7 +2,7 @@ sylius_admin_login:
     path: /login
     methods: [GET]
     defaults:
-        _controller: sylius.controller.security:loginAction
+        _controller: sylius.controller.security::loginAction
         _sylius:
             template: SyliusAdminBundle:Security:login.html.twig
             permission: true
@@ -12,7 +12,7 @@ sylius_admin_login_check:
     path: /login-check
     methods: [POST]
     defaults:
-        _controller: sylius.controller.security:checkAction
+        _controller: sylius.controller.security::checkAction
 
 sylius_admin_logout:
     path: /logout

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shipping_method.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shipping_method.yml
@@ -20,7 +20,7 @@ sylius_admin_shipping_method_archive:
     path: /shipping-methods/{id}/archive
     methods: [PATCH]
     defaults:
-        _controller: sylius.controller.shipping_method:updateAction
+        _controller: sylius.controller.shipping_method::updateAction
         _sylius:
             section: admin
             permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shop_user.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shop_user.yml
@@ -2,7 +2,7 @@ sylius_admin_shop_user_delete:
     path: /{id}
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.shop_user:deleteAction
+        _controller: sylius.controller.shop_user::deleteAction
         _sylius:
             section: admin
             redirect: referer

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/taxon.yml
@@ -17,7 +17,7 @@ sylius_admin_taxon_index:
     path: /taxons/
     methods: [GET]
     defaults:
-        _controller: FrameworkBundle:Redirect:redirect
+        _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction
         route: sylius_admin_taxon_create
         permanent: true
 
@@ -25,7 +25,7 @@ sylius_admin_taxon_create_for_parent:
     path: /taxons/new/{id}
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.taxon:createAction
+        _controller: sylius.controller.taxon::createAction
         _sylius:
             section: admin
             permission: true

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/zone.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/zone.yml
@@ -20,7 +20,7 @@ sylius_admin_zone_create:
     path: /zones/{type}/new
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.zone:createAction
+        _controller: sylius.controller.zone::createAction
         _sylius:
             section: admin
             factory:

--- a/src/Sylius/Bundle/ResourceBundle/Routing/ResourceLoader.php
+++ b/src/Sylius/Bundle/ResourceBundle/Routing/ResourceLoader.php
@@ -154,7 +154,7 @@ final class ResourceLoader implements LoaderInterface
         bool $isApi = false
     ): Route {
         $defaults = [
-            '_controller' => $metadata->getServiceId('controller') . sprintf(':%sAction', $actionName),
+            '_controller' => $metadata->getServiceId('controller') . sprintf('::%sAction', $actionName),
         ];
 
         if ($isApi && 'index' === $actionName) {

--- a/src/Sylius/Bundle/ResourceBundle/spec/Routing/ResourceLoaderSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Routing/ResourceLoaderSpec.php
@@ -87,7 +87,7 @@ alias: sylius.product
 EOT;
 
         $showDefaults = [
-            '_controller' => 'sylius.controller.product:showAction',
+            '_controller' => 'sylius.controller.product::showAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -99,7 +99,7 @@ EOT;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
-            '_controller' => 'sylius.controller.product:indexAction',
+            '_controller' => 'sylius.controller.product::indexAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -111,7 +111,7 @@ EOT;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product:createAction',
+            '_controller' => 'sylius.controller.product::createAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -123,7 +123,7 @@ EOT;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
-            '_controller' => 'sylius.controller.product:updateAction',
+            '_controller' => 'sylius.controller.product::updateAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -135,7 +135,7 @@ EOT;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
 
         $bulkDeleteDefaults = [
-            '_controller' => 'sylius.controller.product:bulkDeleteAction',
+            '_controller' => 'sylius.controller.product::bulkDeleteAction',
             '_sylius' => [
                 'permission' => false,
                 'paginate' => false,
@@ -152,7 +152,7 @@ EOT;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
 
         $deleteDefaults = [
-            '_controller' => 'sylius.controller.product:deleteAction',
+            '_controller' => 'sylius.controller.product::deleteAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -192,7 +192,7 @@ alias: sylius.product_option
 EOT;
 
         $showDefaults = [
-            '_controller' => 'sylius.controller.product_option:showAction',
+            '_controller' => 'sylius.controller.product_option::showAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -204,7 +204,7 @@ EOT;
         $routeCollection->add('sylius_product_option_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
-            '_controller' => 'sylius.controller.product_option:indexAction',
+            '_controller' => 'sylius.controller.product_option::indexAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -216,7 +216,7 @@ EOT;
         $routeCollection->add('sylius_product_option_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product_option:createAction',
+            '_controller' => 'sylius.controller.product_option::createAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -228,7 +228,7 @@ EOT;
         $routeCollection->add('sylius_product_option_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
-            '_controller' => 'sylius.controller.product_option:updateAction',
+            '_controller' => 'sylius.controller.product_option::updateAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -240,7 +240,7 @@ EOT;
         $routeCollection->add('sylius_product_option_update', $updateRoute)->shouldBeCalled();
 
         $bulkDeleteDefaults = [
-            '_controller' => 'sylius.controller.product_option:bulkDeleteAction',
+            '_controller' => 'sylius.controller.product_option::bulkDeleteAction',
             '_sylius' => [
                 'permission' => false,
                 'paginate' => false,
@@ -257,7 +257,7 @@ EOT;
         $routeCollection->add('sylius_product_option_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
 
         $deleteDefaults = [
-            '_controller' => 'sylius.controller.product_option:deleteAction',
+            '_controller' => 'sylius.controller.product_option::deleteAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -301,7 +301,7 @@ filterable: true
 EOT;
 
         $showDefaults = [
-            '_controller' => 'sylius.controller.product_option:showAction',
+            '_controller' => 'sylius.controller.product_option::showAction',
             '_sylius' => [
                 'permission' => false,
                 'criteria' => [
@@ -317,7 +317,7 @@ EOT;
         $routeCollection->add('sylius_product_option_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
-            '_controller' => 'sylius.controller.product_option:indexAction',
+            '_controller' => 'sylius.controller.product_option::indexAction',
             '_sylius' => [
                 'permission' => false,
                 'criteria' => [
@@ -333,7 +333,7 @@ EOT;
         $routeCollection->add('sylius_product_option_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product_option:createAction',
+            '_controller' => 'sylius.controller.product_option::createAction',
             '_sylius' => [
                 'permission' => false,
                 'criteria' => [
@@ -349,7 +349,7 @@ EOT;
         $routeCollection->add('sylius_product_option_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
-            '_controller' => 'sylius.controller.product_option:updateAction',
+            '_controller' => 'sylius.controller.product_option::updateAction',
             '_sylius' => [
                 'permission' => false,
                 'criteria' => [
@@ -365,7 +365,7 @@ EOT;
         $routeCollection->add('sylius_product_option_update', $updateRoute)->shouldBeCalled();
 
         $bulkDeleteDefaults = [
-            '_controller' => 'sylius.controller.product_option:bulkDeleteAction',
+            '_controller' => 'sylius.controller.product_option::bulkDeleteAction',
             '_sylius' => [
                 'permission' => false,
                 'paginate' => false,
@@ -386,7 +386,7 @@ EOT;
         $routeCollection->add('sylius_product_option_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
 
         $deleteDefaults = [
-            '_controller' => 'sylius.controller.product_option:deleteAction',
+            '_controller' => 'sylius.controller.product_option::deleteAction',
             '_sylius' => [
                 'permission' => false,
                 'criteria' => [
@@ -431,7 +431,7 @@ path: super-duper-products
 EOT;
 
         $showDefaults = [
-            '_controller' => 'sylius.controller.product:showAction',
+            '_controller' => 'sylius.controller.product::showAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -443,7 +443,7 @@ EOT;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
-            '_controller' => 'sylius.controller.product:indexAction',
+            '_controller' => 'sylius.controller.product::indexAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -455,7 +455,7 @@ EOT;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product:createAction',
+            '_controller' => 'sylius.controller.product::createAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -467,7 +467,7 @@ EOT;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
-            '_controller' => 'sylius.controller.product:updateAction',
+            '_controller' => 'sylius.controller.product::updateAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -479,7 +479,7 @@ EOT;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
 
         $bulkDeleteDefaults = [
-            '_controller' => 'sylius.controller.product:bulkDeleteAction',
+            '_controller' => 'sylius.controller.product::bulkDeleteAction',
             '_sylius' => [
                 'permission' => false,
                 'paginate' => false,
@@ -496,7 +496,7 @@ EOT;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
 
         $deleteDefaults = [
-            '_controller' => 'sylius.controller.product:deleteAction',
+            '_controller' => 'sylius.controller.product::deleteAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -537,7 +537,7 @@ form: sylius_product_custom
 EOT;
 
         $showDefaults = [
-            '_controller' => 'sylius.controller.product:showAction',
+            '_controller' => 'sylius.controller.product::showAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -549,7 +549,7 @@ EOT;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
-            '_controller' => 'sylius.controller.product:indexAction',
+            '_controller' => 'sylius.controller.product::indexAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -561,7 +561,7 @@ EOT;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product:createAction',
+            '_controller' => 'sylius.controller.product::createAction',
             '_sylius' => [
                 'form' => 'sylius_product_custom',
                 'permission' => false,
@@ -574,7 +574,7 @@ EOT;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
-            '_controller' => 'sylius.controller.product:updateAction',
+            '_controller' => 'sylius.controller.product::updateAction',
             '_sylius' => [
                 'form' => 'sylius_product_custom',
                 'permission' => false,
@@ -587,7 +587,7 @@ EOT;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
 
         $bulkDeleteDefaults = [
-            '_controller' => 'sylius.controller.product:bulkDeleteAction',
+            '_controller' => 'sylius.controller.product::bulkDeleteAction',
             '_sylius' => [
                 'permission' => false,
                 'paginate' => false,
@@ -604,7 +604,7 @@ EOT;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
 
         $deleteDefaults = [
-            '_controller' => 'sylius.controller.product:deleteAction',
+            '_controller' => 'sylius.controller.product::deleteAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -645,7 +645,7 @@ section: admin
 EOT;
 
         $showDefaults = [
-            '_controller' => 'sylius.controller.product:showAction',
+            '_controller' => 'sylius.controller.product::showAction',
             '_sylius' => [
                 'section' => 'admin',
                 'permission' => false,
@@ -658,7 +658,7 @@ EOT;
         $routeCollection->add('sylius_admin_product_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
-            '_controller' => 'sylius.controller.product:indexAction',
+            '_controller' => 'sylius.controller.product::indexAction',
             '_sylius' => [
                 'section' => 'admin',
                 'permission' => false,
@@ -671,7 +671,7 @@ EOT;
         $routeCollection->add('sylius_admin_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product:createAction',
+            '_controller' => 'sylius.controller.product::createAction',
             '_sylius' => [
                 'section' => 'admin',
                 'permission' => false,
@@ -684,7 +684,7 @@ EOT;
         $routeCollection->add('sylius_admin_product_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
-            '_controller' => 'sylius.controller.product:updateAction',
+            '_controller' => 'sylius.controller.product::updateAction',
             '_sylius' => [
                 'section' => 'admin',
                 'permission' => false,
@@ -697,7 +697,7 @@ EOT;
         $routeCollection->add('sylius_admin_product_update', $updateRoute)->shouldBeCalled();
 
         $bulkDeleteDefaults = [
-            '_controller' => 'sylius.controller.product:bulkDeleteAction',
+            '_controller' => 'sylius.controller.product::bulkDeleteAction',
             '_sylius' => [
                 'section' => 'admin',
                 'permission' => false,
@@ -715,7 +715,7 @@ EOT;
         $routeCollection->add('sylius_admin_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
 
         $deleteDefaults = [
-            '_controller' => 'sylius.controller.product:deleteAction',
+            '_controller' => 'sylius.controller.product::deleteAction',
             '_sylius' => [
                 'section' => 'admin',
                 'permission' => false,
@@ -757,7 +757,7 @@ templates: SyliusAdminBundle:Product
 EOT;
 
         $showDefaults = [
-            '_controller' => 'sylius.controller.product:showAction',
+            '_controller' => 'sylius.controller.product::showAction',
             '_sylius' => [
                 'template' => 'SyliusAdminBundle:Product:show.html.twig',
                 'permission' => false,
@@ -770,7 +770,7 @@ EOT;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
-            '_controller' => 'sylius.controller.product:indexAction',
+            '_controller' => 'sylius.controller.product::indexAction',
             '_sylius' => [
                 'template' => 'SyliusAdminBundle:Product:index.html.twig',
                 'permission' => false,
@@ -783,7 +783,7 @@ EOT;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product:createAction',
+            '_controller' => 'sylius.controller.product::createAction',
             '_sylius' => [
                 'template' => 'SyliusAdminBundle:Product:create.html.twig',
                 'permission' => false,
@@ -796,7 +796,7 @@ EOT;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
-            '_controller' => 'sylius.controller.product:updateAction',
+            '_controller' => 'sylius.controller.product::updateAction',
             '_sylius' => [
                 'template' => 'SyliusAdminBundle:Product:update.html.twig',
                 'permission' => false,
@@ -809,7 +809,7 @@ EOT;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
 
         $bulkDeleteDefaults = [
-            '_controller' => 'sylius.controller.product:bulkDeleteAction',
+            '_controller' => 'sylius.controller.product::bulkDeleteAction',
             '_sylius' => [
                 'permission' => false,
                 'paginate' => false,
@@ -826,7 +826,7 @@ EOT;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
 
         $deleteDefaults = [
-            '_controller' => 'sylius.controller.product:deleteAction',
+            '_controller' => 'sylius.controller.product::deleteAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -867,7 +867,7 @@ templates: admin/product
 EOT;
 
         $showDefaults = [
-            '_controller' => 'sylius.controller.product:showAction',
+            '_controller' => 'sylius.controller.product::showAction',
             '_sylius' => [
                 'template' => 'admin/product/show.html.twig',
                 'permission' => false,
@@ -880,7 +880,7 @@ EOT;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
-            '_controller' => 'sylius.controller.product:indexAction',
+            '_controller' => 'sylius.controller.product::indexAction',
             '_sylius' => [
                 'template' => 'admin/product/index.html.twig',
                 'permission' => false,
@@ -893,7 +893,7 @@ EOT;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product:createAction',
+            '_controller' => 'sylius.controller.product::createAction',
             '_sylius' => [
                 'template' => 'admin/product/create.html.twig',
                 'permission' => false,
@@ -906,7 +906,7 @@ EOT;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
-            '_controller' => 'sylius.controller.product:updateAction',
+            '_controller' => 'sylius.controller.product::updateAction',
             '_sylius' => [
                 'template' => 'admin/product/update.html.twig',
                 'permission' => false,
@@ -919,7 +919,7 @@ EOT;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
 
         $bulkDeleteDefaults = [
-            '_controller' => 'sylius.controller.product:bulkDeleteAction',
+            '_controller' => 'sylius.controller.product::bulkDeleteAction',
             '_sylius' => [
                 'permission' => false,
                 'paginate' => false,
@@ -936,7 +936,7 @@ EOT;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
 
         $deleteDefaults = [
-            '_controller' => 'sylius.controller.product:deleteAction',
+            '_controller' => 'sylius.controller.product::deleteAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -974,7 +974,7 @@ except: ['show', 'delete', 'bulkDelete']
 EOT;
 
         $indexDefaults = [
-            '_controller' => 'sylius.controller.product:indexAction',
+            '_controller' => 'sylius.controller.product::indexAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -986,7 +986,7 @@ EOT;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product:createAction',
+            '_controller' => 'sylius.controller.product::createAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -998,7 +998,7 @@ EOT;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
-            '_controller' => 'sylius.controller.product:updateAction',
+            '_controller' => 'sylius.controller.product::updateAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -1035,7 +1035,7 @@ only: ['create', 'index']
 EOT;
 
         $indexDefaults = [
-            '_controller' => 'sylius.controller.product:indexAction',
+            '_controller' => 'sylius.controller.product::indexAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -1047,7 +1047,7 @@ EOT;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product:createAction',
+            '_controller' => 'sylius.controller.product::createAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -1102,7 +1102,7 @@ redirect: update
 EOT;
 
         $showDefaults = [
-            '_controller' => 'sylius.controller.product:showAction',
+            '_controller' => 'sylius.controller.product::showAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -1114,7 +1114,7 @@ EOT;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
-            '_controller' => 'sylius.controller.product:indexAction',
+            '_controller' => 'sylius.controller.product::indexAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -1126,7 +1126,7 @@ EOT;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product:createAction',
+            '_controller' => 'sylius.controller.product::createAction',
             '_sylius' => [
                 'redirect' => 'sylius_product_update',
                 'permission' => false,
@@ -1139,7 +1139,7 @@ EOT;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
-            '_controller' => 'sylius.controller.product:updateAction',
+            '_controller' => 'sylius.controller.product::updateAction',
             '_sylius' => [
                 'redirect' => 'sylius_product_update',
                 'permission' => false,
@@ -1152,7 +1152,7 @@ EOT;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
 
         $bulkDeleteDefaults = [
-            '_controller' => 'sylius.controller.product:bulkDeleteAction',
+            '_controller' => 'sylius.controller.product::bulkDeleteAction',
             '_sylius' => [
                 'permission' => false,
                 'paginate' => false,
@@ -1169,7 +1169,7 @@ EOT;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
 
         $deleteDefaults = [
-            '_controller' => 'sylius.controller.product:deleteAction',
+            '_controller' => 'sylius.controller.product::deleteAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -1208,7 +1208,7 @@ alias: sylius.product
 EOT;
 
         $showDefaults = [
-            '_controller' => 'sylius.controller.product:showAction',
+            '_controller' => 'sylius.controller.product::showAction',
             '_sylius' => [
                 'serialization_groups' => ['Default', 'Detailed'],
                 'permission' => false,
@@ -1221,7 +1221,7 @@ EOT;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
-            '_controller' => 'sylius.controller.product:indexAction',
+            '_controller' => 'sylius.controller.product::indexAction',
             '_sylius' => [
                 'serialization_groups' => ['Default'],
                 'permission' => false,
@@ -1234,7 +1234,7 @@ EOT;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product:createAction',
+            '_controller' => 'sylius.controller.product::createAction',
             '_sylius' => [
                 'serialization_groups' => ['Default', 'Detailed'],
                 'permission' => false,
@@ -1247,7 +1247,7 @@ EOT;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
-            '_controller' => 'sylius.controller.product:updateAction',
+            '_controller' => 'sylius.controller.product::updateAction',
             '_sylius' => [
                 'serialization_groups' => ['Default', 'Detailed'],
                 'permission' => false,
@@ -1260,7 +1260,7 @@ EOT;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
 
         $deleteDefaults = [
-            '_controller' => 'sylius.controller.product:deleteAction',
+            '_controller' => 'sylius.controller.product::deleteAction',
             '_sylius' => [
                 'permission' => false,
                 'csrf_protection' => false,
@@ -1299,7 +1299,7 @@ grid: sylius_admin_product
 EOT;
 
         $indexDefaults = [
-            '_controller' => 'sylius.controller.product:indexAction',
+            '_controller' => 'sylius.controller.product::indexAction',
             '_sylius' => [
                 'grid' => 'sylius_admin_product',
                 'permission' => false,
@@ -1312,7 +1312,7 @@ EOT;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product:createAction',
+            '_controller' => 'sylius.controller.product::createAction',
             '_sylius' => [
                 'permission' => false,
             ],
@@ -1359,7 +1359,7 @@ vars:
 EOT;
 
         $showDefaults = [
-            '_controller' => 'sylius.controller.product:showAction',
+            '_controller' => 'sylius.controller.product::showAction',
             '_sylius' => [
                 'permission' => false,
                 'vars' => [
@@ -1374,7 +1374,7 @@ EOT;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
-            '_controller' => 'sylius.controller.product:indexAction',
+            '_controller' => 'sylius.controller.product::indexAction',
             '_sylius' => [
                 'permission' => false,
                 'vars' => [
@@ -1389,7 +1389,7 @@ EOT;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product:createAction',
+            '_controller' => 'sylius.controller.product::createAction',
             '_sylius' => [
                 'permission' => false,
                 'vars' => [
@@ -1405,7 +1405,7 @@ EOT;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
-            '_controller' => 'sylius.controller.product:updateAction',
+            '_controller' => 'sylius.controller.product::updateAction',
             '_sylius' => [
                 'permission' => false,
                 'vars' => [
@@ -1421,7 +1421,7 @@ EOT;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
 
         $bulkDeleteDefaults = [
-            '_controller' => 'sylius.controller.product:bulkDeleteAction',
+            '_controller' => 'sylius.controller.product::bulkDeleteAction',
             '_sylius' => [
                 'permission' => false,
                 'paginate' => false,
@@ -1441,7 +1441,7 @@ EOT;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
 
         $deleteDefaults = [
-            '_controller' => 'sylius.controller.product:deleteAction',
+            '_controller' => 'sylius.controller.product::deleteAction',
             '_sylius' => [
                 'permission' => false,
                 'vars' => [
@@ -1485,7 +1485,7 @@ permission: true
 EOT;
 
         $showDefaults = [
-            '_controller' => 'sylius.controller.product:showAction',
+            '_controller' => 'sylius.controller.product::showAction',
             '_sylius' => [
                 'permission' => true,
             ],
@@ -1497,7 +1497,7 @@ EOT;
         $routeCollection->add('sylius_product_show', $showRoute)->shouldBeCalled();
 
         $indexDefaults = [
-            '_controller' => 'sylius.controller.product:indexAction',
+            '_controller' => 'sylius.controller.product::indexAction',
             '_sylius' => [
                 'permission' => true,
             ],
@@ -1509,7 +1509,7 @@ EOT;
         $routeCollection->add('sylius_product_index', $indexRoute)->shouldBeCalled();
 
         $createDefaults = [
-            '_controller' => 'sylius.controller.product:createAction',
+            '_controller' => 'sylius.controller.product::createAction',
             '_sylius' => [
                 'permission' => true,
             ],
@@ -1521,7 +1521,7 @@ EOT;
         $routeCollection->add('sylius_product_create', $createRoute)->shouldBeCalled();
 
         $updateDefaults = [
-            '_controller' => 'sylius.controller.product:updateAction',
+            '_controller' => 'sylius.controller.product::updateAction',
             '_sylius' => [
                 'permission' => true,
             ],
@@ -1533,7 +1533,7 @@ EOT;
         $routeCollection->add('sylius_product_update', $updateRoute)->shouldBeCalled();
 
         $bulkDeleteDefaults = [
-            '_controller' => 'sylius.controller.product:bulkDeleteAction',
+            '_controller' => 'sylius.controller.product::bulkDeleteAction',
             '_sylius' => [
                 'permission' => true,
                 'paginate' => false,
@@ -1550,7 +1550,7 @@ EOT;
         $routeCollection->add('sylius_product_bulk_delete', $bulkDeleteRoute)->shouldBeCalled();
 
         $deleteDefaults = [
-            '_controller' => 'sylius.controller.product:deleteAction',
+            '_controller' => 'sylius.controller.product::deleteAction',
             '_sylius' => [
                 'permission' => true,
             ],

--- a/src/Sylius/Bundle/ResourceBundle/spec/Routing/RouteFactorySpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Routing/RouteFactorySpec.php
@@ -33,7 +33,7 @@ final class RouteFactorySpec extends ObjectBehavior
     function it_creates_a_new_route(): void
     {
         $defaults = [
-            '_controller' => 'sylius.controller.product:showAction',
+            '_controller' => 'sylius.controller.product::showAction',
         ];
 
         $requirements = [

--- a/src/Sylius/Bundle/ResourceBundle/test/app/config/routing.yml
+++ b/src/Sylius/Bundle/ResourceBundle/test/app/config/routing.yml
@@ -7,7 +7,7 @@ app_book_sortable_index:
     path: /books/sortable/
     methods: [GET]
     defaults:
-        _controller: app.controller.book:indexAction
+        _controller: app.controller.book::indexAction
         _sylius:
             sortable: true
 
@@ -15,7 +15,7 @@ app_book_filterable_index:
     path: /books/filterable/
     methods: [GET]
     defaults:
-        _controller: app.controller.book:indexAction
+        _controller: app.controller.book::indexAction
         _sylius:
             filterable: true
 
@@ -27,7 +27,7 @@ app_create_book_with_custom_factory:
     path: /books/create-custom
     methods: [POST]
     defaults:
-        _controller: app.controller.book:createAction
+        _controller: app.controller.book::createAction
         _sylius:
             factory:
                 method: ["expr:service('test.custom_book_factory')", "createCustom"]
@@ -36,7 +36,7 @@ app_index_books_with_custom_repository:
     path: /find-custom-books
     methods: [GET]
     defaults:
-        _controller: app.controller.book:indexAction
+        _controller: app.controller.book::indexAction
         _sylius:
             repository:
                 method: ["expr:service('test.custom_book_repository')", "findCustomBooks"]
@@ -45,7 +45,7 @@ app_show_book_with_custom_repository:
     path: /find-custom-book
     methods: [GET]
     defaults:
-        _controller: app.controller.book:showAction
+        _controller: app.controller.book::showAction
         _sylius:
             repository:
                 method: ["expr:service('test.custom_book_repository')", "findCustomBook"]

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing.yml
@@ -13,7 +13,7 @@ sylius_shop_homepage:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.shop.homepage:indexAction
+        _controller: sylius.controller.shop.homepage::indexAction
 
 sylius_shop_security:
     resource: "@SyliusShopBundle/Resources/config/routing/security.yml"
@@ -52,10 +52,10 @@ sylius_shop_switch_currency:
     path: /switch-currency/{code}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.shop.currency_switch:switchAction
+        _controller: sylius.controller.shop.currency_switch::switchAction
 
 sylius_shop_switch_locale:
     path: /switch-locale/{code}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.shop.locale_switch:switchAction
+        _controller: sylius.controller.shop.locale_switch::switchAction

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/account.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/account.yml
@@ -13,7 +13,7 @@ sylius_shop_account_root:
     path: /
     methods: [GET]
     defaults:
-        _controller: FrameworkBundle:Redirect:redirect
+        _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction
         route: sylius_shop_account_dashboard
         permanent: true
 
@@ -21,7 +21,7 @@ sylius_shop_account_dashboard:
     path: /dashboard
     methods: [GET]
     defaults:
-        _controller: sylius.controller.customer:showAction
+        _controller: sylius.controller.customer::showAction
         _sylius:
             template: "@SyliusShop/Account/dashboard.html.twig"
             repository:
@@ -33,7 +33,7 @@ sylius_shop_account_profile_update:
     path: /profile/edit
     methods: [GET, PUT]
     defaults:
-        _controller: sylius.controller.customer:updateAction
+        _controller: sylius.controller.customer::updateAction
         _sylius:
             template: "@SyliusShop/Account/profileUpdate.html.twig"
             form: Sylius\Bundle\CustomerBundle\Form\Type\CustomerProfileType
@@ -49,7 +49,7 @@ sylius_shop_account_change_password:
     path: /change-password
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.shop_user:changePasswordAction
+        _controller: sylius.controller.shop_user::changePasswordAction
         _sylius:
             template: "@SyliusShop/Account/changePassword.html.twig"
             redirect: sylius_shop_account_dashboard

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/account/address_book.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/account/address_book.yml
@@ -5,7 +5,7 @@ sylius_shop_account_address_book_index:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.address:indexAction
+        _controller: sylius.controller.address::indexAction
         _sylius:
             section: shop_account
             template: "@SyliusShop/Account/AddressBook/index.html.twig"
@@ -19,7 +19,7 @@ sylius_shop_account_address_book_create:
     path: /add
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.address:createAction
+        _controller: sylius.controller.address::createAction
         _sylius:
             section: shop_account
             template: "@SyliusShop/Account/AddressBook/create.html.twig"
@@ -36,7 +36,7 @@ sylius_shop_account_address_book_update:
     path: /{id}/edit
     methods: [GET, PUT]
     defaults:
-        _controller: sylius.controller.address:updateAction
+        _controller: sylius.controller.address::updateAction
         _sylius:
             section: shop_account
             template: "@SyliusShop/Account/AddressBook/update.html.twig"
@@ -53,7 +53,7 @@ sylius_shop_account_address_book_delete:
     path: /{id}
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.address:deleteAction
+        _controller: sylius.controller.address::deleteAction
         _sylius:
             section: shop_account
             repository:
@@ -67,7 +67,7 @@ sylius_shop_account_address_book_set_as_default:
     path: /{id}/set-as-default
     methods: [GET, PATCH]
     defaults:
-        _controller: sylius.controller.customer:updateAction
+        _controller: sylius.controller.customer::updateAction
         _sylius:
             section: shop_account
             template: "@SyliusShop/Account/AddressBook/_defaultAddressForm.html.twig"

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/account/order.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/account/order.yml
@@ -5,7 +5,7 @@ sylius_shop_account_order_index:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:indexAction
+        _controller: sylius.controller.order::indexAction
         _sylius:
             section: shop_account
             template: "@SyliusShop/Account/Order/index.html.twig"
@@ -15,7 +15,7 @@ sylius_shop_account_order_show:
     path: /{number}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:showAction
+        _controller: sylius.controller.order::showAction
         _sylius:
             section: shop_account
             template: "@SyliusShop/Account/Order/show.html.twig"

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/ajax.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/ajax.yml
@@ -13,6 +13,6 @@ sylius_shop_ajax_render_province_form:
     path: /render-province-form
     methods: [GET]
     defaults:
-        _controller: sylius.controller.province:choiceOrTextFieldFormAction
+        _controller: sylius.controller.province::choiceOrTextFieldFormAction
         _sylius:
             template: "@SyliusShop/Common/Form/_province.html.twig"

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/ajax/cart.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/ajax/cart.yml
@@ -5,7 +5,7 @@ sylius_shop_ajax_cart_add_item:
     path: /add
     methods: [POST]
     defaults:
-        _controller: sylius.controller.order_item:addAction
+        _controller: sylius.controller.order_item::addAction
         _format: json
         _sylius:
             factory:
@@ -24,7 +24,7 @@ sylius_shop_ajax_cart_item_remove:
     path: /{id}/remove
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.order_item:removeAction
+        _controller: sylius.controller.order_item::removeAction
         _format: json
         _sylius:
             flash: sylius.cart.remove_item

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/ajax/user.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/ajax/user.yml
@@ -5,7 +5,7 @@ sylius_shop_ajax_user_check_action:
     path: /check
     methods: [GET]
     defaults:
-        _controller: sylius.controller.shop_user:showAction
+        _controller: sylius.controller.shop_user::showAction
         _format: json
         _sylius:
             repository:

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/cart.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/cart.yml
@@ -5,7 +5,7 @@ sylius_shop_cart_summary:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:summaryAction
+        _controller: sylius.controller.order::summaryAction
         _sylius:
             template: "@SyliusShop/Cart/summary.html.twig"
             form: Sylius\Bundle\OrderBundle\Form\Type\CartType
@@ -14,7 +14,7 @@ sylius_shop_cart_save:
     path: /
     methods: [PUT, PATCH]
     defaults:
-        _controller: sylius.controller.order:saveAction
+        _controller: sylius.controller.order::saveAction
         _sylius:
             template: "@SyliusShop/Cart/summary.html.twig"
             redirect: sylius_shop_cart_summary
@@ -25,6 +25,6 @@ sylius_shop_cart_clear:
     path: /
     methods: [DELETE]
     defaults:
-        _controller: sylius.controller.order:clearAction
+        _controller: sylius.controller.order::clearAction
         _sylius:
             redirect: sylius_shop_cart_summary

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/checkout.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/checkout.yml
@@ -5,14 +5,14 @@ sylius_shop_checkout_start:
     path: /
     methods: [GET]
     defaults:
-        _controller: FrameworkBundle:Redirect:redirect
+        _controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::redirectAction
         route: sylius_shop_checkout_address
 
 sylius_shop_checkout_address:
     path: /address
     methods: [GET, PUT]
     defaults:
-        _controller: sylius.controller.order:updateAction
+        _controller: sylius.controller.order::updateAction
         _sylius:
             event: address
             flash: false
@@ -33,7 +33,7 @@ sylius_shop_checkout_select_shipping:
     path: /select-shipping
     methods: [GET, PUT]
     defaults:
-        _controller: sylius.controller.order:updateAction
+        _controller: sylius.controller.order::updateAction
         _sylius:
             event: select_shipping
             flash: false
@@ -51,7 +51,7 @@ sylius_shop_checkout_select_payment:
     path: /select-payment
     methods: [GET, PUT]
     defaults:
-        _controller: sylius.controller.order:updateAction
+        _controller: sylius.controller.order::updateAction
         _sylius:
             event: payment
             flash: false
@@ -69,7 +69,7 @@ sylius_shop_checkout_complete:
     path: /complete
     methods: [GET, PUT]
     defaults:
-        _controller: sylius.controller.order:updateAction
+        _controller: sylius.controller.order::updateAction
         _sylius:
             event: complete
             flash: false

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/contact.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/contact.yml
@@ -5,6 +5,6 @@ sylius_shop_contact_request:
     path: /
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.shop.contact:requestAction
+        _controller: sylius.controller.shop.contact::requestAction
         _sylius:
             redirect: sylius_shop_homepage

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/order.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/order.yml
@@ -5,7 +5,7 @@ sylius_shop_order_thank_you:
     path: /thank-you
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:thankYouAction
+        _controller: sylius.controller.order::thankYouAction
         _sylius:
             template: "@SyliusShop/Order/thankYou.html.twig"
 
@@ -13,7 +13,7 @@ sylius_shop_order_pay:
     path: /{tokenValue}/pay
     methods: [GET]
     defaults:
-        _controller: sylius.controller.payum:prepareCaptureAction
+        _controller: sylius.controller.payum::prepareCaptureAction
         _sylius:
             redirect:
                 route: sylius_shop_order_after_pay
@@ -22,13 +22,13 @@ sylius_shop_order_after_pay:
     path: /after-pay
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.payum:afterCaptureAction
+        _controller: sylius.controller.payum::afterCaptureAction
 
 sylius_shop_order_show:
     path: /{tokenValue}
     methods: [GET, PUT]
     defaults:
-        _controller: sylius.controller.order:updateAction
+        _controller: sylius.controller.order::updateAction
         _sylius:
             template: "@SyliusShop/Order/show.html.twig"
             repository:

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/cart.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/cart.yml
@@ -5,7 +5,7 @@ sylius_shop_partial_cart_summary:
     path: /summary
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order:widgetAction
+        _controller: sylius.controller.order::widgetAction
         _sylius:
             template: $template
 
@@ -13,7 +13,7 @@ sylius_shop_partial_cart_add_item:
     path: /add-item
     methods: [GET]
     defaults:
-        _controller: sylius.controller.order_item:addAction
+        _controller: sylius.controller.order_item::addAction
         _sylius:
             template: $template
             factory:

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/product.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/product.yml
@@ -5,7 +5,7 @@ sylius_shop_partial_product_index_latest:
     path: /latest/{count}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product:indexAction
+        _controller: sylius.controller.product::indexAction
         _sylius:
             template: $template
             repository:
@@ -19,7 +19,7 @@ sylius_shop_partial_product_show_by_slug:
     path: /{slug}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product:showAction
+        _controller: sylius.controller.product::showAction
         _sylius:
             template: $template
             repository:

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/product_association.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/product_association.yml
@@ -5,6 +5,6 @@ sylius_shop_partial_product_association_show:
     path: /{id}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product_association:showAction
+        _controller: sylius.controller.product_association::showAction
         _sylius:
             template: $template

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/product_review.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/product_review.yml
@@ -5,7 +5,7 @@ sylius_shop_partial_product_review_latest:
     path: /latest/{count}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product_review:indexAction
+        _controller: sylius.controller.product_review::indexAction
         _sylius:
             template: $template
             repository:

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/taxon.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/taxon.yml
@@ -5,7 +5,7 @@ sylius_shop_partial_taxon_show_by_slug:
     path: /by-slug/{slug}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.taxon:showAction
+        _controller: sylius.controller.taxon::showAction
         _sylius:
             template: $template
             repository:
@@ -20,7 +20,7 @@ sylius_shop_partial_taxon_index_by_code:
     path: /by-code/{code}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.taxon:indexAction
+        _controller: sylius.controller.taxon::indexAction
         _sylius:
             template: $template
             repository:

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/product.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/product.yml
@@ -5,7 +5,7 @@ sylius_shop_product_show:
     path: /products/{slug}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product:showAction
+        _controller: sylius.controller.product::showAction
         _sylius:
             template: "@SyliusShop/Product/show.html.twig"
             repository:
@@ -19,7 +19,7 @@ sylius_shop_product_index:
     path: /taxons/{slug}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product:indexAction
+        _controller: sylius.controller.product::indexAction
         _sylius:
             template: "@SyliusShop/Product/index.html.twig"
             grid: sylius_shop_product

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/product_review.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/product_review.yml
@@ -5,7 +5,7 @@ sylius_shop_product_review_index:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.product_review:indexAction
+        _controller: sylius.controller.product_review::indexAction
         _sylius:
             template: "@SyliusShop/ProductReview/index.html.twig"
             repository:
@@ -19,7 +19,7 @@ sylius_shop_product_review_create:
     path: /new
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.product_review:createAction
+        _controller: sylius.controller.product_review::createAction
         _sylius:
             template: "@SyliusShop/ProductReview/create.html.twig"
             form:

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/security.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/security.yml
@@ -5,7 +5,7 @@ sylius_shop_login:
     path: /login
     methods: [GET]
     defaults:
-        _controller: sylius.controller.security:loginAction
+        _controller: sylius.controller.security::loginAction
         _sylius:
             template: "@SyliusShop/login.html.twig"
             logged_in_route: sylius_shop_account_dashboard
@@ -14,7 +14,7 @@ sylius_shop_login_check:
     path: /login-check
     methods: [POST]
     defaults:
-        _controller: sylius.controller.security:checkAction
+        _controller: sylius.controller.security::checkAction
 
 sylius_shop_logout:
     path: /logout
@@ -24,7 +24,7 @@ sylius_shop_register:
     path: /register
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.customer:createAction
+        _controller: sylius.controller.customer::createAction
         _sylius:
             template: "@SyliusShop/register.html.twig"
             form: Sylius\Bundle\CoreBundle\Form\Type\Customer\CustomerRegistrationType
@@ -37,7 +37,7 @@ sylius_shop_request_password_reset_token:
     path: /forgotten-password
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.shop_user:requestPasswordResetTokenAction
+        _controller: sylius.controller.shop_user::requestPasswordResetTokenAction
         _sylius:
             template: "@SyliusShop/Account/requestPasswordReset.html.twig"
             redirect: sylius_shop_login
@@ -46,7 +46,7 @@ sylius_shop_password_reset:
     path: /forgotten-password/{token}
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.shop_user:resetPasswordAction
+        _controller: sylius.controller.shop_user::resetPasswordAction
         _sylius:
             template: "@SyliusShop/Account/resetPassword.html.twig"
             redirect: sylius_shop_login

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/shop_user.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/shop_user.yml
@@ -5,12 +5,12 @@ sylius_shop_user_request_verification_token:
     path: /verify
     methods: [POST]
     defaults:
-        _controller: sylius.controller.shop_user:requestVerificationTokenAction
+        _controller: sylius.controller.shop_user::requestVerificationTokenAction
 
 sylius_shop_user_verification:
     path: /verify/{token}
     methods: [GET]
     defaults:
-        _controller: sylius.controller.shop_user:verifyAction
+        _controller: sylius.controller.shop_user::verifyAction
         _sylius:
             redirect: sylius_shop_account_dashboard

--- a/src/Sylius/Bundle/TaxonomyBundle/Resources/config/routing/taxon.yml
+++ b/src/Sylius/Bundle/TaxonomyBundle/Resources/config/routing/taxon.yml
@@ -2,16 +2,16 @@ sylius_taxon_create:
     path: /new
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.taxon:createAction
+        _controller: sylius.controller.taxon::createAction
 
 sylius_taxon_update:
     path: /{id}/edit
     methods: [GET, POST]
     defaults:
-        _controller: sylius.controller.taxon:updateAction
+        _controller: sylius.controller.taxon::updateAction
 
 sylius_taxon_delete:
     path: /{id}
     methods: [POST]
     defaults:
-        _controller: sylius.controller.taxon:deleteAction
+        _controller: sylius.controller.taxon::deleteAction


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | 
| License         | MIT

Fix "User Deprecated: Referencing controllers with a single colon is deprecated since Symfony 4.1. Use app.controller.user::indexAction instead."