### PR TITLE
[Resource] [Grid] deprecation warning fixed for deprecated Resource drivers

### DIFF
--- a/src/Sylius/Bundle/GridBundle/Resources/config/services/integrations/doctrine/phpcr-odm.xml
+++ b/src/Sylius/Bundle/GridBundle/Resources/config/services/integrations/doctrine/phpcr-odm.xml
@@ -18,7 +18,7 @@
         <service id="sylius.grid_driver.doctrine.phpcrodm" class="Sylius\Bundle\GridBundle\Doctrine\PHPCRODM\Driver">
             <argument type="service" id="doctrine_phpcr.odm.document_manager" />
             <tag name="sylius.grid_driver" alias="doctrine/phpcr-odm" />
-            <deprecated>The "sylius.grid_driver.doctrine.phpcrodm" service is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.</deprecated>
+            <deprecated>The "%service_id%" service is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.</deprecated>
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ResourceBundle/Resources/config/services/integrations/doctrine/mongodb-odm.xml
+++ b/src/Sylius/Bundle/ResourceBundle/Resources/config/services/integrations/doctrine/mongodb-odm.xml
@@ -22,13 +22,13 @@
         <service id="sylius.event_subscriber.odm_mapped_super_class" class="Sylius\Bundle\ResourceBundle\EventListener\ODMMappedSuperClassSubscriber">
             <argument type="service" id="sylius.resource_registry" />
             <tag name="doctrine_mongodb.odm.event_subscriber" priority="8192" />
-            <deprecated>The "sylius.event_subscriber.odm_mapped_super_class" service is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.</deprecated>
+            <deprecated>The "%service_id%" service is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.</deprecated>
         </service>
 
         <service id="sylius.event_subscriber.odm_repository_class" class="Sylius\Bundle\ResourceBundle\EventListener\ODMRepositoryClassSubscriber">
             <argument type="service" id="sylius.resource_registry" />
             <tag name="doctrine_mongodb.odm.event_subscriber" priority="8192" />
-            <deprecated>The "sylius.event_subscriber.odm_repository_class" service is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.</deprecated>
+            <deprecated>The "%service_id%" service is deprecated since Sylius 1.3. Doctrine MongoDB and PHPCR support will no longer be supported in Sylius 2.0.</deprecated>
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

This PR fixes Symfony error "deprecation template must contain the "%service_id%" placeholder" in Symfony\Component\DependencyInjection\Definition::setDeprecated() method. This error occurs when using deprecated Resource drivers.