### PR TITLE
PHPSpec version not specified in docs

### DIFF
--- a/docs/components_and_bundles/bundles/SyliusCustomerBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusCustomerBundle/summary.rst
@@ -32,7 +32,7 @@ Configuration reference
                     factory: Sylius\Component\Resource\Factory\Factory
                     form: Sylius\Bundle\CustomerBundle\Form\Type\CustomerGroupType
 
-`phpspec2 <http://phpspec.net>`_ examples
+`phpspec <http://phpspec.net>`_ examples
 -----------------------------------------
 
 .. code-block:: bash

--- a/docs/components_and_bundles/bundles/SyliusInventoryBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusInventoryBundle/summary.rst
@@ -30,7 +30,7 @@ Configuration reference
                     model: ~ # The stockable model class.
                     controller: Sylius\Bundle\ResourceBundle\Controller\ResourceController
 
-`phpspec2 <http://phpspec.net>`_ examples
+`phpspec <http://phpspec.net>`_ examples
 -----------------------------------------
 
 .. code-block:: bash

--- a/docs/components_and_bundles/bundles/SyliusOrderBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusOrderBundle/summary.rst
@@ -50,7 +50,7 @@ Configuration reference
             order: '5 days'
 
 
-`phpspec2 <http://phpspec.net>`_ examples
+`phpspec <http://phpspec.net>`_ examples
 -----------------------------------------
 
 .. code-block:: bash

--- a/docs/components_and_bundles/bundles/SyliusPromotionBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusPromotionBundle/summary.rst
@@ -45,7 +45,7 @@ Summary
 
 
 
-`phpspec2 <http://phpspec.net>`_ examples
+`phpspec <http://phpspec.net>`_ examples
 -----------------------------------------
 
 .. code-block:: bash

--- a/docs/components_and_bundles/components/Grid/summary.rst
+++ b/docs/components_and_bundles/components/Grid/summary.rst
@@ -1,7 +1,7 @@
 Summary
 =======
 
-`phpspec2 <http://phpspec.net>`_ examples
+`phpspec <http://phpspec.net>`_ examples
 -----------------------------------------
 
 .. code-block:: bash

--- a/docs/components_and_bundles/components/Resource/summary.rst
+++ b/docs/components_and_bundles/components/Resource/summary.rst
@@ -1,7 +1,7 @@
 Summary
 =======
 
-`phpspec2 <http://phpspec.net>`_ examples
+`phpspec <http://phpspec.net>`_ examples
 -----------------------------------------
 
 .. code-block:: bash


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/9499
| License         | MIT

That was a tough one 😄 