### PR TITLE
Column 'position' cannot be null

### DIFF
--- a/docs/components_and_bundles/bundles/SyliusTaxonomyBundle/installation.rst
+++ b/docs/components_and_bundles/bundles/SyliusTaxonomyBundle/installation.rst
@@ -63,6 +63,7 @@ Configure doctrine extensions which are used in the taxonomy bundle:
             default:
                 tree: true
                 sluggable: true
+                sortable: true
 
 Updating database schema
 ------------------------


### PR DESCRIPTION
It seems gedmo 'sortable' extension required by this bundle. Otherwise it throws an exception

"Integrity constraint violation: 1048 Column 'position' cannot be null"

| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.2 or 1.3 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
