### PR TITLE
Rename shop user factory to help autowiring

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShopUserExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ShopUserExampleFactory.php
@@ -26,7 +26,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class ShopUserExampleFactory extends AbstractExampleFactory implements ExampleFactoryInterface
 {
     /** @var FactoryInterface */
-    private $userFactory;
+    private $shopUserFactory;
 
     /** @var FactoryInterface */
     private $customerFactory;
@@ -41,11 +41,11 @@ class ShopUserExampleFactory extends AbstractExampleFactory implements ExampleFa
     private $optionsResolver;
 
     public function __construct(
-        FactoryInterface $userFactory,
+        FactoryInterface $shopUserFactory,
         FactoryInterface $customerFactory,
         RepositoryInterface $customerGroupRepository
     ) {
-        $this->userFactory = $userFactory;
+        $this->shopUserFactory = $shopUserFactory;
         $this->customerFactory = $customerFactory;
         $this->customerGroupRepository = $customerGroupRepository;
 
@@ -73,7 +73,7 @@ class ShopUserExampleFactory extends AbstractExampleFactory implements ExampleFa
         $customer->setBirthday($options['birthday']);
 
         /** @var ShopUserInterface $user */
-        $user = $this->userFactory->createNew();
+        $user = $this->shopUserFactory->createNew();
         $user->setPlainPassword($options['password']);
         $user->setEnabled($options['enabled']);
         $user->addRole('ROLE_USER');


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.5
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.4, 1.5 or 1.6 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->

When you override this example factory. You have to manually wire this argument.
This change helps Resource bundle to autowire this argument.
