### PR TITLE
Allow easier decoration/extension of the Order fixture

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
@@ -121,26 +121,7 @@ class OrderFixture extends AbstractFixture
         $countries = $this->countryRepository->findAll();
 
         for ($i = 0; $i < $options['amount']; ++$i) {
-            $channel = $this->faker->randomElement($channels);
-            $customer = $this->faker->randomElement($customers);
-            $countryCode = $this->faker->randomElement($countries)->getCode();
-
-            $currencyCode = $channel->getBaseCurrency()->getCode();
-            $localeCode = $this->faker->randomElement($channel->getLocales()->toArray())->getCode();
-
-            /** @var OrderInterface $order */
-            $order = $this->orderFactory->createNew();
-            $order->setChannel($channel);
-            $order->setCustomer($customer);
-            $order->setCurrencyCode($currencyCode);
-            $order->setLocaleCode($localeCode);
-
-            $this->generateItems($order);
-
-            $this->address($order, $countryCode);
-            $this->selectShipping($order);
-            $this->selectPayment($order);
-            $this->completeCheckout($order);
+            $order = $this->createOrder($channels, $customers, $countries);
 
             $this->orderManager->persist($order);
 
@@ -161,6 +142,38 @@ class OrderFixture extends AbstractFixture
     }
 
     /**
+     * @param array $channels
+     * @param array $customers
+     * @param array $countries
+     * @return OrderInterface
+     */
+    protected function createOrder(array $channels, array $customers, array $countries): OrderInterface
+    {
+        $channel = $this->faker->randomElement($channels);
+        $customer = $this->faker->randomElement($customers);
+        $countryCode = $this->faker->randomElement($countries)->getCode();
+
+        $currencyCode = $channel->getBaseCurrency()->getCode();
+        $localeCode = $this->faker->randomElement($channel->getLocales()->toArray())->getCode();
+
+        /** @var OrderInterface $order */
+        $order = $this->orderFactory->createNew();
+        $order->setChannel($channel);
+        $order->setCustomer($customer);
+        $order->setCurrencyCode($currencyCode);
+        $order->setLocaleCode($localeCode);
+
+        $this->generateItems($order);
+
+        $this->address($order, $countryCode);
+        $this->selectShipping($order);
+        $this->selectPayment($order);
+        $this->completeCheckout($order);
+
+        return $order;
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function configureOptionsNode(ArrayNodeDefinition $optionsNode): void
@@ -171,7 +184,7 @@ class OrderFixture extends AbstractFixture
         ;
     }
 
-    private function generateItems(OrderInterface $order): void
+    protected function generateItems(OrderInterface $order): void
     {
         $numberOfItems = random_int(1, 5);
         $products = $this->productRepository->findAll();
@@ -190,7 +203,7 @@ class OrderFixture extends AbstractFixture
         }
     }
 
-    private function address(OrderInterface $order, string $countryCode): void
+    protected function address(OrderInterface $order, string $countryCode): void
     {
         /** @var AddressInterface $address */
         $address = $this->addressFactory->createNew();
@@ -207,7 +220,7 @@ class OrderFixture extends AbstractFixture
         $this->applyCheckoutStateTransition($order, OrderCheckoutTransitions::TRANSITION_ADDRESS);
     }
 
-    private function selectShipping(OrderInterface $order): void
+    protected function selectShipping(OrderInterface $order): void
     {
         $shippingMethod = $this
             ->faker
@@ -224,7 +237,7 @@ class OrderFixture extends AbstractFixture
         }
     }
 
-    private function selectPayment(OrderInterface $order): void
+    protected function selectPayment(OrderInterface $order): void
     {
         $paymentMethod = $this
             ->faker
@@ -241,7 +254,7 @@ class OrderFixture extends AbstractFixture
         }
     }
 
-    private function completeCheckout(OrderInterface $order): void
+    protected function completeCheckout(OrderInterface $order): void
     {
         if ($this->faker->boolean(25)) {
             $order->setNotes($this->faker->sentence);
@@ -250,7 +263,7 @@ class OrderFixture extends AbstractFixture
         $this->applyCheckoutStateTransition($order, OrderCheckoutTransitions::TRANSITION_COMPLETE);
     }
 
-    private function applyCheckoutStateTransition(OrderInterface $order, string $transition): void
+    protected function applyCheckoutStateTransition(OrderInterface $order, string $transition): void
     {
         $this->stateMachineFactory->get($order, OrderCheckoutTransitions::GRAPH)->apply($transition);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.4 or 1.5 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->

I'm not really happy with the new `createOrder` method as it accepts three arrays which are then used to fetch a random element. But it's also not acceptable to call `findAll` n times just to pick one random element out of the collection. Any ideas how to solve this better? One solution might be properties holding the the three result sets...