### PR TITLE
Add authorize constant to payment transitions

### DIFF
--- a/src/Sylius/Component/Payment/PaymentTransitions.php
+++ b/src/Sylius/Component/Payment/PaymentTransitions.php
@@ -22,6 +22,7 @@ final class PaymentTransitions
     public const TRANSITION_COMPLETE = 'complete';
     public const TRANSITION_FAIL = 'fail';
     public const TRANSITION_CANCEL = 'cancel';
+    public const TRANSITION_AUTHORIZE = 'authorize';
     public const TRANSITION_REFUND = 'refund';
     public const TRANSITION_VOID = 'void';
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

It seems like the authorize transition has no constant on the payment.