### PR TITLE
Image / File display in edit form

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -114,6 +114,11 @@
 {% macro collection_item(form, allow_delete, button_delete_label, index) %}
     {% spaceless %}
         <div data-form-collection="item" data-form-collection-index="{{ index }}">
+            {% if form.vars.value.path|default(null) is not null %}
+                {% if form.vars.value.path|split('.')|last in ['jpg', 'jpeg', 'png', 'pdf', 'gif'] %}
+                    <img class="ui small bordered image" src="{{ form.vars.value.path|imagine_filter('sylius_small') }}" alt="{{ form.vars.value.type }}" />
+                {% endif %}
+            {% endif %}
             {{ form_widget(form) }}
             {% if allow_delete %}
                 <a href="#" data-form-collection="delete" class="ui red labeled icon button" style="margin-bottom: 1em;">


### PR DESCRIPTION
If there is a collection of file fields inside the form (for a custom resource with a collection of images for example) and there one or more image already persisted, display a thumbnail of that image for each (I'm not sure of the best way to do it, i think my snippet  could be improved a lot).
Currently there is nothing displayed, the file field in the edit page looks empty even if there is already a file saved, so it's a bit confusing for the admin.

| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no/yes
| Deprecations?   | no/yes <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.2 or 1.3 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
