### PR TITLE
[Payum][Checkout] Pass address data to PayPal after checkout

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Action/Paypal/ExpressCheckout/ConvertPaymentAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Action/Paypal/ExpressCheckout/ConvertPaymentAction.php
@@ -51,6 +51,8 @@ final class ConvertPaymentAction implements ActionInterface
         $details['PAYMENTREQUEST_0_AMT'] = $this->formatPrice($order->getTotal());
         $details['PAYMENTREQUEST_0_ITEMAMT'] = $this->formatPrice($order->getTotal());
 
+        $details = $this->prepareAddressData($order, $details);
+
         $m = 0;
         foreach ($order->getItems() as $item) {
             $details['L_PAYMENTREQUEST_0_NAME' . $m] = $item->getVariant()->getProduct()->getName();
@@ -100,5 +102,28 @@ final class ConvertPaymentAction implements ActionInterface
     private function formatPrice(int $price): float
     {
         return round($price / 100, 2);
+    }
+
+    private function prepareAddressData(OrderInterface $order, array $details): array
+    {
+        $details['EMAIL'] = $order->getCustomer()->getEmail();
+        $billingAddress = $order->getBillingAddress();
+        $details['LOCALECODE'] = $billingAddress->getCountryCode();
+        $details['PAYMENTREQUEST_0_SHIPTONAME'] = $billingAddress->getFullName();
+        $details['PAYMENTREQUEST_0_SHIPTOSTREET'] = $billingAddress->getStreet();
+        $details['PAYMENTREQUEST_0_SHIPTOCITY'] = $billingAddress->getCity();
+        $details['PAYMENTREQUEST_0_SHIPTOZIP'] = $billingAddress->getPostcode();
+        $details['PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE'] = $billingAddress->getCountryCode();
+
+        if ($billingAddress->getPhoneNumber() !== null) {
+            $details['PAYMENTREQUEST_0_SHIPTOPHONENUM'] = $billingAddress->getPhoneNumber();
+        }
+
+        $province = $billingAddress->getProvinceCode() ?? $billingAddress->getProvinceName();
+        if ($province !== null) {
+            $details['PAYMENTREQUEST_0_SHIPTOSTATE'] = $province;
+        }
+
+        return $details;
     }
 }

--- a/src/Sylius/Bundle/PayumBundle/spec/Action/Paypal/ExpressCheckout/ConvertPaymentActionSpec.php
+++ b/src/Sylius/Bundle/PayumBundle/spec/Action/Paypal/ExpressCheckout/ConvertPaymentActionSpec.php
@@ -18,7 +18,9 @@ use Payum\Core\Action\ActionInterface;
 use Payum\Core\Exception\RequestNotSupportedException;
 use Payum\Core\Request\Convert;
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
@@ -45,7 +47,9 @@ final class ConvertPaymentActionSpec extends ObjectBehavior
         OrderInterface $order,
         OrderItemInterface $orderItem,
         ProductVariantInterface $productVariant,
-        ProductInterface $product
+        ProductInterface $product,
+        CustomerInterface $customer,
+        AddressInterface $billingAddress
     ): void {
         $request->getTo()->willReturn('array');
 
@@ -68,6 +72,18 @@ final class ConvertPaymentActionSpec extends ObjectBehavior
 
         $product->getName()->willReturn('Lamborghini Aventador Model');
 
+        $order->getCustomer()->willReturn($customer);
+        $customer->getEmail()->willReturn('john@doe.com');
+
+        $order->getBillingAddress()->willReturn($billingAddress);
+        $billingAddress->getCountryCode()->willReturn('US');
+        $billingAddress->getFullName()->willReturn('John Doe');
+        $billingAddress->getStreet()->willReturn('Main St. 123');
+        $billingAddress->getCity()->willReturn('New York');
+        $billingAddress->getPostcode()->willReturn('20500');
+        $billingAddress->getPhoneNumber()->willReturn('888222111');
+        $billingAddress->getProvinceCode()->willReturn('NY');
+
         $request->getSource()->willReturn($payment);
         $payment->getOrder()->willReturn($order);
 
@@ -77,6 +93,15 @@ final class ConvertPaymentActionSpec extends ObjectBehavior
             'PAYMENTREQUEST_0_CURRENCYCODE' => 'PLN',
             'PAYMENTREQUEST_0_AMT' => 880.00,
             'PAYMENTREQUEST_0_ITEMAMT' => 880.00,
+            'EMAIL' => 'john@doe.com',
+            'LOCALECODE' => 'US',
+            'PAYMENTREQUEST_0_SHIPTONAME' => 'John Doe',
+            'PAYMENTREQUEST_0_SHIPTOSTREET' => 'Main St. 123',
+            'PAYMENTREQUEST_0_SHIPTOCITY' => 'New York',
+            'PAYMENTREQUEST_0_SHIPTOZIP' => '20500',
+            'PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE' => 'US',
+            'PAYMENTREQUEST_0_SHIPTOPHONENUM' => '888222111',
+            'PAYMENTREQUEST_0_SHIPTOSTATE' => 'NY',
             'L_PAYMENTREQUEST_0_NAME0' => 'Lamborghini Aventador Model',
             'L_PAYMENTREQUEST_0_AMT0' => 800.00,
             'L_PAYMENTREQUEST_0_QTY0' => 1,


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

It was frustrating, that after passing all the required data in the "Address" step of checkout, we need to do it again in the PayPal form (when not being logged in, of course :)). With this improvement, we pass billing data to have it prefilled in PayPal - notice, that country code is passed as `LOCALECODE`, as it allows us to pass also country-specific data, like a phone number or province code/name.

**United States**


| Address | PayPal form | 
| ------- | ----------- |
| <img width="256" alt="Zrzut ekranu 2019-11-5 o 15 44 06" src="https://user-images.githubusercontent.com/6212718/68219150-c9d0aa80-ffe5-11e9-8ff8-bd87e40afa20.png"> | <img width="413" alt="Zrzut ekranu 2019-11-5 o 15 43 38" src="https://user-images.githubusercontent.com/6212718/68219174-d5bc6c80-ffe5-11e9-81f8-09698afc52ae.png"> |

**Poland**

| Address | PayPal form | 
| ------- | ----------- |
| <img width="256" alt="Zrzut ekranu 2019-11-5 o 15 45 34" src="https://user-images.githubusercontent.com/6212718/68219183-db19b700-ffe5-11e9-83bf-9822fe9b6a1d.png"> | <img width="367" alt="Zrzut ekranu 2019-11-5 o 15 46 25" src="https://user-images.githubusercontent.com/6212718/68219220-eb319680-ffe5-11e9-9af0-29fe848b0151.png"> |

**Germany**

| Address | PayPal form | 
| ------- | ----------- |
| <img width="257" alt="Zrzut ekranu 2019-11-5 o 16 03 58" src="https://user-images.githubusercontent.com/6212718/68219226-f08ee100-ffe5-11e9-984d-235793ec6041.png"> | <img width="381" alt="Zrzut ekranu 2019-11-5 o 15 54 12" src="https://user-images.githubusercontent.com/6212718/68219254-fa184900-ffe5-11e9-9423-4240f87a4765.png"> |