### PR TITLE
Allowing options to be given with resource[0].id syntax

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/Grid/Parser/OptionsParser.php
+++ b/src/Sylius/Bundle/ResourceBundle/Grid/Parser/OptionsParser.php
@@ -71,6 +71,10 @@ final class OptionsParser implements OptionsParserInterface
             return $this->parseOptionResourceField(substr($parameter, 9), $data);
         }
 
+        if (0 === strpos($parameter, 'resource[')) {
+            return $this->parseOptionResourceField(substr($parameter, 8), $data);
+        }
+
         return $parameter;
     }
 

--- a/src/Sylius/Bundle/ResourceBundle/spec/Grid/Parser/OptionsParserSpec.php
+++ b/src/Sylius/Bundle/ResourceBundle/spec/Grid/Parser/OptionsParserSpec.php
@@ -89,4 +89,26 @@ final class OptionsParserSpec extends ObjectBehavior
             ->shouldReturn(['id' => 21])
         ;
     }
+
+    function it_parses_options_with_array(
+        PropertyAccessorInterface $propertyAccessor,
+        Request $request,
+        ResourceInterface $data
+    ): void {
+        $arrayData = [
+            0 => $data,
+            'name' => 'An awesome name',
+        ];
+        $propertyAccessor->getValue($arrayData, '[0].id')->willReturn(21);
+        $propertyAccessor->getValue($arrayData, 'name')->willReturn('An awesome name');
+
+        $this
+            ->parseOptions(['name' => 'resource.name'], $request, $arrayData)
+            ->shouldReturn(['name' => 'An awesome name'])
+        ;
+        $this
+            ->parseOptions(['id' => 'resource[0].id'], $request, $arrayData)
+            ->shouldReturn(['id' => 21])
+        ;
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | potentially ?
| Deprecations?   | no
| Related tickets | 
| License         | MIT

When customizing grids quite a lot, we might get a queryBuilder returning an array of array instead of an array of entities. this array is built like this : 
```php
$result = [
    0 => new Resource(),
    'custom_value' => 8,
    'other_custom_value' => 'aaa',
]
```

And for this reason, it might be usefull to allow this kind of option parsing.
