### PR TITLE
[Docs] Add missing items to customization guide menu

### DIFF
--- a/docs/customization/index.rst
+++ b/docs/customization/index.rst
@@ -18,9 +18,9 @@ The Customization Guide is helpful while wanting to adapt Sylius to your persona
     flash
     state_machine
     grid
-    tips_and_tricks
     fixtures
     fixture_suites
+    tips_and_tricks
 
 .. include:: /customization/map.rst.inc
 

--- a/docs/customization/map.rst.inc
+++ b/docs/customization/map.rst.inc
@@ -10,4 +10,6 @@
 * :doc:`/customization/flash`
 * :doc:`/customization/state_machine`
 * :doc:`/customization/grid`
+* :doc:`/customization/fixtures`
+* :doc:`/customization/fixture_suites`
 * :doc:`/customization/tips_and_tricks`


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related to https://github.com/Sylius/Sylius/pull/10395
| License         | MIT

I've also changed the order in the left sidebar menu

<img width="727" alt="Zrzut ekranu 2019-08-26 o 15 54 22" src="https://user-images.githubusercontent.com/6212718/63695924-016aeb80-c81a-11e9-9e41-a3ffe0a256d9.png">
<img width="276" alt="Zrzut ekranu 2019-08-26 o 15 54 26" src="https://user-images.githubusercontent.com/6212718/63695925-016aeb80-c81a-11e9-8518-4e4d359ecfa4.png">

