### PR TITLE
[Documentation] Form extension implementation update prior to sf 4.2

### DIFF
--- a/docs/customization/form.rst
+++ b/docs/customization/form.rst
@@ -81,9 +81,9 @@ As a result you will get the ``Sylius\Bundle\CustomerBundle\Form\Type\CustomerPr
         /**
          * {@inheritdoc}
          */
-        public function getExtendedType(): string
+        public static function getExtendedTypes(): iterable
         {
-            return CustomerProfileType::class;
+            return [CustomerProfileType::class];
         }
     }
 


### PR DESCRIPTION


| Q               | A
| --------------- | -----
| Branch?         |1.4
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

On [Customizing forms](https://docs.sylius.com/en/1.4/customization/form.html#how-to-customize-a-form) there is broken code to create a form extension with Sylius 1.4.2 with Symfony 4.2.4. The correct way with symfony 4.2 is described in [symfony documentation](https://symfony.com/doc/current/form/create_form_type_extension.html#defining-the-form-type-extension).
