### PR TITLE
Handle the base locale code in fixtures

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/LocaleFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/LocaleFixture.php
@@ -53,9 +53,7 @@ class LocaleFixture extends AbstractFixture
      */
     public function load(array $options): void
     {
-        $localesCodes = array_merge([$this->baseLocaleCode], $options['locales']);
-
-        foreach ($localesCodes as $localeCode) {
+        foreach ($options['locales'] as $localeCode) {
             /** @var LocaleInterface $locale */
             $locale = $this->localeFactory->createNew();
 
@@ -83,6 +81,9 @@ class LocaleFixture extends AbstractFixture
         $optionsNode
             ->children()
                 ->arrayNode('locales')
+                    ->beforeNormalization()
+                        ->always(function ($v) { return array_merge($v, [$this->baseLocaleCode => true]); })
+                    ->end()
                     ->scalarPrototype()
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/LocaleFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/LocaleFixtureTest.php
@@ -40,6 +40,28 @@ final class LocaleFixtureTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function default_locale_is_always_added() : void
+    {
+        $this->assertProcessedConfigurationEquals(
+            [['locales' => ['en_US' => true, 'pl_PL' => false, 'es_ES' => true]]],
+            ['locales' => ['en_US' => true, 'pl_PL' => false, 'es_ES' => true, 'default_LOCALE' => true]]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function default_locale_is_always_enabled() : void
+    {
+        $this->assertProcessedConfigurationEquals(
+            [['locales' => ['en_US' => true, 'pl_PL' => false, 'es_ES' => true, 'default_LOCALE' => false]]],
+            ['locales' => ['en_US' => true, 'pl_PL' => false, 'es_ES' => true, 'default_LOCALE' => true]]
+        );
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getConfiguration(): LocaleFixture


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2, 1.3, master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

During the training, we ran into an issue where we added the default locale code in the custom fixture suite and it has been added twice. This should avoid the duplicate error constraint. :)