### PR TITLE
Add missing Length constraint on product translation slug

### DIFF
--- a/src/Sylius/Bundle/ProductBundle/Resources/config/validation/ProductTranslation.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/validation/ProductTranslation.xml
@@ -40,6 +40,11 @@
                 <option name="message">sylius.product.slug.not_blank</option>
                 <option name="groups">sylius</option>
             </constraint>
+            <constraint name="Length">
+                <option name="max">255</option>
+                <option name="maxMessage">sylius.product.slug.max_length</option>
+                <option name="groups">sylius</option>
+            </constraint>
         </property>
     </class>
 </constraint-mapping>

--- a/src/Sylius/Bundle/ProductBundle/Resources/translations/validators.en.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/translations/validators.en.yml
@@ -6,6 +6,7 @@ sylius:
         slug:
             not_blank: Please enter product slug.
             unique: Product slug must be unique.
+            max_length: Product slug must not be longer than 1 character.|Product slug must not be longer than {{ limit }} characters.
         code:
             not_blank: Please enter product code.
             regex: Product code can only be comprised of letters, numbers, dashes and underscores.

--- a/tests/Controller/ProductApiTest.php
+++ b/tests/Controller/ProductApiTest.php
@@ -156,6 +156,35 @@ EOT;
     /**
      * @test
      */
+    public function it_does_not_allow_to_create_product_with_too_long_translations()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/locales.yml');
+
+        $longString = str_repeat('s', 256);
+
+        $data =
+<<<EOT
+        {
+            "code": "MUG_TH",
+            "translations": {
+                "en_US": {
+                    "name": "{$longString}",
+                    "slug": "{$longString}"
+                }
+            }
+        }
+EOT;
+
+        $this->client->request('POST', '/api/v1/products/', [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product/create_with_long_translations_validation_fail_response', Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @test
+     */
     public function it_does_not_allow_to_create_product_without_required_fields()
     {
         $this->loadFixturesFromFile('authentication/api_administrator.yml');

--- a/tests/Responses/Expected/product/create_with_long_translations_validation_fail_response.json
+++ b/tests/Responses/Expected/product/create_with_long_translations_validation_fail_response.json
@@ -1,0 +1,69 @@
+{
+    "code": 400,
+    "message": "Validation Failed",
+    "errors": {
+        "children": {
+            "enabled": {},
+            "translations": {
+                "children": {
+                    "en_US": {
+                        "children": {
+                            "name": {
+                                "errors": [
+                                    "Product name must not be longer than 255 characters."
+                                ]
+                            },
+                            "slug": {
+                                "errors": [
+                                    "Product slug must not be longer than 255 characters."
+                                ]
+                            },
+                            "description": {},
+                            "metaKeywords": {},
+                            "metaDescription": {},
+                            "shortDescription": {}
+                        }
+                    },
+                    "nl_NL": {
+                        "children": {
+                            "name": {},
+                            "slug": {},
+                            "description": {},
+                            "metaKeywords": {},
+                            "metaDescription": {},
+                            "shortDescription": {}
+                        }
+                    },
+                    "fr_FR": {
+                        "children": {
+                            "name": {},
+                            "slug": {},
+                            "description": {},
+                            "metaKeywords": {},
+                            "metaDescription": {},
+                            "shortDescription": {}
+                        }
+                    },
+                    "de_CH": {
+                        "children": {
+                            "name": {},
+                            "slug": {},
+                            "description": {},
+                            "metaKeywords": {},
+                            "metaDescription": {},
+                            "shortDescription": {}
+                        }
+                    }
+                }
+            },
+            "attributes": {},
+            "associations": {},
+            "channels": {},
+            "mainTaxon": {},
+            "images": {},
+            "code": {},
+            "options": {},
+            "productTaxons": {}
+        }
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no (?)
| Deprecations?   | no
| Related tickets | -
| License         | MIT

This previously caused database errors when trying to insert data. Discovered this while working with the API, but this may also occur when trying to save a product in the admin GUI and the slug generator converts one character into > 1 characters like `ß` -> `ss`.

>SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'slug' at row 1

About the BC breaks yes/no: I guess someone could have increased the field length for the slug which this would prevent after updating. I personally don't see it as a BC break, but it may be useful to put a "warning" note in the changelog to change the constraint if you modified anything. WDYT?
