### PR TITLE
Upgrade flex to use composer dump-env

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,16 @@
-# This file is a "template" of which env vars needs to be defined in your configuration or in an .env file
-# Set variables here that may be different on each deployment target of the app, e.g. development, staging, production.
+# In all environments, the following files are loaded if they exist,
+# the later taking precedence over the former:
+#
+#  * .env                contains default values for the environment variables needed by the app
+#  * .env.local          uncommitted file with local overrides
+#  * .env.$APP_ENV       committed environment-specific defaults
+#  * .env.$APP_ENV.local uncommitted environment-specific overrides
+#
+# Real environment variables win over .env files.
+#
+# DO NOT DEFINE PRODUCTION SECRETS IN THIS FILE NOR IN ANY OTHER COMMITTED FILES.
+#
+# Run "composer dump-env prod" to compile .env files for production use (requires symfony/flex >=1.2).
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 
 ###> symfony/framework-bundle ###

--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
         "symfony/browser-kit": "^3.4|^4.1",
         "symfony/debug-bundle": "^3.4|^4.1",
         "symfony/dotenv": "^4.2",
-        "symfony/flex": "^1.1",
+        "symfony/flex": "^1.2",
         "symfony/intl": "^3.4|^4.1",
         "symfony/web-profiler-bundle": "^3.4|^4.1",
         "symfony/web-server-bundle": "^3.4|^4.1"

--- a/etc/travis/suites/application/install.sh
+++ b/etc/travis/suites/application/install.sh
@@ -6,6 +6,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../bash/application.
 print_header "Installing dependencies" "Sylius"
 run_command "if [ ! -z \"${SYMFONY_VERSION}\" ]; then bin/require-symfony-version composer.json \"${SYMFONY_VERSION}\"; fi" || exit $?
 run_command "composer install --no-interaction --prefer-dist" || exit $?
+run_command "composer dump-env test_cached" || exit $?
 
 print_header "Warming up dependencies" "Sylius"
 run_command "yarn install" || exit $?


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | no
| New feature?    | kind of
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.3 or 1.4 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->

This is a performance improvement. You can read more on [Symfony blog](https://symfony.com/blog/new-in-symfony-flex-1-2) on **Improved the handling of ``.env`` files** section.

I added this dump-env on travis to speed up build (hope!).
