### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-/docs/ @CoderMaggie


### PR DESCRIPTION
Looks like it brings some confusion to PR open partially to docs and isn't used that often as we thought.