### PR TITLE
Allow nullable shop billing data

### DIFF
--- a/src/Sylius/Component/Core/Model/Channel.php
+++ b/src/Sylius/Component/Core/Model/Channel.php
@@ -283,7 +283,7 @@ class Channel extends BaseChannel implements ChannelInterface
         $this->accountVerificationRequired = $accountVerificationRequired;
     }
 
-    public function getShopBillingData(): ShopBillingDataInterface
+    public function getShopBillingData(): ?ShopBillingDataInterface
     {
         return $this->shopBillingData;
     }

--- a/src/Sylius/Component/Core/Model/ChannelInterface.php
+++ b/src/Sylius/Component/Core/Model/ChannelInterface.php
@@ -61,7 +61,7 @@ interface ChannelInterface extends
 
     public function setAccountVerificationRequired(bool $accountVerificationRequired): void;
 
-    public function getShopBillingData(): ShopBillingDataInterface;
+    public function getShopBillingData(): ?ShopBillingDataInterface;
 
     public function setShopBillingData(ShopBillingDataInterface $shopBillingData): void;
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | introduced in https://github.com/Sylius/Sylius/pull/10079
| License         | MIT

During the implementation, I thought it's not possible to return `null` as shop billing data (as there is a `$this->shopBillingData = new ShopBillingData();` set in a channel constructor), but actually it can happen if you already have some channels in your database, you update Sylius to `1.4` and then you try to edit an existing channel :/

<img width="1060" alt="zrzut ekranu 2019-01-24 o 10 01 33" src="https://user-images.githubusercontent.com/6212718/51667281-06379a80-1fc0-11e9-8460-54dadf1f711a.png">
