### PR TITLE
[FixtureBundle] Add autoconfiguration for instance of FixtureInterface

### DIFF
--- a/docs/components_and_bundles/bundles/SyliusFixturesBundle/architecture.rst
+++ b/docs/components_and_bundles/bundles/SyliusFixturesBundle/architecture.rst
@@ -34,7 +34,7 @@ persist some entities in the database, upload some files, dispatch some events o
                         priority: 0 # The higher priority is, the sooner the fixture will be executed
                         options: ~ # Fixture options
 
-They implement the ``Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface`` and need to be registered under
+They implement the ``Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface`` and are auto-configured with
 the ``sylius_fixtures.fixture`` tag in order to be used in suite configuration.
 
 .. note::
@@ -94,7 +94,7 @@ They implement at least one of four interfaces:
     The former interface extends the ``ConfigurationInterface``, which is widely known from ``Configuration`` classes
     placed under ``DependencyInjection`` directory in Symfony bundles.
 
-In order to be used in suite configuration, they need to be registered under the ``sylius_fixtures.listener``.
+In order to be used in suite configuration, they need to be registered under the ``sylius_fixtures.listener`` (if service auto-configuration is not enabled).
 
 Disabling listeners / fixtures in consecutive configurations
 ------------------------------------------------------------

--- a/docs/components_and_bundles/bundles/SyliusFixturesBundle/custom_fixture.rst
+++ b/docs/components_and_bundles/bundles/SyliusFixturesBundle/custom_fixture.rst
@@ -42,7 +42,7 @@ to skip the configuration part for now:
         }
     }
 
-The next step is to register this fixture:
+The next step is to register this fixture (if the autowiring and auto-configuration are not enabled) :
 
 .. code-block:: xml
 

--- a/docs/components_and_bundles/bundles/SyliusFixturesBundle/custom_listener.rst
+++ b/docs/components_and_bundles/bundles/SyliusFixturesBundle/custom_listener.rst
@@ -28,7 +28,7 @@ Let's create a listener that removes the directory before loading the fixtures.
         }
     }
 
-The next step is to register this listener:
+The next step is to register this listener (if the autowiring and auto-configuration are not enabled) :
 
 .. code-block:: xml
 

--- a/src/Sylius/Bundle/FixturesBundle/DependencyInjection/Compiler/FixtureRegistryPass.php
+++ b/src/Sylius/Bundle/FixturesBundle/DependencyInjection/Compiler/FixtureRegistryPass.php
@@ -19,6 +19,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class FixtureRegistryPass implements CompilerPassInterface
 {
+    public const FIXTURE_SERVICE_TAG = 'sylius_fixtures.fixture';
+
     /**
      * {@inheritdoc}
      */
@@ -30,7 +32,7 @@ final class FixtureRegistryPass implements CompilerPassInterface
 
         $fixtureRegistry = $container->findDefinition('sylius_fixtures.fixture_registry');
 
-        $taggedServices = $container->findTaggedServiceIds('sylius_fixtures.fixture');
+        $taggedServices = $container->findTaggedServiceIds(self::FIXTURE_SERVICE_TAG);
         foreach (array_keys($taggedServices) as $id) {
             $fixtureRegistry->addMethodCall('addFixture', [new Reference($id)]);
         }

--- a/src/Sylius/Bundle/FixturesBundle/DependencyInjection/Compiler/ListenerRegistryPass.php
+++ b/src/Sylius/Bundle/FixturesBundle/DependencyInjection/Compiler/ListenerRegistryPass.php
@@ -19,6 +19,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class ListenerRegistryPass implements CompilerPassInterface
 {
+    public const LISTENER_SERVICE_TAG = 'sylius_fixtures.listener';
+
     /**
      * {@inheritdoc}
      */
@@ -30,7 +32,7 @@ final class ListenerRegistryPass implements CompilerPassInterface
 
         $listenerRegistry = $container->findDefinition('sylius_fixtures.listener_registry');
 
-        $taggedServices = $container->findTaggedServiceIds('sylius_fixtures.listener');
+        $taggedServices = $container->findTaggedServiceIds(self::LISTENER_SERVICE_TAG);
         foreach (array_keys($taggedServices) as $id) {
             $listenerRegistry->addMethodCall('addListener', [new Reference($id)]);
         }

--- a/src/Sylius/Bundle/FixturesBundle/DependencyInjection/SyliusFixturesExtension.php
+++ b/src/Sylius/Bundle/FixturesBundle/DependencyInjection/SyliusFixturesExtension.php
@@ -13,6 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\FixturesBundle\DependencyInjection;
 
+use Sylius\Bundle\FixturesBundle\DependencyInjection\Compiler\FixtureRegistryPass;
+use Sylius\Bundle\FixturesBundle\DependencyInjection\Compiler\ListenerRegistryPass;
+use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
+use Sylius\Bundle\FixturesBundle\Listener\ListenerInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -32,6 +36,11 @@ final class SyliusFixturesExtension extends Extension implements PrependExtensio
         $loader->load('services.xml');
 
         $this->registerSuites($config, $container);
+
+        $container->registerForAutoconfiguration(FixtureInterface::class)
+            ->addTag(FixtureRegistryPass::FIXTURE_SERVICE_TAG);
+        $container->registerForAutoconfiguration(ListenerInterface::class)
+            ->addTag(ListenerRegistryPass::LISTENER_SERVICE_TAG);
     }
 
     /**

--- a/src/Sylius/Bundle/FixturesBundle/Tests/DependencyInjection/Compiler/FixtureRegistryPassTest.php
+++ b/src/Sylius/Bundle/FixturesBundle/Tests/DependencyInjection/Compiler/FixtureRegistryPassTest.php
@@ -27,7 +27,7 @@ final class FixtureRegistryPassTest extends AbstractCompilerPassTestCase
     public function it_registers_fixtures(): void
     {
         $this->setDefinition('sylius_fixtures.fixture_registry', new Definition());
-        $this->setDefinition('acme.fixture', (new Definition())->addTag('sylius_fixtures.fixture'));
+        $this->setDefinition('acme.fixture', (new Definition())->addTag(FixtureRegistryPass::FIXTURE_SERVICE_TAG));
 
         $this->compile();
 

--- a/src/Sylius/Bundle/FixturesBundle/Tests/DependencyInjection/Compiler/ListenerRegistryPassTest.php
+++ b/src/Sylius/Bundle/FixturesBundle/Tests/DependencyInjection/Compiler/ListenerRegistryPassTest.php
@@ -27,7 +27,7 @@ final class ListenerRegistryPassTest extends AbstractCompilerPassTestCase
     public function it_registers_listeners(): void
     {
         $this->setDefinition('sylius_fixtures.listener_registry', new Definition());
-        $this->setDefinition('acme.listener', (new Definition())->addTag('sylius_fixtures.listener'));
+        $this->setDefinition('acme.listener', (new Definition())->addTag(ListenerRegistryPass::LISTENER_SERVICE_TAG));
 
         $this->compile();
 

--- a/src/Sylius/Bundle/FixturesBundle/Tests/DependencyInjection/DummyFixture.php
+++ b/src/Sylius/Bundle/FixturesBundle/Tests/DependencyInjection/DummyFixture.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\FixturesBundle\Tests\DependencyInjection;
+
+use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
+
+class DummyFixture implements FixtureInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $options): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return '';
+    }
+}

--- a/src/Sylius/Bundle/FixturesBundle/Tests/DependencyInjection/DummyListener.php
+++ b/src/Sylius/Bundle/FixturesBundle/Tests/DependencyInjection/DummyListener.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\FixturesBundle\Tests\DependencyInjection;
+
+use Sylius\Bundle\FixturesBundle\Listener\ListenerInterface;
+
+class DummyListener implements ListenerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return '';
+    }
+}

--- a/src/Sylius/Bundle/FixturesBundle/Tests/DependencyInjection/SyliusFixturesExtensionTest.php
+++ b/src/Sylius/Bundle/FixturesBundle/Tests/DependencyInjection/SyliusFixturesExtensionTest.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\FixturesBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sylius\Bundle\FixturesBundle\DependencyInjection\Compiler\FixtureRegistryPass;
+use Sylius\Bundle\FixturesBundle\DependencyInjection\Compiler\ListenerRegistryPass;
 use Sylius\Bundle\FixturesBundle\DependencyInjection\SyliusFixturesExtension;
+use Symfony\Component\DependencyInjection\Definition;
 
 final class SyliusFixturesExtensionTest extends AbstractExtensionTestCase
 {
@@ -40,6 +43,39 @@ final class SyliusFixturesExtensionTest extends AbstractExtensionTestCase
 
         static::assertSame('addSuite', $suiteMethodCall[0]);
         static::assertSame('suite_name', $suiteMethodCall[1][0]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_autoconfigures_fixtures_and_listeners(): void
+    {
+        $this->container->setDefinition(
+            'acme.fixture_autoconfigured',
+            (new Definition())
+                ->setClass(DummyFixture::class)
+                ->setAutoconfigured(true)
+        );
+
+        $this->container->setDefinition(
+            'acme.listener_autoconfigured',
+            (new Definition())
+                ->setClass(DummyListener::class)
+                ->setAutoconfigured(true)
+        );
+
+        $this->load();
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'acme.fixture_autoconfigured',
+            FixtureRegistryPass::FIXTURE_SERVICE_TAG
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'acme.listener_autoconfigured',
+            ListenerRegistryPass::LISTENER_SERVICE_TAG
+        );
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | kindda
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Improve DX by bringing autoconfiguration to services implementing the `Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface`. This allow developper to omit the `sylius_fixtures.fixture` tag on their service definitions (and even omit the whole definition if autowiring is on).

I would suggest to put the tag value in a constant of the `FixtureRegistryPass`, seems like a good idea to you ?