### PR TITLE
Fix deprecation notice

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -15,7 +15,7 @@ if (is_array($env = @include dirname(__DIR__) . '/.env.local.php')) {
     throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
 } else {
     // load all the .env files
-    (new Dotenv())->loadEnv(dirname(__DIR__) . '/.env');
+    (new Dotenv(true))->loadEnv(dirname(__DIR__) . '/.env');
 }
 
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';


### PR DESCRIPTION
Fixes this notice: `The default value of "$usePutenv" argument of "Symfony\Component\Dotenv\Dotenv::__construct" will be changed from "true" to "false" in Symfony 5.0. You should define its value explicitly.`

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

