### PR TITLE
[OrderBundle] Add autoconfiguration for cart contexts and order processor services.

### DIFF
--- a/docs/components_and_bundles/bundles/SyliusOrderBundle/processors.rst
+++ b/docs/components_and_bundles/bundles/SyliusOrderBundle/processors.rst
@@ -6,7 +6,7 @@ Order processors are responsible of manipulating the orders to apply different p
 Registering custom processors
 -----------------------------
 
-Once you have your own :ref:`component_order_processors_order-processor-interface` implementation you need to register it as a service.
+Once you have your own :ref:`component_order_processors_order-processor-interface` implementation, if services autowiring and auto-configuration are not enabled, you need to register it as a service.
 
 .. code-block:: xml
 
@@ -18,7 +18,7 @@ Once you have your own :ref:`component_order_processors_order-processor-interfac
                                    http://symfony.com/schema/dic/services/services-1.0.xsd">
 
         <services>
-            <service id="acme.order_processor.custom" class="Acme\ShopBundle\OrderProcessor\CustomOrderProcessor">
+            <service id="app.order_processor.custom" class="App\OrderProcessor\CustomOrderProcessor">
                 <tag name="sylius.order_processor" priority="0" />
             </service>
         </services>

--- a/src/Sylius/Bundle/OrderBundle/DependencyInjection/Compiler/RegisterCartContextsPass.php
+++ b/src/Sylius/Bundle/OrderBundle/DependencyInjection/Compiler/RegisterCartContextsPass.php
@@ -17,12 +17,14 @@ use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\PrioritizedComposi
 
 final class RegisterCartContextsPass extends PrioritizedCompositeServicePass
 {
+    public const CART_CONTEXT_SERVICE_TAG = 'sylius.context.cart';
+
     public function __construct()
     {
         parent::__construct(
             'sylius.context.cart',
             'sylius.context.cart.composite',
-            'sylius.context.cart',
+            self::CART_CONTEXT_SERVICE_TAG,
             'addContext'
         );
     }

--- a/src/Sylius/Bundle/OrderBundle/DependencyInjection/Compiler/RegisterProcessorsPass.php
+++ b/src/Sylius/Bundle/OrderBundle/DependencyInjection/Compiler/RegisterProcessorsPass.php
@@ -17,12 +17,14 @@ use Sylius\Bundle\ResourceBundle\DependencyInjection\Compiler\PrioritizedComposi
 
 final class RegisterProcessorsPass extends PrioritizedCompositeServicePass
 {
+    public const PROCESSOR_SERVICE_TAG = 'sylius.order_processor';
+
     public function __construct()
     {
         parent::__construct(
             'sylius.order_processing.order_processor',
             'sylius.order_processing.order_processor.composite',
-            'sylius.order_processor',
+            self::PROCESSOR_SERVICE_TAG,
             'addProcessor'
         );
     }

--- a/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
+++ b/src/Sylius/Bundle/OrderBundle/DependencyInjection/SyliusOrderExtension.php
@@ -13,7 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\OrderBundle\DependencyInjection;
 
+use Sylius\Bundle\OrderBundle\DependencyInjection\Compiler\RegisterCartContextsPass;
+use Sylius\Bundle\OrderBundle\DependencyInjection\Compiler\RegisterProcessorsPass;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractResourceExtension;
+use Sylius\Component\Order\Context\CartContextInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -36,5 +40,14 @@ final class SyliusOrderExtension extends AbstractResourceExtension
 
         $container->setParameter('sylius_order.cart_expiration_period', $config['expiration']['cart']);
         $container->setParameter('sylius_order.order_expiration_period', $config['expiration']['order']);
+
+        $container
+            ->registerForAutoconfiguration(CartContextInterface::class)
+            ->addTag(RegisterCartContextsPass::CART_CONTEXT_SERVICE_TAG)
+        ;
+        $container
+            ->registerForAutoconfiguration(OrderProcessorInterface::class)
+            ->addTag(RegisterProcessorsPass::PROCESSOR_SERVICE_TAG)
+        ;
     }
 }

--- a/src/Sylius/Bundle/OrderBundle/Tests/DependencyInjection/SyliusOrderExtensionTest.php
+++ b/src/Sylius/Bundle/OrderBundle/Tests/DependencyInjection/SyliusOrderExtensionTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\OrderBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sylius\Bundle\OrderBundle\DependencyInjection\Compiler\RegisterCartContextsPass;
+use Sylius\Bundle\OrderBundle\DependencyInjection\Compiler\RegisterProcessorsPass;
+use Sylius\Bundle\OrderBundle\DependencyInjection\SyliusOrderExtension;
+use Sylius\Component\Order\Context\CartContextInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class SyliusOrderExtensionTest extends AbstractExtensionTestCase
+{
+    /**
+     * @test
+     */
+    public function it_autoconfigures_cart_contexts_and_order_processors(): void
+    {
+        $this->container->setDefinition(
+            'acme.cart_context_autoconfigured',
+            (new Definition())
+                ->setClass(self::getMockClass(CartContextInterface::class))
+                ->setAutoconfigured(true)
+        );
+
+        $this->container->setDefinition(
+            'acme.processor_autoconfigured',
+            (new Definition())
+                ->setClass(self::getMockClass(OrderProcessorInterface::class))
+                ->setAutoconfigured(true)
+        );
+
+        $this->load();
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'acme.cart_context_autoconfigured',
+            RegisterCartContextsPass::CART_CONTEXT_SERVICE_TAG
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'acme.processor_autoconfigured',
+            RegisterProcessorsPass::PROCESSOR_SERVICE_TAG
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getContainerExtensions(): array
+    {
+        return [new SyliusOrderExtension()];
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | 
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This is made to improve DX by allowing auto-configuration (and thus, autowiring) of services implementing the `CartContextInterface` and the `OrderProcessorInterface` (as for the FixtureBundle - see #9789).

The PR also contains a "fix" about creating dummy classes for the FixtureBundle : phpUnit does that very well and it costs much less lines of codes :)