### PR TITLE
[Shop] Use first variant image on a cart page

### DIFF
--- a/config/packages/test/sylius_uploader.yaml
+++ b/config/packages/test/sylius_uploader.yaml
@@ -1,0 +1,11 @@
+services:
+    sylius_test.filesystem:
+        class: Gaufrette\Filesystem
+        arguments:
+            - "%sylius.uploader.filesystem%"
+        factory: ['@knp_gaufrette.filesystem_map', 'get']
+    sylius.image_uploader:
+        class: Sylius\Behat\Service\Uploader\ImageUploader
+        arguments:
+            - "@sylius_test.filesystem"
+        public: true

--- a/config/packages/test_cached/sylius_uploader.yaml
+++ b/config/packages/test_cached/sylius_uploader.yaml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: "../test/sylius_uploader.yaml" }

--- a/features/cart/shopping_cart/having_proper_product_image_displayed_in_cart.feature
+++ b/features/cart/shopping_cart/having_proper_product_image_displayed_in_cart.feature
@@ -1,0 +1,25 @@
+@shopping_cart
+Feature: Having proper product image displayed in the cart
+    In order be aware of how the product that I'm buying looks like
+    As a Visitor
+    I want to have proper product image displayed in the cart
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "T-shirt Car"
+        And this product has "Small logo" variant priced at "$12.35"
+        And this product has "Medium logo" variant priced at "$15.35"
+        And this product has an image "lamborghini.jpg" with "main" type
+        And this product has an image "ford.jpg" with "main" type for "Medium logo" variant
+
+    @ui
+    Scenario: Having a variant's image displayed in the cart
+        When I add "Medium logo" variant of this product to the cart
+        Then I should be on my cart summary page
+        And 1st item in my cart should have "ford.jpg" image displayed
+
+    @ui
+    Scenario: Having a product's image displayed in the cart if variant does not have one
+        When I add "Small logo" variant of this product to the cart
+        Then I should be on my cart summary page
+        And 1st item in my cart should have "lamborghini.jpg" image displayed

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -409,6 +409,14 @@ final class CartContext implements Context
         Assert::same($this->summaryPage->getCartTotal(), $total);
     }
 
+    /**
+     * @Then /^(\d)(st|nd|rd|th) item in my cart should have "([^"]+)" image displayed$/
+     */
+    public function itemShouldHaveImageDisplayed(int $itemNumber, string $image): void
+    {
+        Assert::contains($this->summaryPage->getItemImage($itemNumber), $image);
+    }
+
     private function getPriceFromString(string $price): int
     {
         return (int) round((float) str_replace(['€', '£', '$'], '', $price) * 100, 2);

--- a/src/Sylius/Behat/Page/Shop/Cart/SummaryPage.php
+++ b/src/Sylius/Behat/Page/Shop/Cart/SummaryPage.php
@@ -107,6 +107,13 @@ class SummaryPage extends SymfonyPage implements SummaryPageInterface
         return $this->getPriceFromString(trim($unitPrice->getText()));
     }
 
+    public function getItemImage(int $itemNumber): string
+    {
+        $itemImage = $this->getElement('item_image', ['%number%' => $itemNumber]);
+
+        return $itemImage->getAttribute('src');
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -276,12 +283,13 @@ class SummaryPage extends SymfonyPage implements SummaryPageInterface
     {
         return array_merge(parent::getDefinedElements(), [
             'apply_coupon_button' => 'button:contains("Apply coupon")',
+            'base_grand_total' => '#sylius-cart-base-grand-total',
             'cart_items' => '#sylius-cart-items',
             'cart_total' => '#sylius-cart-total',
             'clear_button' => '#sylius-cart-clear',
             'coupon_field' => '#sylius_cart_promotionCoupon',
             'grand_total' => '#sylius-cart-grand-total',
-            'base_grand_total' => '#sylius-cart-base-grand-total',
+            'item_image' => '#sylius-cart-items tbody tr:nth-child(%number%) img',
             'product_discounted_total' => '#sylius-cart-items tr:contains("%name%") .sylius-discounted-total',
             'product_row' => '#sylius-cart-items tbody tr:contains("%name%")',
             'product_total' => '#sylius-cart-items tr:contains("%name%") .sylius-total',

--- a/src/Sylius/Behat/Page/Shop/Cart/SummaryPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Cart/SummaryPageInterface.php
@@ -64,6 +64,8 @@ interface SummaryPageInterface extends PageInterface
      */
     public function getItemUnitPrice($productName);
 
+    public function getItemImage(int $itemNumber): string;
+
     /**
      * @param string $productName
      *

--- a/src/Sylius/Behat/Resources/config/suites/ui/cart/shopping_cart.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/cart/shopping_cart.yml
@@ -13,6 +13,7 @@ default:
                 - sylius.behat.context.transform.shared_storage
                 - sylius.behat.context.transform.product
                 - sylius.behat.context.transform.product_option
+                - sylius.behat.context.transform.product_variant
                 - sylius.behat.context.transform.shipping_category
                 - sylius.behat.context.transform.tax_category
                 - sylius.behat.context.transform.zone

--- a/src/Sylius/Behat/Service/Uploader/ImageUploader.php
+++ b/src/Sylius/Behat/Service/Uploader/ImageUploader.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Service\Uploader;
+
+use Sylius\Component\Core\Model\ImageInterface;
+use Sylius\Component\Core\Uploader\ImageUploader as BaseImageUploader;
+use Sylius\Component\Core\Uploader\ImageUploaderInterface;
+use Symfony\Component\HttpFoundation\File\File;
+use Webmozart\Assert\Assert;
+
+final class ImageUploader extends BaseImageUploader implements ImageUploaderInterface
+{
+    public function upload(ImageInterface $image): void
+    {
+        if (!$image->hasFile()) {
+            return;
+        }
+
+        $file = $image->getFile();
+
+        /** @var File $file */
+        Assert::isInstanceOf($file, File::class);
+
+        if (null !== $image->getPath() && $this->has($image->getPath())) {
+            $this->remove($image->getPath());
+        }
+
+        do {
+            $hash = bin2hex(random_bytes(16));
+            $path = $this->expandPath($hash . '/' . $file->getFilename() . '.' . $file->guessExtension());
+        } while ($this->isAdBlockingProne($path) || $this->filesystem->has($path));
+
+        $image->setPath($path);
+
+        $this->filesystem->write(
+            $image->getPath(),
+            file_get_contents($image->getFile()->getPathname())
+        );
+    }
+
+    private function expandPath(string $path): string
+    {
+        return sprintf(
+            '%s/%s/%s',
+            substr($path, 0, 2),
+            substr($path, 2, 2),
+            substr($path, 4)
+        );
+    }
+
+    private function has(string $path): bool
+    {
+        return $this->filesystem->has($path);
+    }
+
+    private function isAdBlockingProne(string $path): bool
+    {
+        return strpos($path, 'ad') !== false;
+    }
+}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/_info.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/_info.html.twig
@@ -1,7 +1,11 @@
 {% set product = variant.product %}
 
 <div class="ui header">
-    {% include '@SyliusShop/Product/_mainImage.html.twig' with {'product': product, 'filter': 'sylius_shop_product_tiny_thumbnail'} %}
+    {% if variant.hasImages %}
+        {% include '@SyliusShop/Product/_mainImage.html.twig' with {'product': variant, 'filter': 'sylius_shop_product_tiny_thumbnail'} %}
+    {% else %}
+        {% include '@SyliusShop/Product/_mainImage.html.twig' with {'product': product, 'filter': 'sylius_shop_product_tiny_thumbnail'} %}
+    {% endif %}
     <div class="content">
         <div class="sylius-product-name">{{ item.productName }}</div>
         <span class="sub header sylius-product-variant-code">


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | replaces https://github.com/Sylius/Sylius/pull/8788, fixes https://github.com/Sylius/Sylius/issues/8787
| License         | MIT

This is a resurrection of linked PR, with some Behat tests added. I'm not very happy with the scenario implementation, as it requires overwriting the whole `ImageUploader` in a test environment, to keep uploaded image name - to give availability to check it in the scenario :/
IMO the best option would be to extract some service that would provide a new name for the uploaded image. I can do it in this or separate PR... What do you think? cc @Sylius/core-team @castler @gabiudrescu 