### PR TITLE
Changed visibility to make it usable when extending

### DIFF
--- a/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
@@ -106,7 +106,7 @@ class TaxonRepository extends EntityRepository implements TaxonRepositoryInterfa
         return $this->createQueryBuilder('o')->leftJoin('o.translations', 'translation');
     }
 
-    private function createTranslationBasedQueryBuilder(?string $locale): QueryBuilder
+    protected function createTranslationBasedQueryBuilder(?string $locale): QueryBuilder
     {
         $queryBuilder = $this->createQueryBuilder('o')
             ->addSelect('translation')


### PR DESCRIPTION
This method could easily be used when extending the repository, therefore it would make sense to make it protected

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | No
| New feature?    | Sort of
| BC breaks?      | No
| Deprecations?   | No
| License         | MIT

