### PR TITLE
Removing unused service

### DIFF
--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
@@ -25,11 +25,6 @@
 
         <service id="sylius.shipping_eligibility_checker" class="Sylius\Component\Shipping\Checker\ShippingMethodEligibilityChecker" />
 
-        <service id="sylius.registry.shipping_rule_checker" class="Sylius\Component\Registry\ServiceRegistry" >
-            <argument>Sylius\Component\Shipping\Checker\RuleCheckerInterface</argument>
-            <argument>shipping rule checker</argument>
-        </service>
-
         <service id="sylius.registry.shipping_methods_resolver" class="Sylius\Component\Registry\PrioritizedServiceRegistry">
             <argument>%sylius.shipping_methods_resolver.interface%</argument>
             <argument>Shipping methods resolver</argument>


### PR DESCRIPTION


| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | I wouldn't say so (see my comment below)
| Deprecations?   | no
| License         | MIT

The service isn't used anywhere and if it would be used it wouldn't work since the `Sylius\Component\Shipping\Checker\RuleCheckerInterface` does not exist.
