### PR TITLE
Add force index for products in admin interface

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -44,6 +44,7 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
     public function createListQueryBuilder(string $locale, $taxonId = null): QueryBuilder
     {
         $queryBuilder = $this->createQueryBuilder('o')
+            ->forceIndex('UNIQ_677B9B7477153098')
             ->addSelect('translation')
             ->innerJoin('o.translations', 'translation', 'WITH', 'translation.locale = :locale')
             ->setParameter('locale', $locale)

--- a/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductRepository.php
@@ -14,10 +14,21 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ProductBundle\Doctrine\ORM;
 
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
+use Sylius\Bundle\ResourceBundle\Doctrine\ORM\IndexQueryBuilder;
 use Sylius\Component\Product\Repository\ProductRepositoryInterface;
 
 class ProductRepository extends EntityRepository implements ProductRepositoryInterface
 {
+    public function createQueryBuilder($alias, $indexBy = null)
+    {
+        $queryBuilder = new IndexQueryBuilder($this->_em);
+
+        return $queryBuilder
+            ->select($alias)
+            ->from($this->_entityName, $alias, $indexBy)
+        ;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/IndexQueryBuilder.php
+++ b/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/IndexQueryBuilder.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Doctrine\ORM;
+
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+
+class IndexQueryBuilder extends QueryBuilder
+{
+    protected $index;
+
+    public function forceIndex(string $indexName): self
+    {
+        $this->index = $indexName;
+
+        return $this;
+    }
+
+    public function getQuery()
+    {
+        $query = parent::getQuery();
+
+        if ($this->index !== null) {
+            $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, UseIndexWalker::class);
+            $query->setHint(UseIndexWalker::HINT_USE_INDEX, $this->index);
+        }
+
+        return $query;
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/UseIndexWalker.php
+++ b/src/Sylius/Bundle/ResourceBundle/Doctrine/ORM/UseIndexWalker.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ResourceBundle\Doctrine\ORM;
+
+use Doctrine\ORM\Query\SqlWalker;
+
+class UseIndexWalker extends SqlWalker
+{
+    public const HINT_USE_INDEX = 'UseIndexWalker.UseIndex';
+
+    public function walkFromClause($fromClause)
+    {
+        $result = parent::walkFromClause($fromClause);
+        if ($index = $this->getQuery()->getHint(self::HINT_USE_INDEX)) {
+            $result = preg_replace('#(\bFROM\s*\w+\s*\w+)#', '\1 USE INDEX (' . $index . ')', $result);
+        }
+
+        return $result;
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no (yes?)
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #9973 
| License         | MIT

@mamazu and I added sql walker functionality to be able to force correct index where mysql can't do it on it's own.

Based on 300k+ products - some queries are x20 (800ms vs 18 seconds) faster and some are x30000 (2ms vs 70 seconds).

