### PR TITLE
Fix Psalm false-positives

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,6 +125,7 @@
         "phpstan/phpstan": "^0.11",
         "phpstan/phpstan-webmozart-assert": "^0.11",
         "phpunit/phpunit": "^7.0",
+        "psr/event-dispatcher": "^1.0",
         "sensiolabs/security-checker": "^5.0",
         "stripe/stripe-php": "^4.1",
         "sylius-labs/coding-standard": "^3.0",

--- a/symfony.lock
+++ b/symfony.lock
@@ -446,6 +446,9 @@
     "psr/container": {
         "version": "1.0.0"
     },
+    "psr/event-dispatcher": {
+        "version": "1.0.0"
+    },
     "psr/http-message": {
         "version": "1.0.1"
     },


### PR DESCRIPTION
Psalm does not recognize conditional definitions like the one used by Symfony's EventDispatcherInterface: https://github.com/symfony/contracts/blob/master/EventDispatcher/EventDispatcherInterface.php#L16