### PR TITLE
[Behat] Mitigate race conditions in Behat tests

### DIFF
--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
@@ -44,6 +44,7 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
      */
     public function saveChanges()
     {
+        usleep(500000);
         $this->getDocument()->pressButton('sylius_save_changes_button');
     }
 

--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
@@ -88,6 +88,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
 
         $this->getDocument()->pressButton('Add attributes');
         $this->waitForFormElement();
+        usleep(500000);
 
         $this->getElement('attribute_value', ['%attributeName%' => $attributeName, '%localeCode%' => $localeCode])->setValue($value);
     }

--- a/src/Sylius/Behat/Page/Shop/Cart/SummaryPage.php
+++ b/src/Sylius/Behat/Page/Shop/Cart/SummaryPage.php
@@ -122,6 +122,7 @@ class SummaryPage extends SymfonyPage implements SummaryPageInterface
     {
         $itemElement = $this->getElement('product_row', ['%name%' => $productName]);
         $itemElement->find('css', 'button.sylius-cart-remove-button')->press();
+        usleep(500000);
     }
 
     /**

--- a/src/Sylius/Behat/Service/Setter/CookieSetter.php
+++ b/src/Sylius/Behat/Service/Setter/CookieSetter.php
@@ -63,6 +63,7 @@ final class CookieSetter implements CookieSetterInterface
     private function prepareMinkSessionIfNeeded(Session $session): void
     {
         if ($this->shouldMinkSessionBePrepared($session)) {
+            usleep(100000);
             $session->visit(rtrim($this->minkParameters['base_url'], '/') . '/');
         }
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes (well, not exactly...)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Sometimes, in a semi-random way (some pages are affected more frequently than others) Javascript Behat tests experience race conditions, leading to failed tests. 

This solution -while probably not the most orthodox- works in the 100% of tests i've done. And given that we are running tests in a controled environment (localhost calls) I think it's just fine.

(There is more advanced solutions involving spinning until success or timeout, but in our case this solutions must be implemented multiple times at context level and requires more code, and deeper changes)