### PR TITLE
Fix lazy choice tree will not automatically expanded

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-lazy-choice-tree.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-lazy-choice-tree.js
@@ -87,6 +87,8 @@ $.fn.extend({
             content.append(leafContainerElement);
             loader.removeClass('active');
             loadedLeafs.push(parentCode);
+
+            leafContainerElement.toggle();
           },
         });
       }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.5
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #10577 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.4 or 1.5 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
