### PR TITLE
[Theme] Allow overriding templates from plugins (^1.3)

### DIFF
--- a/src/Sylius/Bundle/ThemeBundle/Locator/BundleResourceLocator.php
+++ b/src/Sylius/Bundle/ThemeBundle/Locator/BundleResourceLocator.php
@@ -85,15 +85,23 @@ final class BundleResourceLocator implements ResourceLocatorInterface
     private function locateResourceBasedOnTwigNamespace(string $resourcePath, ThemeInterface $theme): string
     {
         $twigNamespace = substr($resourcePath, 1, strpos($resourcePath, '/') - 1);
-        $bundleName = $twigNamespace . 'Bundle';
         $resourceName = substr($resourcePath, strpos($resourcePath, '/') + 1);
 
-        $path = sprintf('%s/%s/views/%s', $theme->getPath(), $bundleName, $resourceName);
+        $path = sprintf('%s/%s/views/%s', $theme->getPath(), $this->getBundleOrPluginName($twigNamespace), $resourceName);
 
         if ($this->filesystem->exists($path)) {
             return $path;
         }
 
         throw new ResourceNotFoundException($resourcePath, $theme);
+    }
+
+    private function getBundleOrPluginName(string $twigNamespace): string
+    {
+        if (preg_match('/Plugin$/', $twigNamespace)) {
+            return $twigNamespace;
+        }
+
+        return $twigNamespace . 'Bundle';
     }
 }

--- a/src/Sylius/Bundle/ThemeBundle/Locator/BundleResourceLocator.php
+++ b/src/Sylius/Bundle/ThemeBundle/Locator/BundleResourceLocator.php
@@ -98,7 +98,7 @@ final class BundleResourceLocator implements ResourceLocatorInterface
 
     private function getBundleOrPluginName(string $twigNamespace): string
     {
-        if (preg_match('/Plugin$/', $twigNamespace)) {
+        if (substr($twigNamespace, -6) === 'Plugin') {
             return $twigNamespace;
         }
 

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/FirstTestTheme/TestPlugin/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/FirstTestTheme/TestPlugin/views/Templating/twigNamespacedBothThemesTemplate.txt.twig
@@ -1,0 +1,1 @@
+@TestPlugin/Templating/twigNamespacedBothThemesTemplate.txt.twig|sylius/first-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/FirstTestTheme/TestPlugin/views/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Fixtures/themes/FirstTestTheme/TestPlugin/views/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig
@@ -1,0 +1,1 @@
+@TestPlugin/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig|sylius/first-test-theme

--- a/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TemplatingTest.php
+++ b/src/Sylius/Bundle/ThemeBundle/Tests/Functional/TemplatingTest.php
@@ -82,6 +82,29 @@ final class TemplatingTest extends WebTestCase
 
     /**
      * @test
+     * @dataProvider getPluginTemplatesUsingNamespacedPaths
+     */
+    public function it_renders_sylius_plugin_templates_using_namespaced_paths(string $templateName, string $contents): void
+    {
+        $client = self::createClient();
+
+        $crawler = $client->request('GET', '/template/' . $templateName);
+        $this->assertEquals($contents, trim($crawler->text()));
+    }
+
+    /**
+     * @return array
+     */
+    public function getPluginTemplatesUsingNamespacedPaths(): array
+    {
+        return [
+            ['@TestPlugin/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig', '@TestPlugin/Templating/twigNamespacedVanillaOverriddenThemeTemplate.txt.twig|sylius/first-test-theme'],
+            ['@TestPlugin/Templating/twigNamespacedBothThemesTemplate.txt.twig', '@TestPlugin/Templating/twigNamespacedBothThemesTemplate.txt.twig|sylius/first-test-theme'],
+        ];
+    }
+
+    /**
+     * @test
      * @dataProvider getAppTemplates
      *
      * @param string $templateName

--- a/src/Sylius/Bundle/ThemeBundle/spec/Locator/BundleResourceLocatorSpec.php
+++ b/src/Sylius/Bundle/ThemeBundle/spec/Locator/BundleResourceLocatorSpec.php
@@ -102,6 +102,17 @@ final class BundleResourceLocatorSpec extends ObjectBehavior
         $this->locateResource('@Just/Directory/index.html.twig', $theme)->shouldReturn('/theme/path/JustBundle/views/Directory/index.html.twig');
     }
 
+    function it_locates_plugin_resource_using_path_derived_from_twig_namespaces(
+        Filesystem $filesystem,
+        ThemeInterface $theme
+    ): void {
+        $theme->getPath()->willReturn('/theme/path');
+
+        $filesystem->exists('/theme/path/JustPlugin/views/Directory/index.html.twig')->shouldBeCalled()->willReturn(true);
+
+        $this->locateResource('@JustPlugin/Directory/index.html.twig', $theme)->shouldReturn('/theme/path/JustPlugin/views/Directory/index.html.twig');
+    }
+
     function it_throws_an_exception_if_resource_can_not_be_located_using_path_derived_from_twig_namespaces(
         Filesystem $filesystem,
         ThemeInterface $theme


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes (kinda) https://github.com/Sylius/Sylius/issues/9654
| License         | MIT

This is, of course, a quick fix and quite straight-forward, but it works 😄 And it is still required to use `@SyliusTestPlugin` notation (maybe it's worth to be documented somehow?). This PR fixes the functionality for Sylius `^1.3`, for working fix on `1.2` take a look here: https://github.com/Sylius/Sylius/pull/10082.

Regarding testing it better (as I've also written in fix for `1.2`):

> It's hard to test this change with some functional test in a current tests structure, as it would require to use `SyliusPluginTrait` in test bundle/plugin, but it's in a core bundle :/ I have some idea have to test it properly with a Behat scenario, but I need to spend a few more minutes on that :)