### PR TITLE
[Documentation] Visually mark most of the component&bundle docs outdated

### DIFF
--- a/docs/_themes/sylius_rtd_theme/static/css/sylius-custom.css
+++ b/docs/_themes/sylius_rtd_theme/static/css/sylius-custom.css
@@ -240,3 +240,24 @@ div[class^='highlight'] {
   background: none !important;
 }
 
+/* Outdated */
+.outdated {
+  padding: 30px;
+  border: 2px dashed #f19e95;
+  background: #fdf2f1;
+  border-radius: 6px;
+  opacity: 0.7;
+}
+
+.outdated::before {
+  content: 'OUTDATED';
+  position: relative;
+  bottom: 40px;
+  right: 2px;
+  background: #f19e95;
+  color: #fdf2f1;
+  padding: 4px 10px;
+  border-radius: 60px;
+  font-size: 11px;
+  letter-spacing: 2px;
+}

--- a/docs/components_and_bundles/bundles/SyliusAddressingBundle/forms.rst
+++ b/docs/components_and_bundles/bundles/SyliusAddressingBundle/forms.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Forms
 =====
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 The bundle ships with a set of useful form types for all models. You can use the defaults or :doc:`override them </customization/form>` with your own types.
 

--- a/docs/components_and_bundles/bundles/SyliusAddressingBundle/index.rst
+++ b/docs/components_and_bundles/bundles/SyliusAddressingBundle/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 SyliusAddressingBundle
 ======================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 This bundle integrates the :doc:`/components_and_bundles/components/Addressing/index` into Symfony and Doctrine.
 

--- a/docs/components_and_bundles/bundles/SyliusAddressingBundle/installation.rst
+++ b/docs/components_and_bundles/bundles/SyliusAddressingBundle/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 We assume you're familiar with `Composer <http://packagist.org>`_, a dependency manager for PHP.
 Use following command to add the bundle to your `composer.json` and download package.

--- a/docs/components_and_bundles/bundles/SyliusAddressingBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusAddressingBundle/summary.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Summary
 =======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Configuration Reference
 -----------------------
@@ -50,14 +57,6 @@ Configuration Reference
                     repository: ~
                     factory: Sylius\Component\Resource\Factory\Factory
                     form: Sylius\Bundle\AddressingBundle\Form\Type\ZoneMemberType
-
-Tests
------
-
-.. code-block:: bash
-
-    $ composer install
-    $ bin/phpspec run -fpretty --verbose
 
 Bug tracking
 ------------

--- a/docs/components_and_bundles/bundles/SyliusAddressingBundle/zones.rst
+++ b/docs/components_and_bundles/bundles/SyliusAddressingBundle/zones.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 ZoneMatcher
 -----------
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 This bundle exposes the **ZoneMatcher** as ``sylius.zone_matcher`` service.
 

--- a/docs/components_and_bundles/bundles/SyliusAttributeBundle/configuration.rst
+++ b/docs/components_and_bundles/bundles/SyliusAttributeBundle/configuration.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Configuration reference
 =======================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. code-block:: yaml
 

--- a/docs/components_and_bundles/bundles/SyliusAttributeBundle/index.rst
+++ b/docs/components_and_bundles/bundles/SyliusAttributeBundle/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 SyliusAttributeBundle
 =====================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 This bundle provides easy integration of the :doc:`Sylius Attribute component </components_and_bundles/components/Attribute/index>`
 with any Symfony full-stack application.

--- a/docs/components_and_bundles/bundles/SyliusAttributeBundle/installation.rst
+++ b/docs/components_and_bundles/bundles/SyliusAttributeBundle/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 We assume you're familiar with `Composer <http://packagist.org>`_, a dependency manager for PHP.
 Use the following command to add the bundle to your `composer.json` and download the package.

--- a/docs/components_and_bundles/bundles/SyliusCustomerBundle/index.rst
+++ b/docs/components_and_bundles/bundles/SyliusCustomerBundle/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 SyliusCustomerBundle
 ====================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 A solution for customer management system inside of a Symfony application.
 

--- a/docs/components_and_bundles/bundles/SyliusCustomerBundle/installation.rst
+++ b/docs/components_and_bundles/bundles/SyliusCustomerBundle/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 We assume you're familiar with `Composer <http://packagist.org>`_, a dependency manager for PHP.
 Use the following command to add the bundle to your `composer.json` and download the package.

--- a/docs/components_and_bundles/bundles/SyliusCustomerBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusCustomerBundle/summary.rst
@@ -1,9 +1,12 @@
+.. rst-class:: outdated
+
 Summary
 =======
 
-.. note::
+.. danger::
 
-    To be written.
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Configuration reference
 -----------------------
@@ -31,14 +34,6 @@ Configuration reference
                     controller: Sylius\Bundle\ResourceBundle\Controller\ResourceController
                     factory: Sylius\Component\Resource\Factory\Factory
                     form: Sylius\Bundle\CustomerBundle\Form\Type\CustomerGroupType
-
-`phpspec <http://phpspec.net>`_ examples
------------------------------------------
-
-.. code-block:: bash
-
-    $ composer install
-    $ bin/phpspec run -fpretty --verbose
 
 Bug tracking
 ------------

--- a/docs/components_and_bundles/bundles/SyliusFixturesBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusFixturesBundle/summary.rst
@@ -1,15 +1,6 @@
 Summary
 =======
 
-Tests
------
-
-.. code-block:: bash
-
-    $ composer install
-    $ bin/phpspec run
-    $ bin/phpunit
-
 Bug tracking
 ------------
 

--- a/docs/components_and_bundles/bundles/SyliusGridBundle/field_types.rst
+++ b/docs/components_and_bundles/bundles/SyliusGridBundle/field_types.rst
@@ -70,18 +70,3 @@ If you wish to render more complex grid fields just redefine the path of the fie
 
     <strong>{{ data.name }}</strong>
     <p>{{ data.description|markdown }}</p>
-
-Boolean (*boolean*)
--------------------
-
-Boolean column type expects the value to be boolean and renders a default or custom Twig template.
-
-.. code-block:: yaml
-
-    sylius_grid:
-        grids:
-            app_user:
-                fields:
-                    status:
-                        type: boolean
-                        label: app.ui.status

--- a/docs/components_and_bundles/bundles/SyliusGridBundle/filters.rst
+++ b/docs/components_and_bundles/bundles/SyliusGridBundle/filters.rst
@@ -105,7 +105,7 @@ This type filters by a chosen entity.
                             class: "%app.model.customer%"
 
 Money
-_____
+-----
 
 This filter checks if an amount is in range and in a specified currency
 

--- a/docs/components_and_bundles/bundles/SyliusInventoryBundle/extension.rst
+++ b/docs/components_and_bundles/bundles/SyliusInventoryBundle/extension.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Twig Extension
 ==============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 There are two handy twig functions bundled in: `sylius_inventory_is_available` and `sylius_inventory_is_sufficient`.
 

--- a/docs/components_and_bundles/bundles/SyliusInventoryBundle/index.rst
+++ b/docs/components_and_bundles/bundles/SyliusInventoryBundle/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 SyliusInventoryBundle
 =====================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Flexible inventory management for Symfony applications.
 

--- a/docs/components_and_bundles/bundles/SyliusInventoryBundle/installation.rst
+++ b/docs/components_and_bundles/bundles/SyliusInventoryBundle/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 We assume you're familiar with `Composer <http://packagist.org>`_, a dependency manager for PHP.
 Use the following command to add the bundle to your `composer.json` and download package.

--- a/docs/components_and_bundles/bundles/SyliusInventoryBundle/models.rst
+++ b/docs/components_and_bundles/bundles/SyliusInventoryBundle/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Here is a quick reference for the default models.
 

--- a/docs/components_and_bundles/bundles/SyliusInventoryBundle/services.rst
+++ b/docs/components_and_bundles/bundles/SyliusInventoryBundle/services.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Using the services
 ==================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 When using the bundle, you have access to several handy services.
 

--- a/docs/components_and_bundles/bundles/SyliusInventoryBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusInventoryBundle/summary.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Summary
 =======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Configuration reference
 -----------------------
@@ -29,14 +36,6 @@ Configuration reference
                 classes:
                     model: ~ # The stockable model class.
                     controller: Sylius\Bundle\ResourceBundle\Controller\ResourceController
-
-`phpspec <http://phpspec.net>`_ examples
------------------------------------------
-
-.. code-block:: bash
-
-    $ composer install
-    $ bin/phpspec run -f pretty
 
 Bug tracking
 ------------

--- a/docs/components_and_bundles/bundles/SyliusOrderBundle/adjustments.rst
+++ b/docs/components_and_bundles/bundles/SyliusOrderBundle/adjustments.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 The Adjustments
 ===============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Adjustments are based on simple but powerful idea inspired by `Spree adjustments <http://guides.spreecommerce.org/developer/adjustments.html>`_.
 They serve as foundation for any tax, shipping and discounts systems.

--- a/docs/components_and_bundles/bundles/SyliusOrderBundle/index.rst
+++ b/docs/components_and_bundles/bundles/SyliusOrderBundle/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 SyliusOrderBundle
 =================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 This bundle is a foundation for sales order handling for Symfony projects.
 It allows you to use any model as the merchandise.

--- a/docs/components_and_bundles/bundles/SyliusOrderBundle/installation.rst
+++ b/docs/components_and_bundles/bundles/SyliusOrderBundle/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 We assume you're familiar with `Composer <http://packagist.org>`_, a dependency manager for PHP.
 Use the following command to add the bundle to your `composer.json` and download package.

--- a/docs/components_and_bundles/bundles/SyliusOrderBundle/models.rst
+++ b/docs/components_and_bundles/bundles/SyliusOrderBundle/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 The Order, OrderItem and OrderItemUnit
 ======================================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Here is a quick reference of what the default models can do for you.
 

--- a/docs/components_and_bundles/bundles/SyliusOrderBundle/processors.rst
+++ b/docs/components_and_bundles/bundles/SyliusOrderBundle/processors.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Processors
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Order processors are responsible of manipulating the orders to apply different predefined adjustments or other modifications based on order state.
 

--- a/docs/components_and_bundles/bundles/SyliusOrderBundle/services.rst
+++ b/docs/components_and_bundles/bundles/SyliusOrderBundle/services.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Using the services
 ==================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 When using the bundle, you have access to several handy services.
 You can use them to retrieve and persist orders.

--- a/docs/components_and_bundles/bundles/SyliusOrderBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusOrderBundle/summary.rst
@@ -1,9 +1,12 @@
+.. rst-class:: outdated
+
 Summary
 =======
 
-.. note::
+.. danger::
 
-    To be written.
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Configuration reference
 -----------------------
@@ -48,15 +51,6 @@ Configuration reference
         expiration:
             cart: '2 days'
             order: '5 days'
-
-
-`phpspec <http://phpspec.net>`_ examples
------------------------------------------
-
-.. code-block:: bash
-
-    $ composer install
-    $ bin/phpspec run -fpretty --verbose
 
 Bug tracking
 ------------

--- a/docs/components_and_bundles/bundles/SyliusProductBundle/forms.rst
+++ b/docs/components_and_bundles/bundles/SyliusProductBundle/forms.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Forms
 =====
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 The bundle ships with a set of useful form types for all models. You can use the defaults or :doc:`override them </customization/form>` with your own forms.
 

--- a/docs/components_and_bundles/bundles/SyliusProductBundle/index.rst
+++ b/docs/components_and_bundles/bundles/SyliusProductBundle/index.rst
@@ -1,7 +1,12 @@
+.. rst-class:: outdated
+
 SyliusProductBundle
 ===================
 
-The Sylius product catalog is made available as set of 2 standalone bundles. This component contains the most basic product model with properties (attributes) support.
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. toctree::
    :maxdepth: 1

--- a/docs/components_and_bundles/bundles/SyliusProductBundle/installation.rst
+++ b/docs/components_and_bundles/bundles/SyliusProductBundle/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 We assume you're familiar with `Composer <http://packagist.org>`_, a dependency manager for PHP.
 Use the following command to add the bundle to your `composer.json` and download the package.

--- a/docs/components_and_bundles/bundles/SyliusProductBundle/product.rst
+++ b/docs/components_and_bundles/bundles/SyliusProductBundle/product.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 The Product
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Retrieving products
 -------------------

--- a/docs/components_and_bundles/bundles/SyliusProductBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusProductBundle/summary.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Summary
 =======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Configuration reference
 -----------------------
@@ -75,14 +82,6 @@ Configuration reference
                     controller: Sylius\Bundle\ResourceBundle\Controller\ResourceController
                     factory: Sylius\Component\Resource\Factory\Factory
                     form: Sylius\Bundle\ProductBundle\Form\Type\ProductAssociationTypeType
-
-Tests
------
-
-.. code-block:: bash
-
-    $ composer install
-    $ bin/phpspec run -fpretty --verbose
 
 Bug tracking
 ------------

--- a/docs/components_and_bundles/bundles/SyliusPromotionBundle/action_applicator.rst
+++ b/docs/components_and_bundles/bundles/SyliusPromotionBundle/action_applicator.rst
@@ -1,5 +1,12 @@
-How actions are applied ?
-=========================
+.. rst-class:: outdated
+
+How actions are applied?
+========================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Everything related to this subject is located in ``Sylius\Component\Promotion\Action``.
 

--- a/docs/components_and_bundles/bundles/SyliusPromotionBundle/applying_promotions.rst
+++ b/docs/components_and_bundles/bundles/SyliusPromotionBundle/applying_promotions.rst
@@ -1,5 +1,12 @@
-How promotions are applied ?
-============================
+.. rst-class:: outdated
+
+How promotions are applied?
+===========================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 By using the :doc:`promotion eligibility checker </components_and_bundles/bundles/SyliusPromotionBundle/rule_checker>` and the :doc:`promotion applicator checker </components_and_bundles/bundles/SyliusPromotionBundle/action_applicator>` services, the promotion processor applies all the possible promotions on a subject.
 

--- a/docs/components_and_bundles/bundles/SyliusPromotionBundle/coupon_based.rst
+++ b/docs/components_and_bundles/bundles/SyliusPromotionBundle/coupon_based.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Coupon based promotions
 =======================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Coupon based promotions require special needs that are covered by this documentation.
 

--- a/docs/components_and_bundles/bundles/SyliusPromotionBundle/index.rst
+++ b/docs/components_and_bundles/bundles/SyliusPromotionBundle/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 SyliusPromotionBundle
 =====================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Promotions system for Symfony applications.
 

--- a/docs/components_and_bundles/bundles/SyliusPromotionBundle/installation.rst
+++ b/docs/components_and_bundles/bundles/SyliusPromotionBundle/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 We assume you're familiar with `Composer <http://packagist.org>`_, a dependency manager for PHP.
 Use the following command to add the bundle to your ``composer.json`` and download the package.

--- a/docs/components_and_bundles/bundles/SyliusPromotionBundle/models.rst
+++ b/docs/components_and_bundles/bundles/SyliusPromotionBundle/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 All the models of this bundle are defined in ``Sylius\Component\Promotion\Model``.
 

--- a/docs/components_and_bundles/bundles/SyliusPromotionBundle/rule_checker.rst
+++ b/docs/components_and_bundles/bundles/SyliusPromotionBundle/rule_checker.rst
@@ -1,5 +1,12 @@
-How are rules checked ?
-=======================
+.. rst-class:: outdated
+
+How are rules checked?
+======================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Everything related to this subject is located in ``Sylius\Component\Promotion\Checker``.
 

--- a/docs/components_and_bundles/bundles/SyliusPromotionBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusPromotionBundle/summary.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Summary
 =======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. code-block:: yaml
 
@@ -42,16 +49,6 @@ Summary
                     repository: ~
                     factory:    Sylius\Component\Resource\Factory\Factory
                     form: Sylius\Bundle\PromotionBundle\Form\Type\PromotionActionType
-
-
-
-`phpspec <http://phpspec.net>`_ examples
------------------------------------------
-
-.. code-block:: bash
-
-    $ composer install
-    $ bin/phpspec run -fpretty --verbose
 
 Bug tracking
 ------------

--- a/docs/components_and_bundles/bundles/SyliusShippingBundle/calculating_shipping_cost.rst
+++ b/docs/components_and_bundles/bundles/SyliusShippingBundle/calculating_shipping_cost.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Calculating shipping cost
 =========================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Calculating shipping cost is as simple as using the ``sylius.shipping_calculator`` service and calling ``calculate`` method on ``ShippingSubjectInterface``.
 

--- a/docs/components_and_bundles/bundles/SyliusShippingBundle/custom_calculators.rst
+++ b/docs/components_and_bundles/bundles/SyliusShippingBundle/custom_calculators.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Custom calculators
 ==================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Sylius ships with several default calculators, but you can easily register your own.
 

--- a/docs/components_and_bundles/bundles/SyliusShippingBundle/default_calculators.rst
+++ b/docs/components_and_bundles/bundles/SyliusShippingBundle/default_calculators.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Default calculators
 ===================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Default calculators can be sufficient solution for many use cases.
 

--- a/docs/components_and_bundles/bundles/SyliusShippingBundle/index.rst
+++ b/docs/components_and_bundles/bundles/SyliusShippingBundle/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 SyliusShippingBundle
 ====================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 **SyliusShippingBundle** is the shipment management component for Symfony e-commerce applications.
 

--- a/docs/components_and_bundles/bundles/SyliusShippingBundle/installation.rst
+++ b/docs/components_and_bundles/bundles/SyliusShippingBundle/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 We assume you're familiar with `Composer <http://packagist.org>`_, a dependency manager for PHP.
 Use the following command to add the bundle to your `composer.json` and download package.

--- a/docs/components_and_bundles/bundles/SyliusShippingBundle/resolving_available_methods.rst
+++ b/docs/components_and_bundles/bundles/SyliusShippingBundle/resolving_available_methods.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Resolving available shipping methods
 ====================================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 In many use cases, you want to decide which shipping methods are available for user.
 Sylius has a dedicated service which serves this purpose.

--- a/docs/components_and_bundles/bundles/SyliusShippingBundle/shippable_interface.rst
+++ b/docs/components_and_bundles/bundles/SyliusShippingBundle/shippable_interface.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 The ShippableInterface
 ======================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 In order to handle your merchandise through the Sylius shipping engine, your models need to implement **ShippableInterface**.
 

--- a/docs/components_and_bundles/bundles/SyliusShippingBundle/shipping_categories.rst
+++ b/docs/components_and_bundles/bundles/SyliusShippingBundle/shipping_categories.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 The Shipping Categories
 =======================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Every shippable object needs to have a shipping category assigned. The **ShippingCategory** model is extremely simple and described below.
 

--- a/docs/components_and_bundles/bundles/SyliusShippingBundle/shipping_method.rst
+++ b/docs/components_and_bundles/bundles/SyliusShippingBundle/shipping_method.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 The Shipping Method
 ===================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 **ShippingMethod** model represents the way that goods need to be shipped. An example of shipping method may be "DHL Express" or "FedEx World Shipping".
 

--- a/docs/components_and_bundles/bundles/SyliusShippingBundle/shipping_requirements.rst
+++ b/docs/components_and_bundles/bundles/SyliusShippingBundle/shipping_requirements.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Shipping method requirements
 ============================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Sylius has a very flexible system for displaying only the right shipping methods to the user.
 

--- a/docs/components_and_bundles/bundles/SyliusShippingBundle/shipping_subject_interface.rst
+++ b/docs/components_and_bundles/bundles/SyliusShippingBundle/shipping_subject_interface.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 The ShippingSubjectInterface
 ============================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 The find available shipping methods or calculate shipping cost you need to use object implementing ``ShippingSubjectInterface``.
 

--- a/docs/components_and_bundles/bundles/SyliusShippingBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusShippingBundle/summary.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Summary
 =======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Configuration Reference
 -----------------------
@@ -13,7 +20,7 @@ Configuration Reference
             shipment:
                 classes:
                     model:      Sylius\Component\Shipping\Model\Shipment
-                    interface:      Sylius\Component\Shipping\Model\ShipmentInterface
+                    interface:  Sylius\Component\Shipping\Model\ShipmentInterface
                     controller: Sylius\Bundle\ResourceBundle\Controller\ResourceController
                     repository: ~
                     factory:    Sylius\Component\Resource\Factory\Factory
@@ -21,7 +28,7 @@ Configuration Reference
             shipment_item:
                 classes:
                     model:      Sylius\Component\Shipping\Model\ShipmentItem
-                    interface:      Sylius\Component\Shipping\Model\ShipmentItemInterface
+                    interface:  Sylius\Component\Shipping\Model\ShipmentItemInterface
                     controller: Sylius\Bundle\ResourceBundle\Controller\ResourceController
                     repository: ~
                     factory:    Sylius\Component\Resource\Factory\Factory
@@ -29,7 +36,7 @@ Configuration Reference
             shipping_method:
                 classes:
                     model:      Sylius\Component\Shipping\Model\ShippingMethod
-                    interface:      Sylius\Component\Shipping\Model\ShippingMethodInterface
+                    interface:  Sylius\Component\Shipping\Model\ShippingMethodInterface
                     controller: Sylius\Bundle\ResourceBundle\Controller\ResourceController
                     repository: ~
                     factory:    Sylius\Component\Resource\Factory\Factory
@@ -50,14 +57,6 @@ Configuration Reference
                     repository: ~
                     factory:    Sylius\Component\Resource\Factory\Factory
                     form: Sylius\Bundle\ShippingBundle\Form\Type\ShippingCategoryType
-
-Tests
------
-
-.. code-block:: bash
-
-    $ composer install
-    $ bin/phpspec run -fpretty --verbose
 
 Bug tracking
 ------------

--- a/docs/components_and_bundles/bundles/SyliusTaxationBundle/calculating_taxes.rst
+++ b/docs/components_and_bundles/bundles/SyliusTaxationBundle/calculating_taxes.rst
@@ -1,11 +1,17 @@
+.. rst-class:: outdated
+
 Calculating taxes
 =================
 
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. warning::
 
     When using the CoreBundle (i.e: full stack Sylius framework), the taxes are already calculated at each cart change.
-    It is implemented by the ``TaxationProcessor`` class, which is called by the `OrderTaxationListener``.
+    It is implemented by the ``TaxationProcessor`` class, which is called by the ``OrderTaxationListener``.
 
 In order to calculate tax amount for given taxable, we need to find out the applicable tax rate.
 The tax rate resolver service is available under ``sylius.tax_rate_resolver`` id, while the delegating tax calculator is accessible via ``sylius.tax_calculator`` name.

--- a/docs/components_and_bundles/bundles/SyliusTaxationBundle/configuring_taxation.rst
+++ b/docs/components_and_bundles/bundles/SyliusTaxationBundle/configuring_taxation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Configuring taxation
 ====================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 To start calculating taxes, we need to configure the system. In most cases, the configuration process is done via web interface, but you can also do it programatically.
 

--- a/docs/components_and_bundles/bundles/SyliusTaxationBundle/custom_calculators.rst
+++ b/docs/components_and_bundles/bundles/SyliusTaxationBundle/custom_calculators.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Using custom tax calculators
 ============================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Every **TaxRate** model holds a *calculator* variable with the name of the tax calculation service, used to compute the tax amount.
 While the default calculator should fit for most common use cases, you're free to define your own implementation.

--- a/docs/components_and_bundles/bundles/SyliusTaxationBundle/index.rst
+++ b/docs/components_and_bundles/bundles/SyliusTaxationBundle/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 SyliusTaxationBundle
 ====================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Calculating and applying taxes is a common task for most of ecommerce applications. **SyliusTaxationBundle** is a reusable taxation component for Symfony.
 You can integrate it into your existing application and enable the tax calculation logic for any model implementing the ``TaxableInterface``.

--- a/docs/components_and_bundles/bundles/SyliusTaxationBundle/installation.rst
+++ b/docs/components_and_bundles/bundles/SyliusTaxationBundle/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 We assume you're familiar with `Composer <http://packagist.org>`_, a dependency manager for PHP.
 Use the following command to add the bundle to your `composer.json` and download package.

--- a/docs/components_and_bundles/bundles/SyliusTaxationBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusTaxationBundle/summary.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Summary
 =======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Configuration Reference
 -----------------------
@@ -12,29 +19,20 @@ Configuration Reference
         resources:
             tax_category:
                 classes:
-                    model: Sylius\Component\Taxation\Model\TaxCategory
-                    interface: Sylius\Component\Taxation\Model\TaxCategoryInterface
+                    model:      Sylius\Component\Taxation\Model\TaxCategory
+                    interface:  Sylius\Component\Taxation\Model\TaxCategoryInterface
                     controller: Sylius\Bundle\ResourceBundle\Controller\ResourceController
                     repository: ~
                     factory:    Sylius\Component\Resource\Factory\Factory
-                    form: Sylius\Bundle\TaxationBundle\Form\Type\TaxCategoryType
+                    form:       Sylius\Bundle\TaxationBundle\Form\Type\TaxCategoryType
             tax_rate:
                 classes:
-                    model: Sylius\Component\Taxation\Model\TaxRate
-                    interface: Sylius\Component\Taxation\Model\TaxRateInterface
+                    model:      Sylius\Component\Taxation\Model\TaxRate
+                    interface:  Sylius\Component\Taxation\Model\TaxRateInterface
                     controller: Sylius\Bundle\ResourceBundle\Controller\ResourceController
                     repository: ~
                     factory:    Sylius\Component\Resource\Factory\Factory
-                    form: Sylius\Bundle\TaxationBundle\Form\Type\TaxRateType
-
-
-Tests
------
-
-.. code-block:: bash
-
-    $ composer install
-    $ bin/phpspec run -fpretty --verbose
+                    form:       Sylius\Bundle\TaxationBundle\Form\Type\TaxRateType
 
 Bug tracking
 ------------

--- a/docs/components_and_bundles/bundles/SyliusTaxationBundle/taxable_interface.rst
+++ b/docs/components_and_bundles/bundles/SyliusTaxationBundle/taxable_interface.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 The TaxableInterface
 ====================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 In order to calculate the taxes for a model in your application, it needs to implement the ``TaxableInterface`` 
 It is a very simple interface, with only one method - the ``getTaxCategory()``, as every taxable has to belong to a specific tax category.

--- a/docs/components_and_bundles/bundles/SyliusTaxonomyBundle/categorization.rst
+++ b/docs/components_and_bundles/bundles/SyliusTaxonomyBundle/categorization.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Categorization
 ==============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 In this example, we will use taxonomies to categorize products and build a nice catalog.
 

--- a/docs/components_and_bundles/bundles/SyliusTaxonomyBundle/index.rst
+++ b/docs/components_and_bundles/bundles/SyliusTaxonomyBundle/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 SyliusTaxonomyBundle
-======================
+====================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Flexible categorization system for Symfony applications.
 

--- a/docs/components_and_bundles/bundles/SyliusTaxonomyBundle/installation.rst
+++ b/docs/components_and_bundles/bundles/SyliusTaxonomyBundle/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 We assume you're familiar with `Composer <http://packagist.org>`_, a dependency manager for PHP.
 Use the following command to add the bundle to your `composer.json` and download the package.

--- a/docs/components_and_bundles/bundles/SyliusTaxonomyBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusTaxonomyBundle/summary.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Summary
 =======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Configuration Reference
 -----------------------
@@ -26,14 +33,6 @@ Configuration Reference
                         repository: ~
                         factory:    Sylius\Component\Resource\Factory\Factory
                         form: Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonTranslationType
-
-Tests
------
-
-.. code-block:: bash
-
-    $ composer install
-    $ bin/phpspec run -fpretty --verbose
 
 Bug tracking
 ------------

--- a/docs/components_and_bundles/bundles/SyliusTaxonomyBundle/taxon.rst
+++ b/docs/components_and_bundles/bundles/SyliusTaxonomyBundle/taxon.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Taxons
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Taxons
 ------

--- a/docs/components_and_bundles/bundles/SyliusUserBundle/index.rst
+++ b/docs/components_and_bundles/bundles/SyliusUserBundle/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 SyliusUserBundle
 ================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 A solution for user management system inside of a Symfony application.
 

--- a/docs/components_and_bundles/bundles/SyliusUserBundle/installation.rst
+++ b/docs/components_and_bundles/bundles/SyliusUserBundle/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 We assume you're familiar with `Composer <http://packagist.org>`_, a dependency manager for PHP.
 Use the following command to add the bundle to your `composer.json` and download the package.

--- a/docs/components_and_bundles/bundles/SyliusUserBundle/summary.rst
+++ b/docs/components_and_bundles/bundles/SyliusUserBundle/summary.rst
@@ -1,9 +1,12 @@
+.. rst-class:: outdated
+
 Summary
 =======
 
-.. note::
+.. danger::
 
-    To be written.
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Configuration reference
 -----------------------
@@ -78,15 +81,6 @@ Configuration reference
                         token:
                             length: 16
                             field_name: emailVerificationToken
-
-
-`phpspec2 <http://phpspec.net>`_ examples
------------------------------------------
-
-.. code-block:: bash
-
-    $ composer install
-    $ bin/phpspec run -fpretty --verbose
 
 Bug tracking
 ------------

--- a/docs/components_and_bundles/components/Addressing/basic_usage.rst
+++ b/docs/components_and_bundles/components/Addressing/basic_usage.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Basic Usage
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_addressing_matcher_zone-matcher:
 

--- a/docs/components_and_bundles/components/Addressing/index.rst
+++ b/docs/components_and_bundles/components/Addressing/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Addressing
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Sylius Addressing component for PHP E-Commerce applications which
 provides you with basic Address, Country, Province and Zone models.

--- a/docs/components_and_bundles/components/Addressing/installation.rst
+++ b/docs/components_and_bundles/components/Addressing/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/Addressing/interfaces.rst
+++ b/docs/components_and_bundles/components/Addressing/interfaces.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Interfaces
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Model Interfaces
 ----------------

--- a/docs/components_and_bundles/components/Addressing/models.rst
+++ b/docs/components_and_bundles/components/Addressing/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_addressing_model_address:
 

--- a/docs/components_and_bundles/components/Addressing/zone_types.rst
+++ b/docs/components_and_bundles/components/Addressing/zone_types.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Zone Types
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 There are three zone types available by default:
 
@@ -14,4 +21,5 @@ There are three zone types available by default:
 +------------------+----------+
 
 .. note::
+
    All of the above types are constant fields in the :ref:`component_addressing_model_zone-interface`.

--- a/docs/components_and_bundles/components/Attribute/basic_usage.rst
+++ b/docs/components_and_bundles/components/Attribute/basic_usage.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Basic Usage
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Creating an attributable class
 ------------------------------

--- a/docs/components_and_bundles/components/Attribute/index.rst
+++ b/docs/components_and_bundles/components/Attribute/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Attribute
 =========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Handling of dynamic attributes on PHP models is a common task for most of modern business applications.
 Sylius component makes it easier to handle different types of attributes

--- a/docs/components_and_bundles/components/Attribute/installation.rst
+++ b/docs/components_and_bundles/components/Attribute/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/Attribute/interfaces.rst
+++ b/docs/components_and_bundles/components/Attribute/interfaces.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Interfaces
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Model Interfaces
 ----------------

--- a/docs/components_and_bundles/components/Attribute/models.rst
+++ b/docs/components_and_bundles/components/Attribute/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_attribute_model_attribute:
 

--- a/docs/components_and_bundles/components/Channel/basic_usage.rst
+++ b/docs/components_and_bundles/components/Channel/basic_usage.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Basic Usage
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_channel_context_channel-context:
 

--- a/docs/components_and_bundles/components/Channel/index.rst
+++ b/docs/components_and_bundles/components/Channel/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Channel
 =======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Sale channels management implementation in PHP.
 

--- a/docs/components_and_bundles/components/Channel/installation.rst
+++ b/docs/components_and_bundles/components/Channel/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/Channel/interfaces.rst
+++ b/docs/components_and_bundles/components/Channel/interfaces.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Interfaces
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Model Interfaces
 ----------------

--- a/docs/components_and_bundles/components/Channel/models.rst
+++ b/docs/components_and_bundles/components/Channel/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_channel_model_channel:
 

--- a/docs/components_and_bundles/components/Currency/basic_usage.rst
+++ b/docs/components_and_bundles/components/Currency/basic_usage.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Basic Usage
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Getting a Currency name
 -----------------------

--- a/docs/components_and_bundles/components/Currency/index.rst
+++ b/docs/components_and_bundles/components/Currency/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Currency
 ========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Managing different currencies, exchange rates and converting cash amounts for PHP applications.
 

--- a/docs/components_and_bundles/components/Currency/installation.rst
+++ b/docs/components_and_bundles/components/Currency/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/Currency/interfaces.rst
+++ b/docs/components_and_bundles/components/Currency/interfaces.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Interfaces
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Model Interfaces
 ----------------

--- a/docs/components_and_bundles/components/Currency/models.rst
+++ b/docs/components_and_bundles/components/Currency/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_currency_model_currency:
 
@@ -21,6 +28,7 @@ Every currency is represented by a **Currency** model which by default has the f
 +--------------+-------------------------------------------+
 
 .. note::
+
    This model implements :ref:`component_currency_model_currency-interface`.
 
    For more detailed information go to `Sylius API Currency`_.

--- a/docs/components_and_bundles/components/Currency/unavailable_currency_exception.rst
+++ b/docs/components_and_bundles/components/Currency/unavailable_currency_exception.rst
@@ -1,3 +1,4 @@
+.. rst-class:: outdated
 .. _component_currency_converter_unavailable-currency-exception:
 
 UnavailableCurrencyException

--- a/docs/components_and_bundles/components/Grid/index.rst
+++ b/docs/components_and_bundles/components/Grid/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Grid
 ====
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Sylius component used for describing data grids. Decoupled from Symfony and useful for any kind of system, which needs to provide user with grid functionality.
 

--- a/docs/components_and_bundles/components/Grid/installation.rst
+++ b/docs/components_and_bundles/components/Grid/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 We assume you're familiar with `Composer <http://packagist.org>`_, a dependency manager for PHP.
 Use following command to add the component to your `composer.json` and download package.

--- a/docs/components_and_bundles/components/Grid/summary.rst
+++ b/docs/components_and_bundles/components/Grid/summary.rst
@@ -1,13 +1,12 @@
+.. rst-class:: outdated
+
 Summary
 =======
 
-`phpspec <http://phpspec.net>`_ examples
------------------------------------------
+.. danger::
 
-.. code-block:: bash
-
-    $ composer install
-    $ bin/phpspec run -fpretty --verbose
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Bug tracking
 ------------

--- a/docs/components_and_bundles/components/Inventory/basic_usage.rst
+++ b/docs/components_and_bundles/components/Inventory/basic_usage.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Basic Usage
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Stockable Object
 ----------------

--- a/docs/components_and_bundles/components/Inventory/index.rst
+++ b/docs/components_and_bundles/components/Inventory/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Inventory
 =========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Inventory management for PHP applications.
 

--- a/docs/components_and_bundles/components/Inventory/installation.rst
+++ b/docs/components_and_bundles/components/Inventory/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/Inventory/interfaces.rst
+++ b/docs/components_and_bundles/components/Inventory/interfaces.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Interfaces
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Model Interfaces
 ----------------

--- a/docs/components_and_bundles/components/Inventory/models.rst
+++ b/docs/components_and_bundles/components/Inventory/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_inventory_model_inventory-unit:
 

--- a/docs/components_and_bundles/components/Inventory/state_machine.rst
+++ b/docs/components_and_bundles/components/Inventory/state_machine.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 State Machine
 =============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Inventory Unit States
 ---------------------

--- a/docs/components_and_bundles/components/Locale/basic_usage.rst
+++ b/docs/components_and_bundles/components/Locale/basic_usage.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Basic Usage
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 LocaleContext
 -------------

--- a/docs/components_and_bundles/components/Locale/index.rst
+++ b/docs/components_and_bundles/components/Locale/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Locale
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Managing different locales for PHP apps.
 

--- a/docs/components_and_bundles/components/Locale/installation.rst
+++ b/docs/components_and_bundles/components/Locale/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/Locale/interfaces.rst
+++ b/docs/components_and_bundles/components/Locale/interfaces.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Interfaces
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Model Interfaces
 ----------------

--- a/docs/components_and_bundles/components/Locale/models.rst
+++ b/docs/components_and_bundles/components/Locale/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_locale_model_locale:
 

--- a/docs/components_and_bundles/components/Mailer/basic_usage.rst
+++ b/docs/components_and_bundles/components/Mailer/basic_usage.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Basic usage
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Sender
 ------

--- a/docs/components_and_bundles/components/Mailer/index.rst
+++ b/docs/components_and_bundles/components/Mailer/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Mailer
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Sylius Mailer component abstracts the process of sending e-mails. It also provides interface to configure various parameters for unique e-mails.
 

--- a/docs/components_and_bundles/components/Mailer/installation.rst
+++ b/docs/components_and_bundles/components/Mailer/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/Mailer/interfaces.rst
+++ b/docs/components_and_bundles/components/Mailer/interfaces.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Interfaces
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Model Interfaces
 ----------------

--- a/docs/components_and_bundles/components/Mailer/models.rst
+++ b/docs/components_and_bundles/components/Mailer/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_mailer_model_email:
 

--- a/docs/components_and_bundles/components/Order/basic_usage.rst
+++ b/docs/components_and_bundles/components/Order/basic_usage.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Basic Usage
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Order
 -----

--- a/docs/components_and_bundles/components/Order/index.rst
+++ b/docs/components_and_bundles/components/Order/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Order
 =====
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 E-Commerce PHP library for creating and managing sales orders.
 

--- a/docs/components_and_bundles/components/Order/installation.rst
+++ b/docs/components_and_bundles/components/Order/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/Order/interfaces.rst
+++ b/docs/components_and_bundles/components/Order/interfaces.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Interfaces
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Model Interfaces
 ----------------

--- a/docs/components_and_bundles/components/Order/models.rst
+++ b/docs/components_and_bundles/components/Order/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_order_model_order:
 

--- a/docs/components_and_bundles/components/Order/processors.rst
+++ b/docs/components_and_bundles/components/Order/processors.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Processors
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Order processors are responsible for manipulating the orders to apply different predefined adjustments or other modifications based on order state.
 

--- a/docs/components_and_bundles/components/Order/state_machine.rst
+++ b/docs/components_and_bundles/components/Order/state_machine.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 State Machine
 =============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Order States
 ------------

--- a/docs/components_and_bundles/components/Payment/index.rst
+++ b/docs/components_and_bundles/components/Payment/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Payment
 =======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 PHP library which provides abstraction of payments management.
 

--- a/docs/components_and_bundles/components/Payment/installation.rst
+++ b/docs/components_and_bundles/components/Payment/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/Payment/interfaces.rst
+++ b/docs/components_and_bundles/components/Payment/interfaces.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Interfaces
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Model Interfaces
 ----------------

--- a/docs/components_and_bundles/components/Payment/models.rst
+++ b/docs/components_and_bundles/components/Payment/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_payment_model_payment:
 

--- a/docs/components_and_bundles/components/Payment/state_machine.rst
+++ b/docs/components_and_bundles/components/Payment/state_machine.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 State Machine
 =============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_payment_payment-states:
 

--- a/docs/components_and_bundles/components/Product/basic_usage.rst
+++ b/docs/components_and_bundles/components/Product/basic_usage.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Basic Usage
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Creating a product
 ------------------

--- a/docs/components_and_bundles/components/Product/index.rst
+++ b/docs/components_and_bundles/components/Product/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Product
 =======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Powerful products catalog for PHP applications.
 

--- a/docs/components_and_bundles/components/Product/installation.rst
+++ b/docs/components_and_bundles/components/Product/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/Product/interfaces.rst
+++ b/docs/components_and_bundles/components/Product/interfaces.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Interfaces
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Model Interfaces
 ----------------

--- a/docs/components_and_bundles/components/Product/models.rst
+++ b/docs/components_and_bundles/components/Product/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_product_model_product:
 

--- a/docs/components_and_bundles/components/Promotion/basic_usage.rst
+++ b/docs/components_and_bundles/components/Promotion/basic_usage.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Basic Usage
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 In order to benefit from the component's features at first you need to create a basic class that will implement
 the :ref:`component_promotion_model_promotion-subject-interface`. Let's assume that you would like to

--- a/docs/components_and_bundles/components/Promotion/checkers.rst
+++ b/docs/components_and_bundles/components/Promotion/checkers.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Checkers
 ========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_promotion_checker_item-count-rule-checker:
 

--- a/docs/components_and_bundles/components/Promotion/index.rst
+++ b/docs/components_and_bundles/components/Promotion/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Promotion
 =========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Super-flexible promotions system with support of complex rules and actions. Coupon codes included!
 

--- a/docs/components_and_bundles/components/Promotion/installation.rst
+++ b/docs/components_and_bundles/components/Promotion/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/Promotion/interfaces.rst
+++ b/docs/components_and_bundles/components/Promotion/interfaces.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Interfaces
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Model Interfaces
 ----------------

--- a/docs/components_and_bundles/components/Promotion/models.rst
+++ b/docs/components_and_bundles/components/Promotion/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_promotion_model_promotion:
 

--- a/docs/components_and_bundles/components/Registry/basic_usage.rst
+++ b/docs/components_and_bundles/components/Registry/basic_usage.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Basic Usage
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 A registry object acts as a collection of objects. The sylius **ServiceRegistry**
 allows you to store objects which implement a specific interface.

--- a/docs/components_and_bundles/components/Registry/exceptions.rst
+++ b/docs/components_and_bundles/components/Registry/exceptions.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Exceptions
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_registry_existing-service-exception:
 

--- a/docs/components_and_bundles/components/Registry/index.rst
+++ b/docs/components_and_bundles/components/Registry/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Registry
 ========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Simple registry component useful for all types of applications.
 

--- a/docs/components_and_bundles/components/Registry/installation.rst
+++ b/docs/components_and_bundles/components/Registry/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/Registry/interfaces.rst
+++ b/docs/components_and_bundles/components/Registry/interfaces.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Interfaces
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. _component_registry_service-registry-interface:
 

--- a/docs/components_and_bundles/components/Shipping/basic_usage.rst
+++ b/docs/components_and_bundles/components/Shipping/basic_usage.rst
@@ -1,7 +1,14 @@
+.. rst-class:: outdated
+
 .. _basic_usage:
 
 Basic Usage
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 In all examples is used an exemplary class implementing **ShippableInterface**, which looks like:
 

--- a/docs/components_and_bundles/components/Shipping/calculators.rst
+++ b/docs/components_and_bundles/components/Shipping/calculators.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Calculators
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 FlatRateCalculator
 ------------------

--- a/docs/components_and_bundles/components/Shipping/checkers.rst
+++ b/docs/components_and_bundles/components/Shipping/checkers.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Checkers
 ========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 ItemCountRuleChecker
 --------------------

--- a/docs/components_and_bundles/components/Shipping/index.rst
+++ b/docs/components_and_bundles/components/Shipping/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Shipping
 ========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Shipments and shipping methods management for PHP E-Commerce applications. It contains flexible calculators system for computing the shipping costs.
 

--- a/docs/components_and_bundles/components/Shipping/installation.rst
+++ b/docs/components_and_bundles/components/Shipping/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/Shipping/interfaces.rst
+++ b/docs/components_and_bundles/components/Shipping/interfaces.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Interfaces
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Model Interfaces
 ----------------

--- a/docs/components_and_bundles/components/Shipping/models.rst
+++ b/docs/components_and_bundles/components/Shipping/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Shipment
 --------

--- a/docs/components_and_bundles/components/Shipping/state_machine.rst
+++ b/docs/components_and_bundles/components/Shipping/state_machine.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 State Machine
 =============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Shipment States
 ---------------

--- a/docs/components_and_bundles/components/Taxation/basic_usage.rst
+++ b/docs/components_and_bundles/components/Taxation/basic_usage.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Basic Usage
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Tax Rate
 --------

--- a/docs/components_and_bundles/components/Taxation/index.rst
+++ b/docs/components_and_bundles/components/Taxation/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Taxation
 ========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Tax rates and tax classification for PHP applications. You can define different tax categories and match them to objects.
 

--- a/docs/components_and_bundles/components/Taxation/installation.rst
+++ b/docs/components_and_bundles/components/Taxation/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/Taxation/interfaces.rst
+++ b/docs/components_and_bundles/components/Taxation/interfaces.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Interfaces
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Model Interfaces
 ----------------

--- a/docs/components_and_bundles/components/Taxation/models.rst
+++ b/docs/components_and_bundles/components/Taxation/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 TaxRate
 -------

--- a/docs/components_and_bundles/components/Taxonomy/basic_usage.rst
+++ b/docs/components_and_bundles/components/Taxonomy/basic_usage.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Basic Usage
 ===========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. code-block:: php
 

--- a/docs/components_and_bundles/components/Taxonomy/index.rst
+++ b/docs/components_and_bundles/components/Taxonomy/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Taxonomy
 ========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Basic taxonomies library for any PHP application. Taxonomies work similarly to the distinction of species in the fauna and flora
 and their aim is to help the store owner manage products.

--- a/docs/components_and_bundles/components/Taxonomy/installation.rst
+++ b/docs/components_and_bundles/components/Taxonomy/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/Taxonomy/interfaces.rst
+++ b/docs/components_and_bundles/components/Taxonomy/interfaces.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Interfaces
 ==========
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Models Interfaces
 -----------------

--- a/docs/components_and_bundles/components/Taxonomy/models.rst
+++ b/docs/components_and_bundles/components/Taxonomy/models.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Models
 ======
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Taxonomy is a list constructed from individual Taxons. Taxonomy is a special case of Taxon itself (it has no parent).
 All taxons can have many child taxons, you can define as many of them as you need.

--- a/docs/components_and_bundles/components/User/basic_usage.rst
+++ b/docs/components_and_bundles/components/User/basic_usage.rst
@@ -1,6 +1,12 @@
+.. rst-class:: outdated
+
 Basic Usage
 ===========
 
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 .. toctree::
     :maxdepth: 1

--- a/docs/components_and_bundles/components/User/index.rst
+++ b/docs/components_and_bundles/components/User/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 User
 ====
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 Users management implementation in PHP.
 

--- a/docs/components_and_bundles/components/User/installation.rst
+++ b/docs/components_and_bundles/components/User/installation.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Installation
 ============
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 You can install the component in 2 different ways:
 

--- a/docs/components_and_bundles/components/User/models.rst
+++ b/docs/components_and_bundles/components/User/models.rst
@@ -1,3 +1,5 @@
+.. rst-class:: outdated
+
 Models
 ======
 

--- a/docs/components_and_bundles/components/User/services/canonicalizing.rst
+++ b/docs/components_and_bundles/components/User/services/canonicalizing.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Canonicalization
 ================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 In order to be able to query or sort by some string, we should normalize it.
 The most common use case for that is canonical email or username. We can

--- a/docs/components_and_bundles/components/User/services/updating_password.rst
+++ b/docs/components_and_bundles/components/User/services/updating_password.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Updating password
 =================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 In order to store user's password safely you need to encode it and get rid of
 the plain password.

--- a/docs/components_and_bundles/components/index.rst
+++ b/docs/components_and_bundles/components/index.rst
@@ -1,5 +1,12 @@
+.. rst-class:: outdated
+
 Sylius Components Documentation
 ===============================
+
+.. danger::
+
+   We're sorry but **this documentation section is outdated**. Please have that in mind when trying to use it.
+   You can help us making documentation up to date via Sylius Github. Thank you!
 
 We provide a set of well-tested and decoupled PHP libraries.
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Related tickets | replaces #10073 and #10074 
| License         | MIT

Thanks to advice given by the community  - https://github.com/Sylius/Sylius/pull/10073#issuecomment-452241569 - we've resigned from removing the outdated docs sections. Instead we are now marking them as outdated and we leave its further usage under your own responsibility. :)

This is how an outdated doc section will look now. The visual change made thanks to @kulczy :) 💪 

![zrzut ekranu 2019-01-15 o 12 40 16](https://user-images.githubusercontent.com/13198869/51178574-3fd31c00-18c3-11e9-87a8-14f46857d1b6.png)

