### PR TITLE
Fixed: use_authorize option comparison (fixes #)

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Controller/PayumController.php
+++ b/src/Sylius/Bundle/PayumBundle/Controller/PayumController.php
@@ -155,7 +155,7 @@ final class PayumController
         /** @var GatewayConfigInterface $gatewayConfig */
         $gatewayConfig = $paymentMethod->getGatewayConfig();
 
-        if (isset($gatewayConfig->getConfig()['use_authorize']) && $gatewayConfig->getConfig()['use_authorize'] === true) {
+        if (isset($gatewayConfig->getConfig()['use_authorize']) && true === (bool) $gatewayConfig->getConfig()['use_authorize']) {
             $token = $this->getTokenFactory()->createAuthorizeToken(
                 $gatewayConfig->getGatewayName(),
                 $payment,


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6 (as it present only since 1.6)
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #10720, related 6c748c9aec878687c610bd440aac9635143df0c3
| License         | MIT

Decided to use `(bool)` here as it converts both `1` and `'1'` to true and `0` and `'0'` to false.
