### PR TITLE
Fix ShopBasedCartContext resetting

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/context.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/context.xml
@@ -33,6 +33,7 @@
         <service id="sylius.context.cart.new_shop_based" class="Sylius\Component\Core\Cart\Context\ShopBasedCartContext" decorates="sylius.context.cart.new" decoration-priority="256" public="false">
             <argument type="service" id="sylius.context.cart.new_shop_based.inner" />
             <argument type="service" id="sylius.context.shopper" />
+            <tag name="kernel.reset" method="reset" />
         </service>
         <service id="sylius.context.cart.customer_and_channel_based" class="Sylius\Bundle\CoreBundle\Context\CustomerAndChannelBasedCartContext">
             <argument type="service" id="sylius.context.customer" />

--- a/src/Sylius/Component/Core/Cart/Context/ShopBasedCartContext.php
+++ b/src/Sylius/Component/Core/Cart/Context/ShopBasedCartContext.php
@@ -102,4 +102,8 @@ final class ShopBasedCartContext implements CartContextInterface
             $cart->setShippingAddress($clonedAddress);
         }
     }
+
+    public function reset() {
+        $this->cart = null;
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| License         | MIT

ShopBasedCartContext keeps an instance of the cart internally. When using [PHP-PM](https://github.com/php-pm/php-pm), this attribute needs to be reset at the end of each request otherwise unexpected behaviors happen. This solution uses the kernel.reset tag introduced specifically for this purpose in https://github.com/symfony/symfony/issues/23984