### PR TITLE
Wrong var used

### DIFF
--- a/.env.test_cached.dist
+++ b/.env.test_cached.dist
@@ -12,7 +12,7 @@ APP_SECRET=EDITME
 # Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # For a sqlite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
 # Set "serverVersion" to your server version to avoid edge-case exceptions and extra database calls
-DATABASE_URL=mysql://root@127.0.0.1/sylius_${APP_ENV}
+DATABASE_URL=mysql://root@127.0.0.1/sylius_%kernel.environment%
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/swiftmailer-bundle ###


### PR DESCRIPTION
Environnement vars could not be composed by other vars

| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | no~yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT
