### PR TITLE
Add backwards compatibility layer for Behat configuration referenced in Sylius-Standard

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+@trigger_error('The "AppKernel" class located at "app/AppKernel.php" is deprecated since Sylius 1.3. Use "Kernel" class located at "src/Kernel.php" instead.', E_USER_DEPRECATED);
+
+class_alias(Kernel::class, AppKernel::class);

--- a/app/TestAppKernel.php
+++ b/app/TestAppKernel.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+@trigger_error('The "TestAppKernel" class located at "app/TestAppKernel.php" is deprecated since Sylius 1.3. Use "Kernel" class located at "src/Kernel.php" instead.', E_USER_DEPRECATED);
+
+class_alias(Kernel::class, TestAppKernel::class);

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -1,6 +1,8 @@
 # This file is part of the Sylius package.
 # (c) Paweł Jędrzejewski
 
+# This file is referenced in Sylius-Standard v1.0.0 - v1.2.x
+
 imports:
     - src/Sylius/Behat/Resources/config/profiles.yml
     - src/Sylius/Behat/Resources/config/suites.yml

--- a/composer.json
+++ b/composer.json
@@ -188,7 +188,7 @@
         "psr-4": {
             "Sylius\\Tests\\": "tests/"
         },
-        "classmap": ["src/Kernel.php"]
+        "classmap": ["app/AppKernel.php", "app/TestAppKernel.php", "src/Kernel.php"]
     },
     "extra": {
         "symfony-app-dir": "app",

--- a/src/Sylius/Behat/Resources/config/profiles/default.yml
+++ b/src/Sylius/Behat/Resources/config/profiles/default.yml
@@ -43,8 +43,8 @@ default:
         FriendsOfBehat\SymfonyExtension:
             env_file: .env.test
             kernel:
-                class: Kernel
-                path: src/Kernel.php
+                class: TestAppKernel
+                path: app/TestAppKernel.php
                 bootstrap: ~
 
         FriendsOfBehat\ContextServiceExtension:


### PR DESCRIPTION
The change in Behat configuration made Sylius-Standard < 1.3.0 applications to fail, as there is no `Kernel` class.