### PR TITLE
Fix false translation for sylius.form.country.select in DE

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.de.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.de.yml
@@ -18,7 +18,7 @@ sylius:
             add_province: Bundesland hinzufügen
             name: Name
             provinces: Bundesländer
-            select: Bundesland auswählen
+            select: Land auswählen
             enabled: Aktiviert
         province:
             name: Name

--- a/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.de.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.de.yml
@@ -36,7 +36,7 @@ sylius:
             scope: Umfang
             scopes:
                 all: Alle
-            select: Bundesland auswählen
+            select: Versandgebiet auswählen
             select_scope: Bereich wählen
         zone_member:
-            select: Bundesland auswählen
+            select: Versandgebiet Mitglied auswählen

--- a/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.de.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.de.yml
@@ -39,4 +39,4 @@ sylius:
             select: Versandgebiet auswählen
             select_scope: Bereich wählen
         zone_member:
-            select: Versandgebiet Mitglied auswählen
+            select: Mitglied auswählen


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | >=1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

Fix false translation for sylius.form.country.select in DE
