### PR TITLE
Improve taxon fixtures with translations

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/BookProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/BookProductFixture.php
@@ -98,7 +98,14 @@ class BookProductFixture extends AbstractFixture
             'children' => [
                 [
                     'code' => 'books',
-                    'name' => 'Books',
+                    'translations' => [
+                        'en_US' => [
+                            'name' => 'Books',
+                        ],
+                        'fr_FR' => [
+                            'name' => 'Livres',
+                        ]
+                    ],
                 ],
             ],
         ]]]);

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
@@ -19,6 +19,7 @@ use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Taxonomy\Generator\TaxonSlugGeneratorInterface;
+use Sylius\Component\Taxonomy\Model\TaxonTranslationInterface;
 use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -95,13 +96,14 @@ class TaxonExampleFactory extends AbstractExampleFactory implements ExampleFacto
 
         $taxon->setCode($options['code']);
 
+        // add translation for each defined locales
         foreach ($this->getLocales() as $localeCode) {
-            $taxon->setCurrentLocale($localeCode);
-            $taxon->setFallbackLocale($localeCode);
+            $this->createTranslation($taxon, $localeCode, $options);
+        }
 
-            $taxon->setName($options['name']);
-            $taxon->setDescription($options['description']);
-            $taxon->setSlug($options['slug'] ?: $this->taxonSlugGenerator->generate($taxon, $localeCode));
+        // create or replace with custom translations
+        foreach ($options['translations'] as $localeCode => $translationOptions) {
+            $this->createTranslation($taxon, $localeCode, $translationOptions);
         }
 
         foreach ($options['children'] as $childOptions) {
@@ -109,6 +111,18 @@ class TaxonExampleFactory extends AbstractExampleFactory implements ExampleFacto
         }
 
         return $taxon;
+    }
+
+    protected function createTranslation(TaxonInterface $taxon, string $localeCode, array $options = []): void
+    {
+        $options = $this->optionsResolver->resolve($options);
+
+        $taxon->setCurrentLocale($localeCode);
+        $taxon->setFallbackLocale($localeCode);
+
+        $taxon->setName($options['name']);
+        $taxon->setDescription($options['description']);
+        $taxon->setSlug($options['slug'] ?: $this->taxonSlugGenerator->generate($taxon, $localeCode));
     }
 
     /**
@@ -127,6 +141,8 @@ class TaxonExampleFactory extends AbstractExampleFactory implements ExampleFacto
             ->setDefault('description', function (Options $options): string {
                 return $this->faker->paragraph;
             })
+            ->setDefault('translations', [])
+            ->setAllowedTypes('translations', ['array'])
             ->setDefault('children', [])
             ->setAllowedTypes('children', ['array'])
         ;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/MugProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/MugProductFixture.php
@@ -104,7 +104,15 @@ class MugProductFixture extends AbstractFixture
             'children' => [
                 [
                     'code' => 'mugs',
-                    'name' => 'Mugs',
+                    'translations' => [
+                        'en_US' => [
+                            'name' => 'Mugs',
+                        ],
+                        'fr_FR' => [
+                            'name' => 'Tasses',
+                        ],
+                    ],
+
                 ],
             ],
         ]]]);

--- a/src/Sylius/Bundle/CoreBundle/Fixture/StickerProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/StickerProductFixture.php
@@ -97,7 +97,14 @@ class StickerProductFixture extends AbstractFixture
             'children' => [
                 [
                     'code' => 'stickers',
-                    'name' => 'Stickers',
+                    'translations' => [
+                        'en_US' => [
+                            'name' => 'Stickers',
+                        ],
+                        'fr_FR' => [
+                            'name' => 'Étiquettes',
+                        ],
+                    ],
                 ],
             ],
         ]]]);

--- a/src/Sylius/Bundle/CoreBundle/Fixture/TaxonFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/TaxonFixture.php
@@ -36,6 +36,7 @@ class TaxonFixture extends AbstractResourceFixture
                 ->scalarNode('code')->cannotBeEmpty()->end()
                 ->scalarNode('slug')->cannotBeEmpty()->end()
                 ->scalarNode('description')->cannotBeEmpty()->end()
+                ->variableNode('translations')->cannotBeEmpty()->defaultValue([])->end()
                 ->variableNode('children')->cannotBeEmpty()->defaultValue([])->end()
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/TshirtProductFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/TshirtProductFixture.php
@@ -101,13 +101,29 @@ class TshirtProductFixture extends AbstractFixture
                     'children' => [
                         [
                             'code' => 'mens_t_shirts',
-                            'name' => 'Men',
-                            'slug' => 't-shirts/men',
+                            'translations' => [
+                                'en_US' => [
+                                    'name' => 'Men',
+                                    'slug' => 't-shirts/men',
+                                ],
+                                'fr_FR' => [
+                                    'name' => 'Hommes',
+                                    'slug' => 't-shirts/hommes',
+                                ],
+                            ],
                         ],
                         [
                             'code' => 'womens_t_shirts',
-                            'name' => 'Women',
-                            'slug' => 't-shirts/women',
+                            'translations' => [
+                                'en_US' => [
+                                    'name' => 'Women',
+                                    'slug' => 't-shirts/women',
+                                ],
+                                'fr_FR' => [
+                                    'name' => 'Hommes',
+                                    'slug' => 't-shirts/femmes',
+                                ],
+                            ],
                         ],
                     ],
                 ],

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/TaxonFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/TaxonFixtureTest.php
@@ -77,6 +77,26 @@ final class TaxonFixtureTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function taxon_translations_are_optional(): void
+    {
+        $this->assertConfigurationIsValid([['custom' => [['translations' => [['en_US' => ['name' => ['foo']]]]]]]], 'custom.*.translations');
+    }
+
+    /**
+     * @test
+     */
+    public function taxon_translations_may_contain_nested_array(): void
+    {
+        $this->assertProcessedConfigurationEquals(
+            [['custom' => [['translations' => [['nested' => ['key' => 'value']]]]]]],
+            ['custom' => [['translations' => [['nested' => ['key' => 'value']]]]]],
+            'custom.*.translations'
+        );
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getConfiguration(): TaxonFixture

--- a/src/Sylius/Bundle/CoreBundle/spec/Fixture/Factory/TaxonExampleFactorySpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Fixture/Factory/TaxonExampleFactorySpec.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace spec\Sylius\Bundle\CoreBundle\Fixture\Factory;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+use Sylius\Component\Locale\Model\Locale;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\Component\Taxonomy\Generator\TaxonSlugGeneratorInterface;
+use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
+
+class TaxonExampleFactorySpec extends ObjectBehavior
+{
+    function let(
+        FactoryInterface $taxonFactory,
+        TaxonRepositoryInterface $taxonRepository,
+        RepositoryInterface $localeRepository,
+        TaxonSlugGeneratorInterface $taxonSlugGenerator
+    ) {
+        $this->beConstructedWith($taxonFactory, $taxonRepository, $localeRepository, $taxonSlugGenerator);
+    }
+
+    function it_is_an_example_factory(): void
+    {
+        $this->shouldHaveType(ExampleFactoryInterface::class);
+    }
+
+    function it_creates_translations_for_each_defined_locales(
+        FactoryInterface $taxonFactory,
+        RepositoryInterface $localeRepository,
+        Locale $locale,
+        TaxonInterface $taxon
+    ) {
+        $taxonFactory->createNew()->willReturn($taxon);
+        $localeRepository->findAll()->willReturn([$locale]);
+        $locale->getCode()->willReturn('en_US');
+
+        $taxon->setCurrentLocale('en_US');
+        $taxon->setFallbackLocale('en_US');
+        $taxon->setCode('Category')->shouldBeCalled();
+        $taxon->setName('Category')->shouldBeCalled();
+        $taxon->setSlug('category')->shouldBeCalled();
+        $taxon->setDescription(Argument::type('string'))->shouldBeCalled();
+
+        $this->create([
+            'name' => 'Category',
+            'slug' => 'category'
+        ]);
+    }
+
+    function it_creates_translations_for_each_custom_translations(
+        FactoryInterface $taxonFactory,
+        RepositoryInterface $localeRepository,
+        Locale $locale,
+        TaxonInterface $taxon
+    ) {
+        $taxonFactory->createNew()->willReturn($taxon);
+        $localeRepository->findAll()->willReturn([$locale]);
+        $locale->getCode()->willReturn('en_US');
+
+        $taxon->setCurrentLocale('en_US');
+        $taxon->setFallbackLocale('en_US');
+        $taxon->setCode('Category')->shouldBeCalled();
+        $taxon->setName('Category')->shouldBeCalled();
+        $taxon->setSlug('category')->shouldBeCalled();
+        $taxon->setDescription(Argument::type('string'))->shouldBeCalled();
+
+        $taxon->setCurrentLocale('fr_FR');
+        $taxon->setFallbackLocale('fr_FR');
+        $taxon->setName('Catégorie')->shouldBeCalled();
+        $taxon->setSlug('categorie')->shouldBeCalled();
+        $taxon->setDescription(Argument::type('string'))->shouldBeCalled();
+
+        $this->create([
+            'name' => 'Category',
+            'slug' => 'category',
+            'translations' => [
+                'fr_FR' => [
+                    'name' => 'Catégorie',
+                    'slug' => 'categorie',
+                ],
+            ],
+        ]);
+    }
+
+    function it_replaces_existing_translations_for_each_custom_translations(
+        FactoryInterface $taxonFactory,
+        RepositoryInterface $localeRepository,
+        Locale $locale,
+        TaxonInterface $taxon
+    ) {
+        $taxonFactory->createNew()->willReturn($taxon);
+        $localeRepository->findAll()->willReturn([$locale]);
+        $locale->getCode()->willReturn('en_US');
+
+        $taxon->setCurrentLocale('en_US');
+        $taxon->setFallbackLocale('en_US');
+        $taxon->setCode('Category')->shouldBeCalled();
+        $taxon->setName('Category')->shouldBeCalled();
+        $taxon->setSlug('category')->shouldBeCalled();
+        $taxon->setDescription(Argument::type('string'))->shouldBeCalled();
+
+        $taxon->setCurrentLocale('en_US');
+        $taxon->setFallbackLocale('en_US');
+        $taxon->setName('Categories')->shouldBeCalled();
+        $taxon->setSlug('categories')->shouldBeCalled();
+        $taxon->setDescription(Argument::type('string'))->shouldBeCalled();
+
+        $this->create([
+            'name' => 'Category',
+            'slug' => 'category',
+            'translations' => [
+                'en_US' => [
+                    'name' => 'Categories',
+                    'slug' => 'categories',
+                ],
+            ],
+        ]);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/spec/Fixture/Factory/TaxonExampleFactorySpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Fixture/Factory/TaxonExampleFactorySpec.php
@@ -38,8 +38,8 @@ class TaxonExampleFactorySpec extends ObjectBehavior
         $localeRepository->findAll()->willReturn([$locale]);
         $locale->getCode()->willReturn('en_US');
 
-        $taxon->setCurrentLocale('en_US');
-        $taxon->setFallbackLocale('en_US');
+        $taxon->setCurrentLocale('en_US')->shouldBeCalled();
+        $taxon->setFallbackLocale('en_US')->shouldBeCalled();
         $taxon->setCode('Category')->shouldBeCalled();
         $taxon->setName('Category')->shouldBeCalled();
         $taxon->setSlug('category')->shouldBeCalled();
@@ -61,8 +61,8 @@ class TaxonExampleFactorySpec extends ObjectBehavior
         $localeRepository->findAll()->willReturn([$locale]);
         $locale->getCode()->willReturn('en_US');
 
-        $taxon->setCurrentLocale('en_US');
-        $taxon->setFallbackLocale('en_US');
+        $taxon->setCurrentLocale('en_US')->shouldBeCalled();
+        $taxon->setFallbackLocale('en_US')->shouldBeCalled();
         $taxon->setCode('Category')->shouldBeCalled();
         $taxon->setName('Category')->shouldBeCalled();
         $taxon->setSlug('category')->shouldBeCalled();
@@ -96,8 +96,8 @@ class TaxonExampleFactorySpec extends ObjectBehavior
         $localeRepository->findAll()->willReturn([$locale]);
         $locale->getCode()->willReturn('en_US');
 
-        $taxon->setCurrentLocale('en_US');
-        $taxon->setFallbackLocale('en_US');
+        $taxon->setCurrentLocale('en_US')->shouldBeCalled();
+        $taxon->setFallbackLocale('en_US')->shouldBeCalled();
         $taxon->setCode('Category')->shouldBeCalled();
         $taxon->setName('Category')->shouldBeCalled();
         $taxon->setSlug('category')->shouldBeCalled();


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master?
| Bug fix?        | no
| New feature?    | kind of
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #9645 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.2 or 1.3 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->

With this PR, we can both use:
```
taxon:
    options:
        custom:
            category:
                code: category               
                name: Category
```
```
taxon:
    options:
        custom:
            category:
                code: category
                translations:
                    en_US:
                        name: Category
                        slug: category
                    cs_CZ: 
                       name: Kategorie
                       slug: kategorie
```
I've updated core fixtures for an example, but we can keep them as this.