### PR TITLE
[Docs] Roadmap Link

### DIFF
--- a/docs/_themes/sylius_rtd_theme/layout.html
+++ b/docs/_themes/sylius_rtd_theme/layout.html
@@ -96,6 +96,7 @@
             <!-- Local TOC -->
             <div class="local-toc">{{ toc }}</div>
         {% endif %}
+        <a href="https://sylius.com/roadmap"><div class="local-toc">🔔 Roadmap</div></a>
       </div>
       &nbsp;
     </nav>

--- a/docs/book/introduction/introduction.rst
+++ b/docs/book/introduction/introduction.rst
@@ -45,6 +45,12 @@ E-Commerce Components for PHP
 If you use a different framework than Symfony, you are welcome to use Sylius components, which will make it much easier to implement a webshop with any PHP application and project.
 They provide you with default models, services and logic for all aspects of e-commerce, completely separated and ready to use.
 
+Roadmap
+-------
+
+Are you wondering about Sylius plans for the next releases? If so then you should follow our `Roadmap <https://sylius.com/roadmap>`_ on Github.
+There you can contribute by conversation and votes on the most desired features and improvements.
+
 Final Thoughts
 --------------
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| License         | MIT

I've realised (thanks to @dukusz 👋 ) that we did not have any references to our Roadmap in the documentation.

That's why I'm adding it to the main menu:
![image](https://user-images.githubusercontent.com/13198869/54365145-9912be00-466e-11e9-9136-80d5721dccee.png)

And to the Book > Introduction :)