### PR TITLE
Make build great again (one more time)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -179,7 +179,11 @@
         "sylius/user-bundle": "self.version"
     },
     "conflict": {
-        "symfony/symfony": "3.4.7 || 4.0.7 || 4.1.8"
+        "symfony/symfony": "3.4.7 || 4.0.7 || 4.1.8",
+        "symfony/browser-kit": "4.1.8",
+        "symfony/dependency-injection": "4.1.8",
+        "symfony/dom-crawler": "4.1.8",
+        "symfony/routing": "4.1.8"
     },
     "suggest": {
         "ext-iconv": "For better performance than using Symfony Polyfill Component",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related with https://github.com/Sylius/Sylius/pull/9970
| License         | MIT

As in the previous PR, we need to disable (for now) some specific versions of some specific packages. `"symfony/symfony": "3.4.7 || 4.0.7 || 4.1.8"` does not work anymore, as we don't use `symfony/symfony` since **Sylius 1.3** :)