### PR TITLE
Remove flush() call, its done in the remover itself

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Command/RemoveExpiredCartsCommand.php
+++ b/src/Sylius/Bundle/OrderBundle/Command/RemoveExpiredCartsCommand.php
@@ -42,7 +42,5 @@ class RemoveExpiredCartsCommand extends ContainerAwareCommand
 
         $expiredCartsRemover = $this->getContainer()->get('sylius.expired_carts_remover');
         $expiredCartsRemover->remove();
-
-        $this->getContainer()->get('sylius.manager.order')->flush();
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Looking through the code, in the `remover` itself (`ExpiredCartsRemover`) a `flush` call is made already on the Order Manager. Seems double and not needed to me here.