### PR TITLE
Make it possible to have no shipping methods for Order fixtures

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
@@ -175,6 +175,8 @@ class OrderFixture extends AbstractFixture
     {
         $numberOfItems = random_int(1, 5);
         $products = $this->productRepository->findAll();
+        $shippingMethods = $this->shippingMethodRepository->findAll();
+        $shippingMethodsAvailable = (bool) count($shippingMethods);
 
         for ($i = 0; $i < $numberOfItems; ++$i) {
             /** @var OrderItemInterface $item */
@@ -182,6 +184,7 @@ class OrderFixture extends AbstractFixture
 
             $product = $this->faker->randomElement($products);
             $variant = $this->faker->randomElement($product->getVariants()->toArray());
+            $variant->setShippingRequired($shippingMethodsAvailable);
 
             $item->setVariant($variant);
             $this->orderItemQuantityModifier->modify($item, random_int(1, 5));
@@ -213,7 +216,6 @@ class OrderFixture extends AbstractFixture
             ->faker
             ->randomElement($this->shippingMethodRepository->findEnabledForChannel($order->getChannel()))
         ;
-        Assert::notNull($shippingMethod, 'Shipping method should not be null.');
 
         foreach ($order->getShipments() as $shipment) {
             $shipment->setMethod($shippingMethod);

--- a/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
@@ -176,7 +176,7 @@ class OrderFixture extends AbstractFixture
         $numberOfItems = random_int(1, 5);
         $products = $this->productRepository->findAll();
         $shippingMethods = $this->shippingMethodRepository->findAll();
-        $shippingMethodsAvailable = (bool) count($shippingMethods);
+        $shippingMethodsAvailable = count($shippingMethods) > 0;
 
         for ($i = 0; $i < $numberOfItems; ++$i) {
             /** @var OrderItemInterface $item */


### PR DESCRIPTION
Currently it's not possible to have fixture suites with no shipping methods (a.k.a. virtual shipping only). This PR makes it possible.

| Q               | A
| --------------- | -----
| Branch?         | 1.4 <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | #10490
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.4 or 1.5 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
