### PR TITLE
Remove `AppBundle` from docs.

### DIFF
--- a/docs/book/architecture/translations.rst
+++ b/docs/book/architecture/translations.rst
@@ -21,7 +21,7 @@ Assuming that we would like to have a translatable model of a ``Supplier``, we n
 
    <?php
 
-   namespace AppBundle\Entity;
+   namespace App\Entity;
 
    use Sylius\Component\Resource\Model\AbstractTranslation;
 
@@ -60,7 +60,7 @@ The actual entity has access to its translation by using the ``TranslatableTrait
 
    <?php
 
-   namespace AppBundle\Entity;
+   namespace App\Entity;
 
    use Sylius\Component\Resource\Model\TranslatableInterface;
    use Sylius\Component\Resource\Model\TranslatableTrait;

--- a/docs/book/installation/installation.rst
+++ b/docs/book/installation/installation.rst
@@ -118,7 +118,7 @@ In the root directory of your project you will find these important subdirectori
 * ``config/`` - here you will be adding the yaml configuration files including routing, security, state machines configurations etc.
 * ``var/log/`` - these are the logs of your application
 * ``var/cache/`` - this is the cache of you project
-* ``src/`` - this is where you will be adding all you custom logic in the ``AppBundle``
+* ``src/`` - this is where you will be adding all you custom logic in the ``App``
 * ``public/`` - there you will be placing assets of your project
 
 .. tip::

--- a/docs/components_and_bundles/bundles/SyliusFixturesBundle/custom_fixture.rst
+++ b/docs/components_and_bundles/bundles/SyliusFixturesBundle/custom_fixture.rst
@@ -9,7 +9,7 @@ to skip the configuration part for now:
 
 .. code-block:: php
 
-    namespace AppBundle\Fixture;
+    namespace App\Fixture;
 
     use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
     use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
@@ -46,7 +46,7 @@ The next step is to register this fixture:
 
 .. code-block:: xml
 
-    <service id="app.fixture.country" class="AppBundle\Fixture\CountryFixture">
+    <service id="app.fixture.country" class="App\Fixture\CountryFixture">
         <argument type="service" id="doctrine.orm.entity_manager" />
         <tag name="sylius_fixtures.fixture" />
     </service>

--- a/docs/components_and_bundles/bundles/SyliusFixturesBundle/custom_listener.rst
+++ b/docs/components_and_bundles/bundles/SyliusFixturesBundle/custom_listener.rst
@@ -8,7 +8,7 @@ Let's create a listener that removes the directory before loading the fixtures.
 
 .. code-block:: php
 
-    namespace AppBundle\Listener;
+    namespace App\Listener;
 
     use Sylius\Bundle\FixturesBundle\Listener\AbstractListener;
     use Sylius\Bundle\FixturesBundle\Listener\BeforeSuiteListenerInterface;
@@ -32,7 +32,7 @@ The next step is to register this listener:
 
 .. code-block:: xml
 
-    <service id="app.listener.directory_purger" class="AppBundle\Listener\DirectoryPurgerListener">
+    <service id="app.listener.directory_purger" class="App\Listener\DirectoryPurgerListener">
         <tag name="sylius_fixtures.listener" />
     </service>
 

--- a/docs/components_and_bundles/bundles/SyliusGridBundle/custom_action.rst
+++ b/docs/components_and_bundles/bundles/SyliusGridBundle/custom_action.rst
@@ -37,7 +37,7 @@ Let's assume that you already have a route for contacting your suppliers, then y
                 driver:
                     name: doctrine/orm
                     options:
-                        class: AppBundle\Entity\Supplier
+                        class: App\Entity\Supplier
                 actions:
                     item:
                         contactSupplier:

--- a/docs/components_and_bundles/bundles/SyliusGridBundle/custom_field_type.rst
+++ b/docs/components_and_bundles/bundles/SyliusGridBundle/custom_field_type.rst
@@ -9,7 +9,7 @@ All you need to do is create your own class implementing FieldTypeInterface and 
 
     <?php
 
-    namespace AppBundle\Grid\FieldType;
+    namespace App\Grid\FieldType;
 
     use Sylius\Component\Grid\Definition\Field;
     use Sylius\Component\Grid\FieldTypes\FieldTypeInterface;
@@ -46,7 +46,7 @@ That is all. Now register your new field type as a service.
 
     # config/services.yaml
     app.grid_field.custom:
-        class: AppBundle\Grid\FieldType\CustomType
+        class: App\Grid\FieldType\CustomType
         tags:
             - { name: sylius.grid_field, type: custom }
 
@@ -60,7 +60,7 @@ Now you can use your new column type in the grid configuration!
                 driver:
                     name: doctrine/orm
                     options:
-                        class: AppBundle\Entity\Supplier
+                        class: App\Entity\Supplier
                 fields:
                     name:
                         type: custom

--- a/docs/components_and_bundles/bundles/SyliusGridBundle/custom_filter.rst
+++ b/docs/components_and_bundles/bundles/SyliusGridBundle/custom_filter.rst
@@ -9,7 +9,7 @@ To add a new filter, we need to create an appropriate class and form type.
 
     <?php
 
-    namespace AppBundle\Grid\Filter;
+    namespace App\Grid\Filter;
 
     use Sylius\Component\Grid\Data\DataSourceInterface;
     use Sylius\Component\Grid\Filtering\FilterInterface;
@@ -31,7 +31,7 @@ And the form type:
 
     <?php
 
-    namespace AppBundle\Form\Type\Filter;
+    namespace App\Form\Type\Filter;
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -77,12 +77,12 @@ That is all. Now let's register your new filter type as service.
 
     services:
         app.grid.filter.suppliers_statistics:
-            class: AppBundle\Grid\Filter\SuppliersStatisticsFilter
+            class: App\Grid\Filter\SuppliersStatisticsFilter
             tags:
                 -
                     name: sylius.grid_filter
                     type: suppliers_statistics
-                    form_type: AppBundle\Form\Type\Filter\SuppliersStatisticsFilterType
+                    form_type: App\Form\Type\Filter\SuppliersStatisticsFilterType
 
 Now you can use your new filter type in the grid configuration!
 
@@ -100,4 +100,4 @@ Now you can use your new filter type in the grid configuration!
                             range: [0, 100]
         templates:
             filter:
-                suppliers_statistics: 'AppBundle:Grid/Filter:suppliers_statistics.html.twig'
+                suppliers_statistics: 'App:Grid/Filter:suppliers_statistics.html.twig'

--- a/docs/components_and_bundles/bundles/SyliusGridBundle/your_first_grid.rst
+++ b/docs/components_and_bundles/bundles/SyliusGridBundle/your_first_grid.rst
@@ -15,7 +15,7 @@ If you don’t have it yet create a file ``app/config/resources.yml``, import it
             app.supplier:
                 driver: doctrine/orm
                 classes:
-                    model: AppBundle\Entity\Supplier
+                    model: App\Entity\Supplier
 
 .. code-block:: yaml
 
@@ -45,7 +45,7 @@ Now we can configure our first grid:
                 driver:
                     name: doctrine/orm
                     options:
-                        class: AppBundle\Entity\Supplier
+                        class: App\Entity\Supplier
                 fields:
                     name:
                         type: string
@@ -185,7 +185,7 @@ This first requires a :doc:`custom repository method </customization/repository>
                 driver:
                     name: doctrine/orm
                     options:
-                        class: AppBundle\Entity\Supplier
+                        class: App\Entity\Supplier
                         repository:
                             method: mySupplierGridQuery
 
@@ -258,7 +258,7 @@ If your field is not of a "simple" type, f.i. a twig template with a specific pa
                     origin:
                         type: twig
                         options:
-                            template: "@AppBundle/Grid/Fields/myCountryFlags.html.twig"
+                            template: "@App/Grid/Fields/myCountryFlags.html.twig"
                         path: address.country
                         label: app.ui.country
                         sortable: address.country

--- a/docs/components_and_bundles/bundles/SyliusInventoryBundle/installation.rst
+++ b/docs/components_and_bundles/bundles/SyliusInventoryBundle/installation.rst
@@ -47,7 +47,7 @@ Let's assume we want to implement a book store application and track the books i
 
 You have to create a `Book` and an `InventoryUnit` entity, living inside your application code.
 We think that **keeping the app-specific bundle structure simple** is a good practice, so
-let's assume you have your ``AppBundle`` registered under ``App\Bundle\AppBundle`` namespace.
+let's assume you have your ``App`` registered under ``App\Bundle\AppBundle`` namespace.
 
 We will create `Book` entity.
 
@@ -55,8 +55,8 @@ We will create `Book` entity.
 
     <?php
 
-    // src/App/AppBundle/Entity/Book.php
-    namespace App\AppBundle\Entity;
+    // src/Entity/Book.php
+    namespace App\Entity;
 
     use Sylius\Component\Inventory\Model\StockableInterface;
     use Doctrine\ORM\Mapping as ORM;
@@ -160,8 +160,8 @@ The next step requires the creating of the `InventoryUnit` entity, let’s do th
 
     <?php
 
-    // src/App/AppBundle/Entity/InventoryUnit.php
-    namespace App\AppBundle\Entity;
+    // src/Entity/InventoryUnit.php
+    namespace App\Entity;
 
     use Sylius\Component\Inventory\Model\InventoryUnit as BaseInventoryUnit;
     use Doctrine\ORM\Mapping as ORM;
@@ -196,7 +196,7 @@ Put this configuration inside your ``app/config/config.yml``.
         resources:
             inventory_unit:
                 classes:
-                    model: App\AppBundle\Entity\InventoryUnit
+                    model: App\Entity\InventoryUnit
 
 
 Updating database schema

--- a/docs/components_and_bundles/bundles/SyliusMailerBundle/configuration.rst
+++ b/docs/components_and_bundles/bundles/SyliusMailerBundle/configuration.rst
@@ -16,14 +16,14 @@ Configuration reference
           emails:
               your_email:
                   subject: Subject of your email
-                  template: AppBundle:Email:yourEmail.html.twig
+                  template: App:Email:yourEmail.html.twig
                   enabled: true/false
                   sender:
                      name: Custom name
                      address: Custom sender address for this e-mail
               your_another_email:
                   subject: Subject of your another email
-                  template: AppBundle:Email:yourAnotherEmail.html.twig
+                  template: App:Email:yourAnotherEmail.html.twig
                   enabled: true/false
                   sender:
                      name: Custom name

--- a/docs/components_and_bundles/bundles/SyliusMailerBundle/your_first_email.rst
+++ b/docs/components_and_bundles/bundles/SyliusMailerBundle/your_first_email.rst
@@ -21,7 +21,7 @@ In your ``app/config/config.yml``, under ``sylius_mailer`` you should configure 
         emails:
             movie_added_notification:
                 subject: A new movie {{ movie.title }} has been submitted
-                template: AppBundle:Email:movieAddedNotification.html.twig
+                template: App:Email:movieAddedNotification.html.twig
 
 That's it! Your unique code is "movie_added_notification". Now, let's create the template.
 
@@ -58,7 +58,7 @@ The service responsible for sending an e-mail has id ``sylius.email_sender``. Al
 
     <?php
 
-    namespace App\AppBundle\Controller;
+    namespace App\Controller;
 
     use Symfony\Component\HttpFoundation\Request;
 
@@ -78,7 +78,7 @@ Listener example:
 
     <?php
 
-    namespace App\AppBundle\Controller;
+    namespace App\Controller;
 
     use App\Event\MovieCreatedEvent;
     use Sylius\Component\Mailer\Sender\SenderInterface;

--- a/docs/components_and_bundles/bundles/SyliusPromotionBundle/installation.rst
+++ b/docs/components_and_bundles/bundles/SyliusPromotionBundle/installation.rst
@@ -67,7 +67,7 @@ Put its configuration inside your ``app/config/config.yml``.
         resources:
             promotion_subject:
                 classes:
-                    model: AppBundle\Entity\CarRentalOrder
+                    model: App\Entity\CarRentalOrder
 
 And configure doctrine extensions which are used by the bundle.
 

--- a/docs/components_and_bundles/bundles/SyliusResourceBundle/configuration.rst
+++ b/docs/components_and_bundles/bundles/SyliusResourceBundle/configuration.rst
@@ -20,7 +20,7 @@ Implement the ResourceInterface in your model class.
 
     <?php
 
-    namespace AppBundle\Entity;
+    namespace App\Entity;
 
     use Sylius\Component\Resource\Model\ResourceInterface;
 
@@ -46,7 +46,7 @@ In your ``app/config/config.yml`` add:
         resources:
             app.book:
                 classes:
-                    model: AppBundle\Entity\Book
+                    model: App\Entity\Book
 
 That's it! Your Book entity is now registered as Sylius Resource.
 
@@ -66,11 +66,11 @@ You can also configure several doctrine drivers.
         resources:
             app.book:
                 classes:
-                    model: AppBundle\Entity\Book
+                    model: App\Entity\Book
             app.article:
                 driver: doctrine/phpcr-odm
                 classes:
-                    model: AppBundle\Document\ArticleDocument
+                    model: App\Document\ArticleDocument
 
 Generate API routing.
 ---------------------

--- a/docs/components_and_bundles/bundles/SyliusResourceBundle/create_resource.rst
+++ b/docs/components_and_bundles/bundles/SyliusResourceBundle/create_resource.rst
@@ -66,7 +66,7 @@ __ http://symfony.com/doc/current/forms.html#building-the-form
         defaults:
             _controller: app.controller.book:createAction
             _sylius:
-                form: AppBundle\Form\BookType
+                form: App\Form\BookType
 
 Passing Custom Options to Form
 ------------------------------

--- a/docs/components_and_bundles/bundles/SyliusResourceBundle/forms.rst
+++ b/docs/components_and_bundles/bundles/SyliusResourceBundle/forms.rst
@@ -13,7 +13,7 @@ Create a FormType class for your resource
 
     <?php
 
-    namespace AppBundle\Form\Type;
+    namespace App\Form\Type;
 
     use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
     use Symfony\Component\Form\FormBuilderInterface;
@@ -53,7 +53,7 @@ Register the FormType as a service
 .. code-block:: yaml
 
     app.book.form.type:
-        class: AppBundle\Form\Type\BookType
+        class: App\Form\Type\BookType
         tags:
             - { name: form.type }
         arguments: ['%app.model.book.class%', '%app.book.form.type.validation_groups%']
@@ -67,7 +67,7 @@ Configure the form for your resource
         resources:
             app.book:
                 classes:
-                    model: AppBundle\Entity\Book
-                    form: AppBundle\Form\Type\BookType
+                    model: App\Entity\Book
+                    form: App\Form\Type\BookType
 
 That's it. Your new class will be used for all forms!

--- a/docs/components_and_bundles/bundles/SyliusResourceBundle/reference.rst
+++ b/docs/components_and_bundles/bundles/SyliusResourceBundle/reference.rst
@@ -47,7 +47,7 @@ Routing Generator Configuration Reference
                 code: $code
             section: admin
             templates: :Book
-            form: AppBundle/Form/Type/SimpleBookType
+            form: App/Form/Type/SimpleBookType
             redirect: create
             except: ['show']
             only: ['create', 'index']

--- a/docs/components_and_bundles/bundles/SyliusResourceBundle/routing.rst
+++ b/docs/components_and_bundles/bundles/SyliusResourceBundle/routing.rst
@@ -208,10 +208,10 @@ If you want to use a custom form:
     app_book:
         resource: |
             alias: app.book
-            form: AppBundle/Form/Type/AdminBookType
+            form: App/Form/Type/AdminBookType
         type: sylius.resource
 
-``create`` and ``update`` actions will use AppBundle/Form/Type/AdminBookType form type.
+``create`` and ``update`` actions will use App/Form/Type/AdminBookType form type.
 
 .. note::
 

--- a/docs/components_and_bundles/bundles/SyliusResourceBundle/update_resource.rst
+++ b/docs/components_and_bundles/bundles/SyliusResourceBundle/update_resource.rst
@@ -63,7 +63,7 @@ Same way like for **createAction** you can override the default form.
         defaults:
             _controller: app.controller.book:updateAction
             _sylius:
-                form: AppBundle\Form\BookType
+                form: App\Form\BookType
 
 Passing Custom Options to Form
 ------------------------------

--- a/docs/components_and_bundles/bundles/SyliusShippingBundle/custom_calculators.rst
+++ b/docs/components_and_bundles/bundles/SyliusShippingBundle/custom_calculators.rst
@@ -10,12 +10,12 @@ All shipping cost calculators implement ``CalculatorInterface``. In our example 
 
 .. code-block:: php
 
-    # src/AppBundle/Shipping/Calculator/DHLCalculator.php
+    # src/Shipping/Calculator/DHLCalculator.php
     <?php
 
     declare(strict_types=1);
 
-    namespace AppBundle\Shipping\Calculator;
+    namespace App\Shipping\Calculator;
 
     use Sylius\Component\Shipping\Calculator\CalculatorInterface;
     use Sylius\Component\Shipping\Model\ShipmentInterface;
@@ -58,7 +58,7 @@ Now, you need to register your new service in container and tag it with ``sylius
 
     services:
         app.shipping_calculator.dhl:
-            class: AppBundle\Shipping\Calculator\DHLCalculator
+            class: App\Shipping\Calculator\DHLCalculator
             arguments: ['@app.dhl_service']
             tags:
                 - { name: sylius.shipping_calculator, calculator: dhl, label: "DHL" }
@@ -75,12 +75,12 @@ First step is to create a form type which will be displayed if our calculator is
 
 .. code-block:: php
 
-    # src/AppBundle/Form/Type/Shipping/Calculator/DHLConfigurationType.php
+    # src/Form/Type/Shipping/Calculator/DHLConfigurationType.php
     <?php
 
     declare(strict_types=1);
 
-    namespace AppBundle\Form\Type\Shipping\Calculator;
+    namespace App\Form\Type\Shipping\Calculator;
 
     use Symfony\Component\Form\AbstractType;
     use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -136,13 +136,13 @@ We also need to register the form type in the container and set this form type i
 
     services:
         app.shipping_calculator.dhl:
-            class: AppBundle\Shipping\Calculator\DHLCalculator
+            class: App\Shipping\Calculator\DHLCalculator
             arguments: ['@app.dhl_service']
             tags:
-                - { name: sylius.shipping_calculator, calculator: dhl, form_type: AppBundle\Form\Type\Shipping\Calculator\DHLConfigurationType, label: "DHL" }
+                - { name: sylius.shipping_calculator, calculator: dhl, form_type: App\Form\Type\Shipping\Calculator\DHLConfigurationType, label: "DHL" }
 
         app.form.type.shipping_calculator.dhl:
-            class: AppBundle\Form\Type\Shipping\Calculator\DHLConfigurationType
+            class: App\Form\Type\Shipping\Calculator\DHLConfigurationType
             tags:
                 - { name: form.type }
 
@@ -150,12 +150,12 @@ Perfect, now we're able to use the configuration inside the ``calculate`` method
 
 .. code-block:: php
 
-    # src/AppBundle/Shipping/Calculator/DHLCalculator.php
+    # src/Shipping/Calculator/DHLCalculator.php
     <?php
 
     declare(strict_types=1);
 
-    namespace AppBundle\Shipping\Calculator;
+    namespace App\Shipping\Calculator;
 
     use Sylius\Component\Shipping\Calculator\CalculatorInterface;
     use Sylius\Component\Shipping\Model\ShipmentInterface;

--- a/docs/components_and_bundles/bundles/SyliusTaxationBundle/custom_calculators.rst
+++ b/docs/components_and_bundles/bundles/SyliusTaxationBundle/custom_calculators.rst
@@ -11,12 +11,12 @@ All tax calculators implement the ``CalculatorInterface``. In our example we'll 
 
 .. code-block:: php
 
-    # src/AppBundle/Taxation/Calculator/FeeCalculator.php
+    # src/Taxation/Calculator/FeeCalculator.php
     <?php
 
     declare(strict_types=1);
 
-    namespace AppBundle\Taxation\Calculator;
+    namespace App\Taxation\Calculator;
 
     use Sylius\Component\Taxation\Calculator\CalculatorInterface;
     use Sylius\Component\Taxation\Model\TaxRateInterface;
@@ -38,7 +38,7 @@ Now, you need to register your new service in container and tag it with ``sylius
 
     services:
         app.tax_calculator.fee:
-            class: AppBundle\Taxation\Calculator\FeeCalculator
+            class: App\Taxation\Calculator\FeeCalculator
             tags:
                 - { name: sylius.tax_calculator, calculator: fee, label: "Fee" }
 

--- a/docs/components_and_bundles/components/Promotion/basic_usage.rst
+++ b/docs/components_and_bundles/components/Promotion/basic_usage.rst
@@ -11,7 +11,7 @@ for promotion application purposes.
 
     <?php
 
-    namespace AppBundle\Entity;
+    namespace App\Entity;
 
     use Doctrine\Common\Collections\Collection;
     use Doctrine\Common\Collections\ArrayCollection;
@@ -148,7 +148,7 @@ and applies configured actions if rules are eligible.
     <?php
 
     use Sylius\Component\Promotion\Processor\PromotionProcessor;
-    use AppBundle\Entity\Ticket;
+    use App\Entity\Ticket;
 
     /**
      * @param PromotionRepositoryInterface         $repository
@@ -184,7 +184,7 @@ Below you can see how it works:
     use Sylius\Component\Promotion\Model\PromotionAction;
     use Sylius\Component\Promotion\Model\PromotionRule;
     use Sylius\Component\Promotion\Checker\CompositePromotionEligibilityChecker;
-    use AppBundle\Entity\Ticket;
+    use App\Entity\Ticket;
 
     $checkerRegistry = new ServiceRegistry('Sylius\Component\Promotion\Checker\RuleCheckerInterface');
     $actionRegistry = new ServiceRegistry('Sylius\Component\Promotion\Model\PromotionActionInterface');
@@ -253,7 +253,7 @@ which is able to apply and revert single promotions on a subject implementing th
     use Sylius\Component\Promotion\PromotionAction\PromotionApplicator;
     use Sylius\Component\Promotion\Model\Promotion;
     use Sylius\Component\Registry\ServiceRegistry;
-    use AppBundle\Entity\Ticket;
+    use App\Entity\Ticket;
 
     // In order for the applicator to work properly you need to have your actions created and registered before.
     $registry = new ServiceRegistry('Sylius\Component\Promotion\Model\PromotionActionInterface');

--- a/docs/cookbook/emails/disabling-order-confirmation-email.rst
+++ b/docs/cookbook/emails/disabling-order-confirmation-email.rst
@@ -48,15 +48,15 @@ This can be done via a CompilerPass.
         }
     }
 
-The above compiler pass needs to be added to your bundle in the ``AppBundle/AppBundle.php`` file:
+The above compiler pass needs to be added to your bundle in the ``App/AppBundle.php`` file:
 
 .. code-block:: php
 
     <?php
 
-    namespace AppBundle;
+    namespace App;
 
-    use AppBundle\DependencyInjection\Compiler\MailPass;
+    use App\DependencyInjection\Compiler\MailPass;
     use Symfony\Component\HttpKernel\Bundle\Bundle;
     use Symfony\Component\DependencyInjection\ContainerBuilder;
 

--- a/docs/cookbook/entities/custom-translatable-model.rst
+++ b/docs/cookbook/entities/custom-translatable-model.rst
@@ -439,7 +439,7 @@ To have templates for your Entity administration out of the box you can use Grid
 
 .. code-block:: php
 
-    # AppBundle/Resources/views/Supplier/_form.html.twig
+    # App/Resources/views/Supplier/_form.html.twig
     {% from '@SyliusAdmin/Macro/translationForm.html.twig' import translationForm %}
 
     {{ form_errors(form) }}

--- a/docs/cookbook/frontend/admin-js-and-css.rst
+++ b/docs/cookbook/frontend/admin-js-and-css.rst
@@ -21,7 +21,7 @@ As an example we will use a popup window script, it is easy for manual testing.
 
 .. code-block:: twig
 
-    {# src/AppBundle/Resources/views/Admin/_javascripts.html.twig #}
+    {# src/Resources/views/Admin/_javascripts.html.twig #}
     {% include 'SyliusUiBundle::_javascripts.html.twig' with {'path': 'assets/admin/js/custom.js'} %}
 
 **3. Use the Sonata block event to insert your javascripts:**
@@ -32,7 +32,7 @@ As an example we will use a popup window script, it is easy for manual testing.
 
 .. code-block:: yaml
 
-    # src/AppBundle/Resources/config/services.yml
+    # src/Resources/config/services.yml
     services:
         app.block_event_listener.admin.layout.javascripts:
             class: Sylius\Bundle\UiBundle\Block\BlockEventListener
@@ -67,7 +67,7 @@ As an example we will change the sidebar menu background color, what is clearly 
 
 .. code-block:: twig
 
-    {# src/AppBundle/Resources/views/Admin/_stylesheets.html.twig #}
+    {# src/Resources/views/Admin/_stylesheets.html.twig #}
     {% include 'SyliusUiBundle::_stylesheets.html.twig' with {'path': 'assets/admin/css/custom.css'} %}
 
 **3. Use the Sonata block event to insert your stylesheets:**
@@ -78,7 +78,7 @@ As an example we will change the sidebar menu background color, what is clearly 
 
 .. code-block:: yaml
 
-    # src/AppBundle/Resources/config/services.yml
+    # src/Resources/config/services.yml
     services:
         app.block_event_listener.admin.layout.stylesheets:
             class: Sylius\Bundle\UiBundle\Block\BlockEventListener

--- a/docs/cookbook/images/images-gridfs.rst
+++ b/docs/cookbook/images/images-gridfs.rst
@@ -187,7 +187,7 @@ To make GridFS files easily reusable, we introduce a mapped superclass which wil
 
 .. code-block:: xml
 
-    <!-- @AppBundle/Resources/doctrine/model/File.odm.xml -->
+    <!-- @App/Resources/doctrine/model/File.odm.xml -->
     <?xml version="1.0" encoding="UTF-8"?>
     <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -224,7 +224,7 @@ cached images. They will be stored in the same collection, but can be differenti
 
 .. code-block:: xml
 
-    <!-- @AppBundle/Resources/doctrine/model/ProductImage.odm.xml -->
+    <!-- @App/Resources/doctrine/model/ProductImage.odm.xml -->
     <?xml version="1.0" encoding="UTF-8"?>
     <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
                             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -288,7 +288,7 @@ cached images. They will be stored in the same collection, but can be differenti
 
 .. code-block:: xml
 
-    <!-- @AppBundle/Resources/doctrine/model/ProductImageCache.odm.xml -->
+    <!-- @App/Resources/doctrine/model/ProductImageCache.odm.xml -->
     <?xml version="1.0" encoding="UTF-8"?>
     <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
                             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -332,7 +332,7 @@ cached images. They will be stored in the same collection, but can be differenti
 
 .. code-block:: xml
 
-    <!-- @AppBundle/Resources/doctrine/model/ProductImageCacheMetadata.odm.xml -->
+    <!-- @App/Resources/doctrine/model/ProductImageCacheMetadata.odm.xml -->
     <?xml version="1.0" encoding="UTF-8"?>
     <doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
                             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -355,7 +355,7 @@ First of all a new service is configured.
 
 .. code-block:: xml
 
-    <!-- @AppBundle/Resources/config/services.xml -->
+    <!-- @App/Resources/config/services.xml -->
     <?xml version="1.0" encoding="UTF-8" ?>
     <container xmlns="http://symfony.com/schema/dic/services"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -449,7 +449,7 @@ Now we can create the service definition for the data loader:
 
 .. code-block:: xml
 
-    <!-- @AppBundle/Resources/config/services.xml -->
+    <!-- @App/Resources/config/services.xml -->
     <?xml version="1.0" encoding="UTF-8" ?>
     <container xmlns="http://symfony.com/schema/dic/services"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -620,7 +620,7 @@ Create the service definition for the resolver:
 
 .. code-block:: xml
 
-    <!-- @AppBundle/Resources/config/services.xml -->
+    <!-- @App/Resources/config/services.xml -->
     <?xml version="1.0" encoding="UTF-8" ?>
     <container xmlns="http://symfony.com/schema/dic/services"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/docs/cookbook/images/images-on-entity.rst
+++ b/docs/cookbook/images/images-on-entity.rst
@@ -141,7 +141,7 @@ of the ``ShippingMethodImage``.
 
 .. code-block:: yaml
 
-    # AppBundle/Resources/config/doctrine/ShippingMethodImage.orm.yml
+    # App/Resources/config/doctrine/ShippingMethodImage.orm.yml
     App\Entity\ShippingMethodImage:
         type: entity
         table: app_shipping_method_image
@@ -162,7 +162,7 @@ The newly added ``images`` field has to be added to the mapping, with a relation
 
 .. code-block:: yaml
 
-    # AppBundle/Resources/config/doctrine/ShippingMethod.orm.yml
+    # App/Resources/config/doctrine/ShippingMethod.orm.yml
     App\Entity\ShippingMethod:
         type: entity
         table: sylius_shipping_method
@@ -406,13 +406,13 @@ and render the ``{{ form_row(form.images) }}`` field.
 ^^^^^^^^^^^^^^
 
 Your form so far is working fine, but don't forget about validation.
-The easiest way is using validation config files under the ``AppBundle/Resources/config/validation`` folder.
+The easiest way is using validation config files under the ``App/Resources/config/validation`` folder.
 
 This could look like this e.g.:
 
 .. code-block:: yaml
 
-    # AppBundle\Resources\config\validation\ShippingMethodImage.yml
+    # src\Resources\config\validation\ShippingMethodImage.yml
     App\Entity\ShippingMethodImage:
       properties:
         file:
@@ -435,7 +435,7 @@ Now connecting the validation of the ``ShippingMethod`` to the validation of eac
 
 .. code-block:: yaml
 
-    # AppBundle\Resources\config\validation\ShippingMethod.yml
+    # src\Resources\config\validation\ShippingMethod.yml
     App\Entity\ShippingMethod:
       properties:
         ...

--- a/docs/customization/factory.rst
+++ b/docs/customization/factory.rst
@@ -23,7 +23,7 @@ How to customize a Factory?
 
 Let's assume that you would want to have a possibility to create disabled products.
 
-**1.** Create your own factory class in the ``AppBundle\Factory`` namespace.
+**1.** Create your own factory class in the ``App\Factory`` namespace.
 Remember that it has to implement a proper interface. How can you check that?
 
 For the ``ProductFactory`` run:

--- a/docs/customization/grid.rst
+++ b/docs/customization/grid.rst
@@ -175,7 +175,7 @@ For example, **sylius_admin_product** grid dispatches such an event:
 To show you an example of a grid customization using events, we will remove a field from a grid using that method.
 Here are the steps, that you need to take:
 
-**1.** In order to remove fields from the product grid in **Sylius** you have to create a ``AppBundle\Grid\AdminProductsGridListener`` class.
+**1.** In order to remove fields from the product grid in **Sylius** you have to create a ``App\Grid\AdminProductsGridListener`` class.
 
 In the example below we are removing the ``images`` field from the ``sylius_admin_product`` grid.
 

--- a/docs/customization/model.rst
+++ b/docs/customization/model.rst
@@ -77,7 +77,7 @@ Assuming that you would want to add another field on the model - for instance a 
 
 **2.** Next define your entity's mapping.
 
-The file should be placed in ``AppBundle/Resources/config/doctrine/Country.orm.yml``
+The file should be placed in ``App/Resources/config/doctrine/Country.orm.yml``
 
 .. code-block:: yaml
 
@@ -197,7 +197,7 @@ Just like for regular models you can also check the class of translatable models
 
 **2.** Next define your entity's mapping.
 
-The file should be placed in ``AppBundle/Resources/config/doctrine/ShippingMethod.orm.yml``
+The file should be placed in ``App/Resources/config/doctrine/ShippingMethod.orm.yml``
 
 .. code-block:: yaml
 
@@ -300,7 +300,7 @@ Just like for regular models you can also check the class of translatable models
 
 **2.** Next define your translation entity's mapping.
 
-The translation's entity file should be placed in ``AppBundle/Resources/config/doctrine/ShippingMethodTranslation.orm.yml``
+The translation's entity file should be placed in ``src/Resources/config/doctrine/ShippingMethodTranslation.orm.yml``
 
 .. code-block:: yaml
 
@@ -348,7 +348,7 @@ The translation's entity file should be placed in ``AppBundle/Resources/config/d
 
 **4.** As we are overriding not only the translation class but also the base class, we need to create an emty mapping also for this base class.
 
-The mapping file should be placed in ``AppBundle/Resources/config/doctrine/ShippingMethod.orm.yml``
+The mapping file should be placed in ``src/Resources/config/doctrine/ShippingMethod.orm.yml``
 
 .. code-block:: yaml
 

--- a/docs/customization/validation.rst
+++ b/docs/customization/validation.rst
@@ -11,7 +11,7 @@ Let's take the example of changing the length of ``name`` for the ``Product`` en
 In the ``sylius`` validation group the minimum length is equal to 2.
 What if you'd want to have at least 10 characters?
 
-**1.** Create the ``AppBundle/Resources/config/validation.yml``.
+**1.** Create the ``src/Resources/config/validation.yml``.
 
 In this file you need to overwrite the whole validation of your field that you are willing to modify.
 Take this configuration from the ``Sylius/Bundle/ProductBundle/Resources/config/validation/ProductTranslation.xml`` - you can choose format ``xml`` or ``yaml``.


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #9951
| License         | MIT

The namespace `AppBundle` is still used in 1.3 docs. Even Symfony 4.x changed it to `App`. Remove or change it.