### PR TITLE
Fix wrong template path syntax

### DIFF
--- a/docs/book/architecture/emails.rst
+++ b/docs/book/architecture/emails.rst
@@ -15,7 +15,7 @@ Every time a customer registers via the registration form, a user registration e
 
 **Code**: ``user_registration``
 
-**The default template**: ``SyliusShopBundle:Email:userRegistration.html.twig``
+**The default template**: ``@SyliusShop/Email/userRegistration.html.twig``
 
 You also have the following parameters available:
 
@@ -28,7 +28,7 @@ When a customer registers via the registration form, besides the User Confirmati
 
 **Code**: ``verification_token``
 
-**The default template**: ``SyliusShopBundle:Email:verification.html.twig``
+**The default template**: ``@SyliusShop/Email/verification.html.twig``
 
 You also have the following parameters available:
 
@@ -41,7 +41,7 @@ This e-mail is used when the user requests to reset their password in the login 
 
 **Code**: ``reset_password_token``
 
-**The default template**: ``SyliusShopBundle:Email:passwordReset.html.twig``
+**The default template**: ``@SyliusShop/Email/passwordReset.html.twig``
 
 You also have the following parameters available:
 
@@ -54,7 +54,7 @@ This e-mail is sent when order is placed.
 
 **Code**: ``order_confirmation``
 
-**The default template**: ``SyliusShopBundle:Email:orderConfirmation.html.twig``
+**The default template**: ``@SyliusShop/Email/orderConfirmation.html.twig``
 
 You also have the following parameters available:
 
@@ -67,7 +67,7 @@ This e-mail is sent when the order's shipping process has started.
 
 **Code**: ``shipment_confirmation``
 
-**The default template**: ``SyliusAdminBundle:Email:shipmentConfirmation.html.twig``
+**The default template**: ``@SyliusAdmin/Email/shipmentConfirmation.html.twig``
 
 You have the following parameters available:
 

--- a/docs/book/architecture/resource_layer.rst
+++ b/docs/book/architecture/resource_layer.rst
@@ -163,7 +163,7 @@ Displaying a resource with a custom template and repository methods:
         defaults:
             _controller: sylius.controller.product:showAction
             _sylius:
-                template: AppStoreBundle:Product:show.html.twig # Use a custom template.
+                template: '@AppStore/Product/show.html.twig' # Use a custom template.
                 repository:
                     method: findForStore # Use a custom repository method.
                     arguments: [$slug] # Pass the slug from the url to the repository.
@@ -180,7 +180,7 @@ Creating a product using custom form and a redirection method:
             _controller: sylius.controller.product:createAction
             _sylius:
                 form: AppStoreBundle/Form/Type/CustomFormType # Use this form type!
-                template: AppStoreBundle:Product:create.html.twig # Use a custom template.
+                template: '@AppStore/Product/create.html.twig' # Use a custom template.
                 factory:
                     method: createForStore # Use a custom factory method to create a product.
                     arguments: [$store] # Pass the store name from the url.

--- a/docs/book/orders/checkout.rst
+++ b/docs/book/orders/checkout.rst
@@ -64,11 +64,11 @@ Addressing
 
 This is a step where the customer provides both **shipping and billing addresses**.
 
-+--------------------------+----------------------------------------------------+
-| Transition after step    | Template                                           |
-+--------------------------+----------------------------------------------------+
-| ``cart``-> ``addressed`` | ``SyliusShopBundle:Checkout:addressing.html.twig`` |
-+--------------------------+----------------------------------------------------+
++--------------------------+-----------------------------------------------+
+| Transition after step    | Template                                      |
++--------------------------+-----------------------------------------------+
+| ``cart``-> ``addressed`` | ``@SyliusShop/Checkout/addressing.html.twig`` |
++--------------------------+-----------------------------------------------+
 
 How to perform the Addressing Step programmatically?
 ''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -124,11 +124,11 @@ Selecting shipping
 It is a step where the customer selects the way their order will be shipped to them.
 Basing on the ShippingMethods configured in the system the options for the Customer are provided together with their prices.
 
-+---------------------------------------+--------------------------------------------------+
-| Transition after step                 | Template                                         |
-+---------------------------------------+--------------------------------------------------+
-| ``addressed``-> ``shipping_selected`` | ``SyliusShopBundle:Checkout:shipping.html.twig`` |
-+---------------------------------------+--------------------------------------------------+
++---------------------------------------+---------------------------------------------+
+| Transition after step                 | Template                                    |
++---------------------------------------+---------------------------------------------+
+| ``addressed``-> ``shipping_selected`` | ``@SyliusShop/Checkout/shipping.html.twig`` |
++---------------------------------------+---------------------------------------------+
 
 How to perform the Selecting shipping Step programmatically?
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -184,11 +184,11 @@ Selecting payment
 This is a step where the customer chooses how are they willing to pay for their order.
 Basing on the PaymentMethods configured in the system the possibilities for the Customer are provided.
 
-+----------------------------------------------+-------------------------------------------------+
-| Transition after step                        | Template                                        |
-+----------------------------------------------+-------------------------------------------------+
-| ``shipping_selected``-> ``payment_selected`` | ``SyliusShopBundle:Checkout:payment.html.twig`` |
-+----------------------------------------------+-------------------------------------------------+
++----------------------------------------------+--------------------------------------------+
+| Transition after step                        | Template                                   |
++----------------------------------------------+--------------------------------------------+
+| ``shipping_selected``-> ``payment_selected`` | ``@SyliusShop/Checkout/payment.html.twig`` |
++----------------------------------------------+--------------------------------------------+
 
 How to perform the Selecting payment step programmatically?
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -232,11 +232,11 @@ Finalizing
 
 In this step the customer gets an order summary and is redirected to complete the payment they have selected.
 
-+--------------------------------------+-------------------------------------------------+
-| Transition after step                | Template                                        |
-+--------------------------------------+-------------------------------------------------+
-| ``payment_selected``-> ``completed`` | ``SyliusShopBundle:Checkout:summary.html.twig`` |
-+--------------------------------------+-------------------------------------------------+
++--------------------------------------+--------------------------------------------+
+| Transition after step                | Template                                   |
++--------------------------------------+--------------------------------------------+
+| ``payment_selected``-> ``completed`` | ``@SyliusShop/Checkout/summary.html.twig`` |
++--------------------------------------+--------------------------------------------+
 
 How to complete Checkout programmatically?
 ''''''''''''''''''''''''''''''''''''''''''

--- a/docs/book/themes/themes.rst
+++ b/docs/book/themes/themes.rst
@@ -81,7 +81,7 @@ When you create a new asset or delete an existing one, it is required to rerun t
 
 4. Customize a template:
 
-In order to customize the login view you should take the content of ``@SyliusShopBundle/views/login.html.twig`` file
+In order to customize the login view you should take the content of ``@SyliusShopBundle/Resources/views/login.html.twig`` file
 and paste it to your theme directory: ``app/themes/CrimsonTheme/SyliusShopBundle/views/login.html.twig``
 
 Let's remove the registration column in this example:
@@ -90,9 +90,9 @@ Let's remove the registration column in this example:
 
    {% extends '@SyliusShop/layout.html.twig' %}
 
-   {% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
+   {% form_theme form '@SyliusUi/Form/theme.html.twig' %}
 
-   {% import 'SyliusUiBundle:Macro:messages.html.twig' as messages %}
+   {% import '@SyliusUi/Macro/messages.html.twig' as messages %}
 
    {% block content %}
        {% include '@SyliusShop/Login/_header.html.twig' %}

--- a/docs/components_and_bundles/bundles/SyliusGridBundle/custom_filter.rst
+++ b/docs/components_and_bundles/bundles/SyliusGridBundle/custom_filter.rst
@@ -65,7 +65,7 @@ Create a template for the filter, similar to the existing ones:
 .. code-block:: html
 
     # app/Resources/views/Grid/Filter/suppliers_statistics.html.twig
-    {% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
+    {% form_theme form '@SyliusUi/Form/theme.html.twig' %}
 
     {{ form_row(form) }}
 
@@ -100,4 +100,4 @@ Now you can use your new filter type in the grid configuration!
                             range: [0, 100]
         templates:
             filter:
-                suppliers_statistics: 'AppBundle:Grid/Filter:suppliers_statistics.html.twig'
+                suppliers_statistics: '@App/Grid/Filter/suppliers_statistics.html.twig'

--- a/docs/components_and_bundles/bundles/SyliusGridBundle/your_first_grid.rst
+++ b/docs/components_and_bundles/bundles/SyliusGridBundle/your_first_grid.rst
@@ -54,7 +54,7 @@ Now we can configure our first grid:
                         type: twig
                         label: sylius.ui.enabled
                         options:
-                            template: SyliusUiBundle:Grid/Field:enabled.html.twig # This will be a checkbox field
+                            template: '@SyliusUi/Grid/Field/enabled.html.twig' # This will be a checkbox field
 
 Remember to import your grid in the ``app/config/grids/grids.yml`` file which has to be imported in the ``app/config/config.yml``.
 

--- a/docs/components_and_bundles/bundles/SyliusMailerBundle/configuration.rst
+++ b/docs/components_and_bundles/bundles/SyliusMailerBundle/configuration.rst
@@ -16,14 +16,14 @@ Configuration reference
           emails:
               your_email:
                   subject: Subject of your email
-                  template: AppBundle:Email:yourEmail.html.twig
+                  template: '@App/Email/yourEmail.html.twig'
                   enabled: true/false
                   sender:
                      name: Custom name
                      address: Custom sender address for this e-mail
               your_another_email:
                   subject: Subject of your another email
-                  template: AppBundle:Email:yourAnotherEmail.html.twig
+                  template: '@App/Email/yourAnotherEmail.html.twig'
                   enabled: true/false
                   sender:
                      name: Custom name

--- a/docs/components_and_bundles/bundles/SyliusMailerBundle/your_first_email.rst
+++ b/docs/components_and_bundles/bundles/SyliusMailerBundle/your_first_email.rst
@@ -21,7 +21,7 @@ In your ``app/config/config.yml``, under ``sylius_mailer`` you should configure 
         emails:
             movie_added_notification:
                 subject: A new movie {{ movie.title }} has been submitted
-                template: AppBundle:Email:movieAddedNotification.html.twig
+                template: '@App/Email/movieAddedNotification.html.twig'
 
 That's it! Your unique code is "movie_added_notification". Now, let's create the template.
 

--- a/docs/components_and_bundles/bundles/SyliusResourceBundle/reference.rst
+++ b/docs/components_and_bundles/bundles/SyliusResourceBundle/reference.rst
@@ -46,11 +46,10 @@ Routing Generator Configuration Reference
             criteria:
                 code: $code
             section: admin
-            templates: :Book
+            templates: Admin/Book
             form: AppBundle/Form/Type/SimpleBookType
             redirect: create
             except: ['show']
             only: ['create', 'index']
             serialization_version: 1
         type: sylius.resource
-

--- a/docs/components_and_bundles/bundles/SyliusUserBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusUserBundle/summary.rst
@@ -22,7 +22,7 @@ Configuration reference
                         interface: Sylius\Component\User\Model\UserInterface
                         controller: Sylius\Bundle\UserBundle\Controller\UserController
                         factory: Sylius\Component\Resource\Factory\Factory
-                    templates: 'SyliusUserBundle:User'
+                    templates: SyliusUserBundle:User
                     resetting:
                         token:
                             ttl: P1D
@@ -44,7 +44,7 @@ Configuration reference
                         interface: Sylius\Component\User\Model\UserInterface
                         controller: Sylius\Bundle\UserBundle\Controller\UserController
                         factory: Sylius\Component\Resource\Factory\Factory
-                    templates: 'SyliusUserBundle:User'
+                    templates: SyliusUserBundle:User
                     resetting:
                         token:
                             ttl: P1D
@@ -65,7 +65,7 @@ Configuration reference
                         controller: Sylius\Bundle\ResourceBundle\Controller\ResourceController
                         factory: Sylius\Component\Resource\Factory\Factory
                         form: Sylius\Bundle\UserBundle\Form\Type\UserType
-                    templates: 'SyliusUserBundle:User'
+                    templates: SyliusUserBundle:User
                     resetting:
                         token:
                             ttl: P1D

--- a/docs/cookbook/configuration/extending-bundles-other-em.rst
+++ b/docs/cookbook/configuration/extending-bundles-other-em.rst
@@ -218,7 +218,7 @@ Extending the SyliusBundles
                         interface: Sylius\Component\User\Model\UserInterface
                         controller: Sylius\Bundle\UserBundle\Controller\UserController
                         factory: Sylius\Component\Resource\Factory\Factory
-                    templates: 'SyliusUserBundle:User'
+                    templates: SyliusUserBundle:User
                     resetting:
                         token:
                             ttl: P1D
@@ -241,7 +241,7 @@ Extending the SyliusBundles
                         controller: Sylius\Bundle\ResourceBundle\Controller\ResourceController
                         factory: Sylius\Component\Resource\Factory\Factory
                         form: Sylius\Bundle\UserBundle\Form\Type\UserType
-                    templates: 'SyliusUserBundle:User'
+                    templates: SyliusUserBundle:User
                     resetting:
                         token:
                             ttl: P1D

--- a/docs/cookbook/emails/custom-email.rst
+++ b/docs/cookbook/emails/custom-email.rst
@@ -53,7 +53,7 @@ To achieve that you will need to:
         emails:
             out_of_stock:
                 subject: "A product has become out of stock!"
-                template: "AppBundle:Email:out_of_stock.html.twig"
+                template: '@App/Email/out_of_stock.html.twig'
 
 .. code-block:: yaml
 

--- a/docs/cookbook/entities/custom-translatable-model.rst
+++ b/docs/cookbook/entities/custom-translatable-model.rst
@@ -483,7 +483,7 @@ should be also included in the ``app/config/routing.yml``.
                 all:
                     subheader: app.ui.supplier
                     templates:
-                        form: AppBundle:Supplier:_form.html.twig
+                        form: '@App/Supplier/_form.html.twig'
                 index:
                     icon: 'file image outline'
         type: sylius.resource

--- a/docs/cookbook/shop/checkout.rst
+++ b/docs/cookbook/shop/checkout.rst
@@ -208,7 +208,7 @@ to the ``app/Resources/SyliusShopBundle/config/routing/checkout.yml`` file.
             _sylius:
                 event: address
                 flash: false
-                template: SyliusShopBundle:Checkout:address.html.twig
+                template: '@SyliusShop/Checkout/address.html.twig'
                 form:
                     type: Sylius\Bundle\CoreBundle\Form\Type\Checkout\AddressType
                     options:
@@ -229,7 +229,7 @@ to the ``app/Resources/SyliusShopBundle/config/routing/checkout.yml`` file.
             _sylius:
                 event: payment
                 flash: false
-                template: SyliusShopBundle:Checkout:selectPayment.html.twig
+                template: '@SyliusShop/Checkout/selectPayment.html.twig'
                 form: Sylius\Bundle\CoreBundle\Form\Type\Checkout\SelectPaymentType
                 repository:
                     method: find
@@ -247,7 +247,7 @@ to the ``app/Resources/SyliusShopBundle/config/routing/checkout.yml`` file.
             _sylius:
                 event: complete
                 flash: false
-                template: SyliusShopBundle:Checkout:complete.html.twig
+                template: '@SyliusShop/Checkout/complete.html.twig'
                 repository:
                     method: find
                     arguments:

--- a/docs/customization/factory.rst
+++ b/docs/customization/factory.rst
@@ -118,12 +118,12 @@ To actually use it overwrite ``sylius_admin_product_create_simple`` route like b
                 section: admin
                 factory:
                     method: createDisabled # like here for example
-                template: SyliusAdminBundle:Crud:create.html.twig
+                template: '@SyliusAdmin/Crud/create.html.twig'
                 redirect: sylius_admin_product_update
                 vars:
                     subheader: sylius.ui.manage_your_product_catalog
                     templates:
-                        form: SyliusAdminBundle:Product:_form.html.twig
+                        form: '@SyliusAdmin/Product/_form.html.twig'
                     route:
                         name: sylius_admin_product_create_simple
 

--- a/docs/customization/template.rst
+++ b/docs/customization/template.rst
@@ -44,7 +44,7 @@ How to customize templates by overriding?
 
 * **Shop** templates: customizing Login Page template:
 
-The default login template is: ``SyliusShopBundle:login.html.twig``.
+The default login template is: ``@SyliusShop/login.html.twig``.
 In order to override it you need to create your own: ``app/Resources/SyliusShopBundle/views/login.html.twig``.
 
 Copy the contents of the original template to make your work easier. And then modify it to your needs.
@@ -89,7 +89,7 @@ Done! If you do not see any changes on the ``/shop/login`` url, clear your cache
 
 * **Admin** templates: Customization of the Country form view.
 
-The default template for the Country form is: ``SyliusAdminBundle:Country:_form.html.twig``.
+The default template for the Country form is: ``@SyliusAdmin/Country/_form.html.twig``.
 In order to override it you need to create your own: ``app/Resources/SyliusAdminBundle/views/Country/_form.html.twig``.
 
 Copy the contents of the original template to make your work easier. And then modify it to your needs.

--- a/src/Sylius/Bundle/AdminBundle/Controller/DashboardController.php
+++ b/src/Sylius/Bundle/AdminBundle/Controller/DashboardController.php
@@ -81,7 +81,7 @@ final class DashboardController
         $statistics = $this->statisticsProvider->getStatisticsForChannel($channel);
 
         return $this->templatingEngine->renderResponse(
-            'SyliusAdminBundle:Dashboard:index.html.twig',
+            '@SyliusAdmin/Dashboard/index.html.twig',
             ['statistics' => $statistics, 'channel' => $channel]
         );
     }

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/sylius/sylius_mailer.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/sylius/sylius_mailer.yml
@@ -5,4 +5,4 @@ sylius_mailer:
     emails:
         shipment_confirmation:
             subject: sylius.emails.shipment_confirmation.subject
-            template: "SyliusAdminBundle:Email:shipmentConfirmation.html.twig"
+            template: '@SyliusAdmin/Email/shipmentConfirmation.html.twig'

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/admin_user.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/admin_user.yml
@@ -12,7 +12,7 @@ sylius_admin_admin_user:
             all:
                 subheader: sylius.ui.manage_users_able_to_access_administration_panel
                 templates:
-                    form: SyliusAdminBundle:AdminUser:_form.html.twig
+                    form: '@SyliusAdmin/AdminUser/_form.html.twig'
             index:
                 icon: lock
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/channel.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/channel.yml
@@ -11,7 +11,7 @@ sylius_admin_channel:
           all:
               subheader: sylius.ui.configure_channels_available_in_your_store
               templates:
-                  form: SyliusAdminBundle:Channel:_form.html.twig
+                  form: '@SyliusAdmin/Channel/_form.html.twig'
           index:
               icon: share alternate
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/country.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/country.yml
@@ -11,7 +11,7 @@ sylius_admin_country:
             all:
                 subheader: sylius.ui.manage_shipping_destinations
                 templates:
-                    form: SyliusAdminBundle:Country:_form.html.twig
+                    form: '@SyliusAdmin/Country/_form.html.twig'
             index:
                 icon: flag
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/currency.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/currency.yml
@@ -11,7 +11,7 @@ sylius_admin_currency:
             all:
                 subheader: sylius.ui.manage_currencies_available_in_the_store
                 templates:
-                    form: SyliusAdminBundle:Currency:_form.html.twig
+                    form: '@SyliusAdmin/Currency/_form.html.twig'
             index:
                 icon: dollar
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer.yml
@@ -11,7 +11,7 @@ sylius_admin_customer:
             all:
                 subheader: sylius.ui.manage_your_customers
                 templates:
-                    form: SyliusAdminBundle:Customer:_form.html.twig
+                    form: '@SyliusAdmin/Customer/_form.html.twig'
             index:
                 icon: users
     type: sylius.resource
@@ -22,7 +22,7 @@ sylius_admin_customer_show:
         _controller: sylius.controller.customer:showAction
         _sylius:
             section: admin
-            template: SyliusAdminBundle:Customer:show.html.twig
+            template: '@SyliusAdmin/Customer/show.html.twig'
             permission: true
 
 sylius_admin_customer_order_index:
@@ -33,7 +33,7 @@ sylius_admin_customer_order_index:
         _sylius:
             section: admin
             permission: true
-            template: "@SyliusAdmin/Crud/index.html.twig"
+            template: '@SyliusAdmin/Crud/index.html.twig'
             grid: sylius_admin_customer_order
             vars:
                 route:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer_group.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/customer_group.yml
@@ -12,7 +12,7 @@ sylius_admin_customer_group:
                 header: sylius.ui.customer_groups
                 subheader: sylius.ui.manage_customer_groups
                 templates:
-                    form: SyliusAdminBundle:CustomerGroup:_form.html.twig
+                    form: '@SyliusAdmin/CustomerGroup/_form.html.twig'
             index:
                 icon: archive
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/exchange_rate.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/exchange_rate.yml
@@ -11,7 +11,7 @@ sylius_admin_exchange_rate:
             all:
                 subheader: sylius.ui.manage_exchange_rates
                 templates:
-                    form: SyliusAdminBundle:ExchangeRate:_form.html.twig
+                    form: '@SyliusAdmin/ExchangeRate/_form.html.twig'
             index:
                 icon: sliders
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/locale.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/locale.yml
@@ -11,7 +11,7 @@ sylius_admin_locale:
             all:
                 subheader: sylius.ui.manage_languages_available_in_the_store
                 templates:
-                    form: SyliusAdminBundle:Locale:_form.html.twig
+                    form: '@SyliusAdmin/Locale/_form.html.twig'
             index:
                 icon: translate
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/order.yml
@@ -21,7 +21,7 @@ sylius_admin_order_show:
         _sylius:
             section: admin
             permission: true
-            template: SyliusAdminBundle:Order:show.html.twig
+            template: '@SyliusAdmin/Order/show.html.twig'
 
 sylius_admin_order_history:
     path: /orders/{id}/history
@@ -31,7 +31,7 @@ sylius_admin_order_history:
         _sylius:
             section: admin
             permission: true
-            template: SyliusAdminBundle:Order:history.html.twig
+            template: '@SyliusAdmin/Order/history.html.twig'
 
 sylius_admin_order_update:
     path: /orders/{id}/edit
@@ -41,7 +41,7 @@ sylius_admin_order_update:
         _sylius:
             section: admin
             permission: true
-            template: SyliusAdminBundle:Order:update.html.twig
+            template: '@SyliusAdmin/Order/update.html.twig'
             form:
                 options:
                     validation_groups:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/payment_method.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/payment_method.yml
@@ -11,7 +11,7 @@ sylius_admin_payment_method:
           all:
               subheader: sylius.ui.manage_payment_methods_available_to_your_customers
               templates:
-                  form: SyliusAdminBundle:PaymentMethod:_form.html.twig
+                  form: '@SyliusAdmin/PaymentMethod/_form.html.twig'
           index:
               icon: payment
     type: sylius.resource
@@ -27,13 +27,13 @@ sylius_admin_payment_method_create:
                 method: createWithGateway
                 arguments:
                     gatewayFactory: $factory
-            template: SyliusAdminBundle:Crud:create.html.twig
+            template: '@SyliusAdmin/Crud/create.html.twig'
             redirect: sylius_admin_payment_method_update
             permission: true
             vars:
                 subheader: sylius.ui.manage_payment_methods_available_to_your_customers
                 templates:
-                    form: SyliusAdminBundle:PaymentMethod:_form.html.twig
+                    form: '@SyliusAdmin/PaymentMethod/_form.html.twig'
                 route:
                     parameters:
                         factory: $factory
@@ -43,4 +43,4 @@ sylius_admin_get_payment_gateways:
     methods: [GET]
     defaults:
         _controller: sylius.controller.payment_method:getPaymentGatewaysAction
-        template: SyliusAdminBundle:PaymentMethod/Gateways:paymentGateways.html.twig
+        template: '@SyliusAdmin/PaymentMethod/Gateways/paymentGateways.html.twig'

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product.yml
@@ -11,7 +11,7 @@ sylius_admin_product:
             all:
                 subheader: sylius.ui.manage_your_product_catalog
                 templates:
-                    form: SyliusAdminBundle:Product:_form.html.twig
+                    form: '@SyliusAdmin/Product/_form.html.twig'
             index:
                 icon: cube
     type: sylius.resource
@@ -25,7 +25,7 @@ sylius_admin_product_index:
             section: admin
             permission: true
             grid: sylius_admin_product
-            template: SyliusAdminBundle:Product:index.html.twig
+            template: '@SyliusAdmin/Product/index.html.twig'
             vars:
                 subheader: sylius.ui.manage_your_product_catalog
                 icon: cube
@@ -39,7 +39,7 @@ sylius_admin_product_per_taxon_index:
             section: admin
             permission: true
             grid: sylius_admin_product_from_taxon
-            template: SyliusAdminBundle:Product:index.html.twig
+            template: '@SyliusAdmin/Product/index.html.twig'
             vars:
                 subheader: sylius.ui.manage_your_product_catalog
                 icon: cube
@@ -52,12 +52,12 @@ sylius_admin_product_create:
         _sylius:
             section: admin
             permission: true
-            template: SyliusAdminBundle:Crud:create.html.twig
+            template: '@SyliusAdmin/Crud/create.html.twig'
             redirect: sylius_admin_product_update
             vars:
                 subheader: sylius.ui.manage_your_product_catalog
                 templates:
-                    form: SyliusAdminBundle:Product:_form.html.twig
+                    form: '@SyliusAdmin/Product/_form.html.twig'
                 route:
                     name: sylius_admin_product_create
 
@@ -71,11 +71,11 @@ sylius_admin_product_create_simple:
             permission: true
             factory:
                 method: createWithVariant
-            template: SyliusAdminBundle:Crud:create.html.twig
+            template: '@SyliusAdmin/Crud/create.html.twig'
             redirect: sylius_admin_product_update
             vars:
                 subheader: sylius.ui.manage_your_product_catalog
                 templates:
-                    form: SyliusAdminBundle:Product:_form.html.twig
+                    form: '@SyliusAdmin/Product/_form.html.twig'
                 route:
                     name: sylius_admin_product_create_simple

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_association_type.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_association_type.yml
@@ -11,7 +11,7 @@ sylius_admin_product_association_type:
             all:
                 subheader: sylius.ui.manage_association_types_of_your_products
                 templates:
-                    form: SyliusAdminBundle:ProductAssociationType:_form.html.twig
+                    form: '@SyliusAdmin/ProductAssociationType/_form.html.twig'
             index:
                 icon: tasks
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_attribute.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_attribute.yml
@@ -11,7 +11,7 @@ sylius_admin_product_attribute:
             all:
                 subheader: sylius.ui.manage_attributes_of_your_products
                 templates:
-                    form: SyliusAdminBundle:ProductAttribute:_form.html.twig
+                    form: '@SyliusAdmin/ProductAttribute/_form.html.twig'
             index:
                 icon: cubes
     type: sylius.resource
@@ -27,13 +27,13 @@ sylius_admin_product_attribute_create:
                 method: createTyped
                 arguments:
                     type: $type
-            template: SyliusAdminBundle:Crud:create.html.twig
+            template: '@SyliusAdmin/Crud/create.html.twig'
             redirect: sylius_admin_product_attribute_update
             permission: true
             vars:
                 subheader: sylius.ui.manage_attributes_of_your_products
                 templates:
-                    form: SyliusAdminBundle:ProductAttribute:_form.html.twig
+                    form: '@SyliusAdmin/ProductAttribute/_form.html.twig'
                 route:
                     parameters:
                         type: $type
@@ -43,18 +43,18 @@ sylius_admin_get_attribute_types:
     methods: [GET]
     defaults:
         _controller: sylius.controller.product_attribute:getAttributeTypesAction
-        template: SyliusAdminBundle:ProductAttribute/Types:attributeTypes.html.twig
+        template: '@SyliusAdmin/ProductAttribute/Types/attributeTypes.html.twig'
 
 sylius_admin_get_product_attributes:
     path: /attributes
     methods: [GET]
     defaults:
         _controller: sylius.controller.product_attribute:renderAttributesAction
-        template: SyliusAdminBundle:Product/Attribute:attributeChoice.html.twig
+        template: '@SyliusAdmin/Product/Attribute/attributeChoice.html.twig'
 
 sylius_admin_render_attribute_forms:
     path: /attribute-forms
     methods: [GET]
     defaults:
         _controller: sylius.controller.product_attribute:renderAttributeValueFormsAction
-        template: SyliusAdminBundle:Product/Attribute:attributeValues.html.twig
+        template: '@SyliusAdmin/Product/Attribute/attributeValues.html.twig'

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_option.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_option.yml
@@ -11,7 +11,7 @@ sylius_admin_product_option:
           all:
               subheader: sylius.ui.manage_configuration_options_of_your_products
               templates:
-                  form: SyliusAdminBundle:ProductOption:_form.html.twig
+                  form: '@SyliusAdmin/ProductOption/_form.html.twig'
           index:
               icon: options
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_review.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product_review.yml
@@ -11,7 +11,7 @@ sylius_admin_product_review:
             all:
                 subheader: sylius.ui.manage_reviews_of_your_products
                 templates:
-                    form: SyliusAdminBundle:ProductReview:_form.html.twig
+                    form: '@SyliusAdmin/ProductReview/_form.html.twig'
             index:
                 icon: newspaper
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/promotion.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/promotion.yml
@@ -16,5 +16,5 @@ sylius_admin_promotion:
                 icon: in cart
             update:
                 templates:
-                    form: "@SyliusAdmin/Promotion/_form.html.twig"
+                    form: '@SyliusAdmin/Promotion/_form.html.twig'
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/security.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/security.yml
@@ -4,7 +4,7 @@ sylius_admin_login:
     defaults:
         _controller: sylius.controller.security:loginAction
         _sylius:
-            template: SyliusAdminBundle:Security:login.html.twig
+            template: '@SyliusAdmin/Security/login.html.twig'
             permission: true
             logged_in_route: sylius_admin_dashboard
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shipping_category.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shipping_category.yml
@@ -11,7 +11,7 @@ sylius_admin_shipping_category:
           all:
               subheader: sylius.ui.manage_shipping_categories_for_your_store
               templates:
-                  form: SyliusAdminBundle:ShippingCategory:_form.html.twig
+                  form: '@SyliusAdmin/ShippingCategory/_form.html.twig'
           index:
               icon: list layout
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shipping_method.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shipping_method.yml
@@ -11,7 +11,7 @@ sylius_admin_shipping_method:
           all:
               subheader: sylius.ui.manage_shipping_methods_for_your_store
               templates:
-                  form: SyliusAdminBundle:ShippingMethod:_form.html.twig
+                  form: '@SyliusAdmin/ShippingMethod/_form.html.twig'
           index:
               icon: shipping
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/tax_category.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/tax_category.yml
@@ -11,7 +11,7 @@ sylius_admin_tax_category:
           all:
               subheader: sylius.ui.manage_taxation_of_your_products
               templates:
-                  form: SyliusAdminBundle:TaxCategory:_form.html.twig
+                  form: '@SyliusAdmin/TaxCategory/_form.html.twig'
           index:
               icon: tags
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/tax_rate.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/tax_rate.yml
@@ -11,7 +11,7 @@ sylius_admin_tax_rate:
           all:
               subheader: sylius.ui.manage_taxation_of_your_products
               templates:
-                  form: SyliusAdminBundle:TaxRate:_form.html.twig
+                  form: '@SyliusAdmin/TaxRate/_form.html.twig'
           index:
               icon: money
     type: sylius.resource

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/taxon.yml
@@ -10,7 +10,7 @@ sylius_admin_taxon:
             all:
                 subheader: sylius.ui.manage_categorization_of_your_products
                 templates:
-                    form: "@SyliusAdmin/Taxon/_form.html.twig"
+                    form: '@SyliusAdmin/Taxon/_form.html.twig'
     type: sylius.resource
 
 sylius_admin_taxon_index:
@@ -29,7 +29,7 @@ sylius_admin_taxon_create_for_parent:
         _sylius:
             section: admin
             permission: true
-            template: 'SyliusAdminBundle:Taxon:create.html.twig'
+            template: '@SyliusAdmin/Taxon/create.html.twig'
             redirect: sylius_admin_taxon_update
             factory:
                 method: createForParent
@@ -37,4 +37,4 @@ sylius_admin_taxon_create_for_parent:
             vars:
                 subheader: sylius.ui.manage_categorization_of_your_products
                 templates:
-                    form: "@SyliusAdmin/Taxon/_form.html.twig"
+                    form: '@SyliusAdmin/Taxon/_form.html.twig'

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/zone.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/zone.yml
@@ -11,7 +11,7 @@ sylius_admin_zone:
             all:
                 subheader: sylius.ui.manage_geographical_zones
                 templates:
-                    form: SyliusAdminBundle:Zone:_form.html.twig
+                    form: '@SyliusAdmin/Zone/_form.html.twig'
             index:
                 icon: world
     type: sylius.resource
@@ -27,13 +27,13 @@ sylius_admin_zone_create:
                 method: createTyped
                 arguments:
                     type: $type
-            template: SyliusAdminBundle:Crud:create.html.twig
+            template: '@SyliusAdmin/Crud/create.html.twig'
             redirect: sylius_admin_zone_update
             permission: true
             vars:
                 subheader: sylius.ui.manage_geographical_zones
                 templates:
-                    form: SyliusAdminBundle:Zone:_form.html.twig
+                    form: '@SyliusAdmin/Zone/_form.html.twig'
                 route:
                     parameters:
                         type: $type

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Order/Index/_customerHeader.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Order/Index/_customerHeader.html.twig
@@ -1,3 +1,3 @@
-{% import 'SyliusUiBundle:Macro:headers.html.twig' as headers %}
+{% import '@SyliusUi/Macro/headers.html.twig' as headers %}
 
 {{ headers.default(customer.fullname, configuration.vars.icon|default('cart'), configuration.vars.subheader|default('sylius.ui.process_your_orders')|trans) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_customers.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_customers.html.twig
@@ -1,6 +1,6 @@
-{% import 'SyliusUiBundle:Macro:messages.html.twig' as messages %}
-{% import 'SyliusUiBundle:Macro:buttons.html.twig' as buttons %}
-{% import 'SyliusUiBundle:Macro:labels.html.twig' as labels %}
+{% import '@SyliusUi/Macro/messages.html.twig' as messages %}
+{% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
+{% import '@SyliusUi/Macro/labels.html.twig' as labels %}
 
 <div class="ui segment">
     <h3 class="ui dividing header">{{ 'sylius.ui.new_customers'|trans }}</h3>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_header.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_header.html.twig
@@ -1,4 +1,4 @@
-{% import 'SyliusUiBundle:Macro:headers.html.twig' as headers %}
+{% import '@SyliusUi/Macro/headers.html.twig' as headers %}
 
 <div class="ui stackable grid">
     <div class="twelve wide column">

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_orders.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Dashboard/_orders.html.twig
@@ -1,5 +1,5 @@
-{% import 'SyliusUiBundle:Macro:messages.html.twig' as messages %}
-{% import 'SyliusUiBundle:Macro:buttons.html.twig' as buttons %}
+{% import '@SyliusUi/Macro/messages.html.twig' as messages %}
+{% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
 {% import "@SyliusAdmin/Common/Macro/money.html.twig" as money %}
 
 <div class="ui segment">

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/update.html.twig
@@ -1,11 +1,11 @@
 {% extends 'SyliusAdminBundle::layout.html.twig' %}
 
-{% import 'SyliusUiBundle:Macro:headers.html.twig' as headers %}
-{% import 'SyliusUiBundle:Macro:buttons.html.twig' as buttons %}
+{% import '@SyliusUi/Macro/headers.html.twig' as headers %}
+{% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
 
 {% block title %}{{ 'sylius.ui.edit_order'|trans ~' #'~ order.number }} {{ parent() }}{% endblock %}
 
-{% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
+{% form_theme form '@SyliusUi/Form/theme.html.twig' %}
 
 {% block content %}
 {{ sonata_block_render_event('sylius.admin.order.update.before_header', {'resource': resource}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
@@ -1,4 +1,4 @@
-{% extends 'SyliusUiBundle:Form:theme.html.twig' %}
+{% extends '@SyliusUi/Form/theme.html.twig' %}
 
 {% block collection_widget -%}
     {% import '@SyliusUi/Macro/flags.html.twig' as flags %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Grid/Action/generateVariants.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Grid/Action/generateVariants.html.twig
@@ -1,4 +1,4 @@
-{% import 'SyliusUiBundle:Macro:buttons.html.twig' as buttons %}
+{% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
 
 {% set path = options.link.url|default(path('sylius_admin_product_variant_generate', {'productId': options.product.id})) %}
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Index/_taxonHeader.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Index/_taxonHeader.html.twig
@@ -1,4 +1,4 @@
-{% import 'SyliusUiBundle:Macro:headers.html.twig' as headers %}
+{% import '@SyliusUi/Macro/headers.html.twig' as headers %}
 
 <div class="column">
     {{ headers.default(taxon.name, configuration.vars.icon|default('cube'), configuration.vars.subheader|default('sylius.ui.manage_your_product_catalog')|trans) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_attributes.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_attributes.html.twig
@@ -1,4 +1,4 @@
-{% form_theme form 'SyliusAdminBundle:Product/Attribute:attributesCollection.html.twig' %}
+{% form_theme form '@SyliusAdmin/Product/Attribute/attributesCollection.html.twig' %}
 
 <div class="ui tab" data-tab="attributes">
     <h3 class="ui dividing header">{{ 'sylius.ui.attributes'|trans }}</h3>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_form.html.twig
@@ -1,2 +1,2 @@
 {% set menu = knp_menu_get('sylius.admin.product_form', [], {'product': product}) %}
-{{ knp_menu_render(menu, {'template': 'SyliusAdminBundle:Product:_menu.html.twig', 'form': form, 'product': product}) }}
+{{ knp_menu_render(menu, {'template': '@SyliusAdmin/Product/_menu.html.twig', 'form': form, 'product': product}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Index/_productHeader.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Index/_productHeader.html.twig
@@ -1,4 +1,4 @@
-{% import 'SyliusUiBundle:Macro:headers.html.twig' as headers %}
+{% import '@SyliusUi/Macro/headers.html.twig' as headers %}
 
 <div class="column">
     {{ headers.default(product.name, configuration.vars.icon|default('cubes'), configuration.vars.subheader|default('sylius.ui.manage_variants')|trans) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/_form.html.twig
@@ -1,2 +1,2 @@
 {% set menu = knp_menu_get('sylius.admin.product_variant_form', [], {'product_variant': product_variant}) %}
-{{ knp_menu_render(menu, {'template': 'SyliusAdminBundle:ProductVariant:_menu.html.twig', 'form': form, 'product_variant': product_variant}) }}
+{{ knp_menu_render(menu, {'template': '@SyliusAdmin/ProductVariant/_menu.html.twig', 'form': form, 'product_variant': product_variant}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/generate.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/generate.html.twig
@@ -1,12 +1,12 @@
 {% extends '@SyliusAdmin/layout.html.twig' %}
 
-{% import 'SyliusUiBundle:Macro:headers.html.twig' as headers %}
+{% import '@SyliusUi/Macro/headers.html.twig' as headers %}
 
 {% set header = 'sylius.ui.generate_variants' %}
 
 {% block title %}{{ header|trans }} {{ parent() }}{% endblock %}
 
-{% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
+{% form_theme form '@SyliusUi/Form/theme.html.twig' %}
 
 {% block content %}
 {{ sonata_block_render_event('sylius.admin.product_variant.generate.before_header', {'resource': resource}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/index.html.twig
@@ -1,6 +1,6 @@
 {% extends 'SyliusAdminBundle::layout.html.twig' %}
 
-{% import 'SyliusUiBundle:Macro:headers.html.twig' as headers %}
+{% import '@SyliusUi/Macro/headers.html.twig' as headers %}
 
 {% set definition = resources.definition %}
 {% set data = resources.data %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/Index/_promotionHeader.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/Index/_promotionHeader.html.twig
@@ -1,4 +1,4 @@
-{% import 'SyliusUiBundle:Macro:headers.html.twig' as headers %}
+{% import '@SyliusUi/Macro/headers.html.twig' as headers %}
 
 <div class="column">
     {{ headers.default(promotion.name, configuration.vars.icon|default('tags'), configuration.vars.subheader|default('sylius.ui.manage_coupons')|trans) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/generate.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/generate.html.twig
@@ -1,12 +1,12 @@
 {% extends '@SyliusAdmin/layout.html.twig' %}
 
-{% import 'SyliusUiBundle:Macro:headers.html.twig' as headers %}
+{% import '@SyliusUi/Macro/headers.html.twig' as headers %}
 
 {% set header = 'sylius.ui.generate_coupons' %}
 
 {% block title %}{{ header|trans }} {{ parent() }}{% endblock %}
 
-{% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
+{% form_theme form '@SyliusUi/Form/theme.html.twig' %}
 
 {% block content %}
 {{ sonata_block_render_event('sylius.admin.promotion_coupon.generate.before_header', {'resource': promotion}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/index.html.twig
@@ -1,6 +1,6 @@
 {% extends 'SyliusAdminBundle::layout.html.twig' %}
 
-{% import 'SyliusUiBundle:Macro:headers.html.twig' as headers %}
+{% import '@SyliusUi/Macro/headers.html.twig' as headers %}
 
 {% set definition = resources.definition %}
 {% set data = resources.data %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/_media.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Taxon/_media.html.twig
@@ -1,4 +1,4 @@
-{% form_theme form 'SyliusUiBundle:Form:imagesTheme.html.twig' %}
+{% form_theme form '@SyliusUi/Form/imagesTheme.html.twig' %}
 
 <div class="ui segment">
     <h3 class="ui dividing header">{{ 'sylius.ui.media'|trans }}</h3>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
@@ -1,4 +1,4 @@
-{% extends 'SyliusUiBundle:Layout:sidebar.html.twig' %}
+{% extends '@SyliusUi/Layout/sidebar.html.twig' %}
 
 {% block title %} | Sylius{% endblock %}
 
@@ -38,7 +38,7 @@
     {{ sonata_block_render_event('sylius.admin.layout.sidebar_top') }}
 
     <a class="item" href="{{ path('sylius_admin_dashboard') }}"><b>Sylius</b></a>
-    {{ knp_menu_render('sylius.admin.main', {'template': 'SyliusUiBundle:Menu:sidebar.html.twig', 'currentClass': 'active'}) }}
+    {{ knp_menu_render('sylius.admin.main', {'template': '@SyliusUi/Menu/sidebar.html.twig', 'currentClass': 'active'}) }}
 
     {{ sonata_block_render_event('sylius.admin.layout.sidebar_down') }}
 {% endblock %}

--- a/src/Sylius/Bundle/ChannelBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ChannelBundle/Resources/config/services.xml
@@ -58,7 +58,7 @@
             <argument type="service" id="sylius.repository.channel" />
             <argument type="service" id="sylius.context.channel" />
             <argument>false</argument>
-            <tag name="data_collector" template="SyliusChannelBundle:Collector:channel.html.twig" id="sylius.channel_collector" />
+            <tag name="data_collector" template="@SyliusChannel/Collector/channel.html.twig" id="sylius.channel_collector" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -50,7 +50,7 @@
             <argument type="service" id="sylius.context.shopper" />
             <argument>%kernel.bundles%</argument>
             <argument>%locale%</argument>
-            <tag name="data_collector" template="SyliusCoreBundle:Collector:sylius.html.twig" id="sylius_core" priority="-512" />
+            <tag name="data_collector" template="@SyliusCore/Collector/sylius.html.twig" id="sylius_core" priority="-512" />
         </service>
         <service id="sylius.shipping_methods_resolver.zones_and_channel_based" class="Sylius\Component\Core\Resolver\ZoneAndChannelBasedShippingMethodsResolver">
             <argument type="service" id="sylius.repository.shipping_method" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/views/Collector/sylius.html.twig
+++ b/src/Sylius/Bundle/CoreBundle/Resources/views/Collector/sylius.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% set icon %}

--- a/src/Sylius/Bundle/GridBundle/Tests/DependencyInjection/SyliusGridExtensionTest.php
+++ b/src/Sylius/Bundle/GridBundle/Tests/DependencyInjection/SyliusGridExtensionTest.php
@@ -83,15 +83,15 @@ final class SyliusGridExtensionTest extends AbstractExtensionTestCase
         $this->load([
             'templates' => [
                 'filter' => [
-                    'string' => 'AppBundle:Grid/Filter:string.html.twig',
-                    'date' => 'AppBundle:Grid/Filter:date.html.twig',
+                    'string' => '@App/Grid/Filter/string.html.twig',
+                    'date' => '@App/Grid/Filter/date.html.twig',
                 ],
             ],
         ]);
 
         $this->assertContainerBuilderHasParameter('sylius.grid.templates.filter', [
-            'string' => 'AppBundle:Grid/Filter:string.html.twig',
-            'date' => 'AppBundle:Grid/Filter:date.html.twig',
+            'string' => '@App/Grid/Filter/string.html.twig',
+            'date' => '@App/Grid/Filter/date.html.twig',
         ]);
     }
 
@@ -103,15 +103,15 @@ final class SyliusGridExtensionTest extends AbstractExtensionTestCase
         $this->load([
             'templates' => [
                 'action' => [
-                    'create' => 'AppBundle:Grid/Filter:create.html.twig',
-                    'update' => 'AppBundle:Grid/Filter:update.html.twig',
+                    'create' => '@App/Grid/Filter/create.html.twig',
+                    'update' => '@App/Grid/Filter/update.html.twig',
                 ],
             ],
         ]);
 
         $this->assertContainerBuilderHasParameter('sylius.grid.templates.action', [
-            'create' => 'AppBundle:Grid/Filter:create.html.twig',
-            'update' => 'AppBundle:Grid/Filter:update.html.twig',
+            'create' => '@App/Grid/Filter/create.html.twig',
+            'update' => '@App/Grid/Filter/update.html.twig',
         ]);
     }
 

--- a/src/Sylius/Bundle/GridBundle/spec/Renderer/TwigBulkActionGridRendererSpec.php
+++ b/src/Sylius/Bundle/GridBundle/spec/Renderer/TwigBulkActionGridRendererSpec.php
@@ -22,7 +22,7 @@ final class TwigBulkActionGridRendererSpec extends ObjectBehavior
 {
     function let(\Twig_Environment $twig): void
     {
-        $this->beConstructedWith($twig, ['delete' => 'SyliusGridBundle:BulkAction:_delete.html.twig']);
+        $this->beConstructedWith($twig, ['delete' => '@SyliusGrid/BulkAction/_delete.html.twig']);
     }
 
     function it_is_a_bulk_action_grid_renderer(): void
@@ -39,7 +39,7 @@ final class TwigBulkActionGridRendererSpec extends ObjectBehavior
         $bulkAction->getOptions()->willReturn([]);
 
         $twig
-            ->render('SyliusGridBundle:BulkAction:_delete.html.twig', [
+            ->render('@SyliusGrid/BulkAction/_delete.html.twig', [
                 'grid' => $gridView,
                 'action' => $bulkAction,
                 'data' => null,

--- a/src/Sylius/Bundle/GridBundle/spec/Renderer/TwigGridRendererSpec.php
+++ b/src/Sylius/Bundle/GridBundle/spec/Renderer/TwigGridRendererSpec.php
@@ -36,11 +36,11 @@ final class TwigGridRendererSpec extends ObjectBehavior
         FormTypeRegistryInterface $formTypeRegistry
     ): void {
         $actionTemplates = [
-            'link' => 'SyliusGridBundle:Action:_link.html.twig',
-            'form' => 'SyliusGridBundle:Action:_form.html.twig',
+            'link' => '@SyliusGrid/Action/_link.html.twig',
+            'form' => '@SyliusGrid/Action/_form.html.twig',
         ];
         $filterTemplates = [
-            StringFilter::NAME => 'SyliusGridBundle:Filter:_string.html.twig',
+            StringFilter::NAME => '@SyliusGrid/Filter/_string.html.twig',
         ];
 
         $this->beConstructedWith(
@@ -48,7 +48,7 @@ final class TwigGridRendererSpec extends ObjectBehavior
             $fieldsRegistry,
             $formFactory,
             $formTypeRegistry,
-            'SyliusGridBundle:default.html.twig',
+            '@SyliusGrid/default.html.twig',
             $actionTemplates,
             $filterTemplates
         );
@@ -61,14 +61,14 @@ final class TwigGridRendererSpec extends ObjectBehavior
 
     function it_uses_twig_to_render_the_grid_view(\Twig_Environment $twig, GridViewInterface $gridView): void
     {
-        $twig->render('SyliusGridBundle:default.html.twig', ['grid' => $gridView])->willReturn('<html>Grid!</html>');
+        $twig->render('@SyliusGrid/default.html.twig', ['grid' => $gridView])->willReturn('<html>Grid!</html>');
         $this->render($gridView)->shouldReturn('<html>Grid!</html>');
     }
 
     function it_uses_custom_template_if_specified(\Twig_Environment $twig, GridView $gridView): void
     {
-        $twig->render('SyliusGridBundle:custom.html.twig', ['grid' => $gridView])->willReturn('<html>Grid!</html>');
-        $this->render($gridView, 'SyliusGridBundle:custom.html.twig')->shouldReturn('<html>Grid!</html>');
+        $twig->render('@SyliusGrid/custom.html.twig', ['grid' => $gridView])->willReturn('<html>Grid!</html>');
+        $this->render($gridView, '@SyliusGrid/custom.html.twig')->shouldReturn('<html>Grid!</html>');
     }
 
     function it_uses_twig_to_render_the_action(\Twig_Environment $twig, GridViewInterface $gridView, Action $action): void
@@ -77,7 +77,7 @@ final class TwigGridRendererSpec extends ObjectBehavior
         $action->getOptions()->willReturn([]);
 
         $twig
-            ->render('SyliusGridBundle:Action:_link.html.twig', [
+            ->render('@SyliusGrid/Action/_link.html.twig', [
                 'grid' => $gridView,
                 'action' => $action,
                 'data' => null,

--- a/src/Sylius/Bundle/PayumBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/PayumBundle/DependencyInjection/Configuration.php
@@ -41,7 +41,7 @@ final class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('layout')->defaultValue('SyliusPayumBundle::layout.html.twig')->end()
-                        ->scalarNode('obtain_credit_card')->defaultValue('SyliusPayumBundle:Action:obtainCreditCard.html.twig')->end()
+                        ->scalarNode('obtain_credit_card')->defaultValue('@SyliusPayum/Action/obtainCreditCard.html.twig')->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Sylius/Bundle/ResourceBundle/Resources/views/forms.html.twig
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/views/forms.html.twig
@@ -1,5 +1,5 @@
 {% block collection_widget -%}
-    {% from 'SyliusResourceBundle:Macros:notification.html.twig' import error %}
+    {% from '@SyliusResource/Macros/notification.html.twig' import error %}
     {% set attr = attr|merge({'class': attr.class|default ~ ' controls collection-widget'}) %}
 
     {% spaceless %}

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/RequestConfigurationSpec.php
@@ -53,6 +53,17 @@ final class RequestConfigurationSpec extends ObjectBehavior
 
     function it_returns_default_template_names(MetadataInterface $metadata): void
     {
+        $metadata->getTemplatesNamespace()->willReturn('@SyliusAdmin/Product');
+
+        $this->getDefaultTemplate('index.html')->shouldReturn('@SyliusAdmin/Product/index.html.twig');
+        $this->getDefaultTemplate('show.html')->shouldReturn('@SyliusAdmin/Product/show.html.twig');
+        $this->getDefaultTemplate('create.html')->shouldReturn('@SyliusAdmin/Product/create.html.twig');
+        $this->getDefaultTemplate('update.html')->shouldReturn('@SyliusAdmin/Product/update.html.twig');
+        $this->getDefaultTemplate('custom.html')->shouldReturn('@SyliusAdmin/Product/custom.html.twig');
+    }
+
+    function it_returns_default_template_names_for_legacy_templates(MetadataInterface $metadata): void
+    {
         $metadata->getTemplatesNamespace()->willReturn('SyliusAdminBundle:Product');
 
         $this->getDefaultTemplate('index.html')->shouldReturn('SyliusAdminBundle:Product:index.html.twig');
@@ -75,10 +86,10 @@ final class RequestConfigurationSpec extends ObjectBehavior
 
     function it_takes_the_custom_template_if_specified(MetadataInterface $metadata, Parameters $parameters): void
     {
-        $metadata->getTemplatesNamespace()->willReturn('SyliusAdminBundle:Product');
-        $parameters->get('template', 'SyliusAdminBundle:Product:foo.html.twig')->willReturn('AppBundle:Product:show.html.twig');
+        $metadata->getTemplatesNamespace()->willReturn('@SyliusAdmin/Product');
+        $parameters->get('template', '@SyliusAdmin/Product/foo.html.twig')->willReturn('@App/Product/show.html.twig');
 
-        $this->getTemplate('foo.html')->shouldReturn('AppBundle:Product:show.html.twig');
+        $this->getTemplate('foo.html')->shouldReturn('@App/Product/show.html.twig');
     }
 
     function it_gets_form_type_and_its_options(MetadataInterface $metadata, Parameters $parameters): void

--- a/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Controller/ResourceControllerSpec.php
@@ -170,7 +170,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::SHOW . '.html')->willReturn('SyliusShopBundle:Product:show.html.twig');
+        $configuration->getTemplate(ResourceActions::SHOW . '.html')->willReturn('@SyliusShop/Product/show.html.twig');
 
         $eventDispatcher->dispatch(ResourceActions::SHOW, $configuration, $resource)->shouldBeCalled();
 
@@ -182,7 +182,7 @@ final class ResourceControllerSpec extends ObjectBehavior
                 'product' => $resource,
             ])
             ->setTemplateVar('product')
-            ->setTemplate('SyliusShopBundle:Product:show.html.twig')
+            ->setTemplate('@SyliusShop/Product/show.html.twig')
         ;
 
         $viewHandler->handle($configuration, Argument::that($this->getViewComparingCallback($expectedView)))->willReturn($response);
@@ -268,7 +268,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.index')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::INDEX . '.html')->willReturn('SyliusShopBundle:Product:index.html.twig');
+        $configuration->getTemplate(ResourceActions::INDEX . '.html')->willReturn('@SyliusShop/Product/index.html.twig');
         $resourcesCollectionProvider->get($configuration, $repository)->willReturn([$resource1, $resource2]);
 
         $eventDispatcher->dispatchMultiple(ResourceActions::INDEX, $configuration, [$resource1, $resource2])->shouldBeCalled();
@@ -281,7 +281,7 @@ final class ResourceControllerSpec extends ObjectBehavior
                 'products' => [$resource1, $resource2],
             ])
             ->setTemplateVar('products')
-            ->setTemplate('SyliusShopBundle:Product:index.html.twig')
+            ->setTemplate('@SyliusShop/Product/index.html.twig')
         ;
 
         $viewHandler->handle($configuration, Argument::that($this->getViewComparingCallback($expectedView)))->willReturn($response);
@@ -335,7 +335,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('@SyliusShop/Product/create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -353,7 +353,7 @@ final class ResourceControllerSpec extends ObjectBehavior
                 'product' => $newResource,
                 'form' => $formView,
             ])
-            ->setTemplate('SyliusShopBundle:Product:create.html.twig')
+            ->setTemplate('@SyliusShop/Product/create.html.twig')
         ;
 
         $viewHandler->handle($configuration, Argument::that($this->getViewComparingCallback($expectedView)))->willReturn($response);
@@ -388,7 +388,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('@SyliusShop/Product/create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -408,7 +408,7 @@ final class ResourceControllerSpec extends ObjectBehavior
                 'product' => $newResource,
                 'form' => $formView,
             ])
-            ->setTemplate('SyliusShopBundle:Product:create.html.twig')
+            ->setTemplate('@SyliusShop/Product/create.html.twig')
         ;
 
         $viewHandler->handle($configuration, Argument::that($this->getViewComparingCallback($expectedView)))->willReturn($response);
@@ -440,7 +440,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(false);
-        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('@SyliusShop/Product/create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -485,7 +485,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('@SyliusShop/Product/create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -538,7 +538,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('@SyliusShop/Product/create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -595,7 +595,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('@SyliusShop/Product/create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -651,7 +651,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('@SyliusShop/Product/create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -706,7 +706,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(false);
-        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('@SyliusShop/Product/create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -759,7 +759,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.create')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(false);
-        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('SyliusShopBundle:Product:create.html.twig');
+        $configuration->getTemplate(ResourceActions::CREATE . '.html')->willReturn('@SyliusShop/Product/create.html.twig');
 
         $newResourceFactory->create($configuration, $factory)->willReturn($newResource);
         $resourceFormFactory->create($configuration, $newResource)->willReturn($form);
@@ -854,7 +854,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::UPDATE . '.html')->willReturn('SyliusShopBundle:Product:update.html.twig');
+        $configuration->getTemplate(ResourceActions::UPDATE . '.html')->willReturn('@SyliusShop/Product/update.html.twig');
 
         $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
         $resourceFormFactory->create($configuration, $resource)->willReturn($form);
@@ -875,7 +875,7 @@ final class ResourceControllerSpec extends ObjectBehavior
                 'product' => $resource,
                 'form' => $formView,
             ])
-            ->setTemplate('SyliusShopBundle:Product:update.html.twig')
+            ->setTemplate('@SyliusShop/Product/update.html.twig')
         ;
 
         $viewHandler->handle($configuration, Argument::that($this->getViewComparingCallback($expectedView)))->willReturn($response);
@@ -910,7 +910,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::UPDATE . '.html')->willReturn('SyliusShopBundle:Product:update.html.twig');
+        $configuration->getTemplate(ResourceActions::UPDATE . '.html')->willReturn('@SyliusShop/Product/update.html.twig');
 
         $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
         $resourceFormFactory->create($configuration, $resource)->willReturn($form);
@@ -933,7 +933,7 @@ final class ResourceControllerSpec extends ObjectBehavior
                 'product' => $resource,
                 'form' => $formView,
             ])
-            ->setTemplate('SyliusShopBundle:Product:update.html.twig')
+            ->setTemplate('@SyliusShop/Product/update.html.twig')
         ;
 
         $viewHandler->handle($configuration, Argument::that($this->getViewComparingCallback($expectedView)))->willReturn($response);
@@ -1066,7 +1066,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::UPDATE . '.html')->willReturn('SyliusShopBundle:Product:update.html.twig');
+        $configuration->getTemplate(ResourceActions::UPDATE . '.html')->willReturn('@SyliusShop/Product/update.html.twig');
 
         $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
         $resourceFormFactory->create($configuration, $resource)->willReturn($form);
@@ -1125,7 +1125,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::UPDATE . '.html')->willReturn('SyliusShopBundle:Product:update.html.twig');
+        $configuration->getTemplate(ResourceActions::UPDATE . '.html')->willReturn('@SyliusShop/Product/update.html.twig');
 
         $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
         $resourceFormFactory->create($configuration, $resource)->willReturn($form);
@@ -1289,7 +1289,7 @@ final class ResourceControllerSpec extends ObjectBehavior
         $authorizationChecker->isGranted($configuration, 'sylius.product.update')->willReturn(true);
 
         $configuration->isHtmlRequest()->willReturn(true);
-        $configuration->getTemplate(ResourceActions::UPDATE)->willReturn('SyliusShopBundle:Product:update.html.twig');
+        $configuration->getTemplate(ResourceActions::UPDATE)->willReturn('@SyliusShop/Product/update.html.twig');
 
         $singleResourceProvider->get($configuration, $repository)->willReturn($resource);
         $resourceFormFactory->create($configuration, $resource)->willReturn($form);

--- a/src/Sylius/Bundle/ResourceBundle/spec/Grid/Renderer/TwigBulkActionGridRendererSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Grid/Renderer/TwigBulkActionGridRendererSpec.php
@@ -28,7 +28,7 @@ final class TwigBulkActionGridRendererSpec extends ObjectBehavior
         $this->beConstructedWith(
             $twig,
             $optionsParser,
-            ['delete' => 'SyliusGridBundle:BulkAction:_delete.html.twig']
+            ['delete' => '@SyliusGrid/BulkAction/_delete.html.twig']
         );
     }
 
@@ -54,7 +54,7 @@ final class TwigBulkActionGridRendererSpec extends ObjectBehavior
         $optionsParser->parseOptions([], $request, null)->shouldBeCalled();
 
         $twig
-            ->render('SyliusGridBundle:BulkAction:_delete.html.twig', [
+            ->render('@SyliusGrid/BulkAction/_delete.html.twig', [
                 'grid' => $gridView,
                 'action' => $bulkAction,
                 'data' => null,

--- a/src/Sylius/Bundle/ResourceBundle/spec/Grid/Renderer/TwigGridRendererSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Grid/Renderer/TwigGridRendererSpec.php
@@ -29,8 +29,8 @@ final class TwigGridRendererSpec extends ObjectBehavior
         OptionsParserInterface $optionsParser
     ): void {
         $actionTemplates = [
-            'link' => 'SyliusGridBundle:Action:_link.html.twig',
-            'form' => 'SyliusGridBundle:Action:_form.html.twig',
+            'link' => '@SyliusGrid/Action/_link.html.twig',
+            'form' => '@SyliusGrid/Action/_form.html.twig',
         ];
 
         $this->beConstructedWith(
@@ -63,7 +63,7 @@ final class TwigGridRendererSpec extends ObjectBehavior
         $optionsParser->parseOptions([], $request, null)->shouldBeCalled();
 
         $twig
-            ->render('SyliusGridBundle:Action:_link.html.twig', [
+            ->render('@SyliusGrid/Action/_link.html.twig', [
                 'grid' => $gridView,
                 'action' => $action,
                 'data' => null,

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/sylius/sylius_mailer.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/sylius/sylius_mailer.yml
@@ -5,22 +5,22 @@ sylius_mailer:
     emails:
         contact_request:
             subject: sylius.emails.contact_request.subject
-            template: "SyliusShopBundle:Email:contactRequest.html.twig"
+            template: '@SyliusShop/Email/contactRequest.html.twig'
         order_confirmation:
             subject: sylius.emails.order_confirmation.subject
-            template: "SyliusShopBundle:Email:orderConfirmation.html.twig"
+            template: '@SyliusShop/Email/orderConfirmation.html.twig'
         user_registration:
             subject: sylius.emails.user_registration.subject
-            template: "SyliusShopBundle:Email:userRegistration.html.twig"
+            template: '@SyliusShop/Email/userRegistration.html.twig'
         password_reset:
             subject: sylius.emails.user.password_reset.subject
-            template: "SyliusShopBundle:Email:passwordReset.html.twig"
+            template: '@SyliusShop/Email/passwordReset.html.twig'
         reset_password_token:
             subject: sylius.emails.user.password_reset.subject
-            template: "SyliusShopBundle:Email:passwordReset.html.twig"
+            template: '@SyliusShop/Email/passwordReset.html.twig'
         reset_password_pin:
             subject: sylius.emails.user.password_reset.subject
-            template: "SyliusShopBundle:Email:passwordReset.html.twig"
+            template: '@SyliusShop/Email/passwordReset.html.twig'
         verification_token:
             subject: sylius.emails.user.verification_token.subject
-            template: "SyliusShopBundle:Email:verification.html.twig"
+            template: '@SyliusShop/Email/verification.html.twig'

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/checkout.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/checkout.yml
@@ -16,7 +16,7 @@ sylius_shop_checkout_address:
         _sylius:
             event: address
             flash: false
-            template: SyliusShopBundle:Checkout:address.html.twig
+            template: '@SyliusShop/Checkout/address.html.twig'
             form:
                 type: Sylius\Bundle\CoreBundle\Form\Type\Checkout\AddressType
                 options:
@@ -37,7 +37,7 @@ sylius_shop_checkout_select_shipping:
         _sylius:
             event: select_shipping
             flash: false
-            template: SyliusShopBundle:Checkout:selectShipping.html.twig
+            template: '@SyliusShop/Checkout/selectShipping.html.twig'
             form: Sylius\Bundle\CoreBundle\Form\Type\Checkout\SelectShippingType
             repository:
                 method: findCartForSelectingShipping
@@ -55,7 +55,7 @@ sylius_shop_checkout_select_payment:
         _sylius:
             event: payment
             flash: false
-            template: SyliusShopBundle:Checkout:selectPayment.html.twig
+            template: '@SyliusShop/Checkout/selectPayment.html.twig'
             form: Sylius\Bundle\CoreBundle\Form\Type\Checkout\SelectPaymentType
             repository:
                 method: findCartForSelectingPayment
@@ -73,7 +73,7 @@ sylius_shop_checkout_complete:
         _sylius:
             event: complete
             flash: false
-            template: SyliusShopBundle:Checkout:complete.html.twig
+            template: '@SyliusShop/Checkout/complete.html.twig'
             repository:
                 method: findCartForSummary
                 arguments:

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/complete.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/complete.html.twig
@@ -20,7 +20,7 @@
 
             {{ sonata_block_render_event('sylius.shop.checkout.complete.before_summary', {'order': order, 'form': form}) }}
 
-            {% include 'SyliusShopBundle:Common/Order:_summary.html.twig' %}
+            {% include '@SyliusShop/Common/Order/_summary.html.twig' %}
 
             {{ sonata_block_render_event('sylius.shop.checkout.complete.after_summary', {'order': order}) }}
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/selectPayment.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/selectPayment.html.twig
@@ -1,6 +1,6 @@
 {% extends '@SyliusShop/Checkout/layout.html.twig' %}
 
-{% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
+{% form_theme form '@SyliusUi/Form/theme.html.twig' %}
 
 {% block content %}
     {% include '@SyliusShop/Checkout/_steps.html.twig' with {'active': 'select_payment', 'orderTotal': order.total} %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/_attributes.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/_attributes.html.twig
@@ -7,7 +7,7 @@
             <tr>
                 <td class="sylius-product-attribute-name">{{ attribute.name }}</td>
                 <td class="sylius-product-attribute-value">
-                    {% include [('SyliusAttributeBundle:Types:'~attribute.attribute.type~'.html.twig'), 'SyliusAttributeBundle:Types:default.html.twig'] with {'attribute': attribute, 'locale': configuration.request.locale, 'fallbackLocale': configuration.request.defaultLocale} %}
+                    {% include [('@SyliusAttribute/Types/'~attribute.attribute.type~'.html.twig'), '@SyliusAttribute/Types/default.html.twig'] with {'attribute': attribute, 'locale': configuration.request.locale, 'fallbackLocale': configuration.request.defaultLocale} %}
                 </td>
             </tr>
         {% endfor %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_addToCart.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_addToCart.html.twig
@@ -1,6 +1,6 @@
 {% set product = order_item.variant.product %}
 
-{% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
+{% form_theme form '@SyliusUi/Form/theme.html.twig' %}
 
 <div class="ui segment" id="sylius-product-selecting-variant">
     {{ sonata_block_render_event('sylius.shop.product.show.before_add_to_cart', {'product': product, 'order_item': order_item}) }}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/login.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/login.html.twig
@@ -1,6 +1,6 @@
 {% extends '@SyliusShop/layout.html.twig' %}
 
-{% form_theme form 'SyliusUiBundle:Form:theme.html.twig' %}
+{% form_theme form '@SyliusUi/Form/theme.html.twig' %}
 
 {% block content %}
     {% include '@SyliusShop/Login/_header.html.twig' %}

--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services.xml
@@ -42,7 +42,7 @@
             <argument type="service" id="sylius.repository.theme" />
             <argument type="service" id="sylius.context.theme" />
             <argument type="service" id="sylius.theme.hierarchy_provider" />
-            <tag name="data_collector" template="SyliusThemeBundle:Collector:theme" id="sylius_theme" />
+            <tag name="data_collector" template="@SyliusTheme/Collector/theme.html.twig" id="sylius_theme" />
         </service>
 
         <service id="sylius.theme.hierarchy_provider" class="Sylius\Bundle\ThemeBundle\HierarchyProvider\ThemeHierarchyProvider" public="false" />

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/imagesTheme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/imagesTheme.html.twig
@@ -1,7 +1,7 @@
 {% extends '@SyliusUi/Form/theme.html.twig' %}
 
 {% block collection_widget -%}
-    {% from 'SyliusResourceBundle:Macros:notification.html.twig' import error %}
+    {% from '@SyliusResource/Macros/notification.html.twig' import error %}
     {% import _self as self %}
     {% set attr = attr|merge({'class': attr.class|default ~ ' controls collection-widget'}) %}
 

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -77,7 +77,7 @@
 {%- endblock percent_widget %}
 
 {% block collection_widget -%}
-    {% from 'SyliusResourceBundle:Macros:notification.html.twig' import error %}
+    {% from '@SyliusResource/Macros/notification.html.twig' import error %}
     {% import _self as self %}
     {% set attr = attr|merge({'class': attr.class|default ~ ' controls collection-widget'}) %}
 

--- a/src/Sylius/Component/Grid/spec/Definition/FieldSpec.php
+++ b/src/Sylius/Component/Grid/spec/Definition/FieldSpec.php
@@ -81,8 +81,8 @@ final class FieldSpec extends ObjectBehavior
 
     function it_can_have_options(): void
     {
-        $this->setOptions(['template' => 'SyliusUiBundle:Grid/Field:_status.html.twig']);
-        $this->getOptions()->shouldReturn(['template' => 'SyliusUiBundle:Grid/Field:_status.html.twig']);
+        $this->setOptions(['template' => '@SyliusUi/Grid/Field/_status.html.twig']);
+        $this->getOptions()->shouldReturn(['template' => '@SyliusUi/Grid/Field/_status.html.twig']);
     }
 
     function it_has_last_position_by_default(): void

--- a/src/Sylius/Component/Grid/spec/Definition/FilterSpec.php
+++ b/src/Sylius/Component/Grid/spec/Definition/FilterSpec.php
@@ -47,8 +47,8 @@ final class FilterSpec extends ObjectBehavior
 
     function its_template_is_mutable(): void
     {
-        $this->setTemplate('SyliusGridBundle:Filter:template.html.twig');
-        $this->getTemplate()->shouldReturn('SyliusGridBundle:Filter:template.html.twig');
+        $this->setTemplate('@SyliusGrid/Filter/template.html.twig');
+        $this->getTemplate()->shouldReturn('@SyliusGrid/Filter/template.html.twig');
     }
 
     function it_has_no_options_by_default(): void

--- a/src/Sylius/Component/Resource/spec/Metadata/MetadataSpec.php
+++ b/src/Sylius/Component/Resource/spec/Metadata/MetadataSpec.php
@@ -24,7 +24,7 @@ final class MetadataSpec extends ObjectBehavior
             'app.product',
             [
                 'driver' => 'doctrine/orm',
-                'templates' => 'AppBundle:Resource',
+                'templates' => '@App/Resource',
                 'classes' => [
                     'model' => 'AppBundle\Model\Resource',
                     'form' => [
@@ -81,7 +81,7 @@ final class MetadataSpec extends ObjectBehavior
 
     function it_has_templates_namespace(): void
     {
-        $this->getTemplatesNamespace()->shouldReturn('AppBundle:Resource');
+        $this->getTemplatesNamespace()->shouldReturn('@App/Resource');
     }
 
     function it_has_access_to_specific_config_parameter(): void


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

Stop using legacy template paths, as it doesn't work well with template overriding through the `templates` directory.