### PR TITLE
#9862 Number of items in order summary page

### DIFF
--- a/features/checkout/paying_for_order/changing_payment_method_after_order_confirmation_item_quantity.feature
+++ b/features/checkout/paying_for_order/changing_payment_method_after_order_confirmation_item_quantity.feature
@@ -1,0 +1,22 @@
+@paying_for_order
+Feature: Having good number of items in changing payment method page
+    In order to verify that I am changing the payment method of correct order
+    As a Customer
+    I want to see correct details about my order on changing the payment method page
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And there is a user "john@example.com" identified by "password123"
+        And the store allows paying "Offline"
+        And the store allows paying "Cash on delivery"
+        And the store has a product "PHP T-Shirt" priced at "$19.99"
+        And the store ships everywhere for free
+        And I am logged in as "john@example.com"
+
+    @ui
+    Scenario: Seeing correct quantity on payment retry page
+        Given I have added 2 products "PHP T-Shirt" to the cart
+        And I have proceeded selecting "Cash on delivery" payment method
+        And I have confirmed order
+        When I go to order details
+        Then I should see 2 as number of items

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutOrderDetailsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutOrderDetailsContext.php
@@ -65,4 +65,12 @@ final class CheckoutOrderDetailsContext implements Context
     {
         Assert::false($this->orderDetails->hasPayAction());
     }
+
+    /**
+     * @Then I should see :quantity as number of items
+     */
+    public function iShouldSeeAsNumberOfItems(int $quantity): void
+    {
+        Assert::same($this->orderDetails->getNumberOfItems(), $quantity);
+    }
 }

--- a/src/Sylius/Behat/Page/Shop/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Shop/Order/ShowPage.php
@@ -68,12 +68,24 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
     }
 
     /**
+     * @inheritdoc
+     */
+    public function getNumberOfItems(): int
+    {
+        $itemsText = trim($this->getElement('items_text')->getText());
+        $itemsTextWords = explode(' ', $itemsText);
+
+        return (int) $itemsTextWords[0];
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getDefinedElements()
     {
         return array_merge(parent::getDefinedElements(), [
             'instructions' => '#sylius-payment-method-instructions',
+            'items_text' => 'div.sub.header div.item:nth-child(3)',
             'pay_link' => '#sylius-pay-link',
             'payment_method' => '.item:contains("%name%") input',
             'thank_you' => '#sylius-thank-you',

--- a/src/Sylius/Behat/Page/Shop/Order/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Order/ShowPageInterface.php
@@ -33,4 +33,6 @@ interface ShowPageInterface extends SymfonyPageInterface
      * @return string[]
      */
     public function getNotifications();
+
+    public function getNumberOfItems(): int;
 }

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Order/_summary.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Order/_summary.html.twig
@@ -13,7 +13,7 @@
                     {{ money.convertAndFormat(order.total) }}
                 </div>
                 <div class="item">
-                    {{ order.items|length }} {{ 'sylius.ui.items'|trans|lower }}
+                    {{ order.totalQuantity }} {{ 'sylius.ui.items'|trans|lower }}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #9862 
| License         | MIT

Fixing number of items displayed in order summary page
