### PR TITLE
[Attributes] Add FloatAttributeType Feature

### DIFF
--- a/features/product/managing_product_attributes/adding_float_product_attribute.feature
+++ b/features/product/managing_product_attributes/adding_float_product_attribute.feature
@@ -1,0 +1,23 @@
+@managing_product_attributes
+Feature: Adding a new float product attribute
+    In order to show specific product's parameters to customer
+    As an Administrator
+    I want to add a new float product attribute
+
+    Background:
+        Given the store is available in "English (United States)"
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Adding a new float product attribute
+        When I want to create a new float product attribute
+        And I specify its code as "display_size"
+        And I name it "Display Size" in "English (United States)"
+        And I add it
+        Then I should be notified that it has been successfully created
+        And the float attribute "Display Size" should appear in the store
+
+    @ui
+    Scenario: Seeing disabled type field while adding a float product attribute
+        When I want to create a new float product attribute
+        Then the type field should be disabled

--- a/features/product/managing_products/adding_product_with_float_attribute.feature
+++ b/features/product/managing_products/adding_product_with_float_attribute.feature
@@ -1,0 +1,22 @@
+@managing_products
+Feature: Adding a new product with a float attribute
+    In order to extend my merchandise with more complex products
+    As an Administrator
+    I want to add a new product with a float attribute to the shop
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a float product attribute "Display Size"
+        And I am logged in as an administrator
+
+    @ui @javascript
+    Scenario: Adding a float attribute to a product
+        When I want to create a new simple product
+        And I specify its code as "display_size"
+        And I name it "Smartphone" in "English (United States)"
+        And I set its price to "$100.00" for "United States" channel
+        And I set its "Display Size" attribute to "12.5" in "English (United States)"
+        And I add it
+        Then I should be notified that it has been successfully created
+        And the product "Smartphone" should appear in the store
+        And attribute "Display Size" of product "Smartphone" should be "12.5"

--- a/src/Sylius/Behat/Context/Setup/ProductAttributeContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductAttributeContext.php
@@ -63,7 +63,7 @@ final class ProductAttributeContext implements Context
     }
 
     /**
-     * @Given /^the store has(?:| also)(?:| a| an) (text|textarea|integer|percent) product attribute "([^"]+)"$/
+     * @Given /^the store has(?:| also)(?:| a| an) (text|textarea|integer|percent|float) product attribute "([^"]+)"$/
      */
     public function theStoreHasAProductAttribute(string $type, string $name): void
     {

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/FloatAttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType/FloatAttributeType.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AttributeBundle\Form\Type\AttributeType;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class FloatAttributeType extends AbstractType
+{
+    public function getParent(): string
+    {
+        return NumberType::class;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver
+            ->setDefaults([
+                'label' => false,
+            ])
+            ->setRequired('configuration')
+            ->setDefined('locale_code')
+        ;
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_attribute_type_float';
+    }
+}

--- a/src/Sylius/Bundle/AttributeBundle/Resources/config/services/attribute_types.xml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/config/services/attribute_types.xml
@@ -36,6 +36,11 @@
                  form-type="Sylius\Bundle\AttributeBundle\Form\Type\AttributeType\IntegerAttributeType" />
         </service>
 
+        <service id="sylius.attribute_type.float" class="Sylius\Component\Attribute\AttributeType\FloatAttributeType">
+            <tag name="sylius.attribute.type" attribute-type="float" label="Float"
+                 form-type="Sylius\Bundle\AttributeBundle\Form\Type\AttributeType\FloatAttributeType"/>
+        </service>
+
         <service id="sylius.attribute_type.percent" class="Sylius\Component\Attribute\AttributeType\PercentAttributeType">
             <tag name="sylius.attribute.type" attribute-type="percent" label="Percent"
                  form-type="Sylius\Bundle\AttributeBundle\Form\Type\AttributeType\PercentAttributeType" />

--- a/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.en.yml
@@ -14,6 +14,7 @@ sylius:
             configuration: Configuration
             date: Date
             datetime: Datetime
+            float: Float
             integer: Integer
             percent: Percent
             select: Select

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
@@ -352,6 +352,7 @@ sylius:
         filters: 'Filters'
         first_name: 'First name'
         fixed_discount: 'Fixed discount'
+        float: 'Float'
         for_products: 'For products'
         for_taxons: 'For taxons'
         for_variants: 'For variants'

--- a/src/Sylius/Component/Attribute/AttributeType/FloatAttributeType.php
+++ b/src/Sylius/Component/Attribute/AttributeType/FloatAttributeType.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Attribute\AttributeType;
+
+use Sylius\Component\Attribute\Model\AttributeValueInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+final class FloatAttributeType implements AttributeTypeInterface
+{
+    public const TYPE = 'float';
+
+    public function getStorageType(): string
+    {
+        return AttributeValueInterface::STORAGE_FLOAT;
+    }
+
+    public function getType(): string
+    {
+        return self::TYPE;
+    }
+
+    public function validate(
+        AttributeValueInterface $attributeValue,
+        ExecutionContextInterface $context,
+        array $configuration
+    ): void {
+        if (!isset($configuration['required'])) {
+            return;
+        }
+
+        $value = $attributeValue->getValue();
+
+        foreach ($this->getValidationErrors($context, $value) as $error) {
+            $context
+                ->buildViolation($error->getMessage())
+                ->atPath('value')
+                ->addViolation()
+            ;
+        }
+    }
+
+    private function getValidationErrors(ExecutionContextInterface $context, ?float $value): ConstraintViolationListInterface
+    {
+        return $context->getValidator()->validate($value, [new NotBlank([])]);
+    }
+}

--- a/src/Sylius/Component/Attribute/spec/AttributeType/FloatAttributeTypeSpec.php
+++ b/src/Sylius/Component/Attribute/spec/AttributeType/FloatAttributeTypeSpec.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Attribute\AttributeType;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Component\Attribute\AttributeType\AttributeTypeInterface;
+use Sylius\Component\Attribute\AttributeType\FloatAttributeType;
+use Sylius\Component\Attribute\AttributeType\PercentAttributeType;
+use Sylius\Component\Attribute\Model\AttributeInterface;
+use Sylius\Component\Attribute\Model\AttributeValueInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+final class FloatAttributeTypeSpec extends ObjectBehavior
+{
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(FloatAttributeType::class);
+    }
+
+    function it_implements_attribute_type_interface(): void
+    {
+        $this->shouldImplement(AttributeTypeInterface::class);
+    }
+
+    function its_storage_type_is_text(): void
+    {
+        $this->getStorageType()->shouldReturn('float');
+    }
+
+    function its_type_is_text(): void
+    {
+        $this->getType()->shouldReturn('float');
+    }
+
+    function it_checks_if_attribute_value_is_valid(
+        AttributeInterface $attribute,
+        AttributeValueInterface $attributeValue,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder,
+        ConstraintViolationInterface $constraintViolation,
+        ConstraintViolationListInterface $constraintViolationList,
+        ExecutionContextInterface $context,
+        ValidatorInterface $validator
+    ): void {
+        $attributeValue->getAttribute()->willReturn($attribute);
+
+        $attributeValue->getValue()->willReturn(null);
+
+        $context->getValidator()->willReturn($validator);
+        $validator->validate(null, Argument::containing(Argument::type(NotBlank::class)))->willReturn($constraintViolationList);
+
+        $constraintViolationList->rewind()->shouldBeCalled();
+        $constraintViolationList->valid()->willReturn(true, false);
+        $constraintViolationList->current()->willReturn($constraintViolation);
+        $constraintViolationList->next()->shouldBeCalled();
+
+        $constraintViolation->getMessage()->willReturn('error message');
+
+        $context->buildViolation('error message')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->atPath('value')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($attributeValue, $context, ['required' => true]);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.4 or 1.5 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
![Selection_001](https://user-images.githubusercontent.com/645895/65385834-925ab700-dd33-11e9-977e-0e353ae7e4d5.png)

This feature adds a float attribute type. As future development it would be nice the [scale](https://symfony.com/doc/current/reference/forms/types/number.html#scale) option of  NumberType to be configurable. 
