### PR TITLE
Fix re-authenticating for impersonated users

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -4,6 +4,7 @@ parameters:
     sylius.security.shop_regex: "^/(?!admin|api/.*|api$|media/.*)[^/]++"
 
 security:
+    always_authenticate_before_granting: true
     providers:
         sylius_admin_user_provider:
             id: sylius.admin_user_provider.email_or_name_based

--- a/src/Sylius/Behat/Service/SecurityService.php
+++ b/src/Sylius/Behat/Service/SecurityService.php
@@ -31,6 +31,9 @@ final class SecurityService implements SecurityServiceInterface
     /** @var string */
     private $sessionTokenVariable;
 
+    /** @var string */
+    private $firewallContextName;
+
     /**
      * @param string $firewallContextName
      */
@@ -39,6 +42,7 @@ final class SecurityService implements SecurityServiceInterface
         $this->session = $session;
         $this->cookieSetter = $cookieSetter;
         $this->sessionTokenVariable = sprintf('_security_%s', $firewallContextName);
+        $this->firewallContextName = $firewallContextName;
     }
 
     /**
@@ -46,7 +50,7 @@ final class SecurityService implements SecurityServiceInterface
      */
     public function logIn(UserInterface $user)
     {
-        $token = new UsernamePasswordToken($user, $user->getPassword(), 'randomstringbutnotnull', $user->getRoles());
+        $token = new UsernamePasswordToken($user, $user->getPassword(), $this->firewallContextName, $user->getRoles());
         $this->setToken($token);
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Security/UserImpersonator.php
+++ b/src/Sylius/Bundle/CoreBundle/Security/UserImpersonator.php
@@ -28,6 +28,9 @@ final class UserImpersonator implements UserImpersonatorInterface
     /** @var string */
     private $sessionTokenParameter;
 
+    /** @var string */
+    private $firewallContextName;
+
     /** @var EventDispatcherInterface */
     private $eventDispatcher;
 
@@ -35,6 +38,7 @@ final class UserImpersonator implements UserImpersonatorInterface
     {
         $this->session = $session;
         $this->sessionTokenParameter = sprintf('_security_%s', $firewallContextName);
+        $this->firewallContextName = $firewallContextName;
         $this->eventDispatcher = $eventDispatcher;
     }
 
@@ -43,8 +47,7 @@ final class UserImpersonator implements UserImpersonatorInterface
      */
     public function impersonate(UserInterface $user): void
     {
-        $token = new UsernamePasswordToken($user, $user->getPassword(), $this->sessionTokenParameter, $user->getRoles());
-
+        $token = new UsernamePasswordToken($user, $user->getPassword(), $this->firewallContextName, $user->getRoles());
         $this->session->set($this->sessionTokenParameter, serialize($token));
         $this->session->save();
 


### PR DESCRIPTION
When always_authenticate_before_granting: is set to true there is infinity loop of redirects to login page because AuthenticationProviderManager can't find a provider which supports UsernamePasswordToken with providerKey _security_shop. So, a provider key in UsernamePasswordToken must be the same as  $firewallContextName, without _security_ prefix.

| Q               | A
| --------------- | -----
| Branch?         | 1.3, 1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.3 or 1.4 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
