### PR TITLE
Skip oauth_user_factory_is_not_overridden test if HWIOAuthBundle is not installed

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/test_services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/test_services.xml
@@ -54,17 +54,5 @@
         </service>
 
         <service id="sylius.liip.filter_service" alias="liip_imagine.service.filter" public="true" />
-
-        <service id="sylius.test.oauth.user_provider" class="Sylius\Bundle\CoreBundle\OAuth\UserProvider" public="true">
-            <argument type="string" id="%sylius.model.shop_user.class%" />
-            <argument type="service" id="sylius.factory.customer" />
-            <argument type="service" id="sylius.factory.shop_user" />
-            <argument type="service" id="sylius.repository.shop_user" />
-            <argument type="service" id="sylius.factory.oauth_user" />
-            <argument type="service" id="sylius.repository.oauth_user" />
-            <argument type="service" id="sylius.manager.shop_user" />
-            <argument type="service" id="sylius.canonicalizer" />
-            <argument type="service" id="sylius.repository.customer" />
-        </service>
     </services>
 </container>

--- a/tests/Functional/UpdatingUserPasswordEncoderTest.php
+++ b/tests/Functional/UpdatingUserPasswordEncoderTest.php
@@ -107,7 +107,13 @@ final class UpdatingUserPasswordEncoderTest extends WebTestCase
     /** @test */
     public function oauth_user_factory_is_not_overridden(): void
     {
-        $oAuthUserProvider = $this->client->getContainer()->get('sylius.test.oauth.user_provider');
+        if (!$this->client->getContainer()->has('sylius.oauth.user_provider')) {
+            $this->markTestSkipped('HWIOAuthBundle not installed');
+
+            return;
+        }
+
+        $oAuthUserProvider = $this->client->getContainer()->get('sylius.oauth.user_provider');
         $shopUserRepository = $this->client->getContainer()->get('sylius.repository.shop_user');
         $shopUser = $shopUserRepository->findOneByEmail('Oliver@doe.com');
         $initialOAuthAccounts = $shopUser->getOAuthAccounts()->count();


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | fixes #10530
| License         | MIT