### PR TITLE
Quote row_number identifier for MySQL queries

### DIFF
--- a/app/migrations/Version20161223091334.php
+++ b/app/migrations/Version20161223091334.php
@@ -17,7 +17,7 @@ class Version20161223091334 extends AbstractMigration
         $this->addSql('ALTER TABLE sylius_product_variant ADD position INT NOT NULL');
         $this->addSql('SET @row_number = -1');
         $this->addSql('CREATE TEMPORARY TABLE IF NOT EXISTS variants_count
-                        SELECT sylius_product.id AS product_id, COUNT(sylius_product_variant.id) AS row_number FROM sylius_product
+                        SELECT sylius_product.id AS product_id, COUNT(sylius_product_variant.id) AS `row_number` FROM sylius_product
                         INNER JOIN sylius_product_variant ON sylius_product.id = sylius_product_variant.product_id
                         GROUP BY sylius_product.id'
         );


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 0
| License         | MIT

When running Migrations on MySQL 8, one query causes an SQL error:
> SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'row_number FROM sylius_product INNER JOIN sylius_product' at line 2

The name has to be properly quoted for MySQL 8 where `ROW_NUMBER` is a reserved identifier.