### PR TITLE
[Core] Make implicit dependency explicit

### DIFF
--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -43,6 +43,7 @@
         "sylius/taxation": "^1.1",
         "sylius/taxonomy": "^1.1",
         "sylius/user": "^1.1",
+        "symfony/http-foundation": "^3.4",
         "webmozart/assert": "^1.0",
         "zendframework/zend-stdlib": "^3.1"
     },


### PR DESCRIPTION
Fixes #7391. `symfony/http-foundation` has been already required through `sylius/user` -> `symfony/security`.