### PR TITLE
Make Flex recipes to be based on Sylius possible (with build passing)

### DIFF
--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -8,7 +8,7 @@
 
 * Run `composer config config.platform.php 7.2.4`
 
-* Run `composer require sylius/sylius:~1.3.0 --no-update`
+* Run `composer require sylius/sylius:~1.3.0 sylius-labs/sensio-distribution-bundle:^6.0 --no-update`
 
 * Add the following code in your `behat.yml(.dist)` file:
 

--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -8,7 +8,7 @@
 
 * Run `composer config config.platform.php 7.2.4`
 
-* Run `composer require sylius/sylius:~1.3.0 sylius-labs/sensio-distribution-bundle:^6.0 --no-update`
+* Run `composer require sylius/sylius:~1.3.0 sylius-labs/sensio-distribution-bundle:^6.0 incenteev/composer-parameter-handler:^2.1 --no-update`
 
 * Add the following code in your `behat.yml(.dist)` file:
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
         "friendsofsymfony/rest-bundle": "^2.1",
         "fzaninotto/faker": "^1.6",
         "gedmo/doctrine-extensions": "^2.4.12",
-        "incenteev/composer-parameter-handler": "^2.1",
         "jms/serializer-bundle": "^2.0",
         "knplabs/knp-gaufrette-bundle": "^0.5",
         "knplabs/knp-menu-bundle": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,6 @@
         "stof/doctrine-extensions-bundle": "^1.2",
         "swiftmailer/swiftmailer": "^6.0",
         "sylius-labs/association-hydrator": "^1.1",
-        "sylius-labs/sensio-distribution-bundle": "^6.0",
         "symfony/asset": "^3.4|^4.1",
         "symfony/config": "^3.4|^4.1",
         "symfony/console": "^3.4|^4.1",

--- a/composer.json
+++ b/composer.json
@@ -117,6 +117,7 @@
         "phpstan/phpstan-symfony": "^0.10",
         "phpstan/phpstan-webmozart-assert": "^0.10",
         "phpunit/phpunit": "^6.5",
+        "sensiolabs/security-checker": "^4.1",
         "stripe/stripe-php": "^4.1",
         "sylius-labs/coding-standard": "^2.0",
         "symfony/browser-kit": "^3.4|^4.1",

--- a/src/Sylius/Bundle/CoreBundle/Application/Kernel.php
+++ b/src/Sylius/Bundle/CoreBundle/Application/Kernel.php
@@ -108,7 +108,6 @@ class Kernel extends HttpKernel
         ];
 
         if (in_array($this->getEnvironment(), ['dev', 'test', 'test_cached'], true)) {
-            $bundles[] = new \Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new \Symfony\Bundle\DebugBundle\DebugBundle();
             $bundles[] = new \Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
         }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | replaces https://github.com/Sylius/Sylius/pull/9735
| License         | MIT

As we remove `sylius-labs/sensio-distribution-bundle` we need to add `sensiolabs/security-checker` to make command `security:check` available