### PR TITLE
Added items option to order fixture

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
@@ -45,6 +45,7 @@ class OrderFixture extends AbstractFixture
         RepositoryInterface $channelRepository,
         RepositoryInterface $customerRepository,
         RepositoryInterface $productRepository,
+        RepositoryInterface $productVariantRepository,
         RepositoryInterface $countryRepository,
         PaymentMethodRepositoryInterface $paymentMethodRepository,
         ShippingMethodRepositoryInterface $shippingMethodRepository,
@@ -63,6 +64,7 @@ class OrderFixture extends AbstractFixture
                 $channelRepository,
                 $customerRepository,
                 $productRepository,
+                $productVariantRepository,
                 $countryRepository,
                 $paymentMethodRepository,
                 $shippingMethodRepository,
@@ -113,6 +115,12 @@ class OrderFixture extends AbstractFixture
                 ->scalarNode('channel')->cannotBeEmpty()->end()
                 ->scalarNode('customer')->cannotBeEmpty()->end()
                 ->scalarNode('country')->cannotBeEmpty()->end()
+                ->arrayNode('items')->arrayPrototype()
+                    ->children()
+                        ->scalarNode('variant')->cannotBeEmpty()->end()
+                        ->integerNode('quantity')->min(1)->defaultValue(1)->end()
+                    ->end()
+                ->end()
             ->end()
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures.xml
@@ -189,6 +189,7 @@
             <argument type="service" id="sylius.repository.channel" />
             <argument type="service" id="sylius.repository.customer" />
             <argument type="service" id="sylius.repository.product" />
+            <argument type="service" id="sylius.repository.product_variant" />
             <argument type="service" id="sylius.repository.country" />
             <argument type="service" id="sylius.repository.payment_method" />
             <argument type="service" id="sylius.repository.shipping_method" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
@@ -153,6 +153,7 @@
             <argument type="service" id="sylius.repository.channel" />
             <argument type="service" id="sylius.repository.customer" />
             <argument type="service" id="sylius.repository.product" />
+            <argument type="service" id="sylius.repository.product_variant" />
             <argument type="service" id="sylius.repository.country" />
             <argument type="service" id="sylius.repository.payment_method" />
             <argument type="service" id="sylius.repository.shipping_method" />


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.4, 1.5 or 1.6 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->

I thought it would be nice if you could decide what products a fixture generated order contains.

```yaml
...
  fixtures:
    order:
      options:
        items:
          - variant: 'some_variant_code'
            quantity: 5
```
