### PR TITLE
Fix ShippingPercentageDiscountPromotionActionCommand.php

### DIFF
--- a/features/promotion/receiving_discount/receiving_percentage_discount_on_shipping.feature
+++ b/features/promotion/receiving_discount/receiving_percentage_discount_on_shipping.feature
@@ -45,6 +45,15 @@ Feature: Receiving percentage discount on shipping
         Then my cart total should be "$50.00"
         And my cart shipping total should be "$10.00"
 
+    @ui
+    Scenario: Not receiving negative discount on shipping
+        Given the promotion gives free shipping to every order over "$70.00"
+        And there is a promotion "Shipping promotion"
+        And this promotion gives free shipping to every order over "$50.00"
+        When I add 4 products "PHP Mug" to the cart
+        Then my cart total should be "$80.00"
+        And my cart shipping total should be "$0.00"
+
     @ui @javascript
     Scenario: Still receiving free shipping after removing the product from the cart
         Given the promotion gives free shipping to every order over "$70.00"

--- a/src/Sylius/Component/Core/Promotion/Action/ShippingPercentageDiscountPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/ShippingPercentageDiscountPromotionActionCommand.php
@@ -52,7 +52,7 @@ final class ShippingPercentageDiscountPromotionActionCommand implements Promotio
         if ($maxShippingDiscount < 0) {
             return false;
         }
-        
+
         $adjustment = $this->createAdjustment($promotion);
 
         $adjustmentAmount = (int) round($subject->getAdjustmentsTotal(AdjustmentInterface::SHIPPING_ADJUSTMENT) * $configuration['percentage']);
@@ -60,10 +60,10 @@ final class ShippingPercentageDiscountPromotionActionCommand implements Promotio
             return false;
         }
 
-        if($maxShippingDiscount < $adjustmentAmount) {
+        if ($maxShippingDiscount < $adjustmentAmount) {
             $adjustmentAmount = $maxShippingDiscount;
         }
-        
+
         $adjustment->setAmount(-$adjustmentAmount);
         $subject->addAdjustment($adjustment);
 

--- a/src/Sylius/Component/Core/Promotion/Action/ShippingPercentageDiscountPromotionActionCommand.php
+++ b/src/Sylius/Component/Core/Promotion/Action/ShippingPercentageDiscountPromotionActionCommand.php
@@ -48,6 +48,11 @@ final class ShippingPercentageDiscountPromotionActionCommand implements Promotio
             return false;
         }
 
+        $maxShippingDiscount = $subject->getAdjustmentsTotal(AdjustmentInterface::SHIPPING_ADJUSTMENT) + $subject->getAdjustmentsTotal(AdjustmentInterface::ORDER_SHIPPING_PROMOTION_ADJUSTMENT);
+        if ($maxShippingDiscount < 0) {
+            return false;
+        }
+        
         $adjustment = $this->createAdjustment($promotion);
 
         $adjustmentAmount = (int) round($subject->getAdjustmentsTotal(AdjustmentInterface::SHIPPING_ADJUSTMENT) * $configuration['percentage']);
@@ -55,6 +60,10 @@ final class ShippingPercentageDiscountPromotionActionCommand implements Promotio
             return false;
         }
 
+        if($maxShippingDiscount < $adjustmentAmount) {
+            $adjustmentAmount = $maxShippingDiscount;
+        }
+        
         $adjustment->setAmount(-$adjustmentAmount);
         $subject->addAdjustment($adjustment);
 


### PR DESCRIPTION
If you create 2 promotions with a 100% discount for shipping, or you add the shipping action twice, 
you will receive a negative shipping cost.

This fix this issue!

| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
