### PR TITLE
Image display in edit form

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Form/imagesTheme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Form/imagesTheme.html.twig
@@ -1,23 +1,12 @@
 {% extends '@SyliusUi/Form/imagesTheme.html.twig' %}
 
 {% block sylius_product_image_widget %}
+    {{ block('sylius_image_widget') }}
+
     {% spaceless %}
-        <div class="ui upload box segment">
-            {{ form_row(form.type) }}
-            <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.choose_file'|trans }}</label>
-            {% if form.vars.value.path|default(null) is not null %}
-                <img class="ui small bordered image" src="{{ form.vars.value.path|imagine_filter('sylius_small') }}" alt="{{ form.vars.value.type }}" />
-            {% endif %}
-            <div class="ui hidden element">
-                {{ form_widget(form.file) }}
-            </div>
-            <div class="ui element">
-                {{- form_errors(form.file) -}}
-            </div>
-            {% if product.id is not null and 0 != product.variants|length and not product.simple %}
-                <br/>
-                {{ form_row(form.productVariants, {'remote_url': path('sylius_admin_ajax_product_variants_by_phrase', {'productCode': product.code}), 'remote_criteria_type': 'contains', 'remote_criteria_name': 'phrase', 'load_edit_url': path('sylius_admin_ajax_product_variants_by_codes', {'productCode': product.code})}) }}
-            {% endif %}
-        </div>
+        {% if product.id is not null and 0 != product.variants|length and not product.simple %}
+            <br/>
+            {{ form_row(form.productVariants, {'remote_url': path('sylius_admin_ajax_product_variants_by_phrase', {'productCode': product.code}), 'remote_criteria_type': 'contains', 'remote_criteria_name': 'phrase', 'load_edit_url': path('sylius_admin_ajax_product_variants_by_codes', {'productCode': product.code})}) }}
+        {% endif %}
     {% endspaceless %}
 {% endblock %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/imagesTheme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/imagesTheme.html.twig
@@ -38,7 +38,9 @@
 {% macro collection_item(form, allow_delete, button_delete_label, index) %}
     {% spaceless %}
         <div data-form-collection="item" data-form-collection-index="{{ index }}" class="column">
-            {{ form_widget(form) }}
+            <div class="ui box segment">
+                {{ form_widget(form) }}
+            </div>
             {% if allow_delete %}
                 <a href="#" data-form-collection="delete" class="ui red labeled icon button" style="margin-bottom: 1em;">
                     <i class="trash icon"></i>
@@ -51,28 +53,25 @@
 
 {% block sylius_product_image_widget %}
     {% spaceless %}
-    <div class="ui upload box segment">
         {{ form_row(form.type) }}
         <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.choose_file'|trans }}</label>
-    {% if form.vars.value.path|default(null) is not null %}
-        <img class="ui small bordered image" src="{{ form.vars.value.path|imagine_filter('sylius_small') }}" alt="{{ form.vars.value.type }}" />
-    {% endif %}
+        {% if form.vars.value.path|default(null) is not null %}
+            <img class="ui small bordered image" src="{{ form.vars.value.path|imagine_filter('sylius_small') }}" alt="{{ form.vars.value.type }}" />
+        {% endif %}
         <div class="ui hidden element">
             {{ form_widget(form.file) }}
         </div>
         <div class="ui element">
             {{- form_errors(form.file) -}}
         </div>
-    {% if product.id is not null and 0 != product.variants|length and not product.simple %}
-        {{ form_row(form.productVariants) }}
-    {% endif %}
-    </div>
+        {% if product.id is not null and 0 != product.variants|length and not product.simple %}
+            {{ form_row(form.productVariants) }}
+        {% endif %}
     {% endspaceless %}
 {% endblock %}
 
 {% block sylius_taxon_image_widget %}
     {% spaceless %}
-    <div class="ui upload box segment">
         {{ form_row(form.type) }}
         {% if form.vars.value.path|default(null) is null %}
             <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.choose_file'|trans }}</label>
@@ -86,6 +85,5 @@
         <div class="ui element">
             {{- form_errors(form.file) -}}
         </div>
-    </div>
     {% endspaceless %}
 {% endblock %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -126,13 +126,13 @@
 {% endmacro %}
 
 {% block sylius_province_widget %}
-<div class="ui compact segment">
-    <div class="inline fields">
-        {{ form_row(form.code) }}
-        {{ form_row(form.name) }}
-        {{ form_row(form.abbreviation) }}
+    <div class="ui compact segment">
+        <div class="inline fields">
+            {{ form_row(form.code) }}
+            {{ form_row(form.name) }}
+            {{ form_row(form.abbreviation) }}
+        </div>
     </div>
-</div>
 {% endblock %}
 
 {% block sylius_zone_member_widget %}
@@ -166,15 +166,15 @@
 {% block sylius_product_option_value_widget %}
     <div class="ui segment">
         {{ form_row(form.code) }}
-            <div class="five fields">
+        <div class="five fields">
             {% for locale, translationForm in form.translations %}
-                {{ form_row(translationForm.value, {'label': locale|sylius_locale_name}) }}
-                {% if 0 == loop.index % 5 %}
-                </div>
-                <div class="five fields">
-                {% endif %}
+            {{ form_row(translationForm.value, {'label': locale|sylius_locale_name}) }}
+            {% if 0 == loop.index % 5 %}
+        </div>
+        <div class="five fields">
+            {% endif %}
             {% endfor %}
-            </div>
+        </div>
     </div>
 {% endblock %}
 
@@ -228,4 +228,20 @@
         <h4 class="ui dividing header">{{ 'sylius.ui.pricing'|trans }}</h4>
         {{ form_row(form.channelPricings, {'label': false}) }}
     </div>
+{% endblock %}
+
+{% block sylius_image_widget %}
+    {% spaceless %}
+        {{ form_row(form.type) }}
+        <label for="{{ form.file.vars.id }}" class="ui icon labeled button"><i class="cloud upload icon"></i> {{ 'sylius.ui.choose_file'|trans }}</label>
+        {% if form.vars.value.path|default(null) is not null %}
+            <img class="ui small bordered image" src="{{ form.vars.value.path|imagine_filter('sylius_small') }}" alt="{{ form.vars.value.type }}" />
+        {% endif %}
+        <div class="ui hidden element">
+            {{ form_widget(form.file) }}
+        </div>
+        <div class="ui element">
+            {{- form_errors(form.file) -}}
+        </div>
+    {% endspaceless %}
 {% endblock %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | Related #9843
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.3 or 1.4 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
Before this changing when you create a custom resource with image, on edit page you don't see uploaded image. 
![Screenshot 2019-05-09 at 14 35 11](https://user-images.githubusercontent.com/29897151/57506662-c55c5b00-72fc-11e9-81af-6d1afafb372d.png)
now you see image uploaded earlier. it works if you don't override sylius image theme
![Screenshot 2019-05-09 at 15 30 45](https://user-images.githubusercontent.com/29897151/57506909-7bc04000-72fd-11e9-9319-a7133cad447e.png)

