### PR TITLE
[Documentation][ResourceBundle] 7.1. Overriding the Template and Criteria invalid config

### DIFF
--- a/docs/components_and_bundles/bundles/SyliusResourceBundle/index_resources.rst
+++ b/docs/components_and_bundles/bundles/SyliusResourceBundle/index_resources.rst
@@ -35,6 +35,7 @@ Just like for the **showAction**, you can override the default template and crit
         defaults:
             _controller: app.controller.book:indexAction
             _sylius:
+                filterable: true
                 criteria:
                     enabled: false
                 template: Book/disabled.html.twig


### PR DESCRIPTION
Added missing config parameter `filterable`

| Q               | A
| --------------- | -----
| Branch?         | 1.0+
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

[Default value](https://github.com/Sylius/Sylius/blob/1.0/src/Sylius/Bundle/ResourceBundle/Controller/RequestConfiguration.php#L323) of `RequestConfiguration::isFiltrable` is `false`. ResourceResolver [checks](https://github.com/Sylius/Sylius/blob/1.0/src/Sylius/Bundle/ResourceBundle/Controller/ResourcesResolver.php#L33) `RequestConfiguration::isFiltrable` to apply `criteria`. 

Current docs are missing `filterable` config parameter. Without it `criteria` are not applied to the query. This PR adds missing config.
