### PR TITLE
[Admin] Taxon order : fix element(data) always returns 0

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-move-taxon.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-move-taxon.js
@@ -20,7 +20,7 @@ $.fn.extend({
       beforeSend(settings) {
         /* eslint-disable-next-line no-param-reassign */
         settings.data = {
-          position: jquery(this).data('position') - 1,
+          position: $(this).data('position') - 1,
         };
 
         return settings;
@@ -40,7 +40,7 @@ $.fn.extend({
       beforeSend(settings) {
         /* eslint-disable-next-line no-param-reassign */
         settings.data = {
-          position: jquery(this).data('position') + 1,
+          position: $(this).data('position') + 1,
         };
 
         return settings;

--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-move-taxon.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-move-taxon.js
@@ -20,7 +20,7 @@ $.fn.extend({
       beforeSend(settings) {
         /* eslint-disable-next-line no-param-reassign */
         settings.data = {
-          position: element.data('position') - 1,
+          position: jquery(this).data('position') - 1,
         };
 
         return settings;
@@ -40,7 +40,7 @@ $.fn.extend({
       beforeSend(settings) {
         /* eslint-disable-next-line no-param-reassign */
         settings.data = {
-          position: element.data('position') + 1,
+          position: jquery(this).data('position') + 1,
         };
 
         return settings;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.2 or 1.3 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
 With element(data), I coulnd't move up the last taxon for example because the script was Always sending -1 instead of the real number (position - 1).