### PR TITLE
Scaling text input field to keep enough room for the buttons

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/scss/style.scss
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/scss/style.scss
@@ -31,3 +31,15 @@ body {
 .ui.unmargined.segments {
   margin: 0;
 }
+
+#searchbar {
+    display: flex;
+}
+
+#searchbarTextField {
+    flex-grow: 100;
+}
+
+#searchbarButtons {
+    width: fit-content;
+}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_search.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Index/_search.html.twig
@@ -1,12 +1,12 @@
 <div class="ui segment">
     <form method="get" action="{{ path('sylius_shop_product_index', {'slug': app.request.attributes.get('slug')}) }}" class="ui loadable form">
-        <div class="ui stackable grid">
-            <div class="eleven wide column">
+        <div class="ui stackable grid" id="searchbar">
+            <div class="column" id="searchbarTextField">
                 {% for filter in products.definition.enabledFilters %}
                     {{ sylius_grid_render_filter(products, filter) }}
                 {% endfor %}
             </div>
-            <div class="three wide column">
+            <div class="right aligned column" id="searchbarButtons">
                 <div class="ui buttons">
                     <button type="submit" class="ui primary icon labeled button"><i class="search icon"></i> {{ 'sylius.ui.search'|trans }}</button>
                     <a href="{{ path('sylius_shop_product_index', {'slug': app.request.attributes.get('slug')}) }}" class="ui negative icon labeled button">


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

When using some languages the buttons break out the search segment, because the text on them is longer than what can fit in the semantic ui determined column size.
This change makes sure that the buttons always get enough room, by scaling the size of the text input field. Without breaking the layout.

To test this or reproduce the original behavior: 
1. please add the Dutch language from the admin side. And assign it to the default channel.
2. Add a translation for a product and for its taxon.
3. Now if you go to the `/nl/taxons/<dutch_taxon_slug>` route you will find that the layout is broken.