### PR TITLE
Promotion fixture coupons

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
@@ -67,7 +67,7 @@ class PromotionExampleFactory extends AbstractExampleFactory implements ExampleF
         $this->configureOptions($this->optionsResolver);
 
         if ($this->couponFactory === null) {
-            @trigger_error(sprintf('Not passing a $couponFactory to %s constructor is deprecated since Sylius 1.6 and will be removed in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+            @trigger_error(sprintf('Not passing a $couponFactory to %s constructor is deprecated since Sylius 1.8 and will be removed in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
         }
     }
 
@@ -164,12 +164,8 @@ class PromotionExampleFactory extends AbstractExampleFactory implements ExampleF
         ;
     }
 
-    /**
-     * @param FactoryInterface|null $couponFactory
-     *
-     * @return \Closure
-     */
-    private static function getCouponNormalizer (?FactoryInterface $couponFactory): \Closure {
+    private static function getCouponNormalizer (?FactoryInterface $couponFactory): \Closure
+    {
         return function (Options $options, array $couponDefinitions) use ($couponFactory): array {
             if (null === $couponFactory) {
                 throw new \RuntimeException('You must configure a $couponFactory');

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/PromotionExampleFactory.php
@@ -65,6 +65,10 @@ class PromotionExampleFactory extends AbstractExampleFactory implements ExampleF
         $this->optionsResolver = new OptionsResolver();
 
         $this->configureOptions($this->optionsResolver);
+
+        if ($this->couponFactory === null) {
+            @trigger_error(sprintf('Not passing a $couponFactory to %s constructor is deprecated since Sylius 1.6 and will be removed in Sylius 2.0.', self::class), \E_USER_DEPRECATED);
+        }
     }
 
     /**
@@ -161,12 +165,16 @@ class PromotionExampleFactory extends AbstractExampleFactory implements ExampleF
     }
 
     /**
-     * @param FactoryInterface $couponFactory
+     * @param FactoryInterface|null $couponFactory
      *
      * @return \Closure
      */
-    private static function getCouponNormalizer (FactoryInterface $couponFactory): \Closure {
+    private static function getCouponNormalizer (?FactoryInterface $couponFactory): \Closure {
         return function (Options $options, array $couponDefinitions) use ($couponFactory): array {
+            if (null === $couponFactory) {
+                throw new \RuntimeException('You must configure a $couponFactory');
+            }
+
             if (!$options['coupon_based'] && count($couponDefinitions) > 0) {
                 throw new InvalidArgumentException('Cannot define coupons for promotion that is not coupon based');
             }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/PromotionFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/PromotionFixture.php
@@ -60,6 +60,15 @@ class PromotionFixture extends AbstractResourceFixture
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('coupons')->arrayPrototype()
+                    ->children()
+                        ->scalarNode('code')->cannotBeEmpty()->end()
+                        ->scalarNode('expires_at')->defaultNull()->end()
+                        ->integerNode('per_customer_usage_limit')->defaultNull()->end()
+                        ->booleanNode('reusable_from_cancelled_orders')->defaultTrue()->end()
+                        ->integerNode('usage_limit')->defaultNull()->end()
+                    ->end()
+                ->end()
         ;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/shop_configuration.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/shop_configuration.yaml
@@ -200,6 +200,12 @@ sylius_fixtures:
                                 name: 'Christmas'
                                 channels:
                                     - 'FASHION_WEB'
+                                coupon_based: true
+                                coupons:
+                                    - code: 'abcde'
+                                      expires_at: 'tomorrow'
+                                      usage_limit: 10
+                                      per_customer_usage_limit: 1
                             new_year:
                                 code: 'new_year'
                                 name: 'New Year'

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/shop_configuration.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/shop_configuration.yaml
@@ -202,8 +202,8 @@ sylius_fixtures:
                                     - 'FASHION_WEB'
                                 coupon_based: true
                                 coupons:
-                                    - code: 'abcde'
-                                      expires_at: 'tomorrow'
+                                    - code: 'CHRISTMAS_SALE'
+                                      expires_at: 'December 24'
                                       usage_limit: 10
                                       per_customer_usage_limit: 1
                             new_year:

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
@@ -60,6 +60,7 @@
 
         <service id="sylius.fixture.example_factory.promotion" class="Sylius\Bundle\CoreBundle\Fixture\Factory\PromotionExampleFactory">
             <argument type="service" id="sylius.factory.promotion" />
+            <argument type="service" id="sylius.factory.promotion_coupon" />
             <argument type="service" id="sylius.fixture.example_factory.promotion_rule" />
             <argument type="service" id="sylius.fixture.example_factory.promotion_action" />
             <argument type="service" id="sylius.repository.channel" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
@@ -60,10 +60,10 @@
 
         <service id="sylius.fixture.example_factory.promotion" class="Sylius\Bundle\CoreBundle\Fixture\Factory\PromotionExampleFactory">
             <argument type="service" id="sylius.factory.promotion" />
-            <argument type="service" id="sylius.factory.promotion_coupon" />
             <argument type="service" id="sylius.fixture.example_factory.promotion_rule" />
             <argument type="service" id="sylius.fixture.example_factory.promotion_action" />
             <argument type="service" id="sylius.repository.channel" />
+            <argument type="service" id="sylius.factory.promotion_coupon" />
         </service>
 
         <service id="sylius.fixture.example_factory.promotion_action" class="Sylius\Bundle\CoreBundle\Fixture\Factory\PromotionActionExampleFactory">


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.4, 1.5 or 1.6 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->

This adds the possibility to define coupons in promotion fixtures.

```yaml
...
 promotion:
   options:
     custom:
       test:
         name: 'Test'
         coupon_based: true
         coupons:
           - code: 'abc'

           - code: 'abcde'
             expires_at: 'tomorrow'
             usage_limit: 10
             per_customer_usage_limit: 1
             reusable_from_cancelled_orders: true
```