### PR TITLE
Hydrate promotion_rules directly on loading active promotions for a channel (1n)

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/PromotionRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/PromotionRepository.php
@@ -13,23 +13,47 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Doctrine\ORM;
 
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping;
 use Sylius\Bundle\PromotionBundle\Doctrine\ORM\PromotionRepository as BasePromotionRepository;
 use Sylius\Component\Channel\Model\ChannelInterface;
 use Sylius\Component\Core\Repository\PromotionRepositoryInterface;
+use SyliusLabs\AssociationHydrator\AssociationHydrator;
 
 class PromotionRepository extends BasePromotionRepository implements PromotionRepositoryInterface
 {
+    /**
+     * @var AssociationHydrator
+     */
+    private $associationHydrator;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(EntityManager $entityManager, Mapping\ClassMetadata $class)
+    {
+        parent::__construct($entityManager, $class);
+
+        $this->associationHydrator = new AssociationHydrator($entityManager, $class);
+    }
+
     /**
      * {@inheritdoc}
      */
     public function findActiveByChannel(ChannelInterface $channel): array
     {
-        return $this->filterByActive($this->createQueryBuilder('o'))
+        $promotions = $this->filterByActive($this->createQueryBuilder('o'))
             ->andWhere(':channel MEMBER OF o.channels')
             ->setParameter('channel', $channel)
             ->addOrderBy('o.priority', 'DESC')
             ->getQuery()
             ->getResult()
         ;
+
+        $this->associationHydrator->hydrateAssociations($promotions, [
+            'rules',
+        ]);
+
+        return $promotions;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in #9882
| License         | MIT

See #9882 for explanation of what it's partially solving.
