### PR TITLE
Do not require clearing cache when changing ResourceBundle drivers or metadata classes

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/SyliusResourceExtension.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ResourceBundle\DependencyInjection;
 
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\Doctrine\DoctrineODMDriver;
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\Doctrine\DoctrineORMDriver;
+use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\Doctrine\DoctrinePHPCRDriver;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Driver\DriverProvider;
 use Sylius\Component\Resource\Metadata\Metadata;
 use Symfony\Component\Config\FileLocator;
@@ -50,6 +53,12 @@ final class SyliusResourceExtension extends Extension
 
         $this->loadPersistence($config['drivers'], $config['resources'], $loader);
         $this->loadResources($config['resources'], $container);
+
+        $container->addObjectResource(Metadata::class);
+        $container->addObjectResource(DriverProvider::class);
+        $container->addObjectResource(DoctrineORMDriver::class);
+        $container->addObjectResource(DoctrineODMDriver::class);
+        $container->addObjectResource(DoctrinePHPCRDriver::class);
     }
 
     private function loadPersistence(array $drivers, array $resources, LoaderInterface $loader): void


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Makes working on PRs like #10062 easier.
