### PR TITLE
[Fixture] Do not skip payments and shipments manually

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
@@ -16,13 +16,12 @@ namespace Sylius\Bundle\CoreBundle\Fixture;
 use Doctrine\Common\Persistence\ObjectManager;
 use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
-use Sylius\Component\Core\Checker\OrderPaymentMethodSelectionRequirementCheckerInterface;
-use Sylius\Component\Core\Checker\OrderShippingMethodSelectionRequirementCheckerInterface;
 use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\OrderCheckoutStates;
 use Sylius\Component\Core\OrderCheckoutTransitions;
 use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
 use Sylius\Component\Core\Repository\ShippingMethodRepositoryInterface;
@@ -70,12 +69,6 @@ class OrderFixture extends AbstractFixture
     /** @var StateMachineFactoryInterface */
     private $stateMachineFactory;
 
-    /** @var OrderShippingMethodSelectionRequirementCheckerInterface */
-    private $orderShippingMethodSelectionRequirementChecker;
-
-    /** @var OrderPaymentMethodSelectionRequirementCheckerInterface */
-    private $orderPaymentMethodSelectionRequirementChecker;
-
     /** @var \Faker\Generator */
     private $faker;
 
@@ -91,9 +84,7 @@ class OrderFixture extends AbstractFixture
         PaymentMethodRepositoryInterface $paymentMethodRepository,
         ShippingMethodRepositoryInterface $shippingMethodRepository,
         FactoryInterface $addressFactory,
-        StateMachineFactoryInterface $stateMachineFactory,
-        OrderShippingMethodSelectionRequirementCheckerInterface $orderShippingMethodSelectionRequirementChecker,
-        OrderPaymentMethodSelectionRequirementCheckerInterface $orderPaymentMethodSelectionRequirementChecker
+        StateMachineFactoryInterface $stateMachineFactory
     ) {
         $this->orderFactory = $orderFactory;
         $this->orderItemFactory = $orderItemFactory;
@@ -107,8 +98,6 @@ class OrderFixture extends AbstractFixture
         $this->shippingMethodRepository = $shippingMethodRepository;
         $this->addressFactory = $addressFactory;
         $this->stateMachineFactory = $stateMachineFactory;
-        $this->orderShippingMethodSelectionRequirementChecker = $orderShippingMethodSelectionRequirementChecker;
-        $this->orderPaymentMethodSelectionRequirementChecker = $orderPaymentMethodSelectionRequirementChecker;
 
         $this->faker = \Faker\Factory::create();
     }
@@ -228,9 +217,7 @@ class OrderFixture extends AbstractFixture
 
     private function selectShipping(OrderInterface $order): void
     {
-        if (!$this->orderShippingMethodSelectionRequirementChecker->isShippingMethodSelectionRequired($order)) {
-            $this->applyCheckoutStateTransition($order, OrderCheckoutTransitions::TRANSITION_SKIP_SHIPPING);
-
+        if ($order->getCheckoutState() === OrderCheckoutStates::STATE_SHIPPING_SKIPPED) {
             return;
         }
 
@@ -259,9 +246,7 @@ class OrderFixture extends AbstractFixture
 
     private function selectPayment(OrderInterface $order): void
     {
-        if (!$this->orderPaymentMethodSelectionRequirementChecker->isPaymentMethodSelectionRequired($order)) {
-            $this->applyCheckoutStateTransition($order, OrderCheckoutTransitions::TRANSITION_SKIP_PAYMENT);
-
+        if ($order->getCheckoutState() === OrderCheckoutStates::STATE_PAYMENT_SKIPPED) {
             return;
         }
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures.xml
@@ -194,8 +194,6 @@
             <argument type="service" id="sylius.repository.shipping_method" />
             <argument type="service" id="sylius.factory.address" />
             <argument type="service" id="sm.factory" />
-            <argument type="service" id="sylius.checker.order_shipping_method_selection_requirement" />
-            <argument type="service" id="sylius.checker.order_payment_method_selection_requirement" />
 
             <tag name="sylius_fixtures.fixture" />
         </service>

--- a/src/Sylius/Component/Core/OrderCheckoutStates.php
+++ b/src/Sylius/Component/Core/OrderCheckoutStates.php
@@ -21,6 +21,7 @@ final class OrderCheckoutStates
     public const STATE_PAYMENT_SELECTED = 'payment_selected';
     public const STATE_PAYMENT_SKIPPED = 'payment_skipped';
     public const STATE_SHIPPING_SELECTED = 'shipping_selected';
+    public const STATE_SHIPPING_SKIPPED = 'shipping_skipped';
 
     private function __construct()
     {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | introduces in https://github.com/Sylius/Sylius/pull/10618
| License         | MIT

There is no need to skip payment and shipment in order manually, as it's done automatically with [this callback](https://github.com/Sylius/Sylius/blob/60134b783c51c4b9da0b58c5a54482824a8baf8a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order_checkout.yml#L53) 🎉 