### PR TITLE
[taxon_fixtures] Fix child taxon slug generation

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
@@ -97,7 +97,7 @@ class TaxonExampleFactory extends AbstractExampleFactory implements ExampleFacto
         }
 
         foreach ($options['children'] as $childOptions) {
-            $this->create($childOptions, $taxon);
+            $this->createTaxon($childOptions, $taxon);
         }
 
         return $taxon;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
@@ -65,7 +65,7 @@ class TaxonExampleFactory extends AbstractExampleFactory implements ExampleFacto
      */
     public function create(array $options = []): TaxonInterface
     {
-        return createTaxon($options);
+        return $this->createTaxon($options);
     }
 
     protected function createTaxon(array $options = [], ?TaxonInterface $parentTaxon = null): ?TaxonInterface

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/TaxonExampleFactory.php
@@ -65,6 +65,11 @@ class TaxonExampleFactory extends AbstractExampleFactory implements ExampleFacto
      */
     public function create(array $options = []): TaxonInterface
     {
+        return createTaxon($options);
+    }
+
+    protected function createTaxon(array $options = [], ?TaxonInterface $parentTaxon = null): ?TaxonInterface
+    {
         $options = $this->optionsResolver->resolve($options);
 
         /** @var TaxonInterface $taxon */
@@ -77,6 +82,10 @@ class TaxonExampleFactory extends AbstractExampleFactory implements ExampleFacto
 
         $taxon->setCode($options['code']);
 
+        if (null !== $parentTaxon) {
+            $taxon->setParent($parentTaxon);
+        }
+        
         // add translation for each defined locales
         foreach ($this->getLocales() as $localeCode) {
             $this->createTranslation($taxon, $localeCode, $options);
@@ -88,7 +97,7 @@ class TaxonExampleFactory extends AbstractExampleFactory implements ExampleFacto
         }
 
         foreach ($options['children'] as $childOptions) {
-            $taxon->addChild($this->create($childOptions));
+            $this->create($childOptions, $taxon);
         }
 
         return $taxon;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

@loevgaard suggested I made this PR for this problem we ran into with using the **Taxon** fixture to add many nested categories into our dev server.

When using the **TaxonFixture** to generate nested categories, with slugs being automatically generated based on name, the slugs generated for the child categories, will not inherit their parents slugs.

This is due to the way child categories are added in the **TaxonExampleFactory**. A child category is added to the parent category after the child category has had it's slug generated via the **taxonSlugGenerator**. Thus the generator does not know about the parent, when trying to generate a slug for the child category.

An side effect of this is that, you can't have child categories with the same name in different parent categories.

Take this configuration as an example
```
sylius_fixtures:
  suites:
    default:
      fixtures:
        taxon:
          options:
            custom:
              - code: 'category'
                name: 'Category'
                children:
                  - code: 'child_1'
                    name: 'ChildOne'
                    children:
                      - code: 'subchild_1'
                        name: 'SubChildOne'
                  - code: 'child_2'
                    name: 'ChildTwo'
                    children:
                      - code: 'subchild_2'
                        name: 'SubChildOne'
```
You would expect the following slugs:
```
category
category/childone
category/childone/subchildone
category/childtwo/
category/childtwo/subchildone
```

But instead you get this when using the above configuration:
```
category
childone
subchildone
childtwo
subchildone
```

This results in the **Taxon** fixture just silently failing, because two of the taxons/categories have the same slug (subchildone) = no taxons are added to the database.

My suggestion for a fix, is to change when the child is added to the parent category, so it happens before the slug for the child is generated.