### PR TITLE
[ChannelPricing] Fixed channelPricing not blank validation

### DIFF
--- a/features/product/managing_products/product_validation.feature
+++ b/features/product/managing_products/product_validation.feature
@@ -143,6 +143,15 @@ Feature: Products validation
         Then I should be notified that slug has to be unique
         And product with code "7-WONDERS-BABEL" should not be added
 
+    @ui
+    Scenario: Trying to remove price from an existing simple product while disabling channel
+        Given the store has a "Dice Brewing" product
+        And I want to modify this product
+        When I remove its price from channel "Web"
+        And I disable it in channel "Web"
+        And I try to save my changes
+        Then I should be notified that price cannot be blank
+
     @ui @javascript
     Scenario: Trying to add a new product with a text attribute without specifying its value in default locale
         When I want to create a new simple product

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -977,4 +977,31 @@ final class ManagingProductsContext implements Context
             $this->updateConfigurableProductPage,
         ]);
     }
+
+    /**
+     * @When I remove its price from channel :channel
+     */
+    public function iRemoveItsPriceFromChannel(ChannelInterface $channel)
+    {
+        $this->updateSimpleProductPage->specifyPrice($channel->getName(), '');
+    }
+
+    /**
+     * @When I disable it in channel :channel
+     */
+    public function iDisableItInChannel(ChannelInterface $channel)
+    {
+        $this->updateSimpleProductPage->checkChannel($channel->getName());
+    }
+
+    /**
+     * @Then /^I should be notified that price cannot be blank$/
+     */
+    public function iShouldBeNotifiedThatPriceCannotBeBlank()
+    {
+        Assert::same(
+            $this->updateSimpleProductPage->getChannelPricingValidationError(),
+            sprintf('Please enter the price.')
+        );
+    }
 }

--- a/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPage.php
+++ b/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPage.php
@@ -372,6 +372,8 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
             'taxonomy' => 'a[data-tab="taxonomy"]',
             'tracked' => '#sylius_product_variant_tracked',
             'toggle_slug_modification_button' => '[data-locale="%locale%"] .toggle-product-slug-modification',
+            'channel_pricing' => '#sylius_product_variant_channelPricings',
+            'channel_checkbox' => '.checkbox:contains("%channelName%") input',
         ]);
     }
 
@@ -460,5 +462,17 @@ class UpdateSimpleProductPage extends BaseUpdatePage implements UpdateSimpleProd
         }
 
         $this->imageUrls[$type] = $imageUrl;
+    }
+
+    public function checkChannel(string $channelName): void
+    {
+        $this->getElement('channel_checkbox', ['%channelName%' => $channelName])->check();
+    }
+
+    public function getChannelPricingValidationError(): string
+    {
+        $validationError = $this->getElement('channel_pricing')->find('css', '.sylius-validation-error');
+
+        return $validationError->getText();
     }
 }

--- a/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Product/UpdateSimpleProductPageInterface.php
@@ -94,4 +94,8 @@ interface UpdateSimpleProductPageInterface extends BaseUpdatePageInterface
     public function getOriginalPriceForChannel(string $channelName): string;
 
     public function isShippingRequired(): bool;
+
+    public function checkChannel(string $channelName): void;
+
+    public function getChannelPricingValidationError(): string;
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation/ChannelPricing.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation/ChannelPricing.xml
@@ -14,6 +14,10 @@
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd">
     <class name="Sylius\Component\Core\Model\ChannelPricing">
         <property name="price">
+            <constraint name="NotBlank">
+                <option name="message">sylius.channel_pricing.price.not_blank</option>
+                <option name="groups">sylius</option>
+                </constraint>
             <constraint name="Range">
                 <option name="min">0.01</option>
                 <option name="minMessage">sylius.channel_pricing.price.min</option>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Removing price from a simple product or variant can cause not null exception if product is disabled in channel.

