### PR TITLE
[PayumBundle] Fixed payment amount when using partial payments

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Action/AuthorizePaymentAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Action/AuthorizePaymentAction.php
@@ -52,10 +52,9 @@ final class AuthorizePaymentAction extends GatewayAwareAction
                 $this->gateway->execute($convert = new Convert($payment, 'array', $request->getToken()));
                 $payment->setDetails($convert->getResult());
             } catch (RequestNotSupportedException $e) {
-                $totalAmount = $order->getTotal();
                 $payumPayment = new PayumPayment();
                 $payumPayment->setNumber($order->getNumber());
-                $payumPayment->setTotalAmount($totalAmount);
+                $payumPayment->setTotalAmount($payment->getAmount());
                 $payumPayment->setCurrencyCode($order->getCurrencyCode());
                 $payumPayment->setClientEmail($order->getCustomer()->getEmail());
                 $payumPayment->setClientId($order->getCustomer()->getId());

--- a/src/Sylius/Bundle/PayumBundle/Action/CapturePaymentAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Action/CapturePaymentAction.php
@@ -55,10 +55,9 @@ final class CapturePaymentAction extends GatewayAwareAction
                 $this->gateway->execute($convert = new Convert($payment, 'array', $request->getToken()));
                 $payment->setDetails($convert->getResult());
             } catch (RequestNotSupportedException $e) {
-                $totalAmount = $order->getTotal();
                 $payumPayment = new PayumPayment();
                 $payumPayment->setNumber($order->getNumber());
-                $payumPayment->setTotalAmount($totalAmount);
+                $payumPayment->setTotalAmount($payment->getAmount());
                 $payumPayment->setCurrencyCode($order->getCurrencyCode());
                 $payumPayment->setClientEmail($order->getCustomer()->getEmail());
                 $payumPayment->setClientId($order->getCustomer()->getId());

--- a/src/Sylius/Bundle/PayumBundle/Provider/PaymentDescriptionProvider.php
+++ b/src/Sylius/Bundle/PayumBundle/Provider/PaymentDescriptionProvider.php
@@ -40,7 +40,7 @@ final class PaymentDescriptionProvider implements PaymentDescriptionProviderInte
             $order->getItems()->count(),
             [
                 '%items%' => $order->getItems()->count(),
-                '%total%' => round($order->getTotal() / 100, 2),
+                '%total%' => round($payment->getAmount() / 100, 2),
             ]
         );
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.5
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #8958
| License         | MIT

As mentioned in #8958, the `AuthorizePaymentAction` and `CapturePaymentAction` (as well as the `PaymentDescriptorProvider`) should use the payment amount instead of the total order amount by default. This allows the use of partial payments as they are supported by Sylius.