### PR TITLE
Add sylius.customer.post_register when the user is created

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
@@ -151,7 +151,7 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
      *
      * @return SyliusUserInterface
      */
-    private function createUserByOAuthUserResponse(UserResponseInterface $response): SyliusUserInterface
+    protected function createUserByOAuthUserResponse(UserResponseInterface $response): SyliusUserInterface
     {
         /** @var SyliusUserInterface $user */
         $user = $this->userFactory->createNew();
@@ -203,7 +203,7 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
      *
      * @return SyliusUserInterface
      */
-    private function updateUserByOAuthUserResponse(UserInterface $user, UserResponseInterface $response): SyliusUserInterface
+    protected function updateUserByOAuthUserResponse(UserInterface $user, UserResponseInterface $response): SyliusUserInterface
     {
         /** @var SyliusUserInterface $user */
         Assert::isInstanceOf($user, SyliusUserInterface::class);

--- a/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
@@ -40,37 +40,37 @@ class UserProvider extends BaseUserProvider implements AccountConnectorInterface
     /**
      * @var FactoryInterface
      */
-    private $oauthFactory;
+    protected $oauthFactory;
 
     /**
      * @var RepositoryInterface
      */
-    private $oauthRepository;
+    protected $oauthRepository;
 
     /**
      * @var FactoryInterface
      */
-    private $customerFactory;
+    protected $customerFactory;
 
     /**
      * @var FactoryInterface
      */
-    private $userFactory;
+    protected $userFactory;
 
     /**
      * @var ObjectManager
      */
-    private $userManager;
+    protected $userManager;
 
     /**
      * @var CustomerRepositoryInterface
      */
-    private $customerRepository;
+    protected $customerRepository;
 
     /**
      * @var EventDispatcherInterface
      */
-    private $eventDispatcher;
+    protected $eventDispatcher;
 
     /**
      * @param string $supportedUserClass

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/integrations/hwi_oauth.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/integrations/hwi_oauth.xml
@@ -25,6 +25,7 @@
             <argument type="service" id="sylius.manager.shop_user" />
             <argument type="service" id="sylius.canonicalizer" />
             <argument type="service" id="sylius.repository.customer" />
+            <argument type="service" id="event_dispatcher" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
When a new user is created by `Sylius\Bundle\CoreBundle\OAuth\UserProvider` no mail was sent to the user to check the email or to just confirm that the account is well created.

| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #9750 
| License         | MIT
