### PR TITLE
Travis with mySQL 5.7 + product sorting fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,14 @@ env:
         - SYLIUS_CACHE_DIR=$HOME/.sylius-cache
         - SYLIUS_BUILD_DIR=etc/build
 
+addons:
+    apt:
+        sources:
+            - mysql-5.7-trusty
+        packages:
+            - mysql-server
+            - mysql-client
+
 matrix:
     include:
         -

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -111,6 +111,8 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
              ;
 
             $queryBuilder
+                ->addSelect('variant')
+                ->addSelect('channelPricing')
                 ->innerJoin('o.variants', 'variant')
                 ->innerJoin('variant.channelPricings', 'channelPricing')
                 ->andWhere('channelPricing.channelCode = :channelCode')


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/10266, replaces https://github.com/Sylius/Sylius/pull/10274
| License         | MIT

The bug from issue #10266 has not been detected on Travis CI, due to the lower mySQL version (without `ONLY_FULL_GROUP_BY` option set). So this PR bumps the mySQL version on the Travis to **5.7** and contains the fix for the products sorting from #10274 (thank @laSyntez for this one!).

As a proof that it didn't work without the fix, you can take a look at [this build](https://travis-ci.org/Zales0123/Sylius/builds/512912936) or check out our failing demo 🚀 🤣 

We have also a PR with changing the ubuntu version on Travis to xenial (https://github.com/Sylius/Sylius/pull/10277), but it does not work for some reasons so bumping a mySQL version can be the first step 🖖 
