### PR TITLE
Simplify code of `sylius-product-images-preview` module

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-product-images-preview.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-product-images-preview.js
@@ -31,20 +31,8 @@ const displayUploadedImage = function displayUploadedImage(input) {
 
 $.fn.extend({
   previewUploadedImage(root) {
-    $(`${root} input[type="file"]`).each((idx, el) => {
-      $(el).change((event) => {
-        displayUploadedImage(event.currentTarget);
-      });
-    });
-
-    $(`${root} [data-form-collection="add"]`).on('click', (evt) => {
-      const self = $(evt.currentTarget);
-
-      setTimeout(() => {
-        self.parent().find('.column:last-child input[type="file"]').on('change', (event) => {
-          displayUploadedImage(event.currentTarget);
-        });
-      }, 500);
+    $(root).on('change', 'input[type="file"]', function() {
+      displayUploadedImage(this);
     });
   },
 });


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | in rare cases
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #9595
| License         | MIT

`$el.on(event, selector, handler)` attaches event handler to the `$el` element. If event is triggered on the `$el`, it is checked that element that triggered the event (child of `$el`) matches given `selector`. In case the element matches the `selector`, `handler` is called - otherwise nothing happens.

So it's not necessary to attach event handler for each element - it's enough to attach it to some parent and specify `selector` of childs for which the `handler` should be called. See https://api.jquery.com/on/#on-events-selector-data-handler for details.