### PR TITLE
Replace EntityManager#flush($entity) by EntityManager#flush()

### DIFF
--- a/docs/book/architecture/translations.rst
+++ b/docs/book/architecture/translations.rst
@@ -128,7 +128,7 @@ Let's see how to do it on the example of a ProductTranslation.
    $product->addTranslation($translation);
 
    // Remember to save the product after adding the translation
-   $this->container->get('sylius.manager.product')->flush($product);
+   $this->container->get('sylius.manager.product')->flush();
 
 Learn more
 ----------

--- a/src/Sylius/Bundle/ReviewBundle/Updater/AverageRatingUpdater.php
+++ b/src/Sylius/Bundle/ReviewBundle/Updater/AverageRatingUpdater.php
@@ -56,6 +56,6 @@ class AverageRatingUpdater implements ReviewableRatingUpdaterInterface
 
         $reviewSubject->setAverageRating($averageRating);
 
-        $this->reviewSubjectManager->flush($reviewSubject);
+        $this->reviewSubjectManager->flush();
     }
 }

--- a/src/Sylius/Bundle/ReviewBundle/spec/Updater/AverageRatingUpdaterSpec.php
+++ b/src/Sylius/Bundle/ReviewBundle/spec/Updater/AverageRatingUpdaterSpec.php
@@ -41,7 +41,7 @@ final class AverageRatingUpdaterSpec extends ObjectBehavior
 
         $reviewSubject->setAverageRating(4.5)->shouldBeCalled();
 
-        $reviewSubjectManager->flush($reviewSubject)->shouldBeCalled();
+        $reviewSubjectManager->flush()->shouldBeCalled();
 
         $this->update($reviewSubject);
     }
@@ -57,7 +57,7 @@ final class AverageRatingUpdaterSpec extends ObjectBehavior
 
         $reviewSubject->setAverageRating(4.5)->shouldBeCalled();
 
-        $reviewSubjectManager->flush($reviewSubject)->shouldBeCalled();
+        $reviewSubjectManager->flush()->shouldBeCalled();
 
         $this->updateFromReview($review);
     }


### PR DESCRIPTION
https://github.com/doctrine/orm/blob/master/UPGRADE.md#bc-break-removed-entitymanagerflushentity-and-entitymanagerflushentities

| Q               | A
| --------------- | -----
| Branch?         | 1.4
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | mentioned in #10107 
| License         | MIT

