### PR TITLE
Fix routing BC layer

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -5,13 +5,9 @@ _routing_deprecation:
     resource: '_routing_deprecation.php' # Triggers a deprecation error
 
 _routing_directory:
-    resource: '../../config/{routes}/*.{php,xml,yaml,yml}'
-    type: glob
-
-_routing_environment_directory:
-    resource: '../../config/{routes}/%kernel.environment%/**/*.{php,xml,yaml,yml}'
+    resource: '../../config/routes/*.{php,xml,yaml,yml}'
     type: glob
 
 _routing_file:
-    resource: '../../config/{routes}.{php,xml,yaml,yml}'
+    resource: '../../config/routes.{php,xml,yaml,yml}'
     type: glob

--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -1,5 +1,17 @@
 # This file is referenced in PluginSkeleton v1.0.0 - v1.2.x
 # It is deprecated since Sylius 1.3 and will be removed in Sylius 2.0
 
-_routing:
-    resource: 'routing.yml'
+_routing_deprecation:
+    resource: '_routing_deprecation.php' # Triggers a deprecation error
+
+_routing_directory:
+    resource: '../../config/routes/*.{php,xml,yaml,yml}'
+    type: glob
+
+_routing_dev_directory:
+    resource: '../../config/routes/dev/**/*.{php,xml,yaml,yml}'
+    type: glob
+
+_routing_file:
+    resource: '../../config/routes.{php,xml,yaml,yml}'
+    type: glob


### PR DESCRIPTION
Symfony's Routing component does not support parameters while importing so that the current implementation didn't work correctly. Related to #9672.

