### PR TITLE
Add info into install command about need of setting the locale in symfony config

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/LocaleSetup.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/LocaleSetup.php
@@ -49,6 +49,10 @@ final class LocaleSetup implements LocaleSetupInterface
 
         $output->writeln(sprintf('Adding <info>%s</info> locale.', $code));
 
+        if ($this->locale !== $code) {
+            $output->writeln('<info>You may also need to add this locale into config/services.yaml configuration.</info>');
+        }
+
         /** @var LocaleInterface $existingLocale */
         $existingLocale = $this->localeRepository->findOneBy(['code' => $code]);
         if (null !== $existingLocale) {


### PR DESCRIPTION
Improve DX by adding additional info about locale settings inside sylius:install:setup command.

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #10398
| License         | MIT