### PR TITLE
[BuildFix] Ignore psalm annotations

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/IgnoreAnnotationsPass.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/IgnoreAnnotationsPass.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class IgnoreAnnotationsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $annotationsReader = $container->getDefinition('annotations.reader');
+
+        $annotationsReader->addMethodCall('addGlobalIgnoredName', ['template']);
+        $annotationsReader->addMethodCall('addGlobalIgnoredName', ['psalm']);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
+++ b/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle;
 
+use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\IgnoreAnnotationsPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\LazyCacheWarmupPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\RegisterTaxCalculationStrategiesPass;
 use Sylius\Bundle\CoreBundle\DependencyInjection\Compiler\TranslatableEntityLocalePass;
@@ -42,6 +43,7 @@ final class SyliusCoreBundle extends AbstractResourceBundle
         $container->addCompilerPass(new LazyCacheWarmupPass());
         $container->addCompilerPass(new RegisterTaxCalculationStrategiesPass());
         $container->addCompilerPass(new TranslatableEntityLocalePass());
+        $container->addCompilerPass(new IgnoreAnnotationsPass());
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

According to recent changes in `doctrine/collections` (specifically in `1.6.0` version), we need to ignore psalm-related annotations to make usage of `ArrayCollection` possible 🚀 