### PR TITLE
Fix Grids archive ability to work on multi-param urls

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/archive.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/archive.html.twig
@@ -1,4 +1,4 @@
-{% set path = path(grid.requestConfiguration.getRouteName('archive'), {'id': data.id}) %}
+{% set path = options.link.url|default(path(options.link.route|default(grid.requestConfiguration.getRouteName('archive')), options.link.parameters|default({'id': data.id}))) %}
 
 <form action="{{ path }}" method="POST" name="sylius_archivable">
     <input type="hidden" name="_method" value="PATCH">


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.0, 1.1, 1.2, master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT

Hi,

I was adding `ArchivableInterface` to my `ProductVariant`, when I've noticed, that `archive.html.twig` can't work on urls with multiple parameters, like `productId`, `id`, e.g. `/admin/products/206/variants/195`

Solution is copy-pasted from `delete.html.twig`, which doesn't have such problem. https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/delete.html.twig

Works for me on `shipping-methods` and custom `product/product-variants` views.

Let me know, if something is unclear.

Cheers.