### PR TITLE
Add search bar css rule for Firefox

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/scss/style.scss
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/scss/style.scss
@@ -42,4 +42,5 @@ body {
 
 #searchbarButtons {
     width: fit-content;
+    width: -moz-fit-content;
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #10425 
| License         | MIT

I was on the page https://demo.sylius.com/en_US/taxons/books using Firefox 60.7.2esr (64-bit) and saw the issue described by #10425.
I added the css rule `width: -moz-fit-content;` online and had the proper display.

