### PR TITLE
Fix removing taxons with numeric codes from products

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-lazy-choice-tree.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-lazy-choice-tree.js
@@ -108,13 +108,13 @@ $.fn.extend({
     const bindCheckboxAction = function bindCheckboxAction(checkboxElement) {
       checkboxElement.checkbox({
         onChecked() {
-          const value = checkboxElement.data('value');
+          const { value } = checkboxElement[0].dataset;
           const checkedValues = $input.val().split(',').filter(Boolean);
           checkedValues.push(value);
           $input.val(checkedValues.join());
         },
         onUnchecked() {
-          const value = checkboxElement.data('value');
+          const { value } = checkboxElement[0].dataset;
           const checkedValues = $input.val().split(',').filter(Boolean);
           const i = checkedValues.indexOf(value);
           if (i !== -1) {


### PR DESCRIPTION
Use native `.dataset` instead of jQuery `.data()` to avoid type conversion which make it impossible to remove taxons with numeric codes from products

| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no<!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #10439
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.4 or 1.5 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
