### PR TITLE
Fix #9899 (main taxon autocomplete drop down now contain full taxon name - with all parents)

### DIFF
--- a/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonAutocompleteChoiceType.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Form/Type/TaxonAutocompleteChoiceType.php
@@ -28,7 +28,7 @@ final class TaxonAutocompleteChoiceType extends AbstractType
     {
         $resolver->setDefaults([
             'resource' => 'sylius.taxon',
-            'choice_name' => 'name',
+            'choice_name' => 'fullname',
             'choice_value' => 'code',
         ]);
     }

--- a/src/Sylius/Bundle/TaxonomyBundle/Resources/config/serializer/Model.Taxon.yml
+++ b/src/Sylius/Bundle/TaxonomyBundle/Resources/config/serializer/Model.Taxon.yml
@@ -50,3 +50,6 @@ Sylius\Component\Taxonomy\Model\Taxon:
         hasChildren:
             serialized_name: hasChildren
             groups: [Autocomplete]
+        getFullname:
+            serialized_name: fullname
+            groups: [Autocomplete]

--- a/src/Sylius/Component/Taxonomy/Model/Taxon.php
+++ b/src/Sylius/Component/Taxonomy/Model/Taxon.php
@@ -206,6 +206,23 @@ class Taxon implements TaxonInterface
     /**
      * {@inheritdoc}
      */
+    public function getFullname(string $pathDelimiter = ' / '): ?string
+    {
+        if ($this->isRoot()) {
+            return $this->getName();
+        }
+
+        return sprintf(
+            '%s%s%s',
+            $this->getParent()->getFullname(),
+            $pathDelimiter,
+            $this->getName()
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getSlug(): ?string
     {
         return $this->getTranslation()->getSlug();

--- a/src/Sylius/Component/Taxonomy/Model/TaxonInterface.php
+++ b/src/Sylius/Component/Taxonomy/Model/TaxonInterface.php
@@ -70,6 +70,8 @@ interface TaxonInterface extends CodeAwareInterface, TranslatableInterface, Reso
 
     public function setName(?string $name): void;
 
+    public function getFullname(string $pathDelimiter = ' / '): ?string;
+
     public function getDescription(): ?string;
 
     public function setDescription(?string $description): void;

--- a/src/Sylius/Component/Taxonomy/spec/Model/TaxonSpec.php
+++ b/src/Sylius/Component/Taxonomy/spec/Model/TaxonSpec.php
@@ -117,6 +117,29 @@ final class TaxonSpec extends ObjectBehavior
         $this->__toString()->shouldReturn('T-Shirt material');
     }
 
+    function its_fullname_is_null_if_unnamed(): void
+    {
+        $this->getFullname()->shouldReturn(null);
+    }
+
+    function its_fullname_equal_name_if_no_parent(): void
+    {
+        $this->setName('Category');
+        $this->getFullname()->shouldReturn('Category');
+    }
+
+    function its_fullname_prepends_with_parents_fullname(TaxonInterface $root): void
+    {
+        $root->getFullname()->willReturn('Category');
+        $this->setName('T-shirts');
+
+        $root->addChild($this)->shouldBeCalled();
+        $this->setParent($root);
+
+        $this->getFullname()->shouldReturn('Category / T-shirts');
+        $this->getFullname(' -- ')->shouldReturn('Category -- T-shirts');
+    }
+
     function it_has_no_description_by_default(): void
     {
         $this->getDescription()->shouldReturn(null);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2 (it based on 1.2, but should be merged to master I guess)
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | not sure
| Deprecations?   | no
| Related tickets | fixes #9899, #8485
| License         | MIT

Was:
<img width="157" alt="9899-was" src="https://user-images.githubusercontent.com/6544038/49199821-810a7d80-f3a2-11e8-8875-04fabdcea773.png">

Become:
<img width="299" alt="9899-become" src="https://user-images.githubusercontent.com/6544038/49199824-85cf3180-f3a2-11e8-9f11-e1233291df16.png">
<img width="245" alt="9899-become-2" src="https://user-images.githubusercontent.com/6544038/49199827-88318b80-f3a2-11e8-9ccf-125f68a4679a.png">
