### PR TITLE
Fixed: Sortable option

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/promotion.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/promotion.yml
@@ -22,7 +22,7 @@ sylius_grid:
                     type: twig
                     label: sylius.ui.name
                     path: .
-                    sortable: ~
+                    sortable: name
                     options:
                         template: "@SyliusUi/Grid/Field/nameAndDescription.html.twig"
                 couponBased:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/promotion.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/promotion.yml
@@ -18,7 +18,7 @@ sylius_grid:
                     type: string
                     label: sylius.ui.code
                     sortable: ~
-                name:
+                nameAndDescription:
                     type: twig
                     label: sylius.ui.name
                     path: .


### PR DESCRIPTION
It can't be default for complex (twig) columns I guess...

| Q               | A
| --------------- | -----
| Branch?         | 1.6
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | not sure
| Deprecations?   | no
| Related tickets | 
| License         | MIT
