### PR TITLE
[GridBundle] Do not put unnecessary "andWhere" in ExpressionBuilder

### DIFF
--- a/src/Sylius/Bundle/GridBundle/Doctrine/ORM/ExpressionBuilder.php
+++ b/src/Sylius/Bundle/GridBundle/Doctrine/ORM/ExpressionBuilder.php
@@ -86,7 +86,7 @@ final class ExpressionBuilder implements ExpressionBuilderInterface
         $parameterName = $this->getParameterName($field);
         $this->queryBuilder->setParameter($parameterName, $value);
 
-        $this->queryBuilder->andWhere($this->getFieldName($field) . ' < :' . $parameterName);
+        return $this->queryBuilder->expr()->lt($this->getFieldName($field), ':' . $parameterName);
     }
 
     /**
@@ -97,7 +97,7 @@ final class ExpressionBuilder implements ExpressionBuilderInterface
         $parameterName = $this->getParameterName($field);
         $this->queryBuilder->setParameter($parameterName, $value);
 
-        $this->queryBuilder->andWhere($this->getFieldName($field) . ' <= :' . $parameterName);
+        return $this->queryBuilder->expr()->lte($this->getFieldName($field), ':' . $parameterName);
     }
 
     /**
@@ -108,7 +108,7 @@ final class ExpressionBuilder implements ExpressionBuilderInterface
         $parameterName = $this->getParameterName($field);
         $this->queryBuilder->setParameter($parameterName, $value);
 
-        $this->queryBuilder->andWhere($this->getFieldName($field) . ' > :' . $parameterName);
+        return $this->queryBuilder->expr()->gt($this->getFieldName($field), ':' . $parameterName);
     }
 
     /**
@@ -119,7 +119,7 @@ final class ExpressionBuilder implements ExpressionBuilderInterface
         $parameterName = $this->getParameterName($field);
         $this->queryBuilder->setParameter($parameterName, $value);
 
-        $this->queryBuilder->andWhere($this->getFieldName($field) . ' >= :' . $parameterName);
+        return $this->queryBuilder->expr()->gte($this->getFieldName($field), ':' . $parameterName);
     }
 
     /**

--- a/src/Sylius/Component/Grid/Filter/DateFilter.php
+++ b/src/Sylius/Component/Grid/Filter/DateFilter.php
@@ -35,9 +35,9 @@ final class DateFilter implements FilterInterface
         if (null !== $from) {
             $inclusive = (bool) $this->getOption($options, 'inclusive_from', self::DEFAULT_INCLUSIVE_FROM);
             if (true === $inclusive) {
-                $expressionBuilder->greaterThanOrEqual($field, $from);
+                $dataSource->restrict($expressionBuilder->greaterThanOrEqual($field, $from));
             } else {
-                $expressionBuilder->greaterThan($field, $from);
+                $dataSource->restrict($expressionBuilder->greaterThan($field, $from));
             }
         }
 
@@ -45,9 +45,9 @@ final class DateFilter implements FilterInterface
         if (null !== $to) {
             $inclusive = (bool) $this->getOption($options, 'inclusive_to', self::DEFAULT_INCLUSIVE_TO);
             if (true === $inclusive) {
-                $expressionBuilder->lessThanOrEqual($field, $to);
+                $dataSource->restrict($expressionBuilder->lessThanOrEqual($field, $to));
             } else {
-                $expressionBuilder->lessThan($field, $to);
+                $dataSource->restrict($expressionBuilder->lessThan($field, $to));
             }
         }
     }

--- a/src/Sylius/Component/Grid/Filter/MoneyFilter.php
+++ b/src/Sylius/Component/Grid/Filter/MoneyFilter.php
@@ -41,10 +41,10 @@ final class MoneyFilter implements FilterInterface
             $dataSource->restrict($expressionBuilder->equals($options['currency_field'], $data['currency']));
         }
         if ('' !== $greaterThan) {
-            $expressionBuilder->greaterThan($field, $this->normalizeAmount((float) $greaterThan, $scale));
+            $dataSource->restrict($expressionBuilder->greaterThan($field, $this->normalizeAmount((float) $greaterThan, $scale)));
         }
         if ('' !== $lessThan) {
-            $expressionBuilder->lessThan($field, $this->normalizeAmount((float) $lessThan, $scale));
+            $dataSource->restrict($expressionBuilder->lessThan($field, $this->normalizeAmount((float) $lessThan, $scale)));
         }
     }
 

--- a/src/Sylius/Component/Grid/spec/Filter/DateFilterSpec.php
+++ b/src/Sylius/Component/Grid/spec/Filter/DateFilterSpec.php
@@ -31,10 +31,8 @@ final class DateFilterSpec extends ObjectBehavior
     ): void {
         $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
 
-        $expressionBuilder
-            ->greaterThanOrEqual('checkoutCompletedAt', '2016-12-05 08:00')
-            ->shouldBeCalled()
-        ;
+        $expressionBuilder->greaterThanOrEqual('checkoutCompletedAt', '2016-12-05 08:00')->willReturn('EXPR');
+        $dataSource->restrict('EXPR')->shouldBeCalled();
 
         $this->apply(
             $dataSource,
@@ -55,10 +53,8 @@ final class DateFilterSpec extends ObjectBehavior
     ): void {
         $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
 
-        $expressionBuilder
-            ->greaterThan('checkoutCompletedAt', '2016-12-05 08:00')
-            ->shouldBeCalled()
-        ;
+        $expressionBuilder->greaterThan('checkoutCompletedAt', '2016-12-05 08:00')->willReturn('EXPR');
+        $dataSource->restrict('EXPR')->shouldBeCalled();
 
         $this->apply(
             $dataSource,
@@ -83,10 +79,8 @@ final class DateFilterSpec extends ObjectBehavior
     ): void {
         $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
 
-        $expressionBuilder
-            ->greaterThanOrEqual('checkoutCompletedAt', '2016-12-05 00:00')
-            ->shouldBeCalled()
-        ;
+        $expressionBuilder->greaterThanOrEqual('checkoutCompletedAt', '2016-12-05 00:00')->willReturn('EXPR');
+        $dataSource->restrict('EXPR')->shouldBeCalled();
 
         $this->apply(
             $dataSource,
@@ -111,10 +105,8 @@ final class DateFilterSpec extends ObjectBehavior
     ): void {
         $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
 
-        $expressionBuilder
-            ->lessThan('checkoutCompletedAt', '2016-12-06 08:00')
-            ->shouldBeCalled()
-        ;
+        $expressionBuilder->lessThan('checkoutCompletedAt', '2016-12-06 08:00')->willReturn('EXPR');
+        $dataSource->restrict('EXPR')->shouldBeCalled();
 
         $this->apply(
             $dataSource,
@@ -135,10 +127,8 @@ final class DateFilterSpec extends ObjectBehavior
     ): void {
         $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
 
-        $expressionBuilder
-            ->lessThanOrEqual('checkoutCompletedAt', '2016-12-06 08:00')
-            ->shouldBeCalled()
-        ;
+        $expressionBuilder->lessThanOrEqual('checkoutCompletedAt', '2016-12-06 08:00')->willReturn('EXPR');
+        $dataSource->restrict('EXPR')->shouldBeCalled();
 
         $this->apply(
             $dataSource,
@@ -163,10 +153,8 @@ final class DateFilterSpec extends ObjectBehavior
     ): void {
         $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
 
-        $expressionBuilder
-            ->lessThan('checkoutCompletedAt', '2016-12-06 23:59')
-            ->shouldBeCalled()
-        ;
+        $expressionBuilder->lessThan('checkoutCompletedAt', '2016-12-06 23:59')->willReturn('EXPR');
+        $dataSource->restrict('EXPR')->shouldBeCalled();
 
         $this->apply(
             $dataSource,
@@ -187,15 +175,11 @@ final class DateFilterSpec extends ObjectBehavior
     ): void {
         $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
 
-        $expressionBuilder
-            ->greaterThanOrEqual('checkoutCompletedAt', '2016-12-05 08:00')
-            ->shouldBeCalled()
-        ;
+        $expressionBuilder->greaterThanOrEqual('checkoutCompletedAt', '2016-12-05 08:00')->willReturn('EXPR1');
+        $dataSource->restrict('EXPR1')->shouldBeCalled();
 
-        $expressionBuilder
-            ->lessThan('checkoutCompletedAt', '2016-12-06 08:00')
-            ->shouldBeCalled()
-        ;
+        $expressionBuilder->lessThan('checkoutCompletedAt', '2016-12-06 08:00')->willReturn('EXPR2');
+        $dataSource->restrict('EXPR2')->shouldBeCalled();
 
         $this->apply(
             $dataSource,

--- a/src/Sylius/Component/Grid/spec/Filter/MoneyFilterSpec.php
+++ b/src/Sylius/Component/Grid/spec/Filter/MoneyFilterSpec.php
@@ -50,8 +50,11 @@ final class MoneyFilterSpec extends ObjectBehavior
 
         $expressionBuilder
             ->greaterThan('total', 1200)
-            ->shouldBeCalledTimes(2)
+            ->willReturn('EXPR1', 'EXPR2')
         ;
+
+        $dataSource->restrict('EXPR1')->shouldBeCalled();
+        $dataSource->restrict('EXPR2')->shouldBeCalled();
 
         $this->apply(
             $dataSource,
@@ -84,15 +87,6 @@ final class MoneyFilterSpec extends ObjectBehavior
         $expressionBuilder->equals('currencyCode', 'GBP')->willReturn('EXPR');
         $dataSource->restrict('EXPR')->shouldBeCalled();
 
-        $expressionBuilder
-            ->greaterThan('total', Argument::any())
-            ->shouldNotBeCalled()
-        ;
-        $expressionBuilder
-            ->lessThan('total', Argument::any())
-            ->shouldNotBeCalled()
-        ;
-
         $this->apply(
             $dataSource,
             'total',
@@ -120,13 +114,11 @@ final class MoneyFilterSpec extends ObjectBehavior
     ): void {
         $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
 
-        $expressionBuilder->equals('currencyCode', 'GBP')->willReturn('EXPR');
-        $dataSource->restrict('EXPR')->shouldBeCalled();
+        $expressionBuilder->equals('currencyCode', 'GBP')->willReturn('EXPR1');
+        $dataSource->restrict('EXPR1')->shouldBeCalled();
 
-        $expressionBuilder
-            ->greaterThan('total', 1200)
-            ->shouldBeCalled()
-        ;
+        $expressionBuilder->greaterThan('total', 1200)->willReturn('EXPR2');
+        $dataSource->restrict('EXPR2')->shouldBeCalled();
 
         $this->apply(
             $dataSource,
@@ -146,13 +138,11 @@ final class MoneyFilterSpec extends ObjectBehavior
     ): void {
         $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
 
-        $expressionBuilder->equals('currencyCode', 'GBP')->willReturn('EXPR');
-        $dataSource->restrict('EXPR')->shouldBeCalled();
+        $expressionBuilder->equals('currencyCode', 'GBP')->willReturn('EXPR1');
+        $dataSource->restrict('EXPR1')->shouldBeCalled();
 
-        $expressionBuilder
-            ->lessThan('total', 12000)
-            ->shouldBeCalled()
-        ;
+        $expressionBuilder->lessThan('total', 12000)->willReturn('EXPR2');
+        $dataSource->restrict('EXPR2')->shouldBeCalled();
 
         $this->apply(
             $dataSource,
@@ -172,17 +162,14 @@ final class MoneyFilterSpec extends ObjectBehavior
     ): void {
         $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
 
-        $expressionBuilder->equals('currencyCode', 'GBP')->willReturn('EXPR');
-        $dataSource->restrict('EXPR')->shouldBeCalled();
+        $expressionBuilder->equals('currencyCode', 'GBP')->willReturn('EXPR1');
+        $dataSource->restrict('EXPR1')->shouldBeCalled();
 
-        $expressionBuilder
-            ->greaterThan('total', 1200)
-            ->shouldBeCalled()
-        ;
-        $expressionBuilder
-            ->lessThan('total', 12000)
-            ->shouldBeCalled()
-        ;
+        $expressionBuilder->greaterThan('total', 1200)->willReturn('EXPR2');
+        $dataSource->restrict('EXPR2')->shouldBeCalled();
+
+        $expressionBuilder->lessThan('total', 12000)->willReturn('EXPR3');
+        $dataSource->restrict('EXPR3')->shouldBeCalled();
 
         $this->apply(
             $dataSource,
@@ -202,17 +189,14 @@ final class MoneyFilterSpec extends ObjectBehavior
     ): void {
         $dataSource->getExpressionBuilder()->willReturn($expressionBuilder);
 
-        $expressionBuilder->equals('currencyCode', 'GBP')->willReturn('EXPR');
-        $dataSource->restrict('EXPR')->shouldBeCalled();
+        $expressionBuilder->equals('currencyCode', 'GBP')->willReturn('EXPR1');
+        $dataSource->restrict('EXPR1')->shouldBeCalled();
 
-        $expressionBuilder
-            ->greaterThan('total', 1200000)
-            ->shouldBeCalled()
-        ;
-        $expressionBuilder
-            ->lessThan('total', 12000000)
-            ->shouldBeCalled()
-        ;
+        $expressionBuilder->greaterThan('total', 1200000)->willReturn('EXPR2');
+        $dataSource->restrict('EXPR2')->shouldBeCalled();
+
+        $expressionBuilder->lessThan('total', 12000000)->willReturn('EXPR3');
+        $dataSource->restrict('EXPR3')->shouldBeCalled();
 
         $this->apply(
             $dataSource,


### PR DESCRIPTION
Fixes #9730.

The behaviour has been inconsistent in the ExpressionBuilder methods.