### PR TITLE
Switch statement conditions

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Context/CustomerContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Context/CustomerContext.php
@@ -42,7 +42,7 @@ final class CustomerContext implements CustomerContextInterface
             return null;
         }
 
-        if ($this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED') && $token->getUser() instanceof ShopUserInterface) {
+        if ($token->getUser() instanceof ShopUserInterface && $this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
             return $token->getUser()->getCustomer();
         }
 


### PR DESCRIPTION
It's much cheaper to run a quick instanceof check first. If it returns false, we skip entire decision manager process. This is better for performance actually, at least when the user is not authenticated. Simple things do matter.

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.4, 1.5 or 1.6 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
