### PR TITLE
Fix error caused by the taxon tree

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-taxon-tree.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-taxon-tree.js
@@ -8,6 +8,7 @@ class SyliusTaxonomyTree {
     };
 
     this.tree = document.querySelector(`[${this.attr.tree}]`);
+    if (!this.tree) return;
     this.hiddenItems = this.getMapFromStorage();
     this.renderMap();
     this.tree.classList.remove('hidden');


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Fixes an error that was displayed on pages where there was no taxon tree