### PR TITLE
Added productTaxon to product list query to prevent an SQL error

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -73,6 +73,7 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
         $queryBuilder = $this->createQueryBuilder('o')
             ->distinct()
             ->addSelect('translation')
+            ->addSelect('productTaxon')
             ->innerJoin('o.translations', 'translation', 'WITH', 'translation.locale = :locale')
             ->innerJoin('o.productTaxons', 'productTaxon');
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fix bug introduced in #10070
| License         | MIT

#10070 has introduced a SQL Error when displaying products by taxon (`for SELECT DISTINCT, ORDER BY expressions must appear in select list`).

This is due to the ordering by ProductTaxon position, as they are not in the `SELECT` clause.

One possible solution is to simply add the ProductTaxon to the `SELECT` DQL clause, as done in this PR.