### PR TITLE
[ResourceBundle] Make it possible to autowire services without interfaces

### DIFF
--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/AbstractDriver.php
@@ -94,6 +94,8 @@ abstract class AbstractDriver implements DriverInterface
         $factoryClass = $metadata->getClass('factory');
         $modelClass = $metadata->getClass('model');
 
+        $container->setAlias($factoryClass, $metadata->getServiceId('factory'));
+
         $definition = new Definition($factoryClass);
         $definition->setPublic(true);
 

--- a/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineORMDriver.php
+++ b/src/Sylius/Bundle/ResourceBundle/DependencyInjection/Driver/Doctrine/DoctrineORMDriver.php
@@ -46,6 +46,7 @@ final class DoctrineORMDriver extends AbstractDoctrineDriver
 
         if ($metadata->hasClass('repository')) {
             $repositoryClass = $metadata->getClass('repository');
+            $container->setAlias($repositoryClass, $metadata->getServiceId('repository'));
         }
 
         $definition = new Definition($repositoryClass);

--- a/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Resources/config/services.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Resources/config/services.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use AppBundle\Service\FirstAutowiredService;
+use AppBundle\Service\NoInterfaceAutowiredService;
 use AppBundle\Service\SecondAutowiredService;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -19,6 +20,7 @@ use Symfony\Component\DependencyInjection\Reference;
 if (method_exists($container, 'registerAliasForArgument')) {
     $container->autowire(FirstAutowiredService::class)->setPublic(true);
     $container->autowire(SecondAutowiredService::class)->setPublic(true);
+    $container->autowire(NoInterfaceAutowiredService::class)->setPublic(true);
 } else {
     $container->setDefinition(FirstAutowiredService::class, (new Definition(FirstAutowiredService::class, [
         new Reference('app.factory.book'),
@@ -27,6 +29,12 @@ if (method_exists($container, 'registerAliasForArgument')) {
     ]))->setPublic(true));
 
     $container->setDefinition(SecondAutowiredService::class, (new Definition(SecondAutowiredService::class, [
+        new Reference('app.factory.book'),
+        new Reference('app.repository.book'),
+        new Reference('app.manager.book'),
+    ]))->setPublic(true));
+
+    $container->setDefinition(NoInterfaceAutowiredService::class, (new Definition(NoInterfaceAutowiredService::class, [
         new Reference('app.factory.book'),
         new Reference('app.repository.book'),
         new Reference('app.manager.book'),

--- a/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Service/NoInterfaceAutowiredService.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Service/NoInterfaceAutowiredService.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace AppBundle\Service;
+
+use AppBundle\Factory\BookFactory;
+use AppBundle\Repository\BookRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+class NoInterfaceAutowiredService
+{
+    /** @var BookFactory */
+    public $bookFactory;
+
+    /** @var BookRepository */
+    public $bookRepository;
+
+    /** @var EntityManagerInterface */
+    public $bookManager;
+
+    public function __construct(
+        BookFactory $bookFactory,
+        BookRepository $bookRepository,
+        EntityManagerInterface $bookManager
+    ) {
+        $this->bookFactory = $bookFactory;
+        $this->bookRepository = $bookRepository;
+        $this->bookManager = $bookManager;
+    }
+}

--- a/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Service/NoInterfaceAutowiredService.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/AppBundle/Service/NoInterfaceAutowiredService.php
@@ -9,6 +9,7 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
 
 namespace AppBundle\Service;
 

--- a/src/Sylius/Bundle/ResourceBundle/test/src/Tests/DependencyInjection/SyliusResourceExtensionTest.php
+++ b/src/Sylius/Bundle/ResourceBundle/test/src/Tests/DependencyInjection/SyliusResourceExtensionTest.php
@@ -15,6 +15,8 @@ namespace Sylius\Bundle\ResourceBundle\Tests\DependencyInjection;
 
 use AppBundle\Entity\Book;
 use AppBundle\Entity\BookTranslation;
+use AppBundle\Entity\ComicBook;
+use AppBundle\Factory\BookFactory;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\SyliusResourceExtension;
 
@@ -80,6 +82,38 @@ class SyliusResourceExtensionTest extends AbstractExtensionTestCase
          ]);
 
         $this->assertContainerBuilderHasAlias('sylius.translation_locale_provider', 'test.custom_locale_provider');
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_break_when_aliasing_two_resources_use_same_factory_class()
+    {
+        // TODO: Move Resource-Grid integration to a dedicated compiler pass
+        $this->setParameter('kernel.bundles', []);
+
+        $this->load([
+            'resources' => [
+                'app.book' => [
+                    'classes' => [
+                        'model' => Book::class,
+                        'factory' => BookFactory::class,
+                    ],
+                ],
+                'app.comic_book' => [
+                    'classes' => [
+                        'model' => ComicBook::class,
+                        'factory' => BookFactory::class,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasService('app.factory.book');
+        $this->assertContainerBuilderHasService('app.factory.comic_book');
+
+        $this->assertContainerBuilderHasAlias(BookFactory::class, 'app.factory.comic_book');
+
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

It allows to custom your repositories and your factories without creating an interface and keep benefits of autowiring.

```
sylius_resource:
    resources:
        app.book:
            classes:
                model: App\Entity\Book
                factory: App\Factory\BookFactory
                repository: App\Repository\BookRepository
```

It aliases:

- **App\Factory\BookFactory** with **app.factory.book**
- **App\Repository\BookRepository** with **app.repository.book**

<!--
 - Bug fixes must be submitted against the 1.2 or 1.3 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
