### PR TITLE
Explicitly list deprecated things in the code & solve Twig deprecations

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -72,12 +72,42 @@
 
         <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
 
-        <DeprecatedMethod errorLevel="info" />
-        <DeprecatedProperty errorLevel="info" />
-        <DeprecatedClass errorLevel="info" />
-        <DeprecatedConstant errorLevel="info" />
-        <DeprecatedInterface errorLevel="info" />
-        <DeprecatedTrait errorLevel="info" />
+        <DeprecatedClass>
+            <errorLevel type="info">
+                <referencedClass name="Payum\Core\Action\GatewayAwareAction" />
+                <referencedClass name="Payum\Core\Security\GenericTokenFactoryInterface" />
+                <referencedClass name="Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand" />
+                <referencedClass name="Symfony\Bundle\FrameworkBundle\Controller\Controller" />
+                <referencedClass name="Symfony\Bundle\FrameworkBundle\Templating\EngineInterface" />
+                <referencedClass name="Symfony\Component\EventDispatcher\Event" />
+                <referencedClass name="Symfony\Component\HttpKernel\Event\FilterResponseEvent" />
+                <referencedClass name="Symfony\Component\HttpKernel\Event\GetResponseEvent" />
+                <referencedClass name="Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent" />
+                <referencedClass name="Symfony\Component\Intl\ResourceBundle\CurrencyBundleInterface" />
+                <referencedClass name="Symfony\Component\Intl\ResourceBundle\LanguageBundleInterface" />
+                <referencedClass name="Symfony\Component\Intl\ResourceBundle\LocaleBundleInterface" />
+                <referencedClass name="Symfony\Component\Intl\ResourceBundle\RegionBundleInterface" />
+                <referencedClass name="Symfony\Component\Security\Core\Role\Role" />
+                <referencedClass name="Symfony\Component\Translation\TranslatorInterface" />
+            </errorLevel>
+        </DeprecatedClass>
+        <DeprecatedInterface>
+            <errorLevel type="info">
+                <referencedClass name="Symfony\Component\Security\Core\User\AdvancedUserInterface" />
+            </errorLevel>
+        </DeprecatedInterface>
+        <DeprecatedMethod>
+            <errorLevel type="info">
+                <referencedMethod name="Payum\Core\Model\GatewayConfigInterface::setFactoryName" />
+                <referencedMethod name="Symfony\Component\Config\Definition\Builder\TreeBuilder::root" />
+                <referencedMethod name="Symfony\Component\EventDispatcher\Event::stopPropagation" />
+                <referencedMethod name="Symfony\Component\HttpKernel\Kernel::getRootDir" />
+                <referencedMethod name="Symfony\Component\Intl\Intl::getCurrencyBundle" />
+                <referencedMethod name="Symfony\Component\Intl\Intl::getLanguageBundle" />
+                <referencedMethod name="Symfony\Component\Intl\Intl::getLocaleBundle" />
+                <referencedMethod name="Symfony\Component\Intl\Intl::getRegionBundle" />
+            </errorLevel>
+        </DeprecatedMethod>
 
         <InternalMethod errorLevel="info" />
         <InternalProperty errorLevel="info" />

--- a/src/Sylius/Bundle/AddressingBundle/Twig/CountryNameExtension.php
+++ b/src/Sylius/Bundle/AddressingBundle/Twig/CountryNameExtension.php
@@ -15,8 +15,10 @@ namespace Sylius\Bundle\AddressingBundle\Twig;
 
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Symfony\Component\Intl\Intl;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
-class CountryNameExtension extends \Twig_Extension
+class CountryNameExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}
@@ -24,7 +26,7 @@ class CountryNameExtension extends \Twig_Extension
     public function getFilters(): array
     {
         return [
-            new \Twig_Filter('sylius_country_name', [$this, 'translateCountryIsoCode']),
+            new TwigFilter('sylius_country_name', [$this, 'translateCountryIsoCode']),
         ];
     }
 

--- a/src/Sylius/Bundle/AddressingBundle/Twig/ProvinceNamingExtension.php
+++ b/src/Sylius/Bundle/AddressingBundle/Twig/ProvinceNamingExtension.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AddressingBundle\Twig;
 
 use Sylius\Component\Addressing\Provider\ProvinceNamingProviderInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
-class ProvinceNamingExtension extends \Twig_Extension
+class ProvinceNamingExtension extends AbstractExtension
 {
     /** @var ProvinceNamingProviderInterface */
     private $provinceNamingProvider;
@@ -31,8 +33,8 @@ class ProvinceNamingExtension extends \Twig_Extension
     public function getFilters(): array
     {
         return [
-            new \Twig_Filter('sylius_province_name', [$this->provinceNamingProvider, 'getName']),
-            new \Twig_Filter('sylius_province_abbreviation', [$this->provinceNamingProvider, 'getAbbreviation']),
+            new TwigFilter('sylius_province_name', [$this->provinceNamingProvider, 'getName']),
+            new TwigFilter('sylius_province_abbreviation', [$this->provinceNamingProvider, 'getAbbreviation']),
         ];
     }
 }

--- a/src/Sylius/Bundle/AdminBundle/Twig/NotificationWidgetExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/NotificationWidgetExtension.php
@@ -14,8 +14,11 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Twig;
 
 use Sylius\Bundle\CoreBundle\Application\Kernel;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-final class NotificationWidgetExtension extends \Twig_Extension
+final class NotificationWidgetExtension extends AbstractExtension
 {
     /** @var bool */
     private $areNotificationsEnabled;
@@ -32,7 +35,7 @@ final class NotificationWidgetExtension extends \Twig_Extension
     public function getFunctions(): array
     {
         return [
-            new \Twig_Function(
+            new TwigFunction(
                 'sylius_render_notifications_widget',
                 [$this, 'renderWidget'],
                 [
@@ -43,7 +46,7 @@ final class NotificationWidgetExtension extends \Twig_Extension
         ];
     }
 
-    public function renderWidget(\Twig_Environment $environment): string
+    public function renderWidget(Environment $environment): string
     {
         if (!$this->areNotificationsEnabled) {
             return '';

--- a/src/Sylius/Bundle/AdminBundle/Twig/ShopExtension.php
+++ b/src/Sylius/Bundle/AdminBundle/Twig/ShopExtension.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminBundle\Twig;
 
-final class ShopExtension extends \Twig_Extension
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class ShopExtension extends AbstractExtension
 {
     /** @var bool */
     private $isShopEnabled;
@@ -23,13 +26,10 @@ final class ShopExtension extends \Twig_Extension
         $this->isShopEnabled = $isShopEnabled;
     }
 
-    /**
-     * @return array|\Twig_Function[]
-     */
     public function getFunctions(): array
     {
         return [
-            new \Twig_Function('is_shop_enabled', function (): bool {
+            new TwigFunction('is_shop_enabled', function (): bool {
                 return $this->isShopEnabled;
             }),
         ];

--- a/src/Sylius/Bundle/CoreBundle/Twig/CheckoutStepsExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/CheckoutStepsExtension.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Twig;
 
 use Sylius\Bundle\CoreBundle\Templating\Helper\CheckoutStepsHelper;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-final class CheckoutStepsExtension extends \Twig_Extension
+final class CheckoutStepsExtension extends AbstractExtension
 {
     /** @var CheckoutStepsHelper */
     private $checkoutStepsHelper;
@@ -31,8 +33,8 @@ final class CheckoutStepsExtension extends \Twig_Extension
     public function getFunctions(): array
     {
         return [
-            new \Twig_Function('sylius_is_shipping_required', [$this->checkoutStepsHelper, 'isShippingRequired']),
-            new \Twig_Function('sylius_is_payment_required', [$this->checkoutStepsHelper, 'isPaymentRequired']),
+            new TwigFunction('sylius_is_shipping_required', [$this->checkoutStepsHelper, 'isShippingRequired']),
+            new TwigFunction('sylius_is_payment_required', [$this->checkoutStepsHelper, 'isPaymentRequired']),
         ];
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Twig/PriceExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/PriceExtension.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Twig;
 
 use Symfony\Component\Templating\Helper\Helper;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
-final class PriceExtension extends \Twig_Extension
+final class PriceExtension extends AbstractExtension
 {
     /** @var Helper */
     private $helper;
@@ -31,7 +33,7 @@ final class PriceExtension extends \Twig_Extension
     public function getFilters(): array
     {
         return [
-            new \Twig_Filter('sylius_calculate_price', [$this->helper, 'getPrice']),
+            new TwigFilter('sylius_calculate_price', [$this->helper, 'getPrice']),
         ];
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Twig/ProductVariantsPricesExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/ProductVariantsPricesExtension.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Twig;
 
 use Sylius\Bundle\CoreBundle\Templating\Helper\ProductVariantsPricesHelper;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-final class ProductVariantsPricesExtension extends \Twig_Extension
+final class ProductVariantsPricesExtension extends AbstractExtension
 {
     /** @var ProductVariantsPricesHelper */
     private $productVariantsPricesHelper;
@@ -31,7 +33,7 @@ final class ProductVariantsPricesExtension extends \Twig_Extension
     public function getFunctions(): array
     {
         return [
-            new \Twig_Function('sylius_product_variant_prices', [$this->productVariantsPricesHelper, 'getPrices']),
+            new TwigFunction('sylius_product_variant_prices', [$this->productVariantsPricesHelper, 'getPrices']),
         ];
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Twig/VariantResolverExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Twig/VariantResolverExtension.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Twig;
 
 use Symfony\Component\Templating\Helper\Helper;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
-final class VariantResolverExtension extends \Twig_Extension
+final class VariantResolverExtension extends AbstractExtension
 {
     /** @var Helper */
     private $helper;
@@ -31,7 +33,7 @@ final class VariantResolverExtension extends \Twig_Extension
     public function getFilters(): array
     {
         return [
-            new \Twig_Filter('sylius_resolve_variant', [$this->helper, 'resolveVariant']),
+            new TwigFilter('sylius_resolve_variant', [$this->helper, 'resolveVariant']),
         ];
     }
 }

--- a/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
+++ b/src/Sylius/Bundle/CurrencyBundle/Twig/CurrencyExtension.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CurrencyBundle\Twig;
 
 use Sylius\Bundle\CurrencyBundle\Templating\Helper\CurrencyHelperInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
-final class CurrencyExtension extends \Twig_Extension
+final class CurrencyExtension extends AbstractExtension
 {
     /** @var CurrencyHelperInterface */
     private $helper;
@@ -31,7 +33,7 @@ final class CurrencyExtension extends \Twig_Extension
     public function getFilters(): array
     {
         return [
-            new \Twig_Filter('sylius_currency_symbol', [$this->helper, 'convertCurrencyCodeToSymbol']),
+            new TwigFilter('sylius_currency_symbol', [$this->helper, 'convertCurrencyCodeToSymbol']),
         ];
     }
 }

--- a/src/Sylius/Bundle/InventoryBundle/Twig/InventoryExtension.php
+++ b/src/Sylius/Bundle/InventoryBundle/Twig/InventoryExtension.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\InventoryBundle\Twig;
 
 use Sylius\Bundle\InventoryBundle\Templating\Helper\InventoryHelper;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-final class InventoryExtension extends \Twig_Extension
+final class InventoryExtension extends AbstractExtension
 {
     /** @var InventoryHelper */
     private $helper;
@@ -31,8 +33,8 @@ final class InventoryExtension extends \Twig_Extension
     public function getFunctions(): array
     {
         return [
-             new \Twig_Function('sylius_inventory_is_available', [$this->helper, 'isStockAvailable']),
-             new \Twig_Function('sylius_inventory_is_sufficient', [$this->helper, 'isStockSufficient']),
+             new TwigFunction('sylius_inventory_is_available', [$this->helper, 'isStockAvailable']),
+             new TwigFunction('sylius_inventory_is_sufficient', [$this->helper, 'isStockSufficient']),
         ];
     }
 }

--- a/src/Sylius/Bundle/LocaleBundle/Twig/LocaleExtension.php
+++ b/src/Sylius/Bundle/LocaleBundle/Twig/LocaleExtension.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\LocaleBundle\Twig;
 
 use Sylius\Bundle\LocaleBundle\Templating\Helper\LocaleHelperInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
-final class LocaleExtension extends \Twig_Extension
+final class LocaleExtension extends AbstractExtension
 {
     /** @var LocaleHelperInterface */
     private $localeHelper;
@@ -31,8 +33,8 @@ final class LocaleExtension extends \Twig_Extension
     public function getFilters(): array
     {
         return [
-            new \Twig_Filter('sylius_locale_name', [$this->localeHelper, 'convertCodeToName']),
-            new \Twig_Filter('sylius_locale_country', [$this, 'getCountryCode']),
+            new TwigFilter('sylius_locale_name', [$this->localeHelper, 'convertCodeToName']),
+            new TwigFilter('sylius_locale_country', [$this, 'getCountryCode']),
         ];
     }
 

--- a/src/Sylius/Bundle/MoneyBundle/Twig/ConvertMoneyExtension.php
+++ b/src/Sylius/Bundle/MoneyBundle/Twig/ConvertMoneyExtension.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\MoneyBundle\Twig;
 
 use Sylius\Bundle\MoneyBundle\Templating\Helper\ConvertMoneyHelperInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
-final class ConvertMoneyExtension extends \Twig_Extension
+final class ConvertMoneyExtension extends AbstractExtension
 {
     /** @var ConvertMoneyHelperInterface */
     private $helper;
@@ -31,7 +33,7 @@ final class ConvertMoneyExtension extends \Twig_Extension
     public function getFilters(): array
     {
         return [
-            new \Twig_Filter('sylius_convert_money', [$this->helper, 'convertAmount']),
+            new TwigFilter('sylius_convert_money', [$this->helper, 'convertAmount']),
         ];
     }
 }

--- a/src/Sylius/Bundle/MoneyBundle/Twig/FormatMoneyExtension.php
+++ b/src/Sylius/Bundle/MoneyBundle/Twig/FormatMoneyExtension.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\MoneyBundle\Twig;
 
 use Sylius\Bundle\MoneyBundle\Templating\Helper\FormatMoneyHelperInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
-final class FormatMoneyExtension extends \Twig_Extension
+final class FormatMoneyExtension extends AbstractExtension
 {
     /** @var FormatMoneyHelperInterface */
     private $helper;
@@ -31,7 +33,7 @@ final class FormatMoneyExtension extends \Twig_Extension
     public function getFilters(): array
     {
         return [
-            new \Twig_Filter('sylius_format_money', [$this->helper, 'formatAmount']),
+            new TwigFilter('sylius_format_money', [$this->helper, 'formatAmount']),
         ];
     }
 }

--- a/src/Sylius/Bundle/OrderBundle/Twig/AggregateAdjustmentsExtension.php
+++ b/src/Sylius/Bundle/OrderBundle/Twig/AggregateAdjustmentsExtension.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\OrderBundle\Twig;
 
 use Sylius\Bundle\OrderBundle\Templating\Helper\AdjustmentsHelper;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-final class AggregateAdjustmentsExtension extends \Twig_Extension
+final class AggregateAdjustmentsExtension extends AbstractExtension
 {
     /** @var AdjustmentsHelper */
     private $adjustmentsHelper;
@@ -31,7 +33,7 @@ final class AggregateAdjustmentsExtension extends \Twig_Extension
     public function getFunctions(): array
     {
         return [
-            new \Twig_Function('sylius_aggregate_adjustments', [$this->adjustmentsHelper, 'getAggregatedAdjustments']),
+            new TwigFunction('sylius_aggregate_adjustments', [$this->adjustmentsHelper, 'getAggregatedAdjustments']),
         ];
     }
 }

--- a/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
@@ -15,13 +15,15 @@ namespace Sylius\Bundle\ShopBundle\Twig;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class OrderItemsSubtotalExtension extends \Twig_Extension
+class OrderItemsSubtotalExtension extends AbstractExtension
 {
     public function getFunctions(): array
     {
         return [
-            new \Twig_Function('sylius_order_items_subtotal', [$this, 'getSubtotal']),
+            new TwigFunction('sylius_order_items_subtotal', [$this, 'getSubtotal']),
         ];
     }
 

--- a/src/Sylius/Bundle/ShopBundle/Twig/OrderTaxesTotalExtension.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/OrderTaxesTotalExtension.php
@@ -16,14 +16,16 @@ namespace Sylius\Bundle\ShopBundle\Twig;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Order\Model\AdjustmentInterface as BaseAdjustmentInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class OrderTaxesTotalExtension extends \Twig_Extension
+class OrderTaxesTotalExtension extends AbstractExtension
 {
     public function getFunctions(): array
     {
         return [
-            new \Twig_Function('sylius_order_tax_included', [$this, 'getIncludedTax']),
-            new \Twig_Function('sylius_order_tax_excluded', [$this, 'getExcludedTax']),
+            new TwigFunction('sylius_order_tax_included', [$this, 'getIncludedTax']),
+            new TwigFunction('sylius_order_tax_excluded', [$this, 'getExcludedTax']),
         ];
     }
 

--- a/src/Sylius/Bundle/UiBundle/Twig/PercentageExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/PercentageExtension.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\UiBundle\Twig;
 
-class PercentageExtension extends \Twig_Extension
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class PercentageExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}
@@ -21,7 +24,7 @@ class PercentageExtension extends \Twig_Extension
     public function getFilters(): array
     {
         return [
-            new \Twig_Filter('sylius_percentage', [$this, 'getPercentage']),
+            new TwigFilter('sylius_percentage', [$this, 'getPercentage']),
         ];
     }
 

--- a/src/Sylius/Bundle/UiBundle/Twig/SortByExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/SortByExtension.php
@@ -15,8 +15,10 @@ namespace Sylius\Bundle\UiBundle\Twig;
 
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
 
-class SortByExtension extends \Twig_Extension
+class SortByExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}
@@ -24,7 +26,7 @@ class SortByExtension extends \Twig_Extension
     public function getFilters(): array
     {
         return [
-            new \Twig_Filter('sort_by', [$this, 'sortBy']),
+            new TwigFilter('sort_by', [$this, 'sortBy']),
         ];
     }
 


### PR DESCRIPTION
Created a list of deprecated classes, interfaces and method calls - it will make fixing them easier, just choose one, delete it in Psalm, fix the errors, done! :)

Also solved Twig deprecations making use of their forward compatibility layer.