### PR TITLE
Deprecate `setState` methods

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -35,3 +35,11 @@
     
         * `sylius.mongodb_odm.repository.class`
         * `sylius.phpcr_odm.repository.class`
+
+* All methods for setting entity states (associated with state machine) has been removed.
+Only state machine should be used to manage entity state:
+
+    * `Sylius\Component\Order\Model\OrderInterface::setState`
+    * `Sylius\Component\Payment\Model\PaymentInterface::setState`
+    * `Sylius\Component\Shipping\Model\ShipmentInterface::setState`
+    * `Sylius\Component\Review\Model\ReviewInterface::setStatus`

--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -271,6 +271,11 @@ class Order implements OrderInterface
      */
     public function setState(string $state): void
     {
+        @trigger_error(
+            'Setting entity state is deprecated since Sylius 1.3 and will be removed in Sylius 2.0. Use state machine to manage order state.',
+            E_USER_DEPRECATED
+        );
+
         $this->state = $state;
     }
 

--- a/src/Sylius/Component/Order/Model/OrderInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderInterface.php
@@ -114,6 +114,7 @@ interface OrderInterface extends AdjustableInterface, ResourceInterface, Timesta
 
     /**
      * @param string $state
+     * @deprecated this method is deprecated since Sylius 1.3 and will be removed in Sylius 2.0, use state machine to manage order state
      */
     public function setState(string $state): void;
 

--- a/src/Sylius/Component/Payment/Model/Payment.php
+++ b/src/Sylius/Component/Payment/Model/Payment.php
@@ -126,6 +126,11 @@ class Payment implements PaymentInterface
      */
     public function setState(string $state): void
     {
+        @trigger_error(
+            'Setting entity state is deprecated since Sylius 1.3 and will be removed in Sylius 2.0. Use state machine to manage payment state.',
+            E_USER_DEPRECATED
+        );
+
         $this->state = $state;
     }
 

--- a/src/Sylius/Component/Payment/Model/PaymentInterface.php
+++ b/src/Sylius/Component/Payment/Model/PaymentInterface.php
@@ -45,6 +45,7 @@ interface PaymentInterface extends TimestampableInterface, ResourceInterface
 
     /**
      * @param string $state
+     * @deprecated this method is deprecated since Sylius 1.3 and will be removed in Sylius 2.0, use state machine to manage payment state
      */
     public function setState(string $state): void;
 

--- a/src/Sylius/Component/Review/Model/Review.php
+++ b/src/Sylius/Component/Review/Model/Review.php
@@ -144,6 +144,11 @@ class Review implements ReviewInterface
      */
     public function setStatus(?string $status): void
     {
+        @trigger_error(
+            'Setting entity state is deprecated since Sylius 1.3 and will be removed in Sylius 2.0. Use state machine to manage review status.',
+            E_USER_DEPRECATED
+        );
+
         $this->status = $status;
     }
 

--- a/src/Sylius/Component/Review/Model/ReviewInterface.php
+++ b/src/Sylius/Component/Review/Model/ReviewInterface.php
@@ -69,6 +69,7 @@ interface ReviewInterface extends TimestampableInterface, ResourceInterface
 
     /**
      * @param string|null $status
+     * @deprecated this method is deprecated since Sylius 1.3 and will be removed in Sylius 2.0, use state machine to manage review status
      */
     public function setStatus(?string $status): void;
 

--- a/src/Sylius/Component/Shipping/Model/Shipment.php
+++ b/src/Sylius/Component/Shipping/Model/Shipment.php
@@ -81,6 +81,11 @@ class Shipment implements ShipmentInterface
      */
     public function setState(?string $state): void
     {
+        @trigger_error(
+            'Setting entity state is deprecated since Sylius 1.3 and will be removed in Sylius 2.0. Use state machine to manage shipment state.',
+            E_USER_DEPRECATED
+        );
+
         $this->state = $state;
     }
 

--- a/src/Sylius/Component/Shipping/Model/ShipmentInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShipmentInterface.php
@@ -31,6 +31,7 @@ interface ShipmentInterface extends ResourceInterface, ShippingSubjectInterface,
 
     /**
      * @param string|null $state
+     * @deprecated this method is deprecated since Sylius 1.3 and will be removed in Sylius 2.0, use state machine to manage shipment state
      */
     public function setState(?string $state): void;
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets |
| License         | MIT

State machine should be the only possible way to manage the entity state. Because of the existence of `setState` methods, we could do such abominations as [this step in Behat context](https://github.com/Sylius/Sylius/blob/b509d978834e1d356e7041b584da3bc85b671a1c/src/Sylius/Behat/Context/Setup/OrderContext.php#L423).