### PR TITLE
Fix grid events to fire on every request in PHP-PM

### DIFF
--- a/src/Sylius/Bundle/GridBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/GridBundle/Resources/config/services.xml
@@ -29,6 +29,7 @@
         <service id="sylius.grid.provider" class="Sylius\Component\Grid\Provider\ArrayGridProvider">
             <argument type="service" id="sylius.grid.array_to_definition_converter" />
             <argument>%sylius.grids_definitions%</argument>
+            <tag name="kernel.reset" method="reset" />
         </service>
 
         <service id="sylius.grid.view_factory" class="Sylius\Component\Grid\View\GridViewFactory">

--- a/src/Sylius/Component/Grid/Provider/ArrayGridProvider.php
+++ b/src/Sylius/Component/Grid/Provider/ArrayGridProvider.php
@@ -44,22 +44,6 @@ final class ArrayGridProvider implements GridProviderInterface
         $this->gridConfigurations = $gridConfigurations;
     }
 
-    private function convertGrids()
-    {
-        foreach ($this->gridConfigurations as $code => $gridConfiguration) {
-            if (isset($gridConfiguration['extends'], $this->gridConfigurations[$gridConfiguration['extends']])) {
-                $gridConfiguration = $this->extend($gridConfiguration, $this->gridConfigurations[$gridConfiguration['extends']]);
-            }
-
-            $this->grids[$code] = $this->converter->convert($code, $gridConfiguration);
-        }
-    }
-
-    public function reset()
-    {
-        $this->grids = [];
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -75,6 +59,22 @@ final class ArrayGridProvider implements GridProviderInterface
 
         // Need to clone grid definition in case of displaying on one page two grids using the same grid definition
         return clone $this->grids[$code];
+    }
+
+    public function reset(): void
+    {
+        $this->grids = [];
+    }
+
+    private function convertGrids(): void
+    {
+        foreach ($this->gridConfigurations as $code => $gridConfiguration) {
+            if (isset($gridConfiguration['extends'], $this->gridConfigurations[$gridConfiguration['extends']])) {
+                $gridConfiguration = $this->extend($gridConfiguration, $this->gridConfigurations[$gridConfiguration['extends']]);
+            }
+
+            $this->grids[$code] = $this->converter->convert($code, $gridConfiguration);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

When using Sylius with [PHP-PM](https://github.com/php-pm/php-pm), the `ArrayGridProvider` service generates a `$grids` array internally. With PHP-PM, this occurs only for the first request, then the array is cached. This means events like `sylius.grid.admin_*` only fire once and cannot be used to modify the grid dynamically.

This PR fixes this by refactoring `ArrayGridProvider` a bit and resetting the grids state at the end of every request.