### PR TITLE
BugFix in wrong comparison object and array

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/EventListener/NonChannelLocaleListener.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/NonChannelLocaleListener.php
@@ -67,7 +67,7 @@ final class NonChannelLocaleListener
         }
 
         $requestLocale = $request->getLocale();
-        if (!in_array($requestLocale, $this->channelBasedLocaleProvider->getAvailableLocalesCodes(), true)) {
+        if (!in_array($requestLocale->getCode(), $this->channelBasedLocaleProvider->getAvailableLocalesCodes(), true)) {
             throw new NotFoundHttpException(
                 sprintf('The "%s" locale is unavailable in this channel.', $requestLocale)
             );


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4 and possibly 1.5 
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | /
| License         | MIT

Bugfix in wrong comparison between object and array this makes the NonChannelLocaleListener not usable and it just doesn't work. Important one to fix.