### PR TITLE
Allow to use Pagerfanta in both ^1.0 and ^2.0

### DIFF
--- a/src/Sylius/Bundle/GridBundle/composer.json
+++ b/src/Sylius/Bundle/GridBundle/composer.json
@@ -36,7 +36,7 @@
         "matthiasnoback/symfony-config-test": "^3.0",
         "matthiasnoback/symfony-dependency-injection-test": "^2.0",
         "ocramius/proxy-manager": "^2.1",
-        "pagerfanta/pagerfanta": "^1.0",
+        "pagerfanta/pagerfanta": "^1.0|^2.0",
         "phpspec/phpspec": "^4.0",
         "phpunit/phpunit": "^6.5",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",

--- a/src/Sylius/Component/Resource/composer.json
+++ b/src/Sylius/Component/Resource/composer.json
@@ -27,7 +27,7 @@
         "symfony/event-dispatcher": "^3.4",
         "symfony/property-access": "^3.4",
         "winzou/state-machine": "^0.3",
-        "pagerfanta/pagerfanta": "^1.0"
+        "pagerfanta/pagerfanta": "^1.0|^2.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^4.0",


### PR DESCRIPTION
Pagerfanta 2.0 only changes [minimum PHP version](https://github.com/whiteoctober/Pagerfanta/releases/tag/v2.0.0), which shouldn't cause a major release btw.