### PR TITLE
Theme translation : Add support of Windows OS

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Translation/Finder/TranslationFilesFinder.php
+++ b/src/Sylius/Bundle/ThemeBundle/Translation/Finder/TranslationFilesFinder.php
@@ -76,7 +76,7 @@ final class TranslationFilesFinder implements TranslationFilesFinderInterface
      */
     private function isTranslationFile(string $file): bool
     {
-        return false !== strpos($file, 'translations/')
+        return false !== strpos($file, 'translations' . DIRECTORY_SEPARATOR)
             && (bool) preg_match('/^[^\.]+?\.[a-zA-Z_]{2,}?\.[a-z0-9]{2,}?$/', basename($file));
     }
 }

--- a/src/Sylius/Bundle/ThemeBundle/Translation/Finder/TranslationFilesFinder.php
+++ b/src/Sylius/Bundle/ThemeBundle/Translation/Finder/TranslationFilesFinder.php
@@ -76,7 +76,7 @@ final class TranslationFilesFinder implements TranslationFilesFinderInterface
      */
     private function isTranslationFile(string $file): bool
     {
-        return false !== strpos($file, 'translations' . DIRECTORY_SEPARATOR)
+        return false !== strpos($file, 'translations'.DIRECTORY_SEPARATOR)
             && (bool) preg_match('/^[^\.]+?\.[a-zA-Z_]{2,}?\.[a-z0-9]{2,}?$/', basename($file));
     }
 }


### PR DESCRIPTION
Where `\` is used instead of `/`.

| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #5289
| License         | MIT
