### PR TITLE
Revert "[HotFix] Conflict with Twig 2.7.3 that breaks themes bundle"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -185,7 +185,7 @@
         "symfony/dom-crawler": "4.1.8",
         "symfony/routing": "4.1.8",
         "symfony/symfony": "3.4.7 || 4.0.7 || 4.1.8",
-        "twig/twig": "2.6.1 | 2.7.3"
+        "twig/twig": "2.6.1"
     },
     "suggest": {
         "ext-iconv": "For better performance than using Symfony Polyfill Component",


### PR DESCRIPTION
Reverts Sylius/Sylius#10255.

See https://github.com/Sylius/SyliusThemeBundle/pull/21.