### PR TITLE
[Product Review] fixed review validation when edited by admin

### DIFF
--- a/features/product/managing_product_reviews/editing_product_review.feature
+++ b/features/product/managing_product_reviews/editing_product_review.feature
@@ -5,7 +5,7 @@ Feature: Editing product reviews
     I want to edit a product review
 
     Background:
-        Given the store has customer "Mike Ross" with email "ross@teammike.com"
+        Given there is a customer "Mike Ross" with an email "ross@teammike.com" and a password "thePassword"
         And the store has a product "Lamborghini Gallardo Model"
         And this product has a review titled "Awesome" and rated 4 with a comment "Nice product" added by customer "ross@teammike.com"
         And I am logged in as an administrator

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -17,6 +17,7 @@
         <import resource="services/email.xml" />
         <import resource="services/listener.xml" />
         <import resource="services/menu.xml" />
+        <import resource="services/form.xml" />
     </imports>
 
     <services>

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/form.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="sylius.form.type.product_review.validation_groups" type="collection">
+            <parameter>sylius</parameter>
+        </parameter>
+    </parameters>
+</container>

--- a/src/Sylius/Bundle/ReviewBundle/Resources/config/validation/Review.xml
+++ b/src/Sylius/Bundle/ReviewBundle/Resources/config/validation/Review.xml
@@ -17,7 +17,7 @@
             <constraint name="NotBlank">
                 <option name="message">sylius.review.title.not_blank</option>
                 <option name="groups">
-                    <value>sylius_review</value>
+                    <value>sylius</value>
                 </option>
             </constraint>
             <constraint name="Length">


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #9895 
| License         | MIT

The test was a false-positive. I've changed it to create Customer and ShopUser so that UniqueReviewerEmailValidator has a user to validate against. 