### PR TITLE
Move symfony/flex dependency to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,6 @@
         "symfony/expression-language": "^3.4|^4.1",
         "symfony/filesystem": "^3.4|^4.1",
         "symfony/finder": "^3.4|^4.1",
-        "symfony/flex": "^1.1",
         "symfony/form": "^3.4|^4.1",
         "symfony/framework-bundle": "^3.4|^4.1",
         "symfony/http-foundation": "^3.4|^4.1",
@@ -124,6 +123,7 @@
         "symfony/browser-kit": "^3.4|^4.1",
         "symfony/debug-bundle": "^3.4|^4.1",
         "symfony/dotenv": "^3.4|^4.1",
+        "symfony/flex": "^1.1",
         "symfony/intl": "^3.4|^4.1",
         "symfony/web-profiler-bundle": "^3.4|^4.1",
         "symfony/web-server-bundle": "^3.4|^4.1"


### PR DESCRIPTION
The ultimate goal is to get rid of the application from Sylius/Sylius without sacrificing the DX while contributing. However, we should allow one not to use Symfony Flex while using Sylius.