### PR TITLE
Adding a reference to all entities in the override doc

### DIFF
--- a/docs/customization/model.rst
+++ b/docs/customization/model.rst
@@ -389,6 +389,36 @@ Which we strongly recommend over updating the schema.
     $ php bin/console doctrine:migrations:diff
     $ php bin/console doctrine:migrations:migrate
 
+List of all core models and how to override them :
+--------------------------------------------------
+
+Here is the list of Code models and the yml index corresponding to their override :
+
+.. code-block:: yaml
+    
+    sylius_addressing:
+        resources:
+            address:
+            
+    
+    sylius_core:
+        resources:
+            channel_pricings:
+    
+    sylius_product:
+        resources:
+            product:
+            product_variant:
+    
+    sylius_customer:
+        resources:
+            customer:
+    
+    sylius_user:
+        resources:
+            shop:
+                user:
+
 .. tip::
 
     Read more about the database modifications and migrations in the `Symfony documentation here <http://symfony.com/doc/current/book/doctrine.html#creating-the-database-tables-schema>`_.


### PR DESCRIPTION
It's not practical to have to search for where the entity has been defined in the first place. And especially the first time you override sylius_user.resources.shop.user, it's not an obvious path. The same is for ChannelPricings.
So this could be really helpful. I'll try to keep it up to date with my further overridings.

| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | doc
| License         | MIT

