### PR TITLE
Fix gulp uglify error with arrow functions

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-lazy-choice-tree.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-lazy-choice-tree.js
@@ -155,13 +155,13 @@
                 checkboxElement.checkbox({
                     onChecked: function() {
                         var value = checkboxElement.data('value');
-                        var checkedValues = $input.val().split(",").filter(x => x);
+                        var checkedValues = $input.val().split(",").filter(Boolean);
                         checkedValues.push(value);
                         $input.val(checkedValues.join());
                     },
                     onUnchecked: function() {
                         var value = checkboxElement.data('value');
-                        var checkedValues = $input.val().split(",").filter(x => x);
+                        var checkedValues = $input.val().split(",").filter(Boolean);
                         var i = checkedValues.indexOf(value);
                         if(i != -1) {
                             checkedValues.splice(i, 1);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT

Avoid *SyntaxError: Unexpected token: operator (>)* error with uglify in production mode.

Initial commit was b376768 "Filter blank values" (taxon selection in tree when product edit).