### PR TITLE
Disable chrome autocomplete

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/app.js
@@ -75,4 +75,6 @@ $(document).ready(() => {
   $(document).provinceField();
   $(document).variantPrices();
   $(document).variantImages();
+
+  $('body').find('input[autocomplete="off"]').prop('autocomplete', 'disable');
 });


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Chrome has changed the way we can block autocomplete. This is the simplest way to change the automatically generated Semantics input properties.