### PR TITLE
[Behat] Improve dashboard page extensibility

### DIFF
--- a/src/Sylius/Behat/Page/Admin/DashboardPage.php
+++ b/src/Sylius/Behat/Page/Admin/DashboardPage.php
@@ -21,7 +21,7 @@ use Symfony\Component\Routing\RouterInterface;
 class DashboardPage extends SymfonyPage implements DashboardPageInterface
 {
     /** @var TableAccessorInterface */
-    private $tableAccessor;
+    protected $tableAccessor;
 
     public function __construct(
         Session $session,


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes (for BDD)
| New feature?    | no
| BC breaks?      | no BC breaks promise on Behat
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.4 or 1.5 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->

When adding grids on admin dashboard, if you extends Sylius\Behat\Page\Admin\DasboardPage, You have no access to tableAccessor to add some tests on your custom grids.

For information, my current workaround:
```
<?php

declare(strict_types=1);

namespace App\Tests\Behat\Page\Admin;

use Behat\Mink\Session;
use Sylius\Behat\Page\Admin\DashboardPage as BaseDashboardPage;
use Sylius\Behat\Service\Accessor\TableAccessorInterface;
use Symfony\Component\Routing\RouterInterface;

class DashboardPage extends BaseDashboardPage
{
    /** @var TableAccessorInterface */
    private $tableAccessor;

    public function __construct(
        Session $session,
        $minkParameters,
        RouterInterface $router,
        TableAccessorInterface $tableAccessor
    ) {
        parent::__construct($session, $minkParameters, $router, $tableAccessor);

        $this->tableAccessor = $tableAccessor;
    }

    public function getNumberOfProductsToReviewInTheList(): int
    {
        return $this->tableAccessor->countTableBodyRows($this->getElement('products_to_review_list'));
    }
}
```