### PR TITLE
[Address book] Extensibility improvements

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-address-book.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-address-book.js
@@ -19,7 +19,7 @@ $.fn.extend({
     const element = this;
     const select = element.find('.address-book-select');
     const findByName = function findByName(name) {
-      return element.find(`[name*=${parseKey(name)}]`);
+      return element.find(`[name*="[${parseKey(name)}]"]`);
     };
 
     select.dropdown({

--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-address-book.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-address-book.js
@@ -29,7 +29,7 @@ $.fn.extend({
         const { provinceCode, provinceName } = choice.data();
         const provinceContainer = select.parent().find('.province-container').get(0);
 
-        element.find('input, select').each((index, input) => {
+        element.find('input:not([type="radio"]):not([type="checkbox"]), select').each((index, input) => {
           $(input).val('');
         });
 
@@ -55,6 +55,9 @@ $.fn.extend({
                 }
               }
             }, 100);
+          } else if (field.is('[type="radio"]') || field.is('[type="checkbox"]')) {
+            field.prop('checked', false);
+            field.filter(`[value="${value}"]`).prop('checked', true);
           } else {
             field.val(value);
           }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

I introduced 2 changes in the AddressBook JS handler, allowing address form to be extended with more freedom :
- checkbox and radio values won't be set to empty string, and will be correctly checked
- prevent input field name collisions : the value of one field could be duplicated in multiple fields with similar names (for instance, the value of « street » would override the value of a « street2 » or « streetComp » field)

This should not break anything in core Sylius. If you think I should rebase this on another branch, just ask as this will be quite easy to adapt :)