### PR TITLE
Allow filtration of Admin API ProductOption

### DIFF
--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/product_option.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/product_option.yml
@@ -7,6 +7,7 @@ sylius_admin_api_product_option:
         alias: sylius.product_option
         section: admin_api
         serialization_version: $version
+        grid: sylius_admin_product_option
         criteria:
             code: $code
     type: sylius.resource_api


### PR DESCRIPTION
Added the grid configuration to admin api ProductOption to allow filtering

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT
