### PR TITLE
Removed leftover Symfony3 references

### DIFF
--- a/docs/contributing/code/bdd.rst
+++ b/docs/contributing/code/bdd.rst
@@ -73,8 +73,8 @@ Add this VirtualHost configuration:
 
         RewriteEngine On
 
-        DocumentRoot /var/www/sylius/web
-        <Directory /var/www/sylius/web>
+        DocumentRoot /var/www/sylius/public
+        <Directory /var/www/sylius/public>
             Options Indexes FollowSymLinks MultiViews
             AllowOverride None
             Order allow,deny

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallCommand.php
@@ -84,14 +84,9 @@ EOT
             }
         }
 
-        $frontControllerPath = 'prod' === $this->getEnvironment() ? '/' : sprintf('/app_%s.php', $this->getEnvironment());
-
         $outputStyle->newLine(2);
         $outputStyle->success($this->getProperFinalMessage($errored));
-        $outputStyle->writeln(sprintf(
-            'You can now open your store at the following path under the website root: <info>%s.</info>',
-            $frontControllerPath
-        ));
+        $outputStyle->writeln('You can now open your store at the following path under the website root: /');
     }
 
     /**

--- a/src/Sylius/Bundle/ThemeBundle/Command/AssetsInstallCommand.php
+++ b/src/Sylius/Bundle/ThemeBundle/Command/AssetsInstallCommand.php
@@ -34,7 +34,7 @@ final class AssetsInstallCommand extends ContainerAwareCommand
         $this
             ->setName('sylius:theme:assets:install')
             ->setDefinition([
-                new InputArgument('target', InputArgument::OPTIONAL, 'The target directory', 'web'),
+                new InputArgument('target', InputArgument::OPTIONAL, 'The target directory', 'public'),
             ])
             ->addOption('symlink', null, InputOption::VALUE_NONE, 'Symlinks the assets instead of copying it')
             ->addOption('relative', null, InputOption::VALUE_NONE, 'Make relative symlinks')
@@ -75,20 +75,20 @@ final class AssetsInstallCommand extends ContainerAwareCommand
     {
         return <<<EOT
 The <info>%command.name%</info> command installs theme assets into a given
-directory (e.g. the <comment>web</comment> directory).
+directory (e.g. the <comment>public</comment> directory).
 
-  <info>php %command.full_name% web</info>
+  <info>php %command.full_name% public</info>
 
 A "themes" directory will be created inside the target directory.
 
 To create a symlink to each theme instead of copying its assets, use the
 <info>--symlink</info> option (will fall back to hard copies when symbolic links aren't possible):
 
-  <info>php %command.full_name% web --symlink</info>
+  <info>php %command.full_name% public --symlink</info>
 
 To make symlink relative, add the <info>--relative</info> option:
 
-  <info>php %command.full_name% web --symlink --relative</info>
+  <info>php %command.full_name% public --symlink --relative</info>
 
 EOT;
     }

--- a/src/Sylius/Bundle/ThemeBundle/Command/AssetsInstallCommand.php
+++ b/src/Sylius/Bundle/ThemeBundle/Command/AssetsInstallCommand.php
@@ -34,7 +34,7 @@ final class AssetsInstallCommand extends ContainerAwareCommand
         $this
             ->setName('sylius:theme:assets:install')
             ->setDefinition([
-                new InputArgument('target', InputArgument::OPTIONAL, 'The target directory', 'public'),
+                new InputArgument('target', InputArgument::OPTIONAL, 'The target directory', 'web'),
             ])
             ->addOption('symlink', null, InputOption::VALUE_NONE, 'Symlinks the assets instead of copying it')
             ->addOption('relative', null, InputOption::VALUE_NONE, 'Make relative symlinks')


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | No
| New feature?    | No
| BC breaks?      | No
| Deprecations?   | No
| Related tickets | No
| License         | MIT

----

This PR removes a few leftover references to Symfony 3. `app.php` and `app_dev.php` are no longer used and `web` has been renamed to `public`.