### PR TITLE
PayumBundle: fix cs plural translation

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Resources/translations/messages.cs.yml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/translations/messages.cs.yml
@@ -20,4 +20,7 @@ sylius:
         stripe_checkout: Platba Stripe
     payum_action:
         payment:
-            description: Platba obsahuje %items% položku za celkem %total% | Platba obsahuje %items% položek za celkem %total%
+            description: |-
+                Platba obsahuje %items% položku za celkem %total%|
+                Platba obsahuje %items% položky za celkem %total%|
+                Platba obsahuje %items% položek za celkem %total%


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.2 or 1.3 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->


There are 3 plural forms in cs language (see [\Symfony\Component\Translation\PluralizationRules](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Translation/PluralizationRules.php#L158)).
I didin't find any other `messages.cs.yml` that has plural forms.

-----

Fixes error:
> ### Symfony\Component\Translation\Exception\InvalidArgumentException
> Uncaught PHP Exception Symfony\Component\Translation\Exception\InvalidArgumentException: "Unable to choose a translation for "Platba obsahuje %items% poloku za celkem %total% | Platba obsahuje %items% poloek za celkem %total%" with locale "cs" for value "10". Double check that this translation has the correct plural options (e.g. "There is one apple|There are %count% apples")." at /src/vendor/symfony/symfony/src/Symfony/Component/Translation/MessageSelector.php line 89
