### PR TITLE
Added: Shipping method configuration normalizer

### DIFF
--- a/UPGRADE-1.6.md
+++ b/UPGRADE-1.6.md
@@ -5,3 +5,49 @@ Require upgraded Sylius version using Composer:
 ```bash
 composer require sylius/sylius:~1.6.0
 ```
+
+#### Shipping method fixture calculator configuration
+
+If you have your custom `shipping_method` fixtures with
+calculator configuration defined, you should update rates
+from XXXX to XX.XX.
+
+Before:
+```yaml
+sylius_fixtures:
+    suites:
+        default:
+            fixtures:
+                shipping_method:
+                    options:
+                        custom:
+                            delivery:
+                                code: "delivery"
+                                name: "Delivery"
+                                enabled: true
+                                calculator:
+                                    type: "flat_rate"
+                                    configuration: 
+                                        US_WEB:
+                                            amount: 2037
+```
+
+After:
+```yaml
+sylius_fixtures:
+   suites:
+       default:
+           fixtures:
+               shipping_method:
+                   options:
+                       custom:
+                           delivery:
+                               code: "delivery"
+                               name: "Delivery"
+                               enabled: true
+                               calculator:
+                                   type: "flat_rate"
+                                   configuration: 
+                                       US_WEB:
+                                           amount: 20.37
+```

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShippingMethodExampleFactory.php
@@ -156,6 +156,17 @@ class ShippingMethodExampleFactory extends AbstractExampleFactory implements Exa
                     'configuration' => $configuration,
                 ];
             })
+            ->setNormalizer('calculator', function (Options $options, $configuration): array {
+                if (isset($configuration['configuration'])) {
+                    foreach ($configuration['configuration'] as $channelCode => $channelConfiguration) {
+                        if (isset($channelConfiguration['amount'])) {
+                            $configuration['configuration'][$channelCode]['amount'] = (int) ($channelConfiguration['amount'] * 100);
+                        }
+                    }
+                }
+
+                return $configuration;
+            })
             ->setDefault('channels', LazyOption::all($this->channelRepository))
             ->setAllowedTypes('channels', 'array')
             ->setNormalizer('channels', LazyOption::findBy($this->channelRepository, 'code'))


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | yes, shipping method calculator rates (if they defined in fixtures) will increase x 100
| Deprecations?   | yes, you should update rates from XXXX to XX.XX at shipping method fixtures calculator configuration
| Related tickets | fixes #10474
| License         | MIT

TODO
- [x] Add notes to UPGRADE.md