### PR TITLE
🇫🇷 Fix "Show" translation

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.fr.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.fr.yml
@@ -731,7 +731,7 @@ sylius:
         shipping_total: 'Total des frais de port'
         shop_by: 'Accès par'
         shop_by_brand: 'Parcourir les produits par marque'
-        show: 'Lister'
+        show: 'Afficher'
         show_all: 'Afficher tout'
         show_deleted: 'Voir les supprimés'
         show_in_store: 'Afficher dans le magasin'


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | any
| Bug fix?        | kind of…
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | not found
| License         | MIT

It bother me everytime I see the `Lister` word, which is `List` in English, and not `Voir` or `Afficher` for `Show` in English.

So, I'm gonna fix that.

Thanks :)