### PR TITLE
Allow custom productName and variantName

### DIFF
--- a/src/Sylius/Component/Core/Order/OrderItemNamesSetter.php
+++ b/src/Sylius/Component/Core/Order/OrderItemNamesSetter.php
@@ -26,11 +26,11 @@ final class OrderItemNamesSetter implements OrderItemNamesSetterInterface
         foreach ($order->getItems() as $item) {
             $variant = $item->getVariant();
 
-            if (null !== $variant) {
+            if (null === $item->getVariantName() && null !== $variant) {
                 $item->setVariantName($variant->getTranslation($localeCode)->getName());
             }
 
-            if (null !== $variant && null !== $variant->getProduct()) {
+            if (null === $item->getProductName() && null !== $variant && null !== $variant->getProduct()) {
                 $item->setProductName($variant->getProduct()->getTranslation($localeCode)->getName());
             }
         }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | all
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

When setting up a custom order sometime it's useful to set some additional informations about the variant or the product name. For exemple in my case it was to add a period infos on a renewal subscription order.

I set the test on `null` value but maybe it could be safer to test it for an empty value ? 
