### PR TITLE
Date field type doesn't exist

### DIFF
--- a/docs/components_and_bundles/bundles/SyliusGridBundle/configuration.rst
+++ b/docs/components_and_bundles/bundles/SyliusGridBundle/configuration.rst
@@ -54,13 +54,14 @@ Here you will find all configuration options of ``sylius_grid``.
                         form_options: { }
                         default_value: ~
                     date:
-                        type: date # Type of filter
+                        type: datetime # Type of filter
                         label: app.ui.created_at
                         enabled: true
                         template: ~
                         position: 100
                         options:
                             field: createdAt
+                            format: 'Y-m-d H:i' # optional
                         form_options: { }
                         default_value: ~
                     channel:


### PR DESCRIPTION
When using the `date` I get:

```
An exception has been thrown during the rendering of a template ("Grid field service "date" does not exist, available grid field services: "currency", "datetime", "string", "twig"").
```

| Q               | A
| --------------- | -----
| Branch?         | >= 1.4
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.4 or 1.5 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
