### PR TITLE
Fix build failing due to newest twig version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -153,7 +153,8 @@
         "symfony/polyfill-php56": "*"
     },
     "conflict": {
-        "symfony/symfony": "3.4.7 || 4.0.7 || 4.1.8"
+        "symfony/symfony": "3.4.7 || 4.0.7 || 4.1.8",
+        "twig/twig": "2.6.1"
     },
     "suggest": {
         "ext-iconv": "For better performance than using Symfony Polyfill Component",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

Something went wrong in Twig 2.6.1 and it fails on accessing `vars` and `parent` of form in twig templates (see https://travis-ci.org/Sylius/Sylius/builds/479368942) :/