### PR TITLE
Fix #9646 by removing lambdas in JS file

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-lazy-choice-tree.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-lazy-choice-tree.js
@@ -155,13 +155,13 @@
                 checkboxElement.checkbox({
                     onChecked: function() {
                         var value = checkboxElement.data('value');
-                        var checkedValues = $input.val().split(",").filter(x => x);
+                        var checkedValues = $input.val().split(",").filter(function(x) { return x; });
                         checkedValues.push(value);
                         $input.val(checkedValues.join());
                     },
                     onUnchecked: function() {
                         var value = checkboxElement.data('value');
-                        var checkedValues = $input.val().split(",").filter(x => x);
+                        var checkedValues = $input.val().split(",").filter(function(x) { return x; });
                         var i = checkedValues.indexOf(value);
                         if(i != -1) {
                             checkedValues.splice(i, 1);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.1
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #9646 again
| License         | MIT

Using lambdas on the `1.1` branch does not work since the `1.1` branch uses **uglifyJS** without Babel, hence, ES6 notation cannot be used.

Without this PR, you cannot run `GULP_ENV=prod npm run gulp` on the `1.1` branch, and thus you cannot build the assets needed for the backoffice.

This PR reverts the lambdas to "regular" functions, unbreaking the asset building for this branch.

Please do not hesitate if I missed some guidelines for this PR
Best