### PR TITLE
[Addressing] Make sure the CountryNameExtension::translateCountryIsoCode() always returns a string

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Twig/CountryNameExtension.php
+++ b/src/Sylius/Bundle/AddressingBundle/Twig/CountryNameExtension.php
@@ -28,12 +28,6 @@ class CountryNameExtension extends \Twig_Extension
         ];
     }
 
-    /**
-     * @param CountryInterface|string $country
-     * @param string|null $locale
-     *
-     * @return string
-     */
     public function translateCountryIsoCode($country, ?string $locale = null): string
     {
         $countryCode = $country instanceof CountryInterface ? $country->getCode() : $country;

--- a/src/Sylius/Bundle/AddressingBundle/Twig/CountryNameExtension.php
+++ b/src/Sylius/Bundle/AddressingBundle/Twig/CountryNameExtension.php
@@ -28,12 +28,20 @@ class CountryNameExtension extends \Twig_Extension
         ];
     }
 
+    /**
+     * @param CountryInterface|string $country
+     * @param string|null $locale
+     *
+     * @return string
+     */
     public function translateCountryIsoCode($country, ?string $locale = null): string
     {
-        if ($country instanceof CountryInterface) {
-            return Intl::getRegionBundle()->getCountryName($country->getCode(), $locale);
+        $countryCode = $country instanceof CountryInterface ? $country->getCode() : $country;
+
+        if ($countryName = Intl::getRegionBundle()->getCountryName($countryCode, $locale)) {
+            return $countryName;
         }
 
-        return Intl::getRegionBundle()->getCountryName($country, $locale);
+        return $countryCode ?? '';
     }
 }

--- a/src/Sylius/Bundle/AddressingBundle/spec/Twig/CountryNameExtensionSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/Twig/CountryNameExtensionSpec.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\AddressingBundle\Twig;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Addressing\Model\Country;
 use Sylius\Component\Addressing\Model\CountryInterface;
 
 final class CountryNameExtensionSpec extends ObjectBehavior
@@ -38,5 +39,17 @@ final class CountryNameExtensionSpec extends ObjectBehavior
     function it_translates_country_code_to_name_according_to_locale(): void
     {
         $this->translateCountryIsoCode('IE', 'es')->shouldReturn('Irlanda');
+    }
+
+    function it_fallbacks_to_country_code_when_there_is_no_translation(): void
+    {
+        $country = 'country_code_without_translation';
+        $this->translateCountryIsoCode($country)->shouldReturn($country);
+    }
+
+    function it_fallbacks_to_an_empty_string_when_there_is_no_code(): void
+    {
+        $this->translateCountryIsoCode(new Country())->shouldReturn('');
+        $this->translateCountryIsoCode(null)->shouldReturn('');
     }
 }

--- a/src/Sylius/Bundle/AddressingBundle/spec/Twig/CountryNameExtensionSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/Twig/CountryNameExtensionSpec.php
@@ -43,13 +43,14 @@ final class CountryNameExtensionSpec extends ObjectBehavior
 
     function it_fallbacks_to_country_code_when_there_is_no_translation(): void
     {
-        $country = 'country_code_without_translation';
-        $this->translateCountryIsoCode($country)->shouldReturn($country);
+        $this->translateCountryIsoCode('country_code_without_translation')->shouldReturn('country_code_without_translation');
     }
 
-    function it_fallbacks_to_an_empty_string_when_there_is_no_code(): void
+    function it_fallbacks_to_an_empty_string_when_there_is_no_code(CountryInterface $country): void
     {
-        $this->translateCountryIsoCode(new Country())->shouldReturn('');
+        $country->getCode()->willReturn(null);
+
+        $this->translateCountryIsoCode($country)->shouldReturn('');
         $this->translateCountryIsoCode(null)->shouldReturn('');
     }
 }


### PR DESCRIPTION
Fallback to code when there's no translation.
Fallback to empty string when there's no code.

| Q               | A
| --------------- | -----
| Branch?         | 1.5
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #10799
| License         | MIT