### PR TITLE
[Currency] added parameterized currency during installation

### DIFF
--- a/docs/book/installation/installation.rst
+++ b/docs/book/installation/installation.rst
@@ -57,7 +57,8 @@ After everything is in place, run the following command to install Sylius:
 
     During the ``sylius:install`` command you will be asked to provide important information, but also its execution ensures
     that the default **currency** (USD) and the default **locale** (English - US) are set.
-    They can be changed later, respectively in the "Configuration > Channels" section of the admin and in the ``config/services.yaml`` file.
+    They can be changed later, respectively in the "Configuration > Channels" section of the admin and in the ``config/services.yaml`` file. If you want
+    to change these before running the installation command, set the ``locale`` and ``sylius_installer_currency`` parameters in the ``config/services.yaml`` file.
     From now on all the prices will be stored in the database in USD as integers, and all the products will have to be added with a base american english name translation.
 
 Installing assets

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/CurrencySetup.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/CurrencySetup.php
@@ -30,6 +30,9 @@ final class CurrencySetup implements CurrencySetupInterface
     /** @var FactoryInterface */
     private $currencyFactory;
 
+    /** @var string */
+    private $currency;
+
     public function __construct(RepositoryInterface $currencyRepository, FactoryInterface $currencyFactory, string $currency = 'CAD')
     {
         $this->currencyRepository = $currencyRepository;

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/CurrencySetup.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/CurrencySetup.php
@@ -30,10 +30,11 @@ final class CurrencySetup implements CurrencySetupInterface
     /** @var FactoryInterface */
     private $currencyFactory;
 
-    public function __construct(RepositoryInterface $currencyRepository, FactoryInterface $currencyFactory)
+    public function __construct(RepositoryInterface $currencyRepository, FactoryInterface $currencyFactory, string $currency = 'CAD')
     {
         $this->currencyRepository = $currencyRepository;
         $this->currencyFactory = $currencyFactory;
+        $this->currency = trim($currency);
     }
 
     /**
@@ -79,7 +80,7 @@ final class CurrencySetup implements CurrencySetupInterface
 
     private function getNewCurrencyCode(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper): string
     {
-        $question = new Question('Currency (press enter to use USD): ', 'USD');
+        $question = new Question('Currency (press enter to use '.$this->currency.'): ', $this->currency);
 
         return trim($questionHelper->ask($input, $output, $question));
     }

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/CurrencySetup.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/CurrencySetup.php
@@ -33,7 +33,7 @@ final class CurrencySetup implements CurrencySetupInterface
     /** @var string */
     private $currency;
 
-    public function __construct(RepositoryInterface $currencyRepository, FactoryInterface $currencyFactory, string $currency = 'CAD')
+    public function __construct(RepositoryInterface $currencyRepository, FactoryInterface $currencyFactory, string $currency = 'USD')
     {
         $this->currencyRepository = $currencyRepository;
         $this->currencyFactory = $currencyFactory;

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/CurrencySetup.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/CurrencySetup.php
@@ -83,7 +83,7 @@ final class CurrencySetup implements CurrencySetupInterface
 
     private function getNewCurrencyCode(InputInterface $input, OutputInterface $output, QuestionHelper $questionHelper): string
     {
-        $question = new Question('Currency (press enter to use '.$this->currency.'): ', $this->currency);
+        $question = new Question(sprintf('Currency (press enter to use %s): ', $this->currency), $this->currency);
 
         return trim($questionHelper->ask($input, $output, $question));
     }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
@@ -12,6 +12,9 @@
 -->
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="currency">USD</parameter>
+    </parameters>
     <services>
         <defaults public="true" />
 
@@ -30,6 +33,7 @@
         <service id="sylius.setup.currency" class="Sylius\Bundle\CoreBundle\Installer\Setup\CurrencySetup">
             <argument type="service" id="sylius.repository.currency" />
             <argument type="service" id="sylius.factory.currency" />
+            <argument>%currency%</argument>
         </service>
         <service id="Sylius\Bundle\CoreBundle\Installer\Setup\CurrencySetupInterface" alias="sylius.setup.currency" />
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
@@ -13,7 +13,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
-        <parameter key="currency">USD</parameter>
+        <parameter key="sylius_installer_currency">USD</parameter>
     </parameters>
     <services>
         <defaults public="true" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/installer.xml
@@ -33,7 +33,7 @@
         <service id="sylius.setup.currency" class="Sylius\Bundle\CoreBundle\Installer\Setup\CurrencySetup">
             <argument type="service" id="sylius.repository.currency" />
             <argument type="service" id="sylius.factory.currency" />
-            <argument>%currency%</argument>
+            <argument>%sylius_installer_currency%</argument>
         </service>
         <service id="Sylius\Bundle\CoreBundle\Installer\Setup\CurrencySetupInterface" alias="sylius.setup.currency" />
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6 (or master)
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Scenario: I want to run the `sylius:install` command with no interaction and use the data from my custom fixture to set up the webshop. This includes using Dutch as the language and Euro as the currency.

Currently: `sylius:install --no-interaction` uses the hardcoded preference of USD for the currency.

After this PR: The default is still USD, but can be overwritten with a `currency:` parameter similar to the locale (which is not a hardcoded preference during installation).