### PR TITLE
Add index on order.cart + order.updated_at for faster expired cart removal selection

### DIFF
--- a/app/migrations/Version20190204092544.php
+++ b/app/migrations/Version20190204092544.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190204092544 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE INDEX IDX_6196A1F9A393D2FB43625D9F ON sylius_order (state, updated_at)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX IDX_6196A1F9A393D2FB43625D9F ON sylius_order');
+    }
+}

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Order.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Order.orm.xml
@@ -51,6 +51,10 @@
         <field name="updatedAt" column="updated_at" type="datetime" nullable="true">
             <gedmo:timestampable on="update"/>
         </field>
+
+        <indexes>
+            <index columns="state,updated_at"/>
+        </indexes>
     </mapped-superclass>
 
 </doctrine-mapping>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.2
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #10148 
| License         | MIT

Makes selection of expired carts way more efficient. Especially helpful in growing projects.

Before:

![image](https://user-images.githubusercontent.com/4903082/52199892-a4045280-2867-11e9-9a09-0fc89bf48c84.png)

After:

![image](https://user-images.githubusercontent.com/4903082/52199904-a8c90680-2867-11e9-8e5e-25f17b36ea80.png)