### PR TITLE
SensioGeneratorBundle vs SymfonyMakerBundle

### DIFF
--- a/docs/cookbook/entities/custom-model.rst
+++ b/docs/cookbook/entities/custom-model.rst
@@ -23,9 +23,17 @@ that simplifies the process of adding a model, or the `SymfonyMakerBundle <https
 
 You need to use such a command in your project directory.
 
+With the Generator Bundle
+
 .. code-block:: bash
 
     $ php bin/console generate:doctrine:entity
+
+With the Maker Bundle
+
+.. code-block:: bash
+
+    $ php bin/console make:entity
 
 The generator will ask you for the entity name and fields. See how it should look like to match our assumptions.
 

--- a/docs/cookbook/entities/custom-model.rst
+++ b/docs/cookbook/entities/custom-model.rst
@@ -15,11 +15,11 @@ A Supplier needs three essential fields: ``name``, ``description`` and ``enabled
 ----------------------
 
 Symfony, the framework Sylius uses, provides the `SensioGeneratorBundle <http://symfony.com/doc/current/bundles/SensioGeneratorBundle/index.html>`_,
-that simplifies the process of adding a model.
+that simplifies the process of adding a model, or the `SymfonyMakerBundle <https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html>`_ for Symfony 4.
 
 .. warning::
 
-    Remember to have the ``SensioGeneratorBundle`` imported in the AppKernel, as it is not there by default.
+    Remember to have the ``SensioGeneratorBundle`` (or SymfonyMakerBundle depending on your Symfony version) imported in the AppKernel, as it is not there by default.
 
 You need to use such a command in your project directory.
 


### PR DESCRIPTION
Sensio Generator Bundle does not support Symfony 4, and we should use the Maker Bundle as it's stated here https://github.com/sensiolabs/SensioGeneratorBundle

| Q               | A
| --------------- | -----
| Branch?         | 1.2, 1.3 or master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.2 or 1.3 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
