### PR TITLE
[BuildFix] Symfony version improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,8 @@
         "symfony/polyfill-intl-icu": "^1.3",
         "symfony/polyfill-mbstring": "^1.3",
         "symfony/swiftmailer-bundle": "^3.0",
-        "symfony/symfony": "^3.4|^4.1.1",
+        "symfony/symfony": "^3.4|4.1.*",
+        "symfony/routing": "^3.4|4.1.8",
         "symfony/thanks": "^1.0",
         "twig/extensions": "^1.4",
         "twig/twig": "^2.0",
@@ -154,7 +155,8 @@
         "symfony/polyfill-php56": "*"
     },
     "conflict": {
-        "symfony/symfony": "3.4.7 || 4.0.7 || 4.1.8"
+        "symfony/symfony": "3.4.7 || 4.0.7 || 4.1.8",
+        "symfony/routing": "4.1.9"
     },
     "suggest": {
         "ext-iconv": "For better performance than using Symfony Polyfill Component",

--- a/etc/travis/suites/application/install.sh
+++ b/etc/travis/suites/application/install.sh
@@ -4,7 +4,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../bash/common.lib.s
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../bash/application.sh"
 
 print_header "Installing dependencies" "Sylius"
-run_command "if [ ! -z \"${SYMFONY_VERSION}\" ]; then bin/require-symfony-version composer.json \"${SYMFONY_VERSION}\"; fi" || exit $?
+run_command "if [ ! -z \"${SYMFONY_VERSION}\" ]; then composer require \"symfony/symfony:${SYMFONY_VERSION}\" --no-update; fi" || exit $?
 run_command "composer install --no-interaction --prefer-dist" || exit $?
 
 print_header "Warming up dependencies" "Sylius"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Because of recent changes in `symfony/routing` component, there is some bug with `UrlMatcher` that is losing its mind in out API routing - especially for `index` and `create` which has the same path (but different methods). We should wait for a fix on the Symfony side and use a previous version of `symfony/routing` still.

Thank you @lchrusciel and @nicolas-grekas for help in investigating what's wrong!

I've also changed supported symfony version to `4.1.*`, as `^4.1.1` was allowing even Symfony 4.2, which we have no tests for yet and we cannot guarantee it works properly (I personally had some problems with the **Stopwatch Component** during the update). For sure we need to think about the support for Symfony 4.2 (sooner than later, as the maintenance of Symfony 4.1 is ending soon).