### PR TITLE
Clarify BC promise for final controllers

### DIFF
--- a/docs/contributing/code/bc.rst
+++ b/docs/contributing/code/bc.rst
@@ -27,6 +27,7 @@ This BC promise applies to all of Sylius' PHP code except for:
     - PHPUnit tests (located at ``tests/``, ``src/**/Tests/``)
     - PHPSpec tests (located at ``src/**/spec/``)
     - Behat tests (located at ``src/Sylius/Behat/``)
+    - final controllers (their service name is still covered with BC promise)
 
 Additional rules
 ----------------
@@ -49,6 +50,12 @@ Event listeners
 
 They are excluded from this BC promise, but they should be as simple as possible and always call another service.
 Behaviour they're providing (the end result) is still included in BC promise.
+
+Final controllers
+~~~~~~~~~~~~~~~~~
+
+It is allowed to change their dependencies, but the behaviour they're providing is still included in BC promise.
+The service name and class name will not change.
 
 Routing
 ~~~~~~~


### PR DESCRIPTION
There is a very unlikely possibility that one would create a new service based on our final controller class but with different arguments injected to the constructor. It is not a recommended way for sure - we try to keep final controllers as small as possible and the bigger ones are still non-final.

If you're using our final controllers, you're still covered with BC promise.

We need this exception for fixes like #10837.