### PR TITLE
Make Sylius tests not fail on PHP 7.3

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -177,6 +177,6 @@ class Kernel extends BaseKernel
             }
         }
 
-        $containerServicesPropertyReflection->setValue($container, null);
+        $containerServicesPropertyReflection->setValue($container, []);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/10055, fixes https://github.com/Sylius/Sylius/issues/10058
| License         | MIT

It was also done here https://github.com/Sylius/Sylius-Standard/pull/306. Together with [AssociationHydrator v1.1.1](https://github.com/SyliusLabs/AssociationHydrator/releases/tag/v1.1.1) it allows Sylius to run with PHP 7.3. Even though we don't have tests on PHP 7.3 yet (and *right now* we probably don't want to have them to not make build even longer than it is), it would be good to make it possible, as we're not hooked strictly into 7.2.