### PR TITLE
Fixed Promotion fixture's exclusive option to false by default

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
@@ -117,7 +117,7 @@ class PromotionExampleFactory extends AbstractExampleFactory implements ExampleF
             ->setDefault('description', $this->faker->sentence())
             ->setDefault('usage_limit', null)
             ->setDefault('coupon_based', false)
-            ->setDefault('exclusive', $this->faker->boolean(25))
+            ->setDefault('exclusive', false)
             ->setDefault('priority', 0)
             ->setDefault('starts_at', null)
             ->setAllowedTypes('starts_at', ['null', 'string'])


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no for core fixtures
| Deprecations?   | no
| Related tickets | fixes #10504 
| License         | MIT
