### PR TITLE
Wrong usage of returned data

### DIFF
--- a/docs/book/configuration/locales.rst
+++ b/docs/book/configuration/locales.rst
@@ -54,7 +54,7 @@ You can easily modify this logic by overriding this service.
         $locales = $this->get('sylius.locale_provider')->getAvailableLocalesCodes();
 
         foreach ($locales as $locale) {
-            echo $locale->getCode();
+            echo $locale;
         }
     }
 


### PR DESCRIPTION
`getAvailableLocalesCodes` return `string[]` not an object

| Q               | A
| --------------- | -----
| Branch?         | 1.2 1.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | unknown
| License         | MIT
