### PR TITLE
Use SyliusShop simple menu template

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/layout.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/layout.html.twig
@@ -8,7 +8,7 @@
         <div class="four wide column">
             {{ sonata_block_render_event('sylius.shop.account.layout.before_menu') }}
 
-            {{ knp_menu_render('sylius.shop.account', {'template': '@SyliusUi/Menu/simple.html.twig'}) }}
+            {{ knp_menu_render('sylius.shop.account', {'template': '@SyliusShop/Menu/simple.html.twig'}) }}
 
             {{ sonata_block_render_event('sylius.shop.account.layout.after_menu') }}
         </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Menu/simple.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Menu/simple.html.twig
@@ -1,0 +1,1 @@
+{% extends '@SyliusUi/Menu/simple.html.twig' %}


### PR DESCRIPTION
## Adding a menu template to ShopBundle

I created the file `Menu/simple.html.twig` in `SyliusShopBundle` in order to be able to override this template in theme and only impact the front. With that, we can customize our shop without break the admin render.

## Change UiBundle calls in ShopBundle

I changed the menu called in `ShopBundle/Resources/views/Account/layout.html.twig`.
The `Menu/simple.html.twig` is only called in this template. In the future, if I want to use it on admin and/or in front I will be able to customize it.

Thank you for your amazing work on Sylius 🚀
If you want more information, ask me 👀