### PR TITLE
Show localised locale names

### DIFF
--- a/UPGRADE-1.4.md
+++ b/UPGRADE-1.4.md
@@ -1,1 +1,4 @@
 # UPGRADE FROM `v1.3.X` TO `v1.4.0`
+
+* Deprecated not passing `Sylius\Component\Locale\Context\LocaleContextInterface` instance as the second argument 
+  to `Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelper`'s constructor.

--- a/features/locale/handling_different_locales_on_multiple_channels.feature
+++ b/features/locale/handling_different_locales_on_multiple_channels.feature
@@ -15,19 +15,19 @@ Feature: Handling different locales on multiple channels
     @ui
     Scenario: Showing locales only from the current channel
         When I browse the "Mobile" channel
-        Then I should shop using the "Polish (Poland)" locale
-        And I should be able to shop using the "Norwegian (Norway)" locale
-        And I should not be able to shop using the "English (United States)" locale
+        Then I should shop using the "polski (Polska)" locale
+        And I should be able to shop using the "norweski (Norwegia)" locale
+        And I should not be able to shop using the "angielski (Stany Zjednoczone)" locale
 
     @ui
     Scenario: Browsing channels using their default locales
         When I browse the "Web" channel
         And I start browsing the "Mobile" channel
-        Then I should shop using the "Polish (Poland)" locale
+        Then I should shop using the "polski (Polska)" locale
 
     @ui
     Scenario: Switching a locale applies only to the current channel
         When I browse the "Web" channel
         And I switch to the "Norwegian (Norway)" locale
         And I start browsing the "Mobile" channel
-        Then I should still shop using the "Polish (Poland)" locale
+        Then I should still shop using the "polski (Polska)" locale

--- a/features/locale/switching_current_locale.feature
+++ b/features/locale/switching_current_locale.feature
@@ -23,5 +23,5 @@ Feature: Switching the current locale
     Scenario: Switching the current locale
         When I browse that channel
         And I switch to the "Polish (Poland)" locale
-        Then I should shop using the "Polish (Poland)" locale
-        And I should be able to shop using the "English (United States)" locale
+        Then I should shop using the "polski (Polska)" locale
+        And I should be able to shop using the "angielski (Stany Zjednoczone)" locale

--- a/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/LocaleBundle/Resources/config/services.xml
@@ -53,6 +53,7 @@
 
         <service id="sylius.templating.helper.locale" class="Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelper">
             <argument type="service" id="sylius.locale_converter" />
+            <argument type="service" id="sylius.context.locale" />
             <tag name="templating.helper" alias="sylius_locale" />
         </service>
 

--- a/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
+++ b/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
@@ -13,30 +13,35 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\LocaleBundle\Templating\Helper;
 
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Sylius\Component\Locale\Context\LocaleNotFoundException;
 use Sylius\Component\Locale\Converter\LocaleConverterInterface;
 use Symfony\Component\Templating\Helper\Helper;
 
 final class LocaleHelper extends Helper implements LocaleHelperInterface
 {
-    /**
-     * @var LocaleConverterInterface
-     */
+    /**@var LocaleConverterInterface */
     private $localeConverter;
 
-    /**
-     * @param LocaleConverterInterface $localeConverter
-     */
-    public function __construct(LocaleConverterInterface $localeConverter)
+    /** @var LocaleContextInterface|null */
+    private $localeContext;
+
+    public function __construct(LocaleConverterInterface $localeConverter, ?LocaleContextInterface $localeContext = null)
     {
+        if (null === $localeContext) {
+            @trigger_error('Not passing LocaleContextInterface explicitly as the second argument is deprecated since 1.4 and will be prohibited in 2.0', \E_USER_DEPRECATED);
+        }
+
         $this->localeConverter = $localeConverter;
+        $this->localeContext = $localeContext;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function convertCodeToName(string $localeCode): ?string
+    public function convertCodeToName(string $code, ?string $localeCode = null): ?string
     {
-        return $this->localeConverter->convertCodeToName($localeCode);
+        return $this->localeConverter->convertCodeToName($code, $this->getLocaleCode($localeCode));
     }
 
     /**
@@ -45,5 +50,22 @@ final class LocaleHelper extends Helper implements LocaleHelperInterface
     public function getName(): string
     {
         return 'sylius_locale';
+    }
+
+    private function getLocaleCode(?string $localeCode): ?string
+    {
+        if (null !== $localeCode) {
+            return $localeCode;
+        }
+
+        if (null === $this->localeContext) {
+            return null;
+        }
+
+        try {
+            return $this->localeContext->getLocaleCode();
+        } catch (LocaleNotFoundException $exception) {
+            return null;
+        }
     }
 }

--- a/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelperInterface.php
+++ b/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelperInterface.php
@@ -18,9 +18,10 @@ use Symfony\Component\Templating\Helper\HelperInterface;
 interface LocaleHelperInterface extends HelperInterface
 {
     /**
-     * @param string $localeCode
+     * @param string $code The code to be converted to a name
+     * @param string|null $localeCode The locale that the returned name should be in
      *
      * @return string|null
      */
-    public function convertCodeToName(string $localeCode): ?string;
+    public function convertCodeToName(string $code, ?string $localeCode = null): ?string;
 }

--- a/src/Sylius/Bundle/LocaleBundle/spec/Templating/Helper/LocaleHelperSpec.php
+++ b/src/Sylius/Bundle/LocaleBundle/spec/Templating/Helper/LocaleHelperSpec.php
@@ -15,6 +15,8 @@ namespace spec\Sylius\Bundle\LocaleBundle\Templating\Helper;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelperInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Sylius\Component\Locale\Context\LocaleNotFoundException;
 use Sylius\Component\Locale\Converter\LocaleConverterInterface;
 use Symfony\Component\Templating\Helper\Helper;
 
@@ -37,9 +39,42 @@ final class LocaleHelperSpec extends ObjectBehavior
 
     function it_converts_locales_code_to_name(LocaleConverterInterface $localeConverter): void
     {
-        $localeConverter->convertCodeToName('fr_FR')->willReturn('French (France)');
+        $localeConverter->convertCodeToName('fr_FR', null)->willReturn('French (France)');
 
         $this->convertCodeToName('fr_FR')->shouldReturn('French (France)');
+    }
+
+    function it_converts_locales_code_to_name_using_given_locale(LocaleConverterInterface $localeConverter): void
+    {
+        $localeConverter->convertCodeToName('en', 'pl')->willReturn('angielski');
+
+        $this->convertCodeToName('en', 'pl')->shouldReturn('angielski');
+    }
+
+    function it_converts_locales_code_to_name_using_locale_from_the_context(
+        LocaleConverterInterface $localeConverter,
+        LocaleContextInterface $localeContext
+    ): void {
+        $this->beConstructedWith($localeConverter, $localeContext);
+
+        $localeContext->getLocaleCode()->willReturn('pl');
+
+        $localeConverter->convertCodeToName('en', 'pl')->willReturn('angielski');
+
+        $this->convertCodeToName('en')->shouldReturn('angielski');
+    }
+
+    function it_converts_locale_code_to_name_using_default_locale_if_passed_locale_context_throws_an_exception(
+        LocaleConverterInterface $localeConverter,
+        LocaleContextInterface $localeContext
+    ): void {
+        $this->beConstructedWith($localeConverter, $localeContext);
+
+        $localeContext->getLocaleCode()->willThrow(LocaleNotFoundException::class);
+
+        $localeConverter->convertCodeToName('en', null)->willReturn('English');
+
+        $this->convertCodeToName('en')->shouldReturn('English');
     }
 
     function it_has_a_name(): void


### PR DESCRIPTION
Fixes #7878, closes #7887.

I reimplemented it instead of using #7887 as this approach lets you specify the locale code in the template by using `{{ 'en_US'|sylius_locale_name('pl_PL') }}`.

Shop:
<img width="248" alt="screenshot 2018-10-03 at 12 36 52" src="https://user-images.githubusercontent.com/1897953/46405644-24277980-c709-11e8-9602-3a55ef50824f.png">

Admin:
<img width="1087" alt="screenshot 2018-10-03 at 12 36 28" src="https://user-images.githubusercontent.com/1897953/46405654-28ec2d80-c709-11e8-8bf7-74ddd357e914.png">
