### PR TITLE
[ThemeBundle] Add support for Twig namespaced paths and "templates/" top-level directory

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/templating.xml
+++ b/src/Sylius/Bundle/ThemeBundle/Resources/config/services/integrations/templating.xml
@@ -29,11 +29,6 @@
             <argument type="service" id="kernel" />
         </service>
 
-        <service id="sylius.theme.templating.name_parser" class="Sylius\Bundle\ThemeBundle\Templating\TemplateNameParser" decorates="templating.name_parser" decoration-priority="256" public="false">
-            <argument type="service" id="sylius.theme.templating.name_parser.inner" />
-            <argument type="service" id="kernel" />
-        </service>
-
         <service id="sylius.theme.templating.cache" class="Doctrine\Common\Cache\ArrayCache" />
 
         <service id="sylius.theme.templating.locator" class="Sylius\Bundle\ThemeBundle\Templating\Locator\TemplateLocator" public="false">

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/FirstTestTheme/TestBundle/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/FirstTestTheme/TestBundle/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
@@ -1,0 +1,1 @@
+@Test/Templating/twigNamespacedBothThemesTemplate.txt.twig|sylius/first-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/FirstTestTheme/TestBundle/views/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/FirstTestTheme/TestBundle/views/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig
@@ -1,0 +1,1 @@
+@Test/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig|sylius/first-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/FirstTestTheme/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/FirstTestTheme/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
@@ -1,0 +1,1 @@
+Templating/twigNamespacedBothThemesTemplate.txt.twig|sylius/first-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/SecondTestTheme/TestBundle/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/SecondTestTheme/TestBundle/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
@@ -1,0 +1,1 @@
+@Test/Templating/twigNamespacedBothThemesTemplate.txt.twig|sylius/second-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/SecondTestTheme/TestBundle/views/Templating/twigNamespacedLastThemeTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/SecondTestTheme/TestBundle/views/Templating/twigNamespacedLastThemeTemplate.txt.twig
@@ -1,0 +1,1 @@
+@Test/Templating/twigNamespacedLastThemeTemplate.txt.twig|sylius/second-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/SecondTestTheme/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/SecondTestTheme/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
@@ -1,0 +1,1 @@
+Templating/twigNamespacedBothThemesTemplate.txt.twig|sylius/second-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/SecondTestTheme/views/Templating/twigNamespacedLastThemeTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/SecondTestTheme/views/Templating/twigNamespacedLastThemeTemplate.txt.twig
@@ -1,0 +1,1 @@
+Templating/twigNamespacedLastThemeTemplate.txt.twig|sylius/second-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/TestBundle/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/TestBundle/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
@@ -1,0 +1,1 @@
+@Test/Templating/twigNamespacedBothThemesTemplate.txt.twig|sylius/third-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/TestBundle/views/Templating/twigNamespacedLastThemeTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/TestBundle/views/Templating/twigNamespacedLastThemeTemplate.txt.twig
@@ -1,0 +1,1 @@
+@Test/Templating/twigNamespacedLastThemeTemplate.txt.twig|sylius/third-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
@@ -1,0 +1,1 @@
+Templating/twigNamespacedBothThemesTemplate.txt.twig|sylius/third-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/views/Templating/twigNamespacedLastThemeTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/YetAnotherTheme/TestTheme/views/Templating/twigNamespacedLastThemeTemplate.txt.twig
@@ -1,0 +1,1 @@
+Templating/twigNamespacedLastThemeTemplate.txt.twig|sylius/third-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TemplatingTest.php
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TemplatingTest.php
@@ -72,6 +72,11 @@ final class TemplatingTest extends WebTestCase
             ['@Test/Templating/vanillaOverriddenThemeTemplate.txt.twig', 'TestBundle:Templating:vanillaOverriddenThemeTemplate.txt.twig|sylius/first-test-theme'],
             ['@Test/Templating/bothThemesTemplate.txt.twig', 'TestBundle:Templating:bothThemesTemplate.txt.twig|sylius/first-test-theme'],
             ['@Test/Templating/lastThemeTemplate.txt.twig', 'TestBundle:Templating:lastThemeTemplate.txt.twig|sylius/second-test-theme'],
+            ['@Test/Templating/twigNamespacedVanillaTemplate.txt.twig', '@Test/Templating/twigNamespacedVanillaTemplate.txt.twig'],
+            ['@Test/Templating/twigNamespacedVanillaOverriddenTemplate.txt.twig', '@Test/Templating/twigNamespacedVanillaOverriddenTemplate.txt.twig (templates overridden)'],
+            ['@Test/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig', '@Test/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig|sylius/first-test-theme'],
+            ['@Test/Templating/twigNamespacedBothThemesTemplate.txt.twig', '@Test/Templating/twigNamespacedBothThemesTemplate.txt.twig|sylius/first-test-theme'],
+            ['@Test/Templating/twigNamespacedLastThemeTemplate.txt.twig', '@Test/Templating/twigNamespacedLastThemeTemplate.txt.twig|sylius/second-test-theme'],
         ];
     }
 
@@ -123,9 +128,12 @@ final class TemplatingTest extends WebTestCase
     public function getAppTemplatesUsingNamespacedPaths()
     {
         return [
-            ['/Templating/vanillaTemplate.txt.twig', ':Templating:vanillaTemplate.txt.twig'],
-            ['/Templating/bothThemesTemplate.txt.twig', ':Templating:bothThemesTemplate.txt.twig|sylius/first-test-theme'],
-            ['/Templating/lastThemeTemplate.txt.twig', ':Templating:lastThemeTemplate.txt.twig|sylius/second-test-theme'],
+            ['Templating/vanillaTemplate.txt.twig', ':Templating:vanillaTemplate.txt.twig'],
+            ['Templating/bothThemesTemplate.txt.twig', ':Templating:bothThemesTemplate.txt.twig|sylius/first-test-theme'],
+            ['Templating/lastThemeTemplate.txt.twig', ':Templating:lastThemeTemplate.txt.twig|sylius/second-test-theme'],
+            ['Templating/twigNamespacedVanillaTemplate.txt.twig', 'Templating/twigNamespacedVanillaTemplate.txt.twig'],
+            ['Templating/twigNamespacedBothThemesTemplate.txt.twig', 'Templating/twigNamespacedBothThemesTemplate.txt.twig|sylius/first-test-theme'],
+            ['Templating/twigNamespacedLastThemeTemplate.txt.twig', 'Templating/twigNamespacedLastThemeTemplate.txt.twig|sylius/second-test-theme'],
         ];
     }
 }

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TestBundle/Resources/views/Templating/bothThemesTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TestBundle/Resources/views/Templating/bothThemesTemplate.txt.twig
@@ -1,1 +1,1 @@
-TestBundle:Templating:firstOverriddenTemplate.txt.twig
+TestBundle:Templating:bothThemesTemplate.txt.twig

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TestBundle/Resources/views/Templating/lastThemeTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TestBundle/Resources/views/Templating/lastThemeTemplate.txt.twig
@@ -1,1 +1,1 @@
-TestBundle:Templating:lastOverriddenTemplate.txt.twig
+TestBundle:Templating:lastThemeTemplate.txt.twig

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TestBundle/Resources/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TestBundle/Resources/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
@@ -1,0 +1,1 @@
+@Test/Templating/twigNamespacedBothThemesTemplate.txt.twig

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TestBundle/Resources/views/Templating/twigNamespacedLastThemeTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TestBundle/Resources/views/Templating/twigNamespacedLastThemeTemplate.txt.twig
@@ -1,0 +1,1 @@
+@Test/Templating/twigNamespacedLastThemeTemplate.txt.twig

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TestBundle/Resources/views/Templating/twigNamespacedVanillaOverriddenTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TestBundle/Resources/views/Templating/twigNamespacedVanillaOverriddenTemplate.txt.twig
@@ -1,0 +1,1 @@
+@Test/Templating/twigNamespacedVanillaOverriddenTemplate.txt.twig

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TestBundle/Resources/views/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TestBundle/Resources/views/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig
@@ -1,0 +1,1 @@
+@Test/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TestBundle/Resources/views/Templating/twigNamespacedVanillaTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TestBundle/Resources/views/Templating/twigNamespacedVanillaTemplate.txt.twig
@@ -1,0 +1,1 @@
+@Test/Templating/twigNamespacedVanillaTemplate.txt.twig

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/Resources/views/Templating/bothThemesTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/Resources/views/Templating/bothThemesTemplate.txt.twig
@@ -1,1 +1,1 @@
-:Templating:firstOverriddenTemplate.txt.twig
+:Templating:bothThemesTemplate.txt.twig

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/Resources/views/Templating/lastThemeTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/Resources/views/Templating/lastThemeTemplate.txt.twig
@@ -1,1 +1,1 @@
-:Templating:lastOverriddenTemplate.txt.twig
+:Templating:lastThemeTemplate.txt.twig

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/config/config.yml
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/app/config/config.yml
@@ -19,6 +19,7 @@ framework:
     test: ~
 
 twig:
+    paths: ['%kernel.project_dir%/templates']
     debug: "%kernel.debug%"
     strict_variables: "%kernel.debug%"
 

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/templates/Templating/twigNamespacedBothThemesTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/templates/Templating/twigNamespacedBothThemesTemplate.txt.twig
@@ -1,0 +1,1 @@
+Templating/twigNamespacedBothThemesTemplate.txt.twig

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/templates/Templating/twigNamespacedLastThemeTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/templates/Templating/twigNamespacedLastThemeTemplate.txt.twig
@@ -1,0 +1,1 @@
+Templating/twigNamespacedLastThemeTemplate.txt.twig

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/templates/Templating/twigNamespacedVanillaTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/templates/Templating/twigNamespacedVanillaTemplate.txt.twig
@@ -1,0 +1,1 @@
+Templating/twigNamespacedVanillaTemplate.txt.twig

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/templates/bundles/TestBundle/Templating/twigNamespacedVanillaOverriddenTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/templates/bundles/TestBundle/Templating/twigNamespacedVanillaOverriddenTemplate.txt.twig
@@ -1,0 +1,1 @@
+@Test/Templating/twigNamespacedVanillaOverriddenTemplate.txt.twig (templates overridden)

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/templates/bundles/TestBundle/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/templates/bundles/TestBundle/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig
@@ -1,0 +1,1 @@
+@Test/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig (templates overridden)

--- a/src/Sylius/Bundle/ThemeBundle/spec/Locator/BundleResourceLocatorSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/Locator/BundleResourceLocatorSpec.php
@@ -33,7 +33,7 @@ final class BundleResourceLocatorSpec extends ObjectBehavior
         $this->shouldImplement(ResourceLocatorInterface::class);
     }
 
-    function it_locates_bundle_resource(
+    function it_locates_bundle_resource_using_path_derived_from_bundle_notation_and_symfony3_kernel_behaviour(
         Filesystem $filesystem,
         KernelInterface $kernel,
         ThemeInterface $theme,
@@ -47,13 +47,30 @@ final class BundleResourceLocatorSpec extends ObjectBehavior
 
         $theme->getPath()->willReturn('/theme/path');
 
-        $filesystem->exists('/theme/path/ChildBundle/views/index.html.twig')->shouldBeCalled()->willReturn(false);
-        $filesystem->exists('/theme/path/ParentBundle/views/index.html.twig')->shouldBeCalled()->willReturn(true);
+        $filesystem->exists('/theme/path/ChildBundle/views/Directory/index.html.twig')->shouldBeCalled()->willReturn(false);
+        $filesystem->exists('/theme/path/ParentBundle/views/Directory/index.html.twig')->shouldBeCalled()->willReturn(true);
 
-        $this->locateResource('@ParentBundle/Resources/views/index.html.twig', $theme)->shouldReturn('/theme/path/ParentBundle/views/index.html.twig');
+        $this->locateResource('@ParentBundle/Resources/views/Directory/index.html.twig', $theme)->shouldReturn('/theme/path/ParentBundle/views/Directory/index.html.twig');
     }
 
-    function it_throws_an_exception_if_resource_can_not_be_located(
+    function it_locates_bundle_resource_using_path_derived_from_bundle_notation_and_symfony4_kernel_behaviour(
+        Filesystem $filesystem,
+        KernelInterface $kernel,
+        ThemeInterface $theme,
+        BundleInterface $justBundle
+    ): void {
+        $kernel->getBundle('JustBundle', false)->willReturn($justBundle);
+
+        $justBundle->getName()->willReturn('JustBundle');
+
+        $theme->getPath()->willReturn('/theme/path');
+
+        $filesystem->exists('/theme/path/JustBundle/views/Directory/index.html.twig')->shouldBeCalled()->willReturn(true);
+
+        $this->locateResource('@JustBundle/Resources/views/Directory/index.html.twig', $theme)->shouldReturn('/theme/path/JustBundle/views/Directory/index.html.twig');
+    }
+
+    function it_throws_an_exception_if_resource_can_not_be_located_using_path_derived_from_bundle_notation(
         Filesystem $filesystem,
         KernelInterface $kernel,
         ThemeInterface $theme,
@@ -68,24 +85,42 @@ final class BundleResourceLocatorSpec extends ObjectBehavior
         $theme->getName()->willReturn('theme/name');
         $theme->getPath()->willReturn('/theme/path');
 
-        $filesystem->exists('/theme/path/ChildBundle/views/index.html.twig')->shouldBeCalled()->willReturn(false);
-        $filesystem->exists('/theme/path/ParentBundle/views/index.html.twig')->shouldBeCalled()->willReturn(false);
+        $filesystem->exists('/theme/path/ChildBundle/views/Directory/index.html.twig')->shouldBeCalled()->willReturn(false);
+        $filesystem->exists('/theme/path/ParentBundle/views/Directory/index.html.twig')->shouldBeCalled()->willReturn(false);
 
-        $this->shouldThrow(ResourceNotFoundException::class)->during('locateResource', ['@ParentBundle/Resources/views/index.html.twig', $theme]);
+        $this->shouldThrow(ResourceNotFoundException::class)->during('locateResource', ['@ParentBundle/Resources/views/Directory/index.html.twig', $theme]);
+    }
+
+    function it_locates_bundle_resource_using_path_derived_from_twig_namespaces(
+        Filesystem $filesystem,
+        ThemeInterface $theme
+    ): void {
+        $theme->getPath()->willReturn('/theme/path');
+
+        $filesystem->exists('/theme/path/JustBundle/views/Directory/index.html.twig')->shouldBeCalled()->willReturn(true);
+
+        $this->locateResource('@Just/Directory/index.html.twig', $theme)->shouldReturn('/theme/path/JustBundle/views/Directory/index.html.twig');
+    }
+
+    function it_throws_an_exception_if_resource_can_not_be_located_using_path_derived_from_twig_namespaces(
+        Filesystem $filesystem,
+        ThemeInterface $theme
+    ): void {
+        $theme->getName()->willReturn('theme/name');
+        $theme->getPath()->willReturn('/theme/path');
+
+        $filesystem->exists('/theme/path/JustBundle/views/Directory/index.html.twig')->shouldBeCalled()->willReturn(false);
+
+        $this->shouldThrow(ResourceNotFoundException::class)->during('locateResource', ['@Just/Directory/index.html.twig', $theme]);
     }
 
     function it_throws_an_exception_if_resource_path_does_not_start_with_an_asperand(ThemeInterface $theme): void
     {
-        $this->shouldThrow(\InvalidArgumentException::class)->during('locateResource', ['ParentBundle/Resources/views/index.html.twig', $theme]);
+        $this->shouldThrow(\InvalidArgumentException::class)->during('locateResource', ['ParentBundle/Resources/views/Directory/index.html.twig', $theme]);
     }
 
     function it_throws_an_exception_if_resource_path_contains_two_dots_in_a_row(ThemeInterface $theme): void
     {
-        $this->shouldThrow(\InvalidArgumentException::class)->during('locateResource', ['@ParentBundle/Resources/views/../views/index.html.twig', $theme]);
-    }
-
-    function it_throws_an_exception_if_resource_path_does_not_contain_resources_dir(ThemeInterface $theme): void
-    {
-        $this->shouldThrow(\InvalidArgumentException::class)->during('locateResource', ['@ParentBundle/views/Resources.index.html.twig', $theme]);
+        $this->shouldThrow(\InvalidArgumentException::class)->during('locateResource', ['@ParentBundle/Resources/views/../views/Directory/index.html.twig', $theme]);
     }
 }

--- a/src/Sylius/Bundle/ThemeBundle/spec/Templating/Locator/TemplateLocatorSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/Templating/Locator/TemplateLocatorSpec.php
@@ -37,9 +37,9 @@ final class TemplateLocatorSpec extends ObjectBehavior
         TemplateReferenceInterface $template,
         ThemeInterface $theme
     ): void {
-        $template->getPath()->willReturn('@AcmeBundle/Resources/views/index.html.twig');
+        $template->getPath()->willReturn('@AcmeBundle/Resources/views/Directory/index.html.twig');
 
-        $resourceLocator->locateResource('@AcmeBundle/Resources/views/index.html.twig', $theme)->willReturn('/acme/index.html.twig');
+        $resourceLocator->locateResource('@AcmeBundle/Resources/views/Directory/index.html.twig', $theme)->willReturn('/acme/index.html.twig');
 
         $this->locateTemplate($template, $theme)->shouldReturn('/acme/index.html.twig');
     }
@@ -49,9 +49,9 @@ final class TemplateLocatorSpec extends ObjectBehavior
         TemplateReferenceInterface $template,
         ThemeInterface $theme
     ): void {
-        $template->getPath()->willReturn('@AcmeBundle/Resources/views/index.html.twig');
+        $template->getPath()->willReturn('@AcmeBundle/Resources/views/Directory/index.html.twig');
 
-        $resourceLocator->locateResource('@AcmeBundle/Resources/views/index.html.twig', $theme)->willThrow(ResourceNotFoundException::class);
+        $resourceLocator->locateResource('@AcmeBundle/Resources/views/Directory/index.html.twig', $theme)->willThrow(ResourceNotFoundException::class);
 
         $this->shouldThrow(ResourceNotFoundException::class)->during('locateTemplate', [$template, $theme]);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3?
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #9719, fixes #8929, fixes #9802
| License         | MIT

It's both a new feature (added support) and a bugfix (Symfony 4 directory structure & Twig namespaced paths aren't handled correctly now, which prevents people from using Sylius 1.3). That's why I target 1.3 with this PR.

First commit is containing all the new tests, second one provides the implementation.
