### PR TITLE
Custom homepage controller as public service

### DIFF
--- a/docs/customization/controller.rst
+++ b/docs/customization/controller.rst
@@ -173,6 +173,7 @@ If you still need the methods of the original HomepageController, then copy its 
         sylius.controller.shop.homepage:
             class: AppBundle\Controller\Shop\HomepageController
             arguments: ['@templating']
+            public: true
 
 Remember to import the ``app/config/services.yml`` into the ``app/config/config.yml``.
 


### PR DESCRIPTION
It seems that the Custom homepage controller service needs to be marked as public as well, otherwise it cannot be fetched from the container. 
It looks like there is a default service configuration for the controllers in config.yml which is supposed to make public all controllers in AppBundle but it doesn't resolve this issue

| Q               | A
| --------------- | -----
| Branch?         | 1.2, 1.3 or master <!-- see the comment below -->
| Bug fix?        | no/yes
| New feature?    | no/yes
| BC breaks?      | no/yes
| Deprecations?   | no/yes <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.2 or 1.3 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
