### PR TITLE
Make possible to autowire services generated by ResourceBundle

### DIFF
--- a/src/Sylius/Bundle/GridBundle/test/app/config/config.yml
+++ b/src/Sylius/Bundle/GridBundle/test/app/config/config.yml
@@ -3,7 +3,6 @@ imports:
 
 framework:
     assets: false
-    translator: { fallbacks: ["%locale%"] }
     secret: "%secret%"
     router:
         resource: "%kernel.project_dir%/app/config/routing.yml"

--- a/src/Sylius/Bundle/ResourceBundle/.gitignore
+++ b/src/Sylius/Bundle/ResourceBundle/.gitignore
@@ -1,9 +1,9 @@
-vendor/
-bin/
+/vendor/
+/bin/
 
-composer.phar
-composer.lock
+/composer.phar
+/composer.lock
 
-test/app/cache
-test/app/logs
-test/app/db.sql
+/test/var/cache
+/test/var/log
+/test/app/db.sql

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
@@ -108,6 +108,16 @@ abstract class AbstractDriver implements DriverInterface
         $definition->setArguments($definitionArgs);
 
         $container->setDefinition($metadata->getServiceId('factory'), $definition);
+
+        if (method_exists($container, 'registerAliasForArgument')) {
+            foreach (class_implements($factoryClass) as $typehintClass) {
+                $container->registerAliasForArgument(
+                    $metadata->getServiceId('factory'),
+                    $typehintClass,
+                    $metadata->getHumanizedName() . ' factory'
+                );
+            }
+        }
     }
 
     protected function getMetadataDefinition(MetadataInterface $metadata): Definition

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/AbstractDoctrineDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/AbstractDoctrineDriver.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\Doctrine;
 
+use Doctrine\Common\Persistence\ObjectManager;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\AbstractDriver;
 use Sylius\Component\Resource\Metadata\MetadataInterface;
 use Symfony\Component\DependencyInjection\Alias;
@@ -43,6 +44,14 @@ abstract class AbstractDoctrineDriver extends AbstractDriver
             $metadata->getServiceId('manager'),
             new Alias($this->getManagerServiceId($metadata), true)
         );
+
+        if (method_exists($container, 'registerAliasForArgument')) {
+            $container->registerAliasForArgument(
+                $metadata->getServiceId('manager'),
+                ObjectManager::class,
+                $metadata->getHumanizedName() . ' manager'
+            );
+        }
     }
 
     /**

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineORMDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineORMDriver.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\Doctrine;
 
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Sylius\Component\Resource\Metadata\MetadataInterface;
@@ -54,6 +56,29 @@ final class DoctrineORMDriver extends AbstractDoctrineDriver
         $definition->setPublic(true);
 
         $container->setDefinition($metadata->getServiceId('repository'), $definition);
+
+        if (method_exists($container, 'registerAliasForArgument')) {
+            foreach (class_implements($repositoryClass) as $typehintClass) {
+                $container->registerAliasForArgument(
+                    $metadata->getServiceId('repository'),
+                    $typehintClass,
+                    $metadata->getHumanizedName() . ' repository'
+                );
+            }
+        }
+    }
+
+    protected function addManager(ContainerBuilder $container, MetadataInterface $metadata): void
+    {
+        parent::addManager($container, $metadata);
+
+        if (method_exists($container, 'registerAliasForArgument')) {
+            $container->registerAliasForArgument(
+                $metadata->getServiceId('manager'),
+                EntityManagerInterface::class,
+                $metadata->getHumanizedName() . ' manager'
+            );
+        }
     }
 
     /**
@@ -73,6 +98,6 @@ final class DoctrineORMDriver extends AbstractDoctrineDriver
      */
     protected function getClassMetadataClassname(): string
     {
-        return 'Doctrine\\ORM\\Mapping\\ClassMetadata';
+        return ClassMetadata::class;
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/phpunit.xml.dist
+++ b/src/Sylius/Bundle/ResourceBundle/phpunit.xml.dist
@@ -7,6 +7,7 @@
     <php>
         <server name="KERNEL_CLASS" value="AppKernel" />
         <server name="IS_DOCTRINE_ORM_SUPPORTED" value="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
     </php>
 
     <testsuites>

--- a/src/Sylius/Bundle/ResourceBundle/test/app/config/resources.yml
+++ b/src/Sylius/Bundle/ResourceBundle/test/app/config/resources.yml
@@ -6,7 +6,8 @@ sylius_resource:
         app.book:
             classes:
                 model: AppBundle\Entity\Book
-                factory: Sylius\Component\Resource\Factory\TranslatableFactory
+                factory: AppBundle\Factory\BookFactory
+                repository: AppBundle\Repository\BookRepository
                 form: AppBundle\Form\Type\BookType
             translation:
                 classes:

--- a/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/DependencyInjection/AppExtension.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/DependencyInjection/AppExtension.php
@@ -16,6 +16,7 @@ namespace AppBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 final class AppExtension extends Extension
@@ -25,7 +26,10 @@ final class AppExtension extends Extension
      */
     public function load(array $config, ContainerBuilder $container)
     {
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
-        $loader->load('services.xml');
+        $xmlFileLoader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $xmlFileLoader->load('services.xml');
+
+        $phpFileLoader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $phpFileLoader->load('services.php');
     }
 }

--- a/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Factory/BookFactory.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Factory/BookFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace AppBundle\Factory;
+
+use AppBundle\Entity\Book;
+use Sylius\Bundle\ResourceBundle\test\src\AppBundle\Factory\BookFactoryInterface;
+use Sylius\Component\Resource\Exception\UnexpectedTypeException;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\Component\Resource\Model\TranslatableInterface;
+use Sylius\Component\Resource\Translation\Provider\TranslationLocaleProviderInterface;
+
+final class BookFactory implements BookFactoryInterface
+{
+    /** @var FactoryInterface */
+    private $factory;
+
+    /** @var TranslationLocaleProviderInterface */
+    private $localeProvider;
+
+    public function __construct(FactoryInterface $factory, TranslationLocaleProviderInterface $localeProvider)
+    {
+        $this->factory = $factory;
+        $this->localeProvider = $localeProvider;
+    }
+
+    public function createNew()
+    {
+        $book = $this->factory->createNew();
+
+        if (!$book instanceof TranslatableInterface) {
+            throw new UnexpectedTypeException($book, TranslatableInterface::class);
+        }
+
+        $book->setCurrentLocale($this->localeProvider->getDefaultLocaleCode());
+        $book->setFallbackLocale($this->localeProvider->getDefaultLocaleCode());
+
+        return $book;
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Factory/BookFactoryInterface.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Factory/BookFactoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\test\src\AppBundle\Factory;
+
+use AppBundle\Entity\Book;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\Component\Resource\Factory\TranslatableFactoryInterface;
+
+interface BookFactoryInterface extends TranslatableFactoryInterface
+{
+}

--- a/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Repository/BookRepository.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Repository/BookRepository.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace AppBundle\Repository;
+
+use AppBundle\Entity\Book;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+use Sylius\Bundle\ResourceBundle\test\src\AppBundle\Repository\BookRepositoryInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+final class BookRepository extends EntityRepository implements BookRepositoryInterface
+{
+}

--- a/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Repository/BookRepositoryInterface.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Repository/BookRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\test\src\AppBundle\Repository;
+
+use AppBundle\Entity\Book;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+interface BookRepositoryInterface extends RepositoryInterface
+{
+}

--- a/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Resources/config/services.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Resources/config/services.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use AppBundle\Service\FirstAutowiredService;
+use AppBundle\Service\SecondAutowiredService;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+if (method_exists($container, 'registerAliasForArgument')) {
+    $container->autowire(FirstAutowiredService::class)->setPublic(true);
+    $container->autowire(SecondAutowiredService::class)->setPublic(true);
+} else {
+    $container->setDefinition(FirstAutowiredService::class, (new Definition(FirstAutowiredService::class, [
+        new Reference('app.factory.book'),
+        new Reference('app.repository.book'),
+        new Reference('app.manager.book'),
+    ]))->setPublic(true));
+
+    $container->setDefinition(SecondAutowiredService::class, (new Definition(SecondAutowiredService::class, [
+        new Reference('app.factory.book'),
+        new Reference('app.repository.book'),
+        new Reference('app.manager.book'),
+    ]))->setPublic(true));
+}

--- a/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Service/FirstAutowiredService.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Service/FirstAutowiredService.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Service;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+
+final class FirstAutowiredService
+{
+    /** @var FactoryInterface */
+    public $bookFactory;
+
+    /** @var RepositoryInterface */
+    public $bookRepository;
+
+    /** @var ObjectManager */
+    public $bookManager;
+
+    public function __construct(
+        FactoryInterface $bookFactory,
+        RepositoryInterface $bookRepository,
+        ObjectManager $bookManager
+    ) {
+        $this->bookFactory = $bookFactory;
+        $this->bookRepository = $bookRepository;
+        $this->bookManager = $bookManager;
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Service/SecondAutowiredService.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Service/SecondAutowiredService.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Service;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Sylius\Bundle\ResourceBundle\test\src\AppBundle\Factory\BookFactoryInterface;
+use Sylius\Bundle\ResourceBundle\test\src\AppBundle\Repository\BookRepositoryInterface;
+
+final class SecondAutowiredService
+{
+    /** @var BookFactoryInterface */
+    public $bookFactory;
+
+    /** @var BookRepositoryInterface */
+    public $bookRepository;
+
+    /** @var EntityManagerInterface */
+    public $bookManager;
+
+    public function __construct(
+        BookFactoryInterface $bookFactory,
+        BookRepositoryInterface $bookRepository,
+        EntityManagerInterface $bookManager
+    ) {
+        $this->bookFactory = $bookFactory;
+        $this->bookRepository = $bookRepository;
+        $this->bookManager = $bookManager;
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

This feature is only available when used with Symfony DependencyInjection ^4.2.

TODO:
 - [x] Automatic tests
 - [x] Symfony 4.2-based job on Travis

<img width="1086" alt="screenshot 2019-01-02 at 16 28 33" src="https://user-images.githubusercontent.com/1897953/50598590-795f5c80-0eab-11e9-8c0c-3b727e0a55b9.png">

