### PR TITLE
Add JQuery Dirtyforms in UPGRADE-1.6.md

### DIFF
--- a/UPGRADE-1.6.md
+++ b/UPGRADE-1.6.md
@@ -11,3 +11,18 @@ Copy [a new migration file](https://raw.githubusercontent.com/Sylius/Sylius-Stan
 ```bash
 bin/console doctrine:migrations:migrate
 ```
+
+Update your `package.json` in order to add `jquery.dirtyforms` as mentionned in [issue #88](https://github.com/Sylius/SyliusDemo/pull/88/files) : 
+
+```diff
+{
+  "dependencies": {
+    "babel-polyfill": "^6.26.0",
+    "jquery": "^3.4.1",
++    "jquery.dirtyforms": "^2.0.0",
+    "lightbox2": "^2.9.0",
+    "semantic-ui-css": "^2.2.0"
+  },
+  ...
+}
+```


### PR DESCRIPTION
Update `package.json` in order to add JQuery Dirtyforms.
See [issue #88](https://github.com/Sylius/SyliusDemo/pull/88/files) for more informations
