### PR TITLE
[Shop] Use a menu builder for the tabs on the product page

### DIFF
--- a/UPGRADE-1.6.md
+++ b/UPGRADE-1.6.md
@@ -5,3 +5,7 @@ Require upgraded Sylius version using Composer:
 ```bash
 composer require sylius/sylius:~1.6.0
 ```
+
+### Deprecations
+
+The `@SyliusShop/Product/Show/Tabs/_content.html.twig` template is deprecated, product tabs should be rendered with the `sylius.shop.product_tabs` menu instead

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -39,3 +39,7 @@
     * The following configuration options were removed:
 
         * `sylius.mailer.templates`
+
+    * The following templates were removed:
+
+        * `@SyliusShop/Product/Show/Tabs/_content.html.twig`

--- a/src/Sylius/Bundle/ShopBundle/Event/ProductMenuBuilderEvent.php
+++ b/src/Sylius/Bundle/ShopBundle/Event/ProductMenuBuilderEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShopBundle\Event;
+
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
+use Sylius\Bundle\UiBundle\Menu\Event\MenuBuilderEvent;
+use Sylius\Component\Product\Model\ProductInterface;
+
+class ProductMenuBuilderEvent extends MenuBuilderEvent
+{
+    /** @var ProductInterface */
+    private $product;
+
+    public function __construct(FactoryInterface $factory, ItemInterface $menu, ProductInterface $product)
+    {
+        parent::__construct($factory, $menu);
+
+        $this->product = $product;
+    }
+
+    public function getProduct(): ProductInterface
+    {
+        return $this->product;
+    }
+}

--- a/src/Sylius/Bundle/ShopBundle/Menu/ProductTabsMenuBuilder.php
+++ b/src/Sylius/Bundle/ShopBundle/Menu/ProductTabsMenuBuilder.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShopBundle\Menu;
+
+use Knp\Menu\FactoryInterface;
+use Knp\Menu\ItemInterface;
+use Sylius\Bundle\ShopBundle\Event\ProductMenuBuilderEvent;
+use Sylius\Component\Core\Model\ProductInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+final class ProductTabsMenuBuilder
+{
+    public const EVENT_NAME = 'sylius.menu.shop.product.tabs';
+
+    /** @var FactoryInterface */
+    private $factory;
+
+    /** @var EventDispatcherInterface */
+    private $eventDispatcher;
+
+    public function __construct(FactoryInterface $factory, EventDispatcherInterface $eventDispatcher)
+    {
+        $this->factory = $factory;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function createMenu(array $options = []): ItemInterface
+    {
+        $menu = $this->factory->createItem('root');
+
+        if (!array_key_exists('product', $options) || !$options['product'] instanceof ProductInterface) {
+            return $menu;
+        }
+
+        /** @var ProductInterface $product */
+        $product = $options['product'];
+
+        $menu
+            ->addChild('details')
+            ->setAttribute('template', '@SyliusShop/Product/Show/Tabs/_details.html.twig')
+            ->setLabel('sylius.ui.details')
+            ->setCurrent(true)
+        ;
+
+        if (count($product->getAttributes()) > 0) {
+            $menu
+                ->addChild('attributes')
+                ->setAttribute('template', '@SyliusShop/Product/Show/Tabs/_attributes.html.twig')
+                ->setLabel('sylius.ui.attributes')
+            ;
+        }
+
+        $menu
+            ->addChild('reviews')
+            ->setAttribute('template', '@SyliusShop/Product/Show/Tabs/_reviews.html.twig')
+            ->setAttribute('item_count', count($product->getAcceptedReviews()))
+            ->setLabel('sylius.ui.reviews_with_count')
+        ;
+
+        $this->eventDispatcher->dispatch(
+            self::EVENT_NAME,
+            new ProductMenuBuilderEvent($this->factory, $menu, $product)
+        );
+
+        return $menu;
+    }
+}

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/menu.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/menu.xml
@@ -20,5 +20,11 @@
             <argument type="service" id="event_dispatcher" />
             <tag name="knp_menu.menu_builder" method="createMenu" alias="sylius.shop.account" />
         </service>
+
+        <service id="sylius.shop.menu_builder.product_tabs" class="Sylius\Bundle\ShopBundle\Menu\ProductTabsMenuBuilder">
+            <argument type="service" id="knp_menu.factory" />
+            <argument type="service" id="event_dispatcher" />
+            <tag name="knp_menu.menu_builder" method="createMenu" alias="sylius.shop.product_tabs" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/_content.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/_content.html.twig
@@ -1,3 +1,5 @@
+{% deprecated 'The "@SyliusShop/Product/Show/Tabs/_content.html.twig" template is deprecated, use the "sylius.shop.product_tabs" menu instead.' %}
+
 {% include '@SyliusShop/Product/Show/Tabs/_details.html.twig' %}
 {% include '@SyliusShop/Product/Show/Tabs/_attributes.html.twig' %}
 {% include '@SyliusShop/Product/Show/Tabs/_reviews.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/_menu.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/_menu.html.twig
@@ -1,5 +1,29 @@
-<a class="item active" data-tab="details">{{ 'sylius.ui.details'|trans }}</a>
-{% if product.attributes|length > 0 %}
-    <a class="item" data-tab="attributes">{{ 'sylius.ui.attributes'|trans }}</a>
-{% endif %}
-<a class="item" data-tab="reviews">{{ 'sylius.ui.reviews'|trans }} ({{ product.acceptedReviews|length }})</a>
+{% extends 'knp_menu.html.twig' %}
+
+{% block list %}
+<div class="ui top attached large tabular menu">
+    {% for item in item.children %}
+        {{ block('item') }}
+    {% endfor %}
+</div>
+{% for item in item.children %}
+    {% include item.attribute('template') with {configuration: options.configuration, 'product': options.product} %}
+{% endfor %}
+{% endblock %}
+
+{% block item %}
+    {%- set attributes = item.attributes %}
+    {%- set classes = item.attribute('class') is not empty ? [item.attribute('class')] : [] %}
+    {%- if item.actsLikeFirst %}
+        {%- set classes = classes|merge(['active']) %}
+    {%- endif %}
+    {%- if classes is not empty %}
+        {%- set attributes = attributes|merge({'class': classes|join(' ')}) %}
+    {%- endif %}
+    {%- if item.attribute('item_count') is not empty %}
+        {%- set label = item.label|transchoice(item.attribute('item_count')) %}
+    {%- else %}
+        {%- set label = item.label|trans %}
+    {%- endif %}
+    <a class="item{% if attributes.class is defined %} {{ attributes.class }}{% endif %}" data-tab="{{ item.name }}">{{ label }}</a>
+{% endblock %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_tabs.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_tabs.html.twig
@@ -1,5 +1,2 @@
-<div class="ui top attached large tabular menu">
-    {% include '@SyliusShop/Product/Show/Tabs/_menu.html.twig' %}
-</div>
-
-{% include '@SyliusShop/Product/Show/Tabs/_content.html.twig' %}
+{% set menu = knp_menu_get('sylius.shop.product_tabs', [], {'product': product}) %}
+{{ knp_menu_render(menu, {'template': '@SyliusShop/Product/Show/Tabs/_menu.html.twig', 'configuration': configuration, 'product': product}) }}

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
@@ -701,6 +701,7 @@ sylius:
         review_and_confirm_your_order: 'Review and confirm your order'
         review_details: 'Review details'
         reviews: 'Reviews'
+        reviews_with_count: 'Reviews (%count%)'
         roles: 'Roles'
         rules: 'Rules'
         sales: 'Sales'


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | probably
| Deprecations?   | yes <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | N/A
| License         | MIT

Right now there isn't a way for plugins to hook into the frontend product page and add new tabs to the display, so this pull request aims to make that a possibility using the same concept from https://github.com/Sylius/Sylius/pull/7468.

Note, I list BC break as "probably" because the `@SyliusShop/Product/Show/_tabs.html.twig` and `@SyliusShop/Product/Show/Tabs/_menu.html.twig` layouts are completely rewritten, which theoretically isn't an issue if you're just using the default layouts or you've overridden both of them in your own install; the default layout still produces the same end result and the override flow isn't impacted by this.  What probably is a break is if you've overwritten the `@SyliusShop/Product/Show/_tabs.html.twig` layout and not the `@SyliusShop/Product/Show/Tabs/_menu.html.twig` layout, but I don't have any bright ideas on this one without coming up with some awkward naming conventions for the menu builder based layouts.