### PR TITLE
Fix in wrong comaprison object and array

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/EventListener/NonChannelLocaleListener.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/NonChannelLocaleListener.php
@@ -67,7 +67,7 @@ final class NonChannelLocaleListener
         }
 
         $requestLocale = $request->getLocale();
-        if (!in_array($requestLocale, $this->channelBasedLocaleProvider->getAvailableLocalesCodes(), true)) {
+        if (!in_array($requestLocale->getCode(), $this->channelBasedLocaleProvider->getAvailableLocalesCodes(), true)) {
             throw new NotFoundHttpException(
                 sprintf('The "%s" locale is unavailable in this channel.', $requestLocale)
             );


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4 possibly later versions aswell
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no/
| Deprecations?   | no
| Related tickets | /
| License         | MIT

Wrong comparison between object and array in in_array this make the NonChannelLocaleListener not usable 
