### PR TITLE
Handle null email in oauth login

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
@@ -115,12 +115,12 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
             $user = $this->userRepository->findOneByEmail($response->getEmail());
             if (null !== $user) {
                 return $this->updateUserByOAuthUserResponse($user, $response);
-            } else {
-                return $this->createUserByOAuthUserResponse($response);
             }
-        } else {
-            throw new UsernameNotFoundException('Email is null or not provided');
+
+            return $this->createUserByOAuthUserResponse($response);
         }
+
+        throw new UsernameNotFoundException('Email is null or not provided');
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
@@ -26,6 +26,7 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\User\Canonicalizer\CanonicalizerInterface;
 use Sylius\Component\User\Model\UserOAuthInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Webmozart\Assert\Assert;
 
@@ -115,6 +116,8 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
             if (null !== $user) {
                 return $this->updateUserByOAuthUserResponse($user, $response);
             }
+        } else {
+            throw new UsernameNotFoundException('Email is null or not provided');
         }
 
         return $this->createUserByOAuthUserResponse($response);

--- a/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
@@ -115,12 +115,12 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
             $user = $this->userRepository->findOneByEmail($response->getEmail());
             if (null !== $user) {
                 return $this->updateUserByOAuthUserResponse($user, $response);
+            } else {
+                return $this->createUserByOAuthUserResponse($response);
             }
         } else {
             throw new UsernameNotFoundException('Email is null or not provided');
         }
-
-        return $this->createUserByOAuthUserResponse($response);
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

If the user tries to log in with Facebook but chooses to not give their email, Sylius crashes because it attempts to insert a user with null email into the database. This PR fixes this by checking this case in the user provider.