### PR TITLE
Change rename in tests/Application/Kernel.php

### DIFF
--- a/docs/plugin-development-guide/naming.rst
+++ b/docs/plugin-development-guide/naming.rst
@@ -24,7 +24,7 @@ to reflect your plugin functionality. Basing on the vendor and plugin names esta
 
 * In ``tests/Application/Kernel.php``:
 
-    * ``\Acme\SyliusExamplePlugin\AcmeSyliusExamplePlugin()`` -> ``\IronMan\SyliusProductOnDemandPlugin\SyliusProductOnDemandPlugin()``
+    * ``Tests\Acme\SyliusExamplePlugin\Application`` -> ``Tests\IronMan\SyliusProductOnDemandPlugin\Application``
 
 * In ``phpspec.yml.dist`` (if you want to use PHPSpec in your plugin):
 


### PR DESCRIPTION
Change the replaced string in `tests/Application/Kernel.php` because `\Acme\SyliusExamplePlugin\AcmeSyliusExamplePlugin()` does not exists
