### PR TITLE
[UI] Hide filters by default on index pages

### DIFF
--- a/etc/travis/suites/application/script/test-behat-with-javascript
+++ b/etc/travis/suites/application/script/test-behat-with-javascript
@@ -4,7 +4,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../../bash/common.li
 
 prepare_for_behat_with_js() {
     # Configure display
-    run_command "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1680x1050x16"
+    run_command "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 2880x1800x16"
     run_command "export DISPLAY=:99"
 
     # Download and configure ChromeDriver

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/_default.html.twig
@@ -11,11 +11,11 @@
 {% if definition.enabledFilters|length > 0 %}
     <div class="ui hidden divider"></div>
     <div class="ui styled fluid accordion">
-        <div class="title active">
+        <div class="title">
             <i class="dropdown icon"></i>
             {{ 'sylius.ui.filters'|trans }}
         </div>
-        <div class="content active">
+        <div class="content">
             <form method="get" action="{{ path }}" class="ui loadable form">
                 <div class="two fields">
                     {% for filter in definition.enabledFilters|sort_by('position') if filter.enabled %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | 

On some pages, especially on the orders index page, filters block is enormous and take almost half of the screen:

<img width="1167" alt="Zrzut ekranu 2019-05-15 o 10 47 49" src="https://user-images.githubusercontent.com/6212718/57765162-35a41b80-7705-11e9-8efc-23cb4d244fbc.png">

It seems a reasonable change to hide filters by default, as they're just an addition to the index page functionality, not the core of it:

<img width="1167" alt="Zrzut ekranu 2019-05-15 o 10 47 58" src="https://user-images.githubusercontent.com/6212718/57765229-52405380-7705-11e9-9922-6a7f3b9ef982.png">
