### PR TITLE
[Docs] Fixes services file path

### DIFF
--- a/docs/customization/form.rst
+++ b/docs/customization/form.rst
@@ -91,7 +91,7 @@ As a result you will get the ``Sylius\Bundle\CustomerBundle\Form\Type\CustomerPr
     Of course remember that you need to define new labels for your fields
     in the ``app\Resources\translations\messages.en.yml`` for english contents of your messages.
 
-**3.** After creating your class, register this extension as a service in the ``AppBundle/Resources/config/services.yml``:
+**3.** After creating your class, register this extension as a service in the ``app/config/services.yml``:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Because probably the customization goes into the end application and the proper location for the service config file is `app/config/services.yml`. Moreover if the extension is registered in `AppBundle/Resources/config/services.yml` it doesn't work if that file is not loaded through the AppBundle DI extension (https://symfony.com/doc/current/bundles/extension.html).