### PR TITLE
Fix ChannelCollector related serialization issue in Symfony profiler

### DIFF
--- a/src/Sylius/Bundle/ChannelBundle/Collector/ChannelCollector.php
+++ b/src/Sylius/Bundle/ChannelBundle/Collector/ChannelCollector.php
@@ -35,12 +35,12 @@ final class ChannelCollector extends DataCollector
 
         $this->data = [
             'channel' => null,
-            'channels' => $channelRepository->findAll(),
+            'channels' => array_map([$this, 'pluckChannel'], $channelRepository->findAll()),
             'channel_change_support' => $channelChangeSupport,
         ];
     }
 
-    public function getChannel(): ?ChannelInterface
+    public function getChannel(): ?array
     {
         return $this->data['channel'];
     }
@@ -64,7 +64,7 @@ final class ChannelCollector extends DataCollector
     public function collect(Request $request, Response $response, \Exception $exception = null): void
     {
         try {
-            $this->data['channel'] = $this->channelContext->getChannel();
+            $this->data['channel'] = $this->pluckChannel($this->channelContext->getChannel());
         } catch (ChannelNotFoundException $exception) {
         }
     }
@@ -83,5 +83,14 @@ final class ChannelCollector extends DataCollector
     public function getName(): string
     {
         return 'sylius.channel_collector';
+    }
+
+    private function pluckChannel(ChannelInterface $channel): array
+    {
+        return [
+            'name' => $channel->getName(),
+            'hostname' => $channel->getHostname(),
+            'code' => $channel->getCode(),
+        ];
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | unlikely, but possible
| Deprecations?   | no
| Related tickets | fixes #10223
| License         | MIT

This is very annoying long standing issue.

I'm pretty sure this will fix the issue (it does in our case). As a side effect, this is more efficient, as there is less data needed to be serialized. 

This issue is related to circular references inside Channel model. In our case we can reproduce with

```php
$n = new Channel();
$locale = new Locale();

$n->addLocale($locale);
$n->setDefaultLocale($locale);

$this->data = [
    'channel' => null,
    'channels' => [$n],
    'channel_change_support' => $channelChangeSupport,
];
```

inside ChannelCollector


I'm aware changing return type is technically BC break, but it's unlikely somebody uses this class. If this is an issue, please advise how to continue.