### PR TITLE
[Behat][Shop] Wait for province form loading

### DIFF
--- a/src/Sylius/Behat/Page/Shop/Account/AddressBook/CreatePage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/AddressBook/CreatePage.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Shop\Account\AddressBook;
 
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
+use Sylius\Behat\Service\JQueryHelper;
 use Sylius\Component\Core\Model\AddressInterface;
 
 class CreatePage extends SymfonyPage implements CreatePageInterface
@@ -37,6 +38,8 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
         $this->getElement('country')->selectOption($address->getCountryCode());
         $this->getElement('city')->setValue($address->getCity());
         $this->getElement('postcode')->setValue($address->getPostcode());
+
+        JQueryHelper::waitForFormToStopLoading($this->getDocument());
     }
 
     /**
@@ -46,9 +49,7 @@ class CreatePage extends SymfonyPage implements CreatePageInterface
     {
         $this->getElement('country')->selectOption($name);
 
-        $this->getDocument()->waitFor(5, function () {
-            return false;
-        });
+        JQueryHelper::waitForFormToStopLoading($this->getDocument());
     }
 
     /**

--- a/src/Sylius/Behat/Page/Shop/Account/AddressBook/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/AddressBook/UpdatePage.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Page\Shop\Account\AddressBook;
 
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
+use Sylius\Behat\Service\JQueryHelper;
 
 class UpdatePage extends SymfonyPage implements UpdatePageInterface
 {
@@ -81,12 +82,18 @@ class UpdatePage extends SymfonyPage implements UpdatePageInterface
      */
     public function selectCountry($name)
     {
+        JQueryHelper::waitForFormToStopLoading($this->getDocument());
+
         $country = $this->getElement('country');
         $country->selectOption($name);
+
+        JQueryHelper::waitForFormToStopLoading($this->getDocument());
     }
 
     public function saveChanges()
     {
+        JQueryHelper::waitForFormToStopLoading($this->getDocument());
+
         $this->getElement('save_button')->press();
     }
 

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
@@ -18,6 +18,7 @@ use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
 use FriendsOfBehat\PageObjectExtension\Page\SymfonyPage;
+use Sylius\Behat\Service\JQueryHelper;
 use Sylius\Component\Core\Factory\AddressFactoryInterface;
 use Sylius\Component\Core\Model\AddressInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -279,6 +280,8 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
         }
 
         $addressOption->click();
+
+        JQueryHelper::waitForFormToStopLoading($this->getDocument());
     }
 
     /**
@@ -393,6 +396,8 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
         $this->getElement(sprintf('%s_country', $type))->selectOption($address->getCountryCode() ?: 'Select');
         $this->getElement(sprintf('%s_city', $type))->setValue($address->getCity());
         $this->getElement(sprintf('%s_postcode', $type))->setValue($address->getPostcode());
+
+        JQueryHelper::waitForFormToStopLoading($this->getDocument());
 
         if (null !== $address->getProvinceName()) {
             $this->waitForElement(5, sprintf('%s_province', $type));

--- a/src/Sylius/Behat/Service/JQueryHelper.php
+++ b/src/Sylius/Behat/Service/JQueryHelper.php
@@ -13,12 +13,21 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Service;
 
+use Behat\Mink\Element\DocumentElement;
 use Behat\Mink\Session;
 
 abstract class JQueryHelper
 {
-    public static function waitForAsynchronousActionsToFinish(Session $session)
+    public static function waitForAsynchronousActionsToFinish(Session $session): void
     {
         $session->wait(5000, '0 === jQuery.active');
+    }
+
+    public static function waitForFormToStopLoading(DocumentElement $document, int $timeout = 10): void
+    {
+        $form = $document->find('css', 'form');
+        $document->waitFor($timeout, function () use ($form) {
+            return !$form->hasClass('loading');
+        });
     }
 }

--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-province-field.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-province-field.js
@@ -27,6 +27,8 @@ $.fn.extend({
       const provinceSelectFieldId = select.attr('id').replace('country', 'province');
       const provinceInputFieldId = select.attr('id').replace('countryCode', 'provinceName');
 
+      const form = select.parents('form');
+
       if (select.val() === '' || select.val() == undefined) {
         provinceContainer.fadeOut('slow', () => {
           provinceContainer.html('');
@@ -36,6 +38,7 @@ $.fn.extend({
       }
 
       provinceContainer.attr('data-loading', true);
+      form.addClass('loading');
 
       $.get(provinceContainer.attr('data-url'), { countryCode: select.val() }, (response) => {
         if (!response.content) {
@@ -43,6 +46,7 @@ $.fn.extend({
             provinceContainer.html('');
 
             provinceContainer.removeAttr('data-loading');
+            form.removeClass('loading');
           });
         } else if (response.content.indexOf('select') !== -1) {
           provinceContainer.fadeOut('slow', () => {
@@ -60,7 +64,9 @@ $.fn.extend({
 
             provinceContainer.removeAttr('data-loading');
 
-            provinceContainer.fadeIn();
+            provinceContainer.fadeIn('fast', () => {
+              form.removeClass('loading');
+            });
           });
         } else {
           provinceContainer.fadeOut('slow', () => {
@@ -74,7 +80,9 @@ $.fn.extend({
 
             provinceContainer.removeAttr('data-loading');
 
-            provinceContainer.fadeIn();
+            provinceContainer.fadeIn('fast', () => {
+              form.removeClass('loading');
+            });
           });
         }
       });


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

From time to time, we're experiencing some random build fails. I've detected that most (if not all) of them are related to two scenarios: `features/checkout/addressing_order/choosing_province_for_country.feature` and `features/checkout/addressing_order/specifying_province_manually.feature`.

The problem is, ajax is used to load a proper province form but it does not add loader spinner to the form (which prevents from any modifications until loading is ended).

I believe a proposed fix can improve these tests to lower the number of randomly failing builds. On the other hand, I consider it as a hotfix, it would be great to set a first available country as a default one and select a proper province field for it (to not load form by ajax on 