### PR TITLE
Remove automatic database environment suffix

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -8,10 +8,6 @@ framework:
     router: { resource: "%kernel.project_dir%/app/config/routing_dev.yml" }
     profiler: { only_exceptions: false }
 
-doctrine:
-    dbal:
-        dbname: "%database_name%_dev"
-
 monolog:
     handlers:
         main:

--- a/app/config/config_staging.yml
+++ b/app/config/config_staging.yml
@@ -15,9 +15,5 @@ monolog:
             path: "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
 
-doctrine:
-    dbal:
-        dbname: "%database_name%_staging"
-
 swiftmailer:
     disable_delivery: true

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -15,10 +15,6 @@ framework:
     session:
         storage_id: session.storage.mock_file
 
-doctrine:
-    dbal:
-        dbname: "%database_name%_test"
-
 monolog:
     handlers:
         main:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

People new to Sylius don't usually know that we add a suffix to the database name (`your_configured_name` + `dev/test/staging` [or none for production]). Also, while working on a Docker environment for Sylius-Standard, it also caused a small issue that needs some workaround.

Therefore I propose to remove these suffixes for Sylius 1.3 to give people full control of their database name by default. It is a backwards compatible change, as it does not change the behaviour for existing projects.