### PR TITLE
change documentation: filename of _form.yml should have the extension…

### DIFF
--- a/docs/cookbook/entities/custom-translatable-model.rst
+++ b/docs/cookbook/entities/custom-translatable-model.rst
@@ -454,7 +454,7 @@ Remember to import your grid in the ``app/config/grids/grids.yml`` file which ha
 
 .. code-block:: php
 
-    # AppBundle/Resources/views/Supplier/_form.yml
+    # AppBundle/Resources/views/Supplier/_form.html.twig
     {% from '@SyliusAdmin/Macro/translationForm.html.twig' import translationForm %}
 
     {{ form_errors(form) }}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no related ticket(s)
| License         | MIT

The documentation mentions an incorrect extension in step 10. This PR fixes that
