### PR TITLE
Fix user impersonated listener when impersonating another user resource

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/EventListener/UserImpersonatedListener.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/UserImpersonatedListener.php
@@ -47,7 +47,10 @@ final class UserImpersonatedListener
     {
         /** @var ShopUserInterface $user */
         $user = $event->getUser();
-        Assert::isInstanceOf($user, ShopUserInterface::class);
+
+        if (!$user instanceof ShopUserInterface) {
+            return;
+        }
 
         $customer = $user->getCustomer();
 

--- a/src/Sylius/Bundle/ShopBundle/spec/EventListener/UserImpersonatedListenerSpec.php
+++ b/src/Sylius/Bundle/ShopBundle/spec/EventListener/UserImpersonatedListenerSpec.php
@@ -22,6 +22,7 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Storage\CartStorageInterface;
+use Sylius\Component\User\Model\UserInterface;
 
 final class UserImpersonatedListenerSpec extends ObjectBehavior
 {
@@ -72,6 +73,15 @@ final class UserImpersonatedListenerSpec extends ObjectBehavior
         $orderRepository->findLatestCartByChannelAndCustomer($channel, $customer)->willReturn(null);
 
         $cartStorage->removeForChannel($channel)->shouldBeCalled();
+
+        $this->onUserImpersonated($event);
+    }
+
+    function it_does_nothing_when_the_user_is_not_a_shop_user_type(
+        UserEvent $event,
+        UserInterface $user
+    ): void {
+        $event->getUser()->willReturn($user);
 
         $this->onUserImpersonated($event);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.5
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.4, 1.5 or 1.6 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->

If you want to impersonate another user resource (for example, in my current project, we have a Partner user), this listener is called and is failed cause it's called on any user resource impersonating action.