### PR TITLE
Avoid useless search with minCharacter

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-auto-complete.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-auto-complete.js
@@ -25,6 +25,7 @@
                             search: 250
                         },
                         forceSelection: false,
+                        minCharacters: 1,
                         apiSettings: {
                             dataType: 'JSON',
                             cache: false,


### PR DESCRIPTION
I noticed with the Admin Order Creation Plugin that event when there is no character, a search is done.

| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT