### PR TITLE
[Grid] Allow not to pass "apply_transition" button class

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/applyTransition.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/applyTransition.html.twig
@@ -2,6 +2,6 @@
     <form action="{{ path(options.link.route, options.link.parameters) }}" method="post">
         <input type="hidden" name="_csrf_token" value="{{ csrf_token(data.id) }}">
         <input type="hidden" name="_method" value="PUT">
-        <button class="ui loadable {{ options.class }} labeled icon button" type="submit"><i class="{{ action.icon }} icon"></i> {{ action.label|trans }}</button>
+        <button class="ui loadable {{ options.class|default }} labeled icon button" type="submit"><i class="{{ action.icon }} icon"></i> {{ action.label|trans }}</button>
     </form>
 {% endif %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I suppose it should not be required. It's quite weird to get an exception if you do not specify the color of the button 🐒 