### PR TITLE
Use SyliusShop grid default template

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Index/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Index/_content.html.twig
@@ -1,1 +1,1 @@
-{{ sylius_grid_render(resources, '@SyliusUi/Grid/_default.html.twig') }}
+{{ sylius_grid_render(resources, '@SyliusAdmin/Grid/_default.html.twig') }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Grid/_default.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Grid/_default.html.twig
@@ -1,0 +1,1 @@
+{% extends '@SyliusUi/Grid/_default.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/Order/index.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/Order/index.html.twig
@@ -9,7 +9,7 @@
 
     {{ sonata_block_render_event('sylius.shop.account.order.index.after_content_header', {'orders': orders}) }}
 
-    {{ sylius_grid_render(resources, '@SyliusUi/Grid/_default.html.twig') }}
+    {{ sylius_grid_render(resources, '@SyliusShop/Grid/_default.html.twig') }}
 
     {{ sonata_block_render_event('sylius.shop.account.order.index.after_grid', {'orders': orders}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Grid/_default.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Grid/_default.html.twig
@@ -1,0 +1,1 @@
+{% extends '@SyliusUi/Grid/_default.html.twig' %}


### PR DESCRIPTION
## Adding a grid template to ShopBundle

I created the file `Grid/_default.html.twig` in `SyliusShopBundle` in order to be able to override this template in theme and only impact the front. With that, we can customize our shop without break the admin render.

## Change UiBundle calls in ShopBundle

I changed the grid called in `ShopBundle/Resources/views/Account/Order/index.html.twig`.

Thank you for your amazing work on Sylius 🚀
If you want more information, ask me 👀