### PR TITLE
[Admin] Improve breadcrumbs (especially for ProductVariants and PromotionCoupons)

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_breadcrumb.html.twig
@@ -3,7 +3,7 @@
 {% set breadcrumbs = [
         { label: 'sylius.ui.administration'|trans, url: path('sylius_admin_dashboard') },
         { label: (metadata.applicationName~'.ui.'~metadata.pluralName)|trans, url: path(configuration.getRouteName('index'), configuration.vars.route.parameters|default({})) },
-        { label: resource.code|default(resource.id)},
+        { label: resource.name|default(resource.code|default(resource.id)) },
         { label: 'sylius.ui.edit'|trans }
     ]
 %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Create/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Create/_breadcrumb.html.twig
@@ -3,7 +3,7 @@
 {% set breadcrumbs = [
         { label: 'sylius.ui.administration'|trans, url: path('sylius_admin_dashboard') },
         { label: 'sylius.ui.products'|trans, url: path('sylius_admin_product_index') },
-        { label: resource.product.code, url: path('sylius_admin_product_update', {'id': resource.product.id}) },
+        { label: resource.product.name|default(resource.product.code), url: path('sylius_admin_product_update', {'id': resource.product.id}) },
         { label: 'sylius.ui.variants'|trans, url: path(configuration.getRouteName('index'), {'productId': resource.product.id}) },
         { label: 'sylius.ui.new'|trans }
     ]

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Generate/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Generate/_breadcrumb.html.twig
@@ -3,7 +3,7 @@
 {% set breadcrumbs = [
         { label: 'sylius.ui.administration'|trans, url: path('sylius_admin_dashboard') },
         { label: 'sylius.ui.products'|trans, url: path('sylius_admin_product_index') },
-        { label: product.code, url: path('sylius_admin_product_update', {'id': product.id}) },
+        { label: product.name|default(product.code), url: path('sylius_admin_product_update', {'id': product.id}) },
         { label: 'sylius.ui.variants'|trans, url: path('sylius_admin_product_variant_index', {'productId': product.id}) },
         { label: 'sylius.ui.generate'|trans }
     ]

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Index/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Index/_breadcrumb.html.twig
@@ -3,7 +3,7 @@
 {% set breadcrumbs = [
         { label: 'sylius.ui.administration'|trans, url: path('sylius_admin_dashboard') },
         { label: 'sylius.ui.products'|trans, url: path('sylius_admin_product_index') },
-        { label: product.code, url: path('sylius_admin_product_update', {'id': product.id}) },
+        { label: product.name|default(product.code), url: path('sylius_admin_product_update', {'id': product.id}) },
         { label: 'sylius.ui.variants'|trans },
     ]
 %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Update/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Update/_breadcrumb.html.twig
@@ -3,9 +3,9 @@
 {% set breadcrumbs = [
         { label: 'sylius.ui.administration'|trans, url: path('sylius_admin_dashboard') },
         { label: 'sylius.ui.products'|trans, url: path('sylius_admin_product_index') },
-        { label: app.request.attributes.get('productId'), url: path('sylius_admin_product_update', {'id': app.request.attributes.get('productId')}) },
-        { label: (metadata.applicationName~'.ui.'~metadata.pluralName)|trans, url: path(configuration.getRouteName('index'), configuration.vars.route.parameters|default({})) },
-        { label: resource.code|default(resource.id) },
+        { label: resource.product.name, url: path('sylius_admin_product_update', {'id': resource.product.id}) },
+        { label: 'sylius.ui.variants'|trans, url: path('sylius_admin_product_variant_index', {'productId': resource.product.id}) },
+        { label: resource.name|default(resource.code) },
         { label: 'sylius.ui.edit'|trans }
     ]
 %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/Create/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/Create/_breadcrumb.html.twig
@@ -3,7 +3,7 @@
 {% set breadcrumbs = [
         { label: 'sylius.ui.administration'|trans, url: path('sylius_admin_dashboard') },
         { label: 'sylius.ui.promotions'|trans, url: path('sylius_admin_promotion_index') },
-        { label: resource.promotion.code, url: path('sylius_admin_promotion_update', {'id': resource.promotion.id}) },
+        { label: resource.promotion.name|default(resource.promotion.code), url: path('sylius_admin_promotion_update', {'id': resource.promotion.id}) },
         { label: 'sylius.ui.coupons'|trans, url: path(configuration.getRouteName('index'), {'promotionId': resource.promotion.id}) },
         { label: 'sylius.ui.new'|trans }
     ]

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/Generate/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/Generate/_breadcrumb.html.twig
@@ -3,7 +3,7 @@
 {% set breadcrumbs = [
         { label: 'sylius.ui.administration'|trans, url: path('sylius_admin_dashboard') },
         { label: 'sylius.ui.promotions'|trans, url: path('sylius_admin_promotion_index') },
-        { label: promotion.code, url: path('sylius_admin_promotion_update', {'id': promotion.id}) },
+        { label: promotion.name|default(promotion.code), url: path('sylius_admin_promotion_update', {'id': promotion.id}) },
         { label: 'sylius.ui.coupons'|trans, url: path('sylius_admin_promotion_coupon_index', {'promotionId': promotion.id}) },
         { label: 'sylius.ui.generate'|trans }
     ]

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/Index/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/Index/_breadcrumb.html.twig
@@ -3,7 +3,7 @@
 {% set breadcrumbs = [
         { label: 'sylius.ui.administration'|trans, url: path('sylius_admin_dashboard') },
         { label: 'sylius.ui.promotions'|trans, url: path('sylius_admin_promotion_index') },
-        { label: promotion.code, url: path('sylius_admin_promotion_update', {'id': promotion.id}) },
+        { label: promotion.name|default(promotion.code), url: path('sylius_admin_promotion_update', {'id': promotion.id}) },
         { label: 'sylius.ui.coupons'|trans },
     ]
 %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/Update/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PromotionCoupon/Update/_breadcrumb.html.twig
@@ -3,8 +3,8 @@
 {% set breadcrumbs = [
         { label: 'sylius.ui.administration'|trans, url: path('sylius_admin_dashboard') },
         { label: 'sylius.ui.promotions'|trans, url: path('sylius_admin_promotion_index') },
-        { label: app.request.attributes.get('promotionId') },
-        { label: (metadata.applicationName~'.ui.'~metadata.pluralName)|trans, url: path(configuration.getRouteName('index'), configuration.vars.route.parameters|default({})) },
+        { label: resource.promotion.name, url: path('sylius_admin_promotion_update', {'id': resource.promotion.id}) },
+        { label: 'sylius.ui.promotion_coupons'|trans, url: path('sylius_admin_promotion_coupon_index', {'promotionId': resource.promotion.id}) },
         { label: resource.code|default(resource.id) },
         { label: 'sylius.ui.edit'|trans }
     ]


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | no
| New feature?    | rather an improvement
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | triggered by #10509 😄 
| License         | MIT

The clue is to use entities **names** instead of **codes**, wherever it is possible. especially in entities that are _under_ other entities like coupons or variants.


Product variant edit:
Before:
![image](https://user-images.githubusercontent.com/13198869/61623526-14b4f500-ac77-11e9-88a4-ec177f812be9.png)

After:
![image](https://user-images.githubusercontent.com/13198869/61623469-fb13ad80-ac76-11e9-8df2-be7bd89532f1.png)

Without the variant name:
![image](https://user-images.githubusercontent.com/13198869/61623756-9147d380-ac77-11e9-83d0-b8c3144f45b0.png)

Channels edit:
Before:
![image](https://user-images.githubusercontent.com/13198869/61623602-3c0bc200-ac77-11e9-853b-a8611e789927.png)

After:
![image](https://user-images.githubusercontent.com/13198869/61623651-5b0a5400-ac77-11e9-893b-bc9fe32b724a.png)

 And while trying to unsuccessfully remove the name:
![image](https://user-images.githubusercontent.com/13198869/61623693-71181480-ac77-11e9-9f0d-e27b6582d685.png)

After (translation of names to Admin locale)
![image](https://user-images.githubusercontent.com/13198869/61624020-159a5680-ac78-11e9-9425-60b159f5f556.png)
![image](https://user-images.githubusercontent.com/13198869/61624038-21861880-ac78-11e9-9e5f-9b1be0100220.png)
![image](https://user-images.githubusercontent.com/13198869/61624000-0adfc180-ac78-11e9-8458-2d1788b31a10.png)


