### PR TITLE
Added account verification option to fixture parser

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/ChannelFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ChannelFixture.php
@@ -41,7 +41,7 @@ class ChannelFixture extends AbstractResourceFixture
                 ->booleanNode('enabled')->end()
                 ->booleanNode('skipping_shipping_step_allowed')->end()
                 ->booleanNode('skipping_payment_step_allowed')->end()
-                ->booleanNode('account_verification_required')->defaultTrue()->end()
+                ->booleanNode('account_verification_required')->end()
                 ->scalarNode('default_locale')->cannotBeEmpty()->end()
                 ->arrayNode('locales')->scalarPrototype()->end()->end()
                 ->scalarNode('base_currency')->cannotBeEmpty()->end()

--- a/src/Sylius/Bundle/CoreBundle/Fixture/ChannelFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ChannelFixture.php
@@ -40,6 +40,7 @@ class ChannelFixture extends AbstractResourceFixture
                 ->scalarNode('tax_calculation_strategy')->end()
                 ->booleanNode('enabled')->end()
                 ->booleanNode('skipping_shipping_step_allowed')->end()
+                ->booleanNode('skipping_payment_step_allowed')->end()
                 ->booleanNode('account_verification_required')->defaultTrue()->end()
                 ->scalarNode('default_locale')->cannotBeEmpty()->end()
                 ->arrayNode('locales')->scalarPrototype()->end()->end()

--- a/src/Sylius/Bundle/CoreBundle/Fixture/ChannelFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ChannelFixture.php
@@ -40,7 +40,7 @@ class ChannelFixture extends AbstractResourceFixture
                 ->scalarNode('tax_calculation_strategy')->end()
                 ->booleanNode('enabled')->end()
                 ->booleanNode('skipping_shipping_step_allowed')->end()
-                ->booleanNode('skipping_payment_step_allowed')->end()
+                ->booleanNode('account_verification_required')->defaultTrue()->end()
                 ->scalarNode('default_locale')->cannotBeEmpty()->end()
                 ->arrayNode('locales')->scalarPrototype()->end()->end()
                 ->scalarNode('base_currency')->cannotBeEmpty()->end()

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -139,6 +139,8 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
             ->setAllowedTypes('skipping_shipping_step_allowed', 'bool')
             ->setDefault('skipping_payment_step_allowed', false)
             ->setAllowedTypes('skipping_payment_step_allowed', 'bool')
+            ->setDefault('account_verification_required', true)
+            ->setAllowedTypes('account_verification_required', 'bool')
             ->setDefault('default_tax_zone', LazyOption::randomOne($this->zoneRepository))
             ->setAllowedTypes('default_tax_zone', ['null', 'string', ZoneInterface::class])
             ->setNormalizer('default_tax_zone', LazyOption::findOneBy($this->zoneRepository, 'code'))

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -98,6 +98,7 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
         $channel->setContactEmail($options['contact_email']);
         $channel->setSkippingShippingStepAllowed($options['skipping_shipping_step_allowed']);
         $channel->setSkippingPaymentStepAllowed($options['skipping_payment_step_allowed']);
+        $channel->setAccountVerificationRequired($options['account_verification_required']);
 
         $channel->setDefaultLocale($options['default_locale']);
         foreach ($options['locales'] as $locale) {

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ChannelFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ChannelFixtureTest.php
@@ -100,6 +100,14 @@ final class ChannelFixtureTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function authentication_required_may_be_toggled(): void
+    {
+        $this->assertConfigurationIsValid([['custom' => [['account_verification_required' => false]]]], 'custom.*.account_verification_required');
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getConfiguration(): ChannelFixture


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

In this pull request the switch for account verification in the channel entity is now configurable in the Sylius fixtures.