### PR TITLE
[Docs] Fix incorrect documentation regarding payments

### DIFF
--- a/docs/book/orders/payments.rst
+++ b/docs/book/orders/payments.rst
@@ -118,21 +118,10 @@ Other Payment Gateways
 
 .. note::
 
-    Learn more about integrating payment gateways in `the Payum docs <https://github.com/Payum/Payum/blob/master/docs/index.md>`_.
+    Learn more about integrating payment gateways in the :doc:`dedicated guide </cookbook/payments/custom-payment-gateway>` and in `the Payum docs <https://github.com/Payum/Payum/blob/master/docs/index.md>`_.
 
 When the Payment Gateway you are trying to use does have a bridge available and you integrate them on your own,
 use our guide on :doc:`extension development </plugins/creating-plugin>`.
-
-.. tip::
-
-    You'll probably need also this kind of configuration in your ``config/packages/payum.yaml`` for the gateway's factory:
-
-    .. code-block:: yaml
-
-        payum:
-            gateways:
-                yourgateway:
-                    factory: yourgateway
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
If you configure a payment gateway the way it's now hinted in the docs, it would prevent the gateway from receiving configuration from the database. This issue may be really frustrating and hard to debug for beginners (like me).
Configuring a factory by hand is not needed if it's been correctly configured with the `payum.gateway_factory_builder` tag.

| Q               | A
| --------------- | -----
| Branch?         | 1.5
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

