### PR TITLE
Improve docblocks and return types

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Controller/ProductTaxonController.php
+++ b/src/Sylius/Bundle/CoreBundle/Controller/ProductTaxonController.php
@@ -37,7 +37,7 @@ class ProductTaxonController extends ResourceController
         }
 
         if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && null !== $productTaxons) {
-            /** @var ProductTaxonInterface $productTaxon */
+            /** @var array $productTaxon */
             foreach ($productTaxons as $productTaxon) {
                 if (!is_numeric($productTaxon['position'])) {
                     throw new HttpException(

--- a/src/Sylius/Bundle/CoreBundle/EventListener/ImagesRemoveListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/ImagesRemoveListener.php
@@ -52,7 +52,7 @@ final class ImagesRemoveListener
             }
 
             if (!in_array($entityDeletion->getPath(), $this->imagesToDelete)) {
-                $this->imagesToDelete[] = $entityDeletion->getPath();
+                $this->imagesToDelete[] = (string) $entityDeletion->getPath();
             }
         }
     }

--- a/src/Sylius/Bundle/FixturesBundle/Suite/Suite.php
+++ b/src/Sylius/Bundle/FixturesBundle/Suite/Suite.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\FixturesBundle\Suite;
 
 use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
 use Sylius\Bundle\FixturesBundle\Listener\ListenerInterface;
+use Traversable;
 use Zend\Stdlib\SplPriorityQueue;
 
 final class Suite implements SuiteInterface
@@ -56,7 +57,7 @@ final class Suite implements SuiteInterface
     /**
      * {@inheritdoc}
      */
-    public function getFixtures(): iterable
+    public function getFixtures(): Traversable
     {
         $fixtures = clone $this->fixtures;
         foreach ($fixtures as $fixture) {
@@ -67,7 +68,7 @@ final class Suite implements SuiteInterface
     /**
      * {@inheritdoc}
      */
-    public function getListeners(): iterable
+    public function getListeners(): Traversable
     {
         $listeners = clone $this->listeners;
         foreach ($listeners as $listener) {

--- a/src/Sylius/Bundle/FixturesBundle/Suite/Suite.php
+++ b/src/Sylius/Bundle/FixturesBundle/Suite/Suite.php
@@ -57,7 +57,7 @@ final class Suite implements SuiteInterface
     /**
      * {@inheritdoc}
      */
-    public function getFixtures(): Traversable
+    public function getFixtures(): iterable
     {
         $fixtures = clone $this->fixtures;
         foreach ($fixtures as $fixture) {
@@ -68,7 +68,7 @@ final class Suite implements SuiteInterface
     /**
      * {@inheritdoc}
      */
-    public function getListeners(): Traversable
+    public function getListeners(): iterable
     {
         $listeners = clone $this->listeners;
         foreach ($listeners as $listener) {

--- a/src/Sylius/Bundle/FixturesBundle/Suite/SuiteInterface.php
+++ b/src/Sylius/Bundle/FixturesBundle/Suite/SuiteInterface.php
@@ -22,15 +22,14 @@ interface SuiteInterface
     public function getName(): string;
 
     /**
-     * @return Traversable Fixtures as keys, options as values
-     * @psalm-return Traversable<FixtureInterface, array>
+     * @return Traversable <FixtureInterface, array> Fixtures as keys, options as values
      */
-    public function getFixtures(): Traversable;
+    public function getFixtures(): iterable;
 
     /**
      * @see \Sylius\Bundle\FixturesBundle\Listener\ListenerInterface
      *
      * @return Traversable <ListenerInterface, array> Listeners as keys, options as values
      */
-    public function getListeners(): Traversable;
+    public function getListeners(): iterable;
 }

--- a/src/Sylius/Bundle/FixturesBundle/Suite/SuiteInterface.php
+++ b/src/Sylius/Bundle/FixturesBundle/Suite/SuiteInterface.php
@@ -30,8 +30,7 @@ interface SuiteInterface
     /**
      * @see \Sylius\Bundle\FixturesBundle\Listener\ListenerInterface
      *
-     * @return Traversable Listeners as keys, options as values
-     * @psalm-return Traversable<ListenerInterface, array>
+     * @return Traversable <ListenerInterface, array> Listeners as keys, options as values
      */
     public function getListeners(): Traversable;
 }

--- a/src/Sylius/Bundle/FixturesBundle/Suite/SuiteInterface.php
+++ b/src/Sylius/Bundle/FixturesBundle/Suite/SuiteInterface.php
@@ -15,20 +15,23 @@ namespace Sylius\Bundle\FixturesBundle\Suite;
 
 use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
 use Sylius\Bundle\FixturesBundle\Listener\ListenerInterface;
+use Traversable;
 
 interface SuiteInterface
 {
     public function getName(): string;
 
     /**
-     * @return iterable|FixtureInterface[] Fixtures as keys, options as values
+     * @return Traversable Fixtures as keys, options as values
+     * @psalm-return Traversable<FixtureInterface, array>
      */
-    public function getFixtures(): iterable;
+    public function getFixtures(): Traversable;
 
     /**
      * @see \Sylius\Bundle\FixturesBundle\Listener\ListenerInterface
      *
-     * @return iterable|ListenerInterface[] Listeners as keys, options as values
+     * @return Traversable Listeners as keys, options as values
+     * @psalm-return Traversable<ListenerInterface, array>
      */
-    public function getListeners(): iterable;
+    public function getListeners(): Traversable;
 }

--- a/src/Sylius/Bundle/ProductBundle/Form/DataTransformer/ProductVariantToProductOptionsTransformer.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/DataTransformer/ProductVariantToProductOptionsTransformer.php
@@ -47,7 +47,7 @@ final class ProductVariantToProductOptionsTransformer implements DataTransformer
 
         return array_combine(
             array_map(function (ProductOptionValueInterface $productOptionValue) {
-                return $productOptionValue->getOptionCode();
+                return (string) $productOptionValue->getOptionCode();
             }, $value->getOptionValues()->toArray()),
             $value->getOptionValues()->toArray()
         );

--- a/src/Sylius/Component/Core/Uploader/ImageUploader.php
+++ b/src/Sylius/Component/Core/Uploader/ImageUploader.php
@@ -37,9 +37,9 @@ class ImageUploader implements ImageUploaderInterface
             return;
         }
 
+        /** @var File $file */
         $file = $image->getFile();
 
-        /** @var File $file */
         Assert::isInstanceOf($file, File::class);
 
         if (null !== $image->getPath() && $this->has($image->getPath())) {
@@ -48,6 +48,7 @@ class ImageUploader implements ImageUploaderInterface
 
         do {
             $hash = bin2hex(random_bytes(16));
+            /** @var File $file */
             $path = $this->expandPath($hash . '.' . $file->guessExtension());
         } while ($this->isAdBlockingProne($path) || $this->filesystem->has($path));
 

--- a/src/Sylius/Component/Core/Uploader/ImageUploader.php
+++ b/src/Sylius/Component/Core/Uploader/ImageUploader.php
@@ -48,7 +48,6 @@ class ImageUploader implements ImageUploaderInterface
 
         do {
             $hash = bin2hex(random_bytes(16));
-            /** @var File $file */
             $path = $this->expandPath($hash . '.' . $file->guessExtension());
         } while ($this->isAdBlockingProne($path) || $this->filesystem->has($path));
 

--- a/src/Sylius/Component/Resource/Metadata/Registry.php
+++ b/src/Sylius/Component/Resource/Metadata/Registry.php
@@ -21,7 +21,7 @@ final class Registry implements RegistryInterface
     /**
      * {@inheritdoc}
      */
-    public function getAll(): array
+    public function getAll(): iterable
     {
         return $this->metadata;
     }

--- a/src/Sylius/Component/Resource/Metadata/Registry.php
+++ b/src/Sylius/Component/Resource/Metadata/Registry.php
@@ -15,13 +15,13 @@ namespace Sylius\Component\Resource\Metadata;
 
 final class Registry implements RegistryInterface
 {
-    /** @var array|MetadataInterface[] */
+    /** @var MetadataInterface[] */
     private $metadata = [];
 
     /**
      * {@inheritdoc}
      */
-    public function getAll(): iterable
+    public function getAll(): array
     {
         return $this->metadata;
     }

--- a/src/Sylius/Component/Resource/Metadata/RegistryInterface.php
+++ b/src/Sylius/Component/Resource/Metadata/RegistryInterface.php
@@ -19,9 +19,9 @@ namespace Sylius\Component\Resource\Metadata;
 interface RegistryInterface
 {
     /**
-     * @return MetadataInterface[]
+     * @return iterable <MetadataInterface>
      */
-    public function getAll(): array;
+    public function getAll(): iterable;
 
     /**
      * @throws \InvalidArgumentException

--- a/src/Sylius/Component/Resource/Metadata/RegistryInterface.php
+++ b/src/Sylius/Component/Resource/Metadata/RegistryInterface.php
@@ -19,9 +19,9 @@ namespace Sylius\Component\Resource\Metadata;
 interface RegistryInterface
 {
     /**
-     * @return iterable|MetadataInterface[]
+     * @return MetadataInterface[]
      */
-    public function getAll(): iterable;
+    public function getAll(): array;
 
     /**
      * @throws \InvalidArgumentException

--- a/src/Sylius/Component/Resource/Model/TranslatableTrait.php
+++ b/src/Sylius/Component/Resource/Model/TranslatableTrait.php
@@ -103,7 +103,7 @@ trait TranslatableTrait
     public function addTranslation(TranslationInterface $translation): void
     {
         if (!$this->hasTranslation($translation)) {
-            $this->translationsCache[$translation->getLocale()] = $translation;
+            $this->translationsCache[(string) $translation->getLocale()] = $translation;
 
             $this->translations->set($translation->getLocale(), $translation);
             $translation->setTranslatable($this);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | not sure
| Deprecations?   | no
| Related tickets | none
| License         | MIT

This PR fixes some issues found by Psalm when running with [this config](https://gist.github.com/muglug/3c35a997ba84dc931e9a810b225286fc).

There are [five remaining errors](https://gist.github.com/muglug/96871c6f3514dfa9d93f2bf2ba87627a), which may or may not map to real bugs. I'm reasonably sure the third one is - `explode` instead of `implode` -  but I've left those unchanged for now.

The `iterable` to `Traversable` change is necessary because arrays can only have string-or-int keys, and the docblock makes clear the keys are objects.
