### PR TITLE
Provide a BC layer for files in "app/config/" referenced by PluginSkeleton

### DIFF
--- a/app/TestAppKernel.php
+++ b/app/TestAppKernel.php
@@ -9,6 +9,10 @@
  * file that was distributed with this source code.
  */
 
+/**
+ * @internal
+ */
+
 declare(strict_types=1);
 
 @trigger_error('The "TestAppKernel" class located at "app/TestAppKernel.php" is deprecated since Sylius 1.3. Use "Kernel" class located at "src/Kernel.php" instead.', E_USER_DEPRECATED);

--- a/app/config/_container_deprecation.php
+++ b/app/config/_container_deprecation.php
@@ -15,6 +15,4 @@
 
 declare(strict_types=1);
 
-@trigger_error('The "AppKernel" class located at "app/AppKernel.php" is deprecated since Sylius 1.3. Use "Kernel" class located at "src/Kernel.php" instead.', E_USER_DEPRECATED);
-
-class_alias(Kernel::class, AppKernel::class);
+@trigger_error('Importing files from Sylius/Sylius\'s "app/config" directory is deprecated since Sylius 1.3.', \E_USER_DEPRECATED);

--- a/app/config/_routing_deprecation.php
+++ b/app/config/_routing_deprecation.php
@@ -15,6 +15,8 @@
 
 declare(strict_types=1);
 
-@trigger_error('The "AppKernel" class located at "app/AppKernel.php" is deprecated since Sylius 1.3. Use "Kernel" class located at "src/Kernel.php" instead.', E_USER_DEPRECATED);
+use Symfony\Component\Routing\RouteCollection;
 
-class_alias(Kernel::class, AppKernel::class);
+@trigger_error('Importing files from Sylius/Sylius\'s "app/config" directory is deprecated since Sylius 1.3.', \E_USER_DEPRECATED);
+
+return new RouteCollection();

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,0 +1,17 @@
+# This file is referenced in PluginSkeleton v1.0.0 - v1.2.x
+# It is deprecated since Sylius 1.3 and will be removed in Sylius 2.0
+
+_routing_deprecation:
+    resource: '_routing_deprecation.php' # Triggers a deprecation error
+
+_routing_directory:
+    resource: '../../config/{routes}/*.{php,xml,yaml,yml}'
+    type: glob
+
+_routing_environment_directory:
+    resource: '../../config/{routes}/%kernel.environment%/**/*.{php,xml,yaml,yml}'
+    type: glob
+
+_routing_file:
+    resource: '../../config/{routes}.{php,xml,yaml,yml}'
+    type: glob

--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -1,0 +1,5 @@
+# This file is referenced in PluginSkeleton v1.0.0 - v1.2.x
+# It is deprecated since Sylius 1.3 and will be removed in Sylius 2.0
+
+_routing:
+    resource: 'routing.yml'

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -1,0 +1,11 @@
+# This file is referenced in PluginSkeleton v1.0.0 - v1.2.x
+# It is deprecated since Sylius 1.3 and will be removed in Sylius 2.0
+
+# Imported new security.yaml makes use of `APP_SECRET` environmental variable
+# We fallback it to `secret` parameter if that env variable is not found to provide a BC layer
+parameters:
+    env(APP_SECRET): '%secret%'
+
+imports:
+    - { resource: '_container_deprecation.php' } # Triggers a deprecation error
+    - { resource: '../../config/packages/security.yaml' }


### PR DESCRIPTION
Files `app/config/routing.yml`, `app/config/routing_dev.yml` and `app/config/security.yml` are referenced in PluginSkeleton. This PR provides a backwards compatibility layer for them.
