### PR TITLE
[Product] Fixed products sorting by price

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -111,6 +111,8 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
              ;
 
             $queryBuilder
+                ->addSelect('variant')
+                ->addSelect('channelPricing')
                 ->innerJoin('o.variants', 'variant')
                 ->innerJoin('variant.channelPricings', 'channelPricing')
                 ->andWhere('channelPricing.channelCode = :channelCode')


### PR DESCRIPTION
Updated the createShopListQueryBuilder method of ProductRepository to get rid of the SQL error that causes a 500 one when trying to sort products by price in the shop.

| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #10266
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.3 or 1.4 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
