### PR TITLE
Do not depend on transient dependencies for "symfony/intl" package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
         "symfony/framework-bundle": "^3.4|^4.1",
         "symfony/http-foundation": "^3.4|^4.1",
         "symfony/http-kernel": "^3.4|^4.1",
+        "symfony/intl": "^3.4|^4.1.1",
         "symfony/monolog-bundle": "^3.0",
         "symfony/options-resolver": "^3.4|^4.1",
         "symfony/polyfill-iconv": "^1.3",
@@ -127,7 +128,6 @@
         "symfony/debug-bundle": "^3.4|^4.1",
         "symfony/dotenv": "^3.4|^4.1",
         "symfony/flex": "^1.1",
-        "symfony/intl": "^3.4|^4.1",
         "symfony/web-profiler-bundle": "^3.4|^4.1",
         "symfony/web-server-bundle": "^3.4|^4.1"
     },

--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -25,7 +25,8 @@
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/addressing": "^1.2",
         "sylius/resource-bundle": "^1.2",
-        "symfony/framework-bundle": "^3.4|^4.1.1"
+        "symfony/framework-bundle": "^3.4|^4.1.1",
+        "symfony/intl": "^3.4|^4.1.1"
     },
     "require-dev": {
         "doctrine/orm": "^2.5",

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -50,6 +50,7 @@
         "sylius/user-bundle": "^1.2",
         "sylius-labs/association-hydrator": "^1.1",
         "symfony/framework-bundle": "^3.4|^4.1.1",
+        "symfony/intl": "^3.4|^4.1.1",
         "winzou/state-machine-bundle": "^0.3",
         "liip/imagine-bundle": "^2.0"
     },

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -25,6 +25,7 @@
         "sylius/currency": "^1.2",
         "sylius/resource-bundle": "^1.2",
         "symfony/framework-bundle": "^3.4|^4.1.1",
+        "symfony/intl": "^3.4|^4.1.1",
         "symfony/templating": "^3.4|^4.1.1"
     },
     "require-dev": {


### PR DESCRIPTION
The following subpackages rely on `symfony/intl`:
 - Behat contexts
 - CoreBundle
 - CurrencyBundle
 - AddressingBundle
 - Addressing
 - Locale
 - Currency

Currently this package is installed because of transient dependencies, but we shouldn't rely on that.