### PR TITLE
[Channel] Shop billing data

### DIFF
--- a/app/migrations/Version20190109091323.php
+++ b/app/migrations/Version20190109091323.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190109091323 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE sylius_shop_billing_data (id INT AUTO_INCREMENT NOT NULL, company VARCHAR(255) NOT NULL, taxId VARCHAR(255) NOT NULL, countryCode VARCHAR(255) NOT NULL, street VARCHAR(255) NOT NULL, city VARCHAR(255) NOT NULL, postcode VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE sylius_channel ADD shop_billing_data_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE sylius_channel ADD CONSTRAINT FK_16C8119EB5282EDF FOREIGN KEY (shop_billing_data_id) REFERENCES sylius_shop_billing_data (id) ON DELETE CASCADE');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_16C8119EB5282EDF ON sylius_channel (shop_billing_data_id)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_channel DROP FOREIGN KEY FK_16C8119EB5282EDF');
+        $this->addSql('DROP TABLE sylius_shop_billing_data');
+        $this->addSql('DROP INDEX UNIQ_16C8119EB5282EDF ON sylius_channel');
+        $this->addSql('ALTER TABLE sylius_channel DROP shop_billing_data_id');
+    }
+}

--- a/app/migrations/Version20190109095211.php
+++ b/app/migrations/Version20190109095211.php
@@ -8,14 +8,14 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20190109091323 extends AbstractMigration
+final class Version20190109095211 extends AbstractMigration
 {
     public function up(Schema $schema) : void
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('CREATE TABLE sylius_shop_billing_data (id INT AUTO_INCREMENT NOT NULL, company VARCHAR(255) NOT NULL, taxId VARCHAR(255) NOT NULL, countryCode VARCHAR(255) NOT NULL, street VARCHAR(255) NOT NULL, city VARCHAR(255) NOT NULL, postcode VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sylius_shop_billing_data (id INT AUTO_INCREMENT NOT NULL, company VARCHAR(255) DEFAULT NULL, taxId VARCHAR(255) DEFAULT NULL, countryCode VARCHAR(255) DEFAULT NULL, street VARCHAR(255) DEFAULT NULL, city VARCHAR(255) DEFAULT NULL, postcode VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
         $this->addSql('ALTER TABLE sylius_channel ADD shop_billing_data_id INT DEFAULT NULL');
         $this->addSql('ALTER TABLE sylius_channel ADD CONSTRAINT FK_16C8119EB5282EDF FOREIGN KEY (shop_billing_data_id) REFERENCES sylius_shop_billing_data (id) ON DELETE CASCADE');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_16C8119EB5282EDF ON sylius_channel (shop_billing_data_id)');

--- a/app/migrations/Version20190109095211.php
+++ b/app/migrations/Version20190109095211.php
@@ -15,7 +15,7 @@ final class Version20190109095211 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('CREATE TABLE sylius_shop_billing_data (id INT AUTO_INCREMENT NOT NULL, company VARCHAR(255) DEFAULT NULL, taxId VARCHAR(255) DEFAULT NULL, countryCode VARCHAR(255) DEFAULT NULL, street VARCHAR(255) DEFAULT NULL, city VARCHAR(255) DEFAULT NULL, postcode VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE sylius_shop_billing_data (id INT AUTO_INCREMENT NOT NULL, company VARCHAR(255) DEFAULT NULL, tax_id VARCHAR(255) DEFAULT NULL, country_code VARCHAR(255) DEFAULT NULL, street VARCHAR(255) DEFAULT NULL, city VARCHAR(255) DEFAULT NULL, postcode VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB');
         $this->addSql('ALTER TABLE sylius_channel ADD shop_billing_data_id INT DEFAULT NULL');
         $this->addSql('ALTER TABLE sylius_channel ADD CONSTRAINT FK_16C8119EB5282EDF FOREIGN KEY (shop_billing_data_id) REFERENCES sylius_shop_billing_data (id) ON DELETE CASCADE');
         $this->addSql('CREATE UNIQUE INDEX UNIQ_16C8119EB5282EDF ON sylius_channel (shop_billing_data_id)');

--- a/features/channel/managing_channels/adding_channel_with_shop_billing_data.feature
+++ b/features/channel/managing_channels/adding_channel_with_shop_billing_data.feature
@@ -1,0 +1,24 @@
+@managing_channels
+Feature: Adding a new channel with shop billing data
+    In order to sell through multiple channels of distributions with specific billing data
+    As an Administrator
+    I want to add a new channel with shop billing data to the registry
+
+    Background:
+        Given the store has currency "Euro"
+        And the store has locale "English (United States)"
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Adding a new channel with shop billing data
+        Given I want to create a new channel
+        When I specify its code as "MOBILE"
+        And I name it "Mobile channel"
+        And I choose "Euro" as the base currency
+        And I choose "English (United States)" as a default locale
+        And I specify company as "Ragnarok"
+        And I specify tax ID as "1100110011"
+        And I specify shop billing address as "Pacific Coast Hwy", "90806" "Los Angeles", "United States"
+        And I add it
+        Then I should be notified that it has been successfully created
+        And the channel "Mobile channel" should appear in the registry

--- a/features/channel/managing_channels/adding_channel_with_shop_billing_data.feature
+++ b/features/channel/managing_channels/adding_channel_with_shop_billing_data.feature
@@ -7,6 +7,7 @@ Feature: Adding a new channel with shop billing data
     Background:
         Given the store has currency "Euro"
         And the store has locale "English (United States)"
+        And the store operates in "United States"
         And I am logged in as an administrator
 
     @ui

--- a/features/channel/managing_channels/editing_shop_billing_data_on_channel.feature
+++ b/features/channel/managing_channels/editing_shop_billing_data_on_channel.feature
@@ -1,0 +1,22 @@
+@managing_channels
+Feature: Editing shop billing data on channel
+    In order to have proper shop billing data on shop-related documents
+    As an Administrator
+    I want to be able to edit shop billing data on a channel
+
+    Background:
+        Given the store operates on a channel named "Web Store"
+        And the store ships to "United States"
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Editing shop billing data on channel
+        When I want to modify a channel "Web Store"
+        And I specify company as "Ragnarok"
+        And I specify tax ID as "1100110011"
+        And I specify shop billing address as "Pacific Coast Hwy", "90806" "Los Angeles", "United States"
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And this channel company should be "Ragnarok"
+        And this channel tax ID should be "1100110011"
+        And this channel shop billing address should be "Pacific Coast Hwy", "90806" "Los Angeles", "United States"

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsBillingDataContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsBillingDataContext.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Ui\Admin;
+
+use Behat\Behat\Context\Context;
+use Sylius\Behat\Element\Admin\Channel\ShopBillingDataElementInterface;
+use Sylius\Component\Addressing\Model\CountryInterface;
+use Webmozart\Assert\Assert;
+
+final class ManagingChannelsBillingDataContext implements Context
+{
+    /** @var ShopBillingDataElementInterface */
+    private $shopBillingDataElement;
+
+    public function __construct(ShopBillingDataElementInterface $shopBillingDataElement)
+    {
+        $this->shopBillingDataElement = $shopBillingDataElement;
+    }
+
+    /**
+     * @When I specify company as :company
+     */
+    public function specifyCompanyAs(string $company): void
+    {
+        $this->shopBillingDataElement->specifyCompany($company);
+    }
+
+    /**
+     * @When I specify tax ID as :taxId
+     */
+    public function specifyTaxIdAs(string $taxId): void
+    {
+        $this->shopBillingDataElement->specifyTaxId($taxId);
+    }
+
+    /**
+     * @When I specify shop billing address as :street, :postcode :city, :country
+     */
+    public function specifyShopBillingAddressAs(
+        string $street,
+        string $postcode,
+        string $city,
+        CountryInterface $country
+    ): void
+    {
+        $this->shopBillingDataElement->specifyBillingAddress($street, $postcode, $city, $country->getCode());
+    }
+
+    /**
+     * @Then this channel company should be :company
+     */
+    public function thisChannelCompanyShouldBe(string $company): void
+    {
+        Assert::true($this->shopBillingDataElement->hasCompany($company));
+    }
+
+    /**
+     * @Then this channel tax ID should be :taxId
+     */
+    public function thisChanneTaxIdShouldBe(string $taxId): void
+    {
+        Assert::true($this->shopBillingDataElement->hasTaxId($taxId));
+    }
+
+    /**
+     * @Then this channel shop billing address should be :street, :postcode :city, :country
+     */
+    public function thisChannelShopBillingAddressShouldBe(
+        string $street,
+        string $postcode,
+        string $city,
+        CountryInterface $country
+    ): void
+    {
+        Assert::true($this->shopBillingDataElement->hasBillingAddress($street, $postcode, $city, $country->getCode()));
+    }
+}

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsBillingDataContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsBillingDataContext.php
@@ -43,8 +43,7 @@ final class ManagingChannelsBillingDataContext implements Context
         string $postcode,
         string $city,
         CountryInterface $country
-    ): void
-    {
+    ): void {
         $this->shopBillingDataElement->specifyBillingAddress($street, $postcode, $city, $country->getCode());
     }
 
@@ -72,8 +71,7 @@ final class ManagingChannelsBillingDataContext implements Context
         string $postcode,
         string $city,
         CountryInterface $country
-    ): void
-    {
+    ): void {
         Assert::true($this->shopBillingDataElement->hasBillingAddress($street, $postcode, $city, $country->getCode()));
     }
 }

--- a/src/Sylius/Behat/Element/Admin/Channel/ShopBillingDataElement.php
+++ b/src/Sylius/Behat/Element/Admin/Channel/ShopBillingDataElement.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Element\Admin\Channel;
+
+use FriendsOfBehat\PageObjectExtension\Element\Element;
+
+final class ShopBillingDataElement extends Element implements ShopBillingDataElementInterface
+{
+    public function specifyCompany(string $company): void
+    {
+        $this->getElement('company')->setValue($company);
+    }
+
+    public function specifyTaxId(string $taxId): void
+    {
+        $this->getElement('tax_id')->setValue($taxId);
+    }
+
+    public function specifyBillingAddress(string $street, string $postcode, string $city, string $countryCode): void
+    {
+        $this->getElement('street')->setValue($street);
+        $this->getElement('postcode')->setValue($postcode);
+        $this->getElement('city')->setValue($city);
+        $this->getElement('country_code')->setValue($countryCode);
+    }
+
+    public function hasCompany(string $company): bool
+    {
+        return $company === $this->getElement('company')->getValue();
+    }
+
+    public function hasTaxId(string $taxId): bool
+    {
+        return $taxId === $this->getElement('tax_id')->getValue();
+    }
+
+    public function hasBillingAddress(string $street, string $postcode, string $city, string $countryCode): bool
+    {
+        return
+            $street === $this->getElement('street')->getValue() &&
+            $postcode === $this->getElement('postcode')->getValue() &&
+            $city === $this->getElement('city')->getValue() &&
+            $countryCode === $this->getElement('country_code')->getValue()
+        ;
+    }
+
+    protected function getDefinedElements(): array
+    {
+        return array_merge(parent::getDefinedElements(), [
+            'city' => '#sylius_channel_billingData_city',
+            'company' => '#sylius_channel_billingData_company',
+            'country_code' => '#sylius_channel_billingData_countryCode',
+            'postcode' => '#sylius_channel_billingData_postcode',
+            'street' => '#sylius_channel_billingData_street',
+            'tax_id' => '#sylius_channel_billingData_taxId',
+        ]);
+    }
+}

--- a/src/Sylius/Behat/Element/Admin/Channel/ShopBillingDataElement.php
+++ b/src/Sylius/Behat/Element/Admin/Channel/ShopBillingDataElement.php
@@ -49,12 +49,12 @@ final class ShopBillingDataElement extends Element implements ShopBillingDataEle
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
-            'city' => '#sylius_channel_billingData_city',
-            'company' => '#sylius_channel_billingData_company',
-            'country_code' => '#sylius_channel_billingData_countryCode',
-            'postcode' => '#sylius_channel_billingData_postcode',
-            'street' => '#sylius_channel_billingData_street',
-            'tax_id' => '#sylius_channel_billingData_taxId',
+            'city' => '#sylius_channel_shopBillingData_city',
+            'company' => '#sylius_channel_shopBillingData_company',
+            'country_code' => '#sylius_channel_shopBillingData_countryCode',
+            'postcode' => '#sylius_channel_shopBillingData_postcode',
+            'street' => '#sylius_channel_shopBillingData_street',
+            'tax_id' => '#sylius_channel_shopBillingData_taxId',
         ]);
     }
 }

--- a/src/Sylius/Behat/Element/Admin/Channel/ShopBillingDataElementInterface.php
+++ b/src/Sylius/Behat/Element/Admin/Channel/ShopBillingDataElementInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Element\Admin\Channel;
+
+interface ShopBillingDataElementInterface
+{
+    public function specifyCompany(string $company): void;
+
+    public function specifyTaxId(string $taxId): void;
+
+    public function specifyBillingAddress(string $street, string $postcode, string $city, string $countryCode): void;
+
+    public function hasCompany(string $company): bool;
+
+    public function hasTaxId(string $taxId): bool;
+
+    public function hasBillingAddress(string $street, string $postcode, string $city, string $countryCode): bool;
+}

--- a/src/Sylius/Behat/Page/Admin/Channel/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/UpdatePage.php
@@ -38,19 +38,9 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         $this->getDocument()->selectFieldOption('Locales', $language);
     }
 
-    public function isLocaleChosen(string $language): bool
-    {
-        return $this->getElement('locales')->find('named', ['option', $language])->hasAttribute('selected');
-    }
-
     public function chooseCurrency(string $currencyCode): void
     {
         $this->getDocument()->selectFieldOption('Currencies', $currencyCode);
-    }
-
-    public function isCurrencyChosen(string $currencyCode): bool
-    {
-        return $this->getElement('currencies')->find('named', ['option', $currencyCode])->hasAttribute('selected');
     }
 
     public function chooseDefaultTaxZone(string $taxZone): void
@@ -61,6 +51,16 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
     public function chooseTaxCalculationStrategy(string $taxZone): void
     {
         $this->getDocument()->selectFieldOption('Tax calculation strategy', $taxZone);
+    }
+
+    public function isLocaleChosen(string $language): bool
+    {
+        return $this->getElement('locales')->find('named', ['option', $language])->hasAttribute('selected');
+    }
+
+    public function isCurrencyChosen(string $currencyCode): bool
+    {
+        return $this->getElement('currencies')->find('named', ['option', $currencyCode])->hasAttribute('selected');
     }
 
     public function isDefaultTaxZoneChosen(string $taxZone): bool

--- a/src/Sylius/Behat/Page/Admin/Channel/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/UpdatePageInterface.php
@@ -29,19 +29,19 @@ interface UpdatePageInterface extends BaseUpdatePageInterface
      */
     public function unsetTheme(): void;
 
-    public function isCodeDisabled(): bool;
-
     public function chooseLocale(string $language): void;
 
-    public function isLocaleChosen(string $language): bool;
-
     public function chooseCurrency(string $currencyCode): void;
-
-    public function isCurrencyChosen(string $currencyCode): bool;
 
     public function chooseDefaultTaxZone(string $taxZone): void;
 
     public function chooseTaxCalculationStrategy(string $taxCalculationStrategy): void;
+
+    public function isCodeDisabled(): bool;
+
+    public function isLocaleChosen(string $language): bool;
+
+    public function isCurrencyChosen(string $currencyCode): bool;
 
     public function isDefaultTaxZoneChosen(string $taxZone): bool;
 

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -49,6 +49,11 @@
             <tag name="fob.context_service" />
         </service>
 
+        <service id="sylius.behat.context.ui.admin.managing_channels_billing_data" class="Sylius\Behat\Context\Ui\Admin\ManagingChannelsBillingDataContext">
+            <argument type="service" id="sylius.behat.element.admin.channel.shop_billing_data" />
+            <tag name="fob.context_service" />
+        </service>
+
         <service id="sylius.behat.context.ui.admin.managing_countries" class="Sylius\Behat\Context\Ui\Admin\ManagingCountriesContext">
             <argument type="service" id="sylius.behat.page.admin.country.index" />
             <argument type="service" id="sylius.behat.page.admin.country.create" />

--- a/src/Sylius/Behat/Resources/config/services/elements.xml
+++ b/src/Sylius/Behat/Resources/config/services/elements.xml
@@ -16,6 +16,13 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
 >
     <imports>
+        <import resource="elements/admin.xml" />
         <import resource="elements/shop.xml" />
     </imports>
+    <services>
+        <service id="sylius.behat.element" class="FriendsOfBehat\PageObjectExtension\Element\Element" abstract="true" public="false">
+            <argument type="service" id="mink.default_session" />
+            <argument>%__behat__.mink.parameters%</argument>
+        </service>
+    </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/services/elements/admin.xml
+++ b/src/Sylius/Behat/Resources/config/services/elements/admin.xml
@@ -15,13 +15,9 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
 >
-    <parameters>
-        <parameter key="sylius.behat.element.shop.account.register.class">Sylius\Behat\Element\Shop\Account\RegisterElement</parameter>
-    </parameters>
-
     <services>
         <defaults public="true" />
 
-        <service id="sylius.behat.element.shop.account.register" class="%sylius.behat.element.shop.account.register.class%" parent="sylius.behat.symfony_page" public="false" />
+        <service id="sylius.behat.element.admin.channel.shop_billing_data" class="Sylius\Behat\Element\Admin\Channel\ShopBillingDataElement" parent="sylius.behat.element" public="false" />
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/services/elements/shop.xml
+++ b/src/Sylius/Behat/Resources/config/services/elements/shop.xml
@@ -15,7 +15,9 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
 >
-    <imports>
-        <import resource="shop/account.xml" />
-    </imports>
+    <services>
+        <defaults public="true" />
+
+        <service id="sylius.behat.element.shop.account.register" class="Sylius\Behat\Element\Shop\Account\RegisterElement" parent="sylius.behat.element" public="false" />
+    </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/suites/ui/channel/managing_channels.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/channel/managing_channels.yml
@@ -7,7 +7,9 @@ default:
             contexts_services:
                 - sylius.behat.context.hook.doctrine_orm
 
+                - sylius.behat.context.transform.address
                 - sylius.behat.context.transform.channel
+                - sylius.behat.context.transform.country
                 - sylius.behat.context.transform.currency
                 - sylius.behat.context.transform.locale
                 - sylius.behat.context.transform.shared_storage
@@ -15,6 +17,7 @@ default:
 
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.currency
+                - sylius.behat.context.setup.geographical
                 - sylius.behat.context.setup.locale
                 - sylius.behat.context.setup.payment
                 - sylius.behat.context.setup.admin_security

--- a/src/Sylius/Behat/Resources/config/suites/ui/channel/managing_channels.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/channel/managing_channels.yml
@@ -22,6 +22,7 @@ default:
                 - sylius.behat.context.setup.zone
 
                 - sylius.behat.context.ui.admin.managing_channels
+                - sylius.behat.context.ui.admin.managing_channels_billing_data
                 - sylius.behat.context.ui.admin.notification
             filters:
                 tags: "@managing_channels && @ui"

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Channel/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Channel/_form.html.twig
@@ -25,6 +25,21 @@
                 {{ form_row(form.themeName) }}
             </div>
         </div>
+        <div class="ui segment">
+            <h4 class="ui dividing header">{{ form_label(form.shopBillingData) }}</h4>
+            <div class="two fields">
+                {{ form_row(form.shopBillingData.company) }}
+                {{ form_row(form.shopBillingData.taxId) }}
+            </div>
+            <div class="two fields">
+                {{ form_row(form.shopBillingData.countryCode) }}
+                {{ form_row(form.shopBillingData.street) }}
+            </div>
+            <div class="two fields">
+                {{ form_row(form.shopBillingData.city) }}
+                {{ form_row(form.shopBillingData.postcode) }}
+            </div>
+        </div>
     </div>
     <div class="column">
         <div class="ui segment">

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
@@ -17,6 +17,7 @@ use Sylius\Bundle\AddressingBundle\Form\Type\ZoneChoiceType;
 use Sylius\Bundle\ChannelBundle\Form\Type\ChannelType;
 use Sylius\Bundle\CoreBundle\Form\EventSubscriber\AddBaseCurrencySubscriber;
 use Sylius\Bundle\CoreBundle\Form\EventSubscriber\ChannelFormSubscriber;
+use Sylius\Bundle\CoreBundle\Form\Type\ShopBillingDataType;
 use Sylius\Bundle\CoreBundle\Form\Type\TaxCalculationStrategyChoiceType;
 use Sylius\Bundle\CurrencyBundle\Form\Type\CurrencyChoiceType;
 use Sylius\Bundle\LocaleBundle\Form\Type\LocaleChoiceType;
@@ -79,6 +80,9 @@ final class ChannelTypeExtension extends AbstractTypeExtension
             ->add('accountVerificationRequired', CheckboxType::class, [
                 'label' => 'sylius.form.channel.account_verification_required',
                 'required' => false,
+            ])
+            ->add('shopBillingData', ShopBillingDataType::class, [
+                'label' => 'sylius.form.channel.shop_billing_data',
             ])
             ->addEventSubscriber(new AddBaseCurrencySubscriber())
             ->addEventSubscriber(new ChannelFormSubscriber())

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/ShopBillingDataType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/ShopBillingDataType.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Form\Type;
+
+use Sylius\Bundle\AddressingBundle\Form\Type\CountryCodeChoiceType;
+use Sylius\Component\Core\Model\ShopBillingData;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class ShopBillingDataType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('taxId', TextType::class, [
+                'label' => 'sylius.form.channel.billing_data.tax_id',
+                'required' => false,
+            ])
+            ->add('company', TextType::class, [
+                'required' => false,
+                'label' => 'sylius.form.channel.billing_data.company',
+            ])
+            ->add('countryCode', CountryCodeChoiceType::class, [
+                'label' => 'sylius.form.channel.billing_data.country',
+                'enabled' => true,
+            ])
+            ->add('street', TextType::class, [
+                'label' => 'sylius.form.channel.billing_data.street',
+            ])
+            ->add('city', TextType::class, [
+                'label' => 'sylius.form.channel.billing_data.city',
+            ])
+            ->add('postcode', TextType::class, [
+                'label' => 'sylius.form.channel.billing_data.postcode',
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefault('data_class', ShopBillingData::class);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/ShopBillingDataType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/ShopBillingDataType.php
@@ -13,6 +13,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class ShopBillingDataType extends AbstractType
 {
+    /** @var string */
+    private $dataClass;
+
+    public function __construct(string $dataClass)
+    {
+        $this->dataClass = $dataClass;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -27,21 +35,25 @@ final class ShopBillingDataType extends AbstractType
             ->add('countryCode', CountryCodeChoiceType::class, [
                 'label' => 'sylius.form.channel.billing_data.country',
                 'enabled' => true,
+                'required' => false,
             ])
             ->add('street', TextType::class, [
                 'label' => 'sylius.form.channel.billing_data.street',
+                'required' => false,
             ])
             ->add('city', TextType::class, [
                 'label' => 'sylius.form.channel.billing_data.city',
+                'required' => false,
             ])
             ->add('postcode', TextType::class, [
                 'label' => 'sylius.form.channel.billing_data.postcode',
+                'required' => false,
             ])
         ;
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefault('data_class', ShopBillingData::class);
+        $resolver->setDefault('data_class', $this->dataClass);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
@@ -57,7 +57,7 @@
         <one-to-one field="shopBillingData" target-entity="Sylius\Component\Core\Model\ShopBillingData">
             <join-column name="shop_billing_data_id" on-delete="CASCADE"/>
             <cascade>
-                <cascade-persist />
+                <cascade-all />
             </cascade>
         </one-to-one>
     </mapped-superclass>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
@@ -53,6 +53,12 @@
                 </inverse-join-columns>
             </join-table>
         </many-to-many>
-    </mapped-superclass>
 
+        <one-to-one field="shopBillingData" target-entity="Sylius\Component\Core\Model\ShopBillingData">
+            <join-column name="shop_billing_data_id" on-delete="CASCADE"/>
+            <cascade>
+                <cascade-persist />
+            </cascade>
+        </one-to-one>
+    </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ShopBillingData.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ShopBillingData.orm.xml
@@ -21,11 +21,11 @@
             <generator/>
         </id>
 
-        <field name="company" />
-        <field name="taxId" />
-        <field name="countryCode" />
-        <field name="street" />
-        <field name="city" />
-        <field name="postcode" />
+        <field name="company" nullable="true" />
+        <field name="taxId" nullable="true" />
+        <field name="countryCode" nullable="true" />
+        <field name="street" nullable="true" />
+        <field name="city" nullable="true" />
+        <field name="postcode" nullable="true" />
     </entity>
 </doctrine-mapping>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ShopBillingData.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ShopBillingData.orm.xml
@@ -22,8 +22,8 @@
         </id>
 
         <field name="company" nullable="true" />
-        <field name="taxId" nullable="true" />
-        <field name="countryCode" nullable="true" />
+        <field name="taxId" column="tax_id" nullable="true" />
+        <field name="countryCode" column="country_code" nullable="true" />
         <field name="street" nullable="true" />
         <field name="city" nullable="true" />
         <field name="postcode" nullable="true" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ShopBillingData.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ShopBillingData.orm.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                                      http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <entity name="Sylius\Component\Core\Model\ShopBillingData" table="sylius_shop_billing_data">
+        <id name="id" column="id" type="integer">
+            <generator/>
+        </id>
+
+        <field name="company" />
+        <field name="taxId" />
+        <field name="countryCode" />
+        <field name="street" />
+        <field name="city" />
+        <field name="postcode" />
+    </entity>
+</doctrine-mapping>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
@@ -48,6 +48,7 @@
         <parameter key="sylius.form.type.product_image.validation_groups" type="collection">
             <parameter>sylius</parameter>
         </parameter>
+        <parameter key="sylius.model.shop_billing_data.class">Sylius\Component\Core\Model\ShopBillingData</parameter>
     </parameters>
 
     <services>
@@ -242,6 +243,7 @@
         </service>
 
         <service id="sylius.form.type.shop_billing_data" class="Sylius\Bundle\CoreBundle\Form\Type\ShopBillingDataType">
+            <argument>%sylius.model.shop_billing_data.class%</argument>
             <tag name="form.type" />
         </service>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
@@ -241,6 +241,10 @@
             <tag name="form.type" />
         </service>
 
+        <service id="sylius.form.type.shop_billing_data" class="Sylius\Bundle\CoreBundle\Form\Type\ShopBillingDataType">
+            <tag name="form.type" />
+        </service>
+
         <service id="sylius.form.type.autocomplete_product_taxon_choice" class="Sylius\Bundle\CoreBundle\Form\Type\Taxon\ProductTaxonAutocompleteChoiceType">
             <argument type="service" id="sylius.factory.product_taxon" />
             <argument type="service" id="sylius.repository.product_taxon" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
@@ -22,6 +22,13 @@ sylius:
             name: Name
             roles: Roles
         channel:
+            billing_data:
+                city: City
+                company: Company
+                country: Country
+                postcode: Postcode
+                street: Street
+                tax_id: Tax ID
             contact_email: Contact email
             currencies: Currencies
             currency_base: Base currency
@@ -31,6 +38,7 @@ sylius:
             locales: Locales
             payment_methods: Payment Methods
             shipping_methods: Shipping Methods
+            shop_billing_data: Shop billing data
             skipping_shipping_step_allowed: Skip shipping step if only one shipping method is available?
             skipping_payment_step_allowed: Skip payment step if only one payment method is available?
             tax_calculation_strategy: Tax calculation strategy

--- a/src/Sylius/Component/Core/Model/Channel.php
+++ b/src/Sylius/Component/Core/Model/Channel.php
@@ -64,6 +64,7 @@ class Channel extends BaseChannel implements ChannelInterface
 
         $this->currencies = new ArrayCollection();
         $this->locales = new ArrayCollection();
+        $this->shopBillingData = new ShopBillingData();
     }
 
     /**
@@ -282,12 +283,12 @@ class Channel extends BaseChannel implements ChannelInterface
         $this->accountVerificationRequired = $accountVerificationRequired;
     }
 
-    public function getShopBillingData(): ?ShopBillingDataInterface
+    public function getShopBillingData(): ShopBillingDataInterface
     {
         return $this->shopBillingData;
     }
 
-    public function setShopBillingData(?ShopBillingDataInterface $shopBillingData): void
+    public function setShopBillingData(ShopBillingDataInterface $shopBillingData): void
     {
         $this->shopBillingData = $shopBillingData;
     }

--- a/src/Sylius/Component/Core/Model/Channel.php
+++ b/src/Sylius/Component/Core/Model/Channel.php
@@ -55,6 +55,9 @@ class Channel extends BaseChannel implements ChannelInterface
     /** @var bool */
     protected $accountVerificationRequired = true;
 
+    /** @var ShopBillingDataInterface|null */
+    protected $shopBillingData;
+
     public function __construct()
     {
         parent::__construct();
@@ -277,5 +280,15 @@ class Channel extends BaseChannel implements ChannelInterface
     public function setAccountVerificationRequired(bool $accountVerificationRequired): void
     {
         $this->accountVerificationRequired = $accountVerificationRequired;
+    }
+
+    public function getShopBillingData(): ?ShopBillingDataInterface
+    {
+        return $this->shopBillingData;
+    }
+
+    public function setShopBillingData(?ShopBillingDataInterface $shopBillingData): void
+    {
+        $this->shopBillingData = $shopBillingData;
     }
 }

--- a/src/Sylius/Component/Core/Model/ChannelInterface.php
+++ b/src/Sylius/Component/Core/Model/ChannelInterface.php
@@ -61,7 +61,7 @@ interface ChannelInterface extends
 
     public function setAccountVerificationRequired(bool $accountVerificationRequired): void;
 
-    public function getShopBillingData(): ?ShopBillingDataInterface;
+    public function getShopBillingData(): ShopBillingDataInterface;
 
-    public function setShopBillingData(?ShopBillingDataInterface $shopBillingData): void;
+    public function setShopBillingData(ShopBillingDataInterface $shopBillingData): void;
 }

--- a/src/Sylius/Component/Core/Model/ChannelInterface.php
+++ b/src/Sylius/Component/Core/Model/ChannelInterface.php
@@ -60,4 +60,8 @@ interface ChannelInterface extends
     public function isAccountVerificationRequired(): bool;
 
     public function setAccountVerificationRequired(bool $accountVerificationRequired): void;
+
+    public function getShopBillingData(): ?ShopBillingDataInterface;
+
+    public function setShopBillingData(?ShopBillingDataInterface $shopBillingData): void;
 }

--- a/src/Sylius/Component/Core/Model/ShopBillingData.php
+++ b/src/Sylius/Component/Core/Model/ShopBillingData.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Model;
+
+/** @final */
+class ShopBillingData implements ShopBillingDataInterface
+{
+    /** @var int|null */
+    private $id;
+
+    /** @var string|null */
+    private $company;
+
+    /** @var string|null */
+    private $taxId;
+
+    /** @var string|null */
+    private $countryCode;
+
+    /** @var string|null */
+    private $street;
+
+    /** @var string|null */
+    private $city;
+
+    /** @var string|null */
+    private $postcode;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getCompany(): ?string
+    {
+        return $this->company;
+    }
+
+    public function setCompany(?string $company): void
+    {
+        $this->company = $company;
+    }
+
+    public function getTaxId(): ?string
+    {
+        return $this->taxId;
+    }
+
+    public function setTaxId(?string $taxId): void
+    {
+        $this->taxId = $taxId;
+    }
+
+    public function getCountryCode(): ?string
+    {
+        return $this->countryCode;
+    }
+
+    public function setCountryCode(?string $countryCode): void
+    {
+        $this->countryCode = $countryCode;
+    }
+
+    public function getStreet(): ?string
+    {
+        return $this->street;
+    }
+
+    public function setStreet(?string $street): void
+    {
+        $this->street = $street;
+    }
+
+    public function getCity(): ?string
+    {
+        return $this->city;
+    }
+
+    public function setCity(?string $city): void
+    {
+        $this->city = $city;
+    }
+
+    public function getPostcode(): ?string
+    {
+        return $this->postcode;
+    }
+
+    public function setPostcode(?string $postcode): void
+    {
+        $this->postcode = $postcode;
+    }
+}

--- a/src/Sylius/Component/Core/Model/ShopBillingData.php
+++ b/src/Sylius/Component/Core/Model/ShopBillingData.php
@@ -17,30 +17,25 @@ namespace Sylius\Component\Core\Model;
 class ShopBillingData implements ShopBillingDataInterface
 {
     /** @var int|null */
-    private $id;
+    protected $id;
 
     /** @var string|null */
-    private $company;
+    protected $company;
 
     /** @var string|null */
-    private $taxId;
+    protected $taxId;
 
     /** @var string|null */
-    private $countryCode;
+    protected $countryCode;
 
     /** @var string|null */
-    private $street;
+    protected $street;
 
     /** @var string|null */
-    private $city;
+    protected $city;
 
     /** @var string|null */
-    private $postcode;
-
-    public function getId(): ?int
-    {
-        return $this->id;
-    }
+    protected $postcode;
 
     public function getCompany(): ?string
     {

--- a/src/Sylius/Component/Core/Model/ShopBillingDataInterface.php
+++ b/src/Sylius/Component/Core/Model/ShopBillingDataInterface.php
@@ -15,8 +15,6 @@ namespace Sylius\Component\Core\Model;
 
 interface ShopBillingDataInterface
 {
-    public function getId(): ?int;
-
     public function getTaxId(): ?string;
 
     public function setTaxId(?string $taxId): void;

--- a/src/Sylius/Component/Core/Model/ShopBillingDataInterface.php
+++ b/src/Sylius/Component/Core/Model/ShopBillingDataInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Model;
+
+interface ShopBillingDataInterface
+{
+    public function getId(): ?int;
+
+    public function getTaxId(): ?string;
+
+    public function setTaxId(?string $taxId): void;
+
+    public function getCompany(): ?string;
+
+    public function setCompany(?string $company): void;
+
+    public function getCountryCode(): ?string;
+
+    public function setCountryCode(?string $countryCode): void;
+
+    public function getStreet(): ?string;
+
+    public function setStreet(?string $street): void;
+
+    public function getCity(): ?string;
+
+    public function setCity(?string $city): void;
+
+    public function getPostcode(): ?string;
+
+    public function setPostcode(?string $postcode): void;
+}

--- a/src/Sylius/Component/Core/spec/Model/ShopBillingDataSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ShopBillingDataSpec.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Core\Model;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\ShopBillingDataInterface;
+
+final class ShopBillingDataSpec extends ObjectBehavior
+{
+    function it_implements_shop_billing_data_interface(): void
+    {
+        $this->shouldImplement(ShopBillingDataInterface::class);
+    }
+
+    function its_company_is_mutable(): void
+    {
+        $this->setCompany('Ragnarok');
+        $this->getCompany()->shouldReturn('Ragnarok');
+    }
+
+    function its_tax_id_is_mutable(): void
+    {
+        $this->setTaxId('1100110011');
+        $this->getTaxId()->shouldReturn('1100110011');
+    }
+
+    function its_country_code_is_mutable(): void
+    {
+        $this->setCountryCode('US');
+        $this->getCountryCode()->shouldReturn('US');
+    }
+
+    function its_street_is_mutable(): void
+    {
+        $this->setStreet('Blue Street');
+        $this->getStreet()->shouldReturn('Blue Street');
+    }
+
+    function its_city_is_mutable(): void
+    {
+        $this->setCity('New York');
+        $this->getCity()->shouldReturn('New York');
+    }
+
+    function its_postcode_is_mutable(): void
+    {
+        $this->setPostcode('94111');
+        $this->getPostcode()->shouldReturn('94111');
+    }
+}

--- a/tests/Responses/Expected/channel/create_validation_fail_response.json
+++ b/tests/Responses/Expected/channel/create_validation_fail_response.json
@@ -34,6 +34,16 @@
       "skippingShippingStepAllowed": {},
       "skippingPaymentStepAllowed": {},
       "accountVerificationRequired": {},
+      "shopBillingData": {
+        "children": {
+          "taxId": {},
+          "company": {},
+          "countryCode": {},
+          "street": {},
+          "city": {},
+          "postcode": {}
+        }
+      },
       "code": {
         "errors": [
           "Please enter channel code."

--- a/tests/Responses/Expected/channel/update_validation_fail_response.json
+++ b/tests/Responses/Expected/channel/update_validation_fail_response.json
@@ -26,6 +26,16 @@
             "skippingShippingStepAllowed": {},
             "skippingPaymentStepAllowed": {},
             "accountVerificationRequired": {},
+            "shopBillingData": {
+                "children": {
+                    "taxId": {},
+                    "company": {},
+                    "countryCode": {},
+                    "street": {},
+                    "city": {},
+                    "postcode": {}
+                }
+            },
             "code": {},
             "baseCurrency": {}
         }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | associated with https://github.com/Sylius/RefundPlugin/issues/106, https://github.com/Sylius/InvoicingPlugin/issues/52
| License         | MIT

During the development of `InvoicingPlugin`, we introduced a concept of shop billing data (set per channel) that is required to be displayed on an invoice. On the other hand, we also should have it in a `RefundPlugin` to generate a credit memo properly.

We considered a few options, but in the end, it's quite a common use case to have such a bunch of data manageable in Admin panel.

<img width="563" alt="zrzut ekranu 2019-01-9 o 11 04 31" src="https://user-images.githubusercontent.com/6212718/50892815-a35ed480-13ff-11e9-81e7-d5a96c6f8e28.png">
