### PR TITLE
[Core] Bad reverting of ShippingPercentageDiscount promotion

### DIFF
--- a/features/checkout/ability_to_confirm_an_order_with_a_promotion_on_shipping.feature
+++ b/features/checkout/ability_to_confirm_an_order_with_a_promotion_on_shipping.feature
@@ -1,0 +1,26 @@
+@checkout
+Feature: Ability to confirm an order with a promotion on shipping
+  In order to be sure that the shipping discount was applied to my order
+  As a Customer
+  I want to be able to see all remaining steps
+
+  Background:
+    Given the store operates on a single channel in "United States"
+    And the store has a product "PHP T-Shirt" priced at "$19.99"
+    And the store has "DHL" shipping method with "$50.00" fee
+    And there is a promotion "Holiday promotion"
+    And the promotion gives "10%" discount on shipping to every order
+    And the store allows paying offline
+    And I am a logged in customer
+
+  @ui
+  Scenario: Successfully placing an order
+    Given I have product "PHP T-Shirt" in the cart
+    And I am at the checkout addressing step
+    When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+    And I proceed with "DHL" shipping method and "Offline" payment
+    Then I should be on the checkout summary step
+    And "Holiday promotion" should be applied to my order shipping
+    And this promotion should give "-$5.00" discount
+    And I confirm my order
+    Then I should see the thank you page

--- a/src/Sylius/Component/Core/Promotion/Action/ShippingPercentageDiscountPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/ShippingPercentageDiscountPromotionActionCommand.php
@@ -80,7 +80,7 @@ final class ShippingPercentageDiscountPromotionActionCommand implements Promotio
             );
         }
 
-        foreach ($subject->getAdjustments(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT) as $adjustment) {
+        foreach ($subject->getAdjustments(AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT) as $adjustment) {
             if ($promotion->getCode() === $adjustment->getOriginCode()) {
                 $subject->removeAdjustment($adjustment);
             }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

When you create a promotion with a discount on delivery, you cannot submit an order.

**Steps to reproduce**
Create a promotion with "Shipping percentage discount" (set any percents). All orders with applied promotions are unable to finish. After submitting on last step, you will see a "Your order total has been changed, check your order information and confirm it again." message.