### PR TITLE
Repaired shipping method fixture

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
@@ -106,8 +106,8 @@ class ShippingMethodExampleFactory extends AbstractExampleFactory implements Exa
         $shippingMethod->setConfiguration($options['calculator']['configuration']);
         $shippingMethod->setArchivedAt($options['archived_at']);
 
-        if (array_key_exists('shipping_category', $options)) {
-            $shippingMethod->setCategory($options['shipping_category']);
+        if (array_key_exists('category', $options)) {
+            $shippingMethod->setCategory($options['category']);
         }
 
         foreach ($this->getLocales() as $localeCode) {
@@ -147,9 +147,9 @@ class ShippingMethodExampleFactory extends AbstractExampleFactory implements Exa
             ->setDefault('zone', LazyOption::randomOne($this->zoneRepository))
             ->setAllowedTypes('zone', ['null', 'string', ZoneInterface::class])
             ->setNormalizer('zone', LazyOption::findOneBy($this->zoneRepository, 'code'))
-            ->setDefined('shipping_category')
-            ->setAllowedTypes('shipping_category', ['null', 'string', ShippingCategoryInterface::class])
-            ->setNormalizer('shipping_category', LazyOption::findOneBy($this->shippingCategoryRepository, 'code'))
+            ->setDefined('category')
+            ->setAllowedTypes('category', ['null', 'string', ShippingCategoryInterface::class])
+            ->setNormalizer('category', LazyOption::findOneBy($this->shippingCategoryRepository, 'code'))
             ->setDefault('calculator', function (Options $options): array {
                 $configuration = [];
                 /** @var ChannelInterface $channel */

--- a/src/Sylius/Bundle/CoreBundle/Fixture/ShippingMethodFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ShippingMethodFixture.php
@@ -37,7 +37,7 @@ class ShippingMethodFixture extends AbstractResourceFixture
                 ->scalarNode('description')->cannotBeEmpty()->end()
                 ->scalarNode('zone')->cannotBeEmpty()->end()
                 ->booleanNode('enabled')->end()
-                ->scalarNode('shipping_category')->end()
+                ->scalarNode('category')->end()
                 ->arrayNode('channels')->scalarPrototype()->end()->end()
                 ->arrayNode('calculator')
                     ->children()

--- a/src/Sylius/Bundle/CoreBundle/Fixture/ShippingMethodFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ShippingMethodFixture.php
@@ -37,7 +37,7 @@ class ShippingMethodFixture extends AbstractResourceFixture
                 ->scalarNode('description')->cannotBeEmpty()->end()
                 ->scalarNode('zone')->cannotBeEmpty()->end()
                 ->booleanNode('enabled')->end()
-                ->scalarNode('category')->end()
+                ->scalarNode('shipping_category')->end()
                 ->arrayNode('channels')->scalarPrototype()->end()->end()
                 ->arrayNode('calculator')
                     ->children()


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.2 or 1.3 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->

Using fixtures it was impossible to set categories for shipping methods, because because the option in the fixture and the corresponding factory had different names.