### PR TITLE
[CoreBundle] Fix Type in Construct for ChannelDeletionListener

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/ChannelDeletionListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/ChannelDeletionListener.php
@@ -13,17 +13,17 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Sylius\Bundle\ChannelBundle\Doctrine\ORM\ChannelRepository;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 use Sylius\Component\Channel\Model\ChannelInterface;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Resource\Exception\UnexpectedTypeException;
 
 final class ChannelDeletionListener
 {
-    /** @var ChannelRepository */
+    /** @var ChannelRepositoryInterface */
     private $channelRepository;
 
-    public function __construct(ChannelRepository $repository)
+    public function __construct(ChannelRepositoryInterface $repository)
     {
         $this->channelRepository = $repository;
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

I needed to decorate sylius.repository.channel but this listener constructor prevented me to do it...