### PR TITLE
Added a REAL EMAIL_PRE_RENDER event. 

### DIFF
--- a/src/Sylius/Bundle/MailerBundle/Renderer/Adapter/EmailTwigAdapter.php
+++ b/src/Sylius/Bundle/MailerBundle/Renderer/Adapter/EmailTwigAdapter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\MailerBundle\Renderer\Adapter;
 
+use Sylius\Component\Mailer\Event\EmailAssemblyEvent;
 use Sylius\Component\Mailer\Event\EmailRenderEvent;
 use Sylius\Component\Mailer\Model\EmailInterface;
 use Sylius\Component\Mailer\Renderer\Adapter\AbstractAdapter;
@@ -34,11 +35,20 @@ class EmailTwigAdapter extends AbstractAdapter
      */
     public function render(EmailInterface $email, array $data = []): RenderedEmail
     {
-        $renderedEmail = $this->getRenderedEmail($email, $data);
+        /** @var EmailAssemblyEvent $preRenderEvent */
+        $preRenderEvent = $this->dispatcher->dispatch(
+            SyliusMailerEvents::EMAIL_PRE_RENDER,
+            new EmailAssemblyEvent($email, $data)
+        );
+
+        $renderedEmail = $this->getRenderedEmail(
+            $preRenderEvent->getEmail(),
+            $preRenderEvent->getData()
+        );
 
         /** @var EmailRenderEvent $event */
         $event = $this->dispatcher->dispatch(
-            SyliusMailerEvents::EMAIL_PRE_RENDER,
+            SyliusMailerEvents::EMAIL_POST_RENDER,
             new EmailRenderEvent($renderedEmail)
         );
 

--- a/src/Sylius/Bundle/MailerBundle/spec/Renderer/Adapter/EmailTwigAdapterSpec.php
+++ b/src/Sylius/Bundle/MailerBundle/spec/Renderer/Adapter/EmailTwigAdapterSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Bundle\MailerBundle\Renderer\Adapter;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Sylius\Component\Mailer\Event\EmailAssemblyEvent;
 use Sylius\Component\Mailer\Event\EmailRenderEvent;
 use Sylius\Component\Mailer\Model\EmailInterface;
 use Sylius\Component\Mailer\Renderer\Adapter\AbstractAdapter;
@@ -39,6 +40,7 @@ final class EmailTwigAdapterSpec extends ObjectBehavior
         \Twig_Template $template,
         EmailInterface $email,
         EmailRenderEvent $event,
+        EmailAssemblyEvent $assemblyEvent,
         EventDispatcherInterface $dispatcher,
         RenderedEmail $renderedEmail
     ): void {
@@ -54,6 +56,11 @@ final class EmailTwigAdapterSpec extends ObjectBehavior
 
         $dispatcher->dispatch(
             SyliusMailerEvents::EMAIL_PRE_RENDER,
+            Argument::type(EmailAssemblyEvent::class)
+        )->shouldBeCalled()->willReturn($assemblyEvent);
+
+        $dispatcher->dispatch(
+            SyliusMailerEvents::EMAIL_POST_RENDER,
             Argument::type(EmailRenderEvent::class)
         )->shouldBeCalled()->willReturn($event);
 
@@ -65,6 +72,7 @@ final class EmailTwigAdapterSpec extends ObjectBehavior
     function it_creates_and_renders_an_email(
         EmailInterface $email,
         EmailRenderEvent $event,
+        EmailAssemblyEvent $assemblyEvent,
         EventDispatcherInterface $dispatcher,
         RenderedEmail $renderedEmail
     ): void {
@@ -76,6 +84,11 @@ final class EmailTwigAdapterSpec extends ObjectBehavior
 
         $dispatcher->dispatch(
             SyliusMailerEvents::EMAIL_PRE_RENDER,
+            Argument::type(EmailAssemblyEvent::class)
+        )->shouldBeCalled()->willReturn($assemblyEvent);
+
+        $dispatcher->dispatch(
+            SyliusMailerEvents::EMAIL_POST_RENDER,
             Argument::type(EmailRenderEvent::class)
         )->shouldBeCalled()->willReturn($event);
 

--- a/src/Sylius/Component/Mailer/Event/EmailAssemblyEvent.php
+++ b/src/Sylius/Component/Mailer/Event/EmailAssemblyEvent.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Mailer\Event;
+
+use Sylius\Component\Mailer\Model\EmailInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+class EmailAssemblyEvent extends Event
+{
+    /** @var EmailInterface */
+    protected $email;
+
+    /** @var mixed[] */
+    protected $data;
+
+    public function __construct(EmailInterface $email, array $data = [])
+    {
+        $this->email = $email;
+        $this->data = $data;
+    }
+
+    public function getEmail(): EmailInterface
+    {
+        return $this->email;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    public function addData(array $data): self
+    {
+        $this->data = array_merge($this->data, $data);
+        return $this;
+    }
+}

--- a/src/Sylius/Component/Mailer/SyliusMailerEvents.php
+++ b/src/Sylius/Component/Mailer/SyliusMailerEvents.php
@@ -15,7 +15,8 @@ namespace Sylius\Component\Mailer;
 
 class SyliusMailerEvents
 {
-    public const EMAIL_PRE_RENDER = 'sylius.email_rendered';
+    public const EMAIL_PRE_RENDER = 'sylius.email_pre_render';
+    public const EMAIL_POST_RENDER = 'sylius.email_rendered';
     public const EMAIL_PRE_SEND = 'sylius.email_send.pre_send';
     public const EMAIL_POST_SEND = 'sylius.email_send.post_send';
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #4329 
| License         | MIT

The previously `PRE_RENDER` event was not really an PRE render event. The template was already rendered. 

This wil move the `PRE_RENDER` event to a` POST_RENDER` event. The original `PRE_RENDER` event is given a different Event, in which you can assemble more variables to the email template. You can think of global footer data, etc.  