### PR TITLE
WIP #9132 Try to change deprecated use of flush($entity) in ReviewBundle

### DIFF
--- a/src/Sylius/Bundle/ReviewBundle/Updater/AverageRatingUpdater.php
+++ b/src/Sylius/Bundle/ReviewBundle/Updater/AverageRatingUpdater.php
@@ -56,6 +56,7 @@ class AverageRatingUpdater implements ReviewableRatingUpdaterInterface
 
         $reviewSubject->setAverageRating($averageRating);
 
-        $this->reviewSubjectManager->flush($reviewSubject);
+        $this->reviewSubjectManager->persist($reviewSubject);
+        $this->reviewSubjectManager->flush();
     }
 }

--- a/src/Sylius/Bundle/ReviewBundle/spec/Updater/AverageRatingUpdaterSpec.php
+++ b/src/Sylius/Bundle/ReviewBundle/spec/Updater/AverageRatingUpdaterSpec.php
@@ -41,7 +41,8 @@ final class AverageRatingUpdaterSpec extends ObjectBehavior
 
         $reviewSubject->setAverageRating(4.5)->shouldBeCalled();
 
-        $reviewSubjectManager->flush($reviewSubject)->shouldBeCalled();
+        $reviewSubjectManager->persist($reviewSubject)->shouldBeCalled();
+        $reviewSubjectManager->flush()->shouldBeCalled();
 
         $this->update($reviewSubject);
     }
@@ -57,7 +58,8 @@ final class AverageRatingUpdaterSpec extends ObjectBehavior
 
         $reviewSubject->setAverageRating(4.5)->shouldBeCalled();
 
-        $reviewSubjectManager->flush($reviewSubject)->shouldBeCalled();
+        $reviewSubjectManager->persist($reviewSubject)->shouldBeCalled();
+        $reviewSubjectManager->flush()->shouldBeCalled();
 
         $this->updateFromReview($review);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #9132
| License         | MIT

PR to see for the moment which scenario is broken after doing this change
