### PR TITLE
[Admin] Add possibility to configure custom index route in routing

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_breadcrumb.html.twig
@@ -1,8 +1,14 @@
 {% import '@SyliusAdmin/Macro/breadcrumb.html.twig' as breadcrumb %}
 
+{% set index_url = path(
+        configuration.vars.index.route.name|default(configuration.getRouteName('index')),
+        configuration.vars.index.route.parameters|default(configuration.vars.route.parameters|default({}))
+    )
+%}
+
 {% set breadcrumbs = [
         { label: 'sylius.ui.administration'|trans, url: path('sylius_admin_dashboard') },
-        { label: (metadata.applicationName~'.ui.'~metadata.pluralName)|trans, url: path(configuration.getRouteName('index'), configuration.vars.route.parameters|default({})) },
+        { label: (metadata.applicationName~'.ui.'~metadata.pluralName)|trans, url: index_url },
         { label: 'sylius.ui.new'|trans }
     ]
 %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_content.html.twig
@@ -1,3 +1,9 @@
+{% set index_url = path(
+        configuration.vars.index.route.name|default(configuration.getRouteName('index')),
+        configuration.vars.index.route.parameters|default(configuration.vars.route.parameters|default({}))
+    )
+%}
+
 <div class="ui segment">
     {{ form_start(form, {'action': path(configuration.vars.route.name|default(configuration.getRouteName('create')), configuration.vars.route.parameters|default({})), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate'}}) }}
     {% if configuration.vars.templates.form is defined %}
@@ -8,7 +14,7 @@
 
     {{ sonata_block_render_event(event_prefix ~ '.form', {'resource': resource, 'form': form}) }}
 
-    {% include '@SyliusUi/Form/Buttons/_create.html.twig' with {'paths': {'cancel': path(configuration.getRouteName('index'), configuration.vars.route.parameters|default({}))}} %}
+    {% include '@SyliusUi/Form/Buttons/_create.html.twig' with {'paths': {'cancel': index_url}} %}
 
     {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_breadcrumb.html.twig
@@ -1,8 +1,14 @@
 {% import '@SyliusAdmin/Macro/breadcrumb.html.twig' as breadcrumb %}
 
+{% set index_url = path(
+        configuration.vars.index.route.name|default(configuration.getRouteName('index')),
+        configuration.vars.index.route.parameters|default(configuration.vars.route.parameters|default({}))
+    )
+%}
+
 {% set breadcrumbs = [
         { label: 'sylius.ui.administration'|trans, url: path('sylius_admin_dashboard') },
-        { label: (metadata.applicationName~'.ui.'~metadata.pluralName)|trans, url: path(configuration.getRouteName('index'), configuration.vars.route.parameters|default({})) },
+        { label: (metadata.applicationName~'.ui.'~metadata.pluralName)|trans, url: index_url },
         { label: resource.code|default(resource.id)},
         { label: 'sylius.ui.edit'|trans }
     ]

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
@@ -1,3 +1,9 @@
+{% set index_url = path(
+        configuration.vars.index.route.name|default(configuration.getRouteName('index')),
+        configuration.vars.index.route.parameters|default(configuration.vars.route.parameters|default({}))
+    )
+%}
+
 <div class="ui segment">
     {{ form_start(form, {'action': path(configuration.getRouteName('update'), configuration.vars.route.parameters|default({ 'id': resource.id })), 'attr': {'class': 'ui loadable form', 'novalidate': 'novalidate'}}) }}
     <input type="hidden" name="_method" value="PUT" />
@@ -9,7 +15,8 @@
 
     {{ sonata_block_render_event(event_prefix ~ '.form', {'resource': resource, 'form': form}) }}
 
-    {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': path(configuration.getRouteName('index'), configuration.vars.route.parameters|default({}))}} %}
+    {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': index_url}} %}
+
     {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}
 </div>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

It gives a possibility to configure:
```
your_route:
    ...
    defaults:
        ...
        _sylius:
            vars:
                ...
                index:
                    route:
                        name: custom_route
                        parameters: custom_parameters
```