### PR TITLE
Fix recent Composer deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,7 @@
         "lakion/mink-debug-extension": "^1.2.3",
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^3.0",
-        "mikey179/vfsStream": "^1.6",
+        "mikey179/vfsstream": "^1.6",
         "pamil/phpspec-skip-example-extension": "^4.0",
         "pamil/prophecy-common": "^0.1",
         "phpspec/phpspec": "^5.0",

--- a/src/Sylius/Bundle/ThemeBundle/composer.json
+++ b/src/Sylius/Bundle/ThemeBundle/composer.json
@@ -41,7 +41,7 @@
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^3.0",
-        "mikey179/vfsStream": "^1.6",
+        "mikey179/vfsstream": "^1.6",
         "phpspec/phpspec": "^5.0",
         "phpunit/phpunit": "^7.0",
         "sylius/registry": "^1.1",


### PR DESCRIPTION
`Deprecation warning: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead. Make sure you fix this as Composer 2.0 will error.`