### PR TITLE
 [Order] Removing after SM callback

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Resources/config/app/state_machine.yml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/app/state_machine.yml
@@ -28,8 +28,3 @@ winzou_state_machine:
                     on: "create"
                     do: ["@sylius.order_number_assigner", "assignNumber"]
                     args: ["object"]
-            after:
-                sylius_complete_checkout:
-                    on: "create"
-                    do: ["@sylius.complete_checkout_callback", "completeCheckout"]
-                    args: ["object"]


### PR DESCRIPTION
This callback refers to nothing so when this file is called, it throws an error : `You have requested a non-existent service "sylius.complete_checkout_callback".`, plus this file is never called anywhere. But still useful as a base file for anyone using this bundle as standalone.

| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | not really
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

