### PR TITLE
Fix select attributes according to recent Symfony form changes

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeChoicesCollectionType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/Configuration/SelectAttributeChoicesCollectionType.php
@@ -36,7 +36,7 @@ class SelectAttributeChoicesCollectionType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+        $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) {
             $data = $event->getData();
             $form = $event->getForm();
 
@@ -57,8 +57,11 @@ class SelectAttributeChoicesCollectionType extends AbstractType
                     $fixedData[$newKey] = $this->resolveValues($values);
 
                     if ($form->offsetExists($key)) {
-                        $form->offsetUnset($key);
-                        $form->offsetSet(null, $newKey);
+                        $type = get_class($form->get($key)->getConfig()->getType()->getInnerType());
+                        $options = $form->get($key)->getConfig()->getOptions();
+
+                        $form->remove($key);
+                        $form->add($newKey, $type, $options);
                     }
                 }
 

--- a/src/Sylius/Bundle/ResourceBundle/test/app/config/routing.yml
+++ b/src/Sylius/Bundle/ResourceBundle/test/app/config/routing.yml
@@ -4,7 +4,7 @@ app_book:
     type: sylius.resource_api
 
 app_book_sortable_index:
-    path: /books/sortable/
+    path: /sortable-books/
     methods: [GET]
     defaults:
         _controller: app.controller.book:indexAction
@@ -12,7 +12,7 @@ app_book_sortable_index:
             sortable: true
 
 app_book_filterable_index:
-    path: /books/filterable/
+    path: /filterable-books/
     methods: [GET]
     defaults:
         _controller: app.controller.book:indexAction
@@ -24,7 +24,7 @@ app_versioned_book:
     prefix: /v{version}
 
 app_create_book_with_custom_factory:
-    path: /books/create-custom
+    path: /create-custom-book
     methods: [POST]
     defaults:
         _controller: app.controller.book:createAction

--- a/src/Sylius/Bundle/ResourceBundle/test/src/Tests/Controller/BookApiTest.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/Tests/Controller/BookApiTest.php
@@ -161,7 +161,7 @@ EOT;
     {
         $this->loadFixturesFromFile('more_books.yml');
 
-        $this->client->request('GET', '/books/sortable/', ['sorting' => ['name' => 'DESC']]);
+        $this->client->request('GET', '/sortable-books/', ['sorting' => ['name' => 'DESC']]);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_OK);
@@ -174,7 +174,7 @@ EOT;
     {
         $this->loadFixturesFromFile('more_books.yml');
 
-        $this->client->request('GET', '/books/filterable/', ['criteria' => ['name' => 'John']]);
+        $this->client->request('GET', '/filterable-books/', ['criteria' => ['name' => 'John']]);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_OK);
@@ -187,7 +187,7 @@ EOT;
     {
         $this->loadFixturesFromFile('more_books.yml');
 
-        $this->client->request('GET', '/books/sortable/', ['sorting' => ['id' => 'DESC']]);
+        $this->client->request('GET', '/sortable-books/', ['sorting' => ['id' => 'DESC']]);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_OK);
@@ -200,7 +200,7 @@ EOT;
     {
         $this->loadFixturesFromFile('more_books.yml');
 
-        $this->client->request('GET', '/books/filterable/', ['criteria' => ['author' => 'J.R.R. Tolkien']]);
+        $this->client->request('GET', '/filterable-books/', ['criteria' => ['author' => 'J.R.R. Tolkien']]);
         $response = $this->client->getResponse();
 
         $this->assertResponseCode($response, Response::HTTP_OK);
@@ -223,7 +223,7 @@ EOT;
         }
 EOT;
 
-        $this->client->request('POST', '/books/create-custom', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
+        $this->client->request('POST', '/create-custom-book', [], [], ['CONTENT_TYPE' => 'application/json'], $data);
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'books/create_response', Response::HTTP_CREATED);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related to https://github.com/symfony/symfony/pull/29307
| License         | MIT

Due to the latest Symfony 4.1.10/3.4.21 release and changes introduced in linked PR, a bug in select attribute type araised 🌤 Apparently, possible to select values in attribute configuration was saved with `TextType` form type, even though `SelectAttributeValueTranslationsType` should be used. It was somehow parsed before, but know it's not possible and this PR fixes this absurdity 🖖 