### PR TITLE
[Shipping] Shipping method rules

### DIFF
--- a/docs/cookbook/index.rst
+++ b/docs/cookbook/index.rst
@@ -77,6 +77,16 @@ Promotions
 
 .. include:: /cookbook/promotions/map.rst.inc
 
+Shipping methods
+----------------
+
+.. toctree::
+    :hidden:
+
+    shipping-methods/custom-shipping-method-rule
+
+.. include:: /cookbook/shipping-methods/map.rst.inc
+
 Images
 ------
 

--- a/docs/cookbook/shipping-methods/custom-shipping-method-rule.rst
+++ b/docs/cookbook/shipping-methods/custom-shipping-method-rule.rst
@@ -1,0 +1,84 @@
+How to add a custom shipping method rule?
+=========================================
+
+Shipping method rules are used to show shipping methods if certain criteria are fulfilled.
+
+Say you have a requirement for one of your shipping methods that the volume of the shipment may not exceed 1 cubic meter (i.e. 1 m x 1 m 1 m).
+To model this requirement you can use a shipping method rule.
+
+Create a new shipping method rule
+---------------------------------
+
+The new rule needs a RuleChecker class:
+
+.. code-block:: php
+
+    <?php
+
+    namespace App\Shipping\Checker\Rule;
+
+    use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+
+    final class TotalVolumeLessThanOrEqualRuleChecker implements RuleCheckerInterface
+    {
+        public const TYPE = 'total_volume_less_than_or_equal';
+
+        public function isEligible(ShippingSubjectInterface $subject, array $configuration): bool
+        {
+            return $subject->getShippingVolume() <= $configuration['volume'];
+        }
+    }
+
+
+Prepare a configuration form type for your new rule
+---------------------------------------------------
+
+To be able to configure a shipping method with your new rule you will need a form type for the admin panel.
+
+Create the configuration form type class:
+
+.. code-block:: php
+
+    <?php
+
+    namespace App\Form\Type\Rule;
+
+    use Symfony\Component\Form\AbstractType;
+    use Symfony\Component\Form\Extension\Core\Type\NumberType;
+    use Symfony\Component\Form\FormBuilderInterface;
+    use Symfony\Component\Validator\Constraints\GreaterThan;
+    use Symfony\Component\Validator\Constraints\NotBlank;
+    use Symfony\Component\Validator\Constraints\Type;
+
+    class TotalVolumeLessThanOrEqualConfigurationType extends AbstractType
+    {
+        public function buildForm(FormBuilderInterface $builder, array $options): void
+        {
+            $builder->add('volume', NumberType::class, [
+                'label' => 'app.form.total_volume_less_than_or_equal_configuration.volume',
+                'constraints' => [
+                    new NotBlank(['groups' => ['sylius']]),
+                    new Type(['type' => 'numeric', 'groups' => ['sylius']]),
+                    new GreaterThan(['value' => 0, 'groups' => ['sylius']])
+                ],
+            ]);
+        }
+
+        public function getBlockPrefix()
+        {
+            return 'app_shipping_method_rule_total_volume_less_than_or_equal_configuration';
+        }
+    }
+
+Register the new rule checker as a service in the ``config/services.yaml``:
+
+.. code-block:: yaml
+
+    # config/services.yml
+    app.shipping_method_rule_checker.total_volume_less_than_or_equal:
+        class: App\Shipping\Checker\Rule\TotalVolumeLessThanOrEqualRuleChecker
+        tags:
+            - { name: sylius.shipping_method_rule_checker, type: total_volume_less_than_or_equal, form_type: App\Form\Type\Rule\TotalVolumeLessThanOrEqualConfigurationType, label: app.form.shipping_method_rule.total_volume_less_than_or_equal }
+
+
+That's all. You will now be able to choose the new rule while creating a new shipping method.

--- a/docs/cookbook/shipping-methods/map.rst.inc
+++ b/docs/cookbook/shipping-methods/map.rst.inc
@@ -1,0 +1,1 @@
+* :doc:`/cookbook/shipping-methods/custom-shipping-method-rule`

--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
@@ -60,9 +60,11 @@ $(document).ready(() => {
       $('select[name^="sylius_promotion[actions]"][name$="[type]"]').last().change();
     }, 50);
   });
-  $('#rules a[data-form-collection="add"]').on('click', () => {
+  $('#rules a[data-form-collection="add"]').on('click', (event) => {
+    const name = $(event.target).closest('form').attr('name');
+
     setTimeout(() => {
-      $('select[name^="sylius_promotion[rules]"][name$="[type]"]').last().change();
+      $(`select[name^="${name}[rules]"][name$="[type]"]`).last().change();
     }, 50);
   });
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ShippingMethod/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ShippingMethod/_form.html.twig
@@ -33,6 +33,11 @@
                     {% endfor %}
                 {% endif %}
             </div>
+
+            <h4 class="ui dividing header">{{ 'sylius.ui.rules'|trans }}</h4>
+            <div id="rules">
+                {{ form_row(form.rules) }}
+            </div>
         </div>
     </div>
     <div class="column">

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -68,7 +68,7 @@
         <service id="sylius.shipping_methods_resolver.zones_and_channel_based" class="Sylius\Component\Core\Resolver\ZoneAndChannelBasedShippingMethodsResolver">
             <argument type="service" id="sylius.repository.shipping_method" />
             <argument type="service" id="sylius.zone_matcher" />
-            <argument type="service" id="sylius.shipping_eligibility_checker" />
+            <argument type="service" id="sylius.shipping_method_eligibility_checker" />
             <tag name="sylius.shipping_method_resolver" type="zones_and_channel_based" label="sylius.shipping_methods_resolver.zones_and_channel_based" priority="1" />
         </service>
 
@@ -84,7 +84,7 @@
 
         <service id="sylius.shipping_method_resolver.default" class="Sylius\Component\Core\Resolver\EligibleDefaultShippingMethodResolver">
             <argument type="service" id="sylius.repository.shipping_method" />
-            <argument type="service" id="sylius.shipping_eligibility_checker" />
+            <argument type="service" id="sylius.shipping_method_eligibility_checker" />
             <argument type="service" id="sylius.zone_matcher" />
         </service>
         <service id="Sylius\Component\Shipping\Resolver\DefaultShippingMethodResolverInterface" alias="sylius.shipping_method_resolver.default" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/validators.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/validators.xml
@@ -50,7 +50,7 @@
         </service>
 
         <service id="sylius.validator.shipping_method_integrity" class="Sylius\Bundle\CoreBundle\Validator\Constraints\OrderShippingMethodEligibilityValidator">
-            <argument type="service" id="sylius.shipping_eligibility_checker" />
+            <argument type="service" id="sylius.shipping_method_eligibility_checker" />
             <tag name="validator.constraint_validator" alias="sylius_order_shipping_method_eligibility_validator" />
         </service>
         <service id="sylius.validator.payment_method_integrity" class="Sylius\Bundle\CoreBundle\Validator\Constraints\OrderPaymentMethodEligibilityValidator">

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderShippingMethodEligibilityValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderShippingMethodEligibilityValidator.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface;
+use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Webmozart\Assert\Assert;

--- a/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Compiler/CompositeShippingMethodEligibilityCheckerPass.php
+++ b/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Compiler/CompositeShippingMethodEligibilityCheckerPass.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShippingBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class CompositeShippingMethodEligibilityCheckerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has('sylius.shipping_method_eligibility_checker')) {
+            return;
+        }
+
+        $container->getDefinition('sylius.shipping_method_eligibility_checker')->setArguments([
+            array_map(
+                function ($id) {
+                    return new Reference($id);
+                },
+                array_keys($container->findTaggedServiceIds('sylius.shipping_method_eligibility_checker'))
+            ),
+        ]);
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Compiler/RegisterRuleCheckersPass.php
+++ b/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Compiler/RegisterRuleCheckersPass.php
@@ -20,9 +20,6 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class RegisterRuleCheckersPass implements CompilerPassInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function process(ContainerBuilder $container): void
     {
         if (!$container->has('sylius.registry.shipping_method_rule_checker') || !$container->has('sylius.form_registry.shipping_method_rule_checker')) {

--- a/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Compiler/RegisterRuleCheckersPass.php
+++ b/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Compiler/RegisterRuleCheckersPass.php
@@ -30,14 +30,16 @@ final class RegisterRuleCheckersPass implements CompilerPassInterface
         $ruleCheckerFormTypeRegistry = $container->getDefinition('sylius.form_registry.shipping_method_rule_checker');
 
         $ruleCheckerTypeToLabelMap = [];
-        foreach ($container->findTaggedServiceIds('sylius.shipping_method_rule_checker') as $id => $attributes) {
-            if (!isset($attributes[0]['type'], $attributes[0]['label'], $attributes[0]['form_type'])) {
-                throw new InvalidArgumentException('Tagged shipping method rule checker `' . $id . '` needs to have `type`, `form_type` and `label` attributes.');
-            }
+        foreach ($container->findTaggedServiceIds('sylius.shipping_method_rule_checker') as $id => $tagged) {
+            foreach ($tagged as $attributes) {
+                if (!isset($attributes['type'], $attributes['label'], $attributes['form_type'])) {
+                    throw new InvalidArgumentException('Tagged shipping method rule checker `' . $id . '` needs to have `type`, `form_type` and `label` attributes.');
+                }
 
-            $ruleCheckerTypeToLabelMap[$attributes[0]['type']] = $attributes[0]['label'];
-            $ruleCheckerRegistry->addMethodCall('register', [$attributes[0]['type'], new Reference($id)]);
-            $ruleCheckerFormTypeRegistry->addMethodCall('add', [$attributes[0]['type'], 'default', $attributes[0]['form_type']]);
+                $ruleCheckerTypeToLabelMap[$attributes['type']] = $attributes['label'];
+                $ruleCheckerRegistry->addMethodCall('register', [$attributes['type'], new Reference($id)]);
+                $ruleCheckerFormTypeRegistry->addMethodCall('add', [$attributes['type'], 'default', $attributes['form_type']]);
+            }
         }
 
         $container->setParameter('sylius.shipping_method_rules', $ruleCheckerTypeToLabelMap);

--- a/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Compiler/RegisterRuleCheckersPass.php
+++ b/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Compiler/RegisterRuleCheckersPass.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShippingBundle\DependencyInjection\Compiler;
+
+use InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class RegisterRuleCheckersPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has('sylius.registry.shipping_method_rule_checker') || !$container->has('sylius.form_registry.shipping_method_rule_checker')) {
+            return;
+        }
+
+        $ruleCheckerRegistry = $container->getDefinition('sylius.registry.shipping_method_rule_checker');
+        $ruleCheckerFormTypeRegistry = $container->getDefinition('sylius.form_registry.shipping_method_rule_checker');
+
+        $ruleCheckerTypeToLabelMap = [];
+        foreach ($container->findTaggedServiceIds('sylius.shipping_method_rule_checker') as $id => $attributes) {
+            if (!isset($attributes[0]['type'], $attributes[0]['label'], $attributes[0]['form_type'])) {
+                throw new InvalidArgumentException('Tagged shipping method rule checker `' . $id . '` needs to have `type`, `form_type` and `label` attributes.');
+            }
+
+            $ruleCheckerTypeToLabelMap[$attributes[0]['type']] = $attributes[0]['label'];
+            $ruleCheckerRegistry->addMethodCall('register', [$attributes[0]['type'], new Reference($id)]);
+            $ruleCheckerFormTypeRegistry->addMethodCall('add', [$attributes[0]['type'], 'default', $attributes[0]['form_type']]);
+        }
+
+        $container->setParameter('sylius.shipping_method_rules', $ruleCheckerTypeToLabelMap);
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Compiler/RegisterShippingMethodsResolversPass.php
+++ b/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Compiler/RegisterShippingMethodsResolversPass.php
@@ -13,15 +13,13 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ShippingBundle\DependencyInjection\Compiler;
 
+use InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 final class RegisterShippingMethodsResolversPass implements CompilerPassInterface
 {
-    /**
-     * {@inheritdoc}
-     */
     public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('sylius.registry.shipping_methods_resolver')) {
@@ -32,8 +30,8 @@ final class RegisterShippingMethodsResolversPass implements CompilerPassInterfac
         $resolvers = [];
 
         foreach ($container->findTaggedServiceIds('sylius.shipping_method_resolver') as $id => $attributes) {
-            if (!isset($attributes[0]['type']) || !isset($attributes[0]['label'])) {
-                throw new \InvalidArgumentException('Tagged shipping methods resolvers need to have `type` and `label` attributes.');
+            if (!isset($attributes[0]['type'], $attributes[0]['label'])) {
+                throw new InvalidArgumentException('Tagged shipping methods resolvers need to have `type` and `label` attributes.');
             }
 
             $priority = (int) ($attributes[0]['priority'] ?? 0);

--- a/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/ShippingBundle/DependencyInjection/Configuration.php
@@ -17,6 +17,7 @@ use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Sylius\Bundle\ShippingBundle\Form\Type\ShipmentType;
 use Sylius\Bundle\ShippingBundle\Form\Type\ShippingCategoryType;
+use Sylius\Bundle\ShippingBundle\Form\Type\ShippingMethodRuleType;
 use Sylius\Bundle\ShippingBundle\Form\Type\ShippingMethodTranslationType;
 use Sylius\Bundle\ShippingBundle\Form\Type\ShippingMethodType;
 use Sylius\Component\Resource\Factory\Factory;
@@ -29,6 +30,8 @@ use Sylius\Component\Shipping\Model\ShippingCategory;
 use Sylius\Component\Shipping\Model\ShippingCategoryInterface;
 use Sylius\Component\Shipping\Model\ShippingMethod;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
+use Sylius\Component\Shipping\Model\ShippingMethodRule;
+use Sylius\Component\Shipping\Model\ShippingMethodRuleInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodTranslation;
 use Sylius\Component\Shipping\Model\ShippingMethodTranslationInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -133,6 +136,23 @@ final class Configuration implements ConfigurationInterface
                                                 ->scalarNode('form')->defaultValue(ShippingMethodTranslationType::class)->cannotBeEmpty()->end()
                                             ->end()
                                         ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('shipping_method_rule')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->variableNode('options')->end()
+                                ->arrayNode('classes')
+                                    ->addDefaultsIfNotSet()
+                                    ->children()
+                                        ->scalarNode('model')->defaultValue(ShippingMethodRule::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('interface')->defaultValue(ShippingMethodRuleInterface::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('controller')->defaultValue(ResourceController::class)->cannotBeEmpty()->end()
+                                        ->scalarNode('repository')->cannotBeEmpty()->end()
+                                        ->scalarNode('factory')->defaultValue(Factory::class)->end()
+                                        ->scalarNode('form')->defaultValue(ShippingMethodRuleType::class)->cannotBeEmpty()->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/src/Sylius/Bundle/ShippingBundle/Form/EventSubscriber/AddWeightFormSubscriber.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/EventSubscriber/AddWeightFormSubscriber.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShippingBundle\Form\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
+
+final class AddWeightFormSubscriber implements EventSubscriberInterface
+{
+    /** @var string */
+    private $type;
+
+    /** @var array */
+    private $options;
+
+    public function __construct(?string $type = null, array $options = [])
+    {
+        $this->type = $type ?? NumberType::class;
+        $this->options = $options;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            FormEvents::PRE_SET_DATA => 'preSetData',
+        ];
+    }
+
+    public function preSetData(FormEvent $event): void
+    {
+        $form = $event->getForm();
+        $form->add('weight', $this->type, array_merge(
+            [
+                'label' => 'sylius.form.shipping_method_rule.weight',
+                'constraints' => [
+                    new NotBlank(['groups' => ['sylius']]),
+                    new Type(['type' => 'numeric', 'groups' => ['sylius']]),
+                    new GreaterThan(['value' => 0, 'groups' => ['sylius']])
+                ],
+            ],
+            $this->options
+        ));
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/AbstractConfigurableShippingMethodElementType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/AbstractConfigurableShippingMethodElementType.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShippingBundle\Form\Type;
+
+use Sylius\Bundle\ResourceBundle\Form\Registry\FormTypeRegistryInterface;
+use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
+use Sylius\Component\Shipping\Model\ConfigurableShippingMethodElementInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+abstract class AbstractConfigurableShippingMethodElementType extends AbstractResourceType
+{
+    /** @var FormTypeRegistryInterface */
+    private $formTypeRegistry;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(string $dataClass, array $validationGroups = [], FormTypeRegistryInterface $formTypeRegistry)
+    {
+        parent::__construct($dataClass, $validationGroups);
+
+        $this->formTypeRegistry = $formTypeRegistry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        parent::buildForm($builder, $options);
+
+        $builder
+            ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event): void {
+                $type = $this->getRegistryIdentifier($event->getForm(), $event->getData());
+                if (null === $type) {
+                    return;
+                }
+
+                $this->addConfigurationFields($event->getForm(), $this->formTypeRegistry->get($type, 'default'));
+            })
+            ->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {
+                $type = $this->getRegistryIdentifier($event->getForm(), $event->getData());
+                if (null === $type) {
+                    return;
+                }
+
+                $event->getForm()->get('type')->setData($type);
+            })
+            ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
+                $data = $event->getData();
+
+                if (!isset($data['type'])) {
+                    return;
+                }
+
+                $this->addConfigurationFields($event->getForm(), $this->formTypeRegistry->get($data['type'], 'default'));
+            })
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        parent::configureOptions($resolver);
+
+        $resolver
+            ->setDefault('configuration_type', null)
+            ->setAllowedTypes('configuration_type', ['string', 'null'])
+        ;
+    }
+
+    protected function addConfigurationFields(FormInterface $form, string $configurationType): void
+    {
+        $form->add('configuration', $configurationType, [
+            'label' => false,
+        ]);
+    }
+
+    protected function getRegistryIdentifier(FormInterface $form, $data = null): ?string
+    {
+        if ($data instanceof ConfigurableShippingMethodElementInterface && null !== $data->getType()) {
+            return $data->getType();
+        }
+
+        if (null !== $form->getConfig()->hasOption('configuration_type')) {
+            return $form->getConfig()->getOption('configuration_type');
+        }
+
+        return null;
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/Core/AbstractConfigurationCollectionType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/Core/AbstractConfigurationCollectionType.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShippingBundle\Form\Type\Core;
+
+use Sylius\Component\Registry\ServiceRegistryInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+abstract class AbstractConfigurationCollectionType extends AbstractType
+{
+    /** @var ServiceRegistryInterface */
+    protected $registry;
+
+    public function __construct(ServiceRegistryInterface $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $prototypes = [];
+        foreach (array_keys($this->registry->all()) as $type) {
+            $formBuilder = $builder->create(
+                $options['prototype_name'],
+                $options['entry_type'],
+                array_replace(
+                    $options['entry_options'],
+                    ['configuration_type' => $type]
+                )
+            );
+
+            $prototypes[$type] = $formBuilder->getForm();
+        }
+
+        $builder->setAttribute('prototypes', $prototypes);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options): void
+    {
+        $view->vars['prototypes'] = [];
+
+        foreach ($form->getConfig()->getAttribute('prototypes') as $type => $prototype) {
+            /** @var FormInterface $prototype */
+            $view->vars['prototypes'][$type] = $prototype->createView($view);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'allow_add' => true,
+            'allow_delete' => true,
+            'by_reference' => false,
+            'error_bubbling' => false,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent(): string
+    {
+        return CollectionType::class;
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/Rule/TotalWeightGreaterThanOrEqualConfigurationType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/Rule/TotalWeightGreaterThanOrEqualConfigurationType.php
@@ -17,7 +17,7 @@ use Sylius\Bundle\ShippingBundle\Form\EventSubscriber\AddWeightFormSubscriber;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-final class TotalWeightLessThanOrEqualConfigurationType extends AbstractType
+final class TotalWeightGreaterThanOrEqualConfigurationType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
@@ -26,6 +26,6 @@ final class TotalWeightLessThanOrEqualConfigurationType extends AbstractType
 
     public function getBlockPrefix(): string
     {
-        return 'sylius_shipping_method_rule_total_weight_less_than_or_equal_configuration';
+        return 'sylius_shipping_method_rule_total_weight_greater_than_or_equal_configuration';
     }
 }

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/Rule/TotalWeightLessThanConfigurationType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/Rule/TotalWeightLessThanConfigurationType.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShippingBundle\Form\Type\Rule;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
+
+final class TotalWeightLessThanConfigurationType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('weight', NumberType::class, [
+                'label' => 'sylius.form.shipping_method_rule.total_weight_less_than_configuration.weight',
+                'constraints' => [
+                    new NotBlank(['groups' => ['sylius']]),
+                    new Type(['type' => 'numeric', 'groups' => ['sylius']]),
+                ],
+            ])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_promotion_rule_cart_quantity_configuration';
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/Rule/TotalWeightLessThanOrEqualConfigurationType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/Rule/TotalWeightLessThanOrEqualConfigurationType.php
@@ -19,16 +19,13 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
 
-final class TotalWeightLessThanConfigurationType extends AbstractType
+final class TotalWeightLessThanOrEqualConfigurationType extends AbstractType
 {
-    /**
-     * {@inheritdoc}
-     */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('weight', NumberType::class, [
-                'label' => 'sylius.form.shipping_method_rule.total_weight_less_than_configuration.weight',
+                'label' => 'sylius.form.shipping_method_rule.total_weight_less_than_or_equal_configuration.weight',
                 'constraints' => [
                     new NotBlank(['groups' => ['sylius']]),
                     new Type(['type' => 'numeric', 'groups' => ['sylius']]),
@@ -37,11 +34,8 @@ final class TotalWeightLessThanConfigurationType extends AbstractType
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getBlockPrefix(): string
     {
-        return 'sylius_promotion_rule_cart_quantity_configuration';
+        return 'sylius_shipping_method_rule_total_weight_less_than_or_equal_configuration';
     }
 }

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodRuleChoiceType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodRuleChoiceType.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShippingBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class ShippingMethodRuleChoiceType extends AbstractType
+{
+    /** @var array */
+    private $rules;
+
+    public function __construct(array $rules)
+    {
+        $this->rules = $rules;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'choices' => array_flip($this->rules),
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent(): string
+    {
+        return ChoiceType::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_shipping_method_rule_choice';
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodRuleCollectionType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodRuleCollectionType.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShippingBundle\Form\Type;
+
+use Sylius\Bundle\ShippingBundle\Form\Type\Core\AbstractConfigurationCollectionType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class ShippingMethodRuleCollectionType extends AbstractConfigurationCollectionType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefault('entry_type', ShippingMethodRuleType::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_shipping_method_rule_collection';
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodRuleType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodRuleType.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShippingBundle\Form\Type;
+
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class ShippingMethodRuleType extends AbstractConfigurableShippingMethodElementType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options = []): void
+    {
+        parent::buildForm($builder, $options);
+
+        $builder
+            ->add('type', ShippingMethodRuleChoiceType::class, [
+                'label' => 'sylius.form.shipping_method_rule.type',
+                'attr' => [
+                    'data-form-collection' => 'update',
+                ],
+            ])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_shipping_method_rule';
+    }
+}

--- a/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodType.php
+++ b/src/Sylius/Bundle/ShippingBundle/Form/Type/ShippingMethodType.php
@@ -90,6 +90,10 @@ final class ShippingMethodType extends AbstractResourceType
             ->add('enabled', CheckboxType::class, [
                 'label' => 'sylius.form.locale.enabled',
             ])
+            ->add('rules', ShippingMethodRuleCollectionType::class, [
+                'label' => 'sylius.form.shipping_method.rules',
+                'button_add_label' => 'sylius.form.shipping_method.add_rule',
+            ])
             ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
                 $method = $event->getData();
 

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/doctrine/model/ShippingMethod.orm.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/doctrine/model/ShippingMethod.orm.xml
@@ -23,6 +23,11 @@
         <many-to-one field="category" target-entity="Sylius\Component\Shipping\Model\ShippingCategoryInterface">
             <join-column name="category_id" referenced-column-name="id" nullable="true" />
         </many-to-one>
+        <one-to-many field="rules" target-entity="Sylius\Component\Shipping\Model\ShippingMethodRuleInterface" mapped-by="shippingMethod" orphan-removal="true">
+            <cascade>
+                <cascade-all />
+            </cascade>
+        </one-to-many>
 
         <field name="categoryRequirement" column="category_requirement" type="integer" />
         <field name="calculator" column="calculator" type="string" />

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/doctrine/model/ShippingMethodRule.orm.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/doctrine/model/ShippingMethodRule.orm.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping">
+
+    <mapped-superclass name="Sylius\Component\Shipping\Model\ShippingMethodRule" table="sylius_shipping_method_rule">
+        <id name="id" type="integer">
+            <generator strategy="AUTO" />
+        </id>
+
+        <field name="type" type="string" />
+        <field name="configuration" type="array" />
+
+        <many-to-one field="shippingMethod" target-entity="Sylius\Component\Shipping\Model\ShippingMethodInterface" inversed-by="rules">
+            <join-column name="shipping_method_id" referenced-column-name="id" nullable="true" />
+        </many-to-one>
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
@@ -13,7 +13,9 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <imports>
+        <import resource="services/checker.xml" />
         <import resource="services/form.xml" />
+        <import resource="services/registry.xml" />
     </imports>
 
     <parameters>
@@ -23,21 +25,6 @@
     <services>
         <defaults public="true" />
 
-        <service id="sylius.shipping_eligibility_checker" class="Sylius\Component\Shipping\Checker\ShippingMethodEligibilityChecker">
-            <argument type="service" id="sylius.registry.shipping_method_rule_checker"/>
-        </service>
-        <service id="Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface" alias="sylius.shipping_eligibility_checker" />
-
-        <service id="sylius.registry.shipping_rule_checker" class="Sylius\Component\Registry\ServiceRegistry">
-            <argument>Sylius\Component\Shipping\Checker\RuleCheckerInterface</argument>
-            <argument>shipping rule checker</argument>
-        </service>
-
-        <service id="sylius.registry.shipping_methods_resolver" class="Sylius\Component\Registry\PrioritizedServiceRegistry">
-            <argument>%sylius.shipping_methods_resolver.interface%</argument>
-            <argument>Shipping methods resolver</argument>
-        </service>
-
         <service id="sylius.shipping_methods_resolver" class="Sylius\Component\Shipping\Resolver\CompositeMethodsResolver">
             <argument type="service" id="sylius.registry.shipping_methods_resolver" />
         </service>
@@ -45,7 +32,7 @@
 
         <service id="sylius.shipping_methods_resolver.default" class="Sylius\Component\Shipping\Resolver\ShippingMethodsResolver">
             <argument type="service" id="sylius.repository.shipping_method" />
-            <argument type="service" id="sylius.shipping_eligibility_checker" />
+            <argument type="service" id="sylius.shipping_method_eligibility_checker" />
             <tag name="sylius.shipping_method_resolver" type="default" label="Default" />
         </service>
 
@@ -53,11 +40,6 @@
             <argument type="service" id="sylius.repository.shipping_method" />
         </service>
         <service id="Sylius\Component\Shipping\Resolver\DefaultShippingMethodResolverInterface" alias="sylius.shipping_method_resolver.default" />
-
-        <service id="sylius.registry.shipping_calculator" class="Sylius\Component\Registry\ServiceRegistry">
-            <argument>Sylius\Component\Shipping\Calculator\CalculatorInterface</argument>
-            <argument>shipping calculator</argument>
-        </service>
 
         <service id="sylius.shipping_calculator" class="Sylius\Component\Shipping\Calculator\DelegatingCalculator">
             <argument type="service" id="sylius.registry.shipping_calculator" />
@@ -76,15 +58,8 @@
                  label="sylius.form.shipping_calculator.per_unit_rate_configuration.label" />
         </service>
 
-        <service id="sylius.shipping_method_rule_checker.total_weight_less_than" class="Sylius\Component\Shipping\Checker\Rule\TotalWeightLessThanRuleChecker">
-            <tag name="sylius.shipping_method_rule_checker" type="total_weight_less_than" label="sylius.form.shipping_method_rule.total_weight_less_than" form-type="Sylius\Bundle\ShippingBundle\Form\Type\Rule\TotalWeightLessThanConfigurationType" />
+        <service id="sylius.shipping_method_rule_checker.total_weight_less_than_or_equal" class="Sylius\Component\Shipping\Checker\Rule\TotalWeightLessThanOrEqualRuleChecker">
+            <tag name="sylius.shipping_method_rule_checker" type="total_weight_less_than_or_equal" label="sylius.form.shipping_method_rule.total_weight_less_than_or_equal" form-type="Sylius\Bundle\ShippingBundle\Form\Type\Rule\TotalWeightLessThanOrEqualConfigurationType" />
         </service>
-
-        <service id="sylius.registry.shipping_method_rule_checker" class="Sylius\Component\Registry\ServiceRegistry">
-            <argument>Sylius\Component\Shipping\Checker\Rule\RuleCheckerInterface</argument>
-            <argument>shipping method rule checker</argument>
-        </service>
-
-        <service id="sylius.form_registry.shipping_method_rule_checker" class="Sylius\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry" />
     </services>
 </container>

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
@@ -23,7 +23,9 @@
     <services>
         <defaults public="true" />
 
-        <service id="sylius.shipping_eligibility_checker" class="Sylius\Component\Shipping\Checker\ShippingMethodEligibilityChecker" />
+        <service id="sylius.shipping_eligibility_checker" class="Sylius\Component\Shipping\Checker\ShippingMethodEligibilityChecker">
+            <argument type="service" id="sylius.registry.shipping_method_rule_checker"/>
+        </service>
         <service id="Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface" alias="sylius.shipping_eligibility_checker" />
 
         <service id="sylius.registry.shipping_rule_checker" class="Sylius\Component\Registry\ServiceRegistry">
@@ -73,5 +75,16 @@
                  form-type="Sylius\Bundle\ShippingBundle\Form\Type\Calculator\PerUnitRateConfigurationType"
                  label="sylius.form.shipping_calculator.per_unit_rate_configuration.label" />
         </service>
+
+        <service id="sylius.shipping_method_rule_checker.total_weight_less_than" class="Sylius\Component\Shipping\Checker\Rule\TotalWeightLessThanRuleChecker">
+            <tag name="sylius.shipping_method_rule_checker" type="total_weight_less_than" label="sylius.form.shipping_method_rule.total_weight_less_than" form-type="Sylius\Bundle\ShippingBundle\Form\Type\Rule\TotalWeightLessThanConfigurationType" />
+        </service>
+
+        <service id="sylius.registry.shipping_method_rule_checker" class="Sylius\Component\Registry\ServiceRegistry">
+            <argument>Sylius\Component\Shipping\Checker\Rule\RuleCheckerInterface</argument>
+            <argument>shipping method rule checker</argument>
+        </service>
+
+        <service id="sylius.form_registry.shipping_method_rule_checker" class="Sylius\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry" />
     </services>
 </container>

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
@@ -58,6 +58,10 @@
                  label="sylius.form.shipping_calculator.per_unit_rate_configuration.label" />
         </service>
 
+        <service id="sylius.shipping_method_rule_checker.total_weight_greater_than_or_equal" class="Sylius\Component\Shipping\Checker\Rule\TotalWeightGreaterThanOrEqualRuleChecker">
+            <tag name="sylius.shipping_method_rule_checker" type="total_weight_greater_than_or_equal" label="sylius.form.shipping_method_rule.total_weight_greater_than_or_equal" form-type="Sylius\Bundle\ShippingBundle\Form\Type\Rule\TotalWeightGreaterThanOrEqualConfigurationType" />
+        </service>
+
         <service id="sylius.shipping_method_rule_checker.total_weight_less_than_or_equal" class="Sylius\Component\Shipping\Checker\Rule\TotalWeightLessThanOrEqualRuleChecker">
             <tag name="sylius.shipping_method_rule_checker" type="total_weight_less_than_or_equal" label="sylius.form.shipping_method_rule.total_weight_less_than_or_equal" form-type="Sylius\Bundle\ShippingBundle\Form\Type\Rule\TotalWeightLessThanOrEqualConfigurationType" />
         </service>

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/services/checker.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/services/checker.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults public="true" />
+
+        <service id="sylius.category_requirement_shipping_method_eligibility_checker" class="Sylius\Component\Shipping\Checker\Eligibility\CategoryRequirementEligibilityChecker">
+            <tag name="sylius.shipping_method_eligibility_checker"/>
+        </service>
+
+        <service id="sylius.shipping_method_rules_shipping_method_eligibility_checker" class="Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodRulesEligibilityChecker">
+            <argument type="service" id="sylius.registry.shipping_method_rule_checker"/>
+            <tag name="sylius.shipping_method_eligibility_checker"/>
+        </service>
+
+        <service id="sylius.shipping_method_eligibility_checker" class="Sylius\Component\Shipping\Checker\Eligibility\CompositeShippingMethodEligibilityChecker">
+            <argument type="collection"/>
+        </service>
+        <service id="Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface" alias="sylius.shipping_method_eligibility_checker" />
+
+        <service id="sylius.shipping_eligibility_checker" class="Sylius\Component\Shipping\Checker\ShippingMethodEligibilityChecker">
+            <deprecated>The "%service_id%" is deprecated since Sylius 1.5 and will be removed in 2.0. Use "sylius.shipping_method_eligibility_checker" instead</deprecated>
+        </service>
+        <service id="Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface" alias="sylius.shipping_eligibility_checker" />
+    </services>
+</container>

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/services/form.xml
@@ -19,6 +19,9 @@
         <parameter key="sylius.form.type.shipping_method_translation.validation_groups" type="collection">
             <parameter>sylius</parameter>
         </parameter>
+        <parameter key="sylius.form.type.shipping_method_rule.validation_groups" type="collection">
+            <parameter>sylius</parameter>
+        </parameter>
         <parameter key="sylius.form.type.shipping_category.validation_groups" type="collection">
             <parameter>sylius</parameter>
         </parameter>
@@ -54,6 +57,23 @@
             <argument type="service" id="sylius.shipping_methods_resolver" />
             <argument type="service" id="sylius.registry.shipping_calculator" />
             <argument type="service" id="sylius.repository.shipping_method" />
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius.form.type.shipping_method_rule" class="Sylius\Bundle\ShippingBundle\Form\Type\ShippingMethodRuleType">
+            <argument>%sylius.model.shipping_method_rule.class%</argument>
+            <argument>%sylius.form.type.shipping_method_rule.validation_groups%</argument>
+            <argument type="service" id="sylius.form_registry.shipping_method_rule_checker" />
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius.form.type.shipping_method_rule.collection" class="Sylius\Bundle\ShippingBundle\Form\Type\ShippingMethodRuleCollectionType">
+            <argument type="service" id="sylius.registry.shipping_method_rule_checker" />
+            <tag name="form.type" />
+        </service>
+
+        <service id="sylius.form.type.shipping_method_rule_choice" class="Sylius\Bundle\ShippingBundle\Form\Type\ShippingMethodRuleChoiceType">
+            <argument>%sylius.shipping_method_rules%</argument>
             <tag name="form.type" />
         </service>
 

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/services/registry.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/services/registry.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <defaults public="true" />
+
+        <service id="sylius.registry.shipping_calculator" class="Sylius\Component\Registry\ServiceRegistry">
+            <argument>Sylius\Component\Shipping\Calculator\CalculatorInterface</argument>
+            <argument>shipping calculator</argument>
+        </service>
+
+        <service id="sylius.registry.shipping_methods_resolver" class="Sylius\Component\Registry\PrioritizedServiceRegistry">
+            <argument>%sylius.shipping_methods_resolver.interface%</argument>
+            <argument>Shipping methods resolver</argument>
+        </service>
+
+        <service id="sylius.registry.shipping_method_rule_checker" class="Sylius\Component\Registry\ServiceRegistry">
+            <argument>Sylius\Component\Shipping\Checker\Rule\RuleCheckerInterface</argument>
+            <argument>shipping method rule checker</argument>
+        </service>
+
+        <service id="sylius.form_registry.shipping_method_rule_checker" class="Sylius\Bundle\ResourceBundle\Form\Registry\FormTypeRegistry" />
+    </services>
+</container>

--- a/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
@@ -47,6 +47,6 @@ sylius:
             translations: Translations
         shipping_method_rule:
             type: Type
+            total_weight_greater_than_or_equal: Total weight greater than or equal
             total_weight_less_than_or_equal: Total weight less than or equal
-            total_weight_less_than_or_equal_configuration: 
-                weight: Weight
+            weight: Weight

--- a/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
@@ -29,6 +29,7 @@ sylius:
             description: Description
             name: Name
         shipping_method:
+            add_rule: Add rule
             calculator: Calculator
             category: Category
             category_requirement: Category requirement
@@ -41,5 +42,11 @@ sylius:
             match_none_category_requirement: None of the units have to match the method category
             name: Name
             position: Position
+            rules: Rules
             tax_category: Tax category
             translations: Translations
+        shipping_method_rule:
+            type: Type
+            total_weight_less_than: Total weight less than
+            total_weight_less_than_configuration: 
+                weight: Weight

--- a/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.en.yml
@@ -47,6 +47,6 @@ sylius:
             translations: Translations
         shipping_method_rule:
             type: Type
-            total_weight_less_than: Total weight less than
-            total_weight_less_than_configuration: 
+            total_weight_less_than_or_equal: Total weight less than or equal
+            total_weight_less_than_or_equal_configuration: 
                 weight: Weight

--- a/src/Sylius/Bundle/ShippingBundle/SyliusShippingBundle.php
+++ b/src/Sylius/Bundle/ShippingBundle/SyliusShippingBundle.php
@@ -16,6 +16,7 @@ namespace Sylius\Bundle\ShippingBundle;
 use Sylius\Bundle\ResourceBundle\AbstractResourceBundle;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
 use Sylius\Bundle\ShippingBundle\DependencyInjection\Compiler\RegisterCalculatorsPass;
+use Sylius\Bundle\ShippingBundle\DependencyInjection\Compiler\RegisterRuleCheckersPass;
 use Sylius\Bundle\ShippingBundle\DependencyInjection\Compiler\RegisterShippingMethodsResolversPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -39,6 +40,7 @@ final class SyliusShippingBundle extends AbstractResourceBundle
         parent::build($container);
 
         $container->addCompilerPass(new RegisterCalculatorsPass());
+        $container->addCompilerPass(new RegisterRuleCheckersPass());
         $container->addCompilerPass(new RegisterShippingMethodsResolversPass());
     }
 

--- a/src/Sylius/Bundle/ShippingBundle/SyliusShippingBundle.php
+++ b/src/Sylius/Bundle/ShippingBundle/SyliusShippingBundle.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ShippingBundle;
 
 use Sylius\Bundle\ResourceBundle\AbstractResourceBundle;
 use Sylius\Bundle\ResourceBundle\SyliusResourceBundle;
+use Sylius\Bundle\ShippingBundle\DependencyInjection\Compiler\CompositeShippingMethodEligibilityCheckerPass;
 use Sylius\Bundle\ShippingBundle\DependencyInjection\Compiler\RegisterCalculatorsPass;
 use Sylius\Bundle\ShippingBundle\DependencyInjection\Compiler\RegisterRuleCheckersPass;
 use Sylius\Bundle\ShippingBundle\DependencyInjection\Compiler\RegisterShippingMethodsResolversPass;
@@ -39,6 +40,7 @@ final class SyliusShippingBundle extends AbstractResourceBundle
     {
         parent::build($container);
 
+        $container->addCompilerPass(new CompositeShippingMethodEligibilityCheckerPass());
         $container->addCompilerPass(new RegisterCalculatorsPass());
         $container->addCompilerPass(new RegisterRuleCheckersPass());
         $container->addCompilerPass(new RegisterShippingMethodsResolversPass());

--- a/src/Sylius/Component/Core/Resolver/EligibleDefaultShippingMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/EligibleDefaultShippingMethodResolver.php
@@ -20,7 +20,7 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface as CoreShipmentInterface;
 use Sylius\Component\Core\Repository\ShippingMethodRepositoryInterface;
-use Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface;
+use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface;
 use Sylius\Component\Shipping\Exception\UnresolvedDefaultShippingMethodException;
 use Sylius\Component\Shipping\Model\ShipmentInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;

--- a/src/Sylius/Component/Core/Resolver/ZoneAndChannelBasedShippingMethodsResolver.php
+++ b/src/Sylius/Component/Core/Resolver/ZoneAndChannelBasedShippingMethodsResolver.php
@@ -18,7 +18,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\Scope;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\Repository\ShippingMethodRepositoryInterface;
-use Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface;
+use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
 use Webmozart\Assert\Assert;

--- a/src/Sylius/Component/Core/spec/Resolver/EligibleDefaultShippingMethodResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/Resolver/EligibleDefaultShippingMethodResolverSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Component\Core\Resolver;
 
+use InvalidArgumentException;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Addressing\Matcher\ZoneMatcherInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
@@ -22,7 +23,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\Model\ShippingMethodInterface;
 use Sylius\Component\Core\Repository\ShippingMethodRepositoryInterface;
-use Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface;
+use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface;
 use Sylius\Component\Shipping\Exception\UnresolvedDefaultShippingMethodException;
 use Sylius\Component\Shipping\Model\ShipmentInterface as BaseShipmentInterface;
 use Sylius\Component\Shipping\Resolver\DefaultShippingMethodResolverInterface;
@@ -132,6 +133,6 @@ final class EligibleDefaultShippingMethodResolverSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_passed_shipment_is_not_core_shipment_object(BaseShipmentInterface $shipment): void
     {
-        $this->shouldThrow(\InvalidArgumentException::class)->during('getDefaultShippingMethod', [$shipment]);
+        $this->shouldThrow(InvalidArgumentException::class)->during('getDefaultShippingMethod', [$shipment]);
     }
 }

--- a/src/Sylius/Component/Core/spec/Resolver/ZoneAndChannelBasedShippingMethodsResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/Resolver/ZoneAndChannelBasedShippingMethodsResolverSpec.php
@@ -23,7 +23,7 @@ use Sylius\Component\Core\Model\Scope;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\Model\ShippingMethodInterface;
 use Sylius\Component\Core\Repository\ShippingMethodRepositoryInterface;
-use Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface;
+use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
 
@@ -73,7 +73,6 @@ final class ZoneAndChannelBasedShippingMethodsResolverSpec extends ObjectBehavio
     }
 
     function it_returns_an_empty_array_if_zone_matcher_could_not_match_any_zone(
-        ShippingMethodEligibilityCheckerInterface $eligibilityChecker,
         OrderInterface $order,
         AddressInterface $address,
         ChannelInterface $channel,

--- a/src/Sylius/Component/Shipping/Checker/Eligibility/CategoryRequirementEligibilityChecker.php
+++ b/src/Sylius/Component/Shipping/Checker/Eligibility/CategoryRequirementEligibilityChecker.php
@@ -11,26 +11,16 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Component\Shipping\Checker;
+namespace Sylius\Component\Shipping\Checker\Eligibility;
 
-use const E_USER_DEPRECATED;
-use Sylius\Component\Shipping\Checker\Eligibility\CompositeShippingMethodEligibilityChecker;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 
-@trigger_error(sprintf('The "%s" class is deprecated since Sylius 1.5, use "%s" instead.', ShippingMethodEligibilityChecker::class, CompositeShippingMethodEligibilityChecker::class), E_USER_DEPRECATED);
-
-/**
- * @deprecated since Sylius 1.5. Use Sylius\Component\Shipping\Checker\Eligibility\CompositeShippingMethodEligibilityChecker instead
- */
-final class ShippingMethodEligibilityChecker implements ShippingMethodEligibilityCheckerInterface
+final class CategoryRequirementEligibilityChecker implements ShippingMethodEligibilityCheckerInterface
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function isEligible(ShippingSubjectInterface $subject, ShippingMethodInterface $method): bool
+    public function isEligible(ShippingSubjectInterface $subject, ShippingMethodInterface $shippingMethod): bool
     {
-        if (!$category = $method->getCategory()) {
+        if (!$category = $shippingMethod->getCategory()) {
             return true;
         }
 
@@ -42,7 +32,7 @@ final class ShippingMethodEligibilityChecker implements ShippingMethodEligibilit
             }
         }
 
-        switch ($method->getCategoryRequirement()) {
+        switch ($shippingMethod->getCategoryRequirement()) {
             case ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_NONE:
                 return 0 === $numMatches;
             case ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_ANY:

--- a/src/Sylius/Component/Shipping/Checker/Eligibility/CompositeShippingMethodEligibilityChecker.php
+++ b/src/Sylius/Component/Shipping/Checker/Eligibility/CompositeShippingMethodEligibilityChecker.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Shipping\Checker\Eligibility;
+
+use Sylius\Component\Shipping\Model\ShippingMethodInterface;
+use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+use Webmozart\Assert\Assert;
+
+final class CompositeShippingMethodEligibilityChecker implements ShippingMethodEligibilityCheckerInterface
+{
+    /** @var ShippingMethodEligibilityCheckerInterface[] */
+    private $eligibilityCheckers;
+
+    /**
+     * @param ShippingMethodEligibilityCheckerInterface[] $eligibilityCheckers
+     */
+    public function __construct(array $eligibilityCheckers)
+    {
+        Assert::notEmpty($eligibilityCheckers);
+        Assert::allIsInstanceOf($eligibilityCheckers, ShippingMethodEligibilityCheckerInterface::class);
+
+        $this->eligibilityCheckers = $eligibilityCheckers;
+    }
+
+    public function isEligible(ShippingSubjectInterface $subject, ShippingMethodInterface $shippingMethod): bool
+    {
+        foreach ($this->eligibilityCheckers as $eligibilityChecker) {
+            if (!$eligibilityChecker->isEligible($subject, $shippingMethod)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Sylius/Component/Shipping/Checker/Eligibility/ShippingMethodEligibilityCheckerInterface.php
+++ b/src/Sylius/Component/Shipping/Checker/Eligibility/ShippingMethodEligibilityCheckerInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Shipping\Checker\Eligibility;
+
+use Sylius\Component\Shipping\Model\ShippingMethodInterface;
+use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+
+interface ShippingMethodEligibilityCheckerInterface
+{
+    public function isEligible(ShippingSubjectInterface $shippingSubject, ShippingMethodInterface $shippingMethod): bool;
+}

--- a/src/Sylius/Component/Shipping/Checker/Eligibility/ShippingMethodRulesEligibilityChecker.php
+++ b/src/Sylius/Component/Shipping/Checker/Eligibility/ShippingMethodRulesEligibilityChecker.php
@@ -31,10 +31,6 @@ final class ShippingMethodRulesEligibilityChecker implements ShippingMethodEligi
 
     public function isEligible(ShippingSubjectInterface $subject, ShippingMethodInterface $shippingMethod): bool
     {
-        if (null === $this->ruleRegistry) {
-            return true;
-        }
-
         if (!$shippingMethod->hasRules()) {
             return true;
         }

--- a/src/Sylius/Component/Shipping/Checker/Eligibility/ShippingMethodRulesEligibilityChecker.php
+++ b/src/Sylius/Component/Shipping/Checker/Eligibility/ShippingMethodRulesEligibilityChecker.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Shipping\Checker\Eligibility;
+
+use Sylius\Component\Registry\ServiceRegistryInterface;
+use Sylius\Component\Shipping\Checker\Rule\RuleCheckerInterface;
+use Sylius\Component\Shipping\Model\ShippingMethodInterface;
+use Sylius\Component\Shipping\Model\ShippingMethodRuleInterface;
+use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+
+final class ShippingMethodRulesEligibilityChecker implements ShippingMethodEligibilityCheckerInterface
+{
+    /** @var ServiceRegistryInterface */
+    private $ruleRegistry;
+
+    public function __construct(ServiceRegistryInterface $ruleRegistry)
+    {
+        $this->ruleRegistry = $ruleRegistry;
+    }
+
+    public function isEligible(ShippingSubjectInterface $subject, ShippingMethodInterface $shippingMethod): bool
+    {
+        if (null === $this->ruleRegistry) {
+            return true;
+        }
+
+        if (!$shippingMethod->hasRules()) {
+            return true;
+        }
+
+        foreach ($shippingMethod->getRules() as $rule) {
+            if (!$this->isEligibleToRule($subject, $rule)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isEligibleToRule(ShippingSubjectInterface $subject, ShippingMethodRuleInterface $rule): bool
+    {
+        /** @var RuleCheckerInterface $checker */
+        $checker = $this->ruleRegistry->get($rule->getType());
+
+        return $checker->isEligible($subject, $rule->getConfiguration());
+    }
+}

--- a/src/Sylius/Component/Shipping/Checker/Rule/RuleCheckerInterface.php
+++ b/src/Sylius/Component/Shipping/Checker/Rule/RuleCheckerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Shipping\Checker\Rule;
+
+use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+
+interface RuleCheckerInterface
+{
+    public function isEligible(ShippingSubjectInterface $subject, array $configuration): bool;
+}

--- a/src/Sylius/Component/Shipping/Checker/Rule/TotalWeightGreaterThanOrEqualRuleChecker.php
+++ b/src/Sylius/Component/Shipping/Checker/Rule/TotalWeightGreaterThanOrEqualRuleChecker.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Shipping\Checker\Rule;
+
+use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+
+final class TotalWeightGreaterThanOrEqualRuleChecker implements RuleCheckerInterface
+{
+    public const TYPE = 'total_weight_greater_than_or_equal';
+
+    public function isEligible(ShippingSubjectInterface $subject, array $configuration): bool
+    {
+        return $subject->getShippingWeight() >= $configuration['weight'];
+    }
+}

--- a/src/Sylius/Component/Shipping/Checker/Rule/TotalWeightLessThanOrEqualRuleChecker.php
+++ b/src/Sylius/Component/Shipping/Checker/Rule/TotalWeightLessThanOrEqualRuleChecker.php
@@ -13,9 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Shipping\Checker\Rule;
 
-use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
-use Webmozart\Assert\Assert;
 
 final class TotalWeightLessThanOrEqualRuleChecker implements RuleCheckerInterface
 {
@@ -23,20 +21,6 @@ final class TotalWeightLessThanOrEqualRuleChecker implements RuleCheckerInterfac
 
     public function isEligible(ShippingSubjectInterface $subject, array $configuration): bool
     {
-        /** @var ShipmentInterface $subject */
-        Assert::isInstanceOf($subject, ShipmentInterface::class);
-
-        $order = $subject->getOrder();
-        if (null === $order) {
-            // if the order is null the weight is less than anything
-            return true;
-        }
-
-        $totalWeight = 0;
-        foreach ($order->getShipments() as $shipment) {
-            $totalWeight += $shipment->getShippingWeight();
-        }
-
-        return $totalWeight <= $configuration['weight'];
+        return $subject->getShippingWeight() <= $configuration['weight'];
     }
 }

--- a/src/Sylius/Component/Shipping/Checker/Rule/TotalWeightLessThanOrEqualRuleChecker.php
+++ b/src/Sylius/Component/Shipping/Checker/Rule/TotalWeightLessThanOrEqualRuleChecker.php
@@ -15,14 +15,10 @@ namespace Sylius\Component\Shipping\Checker\Rule;
 
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 
-// todo should the name be TotalWeightLessThanOrEqualRuleChecker?
-final class TotalWeightLessThanRuleChecker implements RuleCheckerInterface
+final class TotalWeightLessThanOrEqualRuleChecker implements RuleCheckerInterface
 {
-    public const TYPE = 'total_weight_less_than';
+    public const TYPE = 'total_weight_less_than_or_equal';
 
-    /**
-     * {@inheritdoc}
-     */
     public function isEligible(ShippingSubjectInterface $subject, array $configuration): bool
     {
         // todo $subject->getShippingWeight() probably does not return total weight. Figure this out

--- a/src/Sylius/Component/Shipping/Checker/Rule/TotalWeightLessThanRuleChecker.php
+++ b/src/Sylius/Component/Shipping/Checker/Rule/TotalWeightLessThanRuleChecker.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Shipping\Checker\Rule;
+
+use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+
+// todo should the name be TotalWeightLessThanOrEqualRuleChecker?
+final class TotalWeightLessThanRuleChecker implements RuleCheckerInterface
+{
+    public const TYPE = 'total_weight_less_than';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEligible(ShippingSubjectInterface $subject, array $configuration): bool
+    {
+        // todo $subject->getShippingWeight() probably does not return total weight. Figure this out
+        return $subject->getShippingWeight() <= $configuration['weight'];
+    }
+}

--- a/src/Sylius/Component/Shipping/Checker/ShippingMethodEligibilityCheckerInterface.php
+++ b/src/Sylius/Component/Shipping/Checker/ShippingMethodEligibilityCheckerInterface.php
@@ -13,10 +13,19 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Shipping\Checker;
 
+use const E_USER_DEPRECATED;
+use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface as NewShippingMethodEligibilityCheckerInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 
-interface ShippingMethodEligibilityCheckerInterface
+@trigger_error(sprintf('The "%s" interface is deprecated since Sylius 1.5, use "%s" instead.', ShippingMethodEligibilityCheckerInterface::class, NewShippingMethodEligibilityCheckerInterface::class), E_USER_DEPRECATED);
+
+/**
+ * @deprecated since Sylius 1.5. Use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface instead
+ *
+ * We extend the new interface to adhere to backwards compatibility
+ */
+interface ShippingMethodEligibilityCheckerInterface extends NewShippingMethodEligibilityCheckerInterface
 {
     public function isEligible(ShippingSubjectInterface $subject, ShippingMethodInterface $method): bool;
 }

--- a/src/Sylius/Component/Shipping/Model/ConfigurableShippingMethodElementInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ConfigurableShippingMethodElementInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Shipping\Model;
+
+use Sylius\Component\Resource\Model\ResourceInterface;
+
+interface ConfigurableShippingMethodElementInterface extends ResourceInterface
+{
+    public function getType(): ?string;
+
+    public function getConfiguration(): array;
+
+    public function getShippingMethod(): ?ShippingMethodInterface;
+}

--- a/src/Sylius/Component/Shipping/Model/ShippingMethod.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethod.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Shipping\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Resource\Model\ArchivableTrait;
 use Sylius\Component\Resource\Model\TimestampableTrait;
 use Sylius\Component\Resource\Model\ToggleableTrait;
@@ -48,11 +50,15 @@ class ShippingMethod implements ShippingMethodInterface
     /** @var array */
     protected $configuration = [];
 
+    /** @var Collection|ShippingMethodRuleInterface[] */
+    protected $rules;
+
     public function __construct()
     {
         $this->initializeTranslationsCollection();
 
         $this->createdAt = new \DateTime();
+        $this->rules = new ArrayCollection();
     }
 
     public function __toString(): string
@@ -194,6 +200,50 @@ class ShippingMethod implements ShippingMethodInterface
     public function setConfiguration(array $configuration): void
     {
         $this->configuration = $configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRules(): Collection
+    {
+        return $this->rules;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasRules(): bool
+    {
+        return !$this->rules->isEmpty();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasRule(ShippingMethodRuleInterface $rule): bool
+    {
+        return $this->rules->contains($rule);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addRule(ShippingMethodRuleInterface $rule): void
+    {
+        if (!$this->hasRule($rule)) {
+            $rule->setShippingMethod($this);
+            $this->rules->add($rule);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeRule(ShippingMethodRuleInterface $rule): void
+    {
+        $rule->setShippingMethod(null);
+        $this->rules->removeElement($rule);
     }
 
     /**

--- a/src/Sylius/Component/Shipping/Model/ShippingMethodInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethodInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Shipping\Model;
 
+use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Resource\Model\ArchivableInterface;
 use Sylius\Component\Resource\Model\CodeAwareInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
@@ -74,6 +75,19 @@ interface ShippingMethodInterface extends
     public function getConfiguration(): array;
 
     public function setConfiguration(array $configuration): void;
+
+    /**
+     * @return Collection|ShippingMethodRuleInterface[]
+     */
+    public function getRules(): Collection;
+
+    public function hasRules(): bool;
+
+    public function hasRule(ShippingMethodRuleInterface $rule): bool;
+
+    public function addRule(ShippingMethodRuleInterface $rule): void;
+
+    public function removeRule(ShippingMethodRuleInterface $rule): void;
 
     /**
      * @return ShippingMethodTranslationInterface

--- a/src/Sylius/Component/Shipping/Model/ShippingMethodRule.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethodRule.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Shipping\Model;
+
+class ShippingMethodRule implements ShippingMethodRuleInterface
+{
+    /** @var mixed */
+    protected $id;
+
+    /** @var string */
+    protected $type;
+
+    /** @var array */
+    protected $configuration = [];
+
+    /** @var ShippingMethodInterface */
+    protected $shippingMethod;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setType(?string $type): void
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration(): array
+    {
+        return $this->configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConfiguration(array $configuration): void
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getShippingMethod(): ?ShippingMethodInterface
+    {
+        return $this->shippingMethod;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setShippingMethod(?ShippingMethodInterface $shippingMethod): void
+    {
+        $this->shippingMethod = $shippingMethod;
+    }
+}

--- a/src/Sylius/Component/Shipping/Model/ShippingMethodRuleInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingMethodRuleInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Shipping\Model;
+
+use Sylius\Component\Resource\Model\ResourceInterface;
+
+interface ShippingMethodRuleInterface extends ResourceInterface, ConfigurableShippingMethodElementInterface
+{
+    public function setType(?string $type): void;
+
+    public function setConfiguration(array $configuration): void;
+
+    public function setShippingMethod(?ShippingMethodInterface $shippingMethod): void;
+}

--- a/src/Sylius/Component/Shipping/Resolver/ShippingMethodsResolver.php
+++ b/src/Sylius/Component/Shipping/Resolver/ShippingMethodsResolver.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Component\Shipping\Resolver;
 
 use Doctrine\Common\Persistence\ObjectRepository;
-use Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface;
+use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 
 final class ShippingMethodsResolver implements ShippingMethodsResolverInterface

--- a/src/Sylius/Component/Shipping/spec/Checker/Eligibility/CategoryRequirementEligibilityCheckerSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Checker/Eligibility/CategoryRequirementEligibilityCheckerSpec.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Shipping\Checker\Eligibility;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface;
+use Sylius\Component\Shipping\Model\ShippableInterface;
+use Sylius\Component\Shipping\Model\ShippingCategoryInterface;
+use Sylius\Component\Shipping\Model\ShippingMethodInterface;
+use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+
+final class CategoryRequirementEligibilityCheckerSpec extends ObjectBehavior
+{
+    function it_implements_shipping_method_eligibility_checker_interface(): void
+    {
+        $this->shouldImplement(ShippingMethodEligibilityCheckerInterface::class);
+    }
+
+    function it_approves_category_requirement_if_categories_match(
+        ShippingSubjectInterface $subject,
+        ShippingMethodInterface $shippingMethod,
+        ShippingCategoryInterface $shippingCategory,
+        ShippableInterface $shippable
+    ): void {
+        $shippingMethod->getCategory()->willReturn($shippingCategory);
+        $shippingMethod->getCategoryRequirement()->willReturn(ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_ANY);
+
+        $shippable->getShippingCategory()->willReturn($shippingCategory);
+        $subject->getShippables()->willReturn(new ArrayCollection([$shippable->getWrappedObject()]));
+
+        $this->isEligible($subject, $shippingMethod)->shouldReturn(true);
+    }
+
+    function it_approves_category_requirement_if_no_category_is_required(
+        ShippingSubjectInterface $subject,
+        ShippingMethodInterface $shippingMethod
+    ): void {
+        $shippingMethod->getCategory()->willReturn(null);
+
+        $this->isEligible($subject, $shippingMethod)->shouldReturn(true);
+    }
+
+    function it_denies_category_requirement_if_categories_do_not_match(
+        ShippingSubjectInterface $subject,
+        ShippingMethodInterface $shippingMethod,
+        ShippingCategoryInterface $shippingCategory,
+        ShippingCategoryInterface $shippingCategory2,
+        ShippableInterface $shippable
+    ): void {
+        $shippingMethod->getCategory()->willReturn($shippingCategory);
+        $shippingMethod->getCategoryRequirement()->willReturn(ShippingMethodInterface::CATEGORY_REQUIREMENT_MATCH_ANY);
+
+        $shippable->getShippingCategory()->willReturn($shippingCategory2);
+        $subject->getShippables()->willReturn(new ArrayCollection([$shippable->getWrappedObject()]));
+
+        $this->isEligible($subject, $shippingMethod)->shouldReturn(false);
+    }
+}

--- a/src/Sylius/Component/Shipping/spec/Checker/Eligibility/CompositeShippingMethodEligibilityCheckerSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Checker/Eligibility/CompositeShippingMethodEligibilityCheckerSpec.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Shipping\Checker\Eligibility;
+
+use InvalidArgumentException;
+use PhpSpec\ObjectBehavior;
+use stdClass;
+use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface;
+use Sylius\Component\Shipping\Model\ShippingMethodInterface;
+use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+
+final class CompositeShippingMethodEligibilityCheckerSpec extends ObjectBehavior
+{
+    public function let(ShippingMethodEligibilityCheckerInterface $promotionEligibilityChecker): void
+    {
+        $this->beConstructedWith([$promotionEligibilityChecker]);
+    }
+
+    public function it_implements_shipping_method_eligibility_checker_interface(): void
+    {
+        $this->shouldImplement(ShippingMethodEligibilityCheckerInterface::class);
+    }
+
+    public function it_throws_an_exception_if_no_eligibility_checkers_are_passed(): void
+    {
+        $this->beConstructedWith([]);
+
+        $this->shouldThrow(InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    public function it_throws_an_exception_if_passed_array_has_not_only_eligibility_checkers(): void
+    {
+        $this->beConstructedWith([new stdClass()]);
+
+        $this->shouldThrow(InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    public function it_returns_true_if_all_eligibility_checker_returns_true(
+        ShippingMethodEligibilityCheckerInterface $firstShippingMethodEligibilityChecker,
+        ShippingMethodEligibilityCheckerInterface $secondShippingMethodEligibilityChecker,
+        ShippingSubjectInterface $promotionSubject,
+        ShippingMethodInterface $promotion
+    ): void {
+        $this->beConstructedWith([
+            $firstShippingMethodEligibilityChecker,
+            $secondShippingMethodEligibilityChecker,
+        ]);
+
+        $firstShippingMethodEligibilityChecker->isEligible($promotionSubject, $promotion)->willReturn(true);
+        $secondShippingMethodEligibilityChecker->isEligible($promotionSubject, $promotion)->willReturn(true);
+
+        $this->isEligible($promotionSubject, $promotion)->shouldReturn(true);
+    }
+
+    public function it_returns_false_if_any_eligibility_checker_returns_false(
+        ShippingMethodEligibilityCheckerInterface $firstShippingMethodEligibilityChecker,
+        ShippingMethodEligibilityCheckerInterface $secondShippingMethodEligibilityChecker,
+        ShippingSubjectInterface $promotionSubject,
+        ShippingMethodInterface $promotion
+    ): void {
+        $this->beConstructedWith([
+            $firstShippingMethodEligibilityChecker,
+            $secondShippingMethodEligibilityChecker,
+        ]);
+
+        $firstShippingMethodEligibilityChecker->isEligible($promotionSubject, $promotion)->willReturn(true);
+        $secondShippingMethodEligibilityChecker->isEligible($promotionSubject, $promotion)->willReturn(false);
+
+        $this->isEligible($promotionSubject, $promotion)->shouldReturn(false);
+    }
+
+    public function it_stops_checking_at_the_first_failing_eligibility_checker(
+        ShippingMethodEligibilityCheckerInterface $firstShippingMethodEligibilityChecker,
+        ShippingMethodEligibilityCheckerInterface $secondShippingMethodEligibilityChecker,
+        ShippingSubjectInterface $promotionSubject,
+        ShippingMethodInterface $promotion
+    ): void {
+        $this->beConstructedWith([
+            $firstShippingMethodEligibilityChecker,
+            $secondShippingMethodEligibilityChecker,
+        ]);
+
+        $firstShippingMethodEligibilityChecker->isEligible($promotionSubject, $promotion)->willReturn(false);
+        $secondShippingMethodEligibilityChecker->isEligible($promotionSubject, $promotion)->shouldNotBeCalled();
+
+        $this->isEligible($promotionSubject, $promotion)->shouldReturn(false);
+    }
+}

--- a/src/Sylius/Component/Shipping/spec/Checker/Eligibility/ShippingMethodRulesEligibilityCheckerSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Checker/Eligibility/ShippingMethodRulesEligibilityCheckerSpec.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Shipping\Checker\Eligibility;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Registry\ServiceRegistryInterface;
+use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface;
+use Sylius\Component\Shipping\Checker\Rule\RuleCheckerInterface;
+use Sylius\Component\Shipping\Model\ShippingMethodInterface;
+use Sylius\Component\Shipping\Model\ShippingMethodRuleInterface;
+use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+
+final class ShippingMethodRulesEligibilityCheckerSpec extends ObjectBehavior
+{
+    public function let(ServiceRegistryInterface $rulesRegistry): void
+    {
+        $this->beConstructedWith($rulesRegistry);
+    }
+
+    public function it_implements_shipping_method_eligibility_checker_interface(): void
+    {
+        $this->shouldImplement(ShippingMethodEligibilityCheckerInterface::class);
+    }
+
+    public function it_recognizes_a_subject_as_eligible_if_a_shipping_method_has_no_rules(ShippingSubjectInterface $subject, ShippingMethodInterface $shippingMethod): void
+    {
+        $shippingMethod->hasRules()->willReturn(false);
+        $this->isEligible($subject, $shippingMethod)->shouldReturn(true);
+    }
+
+    public function it_recognizes_a_subject_as_eligible_if_all_of_shipping_method_rules_are_fulfilled(
+        ServiceRegistryInterface $rulesRegistry,
+        RuleCheckerInterface $firstRuleChecker,
+        RuleCheckerInterface $secondRuleChecker,
+        ShippingMethodRuleInterface $firstRule,
+        ShippingMethodRuleInterface $secondRule,
+        ShippingSubjectInterface $subject,
+        ShippingMethodInterface $shippingMethod
+    ): void {
+        $shippingMethod->hasRules()->willReturn(true);
+        $shippingMethod->getRules()->willReturn(
+            new ArrayCollection([$firstRule->getWrappedObject(), $secondRule->getWrappedObject()])
+        );
+
+        $firstRule->getType()->willReturn('first_rule');
+        $firstRule->getConfiguration()->willReturn([]);
+
+        $secondRule->getType()->willReturn('second_rule');
+        $secondRule->getConfiguration()->willReturn([]);
+
+        $rulesRegistry->get('first_rule')->willReturn($firstRuleChecker);
+        $rulesRegistry->get('second_rule')->willReturn($secondRuleChecker);
+
+        $firstRuleChecker->isEligible($subject, [])->willReturn(true);
+        $secondRuleChecker->isEligible($subject, [])->willReturn(true);
+
+        $this->isEligible($subject, $shippingMethod)->shouldReturn(true);
+    }
+
+    public function it_recognizes_a_subject_as_not_eligible_if_any_of_shipping_method_rules_is_not_fulfilled(
+        ServiceRegistryInterface $rulesRegistry,
+        RuleCheckerInterface $firstRuleChecker,
+        RuleCheckerInterface $secondRuleChecker,
+        ShippingMethodRuleInterface $firstRule,
+        ShippingMethodRuleInterface $secondRule,
+        ShippingSubjectInterface $subject,
+        ShippingMethodInterface $shippingMethod
+    ): void {
+        $shippingMethod->hasRules()->willReturn(true);
+        $shippingMethod->getRules()->willReturn(
+            new ArrayCollection([$firstRule->getWrappedObject(), $secondRule->getWrappedObject()])
+        );
+
+        $firstRule->getType()->willReturn('first_rule');
+        $firstRule->getConfiguration()->willReturn([]);
+
+        $secondRule->getType()->willReturn('second_rule');
+        $secondRule->getConfiguration()->willReturn([]);
+
+        $rulesRegistry->get('first_rule')->willReturn($firstRuleChecker);
+        $rulesRegistry->get('second_rule')->willReturn($secondRuleChecker);
+
+        $firstRuleChecker->isEligible($subject, [])->willReturn(true);
+        $secondRuleChecker->isEligible($subject, [])->willReturn(false);
+
+        $this->isEligible($subject, $shippingMethod)->shouldReturn(false);
+    }
+
+    function it_does_not_check_more_rules_if_one_has_returned_false(
+        ServiceRegistryInterface $rulesRegistry,
+        RuleCheckerInterface $firstRuleChecker,
+        RuleCheckerInterface $secondRuleChecker,
+        ShippingMethodRuleInterface $firstRule,
+        ShippingMethodRuleInterface $secondRule,
+        ShippingMethodInterface $shippingMethod,
+        ShippingSubjectInterface $subject
+    ): void {
+        $shippingMethod->hasRules()->willReturn(true);
+        $shippingMethod->getRules()->willReturn(
+            new ArrayCollection([$firstRule->getWrappedObject(), $secondRule->getWrappedObject()])
+        );
+
+        $firstRule->getType()->willReturn('first_rule');
+        $firstRule->getConfiguration()->willReturn([]);
+
+        $secondRule->getType()->willReturn('second_rule');
+        $secondRule->getConfiguration()->willReturn([]);
+
+        $rulesRegistry->get('first_rule')->willReturn($firstRuleChecker);
+        $rulesRegistry->get('second_rule')->willReturn($secondRuleChecker);
+
+        $firstRuleChecker->isEligible($subject, [])->willReturn(false);
+        $secondRuleChecker->isEligible($subject, [])->shouldNotBeCalled();
+
+        $this->isEligible($subject, $shippingMethod)->shouldReturn(false);
+    }
+}

--- a/src/Sylius/Component/Shipping/spec/Checker/Rule/TotalWeightGreaterThanOrEqualRuleCheckerSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Checker/Rule/TotalWeightGreaterThanOrEqualRuleCheckerSpec.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Shipping\Checker\Rule;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Shipping\Checker\Rule\RuleCheckerInterface;
+use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+
+final class TotalWeightGreaterThanOrEqualRuleCheckerSpec extends ObjectBehavior
+{
+    public function it_implements_rule_checker_interface(): void
+    {
+        $this->shouldImplement(RuleCheckerInterface::class);
+    }
+
+    public function it_recognizes_subject_if_total_weight_is_greater_than_configured_weight(ShippingSubjectInterface $subject): void
+    {
+        $subject->getShippingWeight()->willReturn(6);
+
+        $this->isEligible($subject, ['weight' => 5])->shouldReturn(true);
+    }
+
+    public function it_recognizes_subject_if_total_weight_is_equal_to_configured_weight(ShippingSubjectInterface $subject): void
+    {
+        $subject->getShippingWeight()->willReturn(5);
+
+        $this->isEligible($subject, ['weight' => 5])->shouldReturn(true);
+    }
+
+    public function it_denies_subject_if_total_weight_is_less_than_configured_weight(ShippingSubjectInterface $subject): void
+    {
+        $subject->getShippingWeight()->willReturn(4);
+
+        $this->isEligible($subject, ['weight' => 5])->shouldReturn(false);
+    }
+}

--- a/src/Sylius/Component/Shipping/spec/Checker/Rule/TotalWeightLessThanOrEqualRuleCheckerSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Checker/Rule/TotalWeightLessThanOrEqualRuleCheckerSpec.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Shipping\Checker\Rule;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use InvalidArgumentException;
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+use Sylius\Component\Shipping\Checker\Rule\RuleCheckerInterface;
+use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
+
+final class TotalWeightLessThanOrEqualRuleCheckerSpec extends ObjectBehavior
+{
+    public function it_implements_rule_checker_interface(): void
+    {
+        $this->shouldImplement(RuleCheckerInterface::class);
+    }
+
+    public function it_throws_exception_if_subject_is_not_a_shipment(ShippingSubjectInterface $subject): void
+    {
+        $this->shouldThrow(InvalidArgumentException::class)->during('isEligible', [$subject, []]);
+    }
+
+    public function it_recognizes_subject_if_order_is_null(ShipmentInterface $shipment): void
+    {
+        $shipment->getOrder()->willReturn(null);
+
+        $this->isEligible($shipment, [])->shouldReturn(true);
+    }
+
+    public function it_recognizes_subject_if_total_weight_is_less_than_configured_weight(
+        ShipmentInterface $subject,
+        OrderInterface $order,
+        ShipmentInterface $shipment1,
+        ShipmentInterface $shipment2
+    ): void {
+        $subject->getOrder()->willReturn($order);
+
+        $shipment1->getShippingWeight()->willReturn(1);
+        $shipment2->getShippingWeight()->willReturn(2);
+
+        $order->getShipments()->willReturn(
+            new ArrayCollection([
+                $shipment1->getWrappedObject(),
+                $shipment2->getWrappedObject(),
+            ])
+        );
+
+        $this->isEligible($subject, ['weight' => 5])->shouldReturn(true);
+    }
+
+    public function it_recognizes_subject_if_total_weight_is_equal_to_configured_weight(
+        ShipmentInterface $subject,
+        OrderInterface $order,
+        ShipmentInterface $shipment1,
+        ShipmentInterface $shipment2
+    ): void {
+        $subject->getOrder()->willReturn($order);
+
+        $shipment1->getShippingWeight()->willReturn(3.55);
+        $shipment2->getShippingWeight()->willReturn(1.45);
+
+        $order->getShipments()->willReturn(
+            new ArrayCollection([
+                $shipment1->getWrappedObject(),
+                $shipment2->getWrappedObject(),
+            ])
+        );
+
+        $this->isEligible($subject, ['weight' => 5])->shouldReturn(true);
+    }
+
+    public function it_denies_subject_if_total_weight_is_greater_than_configured_weight(
+        ShipmentInterface $subject,
+        OrderInterface $order,
+        ShipmentInterface $shipment1,
+        ShipmentInterface $shipment2
+    ): void {
+        $subject->getOrder()->willReturn($order);
+
+        $shipment1->getShippingWeight()->willReturn(3.5);
+        $shipment2->getShippingWeight()->willReturn(2.45);
+
+        $order->getShipments()->willReturn(
+            new ArrayCollection([
+                $shipment1->getWrappedObject(),
+                $shipment2->getWrappedObject(),
+            ])
+        );
+
+        $this->isEligible($subject, ['weight' => 5])->shouldReturn(false);
+    }
+}

--- a/src/Sylius/Component/Shipping/spec/Checker/Rule/TotalWeightLessThanOrEqualRuleCheckerSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Checker/Rule/TotalWeightLessThanOrEqualRuleCheckerSpec.php
@@ -13,11 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Component\Shipping\Checker\Rule;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use InvalidArgumentException;
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Shipping\Checker\Rule\RuleCheckerInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 
@@ -28,77 +24,23 @@ final class TotalWeightLessThanOrEqualRuleCheckerSpec extends ObjectBehavior
         $this->shouldImplement(RuleCheckerInterface::class);
     }
 
-    public function it_throws_exception_if_subject_is_not_a_shipment(ShippingSubjectInterface $subject): void
+    public function it_recognizes_subject_if_total_weight_is_less_than_configured_weight(ShippingSubjectInterface $subject): void
     {
-        $this->shouldThrow(InvalidArgumentException::class)->during('isEligible', [$subject, []]);
-    }
-
-    public function it_recognizes_subject_if_order_is_null(ShipmentInterface $shipment): void
-    {
-        $shipment->getOrder()->willReturn(null);
-
-        $this->isEligible($shipment, [])->shouldReturn(true);
-    }
-
-    public function it_recognizes_subject_if_total_weight_is_less_than_configured_weight(
-        ShipmentInterface $subject,
-        OrderInterface $order,
-        ShipmentInterface $shipment1,
-        ShipmentInterface $shipment2
-    ): void {
-        $subject->getOrder()->willReturn($order);
-
-        $shipment1->getShippingWeight()->willReturn(1);
-        $shipment2->getShippingWeight()->willReturn(2);
-
-        $order->getShipments()->willReturn(
-            new ArrayCollection([
-                $shipment1->getWrappedObject(),
-                $shipment2->getWrappedObject(),
-            ])
-        );
+        $subject->getShippingWeight()->willReturn(4);
 
         $this->isEligible($subject, ['weight' => 5])->shouldReturn(true);
     }
 
-    public function it_recognizes_subject_if_total_weight_is_equal_to_configured_weight(
-        ShipmentInterface $subject,
-        OrderInterface $order,
-        ShipmentInterface $shipment1,
-        ShipmentInterface $shipment2
-    ): void {
-        $subject->getOrder()->willReturn($order);
-
-        $shipment1->getShippingWeight()->willReturn(3.55);
-        $shipment2->getShippingWeight()->willReturn(1.45);
-
-        $order->getShipments()->willReturn(
-            new ArrayCollection([
-                $shipment1->getWrappedObject(),
-                $shipment2->getWrappedObject(),
-            ])
-        );
+    public function it_recognizes_subject_if_total_weight_is_equal_to_configured_weight(ShippingSubjectInterface $subject): void
+    {
+        $subject->getShippingWeight()->willReturn(5);
 
         $this->isEligible($subject, ['weight' => 5])->shouldReturn(true);
     }
 
-    public function it_denies_subject_if_total_weight_is_greater_than_configured_weight(
-        ShipmentInterface $subject,
-        OrderInterface $order,
-        ShipmentInterface $shipment1,
-        ShipmentInterface $shipment2
-    ): void {
-        $subject->getOrder()->willReturn($order);
-
-        $shipment1->getShippingWeight()->willReturn(3.5);
-        $shipment2->getShippingWeight()->willReturn(2.45);
-
-        $order->getShipments()->willReturn(
-            new ArrayCollection([
-                $shipment1->getWrappedObject(),
-                $shipment2->getWrappedObject(),
-            ])
-        );
+    public function it_denies_subject_if_total_weight_is_greater_than_configured_weight(ShippingSubjectInterface $subject): void
+    {
+        $subject->getShippingWeight()->willReturn(6);
 
         $this->isEligible($subject, ['weight' => 5])->shouldReturn(false);
     }

--- a/src/Sylius/Component/Shipping/spec/Resolver/ShippingMethodsResolverSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Resolver/ShippingMethodsResolverSpec.php
@@ -15,7 +15,7 @@ namespace spec\Sylius\Component\Shipping\Resolver;
 
 use Doctrine\Common\Persistence\ObjectRepository;
 use PhpSpec\ObjectBehavior;
-use Sylius\Component\Shipping\Checker\ShippingMethodEligibilityCheckerInterface;
+use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | fixes #10302
| License         | MIT

This pull request adds rules to shipping methods. If any rule returns false the shipping method will not be shown. It is very much based on the same logic as the promotion engine.

- [x] Functionality
- [x] Specs
- [ ] Behat tests
- [ ] Docs
- [ ] ...?