### PR TITLE
[HotFix] 500 on taxons list error fix

### DIFF
--- a/features/product/viewing_products/viewing_products_from_taxon_and_children.feature
+++ b/features/product/viewing_products/viewing_products_from_taxon_and_children.feature
@@ -23,9 +23,6 @@ Feature: Viewing products from taxon children
         And the store has a product "T-Shirt Watermelon" available in "Poland" channel
         And this product belongs to "T-Shirts"
         And this product belongs to "Men"
-        And the store has a product "T-Shirt Lemon" available in "Poland" channel
-        And this product belongs to "T-Shirts"
-        And this product belongs to "Men"
 
     @ui
     Scenario: Viewing products from taxon children
@@ -35,4 +32,3 @@ Feature: Viewing products from taxon children
         And I should see the product "T-Shirt Apple"
         And I should see the product "T-Shirt Pear"
         And I should see the product "T-Shirt Watermelon"
-        And I should see the product "T-Shirt Lemon"

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -72,6 +72,7 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
         $queryBuilder = $this->createQueryBuilder('o')
             ->distinct()
             ->addSelect('translation')
+            ->addSelect('productTaxon')
             ->innerJoin('o.translations', 'translation', 'WITH', 'translation.locale = :locale')
             ->innerJoin('o.productTaxons', 'productTaxon')
             ->andWhere('productTaxon.taxon = :taxon')


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | introduced in https://github.com/Sylius/Sylius/pull/10070, replaces https://github.com/Sylius/Sylius/pull/10114 and https://github.com/Sylius/Sylius/pull/10134, fixes https://github.com/Sylius/Sylius/issues/7389
| License         | MIT

Based on a PR by @yohang (thank you for your work!). The test was failing, as there is another bug with setting max results with paginator (that's why I've reduced the amount of products in the scenario) 🚀 😄 But the 500 error bug is fixed (I've also checked it manually).