### PR TITLE
Taxonomy tree modified - 'go level up' moved to the end of tree

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_verticalMenu.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_verticalMenu.html.twig
@@ -2,14 +2,14 @@
 
 <div class="ui fluid vertical menu">
     <div class="header item">{{ taxon.name }}</div>
+    {% for child in taxon.children %}
+    <a href="{{ path('sylius_shop_product_index', {'slug': child.slug, '_locale': child.translation.locale}) }}" class="item">{{ child.name }}</a>
+    {% endfor %}
     {% if taxon.parent is not empty and not taxon.parent.isRoot() %}
         <a href="{{ path('sylius_shop_product_index', {'slug': taxon.parent.slug, '_locale': taxon.parent.translation.locale}) }}" class="item">
             <i class="up arrow icon"></i> {{ 'sylius.ui.go_level_up'|trans }}
         </a>
     {% endif %}
-    {% for child in taxon.children %}
-    <a href="{{ path('sylius_shop_product_index', {'slug': child.slug, '_locale': child.translation.locale}) }}" class="item">{{ child.name }}</a>
-    {% endfor %}
 </div>
 
 {{ sonata_block_render_event('sylius.shop.product.index.after_vertical_menu', {'taxon': taxon}) }}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #9903 
| License         | MIT

![Screenshot 2019-03-19 at 10 38 43](https://user-images.githubusercontent.com/29897151/54595794-a267a600-4a33-11e9-8711-425fa97f2a6a.png)
