### PR TITLE
[Travis] Update mysql version to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ matrix:
                 apt:
                     packages:
                         - parallel
-        -   
+        -
             php: 7.2
             env:
                 - SYLIUS_SUITE="packages"

--- a/etc/travis/suites/application/before_script.sh
+++ b/etc/travis/suites/application/before_script.sh
@@ -3,6 +3,8 @@
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../bash/common.lib.sh"
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../bash/application.sh"
 
+run_command "sudo mysql_upgrade"
+
 print_header "Setting the application up" "Sylius"
 run_command "bin/console doctrine:database:create --env=test_cached -vvv" || exit $? # Have to be run with debug = true, to omit generating proxies before setting up the database
 run_command "APP_DEBUG=1 bin/console cache:warmup --env=dev -vvv" || exit $? # For PHPStan


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Since merging https://github.com/Sylius/Sylius/pull/10278 Travis jobs takes up to 50 minutes and are closed due to reaching a public repository job time limit :/ I don't know is it an issue with the mySQL version for 100%, but I think we should give it a try (check out https://github.com/travis-ci/travis-ci/issues/9948). I hope it will work, as 50 minutes-long jobs are really painful 🔪 💀 
