### PR TITLE
Fix product form submit

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributeChoice.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributeChoice.html.twig
@@ -1,6 +1,6 @@
 <div class="ui fluid action input" id="attributeChoice" data-action="{{ path('sylius_admin_render_attribute_forms') }}" style="margin-bottom: 15px;">
     {{ form_widget(form, {'attr': {'class': 'ui fluid search dropdown', 'id': 'sylius_product_attribute_choice'}}) }}
-    <button class="ui green labeled icon button">
+    <button class="ui green labeled icon button" type="button">
         <i class="icon plus"></i> {{ 'sylius.ui.add_attributes'|trans }}
     </button>
 </div>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | 
| Related tickets | fixes #6548
| License         | MIT

the problem was that the browser treats the button without the given type as submit, so after clicking enter it activated not this form
