### PR TITLE
Behat JS scenarios war vol.1

### DIFF
--- a/features/account/customer_account/viewing_orders_history/viewing_order_items.feature
+++ b/features/account/customer_account/viewing_orders_history/viewing_order_items.feature
@@ -16,7 +16,7 @@ Feature: Viewing details of an order
         And I addressed it to "Lucifer Morningstar", "Seaside Fwy", "90802" "Los Angeles" in the "United States" with identical billing address
         And I chose "Free" shipping method with "Cash on Delivery" payment
 
-    @ui @javascript
+    @ui
     Scenario: Viewing basic information about an order
         When I view the summary of the order "#00000666"
         And it should has number "#00000666"

--- a/features/checkout/placing_an_order_with_different_scopes_for_shipping_and_taxes.feature
+++ b/features/checkout/placing_an_order_with_different_scopes_for_shipping_and_taxes.feature
@@ -7,30 +7,31 @@ Feature: Placing an order with different scopes for shipping and taxes
     Background:
         Given the store operates on a single channel in "USD" currency
         And the store operates in "United States"
-        And this country has the "Texas" province with "US-TX" code
+        And the store operates in "Germany"
         And the store has a product "Jane's Vest" priced at "$20"
         And the store allows paying offline
         And I am a logged in customer
 
-    @ui @javascript
+    @ui
     Scenario: Placing an order with different tax and shipping zone
-        Given the store has a shipping zone "United States Shipping" with code "US-SHIPPING"
+        Given the store has a shipping zone "Global Shipping" with code "GLOBAL-SHIPPING"
         And it has the "United States" country member
-        And the store has a tax zone "Texas Tax" with code "US-TX-TAX"
-        And it has the "Texas" province member
-        And the store has "TX-VAT" tax rate of 8% for "Clothes" within the "US-TX-TAX" zone
-        And the store ships everything for free within the "US-SHIPPING" zone
+        And it has the "Germany" country member
+        And the store has a tax zone "German Tax" with code "DE-TAX"
+        And it has the "Germany" country member
+        And the store has "DE-VAT" tax rate of 8% for "Clothes" within the "DE-TAX" zone
+        And the store ships everything for free within the "GLOBAL-SHIPPING" zone
         And this product belongs to "Clothes" tax category
         And I have product "Jane's Vest" in the cart
-        Given I am at the checkout addressing step
-        When I specify the shipping address for "Patrick Jane" from "Sixth Street", "78701", "Austin", "United States", "Texas"
+        When I am at the checkout addressing step
+        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "Germany" for "Patrick Jane"
         And I complete the addressing step
         And I proceed with "Free" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And my tax total should be "$1.60"
         And my order total should be "$21.60"
 
-    @ui @javascript
+    @ui
     Scenario: Placing an order with in the same tax and shipping zone
         Given the store has a zone "United States" with code "US"
         And it has the "United States" country member
@@ -39,21 +40,21 @@ Feature: Placing an order with different scopes for shipping and taxes
         And this product belongs to "Clothes" tax category
         And I have product "Jane's Vest" in the cart
         Given I am at the checkout addressing step
-        When I specify the shipping address for "Patrick Jane" from "Sixth Street", "78701", "Austin", "United States", "Texas"
+        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Patrick Jane"
         And I complete the addressing step
         And I proceed with "Free" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And my tax total should be "$1.60"
         And my order total should be "$21.60"
 
-    @ui @javascript
+    @ui
     Scenario: Placing an order within shipping zone
         Given the store has a shipping zone "United States Shipping" with code "US"
         And it has the "United States" country member
         And the store ships everything for free within the "US" zone
         And I have product "Jane's Vest" in the cart
         Given I am at the checkout addressing step
-        When I specify the shipping address for "Patrick Jane" from "Sixth Street", "78701", "Austin", "United States", "Texas"
+        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Patrick Jane"
         And I complete the addressing step
         And I proceed with "Free" shipping method and "Offline" payment
         Then I should be on the checkout summary step

--- a/features/checkout/skipping_payment_method_step_when_only_one_payment_method_is_available.feature
+++ b/features/checkout/skipping_payment_method_step_when_only_one_payment_method_is_available.feature
@@ -1,4 +1,4 @@
-@checkout @javascript
+@checkout
 Feature: Skipping payment step when only one payment method is available
     In order to not select payment method if its unnecessary
     As a Customer

--- a/features/product/adding_product_reviews/adding_product_review_as_a_customer.feature
+++ b/features/product/adding_product_reviews/adding_product_review_as_a_customer.feature
@@ -9,7 +9,7 @@ Feature: Adding product review as a customer
         And the store has a product "Necronomicon"
         And I am a logged in customer
 
-    @ui @javascript
+    @ui
     Scenario: Adding product reviews as a logged in customer
         Given I want to review product "Necronomicon"
         When I leave a comment "Great book for every advanced sorcerer.", titled "Scary but astonishing"

--- a/features/product/adding_product_reviews/adding_product_review_as_a_guest.feature
+++ b/features/product/adding_product_reviews/adding_product_review_as_a_guest.feature
@@ -8,7 +8,7 @@ Feature: Adding product review as a guest
         Given the store operates on a single channel in "United States"
         And the store has a product "Necronomicon"
 
-    @ui @javascript
+    @ui
     Scenario: Adding product reviews as a guest
         Given I want to review product "Necronomicon"
         When I leave a comment "I'm never gonna read this terrible book again.", titled "Never again" as "castiel@heaven.com"

--- a/features/product/adding_product_reviews/review_validation.feature
+++ b/features/product/adding_product_reviews/review_validation.feature
@@ -16,7 +16,7 @@ Feature: Review validation
         And I add it
         Then I should be notified that I must check review rating
 
-    @ui @javascript
+    @ui
     Scenario: Adding a product review without specifying a title
         Given I want to review product "Necronomicon"
         When I leave a comment "This book made me sad, but plot was fine." as "bartholomew@heaven.com"
@@ -24,7 +24,7 @@ Feature: Review validation
         And I add it
         Then I should be notified that title is required
 
-    @ui @javascript
+    @ui
     Scenario: Adding a product review with too short title
         Given I want to review product "Necronomicon"
         When I leave a comment "This book made me sad, but plot was fine.", titled "X" as "bartholomew@heaven.com"
@@ -32,7 +32,7 @@ Feature: Review validation
         And I add it
         Then I should be notified that title must have at least 2 characters
 
-    @ui @javascript
+    @ui
     Scenario: Adding a product review with too long title
         Given I want to review product "Necronomicon"
         When I leave a comment "This book made me sad, but plot was fine." as "bartholomew@heaven.com"
@@ -41,7 +41,7 @@ Feature: Review validation
         And I add it
         Then I should be notified that title must have at most 255 characters
 
-    @ui @javascript
+    @ui
     Scenario: Adding a product review without specifying a comment
         Given I want to review product "Necronomicon"
         When I leave a review titled "Not good, not bad" as "bartholomew@heaven.com"
@@ -49,7 +49,7 @@ Feature: Review validation
         And I add it
         Then I should be notified that comment is required
 
-    @ui @javascript
+    @ui
     Scenario: Adding a product review without specifying an author email
         Given I want to review product "Necronomicon"
         When I leave a comment "Not good, not bad", titled "Not good, not bad"
@@ -57,7 +57,7 @@ Feature: Review validation
         And I add it
         Then I should be notified that I must enter my email
 
-    @ui @javascript
+    @ui
     Scenario: Adding a product review with specifying already registerd author email
         Given there is a customer account "sam@winchester.com" identified by "familybusiness"
         And I want to review product "Necronomicon"

--- a/features/user/managing_customers/being_able_to_create_account_for_existing_customer.feature
+++ b/features/user/managing_customers/being_able_to_create_account_for_existing_customer.feature
@@ -7,7 +7,7 @@ Feature: Create account option availability
     Background:
         And I am logged in as an administrator
 
-    @ui @javascript
+    @ui
     Scenario: Being able to create an account for created customer
         Given I want to create a new customer
         And I do not choose create account option

--- a/src/Sylius/Behat/Page/Shop/ProductReview/CreatePage.php
+++ b/src/Sylius/Behat/Page/Shop/ProductReview/CreatePage.php
@@ -54,7 +54,7 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
      */
     public function rateReview($rate)
     {
-        $this->getElement('rate', ['%rate%' => $rate])->click();
+        $this->getElement('rate')->selectOption($rate);
     }
 
     public function submitReview()
@@ -102,7 +102,7 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
         return array_merge(parent::getDefinedElements(), [
             'author' => '#sylius_product_review_author_email',
             'comment' => '#sylius_product_review_comment',
-            'rate' => '.star.rating .icon:nth-child(%rate%)',
+            'rate' => '[name="sylius_product_review[rating]"]',
             'rating' => '#sylius_product_review_rating',
             'title' => '#sylius_product_review_title',
         ]);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This is a first PR from (planned, hope it will work :D) series of PR's refactoring our javascript Behat scenarios.

I think we're all aware of the value that Behat brings to us, but also we're all struggling with the unbelievably slow scenarios containing `@javascript` tag, run by Selenium. Just looking a the execution times can be scary:

- no-js scenarios: 11525 steps, ~6m18.29s
- js scenarios: 2413 steps, ~16m45.64s

I think that eventually, we should think about some faster and more reliable tool for testing our js features. On the other way, I have a deep premonition that we can still do something already, without even changing a testing tool. I've started with two simple things:

- removing `@javascript` tag whenever it's not needed and it requires no or minimum work
- refactoring "rating product" scenarios to use radio buttons rather than semantic-ui stars (why? because clicking on **stars** is _de facto_ testing a UI framework, which we should assume works properly and test a real value. Maybe we should leave one step tagged with `@javascript`, just to be sure that everything works?)

I know, it's just a few tens of seconds right now, but I strongly believe, that even without changing our testing tools we can make build closer to 20min than 30-35min. I investigated most of the places when javascript is required for scenarios and will try to figure out is it relevant or can it be removed with no big changes and no BC breaks :)