### PR TITLE
Incorrect product count in the grid

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -73,7 +73,6 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
         $queryBuilder = $this->createQueryBuilder('o')
             ->distinct()
             ->addSelect('translation')
-            ->addSelect('productTaxon')
             ->innerJoin('o.translations', 'translation', 'WITH', 'translation.locale = :locale')
             ->innerJoin('o.productTaxons', 'productTaxon');
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | >=1.3
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Grid size is incorrect when one other the product from the page is included in multiple taxons.
The regular usage scenario is when there are two taxons some product category and product brand. In this example, the product will be included in two taxons in the same time. 

The SQL that contains `distinct` works incorrectly when `sylius_product_taxon.taxon_id` is included into `SELECT`. So the solution is simple. Need to remove the following line:
https://github.com/Sylius/Sylius/blob/af11ba747102a86400e5537dc16bcb180e2b70e2/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php#L76
