### PR TITLE
[Sylius][ResourceBundle] Fix missing service doctrine.orm.listeners.resolve_target_entity

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Compiler/DoctrineTargetEntitiesResolverPass.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Compiler/DoctrineTargetEntitiesResolverPass.php
@@ -31,6 +31,7 @@ final class DoctrineTargetEntitiesResolverPass implements CompilerPassInterface
         try {
             $resources = $container->getParameter('sylius.resources');
             $resolveTargetEntityListener = $container->findDefinition('doctrine.orm.listeners.resolve_target_entity');
+            $resolveTargetEntityListener->setPublic(true);
         } catch (InvalidArgumentException $exception) {
             return;
         }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in #4583
| License         | MIT

After i add some mappings to ``doctrine.orm.resolve_target_entities`` i got an exception:

**ServiceNotFoundException** The service "doctrine.dbal.default_connection" has a dependency on a non-existent service "doctrine.orm.listeners.resolve_target_entity" in CheckExceptionOnInvalidReferenceBehaviorPass.php line 86

I search for this error i found a comment on the pull request #4583 facing the same error:

> @pjedrzejewski honestly i don't know why fails. I don't know why doctrine.orm.listeners.resolve_target_entity is missing in the container, but all other test are green

After some research i found out, that this error occurs because the service ``doctrine.orm.resolve_target_entities`` is marked as private. The ``CheckExceptionOnInvalidReferenceBehaviorPass`` will check for invalid reference and therefor it check if the container has the mentioned service. 

```
 if (ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE < $value->getInvalidBehavior() || $this->container->has($id = (string) $value)) {
```

I don't know why but the ``DoctrineTargetEntitiesResolverPass`` in combination with  ``doctrine.orm.resolve_target_entities`` leads to check the service and fail. 

With this fix, the ``ServiceNotFoundException`` will not be thrown. 

