### PR TITLE
Fix the "REST APIs" link in the documentation

### DIFF
--- a/docs/api/introduction.rst
+++ b/docs/api/introduction.rst
@@ -8,7 +8,7 @@ This part of the documentation is about RESTful JSON/XML API for the Sylius plat
 
 .. note::
 
-    This documentation assumes you have at least some experience with `REST APIs <http://symfony.com/doc/current/quick_tour>`_.
+    This documentation assumes you have at least some experience with `REST APIs <https://en.wikipedia.org/wiki/Representational_state_transfer>`_.
 
 .. tip::
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update UPGRADE-*.md file -->
| Related tickets | n/A
| License         | MIT

It was obviously a bad copy/paste.