### PR TITLE
Fix country flag selection by locale

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/views/Macro/flags.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Macro/flags.html.twig
@@ -4,5 +4,39 @@
 
 {% macro fromLocaleCode(locale_code) %}
     {% import _self as flags %}
-    {{ flags.fromCountryCode(locale_code|slice(-2)) }}
+    {% set locale_country = { 
+  		'ak':'gh',
+  		'am':'et',
+  		'am':'et',
+  		'be':'by',
+  		'bs':'ba',
+  		'cs':'cz',
+  		'cy':'wls',
+  		'da':'dk',
+  		'el':'gr',
+  		'et':'ee',
+  		'ga':'ie',
+  		'gd':'sct',
+  		'hi':'in',
+  		'hy':'am',
+  		'ja':'jp',
+  		'kk':'kz',
+  		'lo':'la',
+  		'my':'mm',
+  		'nl':'an',
+  		'sq':'al',
+  		'sr':'cs',
+  		'sv':'se',
+  		'tg':'tj',
+  		'tl':'ph',
+  		'uk':'ua',
+  		'vi':'vn'  
+      } 
+    %}
+    {% set locale_code = locale_code|slice(-2) %}
+    {% if locale_code in locale_country|keys %}
+        {{ flags.fromCountryCode(locale_country[locale_code]) }}
+    {% else %}
+        {{ flags.fromCountryCode(locale_code) }}
+    {% endif %}
 {% endmacro %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #10416, #9479
| License         | MIT

Sometimes happens that the [locale](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) and [country](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) codes are not equal.

That is why for some languages has [another flag](https://semantic-ui.com/elements/flag.html) displayed or flag completely absent.

At that moment, Ukraine(UA) become a colony of the United Kingdom(UK), Vietnam(VN) been invaded by the US Virgin Islands(VI), and the Czech Republic(CZ) has declared itself Serbia(CS) ...

☮️🌍
