### PR TITLE
[Docs] Added Docs and Instructions for how to store images on AWS-S3

### DIFF
--- a/docs/cookbook/images/images-on-aws-s3.rst
+++ b/docs/cookbook/images/images-on-aws-s3.rst
@@ -1,0 +1,93 @@
+How to store images on AWS-S3 automatically?
+============================================
+
+
+Instructions:
+-------------
+
+First you need to ensure that the official ``AWS-S3 SDK`` for PHP is installed:
+
+.. code-block:: bash
+
+    composer require aws/aws-sdk-php
+
+
+1. Configure KNP-Gaufrette
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Place this file under ``config/packages/knp_gaufrette.yaml``:
+
+.. code-block:: yaml
+
+    # config/packages/knp_gaufrette.yaml
+    knp_gaufrette:
+        adapters:
+            sylius_image:
+                aws_s3:
+                    service_id: Aws\S3\S3Client
+                    bucket_name: "%aws.s3.bucket%"
+                    detect_content_type: true
+                    options:
+                        directory: "media/image"
+                        acl: "public-read"
+        stream_wrapper: ~
+
+
+2. Configure LIIP-Imagin:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Add this file under ``config/packages/liip_imagine.yaml`` in order to make LIIP-Image aware of AWS S3 storage:
+
+.. code-block:: yaml
+
+    # config/packages/liip_imagine.yaml
+    liip_imagine:
+        loaders:
+            aws_s3:
+                stream:
+                    wrapper: gaufrette://sylius_image/
+        resolvers:
+            aws_s3:
+                aws_s3:
+                    client_config:
+                        credentials:
+                            key:    "%aws.s3.key%"
+                            secret: "%aws.s3.secret%"
+                        region: "%aws.s3.region%"
+                        version: "%aws.s3.version%"
+                    bucket: "%aws.s3.bucket%"
+                    get_options:
+                        Scheme: https
+                    put_options:
+                        CacheControl: "max-age=86400"
+                    cache_prefix: media/cache
+        data_loader: aws_s3
+        cache: aws_s3
+
+3. Define S3-related parameters and configure final services:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In ``config/services.yaml``:
+
+.. code-block:: yaml
+
+    # config/services.yaml
+    parameters:
+        aws.s3.key: "%env(AWS_S3_KEY)%"
+        aws.s3.secret: "%env(AWS_S3_SECRET)%"
+        aws.s3.bucket: "%env(AWS_S3_BUCKET)%"
+        aws.s3.region: "%env(AWS_S3_REGION)%"
+        aws.s3.version: "%env(AWS_S3_VERSION)%"
+
+    services:
+        # composer require aws/aws-sdk-php
+        Aws\S3\S3Client:
+            factory: [Aws\S3\S3Client, 'factory']
+            arguments:
+                -
+                    version: "%aws.s3.version%"
+                    region: "%aws.s3.region%"
+                    credentials:
+                        key: "%aws.s3.key%"
+                        secret: "%aws.s3.secret%"
+

--- a/docs/cookbook/images/images-on-aws-s3.rst
+++ b/docs/cookbook/images/images-on-aws-s3.rst
@@ -12,7 +12,7 @@ First you need to ensure that the official ``AWS-S3 SDK`` for PHP is installed:
     composer require aws/aws-sdk-php
 
 
-1. Configure KNP-Gaufrette
+1. Configure Knp-Gaufrette
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Place this file under ``config/packages/knp_gaufrette.yaml``:
@@ -33,10 +33,10 @@ Place this file under ``config/packages/knp_gaufrette.yaml``:
         stream_wrapper: ~
 
 
-2. Configure LIIP-Imagin:
+2. Configure Liip-Imagine:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Add this file under ``config/packages/liip_imagine.yaml`` in order to make LIIP-Image aware of AWS S3 storage:
+Add this file under ``config/packages/liip_imagine.yaml`` in order to make Liip-Imagine aware of AWS S3 storage:
 
 .. code-block:: yaml
 

--- a/docs/cookbook/images/map.rst.inc
+++ b/docs/cookbook/images/map.rst.inc
@@ -1,2 +1,3 @@
 * :doc:`/cookbook/images/images`
 * :doc:`/cookbook/images/images-on-entity`
+* :doc:`/cookbook/images/images-on-aws-s3`

--- a/docs/cookbook/index.rst
+++ b/docs/cookbook/index.rst
@@ -86,6 +86,7 @@ Images
 
     images/images
     images/images-on-entity
+    images/images-on-aws-s3
 
 .. include:: /cookbook/images/map.rst.inc
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | docs
| License         | MIT

Added instructions for how to store images on AWS S3, thanks to helpful instructions from @vvasiloi, taken from https://gist.github.com/vvasiloi/dc2ed665de9f38f977babce269029e27
