### PR TITLE
[Theme] Allow overriding templates from plugins (1.2.*)

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Templating/TemplateNameParser.php
+++ b/src/Sylius/Bundle/ThemeBundle/Templating/TemplateNameParser.php
@@ -57,7 +57,7 @@ final class TemplateNameParser implements TemplateNameParserInterface
         }
 
         $template = new TemplateReference(
-            $matches[1] ? $matches[1] . 'Bundle' : '',
+            $this->getBundleOrPluginName($matches[1]),
             $matches[2],
             $matches[3],
             $matches[4],
@@ -73,5 +73,14 @@ final class TemplateNameParser implements TemplateNameParserInterface
         }
 
         return $this->cache[$name] = $template;
+    }
+
+    private function getBundleOrPluginName(string $name): string
+    {
+        if (preg_match('/^.+Plugin$/', $name)) {
+            return $name;
+        }
+
+        return $name ? $name . 'Bundle' : '';
     }
 }

--- a/src/Sylius/Bundle/ThemeBundle/Templating/TemplateNameParser.php
+++ b/src/Sylius/Bundle/ThemeBundle/Templating/TemplateNameParser.php
@@ -77,7 +77,7 @@ final class TemplateNameParser implements TemplateNameParserInterface
 
     private function getBundleOrPluginName(string $name): string
     {
-        if (preg_match('/^.+Plugin$/', $name)) {
+        if (substr($name, -6) === 'Plugin') {
             return $name;
         }
 

--- a/src/Sylius/Bundle/ThemeBundle/spec/Templating/TemplateNameParserSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/Templating/TemplateNameParserSpec.php
@@ -65,6 +65,17 @@ final class TemplateNameParserSpec extends ObjectBehavior
         $this->parse('@Acme/Nested/Directory/app.html.twig')->shouldBeLike(new TemplateReference('AcmeBundle', 'Nested/Directory', 'app', 'html', 'twig'));
     }
 
+    function it_generates_plugin_template_references_from_namespaced_paths(KernelInterface $kernel): void
+    {
+        $kernel->getBundle('AcmePlugin')->willReturn(null); // just do not throw an exception
+
+        $this->parse('@AcmePlugin/app.html.twig')->shouldBeLike(new TemplateReference('AcmePlugin', '', 'app', 'html', 'twig'));
+        $this->parse('@AcmePlugin/Directory/app.html.twig')->shouldBeLike(new TemplateReference('AcmePlugin', 'Directory', 'app', 'html', 'twig'));
+        $this->parse('@AcmePlugin/Directory.WithDot/app.html.twig')->shouldBeLike(new TemplateReference('AcmePlugin', 'Directory.WithDot', 'app', 'html', 'twig'));
+        $this->parse('@AcmePlugin/Directory/app.with.dots.html.twig')->shouldBeLike(new TemplateReference('AcmePlugin', 'Directory', 'app.with.dots', 'html', 'twig'));
+        $this->parse('@AcmePlugin/Nested/Directory/app.html.twig')->shouldBeLike(new TemplateReference('AcmePlugin', 'Nested/Directory', 'app', 'html', 'twig'));
+    }
+
     function it_delegates_custom_namespace_to_decorated_parser(
         KernelInterface $kernel,
         TemplateNameParserInterface $decoratedParser,


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/9654
| License         | MIT

It's hard to test this change with some functional test in a current tests structure, as it would require to use `SyliusPluginTrait` in test bundle/plugin, but it's in a core bundle :/ I have some idea have to test it properly with a Behat scenario, but I need to spend a few more minutes on that :)

It would be nice if someone could incorporate these changes into their application and see does it work as expected (cc @jacquesbh :)). I've of course done that, but _better safe than sorry_ 🐃 

This change only applies to `1.2` branch, for Sylius `^1.3` take a look here: https://github.com/Sylius/Sylius/pull/10083.