### PR TITLE
Fix base locale

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/LocaleFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/LocaleFixture.php
@@ -45,9 +45,7 @@ class LocaleFixture extends AbstractFixture
      */
     public function load(array $options): void
     {
-        $localesCodes = array_merge([$this->baseLocaleCode], $options['locales']);
-
-        foreach ($localesCodes as $localeCode) {
+        foreach ($options['locales'] as $localeCode) {
             /** @var LocaleInterface $locale */
             $locale = $this->localeFactory->createNew();
 
@@ -73,6 +71,21 @@ class LocaleFixture extends AbstractFixture
     protected function configureOptionsNode(ArrayNodeDefinition $optionsNode): void
     {
         $optionsNode
+            ->beforeNormalization()
+                ->ifEmpty()
+                ->then(function(){
+                    @trigger_error(
+                        'Base locale deprecated since 1.3. Please, pass %locale% directly to locales fixture at fixtures option.',
+                        E_USER_DEPRECATED
+                    );
+
+                    return [
+                        'locales'=>[
+                            $this->baseLocaleCode
+                        ]
+                    ];
+                })
+            ->end()
             ->children()
                 ->arrayNode('locales')
                     ->scalarPrototype()

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures.yml
@@ -9,7 +9,11 @@ sylius_fixtures:
                 logger: ~
 
             fixtures:
-                locale: ~
+                locale:
+                    options:
+                        locales:
+                            - "%locale%"
+
                 currency:
                     options:
                         currencies: ['USD']

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/LocaleFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/LocaleFixtureTest.php
@@ -40,6 +40,30 @@ final class LocaleFixtureTest extends TestCase
     }
 
     /**
+     * @test
+     */
+    public function default_locale_is_added_by_default(): void
+    {
+        $this->assertProcessedConfigurationEquals(
+            [[]],
+            ['locales' => ['default_LOCALE']],
+            'locales'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function default_locale_is_not_added_if_locales_passed_directly(): void
+    {
+        $this->assertProcessedConfigurationEquals(
+            [['locales' => ['en_US']]],
+            ['locales' => ['en_US']],
+            'locales'
+        );
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getConfiguration(): LocaleFixture

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/LocaleFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/LocaleFixtureTest.php
@@ -36,7 +36,7 @@ final class LocaleFixtureTest extends TestCase
      */
     public function locales_can_be_set(): void
     {
-        $this->assertConfigurationIsValid([['locales' => ['en_US' => true, 'pl_PL' => false, 'es_ES' => true]]], 'locales');
+        $this->assertConfigurationIsValid([['locales' => ['en_US', 'pl_PL', 'es_ES']]], 'locales');
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | not sure (it backward compatible on default fixtures configuration)
| Deprecations?   | not sure (deprecation messages was added, but not appear on default fixtures configuration)
| Related tickets | fixes #10307, partially #7346
| License         | MIT

So, in BC in mind, with this PR it now will work like this:

- **If you have default (empty) configuration, as was before**:

    ```yaml
    sylius_fixtures:
        # ...
        fixtures:
            locale: ~
    ```
  Then, base locale **will be added** to configuration.

- *But if you provided a list of locales*:

    ```yaml
    sylius_fixtures:
        suites:
            my_custom_suite_to_add_to_existing_database:
                listeners:
                    orm_purger: false
                fixtures:
                    locale:
                        options:
                            locales:
                                - "de_DE"
    ```
   Then, base locale **will NOT be added** to configuration.

Deprecation message was added to avoid usage base locale at all in future. To suppress that message on default configuration, `"%locale%"` was passed directly to the `locales` option at `src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures.yml`.

# TODO

- [ ] Define Sylius version where base locale will be removed OR remove deprecation message if base locale should be kept by default (when fixture defined like `locale: ~`) - I'm not 100% sure about this so want to discuss this first.
