### PR TITLE
[PayumBundle] Fix SK translation

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Resources/translations/messages.sk.yml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/translations/messages.sk.yml
@@ -20,4 +20,4 @@ sylius:
         stripe_checkout: Prúžok Pokladňa
     payum_action:
         payment:
-            description: Platba obsahuje %items% položku v hodnote %total% | Platba obsahuje %items% položky / položiek v hodnote %total%
+            description: Platba obsahuje %items% položku v hodnote %total%|Platba obsahuje %items% položky v hodnote %total%|Platba obsahuje %items% položiek v hodnote %total%


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | >=1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Complete checkout is failing with missing translation when order item count is greater then 3 and order is payed by Payum.