### PR TITLE
Using client from browser kit component instead of http kernel component

### DIFF
--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductVariantsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductVariantsContext.php
@@ -15,9 +15,9 @@ namespace Sylius\Behat\Context\Api\Admin;
 
 use Behat\Behat\Context\Context;
 use Sylius\Component\Core\Model\ProductInterface;
+use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\HttpKernel\Client;
 use Webmozart\Assert\Assert;
 
 final class ManagingProductVariantsContext implements Context

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingTaxonsContext.php
@@ -15,9 +15,9 @@ namespace Sylius\Behat\Context\Api\Admin;
 
 use Behat\Behat\Context\Context;
 use Sylius\Component\Core\Model\TaxonInterface;
+use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\HttpKernel\Client;
 use Webmozart\Assert\Assert;
 
 final class ManagingTaxonsContext implements Context


### PR DESCRIPTION
Using client from browser kit component instead of http kernel component. I am using the deprecated version because the Symfony\Component\BrowserKit\AbstractBrowser is first introduced in SF4.3 (not sure this is correct?).

This commit fixes this issue when running behat tests:

`Argument 1 passed to Sylius\Behat\Context\Api\Admin\ManagingTaxonsContext::__construct() must be an instance of Symfony\Component\HttpKernel\Client, instance of Symfony\Bundle\FrameworkBundle\KernelBrowser given`

| Q               | A
| --------------- | -----
| Branch?         | 1.3 and newer
| Bug fix?        | Somewhat
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.3, 1.4 or 1.5 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
