### PR TITLE
Product images deletion fix

### DIFF
--- a/features/product/managing_products/prevent_deletion_of_purchased_product.feature
+++ b/features/product/managing_products/prevent_deletion_of_purchased_product.feature
@@ -19,3 +19,15 @@ Feature: Prevent deletion of purchased product
         When I try to delete the "Toyota GT86 model" product
         Then I should be notified that this product is in use and cannot be deleted
         And this product should still exist in the product catalog
+
+    @ui
+    Scenario: Purchased product images should be kept
+        Given the store has a product "Lamborghini Gallardo Model"
+        And this product has an image "lamborghini.jpg" with "thumbnail" type
+        And there is a customer "jane.doe@gmail.com" that placed an order "#00000026"
+        And the customer bought a single "Lamborghini Gallardo Model"
+        And the customer chose "Free" shipping method to "United States" with "Cash on Delivery" payment
+        When I try to delete the "Lamborghini Gallardo Model" product
+        Then I should be notified that this product is in use and cannot be deleted
+        And this product should still exist in the product catalog
+        And the product "Lamborghini Gallardo Model" should have an image with "thumbnail" type

--- a/features/product/managing_products/prevent_deletion_of_purchased_product.feature
+++ b/features/product/managing_products/prevent_deletion_of_purchased_product.feature
@@ -30,4 +30,4 @@ Feature: Prevent deletion of purchased product
         When I try to delete the "Lamborghini Gallardo Model" product
         Then I should be notified that this product is in use and cannot be deleted
         And this product should still exist in the product catalog
-        And the product "Lamborghini Gallardo Model" should have an image with "thumbnail" type
+        And the product "Lamborghini Gallardo Model" should still have an accessible image

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -676,11 +676,19 @@ final class ManagingProductsContext implements Context
     }
 
     /**
-     * @Then /^(?:this product|the product "[^"]+"|it) should(?:| also) have an image with "([^"]*)" type$/
+     * @Then /^(this product) should(?:| also) have an image with "([^"]*)" type$/
+     * @Then /^the (product "[^"]+") should(?:| also) have an image with "([^"]*)" type$/
+     * @Then /^(it) should(?:| also) have an image with "([^"]*)" type$/
      */
-    public function thisProductShouldHaveAnImageWithType($type)
+    public function thisProductShouldHaveAnImageWithType(ProductInterface $product, $type)
     {
-        $currentPage = $this->resolveCurrentPage();
+        if ($product->isSimple()) {
+            $currentPage = $this->updateSimpleProductPage;
+        } else {
+            $currentPage = $this->updateConfigurableProductPage;
+        }
+
+        $currentPage->open(['id' => $product->getId()]);
 
         Assert::true($currentPage->isImageWithTypeDisplayed($type));
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -676,21 +676,21 @@ final class ManagingProductsContext implements Context
     }
 
     /**
-     * @Then /^(this product) should(?:| also) have an image with "([^"]*)" type$/
-     * @Then /^the (product "[^"]+") should(?:| also) have an image with "([^"]*)" type$/
-     * @Then /^(it) should(?:| also) have an image with "([^"]*)" type$/
+     * @Then /^(?:this product|the product "[^"]+"|it) should(?:| also) have an image with "([^"]*)" type$/
      */
-    public function thisProductShouldHaveAnImageWithType(ProductInterface $product, $type)
+    public function thisProductShouldHaveAnImageWithType($type)
     {
-        if ($product->isSimple()) {
-            $currentPage = $this->updateSimpleProductPage;
-        } else {
-            $currentPage = $this->updateConfigurableProductPage;
-        }
-
-        $currentPage->open(['id' => $product->getId()]);
+        $currentPage = $this->resolveCurrentPage();
 
         Assert::true($currentPage->isImageWithTypeDisplayed($type));
+    }
+
+    /**
+     * @Then /^the (product "[^"]+") should still have an accessible image$/
+     */
+    public function productShouldStillHaveAnAccessibleImage(ProductInterface $product): void
+    {
+        Assert::true($this->indexPage->hasProductAccessibleImage($product->getCode()));
     }
 
     /**

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPage.php
@@ -13,16 +13,44 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Product;
 
+use Behat\Mink\Session;
 use Sylius\Behat\Page\Admin\Crud\IndexPage as CrudIndexPage;
+use Sylius\Behat\Service\Accessor\TableAccessorInterface;
+use Sylius\Behat\Service\Checker\ImageExistenceCheckerInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 final class IndexPage extends CrudIndexPage implements IndexPageInterface
 {
+    /** @var ImageExistenceCheckerInterface */
+    private $imageExistenceChecker;
+
+    public function __construct(
+        Session $session,
+        array $parameters,
+        RouterInterface $router,
+        TableAccessorInterface $tableAccessor,
+        string $routeName,
+        ImageExistenceCheckerInterface $imageExistenceChecker
+    ) {
+        parent::__construct($session, $parameters, $router, $tableAccessor, $routeName);
+
+        $this->imageExistenceChecker = $imageExistenceChecker;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function filterByTaxon($taxonName)
     {
         $this->getElement('taxon_filter', ['%taxon%' => $taxonName])->click();
+    }
+
+    public function hasProductAccessibleImage(string $productCode): bool
+    {
+        $productRow = $this->getTableAccessor()->getRowWithFields($this->getElement('table'), ['code' => $productCode]);
+        $imageUrl = $productRow->find('css', 'img')->getAttribute('src');
+
+        return $this->imageExistenceChecker->doesImageWithUrlExist($imageUrl, 'sylius_admin_product_thumbnail');
     }
 
     /**

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPageInterface.php
@@ -21,4 +21,6 @@ interface IndexPageInterface extends CrudIndexPageInterface
      * @param string $taxonName
      */
     public function filterByTaxon($taxonName);
+
+    public function hasProductAccessibleImage(string $productCode): bool;
 }

--- a/src/Sylius/Behat/Resources/config/services.xml
+++ b/src/Sylius/Behat/Resources/config/services.xml
@@ -51,6 +51,11 @@
 
         <service id="sylius.behat.table_accessor" class="Sylius\Behat\Service\Accessor\TableAccessor" public="false" />
 
+        <service id="sylius.behat.checker.image_existence" class="Sylius\Behat\Service\Checker\ImageExistenceChecker">
+            <argument type="service" id="__symfony__.sylius.liip.filter_service" />
+            <argument type="string">%__symfony__.kernel.project_dir%/web/</argument>
+        </service>
+
         <service id="sylius.behat.paypal_api_mocker" class="Sylius\Behat\Service\Mocker\PaypalApiMocker" public="false">
             <argument type="service" id="sylius.behat.mocker" />
             <argument type="service" id="sylius.behat.response_loader" />

--- a/src/Sylius/Behat/Resources/config/services.xml
+++ b/src/Sylius/Behat/Resources/config/services.xml
@@ -53,7 +53,7 @@
 
         <service id="sylius.behat.checker.image_existence" class="Sylius\Behat\Service\Checker\ImageExistenceChecker">
             <argument type="service" id="__symfony__.sylius.liip.filter_service" />
-            <argument type="string">%__symfony__.kernel.project_dir%/web/</argument>
+            <argument type="string">%__symfony__.sylius_core.public_dir%</argument>
         </service>
 
         <service id="sylius.behat.paypal_api_mocker" class="Sylius\Behat\Service\Mocker\PaypalApiMocker" public="false">

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -135,6 +135,7 @@
             <argument type="service" id="sylius.behat.page.admin.product.index_per_taxon" />
             <argument type="service" id="sylius.behat.current_page_resolver" />
             <argument type="service" id="sylius.behat.notification_checker" />
+            <argument type="service" id="__symfony__.liip_imagine.cache.manager" />
             <tag name="fob.context_service" />
         </service>
 

--- a/src/Sylius/Behat/Resources/config/services/pages/admin/product.xml
+++ b/src/Sylius/Behat/Resources/config/services/pages/admin/product.xml
@@ -33,6 +33,7 @@
         </service>
         <service id="sylius.behat.page.admin.product.index" class="%sylius.behat.page.admin.product.index.class%" parent="sylius.behat.page.admin.crud.index" public="false">
             <argument type="string">sylius_admin_product_index</argument>
+            <argument type="service" id="sylius.behat.checker.image_existence" />
         </service>
         <service id="sylius.behat.page.admin.product.index_per_taxon" class="%sylius.behat.page.admin.product.index_per_taxon.class%" parent="sylius.behat.page.admin.crud.index" public="false">
             <argument type="string">sylius_admin_product_per_taxon_index</argument>

--- a/src/Sylius/Behat/Service/Checker/ImageExistenceChecker.php
+++ b/src/Sylius/Behat/Service/Checker/ImageExistenceChecker.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Service\Checker;
+
+use Liip\ImagineBundle\Service\FilterService;
+
+final class ImageExistenceChecker implements ImageExistenceCheckerInterface
+{
+    /** @var FilterService */
+    private $filterService;
+
+    /** @var string */
+    private $mediaRootPath;
+
+    public function __construct(FilterService $filterService, string $mediaRootPath)
+    {
+        $this->filterService = $filterService;
+        $this->mediaRootPath = $mediaRootPath;
+    }
+
+    public function doesImageWithUrlExist(string $imageUrl, string $liipImagineFilter): bool
+    {
+        $imageUrl = str_replace($liipImagineFilter.'/', '', substr($imageUrl, strpos($imageUrl, $liipImagineFilter), strlen($imageUrl)));
+
+        $browserImagePath = $this->filterService->getUrlOfFilteredImage($imageUrl, $liipImagineFilter);
+
+        return file_exists($this->mediaRootPath.parse_url($browserImagePath, PHP_URL_PATH));
+    }
+}

--- a/src/Sylius/Behat/Service/Checker/ImageExistenceChecker.php
+++ b/src/Sylius/Behat/Service/Checker/ImageExistenceChecker.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Behat\Service\Checker;
@@ -22,10 +31,10 @@ final class ImageExistenceChecker implements ImageExistenceCheckerInterface
 
     public function doesImageWithUrlExist(string $imageUrl, string $liipImagineFilter): bool
     {
-        $imageUrl = str_replace($liipImagineFilter.'/', '', substr($imageUrl, strpos($imageUrl, $liipImagineFilter), strlen($imageUrl)));
+        $imageUrl = str_replace($liipImagineFilter . '/', '', substr($imageUrl, strpos($imageUrl, $liipImagineFilter), strlen($imageUrl)));
 
         $browserImagePath = $this->filterService->getUrlOfFilteredImage($imageUrl, $liipImagineFilter);
 
-        return file_exists($this->mediaRootPath.parse_url($browserImagePath, PHP_URL_PATH));
+        return file_exists($this->mediaRootPath . parse_url($browserImagePath, PHP_URL_PATH));
     }
 }

--- a/src/Sylius/Behat/Service/Checker/ImageExistenceCheckerInterface.php
+++ b/src/Sylius/Behat/Service/Checker/ImageExistenceCheckerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Service\Checker;
+
+interface ImageExistenceCheckerInterface
+{
+    public function doesImageWithUrlExist(string $imageUrl, string $liipImagineImagineFilter): bool;
+}

--- a/src/Sylius/Behat/Service/Checker/ImageExistenceCheckerInterface.php
+++ b/src/Sylius/Behat/Service/Checker/ImageExistenceCheckerInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Behat\Service\Checker;

--- a/src/Sylius/Bundle/CoreBundle/EventListener/ImagesRemoveListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/ImagesRemoveListener.php
@@ -59,9 +59,10 @@ final class ImagesRemoveListener
 
     public function postFlush(PostFlushEventArgs $event): void
     {
-        foreach ($this->imagesToDelete as $imagePath) {
+        foreach ($this->imagesToDelete as $key => $imagePath) {
             $this->imageUploader->remove($imagePath);
             $this->cacheManager->remove($imagePath, array_keys($this->filterManager->getFilterConfiguration()->all()));
+            unset($this->imagesToDelete[$key]);
         }
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/EventListener/ImagesRemoveListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/ImagesRemoveListener.php
@@ -13,12 +13,16 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Liip\ImagineBundle\Imagine\Filter\FilterManager;
 use Sylius\Component\Core\Model\ImageInterface;
 use Sylius\Component\Core\Uploader\ImageUploaderInterface;
 
+/**
+ * @internal
+ */
 final class ImagesRemoveListener
 {
     /** @var ImageUploaderInterface */
@@ -30,6 +34,9 @@ final class ImagesRemoveListener
     /** @var FilterManager */
     private $filterManager;
 
+    /** @var string[] */
+    private $imagesToDelete = [];
+
     public function __construct(ImageUploaderInterface $imageUploader, CacheManager $cacheManager, FilterManager $filterManager)
     {
         $this->imageUploader = $imageUploader;
@@ -37,13 +44,24 @@ final class ImagesRemoveListener
         $this->filterManager = $filterManager;
     }
 
-    public function postRemove(LifecycleEventArgs $event): void
+    public function onFlush(OnFlushEventArgs $event): void
     {
-        $image = $event->getEntity();
+        foreach ($event->getEntityManager()->getUnitOfWork()->getScheduledEntityDeletions() as $entityDeletion) {
+            if (!$entityDeletion instanceof ImageInterface) {
+                continue;
+            }
 
-        if ($image instanceof ImageInterface) {
-            $this->imageUploader->remove($image->getPath());
-            $this->cacheManager->remove($image->getPath(), array_keys($this->filterManager->getFilterConfiguration()->all()));
+            if (!in_array($entityDeletion->getPath(), $this->imagesToDelete)) {
+                $this->imagesToDelete[] = $entityDeletion->getPath();
+            }
+        }
+    }
+
+    public function postFlush(PostFlushEventArgs $event): void
+    {
+        foreach ($this->imagesToDelete as $imagePath) {
+            $this->imageUploader->remove($imagePath);
+            $this->cacheManager->remove($imagePath, array_keys($this->filterManager->getFilterConfiguration()->all()));
         }
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/parameters.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/parameters.yml
@@ -5,3 +5,4 @@ parameters:
     sylius.cache:
         type: file_system
     sylius.uploader.filesystem: sylius_image
+    sylius_core.public_dir: "%kernel.project_dir%/web"

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -36,7 +36,8 @@
             <argument type="service" id="sylius.image_uploader" />
             <argument type="service" id="liip_imagine.cache.manager" />
             <argument type="service" id="liip_imagine.filter.manager" />
-            <tag name="doctrine.event_listener" event="postRemove" lazy="true" />
+            <tag name="doctrine.event_listener" event="onFlush" lazy="true" />
+            <tag name="doctrine.event_listener" event="postFlush" lazy="true" />
         </service>
         <service id="sylius.listener.order_recalculation" class="Sylius\Bundle\CoreBundle\EventListener\OrderRecalculationListener">
             <argument type="service" id="sylius.order_processing.order_processor" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/test_services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/test_services.xml
@@ -52,6 +52,7 @@
         <service id="sylius.test.factory.promotion" class="Sylius\Component\Core\Test\Factory\TestPromotionFactory">
             <argument type="service" id="sylius.factory.promotion" />
         </service>
-    </services>
 
+        <service id="sylius.liip.filter_service" alias="liip_imagine.service.filter" public="true" />
+    </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/ImagesRemoveListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/ImagesRemoveListenerSpec.php
@@ -13,14 +13,17 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\CoreBundle\EventListener;
 
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\UnitOfWork;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 use Liip\ImagineBundle\Imagine\Filter\FilterManager;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Sylius\Bundle\CoreBundle\EventListener\ImagesRemoveListener;
 use Sylius\Component\Core\Model\ImageInterface;
+use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Uploader\ImageUploaderInterface;
 
 final class ImagesRemoveListenerSpec extends ObjectBehavior
@@ -35,36 +38,49 @@ final class ImagesRemoveListenerSpec extends ObjectBehavior
         $this->shouldHaveType(ImagesRemoveListener::class);
     }
 
-    function it_removes_file_on_post_remove_event(
-        ImageUploaderInterface $imageUploader,
-        CacheManager $cacheManager,
-        FilterManager $filterManager,
-        LifecycleEventArgs $event,
+    function it_saves_scheduled_entity_deletions_images_paths(
+        OnFlushEventArgs $event,
+        EntityManagerInterface $entityManager,
+        UnitOfWork $unitOfWork,
         ImageInterface $image,
-        FilterConfiguration $filterConfiguration
+        ProductInterface $product
     ): void {
-        $event->getEntity()->willReturn($image);
-        $image->getPath()->willReturn('image/path');
+        $event->getEntityManager()->willReturn($entityManager);
+        $entityManager->getUnitOfWork()->willReturn($unitOfWork);
+        $unitOfWork->getScheduledEntityDeletions()->willReturn([$image, $product]);
 
-        $filterManager->getFilterConfiguration()->willReturn($filterConfiguration);
-        $filterConfiguration->all()->willReturn(['sylius_small' => 'thumbnalis']);
-        $imageUploader->remove('image/path')->shouldBeCalled();
-        $cacheManager->remove('image/path', ['sylius_small'])->shouldBeCalled();
+        $image->getPath()->shouldBeCalled();
 
-        $this->postRemove($event);
+        $this->onFlush($event);
     }
 
-    function it_does_nothing_if_entity_is_not_image(
+    function it_removes_saved_images_paths(
         ImageUploaderInterface $imageUploader,
         CacheManager $cacheManager,
         FilterManager $filterManager,
-        LifecycleEventArgs $event
+        OnFlushEventArgs $onFlushEvent,
+        PostFlushEventArgs $postFlushEvent,
+        EntityManagerInterface $entityManager,
+        UnitOfWork $unitOfWork,
+        ImageInterface $image,
+        ProductInterface $product,
+        FilterConfiguration $filterConfiguration
     ): void {
-        $event->getEntity()->willReturn(new \stdClass());
-        $filterManager->getFilterConfiguration()->shouldNotBeCalled();
-        $imageUploader->remove(Argument::any())->shouldNotBeCalled();
-        $cacheManager->remove(Argument::any(), Argument::any())->shouldNotBeCalled();
+        $onFlushEvent->getEntityManager()->willReturn($entityManager);
+        $entityManager->getUnitOfWork()->willReturn($unitOfWork);
+        $unitOfWork->getScheduledEntityDeletions()->willReturn([$image, $product]);
 
-        $this->postRemove($event);
+        $image->getPath()->willReturn('image/path');
+
+        $this->onFlush($onFlushEvent);
+
+        $imageUploader->remove('image/path')->shouldBeCalled();
+
+        $filterManager->getFilterConfiguration()->willReturn($filterConfiguration);
+        $filterConfiguration->all()->willReturn(['test' => 'Test']);
+
+        $cacheManager->remove('image/path', ['test'])->shouldBeCalled();
+
+        $this->postFlush($postFlushEvent);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

### Before

The problem was, whenever product deletion failed (for example because the variant is already used in a placed order), images files were still removed. The reason for that was, that the `ImagesRemoveListener` were listening on `postRemove` doctrine event, which is called **even if** flush ends with an error.

### Proposed solution

I've refactored `ImagesRemoveListener` to listen on both `onFlush` and `postFlush` events. It saves paths from scheduled to remove entities with `ImageInterface` type and removes them with `ImageUploader` and `CacheManager` when the whole transaction passes (is there any BC Break? cc @pamil).

### Test

During the implementation, I've encountered some problems with images assertions in Behat tests. The problem was, the images files in the cache were not generated while visiting them with mink driver in Behat page. I propose a new service `ImageExistenceChecker`, which is based on checking the existence of a file, rather than visiting checked file URL (which I find a little bit more appropriate). I'm not sure about the implementation - I suppose I could have made too many assumptions about the folders structure (parameter `%__symfony__.kernel.project_dir%/web/` should be for sure changed in Sylius 1.3+) and I would be grateful for any ideas how this service can be improved/simplified.

Nonetheless, it works and fixes a bug, which is definitely a good thing 😄 🐃 