### PR TITLE
Fix huge autocomplete queries issue

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/product.yml
@@ -19,6 +19,7 @@ sylius_admin_ajax_product_by_name_phrase:
                 arguments:
                     phrase: $phrase
                     locale: expr:service('sylius.context.locale').getLocaleCode()
+                    limit: 25
 
 sylius_admin_ajax_product_by_code:
     path: /code

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/taxon.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/ajax/taxon.yml
@@ -50,6 +50,8 @@ sylius_admin_ajax_taxon_by_name_phrase:
                 method: findByNamePart
                 arguments:
                     phrase: $phrase
+                    locale: null
+                    limit: 25
 
 sylius_admin_ajax_generate_taxon_slug:
     path: /generate-slug/

--- a/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductRepository.php
@@ -43,6 +43,7 @@ class ProductRepository extends EntityRepository implements ProductRepositoryInt
             ->andWhere('translation.name LIKE :name')
             ->setParameter('name', '%' . $phrase . '%')
             ->setParameter('locale', $locale)
+            ->setMaxResults(25)
             ->getQuery()
             ->getResult()
         ;

--- a/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductRepository.php
@@ -36,14 +36,14 @@ class ProductRepository extends EntityRepository implements ProductRepositoryInt
     /**
      * {@inheritdoc}
      */
-    public function findByNamePart(string $phrase, string $locale): array
+    public function findByNamePart(string $phrase, string $locale, ?int $limit = null): array
     {
         return $this->createQueryBuilder('o')
             ->innerJoin('o.translations', 'translation', 'WITH', 'translation.locale = :locale')
             ->andWhere('translation.name LIKE :name')
             ->setParameter('name', '%' . $phrase . '%')
             ->setParameter('locale', $locale)
-            ->setMaxResults(25)
+            ->setMaxResults($limit)
             ->getQuery()
             ->getResult()
         ;

--- a/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
@@ -87,11 +87,12 @@ class TaxonRepository extends EntityRepository implements TaxonRepositoryInterfa
     /**
      * {@inheritdoc}
      */
-    public function findByNamePart(string $phrase, ?string $locale = null): array
+    public function findByNamePart(string $phrase, ?string $locale = null, ?int $limit = null): array
     {
         return $this->createTranslationBasedQueryBuilder($locale)
             ->andWhere('translation.name LIKE :name')
             ->setParameter('name', '%' . $phrase . '%')
+            ->setMaxResults($limit)
             ->getQuery()
             ->getResult()
         ;

--- a/src/Sylius/Component/Product/Repository/ProductRepositoryInterface.php
+++ b/src/Sylius/Component/Product/Repository/ProductRepositoryInterface.php
@@ -26,5 +26,5 @@ interface ProductRepositoryInterface extends RepositoryInterface
     /**
      * @return array|ProductInterface[]
      */
-    public function findByNamePart(string $phrase, string $locale): array;
+    public function findByNamePart(string $phrase, string $locale, ?int $limit = null): array;
 }

--- a/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
+++ b/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
@@ -39,7 +39,7 @@ interface TaxonRepositoryInterface extends RepositoryInterface
     /**
      * @return array|TaxonInterface[]
      */
-    public function findByNamePart(string $phrase, ?string $locale = null): array;
+    public function findByNamePart(string $phrase, ?string $locale = null, ?int $limit = null): array;
 
     public function createListQueryBuilder(): QueryBuilder;
 }


### PR DESCRIPTION
In case you have a large amount of data (i.e. 100k products), the autocomplete query fetches all matching results which brokes down the whole web server. This simple fix limits the results to 25 as in most cases the end user does not need more than this amount of suggested hits. 
Could be improved by adding the limit parameter to the method signature.

| Q               | A
| --------------- | -----
| Branch?         | 1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.3 or 1.4 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
