### PR TITLE
[Behat] Test for assigning main taxon on new product

### DIFF
--- a/features/product/managing_products/select_taxons_for_new_product.feature
+++ b/features/product/managing_products/select_taxons_for_new_product.feature
@@ -1,0 +1,34 @@
+@managing_products
+Feature: Select taxon for a new product
+    In order to specify in which taxons a product is available
+    As an Administrator
+    I want to be able to select taxons for a new product
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store classifies its products as "T-Shirts", "Accessories", "Funny" and "Sad"
+        And I am logged in as an administrator
+        And I am using "English (United Kingdom)" locale for my panel
+
+    @ui @javascript
+    Scenario: Specifying main taxon for configurable product
+        Given I want to create a new configurable product
+        When I choose main taxon "Sad"
+        And I specify its code as "WHISKEY_GENTLEMEN"
+        And I name it "Gentleman Jack" in "English (United States)"
+        And I set its slug to "whiskey/gentleman-jack" in "English (United States)"
+        And I add it
+        Then I should be notified that it has been successfully created
+        And this product main taxon should be "Sad"
+
+    @ui @javascript
+    Scenario: Specifying main taxon for simple product
+        Given I want to create a new simple product
+        When I choose main taxon "Sad"
+        And I name it "Mansion of Madness" in "English (United States)"
+        And I specify its code as "BOARD_MANSION_OF_MADNESS"
+        And I set its price to "$100.00" for "United States" channel
+        And I set its slug to "mom-board-game" in "English (United States)"
+        And I add it
+        Then I should be notified that it has been successfully created
+        And this product main taxon should be "Sad"

--- a/features/product/managing_products/select_taxons_for_new_product.feature
+++ b/features/product/managing_products/select_taxons_for_new_product.feature
@@ -14,12 +14,12 @@ Feature: Select taxon for a new product
     Scenario: Specifying main taxon for configurable product
         Given I want to create a new configurable product
         When I choose main taxon "Sad"
-        And I specify its code as "WHISKEY_GENTLEMEN"
         And I name it "Gentleman Jack" in "English (United States)"
+        And I specify its code as "WHISKEY_GENTLEMEN"
         And I set its slug to "whiskey/gentleman-jack" in "English (United States)"
         And I add it
         Then I should be notified that it has been successfully created
-        And this product main taxon should be "Sad"
+        And main taxon of product "Gentleman Jack" should be "Sad"
 
     @ui @javascript
     Scenario: Specifying main taxon for simple product
@@ -31,4 +31,4 @@ Feature: Select taxon for a new product
         And I set its slug to "mom-board-game" in "English (United States)"
         And I add it
         Then I should be notified that it has been successfully created
-        And this product main taxon should be "Sad"
+        And main taxon of product "Mansion of Madness" should be "Sad"

--- a/features/product/managing_products/select_taxons_for_product.feature
+++ b/features/product/managing_products/select_taxons_for_product.feature
@@ -1,8 +1,8 @@
 @managing_products
-Feature: Select taxon for a product
+Feature: Select taxon for an existing product
     In order to specify in which taxons a product is available
     As an Administrator
-    I want to be able to select taxons for a product
+    I want to be able to select taxons for an existing product
 
     Background:
         Given the store operates on a single channel in "United States"
@@ -27,3 +27,4 @@ Feature: Select taxon for a product
         And I save my changes
         Then I should be notified that it has been successfully edited
         And this product main taxon should be "Sad"
+

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -579,6 +579,7 @@ final class ManagingProductsContext implements Context
 
     /**
      * @Then /^(this product) main taxon should be "([^"]+)"$/
+     * @Then /^main taxon of (product "[^"]+") should be "([^"]+)"$/
      */
     public function thisProductMainTaxonShouldBe(ProductInterface $product, $taxonName)
     {

--- a/src/Sylius/Behat/Page/Admin/Product/CreateConfigurableProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateConfigurableProductPage.php
@@ -17,6 +17,7 @@ use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\SpecifiesItsCode;
 use Sylius\Behat\Page\Admin\Crud\CreatePage as BaseCreatePage;
+use Sylius\Behat\Service\AutocompleteHelper;
 use Sylius\Behat\Service\SlugGenerationHelper;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Webmozart\Assert\Assert;
@@ -27,6 +28,8 @@ class CreateConfigurableProductPage extends BaseCreatePage implements CreateConf
 
     public function nameItIn(string $name, string $localeCode): void
     {
+        $this->clickTabIfItsNotActive('details');
+
         $this->getDocument()->fillField(
             sprintf('sylius_product_translations_%s_name', $localeCode), $name
         );
@@ -48,15 +51,9 @@ class CreateConfigurableProductPage extends BaseCreatePage implements CreateConf
     {
         $this->openTaxonBookmarks();
 
-        Assert::isInstanceOf($this->getDriver(), Selenium2Driver::class);
+        $mainTaxonElement = $this->getElement('main_taxon')->getParent();
 
-        $this->getDriver()->executeScript(sprintf('$(\'input.search\').val(\'%s\')', $taxon->getName()));
-        $this->getElement('search')->click();
-        $this->getElement('search')->waitFor(10, function () {
-            return $this->hasElement('search_item_selected');
-        });
-        $itemSelected = $this->getElement('search_item_selected');
-        $itemSelected->click();
+        AutocompleteHelper::chooseValue($this->getSession(), $mainTaxonElement, $taxon->getName());
     }
 
     public function selectOption($optionName)
@@ -85,10 +82,11 @@ class CreateConfigurableProductPage extends BaseCreatePage implements CreateConf
         return array_merge(parent::getDefinedElements(), [
             'code' => '#sylius_product_code',
             'images' => '#sylius_product_images',
+            'main_taxon' => '#sylius_product_mainTaxon',
             'name' => '#sylius_product_translations_en_US_name',
-            'slug' => '#sylius_product_translations_en_US_slug',
             'search' => '.ui.fluid.search.selection.dropdown',
             'search_item_selected' => 'div.menu > div.item.selected',
+            'slug' => '#sylius_product_translations_en_US_slug',
             'tab' => '.menu [data-tab="%name%"]',
             'taxonomy' => 'a[data-tab="taxonomy"]',
         ]);

--- a/src/Sylius/Behat/Page/Admin/Product/CreateConfigurableProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateConfigurableProductPage.php
@@ -56,7 +56,7 @@ class CreateConfigurableProductPage extends BaseCreatePage implements CreateConf
         AutocompleteHelper::chooseValue($this->getSession(), $mainTaxonElement, $taxon->getName());
     }
 
-    public function selectOption($optionName)
+    public function selectOption(string $optionName): void
     {
         $this->getDocument()->selectFieldOption('Options', $optionName);
     }

--- a/src/Sylius/Behat/Page/Admin/Product/CreateConfigurableProductPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateConfigurableProductPageInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Admin\Product;
 
 use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
 
 interface CreateConfigurableProductPageInterface extends BaseCreatePageInterface
 {
@@ -23,8 +24,9 @@ interface CreateConfigurableProductPageInterface extends BaseCreatePageInterface
 
     public function nameItIn(string $name, string $localeCode): void;
 
-    /**
-     * @param string $type
-     */
-    public function attachImage(string $path, string $type = null): void;
+    public function isMainTaxonChosen(string $taxonName): bool;
+
+    public function selectMainTaxon(TaxonInterface $taxon): void;
+
+    public function attachImage(string $path, ?string $type = null): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
@@ -17,7 +17,9 @@ use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\SpecifiesItsCode;
 use Sylius\Behat\Page\Admin\Crud\CreatePage as BaseCreatePage;
+use Sylius\Behat\Service\AutocompleteHelper;
 use Sylius\Behat\Service\SlugGenerationHelper;
+use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Product\Model\ProductAssociationTypeInterface;
 use Webmozart\Assert\Assert;
 
@@ -89,6 +91,28 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         $this->clickTabIfItsNotActive('attributes');
 
         $this->getElement('attribute_delete_button', ['%attributeName%' => $attributeName, '%localeCode%' => $localeCode])->press();
+    }
+
+    public function checkAttributeErrors($attributeName, $localeCode): void
+    {
+        $this->clickTabIfItsNotActive('attributes');
+        $this->clickLocaleTabIfItsNotActive($localeCode);
+    }
+
+    public function selectMainTaxon(TaxonInterface $taxon): void
+    {
+        $this->openTaxonBookmarks();
+
+        $mainTaxonElement = $this->getElement('main_taxon')->getParent();
+
+        AutocompleteHelper::chooseValue($this->getSession(), $mainTaxonElement, $taxon->getName());
+    }
+
+    public function isMainTaxonChosen(string $taxonName): bool
+    {
+        $this->openTaxonBookmarks();
+
+        return $taxonName === $this->getDocument()->find('css', '.search > .text')->getText();
     }
 
     public function attachImage(string $path, string $type = null): void
@@ -209,6 +233,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
             'images' => '#sylius_product_images',
             'language_tab' => '[data-locale="%locale%"] .title',
             'locale_tab' => '#attributesContainer .menu [data-tab="%localeCode%"]',
+            'main_taxon' => '#sylius_product_mainTaxon',
             'name' => '#sylius_product_translations_%locale%_name',
             'price' => '#sylius_product_variant_channelPricings > .field:contains("%channelName%") input[name$="[price]"]',
             'original_price' => '#sylius_product_variant_channelPricings > .field:contains("%channelName%") input[name$="[originalPrice]"]',
@@ -217,11 +242,17 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
             'shipping_required' => '#sylius_product_variant_shippingRequired',
             'slug' => '#sylius_product_translations_%locale%_slug',
             'tab' => '.menu [data-tab="%name%"]',
+            'taxonomy' => 'a[data-tab="taxonomy"]',
             'toggle_slug_modification_button' => '.toggle-product-slug-modification',
         ]);
     }
 
-    private function selectElementFromAttributesDropdown(string $id): void
+    private function openTaxonBookmarks(): void
+    {
+        $this->getElement('taxonomy')->click();
+    }
+
+    private function selectElementFromAttributesDropdown(int $id): void
     {
         /** @var Selenium2Driver $driver */
         $driver = $this->getDriver();

--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
@@ -69,7 +69,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         $this->clickLocaleTabIfItsNotActive($localeCode);
 
         $attributeOption = $this->getElement('attributes_choice')->find('css', sprintf('option:contains("%s")', $attributeName));
-        $this->selectElementFromAttributesDropdown($attributeOption->getAttribute('value'));
+        $this->selectElementFromAttributesDropdown((int) $attributeOption->getAttribute('value'));
 
         $this->getDocument()->pressButton('Add attributes');
         $this->waitForFormElement();

--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
@@ -34,6 +34,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
 
     public function nameItIn(string $name, string $localeCode): void
     {
+        $this->clickTabIfItsNotActive('details');
         $this->activateLanguageTab($localeCode);
         $this->getElement('name', ['%locale%' => $localeCode])->setValue($name);
 

--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
@@ -69,7 +69,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         $this->clickLocaleTabIfItsNotActive($localeCode);
 
         $attributeOption = $this->getElement('attributes_choice')->find('css', sprintf('option:contains("%s")', $attributeName));
-        $this->selectElementFromAttributesDropdown((int) $attributeOption->getAttribute('value'));
+        $this->selectElementFromAttributesDropdown($attributeOption->getAttribute('value'));
 
         $this->getDocument()->pressButton('Add attributes');
         $this->waitForFormElement();
@@ -253,7 +253,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         $this->getElement('taxonomy')->click();
     }
 
-    private function selectElementFromAttributesDropdown(int $id): void
+    private function selectElementFromAttributesDropdown(string $id): void
     {
         /** @var Selenium2Driver $driver */
         $driver = $this->getDriver();

--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPageInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Admin\Product;
 
 use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Product\Model\ProductAssociationTypeInterface;
 
 interface CreateSimpleProductPageInterface extends BaseCreatePageInterface
@@ -38,10 +39,11 @@ interface CreateSimpleProductPageInterface extends BaseCreatePageInterface
 
     public function removeAttribute(string $attributeName, string $localeCode): void;
 
-    /**
-     * @param string $type
-     */
-    public function attachImage(string $path, string $type = null): void;
+    public function isMainTaxonChosen(string $taxonName): bool;
+
+    public function selectMainTaxon(TaxonInterface $taxon): void;
+
+    public function attachImage(string $path, ?string $type = null): void;
 
     /**
      * @param string[] $productsNames


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2 
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no/
| License         | MIT

Was running into this while trying to test for choosing a taxon when creating a new product:

```
  Scenario: Creating a product with a custom slug
    Given I want to create a new simple product
    When I specify its code as "BOARD_MANSION_OF_MADNESS"
    And I choose main taxon "Mugs"
      Behat\Testwork\Call\Exception\FatalThrowableError: Fatal error: Call to undefined method Sylius\Behat\Page\Admin\Product\CreateSimpleProductPage::selectMainTaxon() in vendor/sylius/sylius/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php:565
```

Not sure if `master` branch is correct btw.