### PR TITLE
Sylius admin form theme

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/update.html.twig
@@ -5,7 +5,7 @@
 
 {% block title %}{{ 'sylius.ui.edit_order'|trans ~' #'~ order.number }} {{ parent() }}{% endblock %}
 
-{% form_theme form '@SyliusUi/Form/theme.html.twig' %}
+{% form_theme form '@SyliusAdmin/Form/theme.html.twig' %}
 
 {% block content %}
 {{ sonata_block_render_event('sylius.admin.order.update.before_header', {'resource': resource}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
@@ -1,4 +1,4 @@
-{% extends '@SyliusUi/Form/theme.html.twig' %}
+{% extends '@SyliusAdmin/Form/theme.html.twig' %}
 
 {% block collection_widget -%}
     {% import '@SyliusUi/Macro/flags.html.twig' as flags %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/generate.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/generate.html.twig
@@ -6,7 +6,7 @@
 
 {% block title %}{{ header|trans }} {{ parent() }}{% endblock %}
 
-{% form_theme form '@SyliusUi/Form/theme.html.twig' %}
+{% form_theme form '@SyliusAdmin/Form/theme.html.twig' %}
 
 {% block content %}
 {{ sonata_block_render_event('sylius.admin.product_variant.generate.before_header', {'resource': resource}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/generate.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/generate.html.twig
@@ -6,7 +6,7 @@
 
 {% block title %}{{ header|trans }} {{ parent() }}{% endblock %}
 
-{% form_theme form '@SyliusUi/Form/theme.html.twig' %}
+{% form_theme form '@SyliusAdmin/Form/theme.html.twig' %}
 
 {% block content %}
 {{ sonata_block_render_event('sylius.admin.promotion_coupon.generate.before_header', {'resource': promotion}) }}


### PR DESCRIPTION
## Change UiBundle calls in AdminBundle

Actually, only 2 files use the AdminBundle form theme : 
- AdminBundle/Resources/views/Crud/create.html.twig
- AdminBundle/Resources/views/Crud/update.html.twig

I changed the SyliusUi form theme called in `SyliusShopBundle` templates in order to call the SyliusAdmin one.

### Files impacted by `form_theme`

- `AdminBundle/Resources/views/Order/update.html.twig`
- `AdminBundle/Resources/views/ProductVariant/generate.html.twig`
- `AdminBundle/Resources/views/PromotionCoupon/generate.html.twig`

### Files impacted by `extends`

- `AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig`

The `attributesCollection.html.twig` file is used by `AdminBundle/Resources/views/Product/Tab/_attributes.html.twig`

## Want to know more ? 

See the the [previous PR](https://github.com/Sylius/Sylius/pull/9786) for ShopBundle form theme
I didn't test everything at this moment (I'm in the train 🚅), but I will as soon as possible if you can't.

Thank you for your amazing work on Sylius 🚀
If you want more information, ask me 👀