### PR TITLE
Add scalar types in Behat/Page/Admin directory

### DIFF
--- a/src/Sylius/Behat/Behaviour/ChecksCodeImmutability.php
+++ b/src/Sylius/Behat/Behaviour/ChecksCodeImmutability.php
@@ -17,15 +17,9 @@ use Behat\Mink\Element\NodeElement;
 
 trait ChecksCodeImmutability
 {
-    /**
-     * @return NodeElement
-     */
-    abstract protected function getCodeElement();
+    abstract protected function getCodeElement(): NodeElement;
 
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled()
+    public function isCodeDisabled(): bool
     {
         return 'disabled' === $this->getCodeElement()->getAttribute('disabled');
     }

--- a/src/Sylius/Behat/Behaviour/ChoosesName.php
+++ b/src/Sylius/Behat/Behaviour/ChoosesName.php
@@ -17,10 +17,7 @@ trait ChoosesName
 {
     use DocumentAccessor;
 
-    /**
-     * @param string $name
-     */
-    public function chooseName($name)
+    public function chooseName(string $name): void
     {
         $this->getDocument()->selectFieldOption('Name', $name);
     }

--- a/src/Sylius/Behat/Behaviour/DescribesIt.php
+++ b/src/Sylius/Behat/Behaviour/DescribesIt.php
@@ -17,10 +17,7 @@ trait DescribesIt
 {
     use DocumentAccessor;
 
-    /**
-     * @param string $description
-     */
-    public function describeItAs($description)
+    public function describeItAs(string $description): void
     {
         $this->getDocument()->fillField('Description', $description);
     }

--- a/src/Sylius/Behat/Behaviour/NamesIt.php
+++ b/src/Sylius/Behat/Behaviour/NamesIt.php
@@ -17,10 +17,7 @@ trait NamesIt
 {
     use DocumentAccessor;
 
-    /**
-     * @param string $name
-     */
-    public function nameIt($name)
+    public function nameIt(string $name): void
     {
         $this->getDocument()->fillField('Name', $name);
     }

--- a/src/Sylius/Behat/Behaviour/SpecifiesItsCode.php
+++ b/src/Sylius/Behat/Behaviour/SpecifiesItsCode.php
@@ -17,10 +17,7 @@ trait SpecifiesItsCode
 {
     use DocumentAccessor;
 
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code)
+    public function specifyCode(string $code): void
     {
         $this->getDocument()->fillField('Code', $code);
     }

--- a/src/Sylius/Behat/Behaviour/Toggles.php
+++ b/src/Sylius/Behat/Behaviour/Toggles.php
@@ -20,12 +20,12 @@ trait Toggles
     /**
      * @return NodeElement
      */
-    abstract protected function getToggleableElement();
+    abstract protected function getToggleableElement(): NodeElement;
 
     /**
      * @throws \RuntimeException If already enabled
      */
-    public function enable()
+    public function enable(): void
     {
         $toggleableElement = $this->getToggleableElement();
         $this->assertCheckboxState($toggleableElement, false);
@@ -36,7 +36,7 @@ trait Toggles
     /**
      * @throws \RuntimeException If already disabled
      */
-    public function disable()
+    public function disable(): void
     {
         $toggleableElement = $this->getToggleableElement();
         $this->assertCheckboxState($toggleableElement, true);

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -133,7 +133,7 @@ final class ProductContext implements Context
      * @Given /^the store(?:| also) has a product "([^"]+)" priced at ("[^"]+")$/
      * @Given /^the store(?:| also) has a product "([^"]+)" priced at ("[^"]+") in ("[^"]+" channel)$/
      */
-    public function storeHasAProductPricedAt($productName, $price = 100, ChannelInterface $channel = null)
+    public function storeHasAProductPricedAt($productName, int $price = 100, ChannelInterface $channel = null)
     {
         $product = $this->createProduct($productName, $price, $channel);
 
@@ -143,7 +143,7 @@ final class ProductContext implements Context
     /**
      * @Given /^(this product) is(?:| also) priced at ("[^"]+") in ("[^"]+" channel)$/
      */
-    public function thisProductIsAlsoPricedAtInChannel(ProductInterface $product, $price, ChannelInterface $channel)
+    public function thisProductIsAlsoPricedAtInChannel(ProductInterface $product, int $price, ChannelInterface $channel)
     {
         $product->addChannel($channel);
 
@@ -178,7 +178,7 @@ final class ProductContext implements Context
     /**
      * @Given /^the store(?:| also) has a product "([^"]+)" priced at ("[^"]+") available in (channel "[^"]+") and (channel "[^"]+")$/
      */
-    public function storeHasAProductPricedAtAvailableInChannels($productName, $price = 100, ...$channels)
+    public function storeHasAProductPricedAtAvailableInChannels($productName, int $price = 100, ...$channels)
     {
         $product = $this->createProduct($productName, $price);
         /** @var ProductVariantInterface $productVariant */
@@ -381,7 +381,7 @@ final class ProductContext implements Context
     /**
      * @Given /^(this variant) is also priced at ("[^"]+") in ("([^"]+)" channel)$/
      */
-    public function thisVariantIsAlsoPricedAtInChannel(ProductVariantInterface $productVariant, $price, ChannelInterface $channel)
+    public function thisVariantIsAlsoPricedAtInChannel(ProductVariantInterface $productVariant, string $price, ChannelInterface $channel)
     {
         $productVariant->addChannelPricing($this->createChannelPricingForChannel(
             $this->getPriceFromString(str_replace(['$', '€', '£'], '', $price)),
@@ -578,7 +578,7 @@ final class ProductContext implements Context
     /**
      * @Given /^(this product) is available in "([^"]+)" ([^"]+) priced at ("[^"]+")$/
      */
-    public function thisProductIsAvailableInSize(ProductInterface $product, $optionValueName, $optionName, $price)
+    public function thisProductIsAvailableInSize(ProductInterface $product, $optionValueName, $optionName, int $price)
     {
         /** @var ProductVariantInterface $variant */
         $variant = $this->productVariantFactory->createNew();
@@ -681,7 +681,7 @@ final class ProductContext implements Context
      * @Given /^the (product "[^"]+") changed its price to ("[^"]+")$/
      * @Given /^(this product) price has been changed to ("[^"]+")$/
      */
-    public function theProductChangedItsPriceTo(ProductInterface $product, $price)
+    public function theProductChangedItsPriceTo(ProductInterface $product, int $price)
     {
         /** @var ProductVariantInterface $productVariant */
         $productVariant = $this->defaultVariantResolver->getVariant($product);
@@ -752,7 +752,7 @@ final class ProductContext implements Context
      *
      * @return ProductInterface
      */
-    private function createProduct($productName, $price = 100, ChannelInterface $channel = null)
+    private function createProduct($productName, int $price = 100, ChannelInterface $channel = null)
     {
         if (null === $channel && $this->sharedStorage->has('channel')) {
             $channel = $this->sharedStorage->get('channel');
@@ -904,7 +904,7 @@ final class ProductContext implements Context
      *
      * @return ChannelPricingInterface
      */
-    private function createChannelPricingForChannel($price, ChannelInterface $channel = null)
+    private function createChannelPricingForChannel(int $price, ChannelInterface $channel = null)
     {
         /** @var ChannelPricingInterface $channelPricing */
         $channelPricing = $this->channelPricingFactory->createNew();

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingAdministratorsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingAdministratorsContext.php
@@ -80,7 +80,7 @@ final class ManagingAdministratorsContext implements Context
      */
     public function iSpecifyItsNameAs($username = null)
     {
-        $this->createPage->specifyUsername($username);
+        $this->createPage->specifyUsername($username ?? '');
     }
 
     /**
@@ -97,7 +97,7 @@ final class ManagingAdministratorsContext implements Context
      */
     public function iSpecifyItsEmailAs($email = null)
     {
-        $this->createPage->specifyEmail($email);
+        $this->createPage->specifyEmail($email ?? '');
     }
 
     /**
@@ -131,7 +131,7 @@ final class ManagingAdministratorsContext implements Context
      */
     public function iSpecifyItsPasswordAs($password = null)
     {
-        $this->createPage->specifyPassword($password);
+        $this->createPage->specifyPassword($password ?? '');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
@@ -22,6 +22,7 @@ use Sylius\Behat\Service\NotificationCheckerInterface;
 use Sylius\Behat\Service\Resolver\CurrentPageResolverInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Currency\Model\CurrencyInterface;
 use Webmozart\Assert\Assert;
 
 final class ManagingChannelsContext implements Context
@@ -69,7 +70,7 @@ final class ManagingChannelsContext implements Context
      */
     public function iSpecifyItsCodeAs($code = null)
     {
-        $this->createPage->specifyCode($code);
+        $this->createPage->specifyCode($code ?? '');
     }
 
     /**
@@ -80,16 +81,16 @@ final class ManagingChannelsContext implements Context
      */
     public function iNameIt($name = null)
     {
-        $this->createPage->nameIt($name);
+        $this->createPage->nameIt($name ?? '');
     }
 
     /**
      * @When I choose :currency as the base currency
      * @When I do not choose base currency
      */
-    public function iChooseAsABaseCurrency($currency = null)
+    public function iChooseAsABaseCurrency(?CurrencyInterface $currency = null)
     {
-        $this->createPage->chooseBaseCurrency($currency);
+        $this->createPage->chooseBaseCurrency($currency ? $currency->getName() : null);
     }
 
     /**
@@ -427,7 +428,7 @@ final class ManagingChannelsContext implements Context
      */
     public function iRemoveItsDefaultTaxZone()
     {
-        $this->updatePage->chooseDefaultTaxZone(null);
+        $this->updatePage->chooseDefaultTaxZone('');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCountriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCountriesContext.php
@@ -244,7 +244,7 @@ final class ManagingCountriesContext implements Context
      */
     public function iNameTheProvince($provinceName = null)
     {
-        $this->updatePage->nameProvince($provinceName);
+        $this->updatePage->nameProvince($provinceName ?? '');
     }
 
     /**
@@ -253,7 +253,7 @@ final class ManagingCountriesContext implements Context
      */
     public function iSpecifyTheProvinceCode($provinceCode = null)
     {
-        $this->updatePage->specifyProvinceCode($provinceCode);
+        $this->updatePage->specifyProvinceCode($provinceCode ?? '');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomerGroupsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomerGroupsContext.php
@@ -55,7 +55,7 @@ final class ManagingCustomerGroupsContext implements Context
      */
     public function iSpecifyItsCodeAs($code = null)
     {
-        $this->createPage->specifyCode($code);
+        $this->createPage->specifyCode($code ?? '');
     }
 
     /**
@@ -64,7 +64,7 @@ final class ManagingCustomerGroupsContext implements Context
      */
     public function iSpecifyItsNameAs($name = null)
     {
-        $this->createPage->nameIt($name);
+        $this->createPage->nameIt($name ?? '');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCustomersContext.php
@@ -93,16 +93,16 @@ final class ManagingCustomersContext implements Context
      */
     public function iSpecifyItsEmailAs($email = null)
     {
-        $this->createPage->specifyEmail($email);
+        $this->createPage->specifyEmail($email ?? '');
     }
 
     /**
      * @When I change their email to :email
      * @When I remove its email
      */
-    public function iChangeTheirEmailTo(?string $email = null): void
+    public function iChangeTheirEmailTo($email = null): void
     {
-        $this->updatePage->changeEmail($email);
+        $this->updatePage->changeEmail($email ?? '');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingExchangeRatesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingExchangeRatesContext.php
@@ -75,7 +75,7 @@ final class ManagingExchangeRatesContext implements Context
      */
     public function iSpecifyItsRatioAs($ratio = null)
     {
-        $this->createPage->specifyRatio($ratio);
+        $this->createPage->specifyRatio($ratio ?? '');
     }
 
     /**
@@ -107,7 +107,7 @@ final class ManagingExchangeRatesContext implements Context
      */
     public function iChangeRatioTo($ratio)
     {
-        $this->updatePage->changeRatio((float) $ratio);
+        $this->updatePage->changeRatio($ratio);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentMethodsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPaymentMethodsContext.php
@@ -77,7 +77,7 @@ final class ManagingPaymentMethodsContext implements Context
         /** @var CreatePageInterface|UpdatePageInterface $currentPage */
         $currentPage = $this->currentPageResolver->getCurrentPageWithForm([$this->createPage, $this->updatePage]);
 
-        $currentPage->nameIt($name, $language);
+        $currentPage->nameIt($name ?? '', $language);
     }
 
     /**
@@ -154,7 +154,7 @@ final class ManagingPaymentMethodsContext implements Context
      */
     public function iSpecifyItsCodeAs($code = null)
     {
-        $this->createPage->specifyCode($code);
+        $this->createPage->specifyCode($code ?? '');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAssociationTypesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAssociationTypesContext.php
@@ -94,7 +94,7 @@ final class ManagingProductAssociationTypesContext implements Context
      */
     public function iRenameItToInLanguage($name = null, $language)
     {
-        $this->updatePage->nameItIn($name, $language);
+        $this->updatePage->nameItIn($name ?? '', $language);
     }
 
     /**
@@ -103,7 +103,7 @@ final class ManagingProductAssociationTypesContext implements Context
      */
     public function iSpecifyItsCodeAs($code = null)
     {
-        $this->createPage->specifyCode($code);
+        $this->createPage->specifyCode($code ?? '');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductAttributesContext.php
@@ -68,7 +68,7 @@ final class ManagingProductAttributesContext implements Context
      */
     public function iSpecifyItsCodeAs($code = null)
     {
-        $this->createPage->specifyCode($code);
+        $this->createPage->specifyCode($code ?? '');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductOptionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductOptionsContext.php
@@ -103,7 +103,7 @@ final class ManagingProductOptionsContext implements Context
      */
     public function iRenameItToInLanguage($name = null, $language)
     {
-        $this->updatePage->nameItIn($name, $language);
+        $this->updatePage->nameItIn($name ?? '', $language);
     }
 
     /**
@@ -120,7 +120,7 @@ final class ManagingProductOptionsContext implements Context
      */
     public function iSpecifyItsCodeAs($code = null)
     {
-        $this->createPage->specifyCode($code);
+        $this->createPage->specifyCode($code ?? '');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductReviewsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductReviewsContext.php
@@ -98,7 +98,7 @@ final class ManagingProductReviewsContext implements Context
      */
     public function iChangeItsTitleTo($title = null)
     {
-        $this->updatePage->specifyTitle($title);
+        $this->updatePage->specifyTitle($title ?? '');
     }
 
     /**
@@ -107,7 +107,7 @@ final class ManagingProductReviewsContext implements Context
      */
     public function iChangeItsCommentTo($comment = null)
     {
-        $this->updatePage->specifyComment($comment);
+        $this->updatePage->specifyComment($comment ?? '');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsContext.php
@@ -81,7 +81,7 @@ final class ManagingProductVariantsContext implements Context
      */
     public function iSpecifyItsCodeAs($code = null)
     {
-        $this->createPage->specifyCode($code);
+        $this->createPage->specifyCode($code ?? '');
     }
 
     /**
@@ -121,9 +121,9 @@ final class ManagingProductVariantsContext implements Context
      * @When /^I set its(?:| default) price to "(?:€|£|\$)([^"]+)" for "([^"]+)" channel$/
      * @When I do not set its price
      */
-    public function iSetItsPriceTo($price = null, $channelName = null)
+    public function iSetItsPriceTo(?string $price = null, $channelName = null)
     {
-        $this->createPage->specifyPrice($price, $channelName ?? $this->sharedStorage->get('channel'));
+        $this->createPage->specifyPrice($price ?? '', $channelName ?? (string) $this->sharedStorage->get('channel'));
     }
 
     /**
@@ -169,7 +169,7 @@ final class ManagingProductVariantsContext implements Context
     /**
      * @When I set the position of :name to :position
      */
-    public function iSetThePositionOfTo($name, $position)
+    public function iSetThePositionOfTo($name, int $position)
     {
         $this->indexPage->setPosition($name, $position);
     }
@@ -209,7 +209,7 @@ final class ManagingProductVariantsContext implements Context
     /**
      * @Then /^the (variant with code "[^"]+") should be priced at (?:€|£|\$)([^"]+) for channel "([^"]+)"$/
      */
-    public function theVariantWithCodeShouldBePricedAtForChannel(ProductVariantInterface $productVariant, $price, $channelName)
+    public function theVariantWithCodeShouldBePricedAtForChannel(ProductVariantInterface $productVariant, string $price, $channelName)
     {
         $this->updatePage->open(['id' => $productVariant->getId(), 'productId' => $productVariant->getProduct()->getId()]);
 
@@ -427,7 +427,7 @@ final class ManagingProductVariantsContext implements Context
     /**
      * @When /^I specify that the (\d)(?:st|nd|rd|th) variant is identified by "([^"]+)" code and costs "(?:€|£|\$)([^"]+)" in ("[^"]+") channel$/
      */
-    public function iSpecifyThereAreVariantsIdentifiedByCodeWithCost($nthVariant, $code, $price, $channelName)
+    public function iSpecifyThereAreVariantsIdentifiedByCodeWithCost($nthVariant, $code, int $price, $channelName)
     {
         $this->generatePage->specifyCode($nthVariant - 1, $code);
         $this->generatePage->specifyPrice($nthVariant - 1, $price, $channelName);
@@ -444,7 +444,7 @@ final class ManagingProductVariantsContext implements Context
     /**
      * @When /^I specify that the (\d)(?:st|nd|rd|th) variant costs "(?:€|£|\$)([^"]+)" in ("[^"]+") channel$/
      */
-    public function iSpecifyThereAreVariantsWithCost($nthVariant, $price, $channelName)
+    public function iSpecifyThereAreVariantsWithCost($nthVariant, int $price, $channelName)
     {
         $this->generatePage->specifyPrice($nthVariant - 1, $price, $channelName);
     }
@@ -484,7 +484,7 @@ final class ManagingProductVariantsContext implements Context
     /**
      * @When I change its quantity of inventory to :amount
      */
-    public function iChangeItsQuantityOfInventoryTo($amount)
+    public function iChangeItsQuantityOfInventoryTo(int $amount)
     {
         $this->updatePage->specifyCurrentStock($amount);
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -28,6 +28,7 @@ use Sylius\Behat\Page\Admin\ProductReview\IndexPageInterface as ProductReviewInd
 use Sylius\Behat\Service\NotificationCheckerInterface;
 use Sylius\Behat\Service\Resolver\CurrentPageResolverInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Product\Model\ProductAssociationTypeInterface;
@@ -113,7 +114,7 @@ final class ManagingProductsContext implements Context
     {
         $currentPage = $this->resolveCurrentPage();
 
-        $currentPage->specifyCode($code);
+        $currentPage->specifyCode($code ?? '');
     }
 
     /**
@@ -158,7 +159,7 @@ final class ManagingProductsContext implements Context
     /**
      * @When /^I set its(?:| default) price to "(?:€|£|\$)([^"]+)" for "([^"]+)" channel$/
      */
-    public function iSetItsPriceTo($price, $channelName)
+    public function iSetItsPriceTo(string $price, string $channelName)
     {
         $this->createSimpleProductPage->specifyPrice($channelName, $price);
     }
@@ -166,7 +167,7 @@ final class ManagingProductsContext implements Context
     /**
      * @When /^I set its original price to "(?:€|£|\$)([^"]+)" for "([^"]+)" channel$/
      */
-    public function iSetItsOriginalPriceTo($originalPrice, $channelName)
+    public function iSetItsOriginalPriceTo(int $originalPrice, $channelName)
     {
         $this->createSimpleProductPage->specifyOriginalPrice($channelName, $originalPrice);
     }
@@ -174,18 +175,18 @@ final class ManagingProductsContext implements Context
     /**
      * @When I make it available in channel :channel
      */
-    public function iMakeItAvailableInChannel($channel)
+    public function iMakeItAvailableInChannel(ChannelInterface $channel)
     {
-        $this->createSimpleProductPage->checkChannel($channel);
+        $this->createSimpleProductPage->checkChannel($channel->getName());
     }
 
     /**
      * @When I assign it to channel :channel
      */
-    public function iAssignItToChannel($channel)
+    public function iAssignItToChannel(ChannelInterface $channel)
     {
         // Temporary solution until we will make current page resolver work with product pages
-        $this->updateConfigurableProductPage->checkChannel($channel);
+        $this->updateConfigurableProductPage->checkChannel($channel->getName());
     }
 
     /**
@@ -201,7 +202,7 @@ final class ManagingProductsContext implements Context
      * @When I set its slug to :slug in :language
      * @When I remove its slug
      */
-    public function iSetItsSlugToIn($slug = null, $language = 'en_US')
+    public function iSetItsSlugToIn(?string $slug = null, $language = 'en_US')
     {
         $this->createSimpleProductPage->specifySlugIn($slug, $language);
     }
@@ -433,7 +434,7 @@ final class ManagingProductsContext implements Context
     /**
      * @When /^I change its price to (?:€|£|\$)([^"]+) for "([^"]+)" channel$/
      */
-    public function iChangeItsPriceTo($price, $channelName)
+    public function iChangeItsPriceTo(string $price, $channelName)
     {
         $this->updateSimpleProductPage->specifyPrice($channelName, $price);
     }
@@ -441,7 +442,7 @@ final class ManagingProductsContext implements Context
     /**
      * @When /^I change its original price to "(?:€|£|\$)([^"]+)" for "([^"]+)" channel$/
      */
-    public function iChangeItsOriginalPriceTo($price, $channelName)
+    public function iChangeItsOriginalPriceTo(string $price, $channelName)
     {
         $this->updateSimpleProductPage->specifyOriginalPrice($channelName, $price);
     }
@@ -461,7 +462,7 @@ final class ManagingProductsContext implements Context
      */
     public function iSetItsAttributeTo($attribute, $value = null, $language = 'en_US')
     {
-        $this->createSimpleProductPage->addAttribute($attribute, $value, $language);
+        $this->createSimpleProductPage->addAttribute($attribute, $value ?? '', $language);
     }
 
     /**
@@ -851,7 +852,7 @@ final class ManagingProductsContext implements Context
      * @Then /^(it|this product) should be priced at (?:€|£|\$)([^"]+) for channel "([^"]+)"$/
      * @Then /^(product "[^"]+") should be priced at (?:€|£|\$)([^"]+) for channel "([^"]+)"$/
      */
-    public function itShouldBePricedAtForChannel(ProductInterface $product, $price, $channelName)
+    public function itShouldBePricedAtForChannel(ProductInterface $product, string $price, $channelName)
     {
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
 

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionCouponsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionCouponsContext.php
@@ -101,13 +101,13 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function iSpecifyItsCodeLengthAs($codeLength = null)
     {
-        $this->generatePage->specifyCodeLength($codeLength);
+        $this->generatePage->specifyCodeLength($codeLength ?? '');
     }
 
     /**
      * @When /^I limit generated coupons usage to (\d+) times$/
      */
-    public function iSetGeneratedCouponsUsageLimitTo($limit)
+    public function iSetGeneratedCouponsUsageLimitTo(int $limit)
     {
         $this->generatePage->setUsageLimit($limit);
     }
@@ -126,13 +126,13 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function iSpecifyItsCodeAs($code = null)
     {
-        $this->createPage->specifyCode($code);
+        $this->createPage->specifyCode($code ?? '');
     }
 
     /**
      * @When I limit its usage to :limit times
      */
-    public function iLimitItsUsageLimitTo($limit)
+    public function iLimitItsUsageLimitTo(int $limit)
     {
         $this->createPage->setUsageLimit($limit);
     }
@@ -151,13 +151,13 @@ final class ManagingPromotionCouponsContext implements Context
      */
     public function iSpecifyItsAmountAs($amount = null)
     {
-        $this->generatePage->specifyAmount($amount);
+        $this->generatePage->specifyAmount($amount ?? '');
     }
 
     /**
      * @When I limit its per customer usage to :limit times
      */
-    public function iLimitItsPerCustomerUsageLimitTo($limit)
+    public function iLimitItsPerCustomerUsageLimitTo(int $limit)
     {
         $this->createPage->setCustomerUsageLimit($limit);
     }
@@ -165,7 +165,7 @@ final class ManagingPromotionCouponsContext implements Context
     /**
      * @When I change its per customer usage limit to :limit
      */
-    public function iChangeItsPerCustomerUsageLimitTo($limit)
+    public function iChangeItsPerCustomerUsageLimitTo(int $limit)
     {
         $this->updatePage->setCustomerUsageLimit($limit);
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingPromotionsContext.php
@@ -83,7 +83,7 @@ final class ManagingPromotionsContext implements Context
      */
     public function iSpecifyItsCodeAs($code = null)
     {
-        $this->createPage->specifyCode($code);
+        $this->createPage->specifyCode($code ?? '');
     }
 
     /**
@@ -93,7 +93,7 @@ final class ManagingPromotionsContext implements Context
      */
     public function iNameIt($name = null)
     {
-        $this->createPage->nameIt($name);
+        $this->createPage->nameIt($name ?? '');
     }
 
     /**
@@ -228,7 +228,7 @@ final class ManagingPromotionsContext implements Context
     public function iAddTheActionConfiguredWithAPercentageValue($actionType, $percentage = null)
     {
         $this->createPage->addAction($actionType);
-        $this->createPage->fillActionOption('Percentage', $percentage);
+        $this->createPage->fillActionOption('Percentage', $percentage ?? '');
     }
 
     /**
@@ -610,7 +610,7 @@ final class ManagingPromotionsContext implements Context
     /**
      * @Given the :promotion promotion should have priority :priority
      */
-    public function thePromotionsShouldHavePriority(PromotionInterface $promotion, $priority)
+    public function thePromotionsShouldHavePriority(PromotionInterface $promotion, int $priority)
     {
         $this->iWantToModifyAPromotion($promotion);
 

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingCategoriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingCategoriesContext.php
@@ -100,7 +100,7 @@ class ManagingShippingCategoriesContext implements Context
      */
     public function iSpecifyItsCodeAs($shippingCategoryCode = null)
     {
-        $this->createPage->specifyCode($shippingCategoryCode);
+        $this->createPage->specifyCode($shippingCategoryCode ?? '');
     }
 
     /**
@@ -109,7 +109,7 @@ class ManagingShippingCategoriesContext implements Context
      */
     public function iNameIt($shippingCategoryName = null)
     {
-        $this->createPage->nameIt($shippingCategoryName);
+        $this->createPage->nameIt($shippingCategoryName ?? '');
     }
 
     /**
@@ -170,7 +170,7 @@ class ManagingShippingCategoriesContext implements Context
      */
     public function iNameItIn($name)
     {
-        $this->createPage->nameIt($name);
+        $this->createPage->nameIt($name ?? '');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingMethodsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingShippingMethodsContext.php
@@ -69,13 +69,13 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function iSpecifyItsCodeAs($code = null)
     {
-        $this->createPage->specifyCode($code);
+        $this->createPage->specifyCode($code ?? '');
     }
 
     /**
      * @When I specify its position as :position
      */
-    public function iSpecifyItsPositionAs($position = null)
+    public function iSpecifyItsPositionAs(int $position = null)
     {
         $this->createPage->specifyPosition($position);
     }
@@ -356,7 +356,7 @@ final class ManagingShippingMethodsContext implements Context
      */
     public function iRemoveItsNameFromTranslation($language)
     {
-        $this->createPage->nameIt(null, $language);
+        $this->createPage->nameIt('', $language);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxCategoriesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxCategoriesContext.php
@@ -78,7 +78,7 @@ final class ManagingTaxCategoriesContext implements Context
      */
     public function iSpecifyItsCodeAs($code = null)
     {
-        $this->createPage->specifyCode($code);
+        $this->createPage->specifyCode($code ?? '');
     }
 
     /**
@@ -89,7 +89,7 @@ final class ManagingTaxCategoriesContext implements Context
      */
     public function iNameIt($name = null)
     {
-        $this->createPage->nameIt($name);
+        $this->createPage->nameIt($name ?? '');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxRateContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxRateContext.php
@@ -61,7 +61,7 @@ final class ManagingTaxRateContext implements Context
      */
     public function iSpecifyItsCodeAs($code = null)
     {
-        $this->createPage->specifyCode($code);
+        $this->createPage->specifyCode($code ?? '');
     }
 
     /**
@@ -71,7 +71,7 @@ final class ManagingTaxRateContext implements Context
      */
     public function iSpecifyItsAmountAs($amount = null)
     {
-        $this->createPage->specifyAmount($amount);
+        $this->createPage->specifyAmount($amount ?? '');
     }
 
     /**
@@ -108,7 +108,7 @@ final class ManagingTaxRateContext implements Context
      */
     public function iNameIt($name = null)
     {
-        $this->createPage->nameIt($name);
+        $this->createPage->nameIt($name ?? '');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
@@ -84,9 +84,9 @@ final class ManagingTaxonsContext implements Context
      * @When I specify its code as :code
      * @When I do not specify its code
      */
-    public function iSpecifyItsCodeAs($code = null)
+    public function iSpecifyItsCodeAs(?string $code = null)
     {
-        $this->createPage->specifyCode($code);
+        $this->createPage->specifyCode($code ?? '');
     }
 
     /**
@@ -94,11 +94,11 @@ final class ManagingTaxonsContext implements Context
      * @When I rename it to :name in :language
      * @When I do not specify its name
      */
-    public function iNameItIn($name = null, $language = 'en_US')
+    public function iNameItIn(?string $name = null, $language = 'en_US')
     {
         $currentPage = $this->resolveCurrentPage();
 
-        $currentPage->nameIt($name, $language);
+        $currentPage->nameIt($name ?? '', $language);
     }
 
     /**
@@ -106,11 +106,11 @@ final class ManagingTaxonsContext implements Context
      * @When I do not specify its slug
      * @When I set its slug to :slug in :language
      */
-    public function iSetItsSlugToIn($slug = null, $language = 'en_US')
+    public function iSetItsSlugToIn(?string $slug = null, $language = 'en_US')
     {
         $currentPage = $this->resolveCurrentPage();
 
-        $currentPage->specifySlug($slug, $language);
+        $currentPage->specifySlug($slug ?? '', $language);
     }
 
     /**
@@ -206,10 +206,10 @@ final class ManagingTaxonsContext implements Context
     public function thisTaxonElementShouldHaveSlugIn($value, $language = null)
     {
         if (null !== $language) {
-            $this->updatePage->activateLanguageTab($language);
+            $this->updatePage->activateLanguageTab($language ?? '');
         }
 
-        Assert::same($this->updatePage->getSlug($language), $value);
+        Assert::same($this->updatePage->getSlug($language ?? ''), $value);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingZonesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingZonesContext.php
@@ -103,7 +103,7 @@ final class ManagingZonesContext implements Context
      */
     public function iRenameItTo($name)
     {
-        $this->updatePage->nameIt($name);
+        $this->updatePage->nameIt($name ?? '');
     }
 
     /**
@@ -111,7 +111,7 @@ final class ManagingZonesContext implements Context
      */
     public function iNameIt($name)
     {
-        $this->createPage->nameIt($name);
+        $this->createPage->nameIt($name ?? '');
     }
 
     /**
@@ -119,7 +119,7 @@ final class ManagingZonesContext implements Context
      */
     public function iSpecifyItsCodeAs($code)
     {
-        $this->createPage->specifyCode($code);
+        $this->createPage->specifyCode($code ?? '');
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/ThemeContext.php
+++ b/src/Sylius/Behat/Context/Ui/ThemeContext.php
@@ -54,7 +54,7 @@ final class ThemeContext implements Context
     public function iSetChannelThemeTo(ChannelInterface $channel, ThemeInterface $theme)
     {
         $this->channelUpdatePage->open(['id' => $channel->getId()]);
-        $this->channelUpdatePage->setTheme($theme);
+        $this->channelUpdatePage->setTheme($theme->getName());
         $this->channelUpdatePage->saveChanges();
 
         $this->sharedStorage->set('channel', $channel);

--- a/src/Sylius/Behat/Page/Admin/Account/LoginPage.php
+++ b/src/Sylius/Behat/Page/Admin/Account/LoginPage.php
@@ -17,46 +17,31 @@ use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
 
 class LoginPage extends SymfonyPage implements LoginPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function hasValidationErrorWith($message)
+    public function hasValidationErrorWith(string $message): bool
     {
         return $this->getElement('validation_error')->getText() === $message;
     }
 
-    public function logIn()
+    public function logIn(): void
     {
         $this->getDocument()->pressButton('Login');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyPassword($password)
+    public function specifyPassword(string $password): void
     {
         $this->getDocument()->fillField('Password', $password);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyUsername($username)
+    public function specifyUsername(string $username): void
     {
         $this->getDocument()->fillField('Username', $username);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getRouteName(): string
     {
         return 'sylius_admin_login';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Account/LoginPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Account/LoginPageInterface.php
@@ -17,22 +17,11 @@ use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 
 interface LoginPageInterface extends SymfonyPageInterface
 {
-    /**
-     * @param string $message
-     *
-     * @return bool
-     */
-    public function hasValidationErrorWith($message);
+    public function hasValidationErrorWith(string $message): bool;
 
-    public function logIn();
+    public function logIn(): void;
 
-    /**
-     * @param string $password
-     */
-    public function specifyPassword($password);
+    public function specifyPassword(string $password): void;
 
-    /**
-     * @param string $username
-     */
-    public function specifyUsername($username);
+    public function specifyUsername(string $username): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Administrator/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Administrator/CreatePage.php
@@ -17,46 +17,31 @@ use Sylius\Behat\Page\Admin\Crud\CreatePage as BaseCreatePage;
 
 class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
-    public function enable()
+    public function enable(): void
     {
         $this->getElement('enabled')->check();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyUsername($username)
+    public function specifyUsername(string $username): void
     {
         $this->getElement('name')->setValue($username);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyEmail($email)
+    public function specifyEmail(string $email): void
     {
         $this->getElement('email')->setValue($email);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyPassword($password)
+    public function specifyPassword(string $password): void
     {
         $this->getElement('password')->setValue($password);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyLocale($localeCode)
+    public function specifyLocale(string $localeCode): void
     {
         $this->getElement('locale_code')->selectOption($localeCode);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Administrator/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Administrator/CreatePageInterface.php
@@ -17,25 +17,13 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    public function enable();
+    public function enable(): void;
 
-    /**
-     * @param string $username
-     */
-    public function specifyUsername($username);
+    public function specifyUsername(string $username): void;
 
-    /**
-     * @param string $email
-     */
-    public function specifyEmail($email);
+    public function specifyEmail(string $email): void;
 
-    /**
-     * @param string $password
-     */
-    public function specifyPassword($password);
+    public function specifyPassword(string $password): void;
 
-    /**
-     * @param string $localeCode
-     */
-    public function specifyLocale($localeCode);
+    public function specifyLocale(string $localeCode): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Administrator/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Administrator/UpdatePage.php
@@ -17,41 +17,26 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
 
 class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function changeUsername($username)
+    public function changeUsername(string $username): void
     {
         $this->getElement('username')->setValue($username);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function changeEmail($email)
+    public function changeEmail(string $email): void
     {
         $this->getElement('email')->setValue($email);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function changePassword($password)
+    public function changePassword(string $password): void
     {
         $this->getElement('password')->setValue($password);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function changeLocale($localeCode)
+    public function changeLocale(string $localeCode): void
     {
         $this->getElement('locale_code')->selectOption($localeCode);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Administrator/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Administrator/UpdatePageInterface.php
@@ -17,23 +17,11 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @param string $username
-     */
-    public function changeUsername($username);
+    public function changeUsername(string $username): void;
 
-    /**
-     * @param string $email
-     */
-    public function changeEmail($email);
+    public function changeEmail(string $email): void;
 
-    /**
-     * @param string $password
-     */
-    public function changePassword($password);
+    public function changePassword(string $password): void;
 
-    /**
-     * @param string $localeCode
-     */
-    public function changeLocale($localeCode);
+    public function changeLocale(string $localeCode): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Channel/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/CreatePage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Channel;
 
+use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\DescribesIt;
 use Sylius\Behat\Behaviour\NamesIt;
 use Sylius\Behat\Behaviour\SpecifiesItsCode;
@@ -26,58 +27,37 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     use DescribesIt;
     use Toggles;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setHostname($hostname)
+    public function setHostname(string $hostname): void
     {
         $this->getDocument()->fillField('Hostname', $hostname);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setContactEmail($contactEmail)
+    public function setContactEmail(string $contactEmail): void
     {
         $this->getDocument()->fillField('Contact email', $contactEmail);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function defineColor($color)
+    public function defineColor(string $color): void
     {
         $this->getDocument()->fillField('Color', $color);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseCurrency($currencyCode)
+    public function chooseCurrency(string $currencyCode): void
     {
         $this->getDocument()->selectFieldOption('Currencies', $currencyCode);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseLocale($language)
+    public function chooseLocale(string $language): void
     {
         $this->getDocument()->selectFieldOption('Locales', $language);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseDefaultTaxZone($taxZone)
+    public function chooseDefaultTaxZone(string $taxZone): void
     {
         $this->getDocument()->selectFieldOption('Default tax zone', $taxZone);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseDefaultLocale($locale)
+    public function chooseDefaultLocale(?string $locale): void
     {
         if (null !== $locale) {
             $this->getElement('locales')->selectOption($locale);
@@ -85,10 +65,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseBaseCurrency($currency)
+    public function chooseBaseCurrency(?string $currency): void
     {
         if (null !== $currency) {
             $this->getElement('currencies')->selectOption($currency);
@@ -96,35 +73,26 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseTaxCalculationStrategy($taxZone)
+    public function chooseTaxCalculationStrategy(string $taxZone): void
     {
         $this->getDocument()->selectFieldOption('Tax calculation strategy', $taxZone);
     }
 
-    public function allowToSkipShippingStep()
+    public function allowToSkipShippingStep(): void
     {
         $this->getDocument()->checkField('Skip shipping step if only one shipping method is available?');
     }
 
-    public function allowToSkipPaymentStep()
+    public function allowToSkipPaymentStep(): void
     {
         $this->getDocument()->checkField('Skip payment step if only one payment method is available?');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getToggleableElement()
+    protected function getToggleableElement(): NodeElement
     {
         return $this->getElement('enabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Channel/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/CreatePageInterface.php
@@ -17,71 +17,35 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    public function enable();
+    public function enable(): void;
 
-    public function disable();
+    public function disable(): void;
 
-    /**
-     * @param string $name
-     */
-    public function nameIt($name);
+    public function nameIt(string $name): void;
 
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
+    public function specifyCode(string $code): void;
 
-    /**
-     * @param string $description
-     */
-    public function describeItAs($description);
+    public function describeItAs(string $description): void;
 
-    /**
-     * @param string $hostname
-     */
-    public function setHostname($hostname);
+    public function setHostname(string $hostname): void;
 
-    /**
-     * @param string $contactEmail
-     */
-    public function setContactEmail($contactEmail);
+    public function setContactEmail(string $contactEmail): void;
 
-    /**
-     * @param string $color
-     */
-    public function defineColor($color);
+    public function defineColor(string $color): void;
 
-    /**
-     * @param string $language
-     */
-    public function chooseLocale($language);
+    public function chooseLocale(string $language): void;
 
-    /**
-     * @param string $currencyCode
-     */
-    public function chooseCurrency($currencyCode);
+    public function chooseCurrency(string $currencyCode): void;
 
-    /**
-     * @param string $taxZone
-     */
-    public function chooseDefaultTaxZone($taxZone);
+    public function chooseDefaultTaxZone(string $taxZone): void;
 
-    /**
-     * @param string $locale
-     */
-    public function chooseDefaultLocale($locale);
+    public function chooseDefaultLocale(?string $locale): void;
 
-    /**
-     * @param string $currency
-     */
-    public function chooseBaseCurrency($currency);
+    public function chooseBaseCurrency(?string $currency): void;
 
-    /**
-     * @param string $taxCalculationStrategy
-     */
-    public function chooseTaxCalculationStrategy($taxCalculationStrategy);
+    public function chooseTaxCalculationStrategy(string $taxCalculationStrategy): void;
 
-    public function allowToSkipShippingStep();
+    public function allowToSkipShippingStep(): void;
 
-    public function allowToSkipPaymentStep();
+    public function allowToSkipPaymentStep(): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Channel/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/IndexPage.php
@@ -17,10 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\IndexPage as BaseIndexPage;
 
 class IndexPage extends BaseIndexPage implements IndexPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getUsedThemeName($channelCode)
+    public function getUsedThemeName(string $channelCode): ?string
     {
         $table = $this->getDocument()->find('css', 'table');
 

--- a/src/Sylius/Behat/Page/Admin/Channel/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/IndexPageInterface.php
@@ -17,10 +17,5 @@ use Sylius\Behat\Page\Admin\Crud\IndexPageInterface as BaseIndexPageInterface;
 
 interface IndexPageInterface extends BaseIndexPageInterface
 {
-    /**
-     * @param string $channelCode
-     *
-     * @return string|null
-     */
-    public function getUsedThemeName($channelCode);
+    public function getUsedThemeName(string $channelCode): ?string;
 }

--- a/src/Sylius/Behat/Page/Admin/Channel/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/UpdatePage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Channel;
 
+use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\ChecksCodeImmutability;
 use Sylius\Behat\Behaviour\Toggles;
 use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
@@ -22,90 +23,57 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     use ChecksCodeImmutability;
     use Toggles;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setTheme($themeName)
+    public function setTheme(string $themeName): void
     {
         $this->getDocument()->selectFieldOption('Theme', $themeName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function unsetTheme()
+    public function unsetTheme(): void
     {
         $this->getDocument()->selectFieldOption('Theme', '');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseLocale($language)
+    public function chooseLocale(string $language): void
     {
         $this->getDocument()->selectFieldOption('Locales', $language);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isLocaleChosen($language)
+    public function isLocaleChosen(string $language): bool
     {
         return $this->getElement('locales')->find('named', ['option', $language])->hasAttribute('selected');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseCurrency($currencyCode)
+    public function chooseCurrency(string $currencyCode): void
     {
         $this->getDocument()->selectFieldOption('Currencies', $currencyCode);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isCurrencyChosen($currencyCode)
+    public function isCurrencyChosen(string $currencyCode): bool
     {
         return $this->getElement('currencies')->find('named', ['option', $currencyCode])->hasAttribute('selected');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseDefaultTaxZone($taxZone)
+    public function chooseDefaultTaxZone(string $taxZone): void
     {
-        $this->getDocument()->selectFieldOption('Default tax zone', $taxZone ?? '');
+        $this->getDocument()->selectFieldOption('Default tax zone', $taxZone);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseTaxCalculationStrategy($taxZone)
+    public function chooseTaxCalculationStrategy(string $taxZone): void
     {
         $this->getDocument()->selectFieldOption('Tax calculation strategy', $taxZone);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isDefaultTaxZoneChosen($taxZone)
+    public function isDefaultTaxZoneChosen(string $taxZone): bool
     {
         return $this->getElement('default_tax_zone')->find('named', ['option', $taxZone])->hasAttribute('selected');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isAnyDefaultTaxZoneChosen()
+    public function isAnyDefaultTaxZoneChosen(): bool
     {
         return null !== $this->getElement('default_tax_zone')->find('css', '[selected]');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isTaxCalculationStrategyChosen($taxCalculationStrategy)
+    public function isTaxCalculationStrategyChosen(string $taxCalculationStrategy): bool
     {
         return $this
             ->getElement('tax_calculation_strategy')
@@ -114,33 +82,21 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isBaseCurrencyDisabled()
+    public function isBaseCurrencyDisabled(): bool
     {
         return $this->getElement('base_currency')->hasAttribute('disabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getToggleableElement()
+    protected function getToggleableElement(): NodeElement
     {
         return $this->getElement('enabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Channel/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/UpdatePageInterface.php
@@ -18,80 +18,36 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    public function enable();
+    public function enable(): void;
 
-    public function disable();
+    public function disable(): void;
 
-    /**
-     * @param string $themeName
-     */
-    public function setTheme($themeName);
+    public function setTheme(string $themeName): void;
 
     /**
      * @throws ElementNotFoundException
      */
-    public function unsetTheme();
+    public function unsetTheme(): void;
 
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 
-    /**
-     * @param string $language
-     */
-    public function chooseLocale($language);
+    public function chooseLocale(string $language): void;
 
-    /**
-     * @param string $language
-     *
-     * @return bool
-     */
-    public function isLocaleChosen($language);
+    public function isLocaleChosen(string $language): bool;
 
-    /**
-     * @param string $currencyCode
-     */
-    public function chooseCurrency($currencyCode);
+    public function chooseCurrency(string $currencyCode): void;
 
-    /**
-     * @param string $currencyCode
-     *
-     * @return bool
-     */
-    public function isCurrencyChosen($currencyCode);
+    public function isCurrencyChosen(string $currencyCode): bool;
 
-    /**
-     * @param string $taxZone
-     */
-    public function chooseDefaultTaxZone($taxZone);
+    public function chooseDefaultTaxZone(string $taxZone): void;
 
-    /**
-     * @param string $taxCalculationStrategy
-     */
-    public function chooseTaxCalculationStrategy($taxCalculationStrategy);
+    public function chooseTaxCalculationStrategy(string $taxCalculationStrategy): void;
 
-    /**
-     * @param string $taxZone
-     *
-     * @return bool
-     */
-    public function isDefaultTaxZoneChosen($taxZone);
+    public function isDefaultTaxZoneChosen(string $taxZone): bool;
 
-    /**
-     * @return bool
-     */
-    public function isAnyDefaultTaxZoneChosen();
+    public function isAnyDefaultTaxZoneChosen(): bool;
 
-    /**
-     * @param string $taxCalculationStrategy
-     *
-     * @return bool
-     */
-    public function isTaxCalculationStrategyChosen($taxCalculationStrategy);
+    public function isTaxCalculationStrategyChosen(string $taxCalculationStrategy): bool;
 
-    /**
-     * @return bool
-     */
-    public function isBaseCurrencyDisabled();
+    public function isBaseCurrencyDisabled(): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/Country/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Country/CreatePage.php
@@ -22,10 +22,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
     use ChoosesName;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function addProvince($name, $code, $abbreviation = null)
+    public function addProvince(string $name, string $code, string $abbreviation = null): void
     {
         $this->getDocument()->clickLink('Add province');
 

--- a/src/Sylius/Behat/Page/Admin/Country/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Country/CreatePageInterface.php
@@ -17,15 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @param string $name
-     */
-    public function chooseName($name);
+    public function chooseName(string $name): void;
 
-    /**
-     * @param string $name
-     * @param string $code
-     * @param string|null $abbreviation
-     */
-    public function addProvince($name, $code, $abbreviation = null);
+    public function addProvince(string $name, string $code, string $abbreviation = null): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Country/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Country/IndexPage.php
@@ -18,28 +18,17 @@ use Sylius\Component\Addressing\Model\CountryInterface;
 
 class IndexPage extends BaseIndexPage implements IndexPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function isCountryDisabled(CountryInterface $country)
+    public function isCountryDisabled(CountryInterface $country): bool
     {
         return $this->checkCountryStatus($country, 'Disabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isCountryEnabled(CountryInterface $country)
+    public function isCountryEnabled(CountryInterface $country): bool
     {
         return $this->checkCountryStatus($country, 'Enabled');
     }
 
-    /**
-     * @param string $status
-     *
-     * @return bool
-     */
-    private function checkCountryStatus(CountryInterface $country, $status)
+    private function checkCountryStatus(CountryInterface $country, string $status): bool
     {
         $tableAccessor = $this->getTableAccessor();
         $table = $this->getElement('table');

--- a/src/Sylius/Behat/Page/Admin/Country/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Country/IndexPageInterface.php
@@ -18,13 +18,7 @@ use Sylius\Component\Addressing\Model\CountryInterface;
 
 interface IndexPageInterface extends BaseIndexPageInterface
 {
-    /**
-     * @return bool
-     */
-    public function isCountryDisabled(CountryInterface $country);
+    public function isCountryDisabled(CountryInterface $country): bool;
 
-    /**
-     * @return bool
-     */
-    public function isCountryEnabled(CountryInterface $country);
+    public function isCountryEnabled(CountryInterface $country): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/Country/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Country/UpdatePage.php
@@ -23,40 +23,28 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
     use Toggles;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isCodeFieldDisabled()
+    public function isCodeFieldDisabled(): bool
     {
         $codeField = $this->getElement('code');
 
         return $codeField->getAttribute('disabled') === 'disabled';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isThereProvince($provinceName)
+    public function isThereProvince(string $provinceName): bool
     {
         $provinces = $this->getElement('provinces');
 
         return $provinces->has('css', '[value = "' . $provinceName . '"]');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isThereProvinceWithCode($provinceCode)
+    public function isThereProvinceWithCode(string $provinceCode): bool
     {
         $provinces = $this->getElement('provinces');
 
         return $provinces->has('css', '[value = "' . $provinceCode . '"]');
     }
 
-    /**
-     * @param string $provinceName
-     */
-    public function removeProvince($provinceName)
+    public function removeProvince(string $provinceName): void
     {
         if ($this->isThereProvince($provinceName)) {
             $provinces = $this->getElement('provinces');
@@ -74,10 +62,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function addProvince($name, $code, $abbreviation = null)
+    public function addProvince(string $name, string $code, string $abbreviation = null): void
     {
         $this->clickAddProvinceButton();
 
@@ -91,28 +76,19 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function clickAddProvinceButton()
+    public function clickAddProvinceButton(): void
     {
         $this->getDocument()->clickLink('Add province');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameProvince($name)
+    public function nameProvince(string $name): void
     {
         $provinceForm = $this->getLastProvinceElement();
 
         $provinceForm->fillField('Name', $name);
     }
 
-    /**
-     * @param string $provinceName
-     */
-    public function removeProvinceName($provinceName)
+    public function removeProvinceName(string $provinceName): void
     {
         if ($this->isThereProvince($provinceName)) {
             $provinces = $this->getElement('provinces');
@@ -122,20 +98,14 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyProvinceCode($code)
+    public function specifyProvinceCode(string $code): void
     {
         $provinceForm = $this->getLastProvinceElement();
 
         $provinceForm->fillField('Code', $code);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getValidationMessage($element)
+    public function getValidationMessage(string $element): string
     {
         $provinceForm = $this->getLastProvinceElement();
 
@@ -147,17 +117,11 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         return $foundElement->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getToggleableElement()
+    protected function getToggleableElement(): NodeElement
     {
         return $this->getElement('enabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Country/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Country/UpdatePageInterface.php
@@ -17,55 +17,25 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    public function enable();
+    public function enable(): void;
 
-    public function disable();
+    public function disable(): void;
 
-    /**
-     * @return bool
-     */
-    public function isCodeFieldDisabled();
+    public function isCodeFieldDisabled(): bool;
 
-    /**
-     * @param string $provinceName
-     *
-     * @return bool
-     */
-    public function isThereProvince($provinceName);
+    public function isThereProvince(string $provinceName): bool;
 
-    /**
-     * @param string $provinceCode
-     *
-     * @return bool
-     */
-    public function isThereProvinceWithCode($provinceCode);
+    public function isThereProvinceWithCode(string $provinceCode): bool;
 
-    /**
-     * @param string $name
-     * @param string $code
-     * @param string|null $abbreviation
-     */
-    public function addProvince($name, $code, $abbreviation = null);
+    public function addProvince(string $name, string $code, string $abbreviation = null): void;
 
-    /**
-     * @param string $provinceName
-     */
-    public function removeProvince($provinceName);
+    public function removeProvince(string $provinceName): void;
 
-    public function clickAddProvinceButton();
+    public function clickAddProvinceButton(): void;
 
-    /**
-     * @param string $provinceName
-     */
-    public function nameProvince($provinceName);
+    public function nameProvince(string $provinceName): void;
 
-    /**
-     * @param string $provinceName
-     */
-    public function removeProvinceName($provinceName);
+    public function removeProvinceName(string $provinceName): void;
 
-    /**
-     * @param string $provinceCode
-     */
-    public function specifyProvinceCode($provinceCode);
+    public function specifyProvinceCode(string $provinceCode): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/CreatePage.php
@@ -23,28 +23,19 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
     /** @var string */
     private $routeName;
 
-    /**
-     * @param string $routeName
-     */
-    public function __construct(Session $session, array $parameters, RouterInterface $router, $routeName)
+    public function __construct(Session $session, array $parameters, RouterInterface $router, string $routeName)
     {
         parent::__construct($session, $parameters, $router);
 
         $this->routeName = $routeName;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function create()
+    public function create(): void
     {
         $this->getDocument()->pressButton('Create');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getValidationMessage($element)
+    public function getValidationMessage(string $element): string
     {
         $foundElement = $this->getFieldElement($element);
         if (null === $foundElement) {
@@ -59,22 +50,15 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
         return $validationMessage->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getRouteName(): string
     {
         return $this->routeName;
     }
 
     /**
-     * @param string $element
-     *
-     * @return \Behat\Mink\Element\NodeElement|null
-     *
      * @throws ElementNotFoundException
      */
-    private function getFieldElement($element)
+    private function getFieldElement(string $element): ?\Behat\Mink\Element\NodeElement
     {
         $element = $this->getElement($element);
         while (null !== $element && !$element->hasClass('field')) {

--- a/src/Sylius/Behat/Page/Admin/Crud/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/CreatePageInterface.php
@@ -19,16 +19,12 @@ use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 interface CreatePageInterface extends SymfonyPageInterface
 {
     /**
-     * @param string $element
-     *
-     * @return string
-     *
      * @throws ElementNotFoundException
      */
-    public function getValidationMessage($element);
+    public function getValidationMessage(string $element): string;
 
     /**
      * @throws ElementNotFoundException
      */
-    public function create();
+    public function create(): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Crud;
 
+use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
@@ -28,15 +29,12 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
     /** @var string */
     private $routeName;
 
-    /**
-     * @param string $routeName
-     */
     public function __construct(
         Session $session,
         array $parameters,
         RouterInterface $router,
         TableAccessorInterface $tableAccessor,
-        $routeName
+        string $routeName
     ) {
         parent::__construct($session, $parameters, $router);
 
@@ -44,10 +42,7 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
         $this->routeName = $routeName;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isSingleResourceOnPage(array $parameters)
+    public function isSingleResourceOnPage(array $parameters): bool
     {
         try {
             $rows = $this->tableAccessor->getRowsWithFields($this->getElement('table'), $parameters);
@@ -60,18 +55,12 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getColumnFields($columnName)
+    public function getColumnFields(string $columnName): array
     {
         return $this->tableAccessor->getIndexedColumn($this->getElement('table'), $columnName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function sortBy($fieldName)
+    public function sortBy(string $fieldName): void
     {
         $sortableHeaders = $this->tableAccessor->getSortableHeaders($this->getElement('table'));
         Assert::keyExists($sortableHeaders, $fieldName, sprintf('Column "%s" is not sortable.', $fieldName));
@@ -79,10 +68,7 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
         $sortableHeaders[$fieldName]->find('css', 'a')->click();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isSingleResourceWithSpecificElementOnPage(array $parameters, $element)
+    public function isSingleResourceWithSpecificElementOnPage(array $parameters, string $element): bool
     {
         try {
             $rows = $this->tableAccessor->getRowsWithFields($this->getElement('table'), $parameters);
@@ -99,10 +85,7 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
         }
     }
 
-    /**
-     * @return int
-     */
-    public function countItems()
+    public function countItems(): int
     {
         try {
             return $this->getTableAccessor()->countTableBodyRows($this->getElement('table'));
@@ -111,10 +94,7 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function deleteResourceOnPage(array $parameters)
+    public function deleteResourceOnPage(array $parameters): void
     {
         $tableAccessor = $this->getTableAccessor();
         $table = $this->getElement('table');
@@ -125,10 +105,7 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
         $actionButtons->pressButton('Delete');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getActionsForResource(array $parameters)
+    public function getActionsForResource(array $parameters): NodeElement
     {
         $tableAccessor = $this->getTableAccessor();
         $table = $this->getElement('table');
@@ -138,9 +115,6 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
         return $tableAccessor->getFieldFromRow($table, $resourceRow, 'actions');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function checkResourceOnPage(array $parameters): void
     {
         $tableAccessor = $this->getTableAccessor();
@@ -154,7 +128,7 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
         $bulkCheckbox->check();
     }
 
-    public function filter()
+    public function filter(): void
     {
         $this->getElement('filter')->press();
     }
@@ -165,25 +139,16 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
         $this->getElement('confirmation_button')->click();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getRouteName(): string
     {
         return $this->routeName;
     }
 
-    /**
-     * @return TableAccessorInterface
-     */
-    protected function getTableAccessor()
+    protected function getTableAccessor(): TableAccessorInterface
     {
         return $this->tableAccessor;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Crud/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/IndexPageInterface.php
@@ -18,48 +18,23 @@ use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 
 interface IndexPageInterface extends SymfonyPageInterface
 {
-    /**
-     * @return bool
-     */
-    public function isSingleResourceOnPage(array $parameters);
+    public function isSingleResourceOnPage(array $parameters): bool;
 
-    /**
-     * @param string $element
-     *
-     * @return bool
-     */
-    public function isSingleResourceWithSpecificElementOnPage(array $parameters, $element);
+    public function isSingleResourceWithSpecificElementOnPage(array $parameters, string $element): bool;
 
-    /**
-     * @param string $columnName
-     *
-     * @return array
-     */
-    public function getColumnFields($columnName);
+    public function getColumnFields(string $columnName): array;
 
-    /**
-     * @param string $fieldName
-     */
-    public function sortBy($fieldName);
+    public function sortBy(string $fieldName): void;
 
-    /**
-     * @return bool
-     */
-    public function deleteResourceOnPage(array $parameters);
+    public function deleteResourceOnPage(array $parameters): void;
 
-    /**
-     * @return NodeElement
-     */
-    public function getActionsForResource(array $parameters);
+    public function getActionsForResource(array $parameters): NodeElement;
 
     public function checkResourceOnPage(array $parameters): void;
 
-    /**
-     * @return int
-     */
-    public function countItems();
+    public function countItems(): int;
 
-    public function filter();
+    public function filter(): void;
 
     public function bulkDelete(): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePage.php
@@ -24,28 +24,19 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
     /** @var string */
     private $routeName;
 
-    /**
-     * @param string $routeName
-     */
-    public function __construct(Session $session, array $parameters, RouterInterface $router, $routeName)
+    public function __construct(Session $session, array $parameters, RouterInterface $router, string $routeName)
     {
         parent::__construct($session, $parameters, $router);
 
         $this->routeName = $routeName;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function saveChanges()
+    public function saveChanges(): void
     {
         $this->getDocument()->pressButton('sylius_save_changes_button');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getValidationMessage($element)
+    public function getValidationMessage(string $element): string
     {
         $foundElement = $this->getFieldElement($element);
         if (null === $foundElement) {
@@ -60,10 +51,7 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
         return $validationMessage->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasResourceValues(array $parameters)
+    public function hasResourceValues(array $parameters): bool
     {
         foreach ($parameters as $element => $value) {
             if ($this->getElement($element)->getValue() !== (string) $value) {
@@ -74,22 +62,15 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
         return true;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getRouteName(): string
     {
         return $this->routeName;
     }
 
     /**
-     * @param string $element
-     *
-     * @return \Behat\Mink\Element\NodeElement|null
-     *
      * @throws ElementNotFoundException
      */
-    private function getFieldElement($element)
+    private function getFieldElement(string $element): ?\Behat\Mink\Element\NodeElement
     {
         $element = $this->getElement(StringInflector::nameToCode($element));
         while (null !== $element && !$element->hasClass('field')) {

--- a/src/Sylius/Behat/Page/Admin/Crud/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/UpdatePageInterface.php
@@ -19,20 +19,14 @@ use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 interface UpdatePageInterface extends SymfonyPageInterface
 {
     /**
-     * @param string $element
-     *
-     * @return string
-     *
      * @throws ElementNotFoundException
      */
-    public function getValidationMessage($element);
+    public function getValidationMessage(string $element): string;
 
     /**
      * @param array $parameters where keys are some of arbitrary elements defined by user and values are expected values
-     *
-     * @return bool
      */
-    public function hasResourceValues(array $parameters);
+    public function hasResourceValues(array $parameters): bool;
 
-    public function saveChanges();
+    public function saveChanges(): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Currency/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Currency/CreatePage.php
@@ -20,17 +20,11 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
     use ChoosesName;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyExchangeRate($exchangeRate)
+    public function specifyExchangeRate(float $exchangeRate): void
     {
         $this->getDocument()->fillField('Exchange rate', $exchangeRate);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Currency/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Currency/CreatePageInterface.php
@@ -17,13 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @param string $name
-     */
-    public function chooseName($name);
+    public function chooseName(string $name): void;
 
-    /**
-     * @param float $exchangeRate
-     */
-    public function specifyExchangeRate($exchangeRate);
+    public function specifyExchangeRate(float $exchangeRate): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Currency/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Currency/IndexPage.php
@@ -18,30 +18,20 @@ use Sylius\Component\Currency\Model\CurrencyInterface;
 
 class IndexPage extends BaseIndexPage implements IndexPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function isCurrencyDisabled(CurrencyInterface $currency)
+    public function isCurrencyDisabled(CurrencyInterface $currency): bool
     {
         return $this->checkCurrencyStatus($currency, 'Disabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isCurrencyEnabled(CurrencyInterface $currency)
+    public function isCurrencyEnabled(CurrencyInterface $currency): bool
     {
         return $this->checkCurrencyStatus($currency, 'Enabled');
     }
 
     /**
-     * @param string $status
-     *
-     * @return bool
-     *
      * @throws \InvalidArgumentException
      */
-    private function checkCurrencyStatus(CurrencyInterface $currency, $status)
+    private function checkCurrencyStatus(CurrencyInterface $currency, string $status): bool
     {
         $tableAccessor = $this->getTableAccessor();
         $table = $this->getElement('table');

--- a/src/Sylius/Behat/Page/Admin/Currency/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Currency/IndexPageInterface.php
@@ -18,13 +18,7 @@ use Sylius\Component\Currency\Model\CurrencyInterface;
 
 interface IndexPageInterface extends BaseIndexPageInterface
 {
-    /**
-     * @return bool
-     */
-    public function isCurrencyDisabled(CurrencyInterface $currency);
+    public function isCurrencyDisabled(CurrencyInterface $currency): bool;
 
-    /**
-     * @return bool
-     */
-    public function isCurrencyEnabled(CurrencyInterface $currency);
+    public function isCurrencyEnabled(CurrencyInterface $currency): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/Currency/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Currency/UpdatePage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Currency;
 
+use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\Toggles;
 use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
 
@@ -20,10 +21,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
     use Toggles;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function canBeDisabled()
+    public function canBeDisabled(): bool
     {
         $toggleableElement = $this->getToggleableElement();
         $this->assertCheckboxState($toggleableElement, true);
@@ -31,49 +29,31 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         return $toggleableElement->hasAttribute('disabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function canHaveExchangeRateChanged()
+    public function canHaveExchangeRateChanged(): bool
     {
         return $this->getElement('exchangeRate')->hasAttribute('disabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function changeExchangeRate($exchangeRate)
+    public function changeExchangeRate(string $exchangeRate): void
     {
         $this->getDocument()->fillField('Exchange rate', $exchangeRate);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getExchangeRateValue()
+    public function getExchangeRateValue(): string
     {
         return $this->getElement('exchangeRate')->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getCodeDisabledAttribute()
+    public function getCodeDisabledAttribute(): string
     {
         return $this->getElement('code')->getAttribute('disabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getToggleableElement()
+    protected function getToggleableElement(): NodeElement
     {
         return $this->getElement('enabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Currency/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Currency/UpdatePageInterface.php
@@ -17,32 +17,17 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    public function enable();
+    public function enable(): void;
 
-    public function disable();
+    public function disable(): void;
 
-    /**
-     * @return bool
-     */
-    public function canBeDisabled();
+    public function canBeDisabled(): bool;
 
-    /**
-     * @return bool
-     */
-    public function canHaveExchangeRateChanged();
+    public function canHaveExchangeRateChanged(): bool;
 
-    /**
-     * @param string $exchangeRate
-     */
-    public function changeExchangeRate($exchangeRate);
+    public function changeExchangeRate(string $exchangeRate): void;
 
-    /**
-     * @return string
-     */
-    public function getExchangeRateValue();
+    public function getExchangeRateValue(): string;
 
-    /**
-     * @return string
-     */
-    public function getCodeDisabledAttribute();
+    public function getCodeDisabledAttribute(): string;
 }

--- a/src/Sylius/Behat/Page/Admin/Customer/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Customer/CreatePage.php
@@ -17,105 +17,66 @@ use Sylius\Behat\Page\Admin\Crud\CreatePage as BaseCreatePage;
 
 class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyFirstName($name)
+    public function specifyFirstName(string $name): void
     {
         $this->getDocument()->fillField('First name', $name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyLastName($name)
+    public function specifyLastName(string $name): void
     {
         $this->getDocument()->fillField('Last name', $name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyEmail($email)
+    public function specifyEmail(string $email): void
     {
         $this->getDocument()->fillField('Email', $email);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyBirthday($birthday)
+    public function specifyBirthday(string $birthday): void
     {
         $this->getDocument()->fillField('Birthday', $birthday);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyPassword($password)
+    public function specifyPassword(string $password): void
     {
         $this->getDocument()->fillField('Password', $password);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseGender($gender)
+    public function chooseGender(string $gender): void
     {
         $this->getDocument()->selectFieldOption('Gender', $gender);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseGroup($group)
+    public function chooseGroup(string $group): void
     {
         $this->getDocument()->selectFieldOption('Group', $group);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function selectCreateAccount()
+    public function selectCreateAccount(): void
     {
         $this->getDocument()->find('css', 'label[for=sylius_customer_createUser]')->click();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasPasswordField()
+    public function hasPasswordField(): bool
     {
         return null !== $this->getDocument()->find('css', '#sylius_customer_user_plainPassword');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasCheckedCreateOption()
+    public function hasCheckedCreateOption(): bool
     {
         return $this->getElement('create_customer_user')->hasAttribute('checked');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasCreateOption()
+    public function hasCreateOption(): bool
     {
         return null !== $this->getDocument()->find('css', '#sylius_customer_createUser');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isUserFormHidden()
+    public function isUserFormHidden(): bool
     {
         return false !== strpos($this->getElement('user_form')->getAttribute('style'), 'none');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Customer/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Customer/CreatePageInterface.php
@@ -17,60 +17,27 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @param string $name
-     */
-    public function specifyFirstName($name);
+    public function specifyFirstName(string $name): void;
 
-    /**
-     * @param string $name
-     */
-    public function specifyLastName($name);
+    public function specifyLastName(string $name): void;
 
-    /**
-     * @param string $email
-     */
-    public function specifyEmail($email);
+    public function specifyEmail(string $email): void;
 
-    /**
-     * @param string $birthday
-     */
-    public function specifyBirthday($birthday);
+    public function specifyBirthday(string $birthday): void;
 
-    /**
-     * @param string $password
-     */
-    public function specifyPassword($password);
+    public function specifyPassword(string $password): void;
 
-    /**
-     * @param string $gender
-     */
-    public function chooseGender($gender);
+    public function chooseGender(string $gender): void;
 
-    /**
-     * @param string $group
-     */
-    public function chooseGroup($group);
+    public function chooseGroup(string $group): void;
 
-    public function selectCreateAccount();
+    public function selectCreateAccount(): void;
 
-    /**
-     * @return bool
-     */
-    public function hasPasswordField();
+    public function hasPasswordField(): bool;
 
-    /**
-     * @return bool
-     */
-    public function hasCheckedCreateOption();
+    public function hasCheckedCreateOption(): bool;
 
-    /**
-     * @return bool
-     */
-    public function hasCreateOption();
+    public function hasCreateOption(): bool;
 
-    /**
-     * @return bool
-     */
-    public function isUserFormHidden();
+    public function isUserFormHidden(): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/Customer/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Customer/IndexPage.php
@@ -17,10 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\IndexPage as BaseIndexPage;
 
 class IndexPage extends BaseIndexPage implements IndexPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getCustomerAccountStatus($customer)
+    public function getCustomerAccountStatus(\Sylius\Component\Customer\Model\CustomerInterface $customer): string
     {
         $tableAccessor = $this->getTableAccessor();
         $table = $this->getElement('table');

--- a/src/Sylius/Behat/Page/Admin/Customer/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Customer/IndexPageInterface.php
@@ -18,10 +18,5 @@ use Sylius\Component\Customer\Model\CustomerInterface;
 
 interface IndexPageInterface extends BaseIndexPageInterface
 {
-    /**
-     * @param CustomerInterface $customer
-     *
-     * @return string
-     */
-    public function getCustomerAccountStatus($customer);
+    public function getCustomerAccountStatus(CustomerInterface $customer): string;
 }

--- a/src/Sylius/Behat/Page/Admin/Customer/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Customer/ShowPage.php
@@ -19,77 +19,50 @@ use Webmozart\Assert\Assert;
 
 class ShowPage extends SymfonyPage implements ShowPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function isRegistered()
+    public function isRegistered(): bool
     {
         $username = $this->getDocument()->find('css', '#username');
 
         return null !== $username;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function deleteAccount()
+    public function deleteAccount(): void
     {
         $deleteButton = $this->getElement('delete_account_button');
         $deleteButton->pressButton('Delete');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getCustomerEmail()
+    public function getCustomerEmail(): string
     {
         return $this->getElement('customer_email')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getCustomerPhoneNumber()
+    public function getCustomerPhoneNumber(): string
     {
         return $this->getElement('customer_phone_number')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getCustomerName()
+    public function getCustomerName(): string
     {
         return $this->getElement('customer_name')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getRegistrationDate()
+    public function getRegistrationDate(): \DateTimeInterface
     {
         return new \DateTime(str_replace('Customer since ', '', $this->getElement('registration_date')->getText()));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefaultAddress()
+    public function getDefaultAddress(): string
     {
         return $this->getElement('default_address')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasAccount()
+    public function hasAccount(): bool
     {
         return $this->hasElement('no_account');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isSubscribedToNewsletter()
+    public function isSubscribedToNewsletter(): bool
     {
         $subscribedToNewsletter = $this->getElement('subscribed_to_newsletter');
         if ($subscribedToNewsletter->find('css', 'i.green')) {
@@ -99,20 +72,14 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         return false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasDefaultAddressProvinceName($provinceName)
+    public function hasDefaultAddressProvinceName(string $provinceName): bool
     {
         $defaultAddressProvince = $this->getElement('default_address')->getText();
 
         return false !== stripos($defaultAddressProvince, $provinceName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasVerifiedEmail()
+    public function hasVerifiedEmail(): bool
     {
         $verifiedEmail = $this->getElement('verified_email');
         if ($verifiedEmail->find('css', 'i.green')) {
@@ -122,10 +89,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         return false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getGroupName()
+    public function getGroupName(): string
     {
         $group = $this->getElement('group');
 
@@ -136,42 +100,27 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         return trim($groupName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasEmailVerificationInformation()
+    public function hasEmailVerificationInformation(): bool
     {
         return null === $this->getDocument()->find('css', '#verified-email');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasImpersonateButton()
+    public function hasImpersonateButton(): bool
     {
         return $this->hasElement('impersonate_button');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function impersonate()
+    public function impersonate(): void
     {
         $this->getElement('impersonate_button')->click();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasCustomerPlacedAnyOrders()
+    public function hasCustomerPlacedAnyOrders(): bool
     {
         return null !== $this->getElement('statistics')->find('css', '.sylius-orders-overall-count');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getOrdersCountInChannel($channelName)
+    public function getOrdersCountInChannel(string $channelName): int
     {
         return (int) $this
             ->getStatisticsForChannel($channelName)
@@ -180,10 +129,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getOrdersTotalInChannel($channelName)
+    public function getOrdersTotalInChannel(string $channelName): string
     {
         return $this
             ->getStatisticsForChannel($channelName)
@@ -192,10 +138,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getAverageTotalInChannel($channelName)
+    public function getAverageTotalInChannel(string $channelName): string
     {
         return $this
             ->getStatisticsForChannel($channelName)
@@ -204,25 +147,16 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getSuccessFlashMessage()
+    public function getSuccessFlashMessage(): string
     {
         return trim($this->getElement('flash_message')->getText());
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getRouteName(): string
     {
         return 'sylius_admin_customer_show';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -243,13 +177,9 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
     }
 
     /**
-     * @param string $channelName
-     *
-     * @return NodeElement
-     *
      * @throws \InvalidArgumentException
      */
-    private function getStatisticsForChannel($channelName)
+    private function getStatisticsForChannel(string $channelName): NodeElement
     {
         $statisticsRibs = $this
             ->getElement('statistics')

--- a/src/Sylius/Behat/Page/Admin/Customer/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Customer/ShowPageInterface.php
@@ -18,108 +18,46 @@ use FriendsOfBehat\PageObjectExtension\Page\PageInterface;
 
 interface ShowPageInterface extends PageInterface
 {
-    /**
-     * @return bool
-     */
-    public function isRegistered();
+    public function isRegistered(): bool;
 
     /**
      * @throws ElementNotFoundException If there is no delete account button on the page
      */
-    public function deleteAccount();
+    public function deleteAccount(): void;
 
-    /**
-     * @return string
-     */
-    public function getCustomerEmail();
+    public function getCustomerEmail(): string;
 
-    /**
-     * @return string
-     */
-    public function getCustomerPhoneNumber();
+    public function getCustomerPhoneNumber(): string;
 
-    /**
-     * @return string
-     */
-    public function getCustomerName();
+    public function getCustomerName(): string;
 
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getRegistrationDate();
+    public function getRegistrationDate(): \DateTimeInterface;
 
-    /**
-     * @return string
-     */
-    public function getDefaultAddress();
+    public function getDefaultAddress(): string;
 
-    /**
-     * @return bool
-     */
-    public function hasAccount();
+    public function hasAccount(): bool;
 
-    /**
-     * @return bool
-     */
-    public function isSubscribedToNewsletter();
+    public function isSubscribedToNewsletter(): bool;
 
-    /**
-     * @param string $provinceName
-     *
-     * @return bool
-     */
-    public function hasDefaultAddressProvinceName($provinceName);
+    public function hasDefaultAddressProvinceName(string $provinceName): bool;
 
-    /**
-     * @return bool
-     */
-    public function hasVerifiedEmail();
+    public function hasVerifiedEmail(): bool;
 
-    /**
-     * @return string
-     */
-    public function getGroupName();
+    public function getGroupName(): string;
 
-    /**
-     * @return bool
-     */
-    public function hasEmailVerificationInformation();
+    public function hasEmailVerificationInformation(): bool;
 
-    /**
-     * @return bool
-     */
-    public function hasImpersonateButton();
+    public function hasImpersonateButton(): bool;
 
-    public function impersonate();
+    public function impersonate(): void;
 
-    /**
-     * @return bool
-     */
-    public function hasCustomerPlacedAnyOrders();
+    public function hasCustomerPlacedAnyOrders(): bool;
 
-    /**
-     * @param string $channelName
-     *
-     * @return int
-     */
-    public function getOrdersCountInChannel($channelName);
+    public function getOrdersCountInChannel(string $channelName): int;
 
-    /**
-     * @param string $channelName
-     *
-     * @return string
-     */
-    public function getOrdersTotalInChannel($channelName);
+    public function getOrdersTotalInChannel(string $channelName): string;
 
-    /**
-     * @param string $channelName
-     *
-     * @return string
-     */
-    public function getAverageTotalInChannel($channelName);
+    public function getAverageTotalInChannel(string $channelName): string;
 
-    /**
-     * @return string
-     */
-    public function getSuccessFlashMessage();
+    public function getSuccessFlashMessage(): string;
 }

--- a/src/Sylius/Behat/Page/Admin/Customer/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Customer/UpdatePage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Customer;
 
+use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\Toggles;
 use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
 
@@ -20,10 +21,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
     use Toggles;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getFullName()
+    public function getFullName(): string
     {
         $firstNameElement = $this->getElement('first_name')->getValue();
         $lastNameElement = $this->getElement('last_name')->getValue();
@@ -31,94 +29,61 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         return sprintf('%s %s', $firstNameElement, $lastNameElement);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function changeFirstName($firstName)
+    public function changeFirstName(string $firstName): void
     {
         $this->getDocument()->fillField('First name', $firstName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getFirstName()
+    public function getFirstName(): string
     {
         return $this->getElement('first_name')->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function changeLastName($lastName)
+    public function changeLastName(string $lastName): void
     {
         $this->getDocument()->fillField('Last name', $lastName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getLastName()
+    public function getLastName(): string
     {
         return $this->getElement('last_name')->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function changeEmail($email)
+    public function changeEmail(string $email): void
     {
         $this->getDocument()->fillField('Email', $email);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function changePassword($password)
+    public function changePassword(string $password): void
     {
         $this->getDocument()->fillField('Password', $password);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPassword()
+    public function getPassword(): string
     {
-        return $this->getElement('password');
+        return $this->getElement('password')->getValue();
     }
 
-    public function subscribeToTheNewsletter()
+    public function subscribeToTheNewsletter(): void
     {
         $this->getDocument()->checkField('Subscribe to the newsletter');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isSubscribedToTheNewsletter()
+    public function isSubscribedToTheNewsletter(): bool
     {
         return $this->getDocument()->hasCheckedField('Subscribe to the newsletter');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getGroupName()
+    public function getGroupName(): string
     {
         return $this->getElement('group')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getToggleableElement()
+    protected function getToggleableElement(): NodeElement
     {
         return $this->getElement('enabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Customer/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Customer/UpdatePageInterface.php
@@ -17,59 +17,29 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    public function enable();
+    public function enable(): void;
 
-    public function disable();
+    public function disable(): void;
 
-    /**
-     * @return string
-     */
-    public function getFullName();
+    public function getFullName(): string;
 
-    /**
-     * @param string $firstName
-     */
-    public function changeFirstName($firstName);
+    public function changeFirstName(string $firstName): void;
 
-    /**
-     * @return string
-     */
-    public function getFirstName();
+    public function getFirstName(): string;
 
-    /**
-     * @param string $lastName
-     */
-    public function changeLastName($lastName);
+    public function changeLastName(string $lastName): void;
 
-    /**
-     * @return string
-     */
-    public function getLastName();
+    public function getLastName(): string;
 
-    /**
-     * @param string $email
-     */
-    public function changeEmail($email);
+    public function changeEmail(string $email): void;
 
-    /**
-     * @param string $password
-     */
-    public function changePassword($password);
+    public function changePassword(string $password): void;
 
-    /**
-     * @return string
-     */
-    public function getPassword();
+    public function getPassword(): string;
 
-    public function subscribeToTheNewsletter();
+    public function subscribeToTheNewsletter(): void;
 
-    /**
-     * @return bool
-     */
-    public function isSubscribedToTheNewsletter();
+    public function isSubscribedToTheNewsletter(): bool;
 
-    /**
-     * @return string
-     */
-    public function getGroupName();
+    public function getGroupName(): string;
 }

--- a/src/Sylius/Behat/Page/Admin/CustomerGroup/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/CustomerGroup/CreatePage.php
@@ -22,9 +22,6 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     use SpecifiesItsCode;
     use NamesIt;
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/CustomerGroup/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/CustomerGroup/CreatePageInterface.php
@@ -17,13 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
+    public function specifyCode(string $code): void;
 
-    /**
-     * @param string $name
-     */
-    public function nameIt($name);
+    public function nameIt(string $name): void;
 }

--- a/src/Sylius/Behat/Page/Admin/CustomerGroup/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/CustomerGroup/UpdatePage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\CustomerGroup;
 
+use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\ChecksCodeImmutability;
 use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
 
@@ -20,25 +21,16 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
     use ChecksCodeImmutability;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameIt($name)
+    public function nameIt(string $name): void
     {
         $this->getElement('name')->setValue($name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/CustomerGroup/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/CustomerGroup/UpdatePageInterface.php
@@ -17,13 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @param string $name
-     */
-    public function nameIt($name);
+    public function nameIt(string $name): void;
 
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/DashboardPage.php
+++ b/src/Sylius/Behat/Page/Admin/DashboardPage.php
@@ -34,89 +34,56 @@ class DashboardPage extends SymfonyPage implements DashboardPageInterface
         $this->tableAccessor = $tableAccessor;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getTotalSales()
+    public function getTotalSales(): string
     {
         return $this->getElement('total_sales')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getNumberOfNewOrders()
+    public function getNumberOfNewOrders(): int
     {
         return (int) $this->getElement('new_orders')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getNumberOfNewOrdersInTheList()
+    public function getNumberOfNewOrdersInTheList(): int
     {
         return $this->tableAccessor->countTableBodyRows($this->getElement('order_list'));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getNumberOfNewCustomers()
+    public function getNumberOfNewCustomers(): int
     {
         return (int) $this->getElement('new_customers')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getNumberOfNewCustomersInTheList()
+    public function getNumberOfNewCustomersInTheList(): int
     {
         return $this->tableAccessor->countTableBodyRows($this->getElement('customer_list'));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getAverageOrderValue()
+    public function getAverageOrderValue(): string
     {
         return $this->getElement('average_order_value')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getSubHeader()
+    public function getSubHeader(): string
     {
         return trim($this->getElement('sub_header')->getText());
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function logOut()
+    public function logOut(): void
     {
         $this->getElement('logout')->click();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseChannel($channelName)
+    public function chooseChannel(string $channelName): void
     {
         $this->getElement('channel_choosing_link', ['%channelName%' => $channelName])->click();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getRouteName(): string
     {
         return 'sylius_admin_dashboard';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/DashboardPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/DashboardPageInterface.php
@@ -17,45 +17,21 @@ use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 
 interface DashboardPageInterface extends SymfonyPageInterface
 {
-    /**
-     * @return int
-     */
-    public function getTotalSales();
+    public function getTotalSales(): string;
 
-    /**
-     * @return int
-     */
-    public function getNumberOfNewOrders();
+    public function getNumberOfNewOrders(): int;
 
-    /**
-     * @return int
-     */
-    public function getNumberOfNewOrdersInTheList();
+    public function getNumberOfNewOrdersInTheList(): int;
 
-    /**
-     * @return int
-     */
-    public function getNumberOfNewCustomers();
+    public function getNumberOfNewCustomers(): int;
 
-    /**
-     * @return int
-     */
-    public function getNumberOfNewCustomersInTheList();
+    public function getNumberOfNewCustomersInTheList(): int;
 
-    /**
-     * @return int
-     */
-    public function getAverageOrderValue();
+    public function getAverageOrderValue(): string;
 
-    /**
-     * @return string
-     */
-    public function getSubHeader();
+    public function getSubHeader(): string;
 
-    public function logOut();
+    public function logOut(): void;
 
-    /**
-     * @param string $channelName
-     */
-    public function chooseChannel($channelName);
+    public function chooseChannel(string $channelName): void;
 }

--- a/src/Sylius/Behat/Page/Admin/ExchangeRate/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ExchangeRate/CreatePage.php
@@ -17,34 +17,22 @@ use Sylius\Behat\Page\Admin\Crud\CreatePage as BaseCreatePage;
 
 class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyRatio($ratio)
+    public function specifyRatio(string $ratio): void
     {
         $this->getDocument()->fillField('Ratio', $ratio);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseSourceCurrency($currency)
+    public function chooseSourceCurrency(string $currency): void
     {
         $this->getDocument()->selectFieldOption('Source currency', $currency);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseTargetCurrency($currency)
+    public function chooseTargetCurrency(string $currency): void
     {
         $this->getDocument()->selectFieldOption('Target currency', $currency);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasFormValidationError($expectedMessage)
+    public function hasFormValidationError(string $expectedMessage): bool
     {
         $formValidationErrors = $this->getDocument()->find('css', 'form > div.ui.red.label.sylius-validation-error');
         if (null === $formValidationErrors) {
@@ -54,9 +42,6 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         return $expectedMessage === $formValidationErrors->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ExchangeRate/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ExchangeRate/CreatePageInterface.php
@@ -17,25 +17,11 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePage;
 
 interface CreatePageInterface extends BaseCreatePage
 {
-    /**
-     * @param float $ratio
-     */
-    public function specifyRatio($ratio);
+    public function specifyRatio(string $ratio): void;
 
-    /**
-     * @param string $currency
-     */
-    public function chooseSourceCurrency($currency);
+    public function chooseSourceCurrency(string $currency): void;
 
-    /**
-     * @param string $currency
-     */
-    public function chooseTargetCurrency($currency);
+    public function chooseTargetCurrency(string $currency): void;
 
-    /**
-     * @param string $expectedMessage
-     *
-     * @return bool
-     */
-    public function hasFormValidationError($expectedMessage);
+    public function hasFormValidationError(string $expectedMessage): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/ExchangeRate/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/ExchangeRate/IndexPage.php
@@ -17,17 +17,11 @@ use Sylius\Behat\Page\Admin\Crud\IndexPage as BaseIndexPage;
 
 class IndexPage extends BaseIndexPage implements IndexPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseCurrencyFilter($currencyName)
+    public function chooseCurrencyFilter(string $currencyName): void
     {
         $this->getElement('filter_currency')->selectOption($currencyName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ExchangeRate/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ExchangeRate/IndexPageInterface.php
@@ -17,8 +17,5 @@ use Sylius\Behat\Page\Admin\Crud\IndexPageInterface as BaseIndexPageInterface;
 
 interface IndexPageInterface extends BaseIndexPageInterface
 {
-    /**
-     * @param string $currencyName
-     */
-    public function chooseCurrencyFilter($currencyName);
+    public function chooseCurrencyFilter(string $currencyName): void;
 }

--- a/src/Sylius/Behat/Page/Admin/ExchangeRate/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ExchangeRate/UpdatePage.php
@@ -17,41 +17,26 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
 
 class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getRatio()
+    public function getRatio(): string
     {
         return $this->getElement('ratio')->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function changeRatio($ratio)
+    public function changeRatio(string $ratio): void
     {
         $this->getElement('ratio')->setValue($ratio);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isSourceCurrencyDisabled()
+    public function isSourceCurrencyDisabled(): bool
     {
         return null !== $this->getElement('sourceCurrency')->getAttribute('disabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isTargetCurrencyDisabled()
+    public function isTargetCurrencyDisabled(): bool
     {
         return null !== $this->getElement('targetCurrency')->getAttribute('disabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ExchangeRate/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ExchangeRate/UpdatePageInterface.php
@@ -17,23 +17,11 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @return string
-     */
-    public function getRatio();
+    public function getRatio(): string;
 
-    /**
-     * @param string $ratio
-     */
-    public function changeRatio($ratio);
+    public function changeRatio(string $ratio): void;
 
-    /**
-     * @return bool
-     */
-    public function isSourceCurrencyDisabled();
+    public function isSourceCurrencyDisabled(): bool;
 
-    /**
-     * @return bool
-     */
-    public function isTargetCurrencyDisabled();
+    public function isTargetCurrencyDisabled(): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/Inventory/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Inventory/IndexPage.php
@@ -17,18 +17,12 @@ use Sylius\Behat\Page\Admin\Crud\IndexPage as BaseIndexPage;
 
 class IndexPage extends BaseIndexPage implements IndexPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyFilterType($field, $type)
+    public function specifyFilterType(string $field, string $type): void
     {
         $this->getDocument()->fillField(sprintf('criteria_%s_value', $field), $type);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyFilterValue($field, $value)
+    public function specifyFilterValue(string $field, string $value): void
     {
         $this->getDocument()->fillField(sprintf('criteria_%s_value', $field), $value);
     }

--- a/src/Sylius/Behat/Page/Admin/Inventory/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Inventory/IndexPageInterface.php
@@ -17,15 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\IndexPageInterface as BaseIndexPageInterface;
 
 interface IndexPageInterface extends BaseIndexPageInterface
 {
-    /**
-     * @param string $field
-     * @param string $type
-     */
-    public function specifyFilterType($field, $type);
+    public function specifyFilterType(string $field, string $type): void;
 
-    /**
-     * @param string $field
-     * @param string $value
-     */
-    public function specifyFilterValue($field, $value);
+    public function specifyFilterValue(string $field, string $value): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Locale/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Locale/CreatePage.php
@@ -21,10 +21,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
     use ChoosesName;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isOptionAvailable($name)
+    public function isOptionAvailable(string $name): bool
     {
         try {
             $this->chooseName($name);

--- a/src/Sylius/Behat/Page/Admin/Locale/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Locale/CreatePageInterface.php
@@ -19,16 +19,9 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 interface CreatePageInterface extends BaseCreatePageInterface
 {
     /**
-     * @param string $name
-     *
      * @throws ElementNotFoundException
      */
-    public function chooseName($name);
+    public function chooseName(string $name): void;
 
-    /**
-     * @param string $name
-     *
-     * @return bool
-     */
-    public function isOptionAvailable($name);
+    public function isOptionAvailable(string $name): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/Order/HistoryPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/HistoryPage.php
@@ -17,18 +17,12 @@ use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
 
 class HistoryPage extends SymfonyPage implements HistoryPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function getRouteName(): string
     {
         return 'sylius_admin_order_history';
     }
 
-    /**
-     * @return int
-     */
-    public function countShippingAddressChanges()
+    public function countShippingAddressChanges(): int
     {
         return count($this->getDocument()->findAll('css', '#shipping-address-changes tbody tr'));
     }

--- a/src/Sylius/Behat/Page/Admin/Order/HistoryPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Order/HistoryPageInterface.php
@@ -17,8 +17,5 @@ use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 
 interface HistoryPageInterface extends SymfonyPageInterface
 {
-    /**
-     * @return int
-     */
-    public function countShippingAddressChanges();
+    public function countShippingAddressChanges(): int;
 }

--- a/src/Sylius/Behat/Page/Admin/Order/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/IndexPage.php
@@ -17,10 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\IndexPage as BaseIndexPage;
 
 class IndexPage extends BaseIndexPage implements IndexPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyFilterDateFrom(string $dateTime)
+    public function specifyFilterDateFrom(string $dateTime): void
     {
         $dateAndTime = explode(' ', $dateTime);
 
@@ -28,10 +25,7 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         $this->getDocument()->fillField('criteria_date_from_time', $dateAndTime[1] ?? '');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyFilterDateTo(string $dateTime)
+    public function specifyFilterDateTo(string $dateTime): void
     {
         $dateAndTime = explode(' ', $dateTime);
 
@@ -39,41 +33,26 @@ class IndexPage extends BaseIndexPage implements IndexPageInterface
         $this->getDocument()->fillField('criteria_date_to_time', $dateAndTime[1] ?? '');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseChannelFilter($channelName)
+    public function chooseChannelFilter(string $channelName): void
     {
         $this->getElement('filter_channel')->selectOption($channelName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseCurrencyFilter($currencyName)
+    public function chooseCurrencyFilter(string $currencyName): void
     {
         $this->getElement('filter_currency')->selectOption($currencyName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyFilterTotalGreaterThan($total)
+    public function specifyFilterTotalGreaterThan(string $total): void
     {
         $this->getDocument()->fillField('criteria_total_greaterThan', $total);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyFilterTotalLessThan($total)
+    public function specifyFilterTotalLessThan(string $total): void
     {
         $this->getDocument()->fillField('criteria_total_lessThan', $total);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Order/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Order/IndexPageInterface.php
@@ -17,27 +17,15 @@ use Sylius\Behat\Page\Admin\Crud\IndexPageInterface as BaseIndexPageInterface;
 
 interface IndexPageInterface extends BaseIndexPageInterface
 {
-    public function specifyFilterDateFrom(string $dateTime);
+    public function specifyFilterDateFrom(string $dateTime): void;
 
-    public function specifyFilterDateTo(string $dateTime);
+    public function specifyFilterDateTo(string $dateTime): void;
 
-    /**
-     * @param string $channelName
-     */
-    public function chooseChannelFilter($channelName);
+    public function chooseChannelFilter(string $channelName): void;
 
-    /**
-     * @param string $currencyName
-     */
-    public function chooseCurrencyFilter($currencyName);
+    public function chooseCurrencyFilter(string $currencyName): void;
 
-    /**
-     * @param string $total
-     */
-    public function specifyFilterTotalGreaterThan($total);
+    public function specifyFilterTotalGreaterThan(string $total): void;
 
-    /**
-     * @param string $total
-     */
-    public function specifyFilterTotalLessThan($total);
+    public function specifyFilterTotalLessThan(string $total): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
@@ -37,106 +37,76 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         $this->tableAccessor = $tableAccessor;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasCustomer($customerName)
+    public function hasCustomer(string $customerName): bool
     {
         $customerText = $this->getElement('customer')->getText();
 
         return stripos($customerText, $customerName) !== false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasShippingAddress($customerName, $street, $postcode, $city, $countryName)
+    public function hasShippingAddress(string $customerName, string $street, string $postcode, string $city, string $countryName): bool
     {
         $shippingAddressText = $this->getElement('shipping_address')->getText();
 
         return $this->hasAddress($shippingAddressText, $customerName, $street, $postcode, $city, $countryName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasBillingAddress($customerName, $street, $postcode, $city, $countryName)
+    public function hasBillingAddress(string $customerName, string $street, string $postcode, string $city, string $countryName): bool
     {
         $billingAddressText = $this->getElement('billing_address')->getText();
 
         return $this->hasAddress($billingAddressText, $customerName, $street, $postcode, $city, $countryName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasShipment($shippingDetails)
+    public function hasShipment(string $shippingDetails): bool
     {
         $shipmentsText = $this->getElement('shipments')->getText();
 
         return stripos($shipmentsText, $shippingDetails) !== false;
     }
 
-    public function specifyTrackingCode($code)
+    public function specifyTrackingCode(string $code): void
     {
         $this->getDocument()->fillField('sylius_shipment_ship_tracking', $code);
     }
 
-    public function canShipOrder(OrderInterface $order)
+    public function canShipOrder(OrderInterface $order): bool
     {
         return $this->getLastOrderShipmentElement($order)->hasButton('Ship');
     }
 
-    public function shipOrder(OrderInterface $order)
+    public function shipOrder(OrderInterface $order): void
     {
         $this->getLastOrderShipmentElement($order)->pressButton('Ship');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasPayment($paymentDetails)
+    public function hasPayment(string $paymentDetails): bool
     {
         $paymentsText = $this->getElement('payments')->getText();
 
         return stripos($paymentsText, $paymentDetails) !== false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function canCompleteOrderLastPayment(OrderInterface $order)
+    public function canCompleteOrderLastPayment(OrderInterface $order): bool
     {
         return $this->getLastOrderPaymentElement($order)->hasButton('Complete');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function completeOrderLastPayment(OrderInterface $order)
+    public function completeOrderLastPayment(OrderInterface $order): void
     {
         $this->getLastOrderPaymentElement($order)->pressButton('Complete');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function refundOrderLastPayment(OrderInterface $order)
+    public function refundOrderLastPayment(OrderInterface $order): void
     {
         $this->getLastOrderPaymentElement($order)->pressButton('Refund');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function countItems()
+    public function countItems(): int
     {
         return $this->tableAccessor->countTableBodyRows($this->getElement('table'));
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isProductInTheList(string $productName): bool
     {
         try {
@@ -160,172 +130,110 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getItemsTotal()
+    public function getItemsTotal(): string
     {
         $itemsTotalElement = $this->getElement('items_total');
 
         return trim(str_replace('Subtotal:', '', $itemsTotalElement->getText()));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getTotal()
+    public function getTotal(): string
     {
         $totalElement = $this->getElement('total');
 
         return trim(str_replace('Total:', '', $totalElement->getText()));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getShippingTotal()
+    public function getShippingTotal(): string
     {
         $shippingTotalElement = $this->getElement('shipping_total');
 
         return trim(str_replace('Shipping total:', '', $shippingTotalElement->getText()));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getTaxTotal()
+    public function getTaxTotal(): string
     {
         $taxTotalElement = $this->getElement('tax_total');
 
         return trim(str_replace('Tax total:', '', $taxTotalElement->getText()));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasShippingCharge($shippingCharge)
+    public function hasShippingCharge(string $shippingCharge): bool
     {
         $shippingChargesText = $this->getElement('shipping_charges')->getText();
 
         return stripos($shippingChargesText, $shippingCharge) !== false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPromotionTotal()
+    public function getPromotionTotal(): string
     {
         $promotionTotalElement = $this->getElement('promotion_total');
 
         return trim(str_replace('Promotion total:', '', $promotionTotalElement->getText()));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasPromotionDiscount($promotionDiscount)
+    public function hasPromotionDiscount(string $promotionDiscount): bool
     {
         $promotionDiscountsText = $this->getElement('promotion_discounts')->getText();
 
         return stripos($promotionDiscountsText, $promotionDiscount) !== false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasShippingPromotion($promotionName)
-    {
-        return $this->getElement('promotion_shipping_discounts')->getText();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function hasTax($tax)
+    public function hasTax(string $tax): bool
     {
         $taxesText = $this->getElement('taxes')->getText();
 
         return stripos($taxesText, $tax) !== false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getItemCode($itemName)
+    public function getItemCode(string $itemName): string
     {
         return $this->getItemProperty($itemName, 'sylius-product-variant-code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getItemUnitPrice($itemName)
+    public function getItemUnitPrice(string $itemName): string
     {
         return $this->getItemProperty($itemName, 'unit-price');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getItemDiscountedUnitPrice($itemName)
+    public function getItemDiscountedUnitPrice(string $itemName): string
     {
         return $this->getItemProperty($itemName, 'discounted-unit-price');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getItemQuantity($itemName)
+    public function getItemQuantity(string $itemName): string
     {
         return $this->getItemProperty($itemName, 'quantity');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getItemSubtotal($itemName)
+    public function getItemSubtotal(string $itemName): string
     {
         return $this->getItemProperty($itemName, 'subtotal');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getItemDiscount($itemName)
+    public function getItemDiscount(string $itemName): string
     {
         return $this->getItemProperty($itemName, 'discount');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getItemTax($itemName)
+    public function getItemTax(string $itemName): string
     {
         return $this->getItemProperty($itemName, 'tax');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getItemTotal($itemName)
+    public function getItemTotal(string $itemName): string
     {
         return $this->getItemProperty($itemName, 'total');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPaymentAmount()
+    public function getPaymentAmount(): string
     {
         $paymentsPrice = $this->getElement('payments')->find('css', '.description');
 
         return $paymentsPrice->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPaymentsCount()
+    public function getPaymentsCount(): int
     {
         try {
             $payments = $this->getElement('payments')->findAll('css', '.item');
@@ -336,9 +244,6 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         return count($payments);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getShipmentsCount(): int
     {
         try {
@@ -350,121 +255,82 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         return count($shipments);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasCancelButton()
+    public function hasCancelButton(): bool
     {
         return $this->getDocument()->hasButton('Cancel');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getOrderState()
+    public function getOrderState(): string
     {
         return $this->getElement('order_state')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPaymentState()
+    public function getPaymentState(): string
     {
         return $this->getElement('order_payment_state')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getShippingState()
+    public function getShippingState(): string
     {
         return $this->getElement('order_shipping_state')->getText();
     }
 
-    public function cancelOrder()
+    public function cancelOrder(): void
     {
         $this->getDocument()->pressButton('Cancel');
     }
 
-    public function deleteOrder()
+    public function deleteOrder(): void
     {
         $this->getDocument()->pressButton('Delete');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasNote($note)
+    public function hasNote(string $note): bool
     {
         $orderNotesElement = $this->getElement('order_notes');
 
         return $orderNotesElement->getText() === $note;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasShippingProvinceName($provinceName)
+    public function hasShippingProvinceName(string $provinceName): bool
     {
         $shippingAddressText = $this->getElement('shipping_address')->getText();
 
         return false !== stripos($shippingAddressText, $provinceName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasBillingProvinceName($provinceName)
+    public function hasBillingProvinceName(string $provinceName): bool
     {
         $billingAddressText = $this->getElement('billing_address')->getText();
 
         return false !== stripos($billingAddressText, $provinceName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getIpAddressAssigned()
+    public function getIpAddressAssigned(): string
     {
         return $this->getElement('ip_address')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getOrderCurrency()
+    public function getOrderCurrency(): string
     {
         return $this->getElement('currency')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasRefundButton()
+    public function hasRefundButton(): bool
     {
         return $this->getDocument()->hasButton('Refund');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getShippingPromotionData()
+    public function getShippingPromotionData(): string
     {
         return $this->getElement('promotion_shipping_discounts')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getRouteName(): string
     {
         return 'sylius_admin_order_show';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -492,25 +358,12 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         ]);
     }
 
-    /**
-     * @return TableAccessorInterface
-     */
-    protected function getTableAccessor()
+    protected function getTableAccessor(): TableAccessorInterface
     {
         return $this->tableAccessor;
     }
 
-    /**
-     * @param string $elementText
-     * @param string $customerName
-     * @param string $street
-     * @param string $postcode
-     * @param string $city
-     * @param string $countryName
-     *
-     * @return bool
-     */
-    private function hasAddress($elementText, $customerName, $street, $postcode, $city, $countryName)
+    private function hasAddress(string $elementText, string $customerName, string $street, string $postcode, string $city, string $countryName): bool
     {
         return
             (stripos($elementText, $customerName) !== false) &&
@@ -520,13 +373,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         ;
     }
 
-    /**
-     * @param string $itemName
-     * @param string $property
-     *
-     * @return string
-     */
-    private function getItemProperty($itemName, $property)
+    private function getItemProperty(string $itemName, string $property): string
     {
         $rows = $this->tableAccessor->getRowsWithFields(
             $this->getElement('table'),
@@ -536,10 +383,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         return $rows[0]->find('css', '.' . $property)->getText();
     }
 
-    /**
-     * @return NodeElement|null
-     */
-    private function getLastOrderPaymentElement(OrderInterface $order)
+    private function getLastOrderPaymentElement(OrderInterface $order): ?NodeElement
     {
         $payment = $order->getPayments()->last();
 
@@ -549,10 +393,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         return $paymentStateElement->getParent()->getParent();
     }
 
-    /**
-     * @return NodeElement|null
-     */
-    private function getLastOrderShipmentElement(OrderInterface $order)
+    private function getLastOrderShipmentElement(OrderInterface $order): ?NodeElement
     {
         $shipment = $order->getShipments()->last();
 

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
@@ -18,261 +18,93 @@ use Sylius\Component\Core\Model\OrderInterface;
 
 interface ShowPageInterface extends SymfonyPageInterface
 {
-    /**
-     * @param string $customerName
-     */
-    public function hasCustomer($customerName);
+    public function hasCustomer(string $customerName): bool;
 
-    /**
-     * @param string $customerName
-     * @param string $street
-     * @param string $postcode
-     * @param string $city
-     * @param string $countryName
-     *
-     * @return bool
-     */
-    public function hasShippingAddress($customerName, $street, $postcode, $city, $countryName);
+    public function hasShippingAddress(string $customerName, string $street, string $postcode, string $city, string $countryName): bool;
 
-    /**
-     * @param string $customerName
-     * @param string $street
-     * @param string $postcode
-     * @param string $city
-     * @param string $countryName
-     *
-     * @return bool
-     */
-    public function hasBillingAddress($customerName, $street, $postcode, $city, $countryName);
+    public function hasBillingAddress(string $customerName, string $street, string $postcode, string $city, string $countryName): bool;
 
-    /**
-     * @param string $shippingMethodName
-     *
-     * @return bool
-     */
-    public function hasShipment($shippingMethodName);
+    public function hasShipment(string $shippingMethodName): bool;
 
-    /**
-     * @param string $code
-     */
-    public function specifyTrackingCode($code);
+    public function specifyTrackingCode(string $code): void;
 
-    /**
-     * @return bool
-     */
-    public function canShipOrder(OrderInterface $order);
+    public function canShipOrder(OrderInterface $order): bool;
 
-    public function shipOrder(OrderInterface $order);
+    public function shipOrder(OrderInterface $order): void;
 
-    /**
-     * @param string $paymentMethodName
-     *
-     * @return bool
-     */
-    public function hasPayment($paymentMethodName);
+    public function hasPayment(string $paymentMethodName): bool;
 
-    /**
-     * @return bool
-     */
-    public function canCompleteOrderLastPayment(OrderInterface $order);
+    public function canCompleteOrderLastPayment(OrderInterface $order): bool;
 
-    public function completeOrderLastPayment(OrderInterface $order);
+    public function completeOrderLastPayment(OrderInterface $order): void;
 
-    public function refundOrderLastPayment(OrderInterface $order);
+    public function refundOrderLastPayment(OrderInterface $order): void;
 
-    /**
-     * @return int
-     */
-    public function countItems();
+    public function countItems(): int;
 
     public function isProductInTheList(string $productName): bool;
 
-    /**
-     * @return string
-     */
-    public function getItemsTotal();
+    public function getItemsTotal(): string;
 
-    /**
-     * @return string
-     */
-    public function getTotal();
+    public function getTotal(): string;
 
-    /**
-     * @return string
-     */
-    public function getShippingTotal();
+    public function getShippingTotal(): string;
 
-    /**
-     * @param string $shippingCharge
-     *
-     * @return bool
-     */
-    public function hasShippingCharge($shippingCharge);
+    public function hasShippingCharge(string $shippingCharge): bool;
 
-    /**
-     * @return string
-     */
-    public function getTaxTotal();
+    public function getTaxTotal(): string;
 
-    /**
-     * @return string
-     */
-    public function getPromotionTotal();
+    public function getPromotionTotal(): string;
 
-    /**
-     * @param string $promotionDiscount
-     *
-     * @return bool
-     */
-    public function hasPromotionDiscount($promotionDiscount);
+    public function hasPromotionDiscount(string $promotionDiscount): bool;
 
-    /**
-     * @param string $promotionName
-     *
-     * @return bool
-     */
-    public function hasShippingPromotion($promotionName);
+    public function hasTax(string $tax): bool;
 
-    /**
-     * @param string $tax
-     *
-     * @return bool
-     */
-    public function hasTax($tax);
+    public function getItemCode(string $itemName): string;
 
-    /**
-     * @param string $itemName
-     *
-     * @return string
-     */
-    public function getItemCode($itemName);
+    public function getItemUnitPrice(string $itemName): string;
 
-    /**
-     * @param string $itemName
-     *
-     * @return string
-     */
-    public function getItemUnitPrice($itemName);
+    public function getItemDiscountedUnitPrice(string $itemName): string;
 
-    /**
-     * @param string $itemName
-     *
-     * @return string
-     */
-    public function getItemDiscountedUnitPrice($itemName);
+    public function getItemQuantity(string $itemName): string;
 
-    /**
-     * @param string $itemName
-     *
-     * @return string
-     */
-    public function getItemQuantity($itemName);
+    public function getItemSubtotal(string $itemName): string;
 
-    /**
-     * @param string $itemName
-     *
-     * @return string
-     */
-    public function getItemSubtotal($itemName);
+    public function getItemDiscount(string $itemName): string;
 
-    /**
-     * @param string $itemName
-     *
-     * @return string
-     */
-    public function getItemDiscount($itemName);
+    public function getItemTax(string $itemName): string;
 
-    /**
-     * @param string $itemName
-     *
-     * @return string
-     */
-    public function getItemTax($itemName);
+    public function getItemTotal(string $itemName): string;
 
-    /**
-     * @param string $itemName
-     *
-     * @return string
-     */
-    public function getItemTotal($itemName);
+    public function getPaymentAmount(): string;
 
-    /**
-     * @return string
-     */
-    public function getPaymentAmount();
+    public function getPaymentsCount(): int;
 
-    /**
-     * @return int
-     */
-    public function getPaymentsCount();
+    public function getShipmentsCount(): int;
 
-    /**
-     * @return int
-     */
-    public function getShipmentsCount();
+    public function hasCancelButton(): bool;
 
-    /**
-     * @return bool
-     */
-    public function hasCancelButton();
+    public function getOrderState(): string;
 
-    /**
-     * @return string
-     */
-    public function getOrderState();
+    public function getPaymentState(): string;
 
-    /**
-     * @return string
-     */
-    public function getPaymentState();
+    public function getShippingState(): string;
 
-    /**
-     * @return string
-     */
-    public function getShippingState();
+    public function cancelOrder(): void;
 
-    public function cancelOrder();
+    public function deleteOrder(): void;
 
-    public function deleteOrder();
+    public function hasNote(string $note): bool;
 
-    /**
-     * @param string $note
-     *
-     * @return bool
-     */
-    public function hasNote($note);
+    public function hasShippingProvinceName(string $provinceName): bool;
 
-    /**
-     * @param string $provinceName
-     *
-     * @return bool
-     */
-    public function hasShippingProvinceName($provinceName);
+    public function hasBillingProvinceName(string $provinceName): bool;
 
-    /**
-     * @param string $provinceName
-     *
-     * @return bool
-     */
-    public function hasBillingProvinceName($provinceName);
+    public function getIpAddressAssigned(): string;
 
-    /**
-     * @return string
-     */
-    public function getIpAddressAssigned();
+    public function getOrderCurrency(): string;
 
-    /**
-     * @return string
-     */
-    public function getOrderCurrency();
+    public function hasRefundButton(): bool;
 
-    /**
-     * @return bool
-     */
-    public function hasRefundButton();
-
-    /**
-     * @return string
-     */
-    public function getShippingPromotionData();
+    public function getShippingPromotionData(): string;
 }

--- a/src/Sylius/Behat/Page/Admin/Order/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/UpdatePage.php
@@ -23,26 +23,17 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     public const TYPE_BILLING = 'billing';
     public const TYPE_SHIPPING = 'shipping';
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyBillingAddress(AddressInterface $address)
+    public function specifyBillingAddress(AddressInterface $address): void
     {
         $this->specifyAddress($address, self::TYPE_BILLING);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyShippingAddress(AddressInterface $address)
+    public function specifyShippingAddress(AddressInterface $address): void
     {
         $this->specifyAddress($address, self::TYPE_SHIPPING);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    private function specifyAddress(AddressInterface $address, $addressType)
+    private function specifyAddress(AddressInterface $address, $addressType): void
     {
         $this->specifyElementValue($addressType . '_first_name', $address->getFirstName());
         $this->specifyElementValue($addressType . '_last_name', $address->getLastName());
@@ -58,7 +49,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
      *
      * @throws ElementNotFoundException
      */
-    public function checkValidationMessageFor($element, $message)
+    public function checkValidationMessageFor(string $element, string $message): bool
     {
         $foundElement = $this->getFieldElement($element);
         if (null === $foundElement) {
@@ -73,9 +64,6 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         return $message === $validationMessage->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -95,35 +83,25 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     }
 
     /**
-     * @param string $elementName
-     * @param string $value
-     *
      * @throws ElementNotFoundException
      */
-    private function specifyElementValue($elementName, $value)
+    private function specifyElementValue(string $elementName, ?string $value): void
     {
         $this->getElement($elementName)->setValue($value);
     }
 
     /**
-     * @param string $country
-     * @param string $addressType
-     *
      * @throws ElementNotFoundException
      */
-    private function chooseCountry($country, $addressType)
+    private function chooseCountry(?string $country, string $addressType): void
     {
         $this->getElement($addressType . '_country')->selectOption($country ?? 'Select');
     }
 
     /**
-     * @param string $element
-     *
-     * @return NodeElement|null
-     *
      * @throws ElementNotFoundException
      */
-    private function getFieldElement($element)
+    private function getFieldElement(string $element): ?NodeElement
     {
         $element = $this->getElement($element);
         while (null !== $element && !$element->hasClass('field')) {

--- a/src/Sylius/Behat/Page/Admin/Order/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Order/UpdatePageInterface.php
@@ -18,15 +18,9 @@ use Sylius\Component\Addressing\Model\AddressInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    public function specifyShippingAddress(AddressInterface $address);
+    public function specifyShippingAddress(AddressInterface $address): void;
 
-    public function specifyBillingAddress(AddressInterface $address);
+    public function specifyBillingAddress(AddressInterface $address): void;
 
-    /**
-     * @param string $element
-     * @param string $message
-     *
-     * @return bool
-     */
-    public function checkValidationMessageFor($element, $message);
+    public function checkValidationMessageFor(string $element, string $message): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/PaymentMethod/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/PaymentMethod/CreatePage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\PaymentMethod;
 
+use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\ChecksCodeImmutability;
 use Sylius\Behat\Behaviour\SpecifiesItsCode;
 use Sylius\Behat\Behaviour\Toggles;
@@ -24,111 +25,72 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     use Toggles;
     use SpecifiesItsCode;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameIt($name, $languageCode)
+    public function nameIt(string $name, string $languageCode): void
     {
         $this->getDocument()->fillField(
             sprintf('sylius_payment_method_translations_%s_name', $languageCode), $name
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function checkChannel($channelName)
+    public function checkChannel(string $channelName): void
     {
         $this->getDocument()->checkField($channelName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function describeIt($description, $languageCode)
+    public function describeIt(string $description, string $languageCode): void
     {
         $this->getDocument()->fillField(
             sprintf('sylius_payment_method_translations_%s_description', $languageCode), $description
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setInstructions($instructions, $languageCode)
+    public function setInstructions(string $instructions, string $languageCode): void
     {
         $this->getDocument()->fillField(
             sprintf('sylius_payment_method_translations_%s_instructions', $languageCode), $instructions
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setPaypalGatewayUsername($username)
+    public function setPaypalGatewayUsername(string $username): void
     {
         $this->getDocument()->fillField('Username', $username);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setPaypalGatewayPassword($password)
+    public function setPaypalGatewayPassword(string $password): void
     {
         $this->getDocument()->fillField('Password', $password);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setPaypalGatewaySignature($signature)
+    public function setPaypalGatewaySignature(string $signature): void
     {
         $this->getDocument()->fillField('Signature', $signature);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setStripeSecretKey($secretKey)
+    public function setStripeSecretKey(string $secretKey): void
     {
         $this->getDocument()->fillField('Secret key', $secretKey);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setStripePublishableKey($publishableKey)
+    public function setStripePublishableKey(string $publishableKey): void
     {
         $this->getDocument()->fillField('Publishable key', $publishableKey);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isPaymentMethodEnabled()
+    public function isPaymentMethodEnabled(): bool
     {
         return (bool) $this->getToggleableElement()->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getToggleableElement()
+    protected function getToggleableElement(): NodeElement
     {
         return $this->getElement('enabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/PaymentMethod/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/PaymentMethod/CreatePageInterface.php
@@ -17,70 +17,31 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    public function enable();
+    public function enable(): void;
 
-    public function disable();
+    public function disable(): void;
 
-    /**
-     * @param string $name
-     * @param string $languageCode
-     */
-    public function nameIt($name, $languageCode);
+    public function nameIt(string $name, string $languageCode): void;
 
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
+    public function specifyCode(string $code): void;
 
-    /**
-     * @param string $channelName
-     */
-    public function checkChannel($channelName);
+    public function checkChannel(string $channelName): void;
 
-    /**
-     * @param string $description
-     * @param string $languageCode
-     */
-    public function describeIt($description, $languageCode);
+    public function describeIt(string $description, string $languageCode): void;
 
-    /**
-     * @param string $instructions
-     * @param string $languageCode
-     */
-    public function setInstructions($instructions, $languageCode);
+    public function setInstructions(string $instructions, string $languageCode): void;
 
-    /**
-     * @param string $username
-     */
-    public function setPaypalGatewayUsername($username);
+    public function setPaypalGatewayUsername(string $username): void;
 
-    /**
-     * @param string $password
-     */
-    public function setPaypalGatewayPassword($password);
+    public function setPaypalGatewayPassword(string $password): void;
 
-    /**
-     * @param string $signature
-     */
-    public function setPaypalGatewaySignature($signature);
+    public function setPaypalGatewaySignature(string $signature): void;
 
-    /**
-     * @param string $secretKey
-     */
-    public function setStripeSecretKey($secretKey);
+    public function setStripeSecretKey(string $secretKey): void;
 
-    /**
-     * @param string $publishableKey
-     */
-    public function setStripePublishableKey($publishableKey);
+    public function setStripePublishableKey(string $publishableKey): void;
 
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 
-    /**
-     * @return bool
-     */
-    public function isPaymentMethodEnabled();
+    public function isPaymentMethodEnabled(): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/PaymentMethod/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/PaymentMethod/UpdatePage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\PaymentMethod;
 
+use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\ChecksCodeImmutability;
 use Sylius\Behat\Behaviour\Toggles;
 use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
@@ -22,89 +23,56 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     use ChecksCodeImmutability;
     use Toggles;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setPaypalGatewayUsername($username)
+    public function setPaypalGatewayUsername(string $username): void
     {
         $this->getDocument()->fillField('Username', $username);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setPaypalGatewayPassword($password)
+    public function setPaypalGatewayPassword(string $password): void
     {
         $this->getDocument()->fillField('Password', $password);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setPaypalGatewaySignature($signature)
+    public function setPaypalGatewaySignature(string $signature): void
     {
         $this->getDocument()->fillField('Signature', $signature);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameIt($name, $languageCode)
+    public function nameIt(string $name, string $languageCode): void
     {
         $this->getDocument()->fillField(sprintf('sylius_payment_method_translations_%s_name', $languageCode), $name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isPaymentMethodEnabled()
+    public function isPaymentMethodEnabled(): bool
     {
         return (bool) $this->getToggleableElement()->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isFactoryNameFieldDisabled()
+    public function isFactoryNameFieldDisabled(): bool
     {
         return 'disabled' === $this->getElement('factory_name')->getAttribute('disabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isAvailableInChannel($channelName)
+    public function isAvailableInChannel(string $channelName): bool
     {
         return $this->getElement('channel', ['%channel%' => $channelName])->hasAttribute('checked');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPaymentMethodInstructions($language)
+    public function getPaymentMethodInstructions(string $language): string
     {
         return $this->getElement('instructions', ['%language%' => $language])->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getToggleableElement()
+    protected function getToggleableElement(): NodeElement
     {
         return $this->getElement('enabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/PaymentMethod/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/PaymentMethod/UpdatePageInterface.php
@@ -17,57 +17,25 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    public function enable();
+    public function enable(): void;
 
-    public function disable();
+    public function disable(): void;
 
-    /**
-     * @param string $name
-     * @param string $languageCode
-     */
-    public function nameIt($name, $languageCode);
+    public function nameIt(string $name, string $languageCode): void;
 
-    /**
-     * @param string $username
-     */
-    public function setPaypalGatewayUsername($username);
+    public function setPaypalGatewayUsername(string $username): void;
 
-    /**
-     * @param string $password
-     */
-    public function setPaypalGatewayPassword($password);
+    public function setPaypalGatewayPassword(string $password): void;
 
-    /**
-     * @param string $signature
-     */
-    public function setPaypalGatewaySignature($signature);
+    public function setPaypalGatewaySignature(string $signature): void;
 
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 
-    /**
-     * @return bool
-     */
-    public function isFactoryNameFieldDisabled();
+    public function isFactoryNameFieldDisabled(): bool;
 
-    /**
-     * @return bool
-     */
-    public function isPaymentMethodEnabled();
+    public function isPaymentMethodEnabled(): bool;
 
-    /**
-     * @param string $channelName
-     *
-     * @return bool
-     */
-    public function isAvailableInChannel($channelName);
+    public function isAvailableInChannel(string $channelName): bool;
 
-    /**
-     * @param string $language
-     *
-     * @return string
-     */
-    public function getPaymentMethodInstructions($language);
+    public function getPaymentMethodInstructions(string $language): string;
 }

--- a/src/Sylius/Behat/Page/Admin/Product/CreateConfigurableProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateConfigurableProductPage.php
@@ -24,10 +24,7 @@ class CreateConfigurableProductPage extends BaseCreatePage implements CreateConf
 {
     use SpecifiesItsCode;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameItIn($name, $localeCode)
+    public function nameItIn(string $name, string $localeCode): void
     {
         $this->getDocument()->fillField(
             sprintf('sylius_product_translations_%s_name', $localeCode), $name
@@ -38,18 +35,12 @@ class CreateConfigurableProductPage extends BaseCreatePage implements CreateConf
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function selectOption($optionName)
+    public function selectOption(string $optionName): void
     {
         $this->getDocument()->selectFieldOption('Options', $optionName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function attachImage($path, $type = null)
+    public function attachImage(string $path, string $type = null): void
     {
         $this->clickTabIfItsNotActive('media');
 
@@ -65,9 +56,6 @@ class CreateConfigurableProductPage extends BaseCreatePage implements CreateConf
         $imageForm->find('css', 'input[type="file"]')->attachFile($filesPath . $path);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -79,10 +67,7 @@ class CreateConfigurableProductPage extends BaseCreatePage implements CreateConf
         ]);
     }
 
-    /**
-     * @param string $tabName
-     */
-    private function clickTabIfItsNotActive($tabName)
+    private function clickTabIfItsNotActive(string $tabName): void
     {
         $attributesTab = $this->getElement('tab', ['%name%' => $tabName]);
         if (!$attributesTab->hasClass('active')) {
@@ -90,10 +75,7 @@ class CreateConfigurableProductPage extends BaseCreatePage implements CreateConf
         }
     }
 
-    /**
-     * @return NodeElement
-     */
-    private function getLastImageElement()
+    private function getLastImageElement(): NodeElement
     {
         $images = $this->getElement('images');
         $items = $images->findAll('css', 'div[data-form-collection="item"]');

--- a/src/Sylius/Behat/Page/Admin/Product/CreateConfigurableProductPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateConfigurableProductPageInterface.php
@@ -17,25 +17,14 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreateConfigurableProductPageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @param string $optionName
-     */
-    public function selectOption($optionName);
+    public function selectOption(string $optionName): void;
+
+    public function specifyCode(string $code): void;
+
+    public function nameItIn(string $name, string $localeCode): void;
 
     /**
-     * @param string $code
-     */
-    public function specifyCode($code);
-
-    /**
-     * @param string $name
-     * @param string $localeCode
-     */
-    public function nameItIn($name, $localeCode);
-
-    /**
-     * @param string $path
      * @param string $type
      */
-    public function attachImage($path, $type = null);
+    public function attachImage(string $path, string $type = null): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPage.php
@@ -25,18 +25,12 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
 {
     use SpecifiesItsCode;
 
-    /**
-     * {@inheritdoc}
-     */
     public function getRouteName(): string
     {
         return parent::getRouteName() . '_simple';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameItIn($name, $localeCode)
+    public function nameItIn(string $name, string $localeCode): void
     {
         $this->activateLanguageTab($localeCode);
         $this->getElement('name', ['%locale%' => $localeCode])->setValue($name);
@@ -49,36 +43,24 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifySlugIn($slug, $locale)
+    public function specifySlugIn(?string $slug, string $locale): void
     {
         $this->activateLanguageTab($locale);
 
         $this->getElement('slug', ['%locale%' => $locale])->setValue($slug);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyPrice($channelName, $price)
+    public function specifyPrice(string $channelName, string $price): void
     {
         $this->getElement('price', ['%channelName%' => $channelName])->setValue($price);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyOriginalPrice($channelName, $originalPrice)
+    public function specifyOriginalPrice(string $channelName, int $originalPrice): void
     {
         $this->getElement('original_price', ['%channelName%' => $channelName])->setValue($originalPrice);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function addAttribute($attributeName, $value, $localeCode)
+    public function addAttribute(string $attributeName, string $value, string $localeCode): void
     {
         $this->clickTabIfItsNotActive('attributes');
         $this->clickLocaleTabIfItsNotActive($localeCode);
@@ -92,10 +74,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         $this->getElement('attribute_value', ['%attributeName%' => $attributeName, '%localeCode%' => $localeCode])->setValue($value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getAttributeValidationErrors($attributeName, $localeCode)
+    public function getAttributeValidationErrors(string $attributeName, string $localeCode): string
     {
         $this->clickTabIfItsNotActive('attributes');
         $this->clickLocaleTabIfItsNotActive($localeCode);
@@ -105,26 +84,20 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         return $validationError->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function removeAttribute($attributeName, $localeCode)
+    public function removeAttribute(string $attributeName, string $localeCode): void
     {
         $this->clickTabIfItsNotActive('attributes');
 
         $this->getElement('attribute_delete_button', ['%attributeName%' => $attributeName, '%localeCode%' => $localeCode])->press();
     }
 
-    public function checkAttributeErrors($attributeName, $localeCode)
+    public function checkAttributeErrors($attributeName, $localeCode): void
     {
         $this->clickTabIfItsNotActive('attributes');
         $this->clickLocaleTabIfItsNotActive($localeCode);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function attachImage($path, $type = null)
+    public function attachImage(string $path, string $type = null): void
     {
         $this->clickTabIfItsNotActive('media');
 
@@ -140,10 +113,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         $imageForm->find('css', 'input[type="file"]')->attachFile($filesPath . $path);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function associateProducts(ProductAssociationTypeInterface $productAssociationType, array $productsNames)
+    public function associateProducts(ProductAssociationTypeInterface $productAssociationType, array $productsNames): void
     {
         $this->clickTab('associations');
 
@@ -170,10 +140,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function removeAssociatedProduct($productName, ProductAssociationTypeInterface $productAssociationType)
+    public function removeAssociatedProduct(string $productName, ProductAssociationTypeInterface $productAssociationType): void
     {
         $this->clickTabIfItsNotActive('associations');
 
@@ -184,26 +151,17 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         $item->find('css', 'i.delete')->click();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function choosePricingCalculator($name)
+    public function choosePricingCalculator(string $name): void
     {
         $this->getElement('price_calculator')->selectOption($name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function checkChannel($channelName)
+    public function checkChannel(string $channelName): void
     {
         $this->getElement('channel_checkbox', ['%channelName%' => $channelName])->check();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function activateLanguageTab($locale)
+    public function activateLanguageTab(string $locale): void
     {
         if (!$this->getDriver() instanceof Selenium2Driver) {
             return;
@@ -215,18 +173,12 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function selectShippingCategory($shippingCategoryName)
+    public function selectShippingCategory(string $shippingCategoryName): void
     {
         $this->getElement('shipping_category')->selectOption($shippingCategoryName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setShippingRequired($isShippingRequired)
+    public function setShippingRequired(bool $isShippingRequired): void
     {
         if ($isShippingRequired) {
             $this->getElement('shipping_required')->check();
@@ -237,9 +189,6 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         $this->getElement('shipping_required')->uncheck();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getElement(string $name, array $parameters = []): NodeElement
     {
         if (!isset($parameters['%locale%'])) {
@@ -249,9 +198,6 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         return parent::getElement($name, $parameters);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -281,10 +227,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         ]);
     }
 
-    /**
-     * @param int $id
-     */
-    private function selectElementFromAttributesDropdown($id)
+    private function selectElementFromAttributesDropdown(string $id): void
     {
         /** @var Selenium2Driver $driver */
         $driver = $this->getDriver();
@@ -294,10 +237,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         $driver->executeScript(sprintf('$(\'#sylius_product_attribute_choice\').dropdown(\'set selected\', \'%s\');', $id));
     }
 
-    /**
-     * @param int $timeout
-     */
-    private function waitForFormElement($timeout = 5)
+    private function waitForFormElement(int $timeout = 5): void
     {
         $form = $this->getElement('form');
         $this->getDocument()->waitFor($timeout, function () use ($form) {
@@ -305,10 +245,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         });
     }
 
-    /**
-     * @param string $tabName
-     */
-    private function clickTabIfItsNotActive($tabName)
+    private function clickTabIfItsNotActive(string $tabName): void
     {
         $attributesTab = $this->getElement('tab', ['%name%' => $tabName]);
         if (!$attributesTab->hasClass('active')) {
@@ -316,19 +253,13 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         }
     }
 
-    /**
-     * @param string $tabName
-     */
-    private function clickTab($tabName)
+    private function clickTab(string $tabName): void
     {
         $attributesTab = $this->getElement('tab', ['%name%' => $tabName]);
         $attributesTab->click();
     }
 
-    /**
-     * @param string $localeCode
-     */
-    private function clickLocaleTabIfItsNotActive($localeCode)
+    private function clickLocaleTabIfItsNotActive(string $localeCode): void
     {
         $localeTab = $this->getElement('locale_tab', ['%localeCode%' => $localeCode]);
         if (!$localeTab->hasClass('active')) {
@@ -336,10 +267,7 @@ class CreateSimpleProductPage extends BaseCreatePage implements CreateSimpleProd
         }
     }
 
-    /**
-     * @return NodeElement
-     */
-    private function getLastImageElement()
+    private function getLastImageElement(): NodeElement
     {
         $images = $this->getElement('images');
         $items = $images->findAll('css', 'div[data-form-collection="item"]');

--- a/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/CreateSimpleProductPageInterface.php
@@ -18,94 +18,41 @@ use Sylius\Component\Product\Model\ProductAssociationTypeInterface;
 
 interface CreateSimpleProductPageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @param string $channelName
-     * @param int $price
-     */
-    public function specifyPrice($channelName, $price);
+    public function specifyPrice(string $channelName, string $price): void;
+
+    public function specifyOriginalPrice(string $channelName, int $originalPrice): void;
+
+    public function choosePricingCalculator(string $name): void;
+
+    public function checkChannel(string $channelName): void;
+
+    public function specifyCode(string $code): void;
+
+    public function nameItIn(string $name, string $localeCode): void;
+
+    public function specifySlugIn(?string $slug, string $locale): void;
+
+    public function addAttribute(string $attributeName, string $value, string $localeCode): void;
+
+    public function getAttributeValidationErrors(string $attributeName, string $localeCode): string;
+
+    public function removeAttribute(string $attributeName, string $localeCode): void;
 
     /**
-     * @param string $channelName
-     * @param int $originalPrice
-     */
-    public function specifyOriginalPrice($channelName, $originalPrice);
-
-    /**
-     * @param string $name
-     */
-    public function choosePricingCalculator($name);
-
-    /**
-     * @param string $channelName
-     */
-    public function checkChannel($channelName);
-
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
-
-    /**
-     * @param string $name
-     * @param string $localeCode
-     */
-    public function nameItIn($name, $localeCode);
-
-    /**
-     * @param string $slug
-     * @param string $locale
-     */
-    public function specifySlugIn($slug, $locale);
-
-    /**
-     * @param string $attributeName
-     * @param string $value
-     * @param string $localeCode
-     */
-    public function addAttribute($attributeName, $value, $localeCode);
-
-    /**
-     * @param string $attributeName
-     * @param string $localeCode
-     *
-     * @return string
-     */
-    public function getAttributeValidationErrors($attributeName, $localeCode);
-
-    /**
-     * @param string $attributeName
-     * @param string $localeCode
-     */
-    public function removeAttribute($attributeName, $localeCode);
-
-    /**
-     * @param string $path
      * @param string $type
      */
-    public function attachImage($path, $type = null);
+    public function attachImage(string $path, string $type = null): void;
 
     /**
      * @param string[] $productsNames
      */
-    public function associateProducts(ProductAssociationTypeInterface $productAssociationType, array $productsNames);
+    public function associateProducts(ProductAssociationTypeInterface $productAssociationType, array $productsNames): void;
 
-    /**
-     * @param string $productName
-     */
-    public function removeAssociatedProduct($productName, ProductAssociationTypeInterface $productAssociationType);
+    public function removeAssociatedProduct(string $productName, ProductAssociationTypeInterface $productAssociationType): void;
 
-    /**
-     * @param string $locale
-     */
-    public function activateLanguageTab($locale);
+    public function activateLanguageTab(string $locale): void;
 
-    /**
-     * @param string $shippingCategoryName
-     */
-    public function selectShippingCategory($shippingCategoryName);
+    public function selectShippingCategory(string $shippingCategoryName): void;
 
-    /**
-     * @param bool $isShippingRequired
-     */
-    public function setShippingRequired($isShippingRequired);
+    public function setShippingRequired(bool $isShippingRequired): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPage.php
@@ -37,10 +37,7 @@ final class IndexPage extends CrudIndexPage implements IndexPageInterface
         $this->imageExistenceChecker = $imageExistenceChecker;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function filterByTaxon($taxonName)
+    public function filterByTaxon(string $taxonName): void
     {
         $this->getElement('taxon_filter', ['%taxon%' => $taxonName])->click();
     }
@@ -53,9 +50,6 @@ final class IndexPage extends CrudIndexPage implements IndexPageInterface
         return $this->imageExistenceChecker->doesImageWithUrlExist($imageUrl, 'sylius_admin_product_thumbnail');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPageInterface.php
@@ -17,10 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\IndexPageInterface as CrudIndexPageInterface;
 
 interface IndexPageInterface extends CrudIndexPageInterface
 {
-    /**
-     * @param string $taxonName
-     */
-    public function filterByTaxon($taxonName);
+    public function filterByTaxon(string $taxonName): void;
 
     public function hasProductAccessibleImage(string $productCode): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPerTaxonPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPerTaxonPage.php
@@ -19,10 +19,7 @@ use Webmozart\Assert\Assert;
 
 class IndexPerTaxonPage extends CrudIndexPage implements IndexPerTaxonPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function hasProductsInOrder(array $productNames)
+    public function hasProductsInOrder(array $productNames): bool
     {
         $productsOnPage = $this->getColumnFields('name');
 
@@ -35,10 +32,7 @@ class IndexPerTaxonPage extends CrudIndexPage implements IndexPerTaxonPageInterf
         return true;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setPositionOfProduct($productName, $position)
+    public function setPositionOfProduct(string $productName, int $position): void
     {
         /** @var NodeElement $productsRow */
         $productsRow = $this->getElement('table')->find('css', sprintf('tbody > tr:contains("%s")', $productName));
@@ -47,7 +41,7 @@ class IndexPerTaxonPage extends CrudIndexPage implements IndexPerTaxonPageInterf
         $productsRow->find('css', '.sylius-product-taxon-position')->setValue($position);
     }
 
-    public function savePositions()
+    public function savePositions(): void
     {
         $this->getElement('save_configuration_button')->press();
 
@@ -56,9 +50,6 @@ class IndexPerTaxonPage extends CrudIndexPage implements IndexPerTaxonPageInterf
         });
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Product/IndexPerTaxonPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/IndexPerTaxonPageInterface.php
@@ -17,16 +17,9 @@ use Sylius\Behat\Page\Admin\Crud\IndexPageInterface as CrudIndexPageInterface;
 
 interface IndexPerTaxonPageInterface extends CrudIndexPageInterface
 {
-    /**
-     * @return bool
-     */
-    public function hasProductsInOrder(array $productNames);
+    public function hasProductsInOrder(array $productNames): bool;
 
-    /**
-     * @param string $productName
-     * @param int $position
-     */
-    public function setPositionOfProduct($productName, $position);
+    public function setPositionOfProduct(string $productName, int $position): void;
 
-    public function savePositions();
+    public function savePositions(): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Product/UpdateConfigurableProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/UpdateConfigurableProductPage.php
@@ -27,36 +27,24 @@ class UpdateConfigurableProductPage extends BaseUpdatePage implements UpdateConf
     /** @var array */
     private $imageUrls = [];
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameItIn($name, $localeCode)
+    public function nameItIn(string $name, string $localeCode): void
     {
         $this->getDocument()->fillField(
             sprintf('sylius_product_translations_%s_name', $localeCode), $name
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isProductOptionChosen($option)
+    public function isProductOptionChosen(string $option): bool
     {
         return $this->getElement('options')->find('named', ['option', $option])->hasAttribute('selected');
     }
 
-    /**
-     * @return bool
-     */
-    public function isProductOptionsDisabled()
+    public function isProductOptionsDisabled(): bool
     {
         return 'disabled' === $this->getElement('options')->getAttribute('disabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isMainTaxonChosen($taxonName)
+    public function isMainTaxonChosen(string $taxonName): bool
     {
         $this->openTaxonBookmarks();
         Assert::notNull($this->getDocument()->find('css', '.search > .text'));
@@ -64,10 +52,7 @@ class UpdateConfigurableProductPage extends BaseUpdatePage implements UpdateConf
         return $taxonName === $this->getDocument()->find('css', '.search > .text')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function selectMainTaxon(TaxonInterface $taxon)
+    public function selectMainTaxon(TaxonInterface $taxon): void
     {
         $this->openTaxonBookmarks();
 
@@ -82,18 +67,12 @@ class UpdateConfigurableProductPage extends BaseUpdatePage implements UpdateConf
         $itemSelected->click();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function checkChannel($channelName)
+    public function checkChannel(string $channelName): void
     {
         $this->getElement('channel_checkbox', ['%channel%' => $channelName])->check();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isImageWithTypeDisplayed($type)
+    public function isImageWithTypeDisplayed(string $type): bool
     {
         $imageElement = $this->getImageElementByType($type);
 
@@ -109,10 +88,7 @@ class UpdateConfigurableProductPage extends BaseUpdatePage implements UpdateConf
         return false === stripos($pageText, '404 Not Found');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function attachImage($path, $type = null)
+    public function attachImage(string $path, string $type = null): void
     {
         $this->clickTabIfItsNotActive('media');
 
@@ -128,10 +104,7 @@ class UpdateConfigurableProductPage extends BaseUpdatePage implements UpdateConf
         $imageForm->find('css', 'input[type="file"]')->attachFile($filesPath . $path);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function changeImageWithType($type, $path)
+    public function changeImageWithType(string $type, string $path): void
     {
         $filesPath = $this->getParameter('files_path');
 
@@ -139,10 +112,7 @@ class UpdateConfigurableProductPage extends BaseUpdatePage implements UpdateConf
         $imageForm->find('css', 'input[type="file"]')->attachFile($filesPath . $path);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function removeImageWithType($type)
+    public function removeImageWithType(string $type): void
     {
         $this->clickTabIfItsNotActive('media');
 
@@ -155,7 +125,7 @@ class UpdateConfigurableProductPage extends BaseUpdatePage implements UpdateConf
         $imageElement->clickLink('Delete');
     }
 
-    public function removeFirstImage()
+    public function removeFirstImage(): void
     {
         $this->clickTabIfItsNotActive('media');
         $imageElement = $this->getFirstImageElement();
@@ -172,10 +142,7 @@ class UpdateConfigurableProductPage extends BaseUpdatePage implements UpdateConf
         $imageElement->clickLink('Delete');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function modifyFirstImageType($type)
+    public function modifyFirstImageType(string $type): void
     {
         $this->clickTabIfItsNotActive('media');
 
@@ -183,27 +150,18 @@ class UpdateConfigurableProductPage extends BaseUpdatePage implements UpdateConf
         $this->setImageType($firstImage, $type);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function countImages()
+    public function countImages(): int
     {
         $imageElements = $this->getImageElements();
 
         return count($imageElements);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -221,15 +179,12 @@ class UpdateConfigurableProductPage extends BaseUpdatePage implements UpdateConf
         ]);
     }
 
-    private function openTaxonBookmarks()
+    private function openTaxonBookmarks(): void
     {
         $this->getElement('taxonomy')->click();
     }
 
-    /**
-     * @param string $tabName
-     */
-    private function clickTabIfItsNotActive($tabName)
+    private function clickTabIfItsNotActive(string $tabName): void
     {
         $attributesTab = $this->getElement('tab', ['%name%' => $tabName]);
         if (!$attributesTab->hasClass('active')) {
@@ -237,12 +192,7 @@ class UpdateConfigurableProductPage extends BaseUpdatePage implements UpdateConf
         }
     }
 
-    /**
-     * @param string $type
-     *
-     * @return NodeElement
-     */
-    private function getImageElementByType($type)
+    private function getImageElementByType(string $type): ?NodeElement
     {
         $images = $this->getElement('images');
         $typeInput = $images->find('css', 'input[value="' . $type . '"]');
@@ -257,17 +207,14 @@ class UpdateConfigurableProductPage extends BaseUpdatePage implements UpdateConf
     /**
      * @return NodeElement[]
      */
-    private function getImageElements()
+    private function getImageElements(): array
     {
         $images = $this->getElement('images');
 
         return $images->findAll('css', 'div[data-form-collection="item"]');
     }
 
-    /**
-     * @return NodeElement
-     */
-    private function getLastImageElement()
+    private function getLastImageElement(): NodeElement
     {
         $imageElements = $this->getImageElements();
 
@@ -276,10 +223,7 @@ class UpdateConfigurableProductPage extends BaseUpdatePage implements UpdateConf
         return end($imageElements);
     }
 
-    /**
-     * @return NodeElement
-     */
-    private function getFirstImageElement()
+    private function getFirstImageElement(): NodeElement
     {
         $imageElements = $this->getImageElements();
 
@@ -288,10 +232,7 @@ class UpdateConfigurableProductPage extends BaseUpdatePage implements UpdateConf
         return reset($imageElements);
     }
 
-    /**
-     * @param string $type
-     */
-    private function setImageType(NodeElement $imageElement, $type)
+    private function setImageType(NodeElement $imageElement, string $type): void
     {
         $typeField = $imageElement->findField('Type');
         $typeField->setValue($type);

--- a/src/Sylius/Behat/Page/Admin/Product/UpdateConfigurableProductPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/UpdateConfigurableProductPageInterface.php
@@ -18,74 +18,34 @@ use Sylius\Component\Taxonomy\Model\TaxonInterface;
 
 interface UpdateConfigurableProductPageInterface extends UpdatePageInterface
 {
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 
-    /**
-     * @param string $name
-     * @param string $localeCode
-     */
-    public function nameItIn($name, $localeCode);
+    public function nameItIn(string $name, string $localeCode): void;
 
-    /**
-     * @param string $option
-     */
-    public function isProductOptionChosen($option);
+    public function isProductOptionChosen(string $option): bool;
 
-    /**
-     * @return bool
-     */
-    public function isProductOptionsDisabled();
+    public function isProductOptionsDisabled(): bool;
 
-    /**
-     * @param string $taxonName
-     *
-     * @return bool
-     */
-    public function isMainTaxonChosen($taxonName);
+    public function isMainTaxonChosen(string $taxonName): bool;
 
-    public function selectMainTaxon(TaxonInterface $taxon);
+    public function selectMainTaxon(TaxonInterface $taxon): void;
 
-    /**
-     * @param string $channelName
-     */
-    public function checkChannel($channelName);
+    public function checkChannel(string $channelName): void;
 
-    /**
-     * @param string $type
-     *
-     * @return bool
-     */
-    public function isImageWithTypeDisplayed($type);
-
-    /**
-     * @param string $path
-     * @param string $type
-     */
-    public function attachImage($path, $type = null);
-
-    /**
-     * @param string $type
-     * @param string $path
-     */
-    public function changeImageWithType($type, $path);
+    public function isImageWithTypeDisplayed(string $type): bool;
 
     /**
      * @param string $type
      */
-    public function removeImageWithType($type);
+    public function attachImage(string $path, string $type = null): void;
 
-    public function removeFirstImage();
+    public function changeImageWithType(string $type, string $path): void;
 
-    /**
-     * @param string $type
-     */
-    public function modifyFirstImageType($type);
+    public function removeImageWithType(string $type): void;
 
-    /**
-     * @return int
-     */
-    public function countImages();
+    public function removeFirstImage(): void;
+
+    public function modifyFirstImageType(string $type): void;
+
+    public function countImages(): int;
 }

--- a/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPage.php
@@ -32,10 +32,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
     /** @var array */
     private $imageUrls = [];
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameItIn($name, $localeCode)
+    public function nameItIn(string $name, string $localeCode): void
     {
         $this->activateLanguageTab($localeCode);
         $this->getElement('name', ['%locale%' => $localeCode])->setValue($name);
@@ -48,23 +45,17 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyPrice($channelName, $price)
+    public function specifyPrice(string $channelName, string $price): void
     {
         $this->getElement('price', ['%channelName%' => $channelName])->setValue($price);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyOriginalPrice($channelName, $originalPrice)
+    public function specifyOriginalPrice(string $channelName, string $originalPrice): void
     {
         $this->getElement('original_price', ['%channelName%' => $channelName])->setValue($originalPrice);
     }
 
-    public function addSelectedAttributes()
+    public function addSelectedAttributes(): void
     {
         $this->clickTabIfItsNotActive('attributes');
         $this->getDocument()->pressButton('Add attributes');
@@ -76,20 +67,14 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         });
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function removeAttribute($attributeName, $localeCode)
+    public function removeAttribute(string $attributeName, string $localeCode): void
     {
         $this->clickTabIfItsNotActive('attributes');
 
         $this->getElement('attribute_delete_button', ['%attributeName%' => $attributeName, '$localeCode%' => $localeCode])->press();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getAttributeValue($attribute, $localeCode)
+    public function getAttributeValue(string $attribute, string $localeCode): string
     {
         $this->clickTabIfItsNotActive('attributes');
         $this->clickLocaleTabIfItsNotActive($localeCode);
@@ -97,10 +82,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         return $this->getElement('attribute', ['%attributeName%' => $attribute, '%localeCode%' => $localeCode])->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getAttributeValidationErrors($attributeName, $localeCode)
+    public function getAttributeValidationErrors(string $attributeName, string $localeCode): string
     {
         $this->clickTabIfItsNotActive('attributes');
         $this->clickLocaleTabIfItsNotActive($localeCode);
@@ -110,26 +92,17 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         return $validationError->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getNumberOfAttributes()
+    public function getNumberOfAttributes(): int
     {
         return count($this->getDocument()->findAll('css', '.attribute'));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasAttribute($attributeName)
+    public function hasAttribute(string $attributeName): bool
     {
         return null !== $this->getDocument()->find('css', sprintf('.attribute .label:contains("%s")', $attributeName));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function selectMainTaxon(TaxonInterface $taxon)
+    public function selectMainTaxon(TaxonInterface $taxon): void
     {
         $this->openTaxonBookmarks();
 
@@ -138,38 +111,29 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         AutocompleteHelper::chooseValue($this->getSession(), $mainTaxonElement, $taxon->getName());
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isMainTaxonChosen($taxonName)
+    public function isMainTaxonChosen(string $taxonName): bool
     {
         $this->openTaxonBookmarks();
 
         return $taxonName === $this->getDocument()->find('css', '.search > .text')->getText();
     }
 
-    public function disableTracking()
+    public function disableTracking(): void
     {
         $this->getElement('tracked')->uncheck();
     }
 
-    public function enableTracking()
+    public function enableTracking(): void
     {
         $this->getElement('tracked')->check();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isTracked()
+    public function isTracked(): bool
     {
         return $this->getElement('tracked')->isChecked();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function enableSlugModification($locale)
+    public function enableSlugModification(string $locale): void
     {
         SlugGenerationHelper::enableSlugModification(
             $this->getSession(),
@@ -177,10 +141,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isImageWithTypeDisplayed($type)
+    public function isImageWithTypeDisplayed(string $type): bool
     {
         $imageElement = $this->getImageElementByType($type);
 
@@ -196,10 +157,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         return false === stripos($pageText, '404 Not Found');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function attachImage($path, $type = null)
+    public function attachImage(string $path, string $type = null): void
     {
         $this->clickTabIfItsNotActive('media');
 
@@ -215,10 +173,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         $imageForm->find('css', 'input[type="file"]')->attachFile($filesPath . $path);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function changeImageWithType($type, $path)
+    public function changeImageWithType(string $type, string $path): void
     {
         $filesPath = $this->getParameter('files_path');
 
@@ -226,10 +181,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         $imageForm->find('css', 'input[type="file"]')->attachFile($filesPath . $path);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function removeImageWithType($type)
+    public function removeImageWithType(string $type): void
     {
         $this->clickTabIfItsNotActive('media');
 
@@ -242,7 +194,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         $imageElement->clickLink('Delete');
     }
 
-    public function removeFirstImage()
+    public function removeFirstImage(): void
     {
         $this->clickTabIfItsNotActive('media');
         $imageElement = $this->getFirstImageElement();
@@ -258,10 +210,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         $imageElement->clickLink('Delete');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function modifyFirstImageType($type)
+    public function modifyFirstImageType(string $type): void
     {
         $this->clickTabIfItsNotActive('media');
 
@@ -269,20 +218,14 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         $this->setImageType($firstImage, $type);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function countImages()
+    public function countImages(): int
     {
         $imageElements = $this->getImageElements();
 
         return count($imageElements);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isSlugReadonlyIn($locale)
+    public function isSlugReadonlyIn(string $locale): bool
     {
         return SlugGenerationHelper::isSlugReadonly(
             $this->getSession(),
@@ -290,10 +233,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function associateProducts(ProductAssociationTypeInterface $productAssociationType, array $productsNames)
+    public function associateProducts(ProductAssociationTypeInterface $productAssociationType, array $productsNames): void
     {
         $this->clickTab('associations');
 
@@ -320,10 +260,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasAssociatedProduct($productName, ProductAssociationTypeInterface $productAssociationType)
+    public function hasAssociatedProduct(string $productName, ProductAssociationTypeInterface $productAssociationType): bool
     {
         $this->clickTabIfItsNotActive('associations');
 
@@ -333,10 +270,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function removeAssociatedProduct($productName, ProductAssociationTypeInterface $productAssociationType)
+    public function removeAssociatedProduct(string $productName, ProductAssociationTypeInterface $productAssociationType): void
     {
         $this->clickTabIfItsNotActive('associations');
 
@@ -350,10 +284,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         $deleteIcon->click();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPricingConfigurationForChannelAndCurrencyCalculator(ChannelInterface $channel, CurrencyInterface $currency)
+    public function getPricingConfigurationForChannelAndCurrencyCalculator(ChannelInterface $channel, CurrencyInterface $currency): string
     {
         $priceConfigurationElement = $this->getElement('pricing_configuration');
         $priceElement = $priceConfigurationElement
@@ -362,30 +293,21 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         return $priceElement->find('css', 'input')->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getSlug($locale)
+    public function getSlug(string $locale): string
     {
         $this->activateLanguageTab($locale);
 
         return $this->getElement('slug', ['%locale%' => $locale])->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifySlugIn($slug, $locale)
+    public function specifySlugIn(string $slug, string $locale): void
     {
         $this->activateLanguageTab($locale);
 
         $this->getElement('slug', ['%locale%' => $locale])->setValue($slug);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function activateLanguageTab($locale)
+    public function activateLanguageTab(string $locale): void
     {
         if (!$this->getDriver() instanceof Selenium2Driver) {
             return;
@@ -397,38 +319,26 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         }
     }
 
-    public function getPriceForChannel($channelName)
+    public function getPriceForChannel(string $channelName): string
     {
         return $this->getElement('price', ['%channelName%' => $channelName])->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getOriginalPriceForChannel($channelName)
+    public function getOriginalPriceForChannel(string $channelName): string
     {
         return $this->getElement('original_price', ['%channelName%' => $channelName])->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isShippingRequired()
+    public function isShippingRequired(): bool
     {
         return $this->getElement('shipping_required')->isChecked();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getElement(string $name, array $parameters = []): NodeElement
     {
         if (!isset($parameters['%locale%'])) {
@@ -438,9 +348,6 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         return parent::getElement($name, $parameters);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -468,15 +375,12 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         ]);
     }
 
-    private function openTaxonBookmarks()
+    private function openTaxonBookmarks(): void
     {
         $this->getElement('taxonomy')->click();
     }
 
-    /**
-     * @param string $tabName
-     */
-    private function clickTabIfItsNotActive($tabName)
+    private function clickTabIfItsNotActive(string $tabName): void
     {
         $attributesTab = $this->getElement('tab', ['%name%' => $tabName]);
         if (!$attributesTab->hasClass('active')) {
@@ -484,19 +388,13 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         }
     }
 
-    /**
-     * @param string $tabName
-     */
-    private function clickTab($tabName)
+    private function clickTab(string $tabName): void
     {
         $attributesTab = $this->getElement('tab', ['%name%' => $tabName]);
         $attributesTab->click();
     }
 
-    /**
-     * @param string $localeCode
-     */
-    private function clickLocaleTabIfItsNotActive($localeCode)
+    private function clickLocaleTabIfItsNotActive(string $localeCode): void
     {
         $localeTab = $this->getElement('locale_tab', ['%localeCode%' => $localeCode]);
         if (!$localeTab->hasClass('active')) {
@@ -504,12 +402,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         }
     }
 
-    /**
-     * @param string $type
-     *
-     * @return NodeElement
-     */
-    private function getImageElementByType($type)
+    private function getImageElementByType(string $type): ?NodeElement
     {
         $images = $this->getElement('images');
         $typeInput = $images->find('css', 'input[value="' . $type . '"]');
@@ -524,17 +417,14 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
     /**
      * @return NodeElement[]
      */
-    private function getImageElements()
+    private function getImageElements(): array
     {
         $images = $this->getElement('images');
 
         return $images->findAll('css', 'div[data-form-collection="item"]');
     }
 
-    /**
-     * @return NodeElement
-     */
-    private function getLastImageElement()
+    private function getLastImageElement(): NodeElement
     {
         $imageElements = $this->getImageElements();
 
@@ -543,10 +433,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         return end($imageElements);
     }
 
-    /**
-     * @return NodeElement
-     */
-    private function getFirstImageElement()
+    private function getFirstImageElement(): NodeElement
     {
         $imageElements = $this->getImageElements();
 
@@ -555,10 +442,7 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         return reset($imageElements);
     }
 
-    /**
-     * @param string $type
-     */
-    private function setImageType(NodeElement $imageElement, $type)
+    private function setImageType(NodeElement $imageElement, string $type): void
     {
         $typeField = $imageElement->findField('Type');
         $typeField->setValue($type);

--- a/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPageInterface.php
@@ -21,187 +21,77 @@ use Sylius\Component\Product\Model\ProductAssociationTypeInterface;
 
 interface UpdateSimpleProductPageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 
-    /**
-     * @param string $locale
-     *
-     * @return bool
-     */
-    public function isSlugReadonlyIn($locale);
+    public function isSlugReadonlyIn(string $locale): bool;
 
-    /**
-     * @param string $channelName
-     * @param int $price
-     */
-    public function specifyPrice($channelName, $price);
+    public function specifyPrice(string $channelName, string $price): void;
 
-    /**
-     * @param string $channelName
-     * @param int $originalPrice
-     */
-    public function specifyOriginalPrice($channelName, $originalPrice);
+    public function specifyOriginalPrice(string $channelName, string $originalPrice): void;
 
-    /**
-     * @param string $name
-     * @param string $localeCode
-     */
-    public function nameItIn($name, $localeCode);
+    public function nameItIn(string $name, string $localeCode): void;
 
-    public function addSelectedAttributes();
+    public function addSelectedAttributes(): void;
 
-    /**
-     * @param string $attributeName
-     * @param string $localeCode
-     */
-    public function removeAttribute($attributeName, $localeCode);
+    public function removeAttribute(string $attributeName, string $localeCode): void;
 
-    /**
-     * @param string $attributeName
-     * @param string $localeCode
-     *
-     * @return string
-     */
-    public function getAttributeValue($attributeName, $localeCode);
+    public function getAttributeValue(string $attributeName, string $localeCode): string;
 
-    /**
-     * @param string $attributeName
-     * @param string $localeCode
-     *
-     * @return string
-     */
-    public function getAttributeValidationErrors($attributeName, $localeCode);
+    public function getAttributeValidationErrors(string $attributeName, string $localeCode): string;
 
-    /**
-     * @return int
-     */
-    public function getNumberOfAttributes();
+    public function getNumberOfAttributes(): int;
 
-    /**
-     * @param string $attributeName
-     *
-     * @return bool
-     */
-    public function hasAttribute($attributeName);
+    public function hasAttribute(string $attributeName): bool;
 
-    /**
-     * @param string $taxonName
-     *
-     * @return bool
-     */
-    public function isMainTaxonChosen($taxonName);
+    public function isMainTaxonChosen(string $taxonName): bool;
 
-    public function selectMainTaxon(TaxonInterface $taxon);
+    public function selectMainTaxon(TaxonInterface $taxon): void;
 
-    public function disableTracking();
+    public function disableTracking(): void;
 
-    public function enableTracking();
+    public function enableTracking(): void;
 
-    /**
-     * @return bool
-     */
-    public function isTracked();
+    public function isTracked(): bool;
 
-    /**
-     * @param string $locale
-     */
-    public function enableSlugModification($locale);
+    public function enableSlugModification(string $locale): void;
 
-    /**
-     * @param string $type
-     *
-     * @return bool
-     */
-    public function isImageWithTypeDisplayed($type);
-
-    /**
-     * @param string $path
-     * @param string $type
-     */
-    public function attachImage($path, $type = null);
-
-    /**
-     * @param string $type
-     * @param string $path
-     */
-    public function changeImageWithType($type, $path);
+    public function isImageWithTypeDisplayed(string $type): bool;
 
     /**
      * @param string $type
      */
-    public function removeImageWithType($type);
+    public function attachImage(string $path, string $type = null): void;
 
-    public function removeFirstImage();
+    public function changeImageWithType(string $type, string $path): void;
 
-    /**
-     * @param string $type
-     */
-    public function modifyFirstImageType($type);
+    public function removeImageWithType(string $type): void;
 
-    /**
-     * @return int
-     */
-    public function countImages();
+    public function removeFirstImage(): void;
+
+    public function modifyFirstImageType(string $type): void;
+
+    public function countImages(): int;
 
     /**
      * @param string[] $productsNames
      */
-    public function associateProducts(ProductAssociationTypeInterface $productAssociationType, array $productsNames);
+    public function associateProducts(ProductAssociationTypeInterface $productAssociationType, array $productsNames): void;
 
-    /**
-     * @param string $productName
-     *
-     * @return bool
-     */
-    public function hasAssociatedProduct($productName, ProductAssociationTypeInterface $productAssociationType);
+    public function hasAssociatedProduct(string $productName, ProductAssociationTypeInterface $productAssociationType): bool;
 
-    /**
-     * @param string $productName
-     */
-    public function removeAssociatedProduct($productName, ProductAssociationTypeInterface $productAssociationType);
+    public function removeAssociatedProduct(string $productName, ProductAssociationTypeInterface $productAssociationType): void;
 
-    /**
-     * @return string
-     */
-    public function getPricingConfigurationForChannelAndCurrencyCalculator(ChannelInterface $channel, CurrencyInterface $currency);
+    public function getPricingConfigurationForChannelAndCurrencyCalculator(ChannelInterface $channel, CurrencyInterface $currency): string;
 
-    /**
-     * @param string $locale
-     */
-    public function activateLanguageTab($locale);
+    public function activateLanguageTab(string $locale): void;
 
-    /**
-     * @param string $locale
-     *
-     * @return string
-     */
-    public function getSlug($locale);
+    public function getSlug(string $locale): string;
 
-    /**
-     * @param string $slug
-     * @param string $locale
-     */
-    public function specifySlugIn($slug, $locale);
+    public function specifySlugIn(string $slug, string $locale): void;
 
-    /**
-     * @param string $channelName
-     *
-     * @return string
-     */
-    public function getPriceForChannel($channelName);
+    public function getPriceForChannel(string $channelName): string;
 
-    /**
-     * @param string $channelName
-     *
-     * @return string
-     */
-    public function getOriginalPriceForChannel($channelName);
+    public function getOriginalPriceForChannel(string $channelName): string;
 
-    /**
-     * @return bool
-     */
-    public function isShippingRequired();
+    public function isShippingRequired(): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/ProductAssociationType/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductAssociationType/CreatePage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\ProductAssociationType;
 
+use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\SpecifiesItsCode;
 use Sylius\Behat\Page\Admin\Crud\CreatePage as BaseCreatePage;
 
@@ -20,27 +21,18 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
     use SpecifiesItsCode;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameItIn($name, $language)
+    public function nameItIn(string $name, string $language): void
     {
         $this->getDocument()->fillField(
             sprintf('sylius_product_association_type_translations_%s_name', $language), $name
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ProductAssociationType/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductAssociationType/CreatePageInterface.php
@@ -17,14 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
+    public function specifyCode(string $code): void;
 
-    /**
-     * @param string $name
-     * @param string $language
-     */
-    public function nameItIn($name, $language);
+    public function nameItIn(string $name, string $language): void;
 }

--- a/src/Sylius/Behat/Page/Admin/ProductAssociationType/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductAssociationType/IndexPage.php
@@ -17,18 +17,12 @@ use Sylius\Behat\Page\Admin\Crud\IndexPage as BaseIndexPage;
 
 class IndexPage extends BaseIndexPage implements IndexPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyFilterType($field, $type)
+    public function specifyFilterType(string $field, string $type): void
     {
         $this->getDocument()->fillField(sprintf('criteria_%s_value', $field), $type);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyFilterValue($field, $value)
+    public function specifyFilterValue(string $field, string $value): void
     {
         $this->getDocument()->fillField(sprintf('criteria_%s_value', $field), $value);
     }

--- a/src/Sylius/Behat/Page/Admin/ProductAssociationType/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductAssociationType/IndexPageInterface.php
@@ -17,15 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\IndexPageInterface as BaseIndexPageInterface;
 
 interface IndexPageInterface extends BaseIndexPageInterface
 {
-    /**
-     * @param string $field
-     * @param string $type
-     */
-    public function specifyFilterType($field, $type);
+    public function specifyFilterType(string $field, string $type): void;
 
-    /**
-     * @param string $field
-     * @param string $value
-     */
-    public function specifyFilterValue($field, $value);
+    public function specifyFilterValue(string $field, string $value): void;
 }

--- a/src/Sylius/Behat/Page/Admin/ProductAssociationType/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductAssociationType/UpdatePage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\ProductAssociationType;
 
+use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\ChecksCodeImmutability;
 use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
 
@@ -20,35 +21,23 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
     use ChecksCodeImmutability;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameItIn($name, $language)
+    public function nameItIn(string $name, string $language): void
     {
         $this->getDocument()->fillField(
             sprintf('sylius_product_association_type_translations_%s_name', $language), $name
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameIt($name)
+    public function nameIt($name): void
     {
         $this->getElement('name')->setValue($name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ProductAssociationType/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductAssociationType/UpdatePageInterface.php
@@ -17,14 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @param string $name
-     * @param string $languageCode
-     */
-    public function nameItIn($name, $languageCode);
+    public function nameItIn(string $name, string $languageCode): void;
 
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/ProductAttribute/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductAttribute/CreatePage.php
@@ -24,25 +24,16 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     /** @var int */
     private $choiceListIndex = 0;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameIt($name, $language)
+    public function nameIt(string $name, string $language): void
     {
         $this->getDocument()->fillField(sprintf('sylius_product_attribute_translations_%s_name', $language), $name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isTypeDisabled()
+    public function isTypeDisabled(): bool
     {
         return 'disabled' === $this->getElement('type')->getAttribute('disabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function addAttributeValue(string $value, string $localeCode): void
     {
         $this->getDocument()->clickLink('Add');
@@ -56,17 +47,11 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         ++$this->choiceListIndex;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function specifyMinValue(int $min): void
     {
         $this->getElement('min')->setValue($min);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function specifyMaxValue(int $max): void
     {
         $this->getElement('max')->setValue($max);
@@ -77,9 +62,6 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $this->getElement('multiple')->click();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getValidationErrors(): string
     {
         $validationMessage = $this->getDocument()->find('css', '.sylius-validation-error');
@@ -90,9 +72,6 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         return $validationMessage->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ProductAttribute/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductAttribute/CreatePageInterface.php
@@ -18,21 +18,11 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
+    public function specifyCode(string $code): void;
 
-    /**
-     * @param string $name
-     * @param string $language
-     */
-    public function nameIt($name, $language);
+    public function nameIt(string $name, string $language): void;
 
-    /**
-     * @return bool
-     */
-    public function isTypeDisabled();
+    public function isTypeDisabled(): bool;
 
     public function addAttributeValue(string $value, string $localeCode): void;
 

--- a/src/Sylius/Behat/Page/Admin/ProductAttribute/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductAttribute/UpdatePage.php
@@ -22,49 +22,31 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
     use ChecksCodeImmutability;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function changeName($name, $language)
+    public function changeName(string $name, string $language): void
     {
         $this->getDocument()->fillField(sprintf('sylius_product_attribute_translations_%s_name', $language), $name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isTypeDisabled()
+    public function isTypeDisabled(): bool
     {
         return 'disabled' === $this->getElement('type')->getAttribute('disabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function changeAttributeValue(string $oldValue, string $newValue): void
     {
         $this->getElement('attribute_choice_list_element', ['%value%' => $oldValue])->setValue($newValue);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function hasAttributeValue(string $value): bool
     {
         return $this->hasElement('attribute_choice_list_element', ['%value%' => $value]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function addAttributeValue(string $value, string $localeCode): void
     {
         $this->getDocument()->clickLink('Add');
@@ -75,9 +57,6 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function deleteAttributeValue(string $value): void
     {
         $attributeChoiceElement = $this
@@ -87,9 +66,6 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         $attributeChoiceElement->clickLink('Delete');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ProductAttribute/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductAttribute/UpdatePageInterface.php
@@ -17,21 +17,11 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @param string $name
-     * @param string $language
-     */
-    public function changeName($name, $language);
+    public function changeName(string $name, string $language): void;
 
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 
-    /**
-     * @return bool
-     */
-    public function isTypeDisabled();
+    public function isTypeDisabled(): bool;
 
     public function changeAttributeValue(string $oldValue, string $newValue): void;
 

--- a/src/Sylius/Behat/Page/Admin/ProductOption/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductOption/CreatePage.php
@@ -23,20 +23,14 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
     use SpecifiesItsCode;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameItIn($name, $language)
+    public function nameItIn(string $name, string $language): void
     {
         $this->getDocument()->fillField(
             sprintf('sylius_product_option_translations_%s_name', $language), $name
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function addOptionValue($code, $value)
+    public function addOptionValue(string $code, string $value): void
     {
         $this->getDocument()->clickLink('Add value');
 
@@ -46,10 +40,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $optionValueForm->fillField('English (United States)', $value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function checkValidationMessageForOptionValues($message)
+    public function checkValidationMessageForOptionValues(string $message): bool
     {
         $optionValuesValidationElement = $this->getElement('values_validation')->find('css', '.sylius-validation-error');
         if (null === $optionValuesValidationElement) {
@@ -59,9 +50,6 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         return $optionValuesValidationElement->getText() === $message;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ProductOption/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductOption/CreatePageInterface.php
@@ -17,25 +17,11 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
+    public function specifyCode(string $code): void;
 
-    /**
-     * @param string $name
-     * @param string $language
-     */
-    public function nameItIn($name, $language);
+    public function nameItIn(string $name, string $language): void;
 
-    /**
-     * @param string $code
-     * @param string $value
-     */
-    public function addOptionValue($code, $value);
+    public function addOptionValue(string $code, string $value): void;
 
-    /**
-     * @param string $message
-     */
-    public function checkValidationMessageForOptionValues($message);
+    public function checkValidationMessageForOptionValues(string $message): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/ProductOption/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductOption/UpdatePage.php
@@ -22,30 +22,21 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
     use ChecksCodeImmutability;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameItIn($name, $language)
+    public function nameItIn(string $name, string $language): void
     {
         $this->getDocument()->fillField(
             sprintf('sylius_product_option_translations_%s_name', $language), $name
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isThereOptionValue($optionValue)
+    public function isThereOptionValue(string $optionValue): bool
     {
         $optionValues = $this->getElement('values');
 
         return $optionValues->has('css', sprintf('input[value="%s"]', $optionValue));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function addOptionValue($code, $value)
+    public function addOptionValue(string $code, string $value): void
     {
         $this->getDocument()->clickLink('Add value');
 
@@ -55,10 +46,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         $optionValueForm->fillField('English (United States)', $value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function removeOptionValue($optionValue)
+    public function removeOptionValue(string $optionValue): void
     {
         if ($this->isThereOptionValue($optionValue)) {
             $optionValues = $this->getElement('values');
@@ -74,17 +62,11 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ProductOption/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductOption/UpdatePageInterface.php
@@ -17,30 +17,13 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 
-    /**
-     * @param string $name
-     * @param string $languageCode
-     */
-    public function nameItIn($name, $languageCode);
+    public function nameItIn(string $name, string $languageCode): void;
 
-    /**
-     * @param string $optionValue
-     */
-    public function isThereOptionValue($optionValue);
+    public function isThereOptionValue(string $optionValue): bool;
 
-    /**
-     * @param string $code
-     * @param string $value
-     */
-    public function addOptionValue($code, $value);
+    public function addOptionValue(string $code, string $value): void;
 
-    /**
-     * @param string $optionValue
-     */
-    public function removeOptionValue($optionValue);
+    public function removeOptionValue(string $optionValue): void;
 }

--- a/src/Sylius/Behat/Page/Admin/ProductReview/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductReview/IndexPage.php
@@ -18,26 +18,17 @@ use Sylius\Behat\Page\Admin\Crud\IndexPage as BaseIndexPage;
 
 class IndexPage extends BaseIndexPage implements IndexPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function accept(array $parameters)
+    public function accept(array $parameters): void
     {
         $this->getActionButtonsField($parameters)->pressButton('Accept');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function reject(array $parameters)
+    public function reject(array $parameters): void
     {
         $this->getActionButtonsField($parameters)->pressButton('Reject');
     }
 
-    /**
-     * @return NodeElement
-     */
-    private function getActionButtonsField(array $parameters)
+    private function getActionButtonsField(array $parameters): NodeElement
     {
         $tableAccessor = $this->getTableAccessor();
         $table = $this->getElement('table');

--- a/src/Sylius/Behat/Page/Admin/ProductReview/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductReview/IndexPageInterface.php
@@ -17,7 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\IndexPageInterface as BaseIndexPageInterface;
 
 interface IndexPageInterface extends BaseIndexPageInterface
 {
-    public function accept(array $parameters);
+    public function accept(array $parameters): void;
 
-    public function reject(array $parameters);
+    public function reject(array $parameters): void;
 }

--- a/src/Sylius/Behat/Page/Admin/ProductReview/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductReview/UpdatePage.php
@@ -17,59 +17,38 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
 
 class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyTitle($title)
+    public function specifyTitle(string $title): void
     {
         $this->getElement('title')->setValue($title);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyComment($comment)
+    public function specifyComment(string $comment): void
     {
         $this->getElement('comment')->setValue($comment);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseRating($rating)
+    public function chooseRating(string $rating): void
     {
         $position = (int) $rating - 1;
 
         $this->getElement('rating', ['%position%' => $position])->getParent()->click();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getRating()
+    public function getRating(): string
     {
         return $this->getElement('checked_rating')->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getProductName()
+    public function getProductName(): string
     {
         return $this->getElement('product_name')->getHtml();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getCustomerName()
+    public function getCustomerName(): string
     {
         return $this->getElement('customer_name')->getHtml();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ProductReview/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductReview/UpdatePageInterface.php
@@ -17,33 +17,15 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @param string $title
-     */
-    public function specifyTitle($title);
+    public function specifyTitle(string $title): void;
 
-    /**
-     * @param string $comment
-     */
-    public function specifyComment($comment);
+    public function specifyComment(string $comment): void;
 
-    /**
-     * @param string $rating
-     */
-    public function chooseRating($rating);
+    public function chooseRating(string $rating): void;
 
-    /**
-     * @return string
-     */
-    public function getRating();
+    public function getRating(): string;
 
-    /**
-     * @return string
-     */
-    public function getProductName();
+    public function getProductName(): string;
 
-    /**
-     * @return string
-     */
-    public function getCustomerName();
+    public function getCustomerName(): string;
 }

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/CreatePage.php
@@ -21,34 +21,22 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
     use SpecifiesItsCode;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyPrice($price, $channelName)
+    public function specifyPrice(string $price, string $channelName): void
     {
         $this->getElement('price', ['%channelName%' => $channelName])->setValue($price);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyOriginalPrice($originalPrice, $channelName)
+    public function specifyOriginalPrice(string $originalPrice, string $channelName): void
     {
         $this->getElement('original_price', ['%channelName%' => $channelName])->setValue($originalPrice);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyCurrentStock($currentStock)
+    public function specifyCurrentStock(string $currentStock): void
     {
         $this->getDocument()->fillField('Current stock', $currentStock);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyHeightWidthDepthAndWeight($height, $width, $depth, $weight)
+    public function specifyHeightWidthDepthAndWeight(string $height, string $width, string $depth, string $weight): void
     {
         $this->getDocument()->fillField('Height', $height);
         $this->getDocument()->fillField('Width', $width);
@@ -56,37 +44,25 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $this->getDocument()->fillField('Weight', $weight);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameItIn($name, $language)
+    public function nameItIn(string $name, string $language): void
     {
         $this->getDocument()->fillField(
             sprintf('sylius_product_variant_translations_%s_name', $language), $name
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function selectOption($optionName, $optionValue)
+    public function selectOption(string $optionName, string $optionValue): void
     {
         $optionName = strtoupper($optionName);
         $this->getElement('option_select', ['%option-name%' => $optionName])->selectOption($optionValue);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function choosePricingCalculator($name)
+    public function choosePricingCalculator(string $name): void
     {
         $this->getElement('price_calculator')->selectOption($name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getValidationMessageForForm()
+    public function getValidationMessageForForm(): string
     {
         $formElement = $this->getDocument()->find('css', 'form[name="sylius_product_variant"]');
         if (null === $formElement) {
@@ -101,26 +77,17 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         return $validationMessage->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function selectShippingCategory($shippingCategoryName)
+    public function selectShippingCategory(string $shippingCategoryName): void
     {
         $this->getElement('shipping_category')->selectOption($shippingCategoryName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPricesValidationMessage()
+    public function getPricesValidationMessage(): string
     {
         return $this->getElement('prices_validation_message')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setShippingRequired($isShippingRequired)
+    public function setShippingRequired(bool $isShippingRequired): void
     {
         if ($isShippingRequired) {
             $this->getElement('shipping_required')->check();
@@ -131,9 +98,6 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $this->getElement('shipping_required')->uncheck();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/CreatePageInterface.php
@@ -17,70 +17,27 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @param int $price
-     * @param string $channelName
-     */
-    public function specifyPrice($price, $channelName);
+    public function specifyPrice(string $price, string $channelName): void;
 
-    /**
-     * @param int $originalPrice
-     * @param string $channelName
-     */
-    public function specifyOriginalPrice($originalPrice, $channelName);
+    public function specifyOriginalPrice(string $originalPrice, string $channelName): void;
 
-    /**
-     * @param int $height
-     * @param int $width
-     * @param int $depth
-     * @param int $weight
-     */
-    public function specifyHeightWidthDepthAndWeight($height, $width, $depth, $weight);
+    public function specifyHeightWidthDepthAndWeight(string $height, string $width, string $depth, string $weight): void;
 
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
+    public function specifyCode(string $code): void;
 
-    /**
-     * @param int $currentStock
-     */
-    public function specifyCurrentStock($currentStock);
+    public function specifyCurrentStock(string $currentStock): void;
 
-    /**
-     * @param string $name
-     * @param string $language
-     */
-    public function nameItIn($name, $language);
+    public function nameItIn(string $name, string $language): void;
 
-    /**
-     * @param string $optionName
-     * @param string $optionValue
-     */
-    public function selectOption($optionName, $optionValue);
+    public function selectOption(string $optionName, string $optionValue): void;
 
-    /**
-     * @param string $name
-     */
-    public function choosePricingCalculator($name);
+    public function choosePricingCalculator(string $name): void;
 
-    /**
-     * @return string
-     */
-    public function getValidationMessageForForm();
+    public function getValidationMessageForForm(): string;
 
-    /**
-     * @param string $shippingCategoryName
-     */
-    public function selectShippingCategory($shippingCategoryName);
+    public function selectShippingCategory(string $shippingCategoryName): void;
 
-    /**
-     * @return string
-     */
-    public function getPricesValidationMessage();
+    public function getPricesValidationMessage(): string;
 
-    /**
-     * @param bool $isShippingRequired
-     */
-    public function setShippingRequired($isShippingRequired);
+    public function setShippingRequired(bool $isShippingRequired): void;
 }

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/GeneratePage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/GeneratePage.php
@@ -19,72 +19,49 @@ use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
 
 class GeneratePage extends SymfonyPage implements GeneratePageInterface
 {
-    public function generate()
+    public function generate(): void
     {
         $this->getDocument()->pressButton('Generate');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyPrice($nth, $price, $channelName)
+    public function specifyPrice(int $nth, int $price, string $channelName): void
     {
         $this->getElement('price', ['%position%' => $nth, '%channelName%' => $channelName])->setValue($price);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyCode($nth, $code)
+    public function specifyCode(int $nth, string $code): void
     {
         $this->getDocument()->fillField(sprintf('sylius_product_generate_variants_variants_%s_code', $nth), $code);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function removeVariant($nth)
+    public function removeVariant(int $nth): void
     {
         $item = $this->getDocument()->find('css', sprintf('div[data-form-collection-index="%s"]', $nth));
 
         $item->clickLink('Delete');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getRouteName(): string
     {
         return 'sylius_admin_product_variant_generate';
     }
 
     /**
-     * {@inheritdoc}
-     *
      * @throws ElementNotFoundException
      */
-    public function getValidationMessage($element, $position)
+    public function getValidationMessage(string $element, int $position): string
     {
         $foundElement = $this->getElement($element, ['%position%' => $position]);
         $validatedField = $this->getValidatedField($foundElement);
-        if (null === $validatedField) {
-            throw new ElementNotFoundException($this->getSession(), 'Element', 'css', $foundElement);
-        }
 
         return $validatedField->find('css', '.sylius-validation-error')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPricesValidationMessage($position)
+    public function getPricesValidationMessage(int $position): string
     {
         return $this->getElement('prices_validation_message', ['%position%' => $position])->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -95,11 +72,9 @@ class GeneratePage extends SymfonyPage implements GeneratePageInterface
     }
 
     /**
-     * @return NodeElement
-     *
      * @throws ElementNotFoundException
      */
-    private function getValidatedField(NodeElement $element)
+    private function getValidatedField(NodeElement $element): NodeElement
     {
         while (null !== $element && !$element->hasClass('field')) {
             $element = $element->getParent();

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/GeneratePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/GeneratePageInterface.php
@@ -17,38 +17,15 @@ use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 
 interface GeneratePageInterface extends SymfonyPageInterface
 {
-    public function generate();
+    public function generate(): void;
 
-    /**
-     * @param int $nth
-     * @param int $price
-     * @param string $channelName
-     */
-    public function specifyPrice($nth, $price, $channelName);
+    public function specifyPrice(int $nth, int $price, string $channelName): void;
 
-    /**
-     * @param int $nth
-     * @param string $code
-     */
-    public function specifyCode($nth, $code);
+    public function specifyCode(int $nth, string $code): void;
 
-    /**
-     * @param int $nth
-     */
-    public function removeVariant($nth);
+    public function removeVariant(int $nth): void;
 
-    /**
-     * @param string $element
-     * @param int $position
-     *
-     * @return string
-     */
-    public function getValidationMessage($element, $position);
+    public function getValidationMessage(string $element, int $position): string;
 
-    /**
-     * @param string $position
-     *
-     * @return string
-     */
-    public function getPricesValidationMessage($position);
+    public function getPricesValidationMessage(int $position): string;
 }

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/IndexPage.php
@@ -21,18 +21,12 @@ use Webmozart\Assert\Assert;
 
 final class IndexPage extends BaseIndexPage implements IndexPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getOnHandQuantityFor(ProductVariantInterface $productVariant)
+    public function getOnHandQuantityFor(ProductVariantInterface $productVariant): int
     {
         return (int) $this->getElement('on_hand_quantity', ['%id%' => $productVariant->getId()])->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getOnHoldQuantityFor(ProductVariantInterface $productVariant)
+    public function getOnHoldQuantityFor(ProductVariantInterface $productVariant): int
     {
         try {
             return (int) $this->getElement('on_hold_quantity', ['%id%' => $productVariant->getId()])->getText();
@@ -41,10 +35,7 @@ final class IndexPage extends BaseIndexPage implements IndexPageInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setPosition($name, $position)
+    public function setPosition(string $name, int $position): void
     {
         /** @var NodeElement $productVariantsRow */
         $productVariantsRow = $this->getElement('table')->find('css', sprintf('tbody > tr:contains("%s")', $name));
@@ -55,7 +46,7 @@ final class IndexPage extends BaseIndexPage implements IndexPageInterface
         $productVariantPosition->setValue($position);
     }
 
-    public function savePositions()
+    public function savePositions(): void
     {
         $this->getElement('save_configuration_button')->press();
 
@@ -64,9 +55,6 @@ final class IndexPage extends BaseIndexPage implements IndexPageInterface
         });
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/IndexPageInterface.php
@@ -18,21 +18,11 @@ use Sylius\Component\Core\Model\ProductVariantInterface;
 
 interface IndexPageInterface extends BaseIndexPageInterface
 {
-    /**
-     * @return int
-     */
-    public function getOnHandQuantityFor(ProductVariantInterface $productVariant);
+    public function getOnHandQuantityFor(ProductVariantInterface $productVariant): int;
 
-    /**
-     * @return int
-     */
-    public function getOnHoldQuantityFor(ProductVariantInterface $productVariant);
+    public function getOnHoldQuantityFor(ProductVariantInterface $productVariant): int;
 
-    /**
-     * @param string $name
-     * @param int $position
-     */
-    public function setPosition($name, $position);
+    public function setPosition(string $name, int $position): void;
 
-    public function savePositions();
+    public function savePositions(): void;
 }

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/UpdatePage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\ProductVariant;
 
+use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\ChecksCodeImmutability;
 use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
 use Sylius\Component\Core\Model\ChannelInterface;
@@ -22,93 +23,63 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
     use ChecksCodeImmutability;
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyPrice($price)
+    public function specifyPrice(int $price): void
     {
         $this->getDocument()->fillField('Price', $price);
     }
 
-    public function disableTracking()
+    public function disableTracking(): void
     {
         $this->getElement('tracked')->uncheck();
     }
 
-    public function enableTracking()
+    public function enableTracking(): void
     {
         $this->getElement('tracked')->check();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isTracked()
+    public function isTracked(): bool
     {
         return $this->getElement('tracked')->isChecked();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPricingConfigurationForChannelAndCurrencyCalculator(ChannelInterface $channel, CurrencyInterface $currency)
+    public function getPricingConfigurationForChannelAndCurrencyCalculator(ChannelInterface $channel, CurrencyInterface $currency): string
     {
         $priceElement = $this->getElement('pricing_configuration')->find('css', sprintf('label:contains("%s %s")', $channel->getCode(), $currency->getCode()))->getParent();
 
         return $priceElement->find('css', 'input')->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPriceForChannel($channelName)
+    public function getPriceForChannel(string $channelName): string
     {
         return $this->getElement('price', ['%channelName%' => $channelName])->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getOriginalPriceForChannel($channelName)
+    public function getOriginalPriceForChannel(string $channelName): string
     {
         return $this->getElement('original_price', ['%channelName%' => $channelName])->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getNameInLanguage($language)
+    public function getNameInLanguage(string $language): string
     {
         return $this->getElement('name', ['%language%' => $language])->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyCurrentStock($amount)
+    public function specifyCurrentStock(int $amount): void
     {
         $this->getElement('on_hand')->setValue($amount);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isShippingRequired()
+    public function isShippingRequired(): bool
     {
         return $this->getElement('shipping_required')->isChecked();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/UpdatePageInterface.php
@@ -19,58 +19,25 @@ use Sylius\Component\Currency\Model\CurrencyInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 
-    /**
-     * @param int $price
-     */
-    public function specifyPrice($price);
+    public function specifyPrice(int $price): void;
 
-    public function disableTracking();
+    public function disableTracking(): void;
 
-    public function enableTracking();
+    public function enableTracking(): void;
 
-    /**
-     * @return bool
-     */
-    public function isTracked();
+    public function isTracked(): bool;
 
-    /**
-     * @return string
-     */
-    public function getPricingConfigurationForChannelAndCurrencyCalculator(ChannelInterface $channel, CurrencyInterface $currency);
+    public function getPricingConfigurationForChannelAndCurrencyCalculator(ChannelInterface $channel, CurrencyInterface $currency): string;
 
-    /**
-     * @param string $channelName
-     *
-     * @return string
-     */
-    public function getPriceForChannel($channelName);
+    public function getPriceForChannel(string $channelName): string;
 
-    /**
-     * @param string $channelName
-     *
-     * @return string
-     */
-    public function getOriginalPriceForChannel($channelName);
+    public function getOriginalPriceForChannel(string $channelName): string;
 
-    /**
-     * @param string $language
-     *
-     * @return string
-     */
-    public function getNameInLanguage($language);
+    public function getNameInLanguage(string $language): string;
 
-    /**
-     * @param int $amount
-     */
-    public function specifyCurrentStock($amount);
+    public function specifyCurrentStock(int $amount): void;
 
-    /**
-     * @return bool
-     */
-    public function isShippingRequired();
+    public function isShippingRequired(): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/CreatePage.php
@@ -26,10 +26,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     use NamesIt;
     use SpecifiesItsCode;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function addRule($ruleName)
+    public function addRule(string $ruleName): void
     {
         $count = count($this->getCollectionItems('rules'));
 
@@ -42,18 +39,12 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $this->selectRuleOption('Type', $ruleName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function selectRuleOption($option, $value, $multiple = false)
+    public function selectRuleOption(string $option, string $value, bool $multiple = false): void
     {
         $this->getLastCollectionItem('rules')->find('named', ['select', $option])->selectOption($value, $multiple);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function selectAutocompleteRuleOption($option, $value, $multiple = false)
+    public function selectAutocompleteRuleOption(string $option, $value, bool $multiple = false): void
     {
         $option = strtolower(str_replace(' ', '_', $option));
 
@@ -72,27 +63,18 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         AutocompleteHelper::chooseValue($this->getSession(), $ruleAutocomplete, $value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function fillRuleOption($option, $value)
+    public function fillRuleOption(string $option, string $value): void
     {
         $this->getLastCollectionItem('rules')->fillField($option, $value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function fillRuleOptionForChannel($channelName, $option, $value)
+    public function fillRuleOptionForChannel(string $channelName, string $option, string $value): void
     {
         $lastAction = $this->getChannelConfigurationOfLastRule($channelName);
         $lastAction->fillField($option, $value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function addAction($actionName)
+    public function addAction(string $actionName): void
     {
         $count = count($this->getCollectionItems('actions'));
 
@@ -105,58 +87,43 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $this->selectActionOption('Type', $actionName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function selectActionOption($option, $value, $multiple = false)
+    public function selectActionOption(string $option, string $value, bool $multiple = false): void
     {
         $this->getLastCollectionItem('actions')->find('named', ['select', $option])->selectOption($value, $multiple);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function fillActionOption($option, $value)
+    public function fillActionOption(string $option, string $value): void
     {
         $this->getLastCollectionItem('actions')->fillField($option, $value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function fillActionOptionForChannel($channelName, $option, $value)
+    public function fillActionOptionForChannel(string $channelName, string $option, string $value): void
     {
         $lastAction = $this->getChannelConfigurationOfLastAction($channelName);
         $lastAction->fillField($option, $value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function fillUsageLimit($limit)
+    public function fillUsageLimit(string $limit): void
     {
         $this->getDocument()->fillField('Usage limit', $limit);
     }
 
-    public function makeExclusive()
+    public function makeExclusive(): void
     {
         $this->getDocument()->checkField('Exclusive');
     }
 
-    public function checkCouponBased()
+    public function checkCouponBased(): void
     {
         $this->getDocument()->checkField('Coupon based');
     }
 
-    public function checkChannel($name)
+    public function checkChannel(string $name): void
     {
         $this->getDocument()->checkField($name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setStartsAt(\DateTimeInterface $dateTime)
+    public function setStartsAt(\DateTimeInterface $dateTime): void
     {
         $timestamp = $dateTime->getTimestamp();
 
@@ -164,10 +131,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $this->getDocument()->fillField('sylius_promotion_startsAt_time', date('H:i', $timestamp));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setEndsAt(\DateTimeInterface $dateTime)
+    public function setEndsAt(\DateTimeInterface $dateTime): void
     {
         $timestamp = $dateTime->getTimestamp();
 
@@ -175,10 +139,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $this->getDocument()->fillField('sylius_promotion_endsAt_time', date('H:i', $timestamp));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getValidationMessageForAction()
+    public function getValidationMessageForAction(): string
     {
         $actionForm = $this->getLastCollectionItem('actions');
 
@@ -190,10 +151,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         return $foundElement->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function selectAutoCompleteFilterOption($option, $value, $multiple = false)
+    public function selectAutoCompleteFilterOption(string $option, $value, bool $multiple = false): void
     {
         $option = strtolower(str_replace(' ', '_', $option));
 
@@ -212,9 +170,6 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         AutocompleteHelper::chooseValue($this->getSession(), $filterAutocomplete, $value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return [
@@ -229,12 +184,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         ];
     }
 
-    /**
-     * @param string $channelName
-     *
-     * @return NodeElement
-     */
-    private function getChannelConfigurationOfLastAction($channelName)
+    private function getChannelConfigurationOfLastAction(string $channelName): NodeElement
     {
         return $this
             ->getLastCollectionItem('actions')
@@ -242,12 +192,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         ;
     }
 
-    /**
-     * @param string $channelName
-     *
-     * @return NodeElement
-     */
-    private function getChannelConfigurationOfLastRule($channelName)
+    private function getChannelConfigurationOfLastRule(string $channelName): NodeElement
     {
         return $this
             ->getLastCollectionItem('rules')
@@ -255,12 +200,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         ;
     }
 
-    /**
-     * @param string $collection
-     *
-     * @return NodeElement
-     */
-    private function getLastCollectionItem($collection)
+    private function getLastCollectionItem(string $collection): NodeElement
     {
         $items = $this->getCollectionItems($collection);
 
@@ -270,11 +210,9 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     }
 
     /**
-     * @param string $collection
-     *
      * @return NodeElement[]
      */
-    private function getCollectionItems($collection)
+    private function getCollectionItems(string $collection): array
     {
         $items = $this->getElement($collection)->findAll('css', 'div[data-form-collection="item"]');
 

--- a/src/Sylius/Behat/Page/Admin/Promotion/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/CreatePageInterface.php
@@ -18,102 +18,50 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
+    public function specifyCode(string $code): void;
+
+    public function nameIt(string $name): void;
+
+    public function addRule(string $ruleName): void;
+
+    public function selectRuleOption(string $option, string $value, bool $multiple = false): void;
 
     /**
-     * @param string $name
-     */
-    public function nameIt($name);
-
-    /**
-     * @param string $ruleName
-     */
-    public function addRule($ruleName);
-
-    /**
-     * @param string $option
-     * @param string $value
-     * @param bool $multiple
-     */
-    public function selectRuleOption($option, $value, $multiple = false);
-
-    /**
-     * @param string $option
      * @param string|string[] $value
-     * @param bool $multiple
      */
-    public function selectAutocompleteRuleOption($option, $value, $multiple = false);
+    public function selectAutocompleteRuleOption(string $option, $value, bool $multiple = false): void;
+
+    public function fillRuleOption(string $option, string $value): void;
+
+    public function fillRuleOptionForChannel(string $channelName, string $option, string $value): void;
+
+    public function addAction(string $actionName): void;
+
+    public function selectActionOption(string $option, string $value, bool $multiple = false): void;
+
+    public function fillActionOption(string $option, string $value): void;
+
+    public function fillActionOptionForChannel(string $channelName, string $option, string $value): void;
+
+    public function fillUsageLimit(string $limit): void;
+
+    public function makeExclusive(): void;
+
+    public function checkCouponBased(): void;
+
+    public function checkChannel(string $name): void;
+
+    public function setStartsAt(\DateTimeInterface $dateTime): void;
+
+    public function setEndsAt(\DateTimeInterface $dateTime): void;
 
     /**
-     * @param string $option
-     * @param string $value
-     */
-    public function fillRuleOption($option, $value);
-
-    /**
-     * @param string $channelName
-     * @param string $option
-     * @param string $value
-     */
-    public function fillRuleOptionForChannel($channelName, $option, $value);
-
-    /**
-     * @param string $actionName
-     */
-    public function addAction($actionName);
-
-    /**
-     * @param string $option
-     * @param string $value
-     * @param bool $multiple
-     */
-    public function selectActionOption($option, $value, $multiple = false);
-
-    /**
-     * @param string $option
-     * @param string $value
-     */
-    public function fillActionOption($option, $value);
-
-    /**
-     * @param string $channelName
-     * @param string $option
-     * @param string $value
-     */
-    public function fillActionOptionForChannel($channelName, $option, $value);
-
-    /**
-     * @param string $limit
-     */
-    public function fillUsageLimit($limit);
-
-    public function makeExclusive();
-
-    public function checkCouponBased();
-
-    /**
-     * @param string $name
-     */
-    public function checkChannel($name);
-
-    public function setStartsAt(\DateTimeInterface $dateTime);
-
-    public function setEndsAt(\DateTimeInterface $dateTime);
-
-    /**
-     * @return string
-     *
      * @throws ElementNotFoundException
      */
-    public function getValidationMessageForAction();
+    public function getValidationMessageForAction(): string;
 
     /**
-     * @param string $option
      * @param string|string[] $value
-     * @param bool $multiple
      */
-    public function selectAutoCompleteFilterOption($option, $value, $multiple = false);
+    public function selectAutoCompleteFilterOption(string $option, $value, bool $multiple = false): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Promotion/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/IndexPage.php
@@ -19,42 +19,28 @@ use Sylius\Component\Promotion\Model\PromotionInterface;
 
 class IndexPage extends BaseIndexPage implements IndexPageInterface
 {
-    /**
-     * @return int
-     */
-    public function getUsageNumber(PromotionInterface $promotion)
+    public function getUsageNumber(PromotionInterface $promotion): int
     {
         $usage = $this->getPromotionFieldsWithHeader($promotion, 'usage');
 
         return (int) $usage->find('css', 'span:first-child')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isAbleToManageCouponsFor(PromotionInterface $promotion)
+    public function isAbleToManageCouponsFor(PromotionInterface $promotion): bool
     {
         $actions = $this->getPromotionFieldsWithHeader($promotion, 'actions');
 
         return $actions->hasLink('List coupons');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isCouponBasedFor(PromotionInterface $promotion)
+    public function isCouponBasedFor(PromotionInterface $promotion): bool
     {
         $coupons = $this->getPromotionFieldsWithHeader($promotion, 'couponBased');
 
         return 'Yes' === $coupons->getText();
     }
 
-    /**
-     * @param string $header
-     *
-     * @return NodeElement
-     */
-    private function getPromotionFieldsWithHeader(PromotionInterface $promotion, $header)
+    private function getPromotionFieldsWithHeader(PromotionInterface $promotion, string $header): NodeElement
     {
         $tableAccessor = $this->getTableAccessor();
         $table = $this->getElement('table');

--- a/src/Sylius/Behat/Page/Admin/Promotion/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/IndexPageInterface.php
@@ -18,18 +18,9 @@ use Sylius\Component\Promotion\Model\PromotionInterface;
 
 interface IndexPageInterface extends BaseIndexPageInterface
 {
-    /**
-     * @return int
-     */
-    public function getUsageNumber(PromotionInterface $promotion);
+    public function getUsageNumber(PromotionInterface $promotion): int;
 
-    /**
-     * @return bool
-     */
-    public function isAbleToManageCouponsFor(PromotionInterface $promotion);
+    public function isAbleToManageCouponsFor(PromotionInterface $promotion): bool;
 
-    /**
-     * @return bool
-     */
-    public function isCouponBasedFor(PromotionInterface $promotion);
+    public function isCouponBasedFor(PromotionInterface $promotion): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/Promotion/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/UpdatePage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Promotion;
 
+use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\ChecksCodeImmutability;
 use Sylius\Behat\Behaviour\NamesIt;
 use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
@@ -22,59 +23,44 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     use NamesIt;
     use ChecksCodeImmutability;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setPriority($priority)
+    public function setPriority(?int $priority): void
     {
         $this->getDocument()->fillField('Priority', $priority);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getPriority()
+    public function getPriority(): int
     {
-        return $this->getElement('priority')->getValue();
+        return (int) $this->getElement('priority')->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function checkChannelsState($channelName)
+    public function checkChannelsState(string $channelName): bool
     {
         $field = $this->getDocument()->findField($channelName);
 
         return (bool) $field->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function fillUsageLimit($limit)
+    public function fillUsageLimit(string $limit): void
     {
         $this->getDocument()->fillField('Usage limit', $limit);
     }
 
-    public function makeExclusive()
+    public function makeExclusive(): void
     {
         $this->getDocument()->checkField('Exclusive');
     }
 
-    public function checkCouponBased()
+    public function checkCouponBased(): void
     {
         $this->getDocument()->checkField('Coupon based');
     }
 
-    public function checkChannel($name)
+    public function checkChannel(string $name): void
     {
         $this->getDocument()->checkField($name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setStartsAt(\DateTimeInterface $dateTime)
+    public function setStartsAt(\DateTimeInterface $dateTime): void
     {
         $timestamp = $dateTime->getTimestamp();
 
@@ -82,10 +68,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         $this->getDocument()->fillField('sylius_promotion_startsAt_time', date('H:i', $timestamp));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setEndsAt(\DateTimeInterface $dateTime)
+    public function setEndsAt(\DateTimeInterface $dateTime): void
     {
         $timestamp = $dateTime->getTimestamp();
 
@@ -93,10 +76,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         $this->getDocument()->fillField('sylius_promotion_endsAt_time', date('H:i', $timestamp));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasStartsAt(\DateTimeInterface $dateTime)
+    public function hasStartsAt(\DateTimeInterface $dateTime): bool
     {
         $timestamp = $dateTime->getTimestamp();
 
@@ -104,10 +84,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
             && $this->getElement('starts_at_time')->getValue() === date('H:i', $timestamp);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasEndsAt(\DateTimeInterface $dateTime)
+    public function hasEndsAt(\DateTimeInterface $dateTime): bool
     {
         $timestamp = $dateTime->getTimestamp();
 
@@ -115,17 +92,11 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
             && $this->getElement('ends_at_time')->getValue() === date('H:i', $timestamp);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return [

--- a/src/Sylius/Behat/Page/Admin/Promotion/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Promotion/UpdatePageInterface.php
@@ -17,58 +17,29 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @param int|null $priority
-     */
-    public function setPriority($priority);
+    public function setPriority(?int $priority): void;
 
-    /**
-     * @return int
-     */
-    public function getPriority();
+    public function getPriority(): int;
 
-    /**
-     * @param string $name
-     */
-    public function nameIt($name);
+    public function nameIt(string $name): void;
 
-    /**
-     * @param string $channelName
-     *
-     * @return bool
-     */
-    public function checkChannelsState($channelName);
+    public function checkChannelsState(string $channelName): bool;
 
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 
-    /**
-     * @param string $limit
-     */
-    public function fillUsageLimit($limit);
+    public function fillUsageLimit(string $limit): void;
 
-    public function makeExclusive();
+    public function makeExclusive(): void;
 
-    public function checkCouponBased();
+    public function checkCouponBased(): void;
 
-    /**
-     * @param string $name
-     */
-    public function checkChannel($name);
+    public function checkChannel(string $name): void;
 
-    public function setStartsAt(\DateTimeInterface $dateTime);
+    public function setStartsAt(\DateTimeInterface $dateTime): void;
 
-    public function setEndsAt(\DateTimeInterface $dateTime);
+    public function setEndsAt(\DateTimeInterface $dateTime): void;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasStartsAt(\DateTimeInterface $dateTime);
+    public function hasStartsAt(\DateTimeInterface $dateTime): bool;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasEndsAt(\DateTimeInterface $dateTime);
+    public function hasEndsAt(\DateTimeInterface $dateTime): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/PromotionCoupon/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/PromotionCoupon/CreatePage.php
@@ -20,35 +20,23 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
     use SpecifiesItsCode;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setCustomerUsageLimit($limit)
+    public function setCustomerUsageLimit(int $limit): void
     {
         $this->getDocument()->fillField('Per-Customer Usage Limit', $limit);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setExpiresAt(\DateTimeInterface $date)
+    public function setExpiresAt(\DateTimeInterface $date): void
     {
         $timestamp = $date->getTimestamp();
 
         $this->getDocument()->fillField('Expires at', date('Y-m-d', $timestamp));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setUsageLimit($limit)
+    public function setUsageLimit(int $limit): void
     {
         $this->getDocument()->fillField('Usage limit', $limit);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/PromotionCoupon/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/PromotionCoupon/CreatePageInterface.php
@@ -17,20 +17,11 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @param int $limit
-     */
-    public function setCustomerUsageLimit($limit);
+    public function setCustomerUsageLimit(int $limit): void;
 
-    public function setExpiresAt(\DateTimeInterface $date);
+    public function setExpiresAt(\DateTimeInterface $date): void;
 
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
+    public function specifyCode(string $code): void;
 
-    /**
-     * @param int $limit
-     */
-    public function setUsageLimit($limit);
+    public function setUsageLimit(int $limit): void;
 }

--- a/src/Sylius/Behat/Page/Admin/PromotionCoupon/GeneratePage.php
+++ b/src/Sylius/Behat/Page/Admin/PromotionCoupon/GeneratePage.php
@@ -19,80 +19,53 @@ use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
 
 class GeneratePage extends SymfonyPage implements GeneratePageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function checkAmountValidation($message)
+    public function checkAmountValidation(string $message): bool
     {
         return $this->checkValidationMessageFor('amount', $message);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function checkCodeLengthValidation($message)
+    public function checkCodeLengthValidation(string $message): bool
     {
         return $this->checkValidationMessageFor('code_length', $message);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function checkGenerationValidation($message)
+    public function checkGenerationValidation(string $message): bool
     {
         return false !== strpos($this->getElement('form')->find('css', '.ui.red.label')->getText(), $message);
     }
 
-    public function generate()
+    public function generate(): void
     {
         $this->getDocument()->pressButton('Generate');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyAmount($amount)
+    public function specifyAmount(string $amount): void
     {
         $this->getDocument()->fillField('Amount', $amount);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyCodeLength($codeLength)
+    public function specifyCodeLength(string $codeLength): void
     {
         $this->getDocument()->fillField('Code length', $codeLength);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setExpiresAt(\DateTimeInterface $date)
+    public function setExpiresAt(\DateTimeInterface $date): void
     {
         $timestamp = $date->getTimestamp();
 
         $this->getDocument()->fillField('Expires at', date('Y-m-d', $timestamp));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setUsageLimit($limit)
+    public function setUsageLimit(int $limit): void
     {
         $this->getDocument()->fillField('Usage limit', $limit);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getRouteName(): string
     {
         return 'sylius_admin_promotion_coupon_generate';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -105,30 +78,20 @@ class GeneratePage extends SymfonyPage implements GeneratePageInterface
     }
 
     /**
-     * @param string $element
-     * @param string $message
-     *
-     * @return bool
-     *
      * @throws ElementNotFoundException
      */
-    private function checkValidationMessageFor($element, $message)
+    private function checkValidationMessageFor(string $element, string $message): bool
     {
         $foundElement = $this->getElement($element);
         $validatedField = $this->getValidatedField($foundElement);
-        if (null === $validatedField) {
-            throw new ElementNotFoundException($this->getSession(), 'Element', 'css', $foundElement);
-        }
 
         return $message === $validatedField->find('css', '.sylius-validation-error')->getText();
     }
 
     /**
-     * @return NodeElement
-     *
      * @throws ElementNotFoundException
      */
-    private function getValidatedField(NodeElement $element)
+    private function getValidatedField(NodeElement $element): NodeElement
     {
         while (null !== $element && !$element->hasClass('field')) {
             $element = $element->getParent();

--- a/src/Sylius/Behat/Page/Admin/PromotionCoupon/GeneratePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/PromotionCoupon/GeneratePageInterface.php
@@ -17,43 +17,19 @@ use FriendsOfBehat\PageObjectExtension\Page\SymfonyPageInterface;
 
 interface GeneratePageInterface extends SymfonyPageInterface
 {
-    /**
-     * @param string $message
-     *
-     * @return bool
-     */
-    public function checkAmountValidation($message);
+    public function checkAmountValidation(string $message): bool;
 
-    /**
-     * @param string $message
-     *
-     * @return bool
-     */
-    public function checkCodeLengthValidation($message);
+    public function checkCodeLengthValidation(string $message): bool;
 
-    /**
-     * @param string $message
-     *
-     * @return bool
-     */
-    public function checkGenerationValidation($message);
+    public function checkGenerationValidation(string $message): bool;
 
-    public function generate();
+    public function generate(): void;
 
-    /**
-     * @param int $amount
-     */
-    public function specifyAmount($amount);
+    public function specifyAmount(string $amount): void;
 
-    /**
-     * @param int $codeLength
-     */
-    public function specifyCodeLength($codeLength);
+    public function specifyCodeLength(string $codeLength): void;
 
-    public function setExpiresAt(\DateTimeInterface $date);
+    public function setExpiresAt(\DateTimeInterface $date): void;
 
-    /**
-     * @param int $limit
-     */
-    public function setUsageLimit($limit);
+    public function setUsageLimit(int $limit): void;
 }

--- a/src/Sylius/Behat/Page/Admin/PromotionCoupon/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/PromotionCoupon/UpdatePage.php
@@ -21,40 +21,28 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
     use ChecksCodeImmutability;
 
-    /**
-     * @param int $limit
-     */
-    public function setCustomerUsageLimit($limit)
+    public function setCustomerUsageLimit(int $limit): void
     {
         $this->getDocument()->fillField('Per-Customer Usage Limit', $limit);
     }
 
-    public function setExpiresAt(\DateTimeInterface $date)
+    public function setExpiresAt(\DateTimeInterface $date): void
     {
         $timestamp = $date->getTimestamp();
 
         $this->getDocument()->fillField('Expires at', date('Y-m-d', $timestamp));
     }
 
-    /**
-     * @param int $limit
-     */
-    public function setUsageLimit($limit)
+    public function setUsageLimit(string $limit): void
     {
         $this->getDocument()->fillField('Usage limit', $limit);
     }
 
-    /**
-     * @return NodeElement
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/PromotionCoupon/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/PromotionCoupon/UpdatePageInterface.php
@@ -17,20 +17,11 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 
-    /**
-     * @param int $limit
-     */
-    public function setCustomerUsageLimit($limit);
+    public function setCustomerUsageLimit(int $limit): void;
 
-    public function setExpiresAt(\DateTimeInterface $date);
+    public function setExpiresAt(\DateTimeInterface $date): void;
 
-    /**
-     * @param int $limit
-     */
-    public function setUsageLimit($limit);
+    public function setUsageLimit(string $limit): void;
 }

--- a/src/Sylius/Behat/Page/Admin/ShippingCategory/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ShippingCategory/CreatePage.php
@@ -22,17 +22,11 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     use NamesIt;
     use SpecifiesItsCode;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyDescription($description)
+    public function specifyDescription(string $description): void
     {
         $this->getElement('description')->setValue($description);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ShippingCategory/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ShippingCategory/CreatePageInterface.php
@@ -17,18 +17,9 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInteface;
 
 interface CreatePageInterface extends BaseCreatePageInteface
 {
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
+    public function specifyCode(string $code): void;
 
-    /**
-     * @param string $name
-     */
-    public function nameIt($name);
+    public function nameIt(string $name): void;
 
-    /**
-     * @param string $description
-     */
-    public function specifyDescription($description);
+    public function specifyDescription(string $description): void;
 }

--- a/src/Sylius/Behat/Page/Admin/ShippingCategory/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ShippingCategory/UpdatePage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\ShippingCategory;
 
+use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\ChecksCodeImmutability;
 use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
 
@@ -20,17 +21,11 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
     use ChecksCodeImmutability;
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ShippingCategory/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ShippingCategory/UpdatePageInterface.php
@@ -17,8 +17,5 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInteface;
 
 interface UpdatePageInterface extends BaseUpdatePageInteface
 {
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/ShippingMethod/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ShippingMethod/CreatePage.php
@@ -23,60 +23,39 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
     use SpecifiesItsCode;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyPosition($position)
+    public function specifyPosition(?int $position): void
     {
         $this->getDocument()->fillField('Position', $position);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameIt($name, $language)
+    public function nameIt(string $name, string $language): void
     {
         $this->getDocument()->fillField(sprintf('sylius_shipping_method_translations_%s_name', $language), $name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function describeIt($description, $languageCode)
+    public function describeIt(string $description, string $languageCode): void
     {
         $this->getDocument()->fillField(
             sprintf('sylius_shipping_method_translations_%s_description', $languageCode), $description
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyAmountForChannel($channelCode, $amount)
+    public function specifyAmountForChannel(string $channelCode, string $amount): void
     {
         $this->getElement('amount', ['%channelCode%' => $channelCode])->setValue($amount);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseZone($name)
+    public function chooseZone(string $name): void
     {
         $this->getDocument()->selectFieldOption('Zone', $name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseCalculator($name)
+    public function chooseCalculator(string $name): void
     {
         $this->getDocument()->selectFieldOption('Calculator', $name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function checkChannel($channelName)
+    public function checkChannel($channelName): void
     {
         if ($this->getDriver() instanceof Selenium2Driver) {
             $this->getElement('channel', ['%channel%' => $channelName])->click();
@@ -87,10 +66,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $this->getDocument()->checkField($channelName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getValidationMessageForAmount($channelCode)
+    public function getValidationMessageForAmount(string $channelCode): string
     {
         $foundElement = $this->getFieldElement('amount', ['%channelCode%' => $channelCode]);
         if (null === $foundElement) {
@@ -110,9 +86,6 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         return $validationMessage->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -126,13 +99,9 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     }
 
     /**
-     * @param string $element
-     *
-     * @return \Behat\Mink\Element\NodeElement|null
-     *
      * @throws ElementNotFoundException
      */
-    private function getFieldElement($element, array $parameters = [])
+    private function getFieldElement(string $element, array $parameters = []): ?\Behat\Mink\Element\NodeElement
     {
         $element = $this->getElement(StringInflector::nameToCode($element), $parameters);
         while (null !== $element && !$element->hasClass('field')) {

--- a/src/Sylius/Behat/Page/Admin/ShippingMethod/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ShippingMethod/CreatePageInterface.php
@@ -18,55 +18,24 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
+    public function specifyCode(string $code): void;
+
+    public function specifyPosition(?int $position): void;
+
+    public function nameIt(string $name, string $language): void;
+
+    public function describeIt(string $description, string $languageCode): void;
+
+    public function specifyAmountForChannel(string $channelCode, string $amount): void;
+
+    public function chooseZone(string $name): void;
+
+    public function chooseCalculator(string $name): void;
+
+    public function checkChannel($channelName): void;
 
     /**
-     * @param int|null $position
-     */
-    public function specifyPosition($position);
-
-    /**
-     * @param string $name
-     * @param string $language
-     */
-    public function nameIt($name, $language);
-
-    /**
-     * @param string $description
-     * @param string $languageCode
-     */
-    public function describeIt($description, $languageCode);
-
-    /**
-     * @param string $channelCode
-     * @param string $amount
-     */
-    public function specifyAmountForChannel($channelCode, $amount);
-
-    /**
-     * @param string $name
-     */
-    public function chooseZone($name);
-
-    /**
-     * @param string $name
-     */
-    public function chooseCalculator($name);
-
-    /**
-     * @return string $channelName
-     */
-    public function checkChannel($channelName);
-
-    /**
-     * @param string $channelCode
-     *
-     * @return string
-     *
      * @throws ElementNotFoundException
      */
-    public function getValidationMessageForAmount($channelCode);
+    public function getValidationMessageForAmount(string $channelCode): string;
 }

--- a/src/Sylius/Behat/Page/Admin/ShippingMethod/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/ShippingMethod/IndexPage.php
@@ -17,27 +17,18 @@ use Sylius\Behat\Page\Admin\Crud\IndexPage as BaseIndexPage;
 
 class IndexPage extends BaseIndexPage implements IndexPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseArchival($isArchival)
+    public function chooseArchival(string $isArchival): void
     {
         $this->getElement('filter_archival')->selectOption($isArchival);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isArchivalFilterEnabled()
+    public function isArchivalFilterEnabled(): bool
     {
         $archival = $this->getDocument()->find('css', 'button:contains("Restore")');
 
         return null !== $archival;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ShippingMethod/IndexPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ShippingMethod/IndexPageInterface.php
@@ -17,13 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\IndexPageInterface as BaseIndexPageInterface;
 
 interface IndexPageInterface extends BaseIndexPageInterface
 {
-    /**
-     * @param string $isArchival
-     */
-    public function chooseArchival($isArchival);
+    public function chooseArchival(string $isArchival): void;
 
-    /**
-     * @return bool
-     */
-    public function isArchivalFilterEnabled();
+    public function isArchivalFilterEnabled(): bool;
 }

--- a/src/Sylius/Behat/Page/Admin/ShippingMethod/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ShippingMethod/UpdatePage.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\ShippingMethod;
 
-use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\ChecksCodeImmutability;
 use Sylius\Behat\Behaviour\Toggles;
 use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
@@ -23,56 +23,33 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     use ChecksCodeImmutability;
     use Toggles;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isAvailableInChannel($channelName)
+    public function isAvailableInChannel(string $channelName): bool
     {
         return $this->getElement('channel', ['%channel%' => $channelName])->hasAttribute('checked');
     }
 
-    public function removeZone()
+    public function removeZone(): void
     {
         $this->getDocument()->selectFieldOption('Zone', 'Select');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getValidationMessageForAmount($channelCode)
+    public function getValidationMessageForAmount(string $channelCode): string
     {
         $foundElement = $this->getElement('amount', ['%channelCode%' => $channelCode]);
-        if (null === $foundElement) {
-            throw new ElementNotFoundException($this->getSession(), 'Field element');
-        }
 
-        $validationMessage = $foundElement->find('css', '.sylius-validation-error');
-        if (null === $validationMessage) {
-            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '.sylius-validation-error');
-        }
-
-        return $validationMessage->getText();
+        return $foundElement->find('css', '.sylius-validation-error')->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getToggleableElement()
+    protected function getToggleableElement(): NodeElement
     {
         return $this->getElement('enabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/ShippingMethod/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ShippingMethod/UpdatePageInterface.php
@@ -18,30 +18,18 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
+
+    public function isAvailableInChannel(string $channelName): bool;
+
+    public function enable(): void;
+
+    public function disable(): void;
+
+    public function removeZone(): void;
 
     /**
-     * @param string $channelName
-     *
-     * @return bool
-     */
-    public function isAvailableInChannel($channelName);
-
-    public function enable();
-
-    public function disable();
-
-    public function removeZone();
-
-    /**
-     * @param string $channelCode
-     *
-     * @return string
-     *
      * @throws ElementNotFoundException
      */
-    public function getValidationMessageForAmount($channelCode);
+    public function getValidationMessageForAmount(string $channelCode): string;
 }

--- a/src/Sylius/Behat/Page/Admin/TaxCategory/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/TaxCategory/CreatePage.php
@@ -24,9 +24,6 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     use NamesIt;
     use DescribesIt;
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/TaxCategory/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/TaxCategory/CreatePageInterface.php
@@ -17,18 +17,9 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
+    public function specifyCode(string $code): void;
 
-    /**
-     * @param string $name
-     */
-    public function nameIt($name);
+    public function nameIt(string $name): void;
 
-    /**
-     * @param string $description
-     */
-    public function describeItAs($description);
+    public function describeItAs(string $description): void;
 }

--- a/src/Sylius/Behat/Page/Admin/TaxCategory/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/TaxCategory/UpdatePage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\TaxCategory;
 
+use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\ChecksCodeImmutability;
 use Sylius\Behat\Behaviour\NamesIt;
 use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
@@ -22,17 +23,11 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     use ChecksCodeImmutability;
     use NamesIt;
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/TaxCategory/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/TaxCategory/UpdatePageInterface.php
@@ -17,13 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 
-    /**
-     * @param string $name
-     */
-    public function nameIt($name);
+    public function nameIt(string $name): void;
 }

--- a/src/Sylius/Behat/Page/Admin/TaxRate/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/TaxRate/CreatePage.php
@@ -22,46 +22,31 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     use NamesIt;
     use SpecifiesItsCode;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseZone($name)
+    public function chooseZone(string $name): void
     {
         $this->getDocument()->selectFieldOption('Zone', $name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseCategory($name)
+    public function chooseCategory(string $name): void
     {
         $this->getDocument()->selectFieldOption('Category', $name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseCalculator($name)
+    public function chooseCalculator(string $name): void
     {
         $this->getDocument()->selectFieldOption('Calculator', $name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifyAmount($amount)
+    public function specifyAmount(string $amount): void
     {
         $this->getDocument()->fillField('Amount', $amount);
     }
 
-    public function chooseIncludedInPrice()
+    public function chooseIncludedInPrice(): void
     {
         $this->getDocument()->find('css', 'label[for=sylius_tax_rate_includedInPrice]')->click();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/TaxRate/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/TaxRate/CreatePageInterface.php
@@ -17,35 +17,17 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
+    public function specifyCode(string $code): void;
 
-    /**
-     * @param string $name
-     */
-    public function nameIt($name);
+    public function nameIt(string $name): void;
 
-    /**
-     * @param string $amount
-     */
-    public function specifyAmount($amount);
+    public function specifyAmount(string $amount): void;
 
-    /**
-     * @param string $name
-     */
-    public function chooseZone($name);
+    public function chooseZone(string $name): void;
 
-    /**
-     * @param string $name
-     */
-    public function chooseCategory($name);
+    public function chooseCategory(string $name): void;
 
-    /**
-     * @param string $name
-     */
-    public function chooseCalculator($name);
+    public function chooseCalculator(string $name): void;
 
-    public function chooseIncludedInPrice();
+    public function chooseIncludedInPrice(): void;
 }

--- a/src/Sylius/Behat/Page/Admin/TaxRate/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/TaxRate/UpdatePage.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\TaxRate;
 
+use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\ChecksCodeImmutability;
 use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
 
@@ -20,22 +21,16 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
     use ChecksCodeImmutability;
 
-    public function removeZone()
+    public function removeZone(): void
     {
         $this->getDocument()->selectFieldOption('Zone', 'Select');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/TaxRate/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/TaxRate/UpdatePageInterface.php
@@ -17,10 +17,7 @@ use Sylius\Behat\Page\Admin\Crud\UpdatePageInterface as BaseUpdatePageInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 
-    public function removeZone();
+    public function removeZone(): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Taxon/CreateForParentPage.php
+++ b/src/Sylius/Behat/Page/Admin/Taxon/CreateForParentPage.php
@@ -15,9 +15,6 @@ namespace Sylius\Behat\Page\Admin\Taxon;
 
 class CreateForParentPage extends CreatePage implements CreateForParentPageInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function getRouteName(): string
     {
         return 'sylius_admin_taxon_create_for_parent';

--- a/src/Sylius/Behat/Page/Admin/Taxon/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Taxon/CreatePage.php
@@ -26,18 +26,12 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
     use SpecifiesItsCode;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function countTaxons()
+    public function countTaxons(): int
     {
         return count($this->getLeaves());
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function countTaxonsByName($name)
+    public function countTaxonsByName(string $name): int
     {
         $matchedLeavesCounter = 0;
         $leaves = $this->getLeaves();
@@ -50,10 +44,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         return $matchedLeavesCounter;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function deleteTaxonOnPageByName($name)
+    public function deleteTaxonOnPageByName(string $name): void
     {
         $leaves = $this->getLeaves();
         foreach ($leaves as $leaf) {
@@ -67,26 +58,17 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         throw new ElementNotFoundException($this->getDriver(), 'Delete button');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function describeItAs($description, $languageCode)
+    public function describeItAs(string $description, string $languageCode): void
     {
         $this->getDocument()->fillField(sprintf('sylius_taxon_translations_%s_description', $languageCode), $description);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasTaxonWithName($name)
+    public function hasTaxonWithName(string $name): bool
     {
         return 0 !== $this->countTaxonsByName($name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameIt($name, $languageCode)
+    public function nameIt(string $name, string $languageCode): void
     {
         $this->activateLanguageTab($languageCode);
         $this->getElement('name', ['%language%' => $languageCode])->setValue($name);
@@ -99,18 +81,12 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifySlug($slug, $languageCode)
+    public function specifySlug(string $slug, string $languageCode): void
     {
         $this->getDocument()->fillField(sprintf('sylius_taxon_translations_%s_slug', $languageCode), $slug);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function attachImage($path, $type = null)
+    public function attachImage(string $path, string $type = null): void
     {
         $filesPath = $this->getParameter('files_path');
 
@@ -121,10 +97,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $imageForm->find('css', 'input[type="file"]')->attachFile($filesPath . $path);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getLeaves(TaxonInterface $parentTaxon = null)
+    public function getLeaves(TaxonInterface $parentTaxon = null): array
     {
         $tree = $this->getElement('tree');
         Assert::notNull($tree);
@@ -144,10 +117,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function activateLanguageTab($locale)
+    public function activateLanguageTab(string $locale): void
     {
         if (!$this->getDriver() instanceof Selenium2Driver) {
             return;
@@ -159,9 +129,6 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getElement(string $name, array $parameters = []): NodeElement
     {
         if (!isset($parameters['%language%'])) {
@@ -171,9 +138,6 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         return parent::getElement($name, $parameters);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -187,10 +151,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         ]);
     }
 
-    /**
-     * @return NodeElement
-     */
-    private function getLastImageElement()
+    private function getLastImageElement(): NodeElement
     {
         $images = $this->getElement('images');
         $items = $images->findAll('css', 'div[data-form-collection="item"]');

--- a/src/Sylius/Behat/Page/Admin/Taxon/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Taxon/CreatePageInterface.php
@@ -20,68 +20,33 @@ use Sylius\Component\Core\Model\TaxonInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    /**
-     * @return int
-     */
-    public function countTaxons();
+    public function countTaxons(): int;
+
+    public function countTaxonsByName(string $name): int;
+
+    public function deleteTaxonOnPageByName(string $name): void;
+
+    public function describeItAs(string $description, string $languageCode): void;
+
+    public function hasTaxonWithName(string $name): bool;
+
+    public function nameIt(string $name, string $languageCode): void;
+
+    public function specifyCode(string $code): void;
+
+    public function specifySlug(string $slug, string $languageCode): void;
 
     /**
-     * @param string $name
-     *
-     * @return int
-     */
-    public function countTaxonsByName($name);
-
-    /**
-     * @param string $name
-     */
-    public function deleteTaxonOnPageByName($name);
-
-    /**
-     * @param string $description
-     * @param string $languageCode
-     */
-    public function describeItAs($description, $languageCode);
-
-    /**
-     * @param string $name
-     *
-     * @return bool
-     */
-    public function hasTaxonWithName($name);
-
-    /**
-     * @param string $name
-     * @param string $languageCode
-     */
-    public function nameIt($name, $languageCode);
-
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
-
-    /**
-     * @param string $slug
-     * @param string $languageCode
-     */
-    public function specifySlug($slug, $languageCode);
-
-    /**
-     * @param string $path
      * @param string $type
      */
-    public function attachImage($path, $type = null);
+    public function attachImage(string $path, string $type = null): void;
 
     /**
      * @return NodeElement[]
      *
      * @throws ElementNotFoundException
      */
-    public function getLeaves(TaxonInterface $parentTaxon = null);
+    public function getLeaves(TaxonInterface $parentTaxon = null): array;
 
-    /**
-     * @param string $locale
-     */
-    public function activateLanguageTab($locale);
+    public function activateLanguageTab(string $locale): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Taxon/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Taxon/UpdatePage.php
@@ -30,26 +30,17 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     /** @var array */
     private $imageUrls = [];
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseParent(TaxonInterface $taxon)
+    public function chooseParent(TaxonInterface $taxon): void
     {
         AutocompleteHelper::chooseValue($this->getSession(), $this->getElement('parent')->getParent(), $taxon->getName());
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function describeItAs($description, $languageCode)
+    public function describeItAs(string $description, string $languageCode): void
     {
         $this->getDocument()->fillField(sprintf('sylius_taxon_translations_%s_description', $languageCode), $description);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nameIt($name, $languageCode)
+    public function nameIt(string $name, string $languageCode): void
     {
         $this->activateLanguageTab($languageCode);
         $this->getDocument()->fillField(sprintf('sylius_taxon_translations_%s_name', $languageCode), $name);
@@ -62,18 +53,12 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function specifySlug($slug, $languageCode)
+    public function specifySlug(string $slug, string $languageCode): void
     {
         $this->getDocument()->fillField(sprintf('sylius_taxon_translations_%s_slug', $languageCode), $slug);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function attachImage($path, $type = null)
+    public function attachImage(string $path, string $type = null): void
     {
         $filesPath = $this->getParameter('files_path');
 
@@ -87,10 +72,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         $imageForm->find('css', 'input[type="file"]')->attachFile($filesPath . $path);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isImageWithTypeDisplayed($type)
+    public function isImageWithTypeDisplayed(string $type): bool
     {
         $imageElement = $this->getImageElementByType($type);
 
@@ -106,10 +88,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         return false === stripos($pageText, '404 Not Found');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isSlugReadonly($languageCode = 'en_US')
+    public function isSlugReadonly(string $languageCode = 'en_US'): bool
     {
         return SlugGenerationHelper::isSlugReadonly(
             $this->getSession(),
@@ -117,10 +96,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function removeImageWithType($type)
+    public function removeImageWithType(string $type): void
     {
         $imageElement = $this->getImageElementByType($type);
         $imageSourceElement = $imageElement->find('css', 'img');
@@ -131,7 +107,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         $imageElement->clickLink('Delete');
     }
 
-    public function removeFirstImage()
+    public function removeFirstImage(): void
     {
         $imageElement = $this->getFirstImageElement();
         $imageTypeElement = $imageElement->find('css', 'input[type=text]');
@@ -147,10 +123,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         $imageElement->clickLink('Delete');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function enableSlugModification($languageCode = 'en_US')
+    public function enableSlugModification(string $languageCode = 'en_US'): void
     {
         SlugGenerationHelper::enableSlugModification(
             $this->getSession(),
@@ -158,20 +131,14 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function countImages()
+    public function countImages(): int
     {
         $imageElements = $this->getImageElements();
 
         return count($imageElements);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function changeImageWithType($type, $path)
+    public function changeImageWithType(string $type, string $path): void
     {
         $filesPath = $this->getParameter('files_path');
 
@@ -179,10 +146,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         $imageForm->find('css', 'input[type="file"]')->attachFile($filesPath . $path);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function modifyFirstImageType($type)
+    public function modifyFirstImageType(string $type): void
     {
         $firstImage = $this->getFirstImageElement();
 
@@ -190,26 +154,17 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         $typeField->setValue($type);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getParent()
+    public function getParent(): string
     {
         return $this->getElement('parent')->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getSlug($languageCode = 'en_US')
+    public function getSlug(string $languageCode = 'en_US'): string
     {
         return $this->getElement('slug', ['%language%' => $languageCode])->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getValidationMessageForImage()
+    public function getValidationMessageForImage(): string
     {
         $lastImageElement = $this->getLastImageElement();
 
@@ -221,10 +176,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         return $foundElement->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getValidationMessageForImageAtPlace($place)
+    public function getValidationMessageForImageAtPlace(int $place): string
     {
         $images = $this->getImageElements();
 
@@ -236,10 +188,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         return $foundElement->getText();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function activateLanguageTab($locale)
+    public function activateLanguageTab(string $locale): void
     {
         if (!$this->getDriver() instanceof Selenium2Driver) {
             return;
@@ -255,9 +204,6 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         });
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getElement(string $name, array $parameters = []): NodeElement
     {
         if (!isset($parameters['%language%'])) {
@@ -267,17 +213,11 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         return parent::getElement($name, $parameters);
     }
 
-    /**
-     * @return NodeElement
-     */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -292,10 +232,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         ]);
     }
 
-    /**
-     * @return NodeElement
-     */
-    private function getLastImageElement()
+    private function getLastImageElement(): NodeElement
     {
         $imageElements = $this->getImageElements();
 
@@ -304,10 +241,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         return end($imageElements);
     }
 
-    /**
-     * @return NodeElement
-     */
-    private function getFirstImageElement()
+    private function getFirstImageElement(): NodeElement
     {
         $imageElements = $this->getImageElements();
 
@@ -319,19 +253,14 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     /**
      * @return NodeElement[]
      */
-    private function getImageElements()
+    private function getImageElements(): array
     {
         $images = $this->getElement('images');
 
         return $images->findAll('css', 'div[data-form-collection="item"]');
     }
 
-    /**
-     * @param string $type
-     *
-     * @return NodeElement
-     */
-    private function getImageElementByType($type)
+    private function getImageElementByType(string $type): ?NodeElement
     {
         $images = $this->getElement('images');
         $typeInput = $images->find('css', 'input[value="' . $type . '"]');

--- a/src/Sylius/Behat/Page/Admin/Taxon/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Taxon/UpdatePageInterface.php
@@ -19,109 +19,50 @@ use Sylius\Component\Core\Model\TaxonInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @param string $description
-     * @param string $languageCode
-     */
-    public function describeItAs($description, $languageCode);
+    public function describeItAs(string $description, string $languageCode): void;
 
-    public function chooseParent(TaxonInterface $taxon);
+    public function chooseParent(TaxonInterface $taxon): void;
 
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 
-    /**
-     * @param string $name
-     * @param string $languageCode
-     */
-    public function nameIt($name, $languageCode);
+    public function nameIt(string $name, string $languageCode): void;
 
-    /**
-     * @param string $slug
-     * @param string $languageCode
-     */
-    public function specifySlug($slug, $languageCode);
-
-    /**
-     * @param string $path
-     * @param string $type
-     */
-    public function attachImage($path, $type = null);
-
-    /**
-     * @param string $type
-     *
-     * @return bool
-     */
-    public function isImageWithTypeDisplayed($type);
-
-    /**
-     * @param string $languageCode
-     *
-     * @return bool
-     */
-    public function isSlugReadonly($languageCode = 'en_US');
+    public function specifySlug(string $slug, string $languageCode): void;
 
     /**
      * @param string $type
      */
-    public function removeImageWithType($type);
+    public function attachImage(string $path, string $type = null): void;
 
-    public function removeFirstImage();
+    public function isImageWithTypeDisplayed(string $type): bool;
 
-    /**
-     * @param string $languageCode
-     */
-    public function enableSlugModification($languageCode = 'en_US');
+    public function isSlugReadonly(string $languageCode = 'en_US'): bool;
 
-    /**
-     * @return int
-     */
-    public function countImages();
+    public function removeImageWithType(string $type): void;
 
-    /**
-     * @param string $type
-     * @param string $path
-     */
-    public function changeImageWithType($type, $path);
+    public function removeFirstImage(): void;
 
-    /**
-     * @param string $type
-     */
-    public function modifyFirstImageType($type);
+    public function enableSlugModification(string $languageCode = 'en_US'): void;
+
+    public function countImages(): int;
+
+    public function changeImageWithType(string $type, string $path): void;
+
+    public function modifyFirstImageType(string $type): void;
+
+    public function getParent(): string;
+
+    public function getSlug(string $languageCode = 'en_US'): string;
 
     /**
-     * @return string
-     */
-    public function getParent();
-
-    /**
-     * @param string $languageCode
-     *
-     * @return string
-     */
-    public function getSlug($languageCode = 'en_US');
-
-    /**
-     * @return string
-     *
      * @throws ElementNotFoundException
      */
-    public function getValidationMessageForImage();
+    public function getValidationMessageForImage(): string;
 
     /**
-     * @param int $place
-     *
-     * @return string
-     *
      * @throws ElementNotFoundException
      */
-    public function getValidationMessageForImageAtPlace($place);
+    public function getValidationMessageForImageAtPlace(int $place): string;
 
-    /**
-     * @param string $locale
-     */
-    public function activateLanguageTab($locale);
+    public function activateLanguageTab(string $locale): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Zone/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Zone/CreatePage.php
@@ -23,15 +23,12 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
     use NamesIt;
     use SpecifiesItsCode;
 
-    public function addMember()
+    public function addMember(): void
     {
         $this->getDocument()->clickLink('Add member');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function checkValidationMessageForMembers($message)
+    public function checkValidationMessageForMembers(string $message): bool
     {
         $membersValidationElement = $this->getElement('ui_segment')->find('css', '.sylius-validation-error');
         if (null === $membersValidationElement) {
@@ -41,10 +38,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         return $membersValidationElement->getText() === $message;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function chooseMember($name)
+    public function chooseMember(string $name): void
     {
         $selectItems = $this->getDocument()->waitFor(2, function () {
             return $this->getDocument()->findAll('css', 'div[data-form-type="collection"] select');
@@ -58,18 +52,12 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $lastSelectItem->selectOption($name);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function selectScope($scope)
+    public function selectScope(string $scope): void
     {
         $this->getDocument()->selectFieldOption('Scope', $scope);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasType($type)
+    public function hasType(string $type): bool
     {
         $typeField = $this->getElement('type');
         $selectedOption = $typeField->find('css', 'option[selected]');
@@ -77,17 +65,11 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         return lcfirst($selectedOption->getText()) === $type;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function isTypeFieldDisabled()
+    public function isTypeFieldDisabled(): bool
     {
         return $this->getElement('type')->hasAttribute('disabled');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [

--- a/src/Sylius/Behat/Page/Admin/Zone/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Zone/CreatePageInterface.php
@@ -17,42 +17,19 @@ use Sylius\Behat\Page\Admin\Crud\CreatePageInterface as BaseCreatePageInterface;
 
 interface CreatePageInterface extends BaseCreatePageInterface
 {
-    public function addMember();
+    public function addMember(): void;
 
-    /**
-     * @param string $message
-     */
-    public function checkValidationMessageForMembers($message);
+    public function checkValidationMessageForMembers(string $message): bool;
 
-    /**
-     * @param string $name
-     */
-    public function chooseMember($name);
+    public function chooseMember(string $name): void;
 
-    /**
-     * @param string $scope
-     */
-    public function selectScope($scope);
+    public function selectScope(string $scope): void;
 
-    /**
-     * @param string $type
-     *
-     * @return bool
-     */
-    public function hasType($type);
+    public function hasType(string $type): bool;
 
-    /**
-     * @return bool
-     */
-    public function isTypeFieldDisabled();
+    public function isTypeFieldDisabled(): bool;
 
-    /**
-     * @param string $name
-     */
-    public function nameIt($name);
+    public function nameIt(string $name): void;
 
-    /**
-     * @param string $code
-     */
-    public function specifyCode($code);
+    public function specifyCode(string $code): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Zone/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Zone/UpdatePage.php
@@ -25,28 +25,19 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     use NamesIt;
     use ChecksCodeImmutability;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function countMembers()
+    public function countMembers(): int
     {
         $selectedZoneMembers = $this->getSelectedZoneMembers();
 
         return count($selectedZoneMembers);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getScope()
+    public function getScope(): string
     {
         return $this->getElement('scope')->getValue();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function hasMember(ZoneMemberInterface $zoneMember)
+    public function hasMember(ZoneMemberInterface $zoneMember): bool
     {
         $selectedZoneMembers = $this->getSelectedZoneMembers();
 
@@ -59,10 +50,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         return false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function removeMember(ZoneMemberInterface $zoneMember)
+    public function removeMember(ZoneMemberInterface $zoneMember): void
     {
         $zoneMembers = $this->getElement('zone_members');
         $items = $zoneMembers->findAll('css', 'div[data-form-collection="item"]');
@@ -84,18 +72,13 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     }
 
     /**
-     * @return NodeElement
-     *
      * @throws ElementNotFoundException
      */
-    protected function getCodeElement()
+    protected function getCodeElement(): NodeElement
     {
         return $this->getElement('code');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -109,11 +92,9 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     }
 
     /**
-     * @return NodeElement
-     *
      * @throws ElementNotFoundException
      */
-    private function getDeleteButtonForCollectionItem(NodeElement $item)
+    private function getDeleteButtonForCollectionItem(NodeElement $item): NodeElement
     {
         $deleteButton = $item->find('css', 'a[data-form-collection="delete"]');
         if (null === $deleteButton) {
@@ -128,7 +109,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
      *
      * @throws ElementNotFoundException
      */
-    private function getSelectedZoneMembers()
+    private function getSelectedZoneMembers(): array
     {
         $zoneMembers = $this->getElement('zone_members');
         $selectedZoneMembers = $zoneMembers->findAll('css', 'option[selected="selected"]');

--- a/src/Sylius/Behat/Page/Admin/Zone/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Zone/UpdatePageInterface.php
@@ -18,30 +18,15 @@ use Sylius\Component\Addressing\Model\ZoneMemberInterface;
 
 interface UpdatePageInterface extends BaseUpdatePageInterface
 {
-    /**
-     * @param string $name
-     */
-    public function nameIt($name);
+    public function nameIt(string $name): void;
 
-    /**
-     * @return int
-     */
-    public function countMembers();
+    public function countMembers(): int;
 
-    /**
-     * @return string
-     */
-    public function getScope();
+    public function getScope(): string;
 
-    /**
-     * @return bool
-     */
-    public function hasMember(ZoneMemberInterface $zoneMember);
+    public function hasMember(ZoneMemberInterface $zoneMember): bool;
 
-    /**
-     * @return bool
-     */
-    public function isCodeDisabled();
+    public function isCodeDisabled(): bool;
 
-    public function removeMember(ZoneMemberInterface $zoneMember);
+    public function removeMember(ZoneMemberInterface $zoneMember): void;
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Million years ago, we introduced scalar types to Sylius code (https://github.com/Sylius/Sylius/issues/8425) and it is a blessing :) However, our (big and strong) Behat-related code is still missing them. I know, they're not so valuable for the test code, but still allows us to reduce amount of unnecessary inaccuracies (and code lines :)). We should do something about it, or we will stay without these PHP7 features until PHP8 😄 

This PR aims to add scalar types only in **admin pages**, which means `src/Sylius/Behat/Page/Admin` directory. Rest of the changes are just required to avoid failing tests. I believe it's doable to introduce scalar types in a reasonable amount of time and energy for the whole Behat suite, but it should be done in separated PR's per section.

To be honest, it was not so bad as I've expected 🐃 