### PR TITLE
[Psalm] Treat MismatchingDocblockReturnType as errors

### DIFF
--- a/etc/psalm/ZendPriorityQueueStub.php
+++ b/etc/psalm/ZendPriorityQueueStub.php
@@ -1,0 +1,125 @@
+<?php
+
+// This stub is created to support Psalm generics.
+
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Stdlib;
+
+use Countable;
+use IteratorAggregate;
+use Serializable;
+
+/**
+ * @psalm-template T
+ * @template-extends IteratorAggregate<int, T>
+ * @template-extends ArrayAccess<int|null, T>
+ */
+class PriorityQueue implements Countable, IteratorAggregate, Serializable
+{
+    const EXTR_DATA = 0x00000001;
+    const EXTR_PRIORITY = 0x00000002;
+    const EXTR_BOTH = 0x00000003;
+
+    /**
+     * @param mixed $data
+     * @param int $priority
+     *
+     * @return PriorityQueue
+     *
+     * @psalm-param T $data
+     * @psalm-return PriorityQueue<T>
+     */
+    public function insert($data, $priority = 1) { }
+
+    /**
+     * @param mixed $datum
+     *
+     * @return bool False if the item was not found, true otherwise.
+     *
+     * @psalm-param T $datum
+     */
+    public function remove($datum) { }
+
+    /**
+     * @return bool
+     */
+    public function isEmpty() { }
+
+    /**
+     * @return int
+     */
+    public function count() { }
+
+    /**
+     * @return mixed
+     */
+    public function top() { }
+
+    /**
+     * @return mixed
+     */
+    public function extract() { }
+
+    /**
+     * @return SplPriorityQueue
+     *
+     * @psalm-return SplPriorityQueue<T>
+     */
+    public function getIterator() { }
+
+    /**
+     * @return string
+     */
+    public function serialize() { }
+
+    /**
+     * @param string $data
+     *
+     * @return void
+     */
+    public function unserialize($data) { }
+
+    /**
+     * @param int $flag
+     *
+     * @return array
+     */
+    public function toArray($flag = self::EXTR_DATA) { }
+
+    /**
+     * @param string $class
+     *
+     * @return PriorityQueue
+     *
+     * @psalm-return PriorityQueue<T>
+     */
+    public function setInternalQueueClass($class) { }
+
+    /**
+     * @param mixed $datum
+     *
+     * @return bool
+     *
+     * @psalm-param T $datum
+     */
+    public function contains($datum) { }
+
+    /**
+     * @param int $priority
+     *
+     * @return bool
+     */
+    public function hasPriority($priority) { }
+
+    /**
+     * @return void
+     */
+    public function __clone() { }
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -199,10 +199,13 @@
 
         <!-- Custom -->
 
-        <MismatchingDocblockReturnType errorLevel="info" />
         <!-- remove after guzzlehttp-release -->
         <!-- see https://github.com/guzzle/guzzle/pull/2273 -->
         <InvalidCatch errorLevel="info" />
 
     </issueHandlers>
+
+    <stubs>
+        <file name="etc/psalm/ZendPriorityQueueStub.php" />
+    </stubs>
 </psalm>

--- a/src/Sylius/Bundle/AddressingBundle/SyliusAddressingBundle.php
+++ b/src/Sylius/Bundle/AddressingBundle/SyliusAddressingBundle.php
@@ -29,7 +29,7 @@ final class SyliusAddressingBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/AttributeBundle/SyliusAttributeBundle.php
+++ b/src/Sylius/Bundle/AttributeBundle/SyliusAttributeBundle.php
@@ -43,7 +43,7 @@ final class SyliusAttributeBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/ChannelBundle/SyliusChannelBundle.php
+++ b/src/Sylius/Bundle/ChannelBundle/SyliusChannelBundle.php
@@ -43,7 +43,7 @@ final class SyliusChannelBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
+++ b/src/Sylius/Bundle/CoreBundle/SyliusCoreBundle.php
@@ -49,7 +49,7 @@ final class SyliusCoreBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderShippingMethodEligibilityValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/OrderShippingMethodEligibilityValidator.php
@@ -50,8 +50,6 @@ final class OrderShippingMethodEligibilityValidator extends ConstraintValidator
 
         foreach ($shipments as $shipment) {
             if (!$this->methodEligibilityChecker->isEligible($shipment, $shipment->getMethod())) {
-                Assert::isInstanceOf($shipment, ShipmentInterface::class);
-
                 $this->context->addViolation(
                     $constraint->message,
                     ['%shippingMethodName%' => $shipment->getMethod()->getName()]

--- a/src/Sylius/Bundle/CurrencyBundle/SyliusCurrencyBundle.php
+++ b/src/Sylius/Bundle/CurrencyBundle/SyliusCurrencyBundle.php
@@ -42,7 +42,7 @@ final class SyliusCurrencyBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/CustomerBundle/SyliusCustomerBundle.php
+++ b/src/Sylius/Bundle/CustomerBundle/SyliusCustomerBundle.php
@@ -29,7 +29,7 @@ final class SyliusCustomerBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/InventoryBundle/SyliusInventoryBundle.php
+++ b/src/Sylius/Bundle/InventoryBundle/SyliusInventoryBundle.php
@@ -30,7 +30,7 @@ final class SyliusInventoryBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/LocaleBundle/SyliusLocaleBundle.php
+++ b/src/Sylius/Bundle/LocaleBundle/SyliusLocaleBundle.php
@@ -42,7 +42,7 @@ final class SyliusLocaleBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/OrderBundle/SyliusOrderBundle.php
+++ b/src/Sylius/Bundle/OrderBundle/SyliusOrderBundle.php
@@ -43,7 +43,7 @@ final class SyliusOrderBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/PaymentBundle/SyliusPaymentBundle.php
+++ b/src/Sylius/Bundle/PaymentBundle/SyliusPaymentBundle.php
@@ -44,7 +44,7 @@ final class SyliusPaymentBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/ProductBundle/Form/DataTransformer/ProductVariantToProductOptionsTransformer.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/DataTransformer/ProductVariantToProductOptionsTransformer.php
@@ -47,7 +47,6 @@ final class ProductVariantToProductOptionsTransformer implements DataTransformer
 
         return array_combine(
             array_map(
-                /** @psalm-return array-key */
                 function (ProductOptionValueInterface $productOptionValue): string {
                     return (string) $productOptionValue->getOptionCode();
                 },
@@ -78,7 +77,7 @@ final class ProductVariantToProductOptionsTransformer implements DataTransformer
      *
      * @throws TransformationFailedException
      */
-    private function matches(array $optionValues): ?ProductVariantInterface
+    private function matches(array $optionValues): ProductVariantInterface
     {
         foreach ($this->product->getVariants() as $variant) {
             foreach ($optionValues as $optionValue) {

--- a/src/Sylius/Bundle/ProductBundle/Form/DataTransformer/ProductsToProductAssociationsTransformer.php
+++ b/src/Sylius/Bundle/ProductBundle/Form/DataTransformer/ProductsToProductAssociationsTransformer.php
@@ -34,7 +34,11 @@ final class ProductsToProductAssociationsTransformer implements DataTransformerI
     /** @var RepositoryInterface */
     private $productAssociationTypeRepository;
 
-    /** @var Collection<array-key, ProductAssociationInterface> */
+    /**
+     * @var Collection|ProductAssociationInterface[]
+     *
+     * @psalm-var Collection<array-key, ProductAssociationInterface>
+     */
     private $productAssociations;
 
     public function __construct(
@@ -79,7 +83,9 @@ final class ProductsToProductAssociationsTransformer implements DataTransformerI
             return null;
         }
 
-        /** @var Collection<array-key, ProductAssociationInterface> $productAssociations */
+        /**
+         * @psalm-var Collection<array-key, ProductAssociationInterface> $productAssociations
+         */
         $productAssociations = new ArrayCollection();
         foreach ($values as $productAssociationTypeCode => $productCodes) {
             if (null === $productCodes) {

--- a/src/Sylius/Bundle/ProductBundle/SyliusProductBundle.php
+++ b/src/Sylius/Bundle/ProductBundle/SyliusProductBundle.php
@@ -29,7 +29,7 @@ final class SyliusProductBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/PromotionBundle/SyliusPromotionBundle.php
+++ b/src/Sylius/Bundle/PromotionBundle/SyliusPromotionBundle.php
@@ -48,7 +48,7 @@ final class SyliusPromotionBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/PromotionBundle/test/src/AppBundle/Entity/PromotionSubject.php
+++ b/src/Sylius/Bundle/PromotionBundle/test/src/AppBundle/Entity/PromotionSubject.php
@@ -31,7 +31,11 @@ class PromotionSubject implements ResourceInterface, PromotionSubjectInterface
     /** @var int */
     private $id;
 
-    /** @var Collection|PromotionInterface[] */
+    /**
+     * @var Collection|PromotionInterface[]
+     *
+     * @psalm-var Collection<array-key, PromotionInterface>
+     */
     protected $promotions;
 
     /**

--- a/src/Sylius/Bundle/ReviewBundle/SyliusReviewBundle.php
+++ b/src/Sylius/Bundle/ReviewBundle/SyliusReviewBundle.php
@@ -41,7 +41,7 @@ final class SyliusReviewBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/ShippingBundle/SyliusShippingBundle.php
+++ b/src/Sylius/Bundle/ShippingBundle/SyliusShippingBundle.php
@@ -43,7 +43,7 @@ final class SyliusShippingBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/ShopBundle/EventListener/OrderIntegrityChecker.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/OrderIntegrityChecker.php
@@ -51,6 +51,7 @@ final class OrderIntegrityChecker
         /** @var OrderInterface $order */
         Assert::isInstanceOf($order, OrderInterface::class);
 
+        /** @var ArrayCollection<array-key, PromotionInterface> $previousPromotions */
         $previousPromotions = new ArrayCollection($order->getPromotions()->toArray());
         $oldTotal = $order->getTotal();
 

--- a/src/Sylius/Bundle/TaxationBundle/SyliusTaxationBundle.php
+++ b/src/Sylius/Bundle/TaxationBundle/SyliusTaxationBundle.php
@@ -41,7 +41,7 @@ final class SyliusTaxationBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/TaxonomyBundle/SyliusTaxonomyBundle.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/SyliusTaxonomyBundle.php
@@ -30,7 +30,7 @@ final class SyliusTaxonomyBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Bundle/UserBundle/SyliusUserBundle.php
+++ b/src/Sylius/Bundle/UserBundle/SyliusUserBundle.php
@@ -29,7 +29,7 @@ final class SyliusUserBundle extends AbstractResourceBundle
     }
 
     /**
-     * {@inheritdoc}
+     * @psalm-suppress MismatchingDocblockReturnType https://github.com/vimeo/psalm/issues/2345
      */
     protected function getModelNamespace(): string
     {

--- a/src/Sylius/Component/Addressing/Model/Country.php
+++ b/src/Sylius/Component/Addressing/Model/Country.php
@@ -32,11 +32,16 @@ class Country implements CountryInterface
      */
     protected $code;
 
-    /** @var Collection|ProvinceInterface[] */
+    /**
+     * @var Collection|ProvinceInterface[]
+     *
+     * @psalm-var Collection<array-key, ProvinceInterface>
+     */
     protected $provinces;
 
     public function __construct()
     {
+        /** @var ArrayCollection<array-key, ProvinceInterface> $this->provinces */
         $this->provinces = new ArrayCollection();
     }
 

--- a/src/Sylius/Component/Addressing/Model/CountryInterface.php
+++ b/src/Sylius/Component/Addressing/Model/CountryInterface.php
@@ -24,6 +24,8 @@ interface CountryInterface extends ToggleableInterface, ResourceInterface, CodeA
 
     /**
      * @return Collection|ProvinceInterface[]
+     *
+     * @psalm-return Collection<array-key, ProvinceInterface>
      */
     public function getProvinces(): Collection;
 

--- a/src/Sylius/Component/Addressing/Model/Zone.php
+++ b/src/Sylius/Component/Addressing/Model/Zone.php
@@ -33,11 +33,16 @@ class Zone implements ZoneInterface
     /** @var string|null */
     protected $scope = Scope::ALL;
 
-    /** @var Collection|ZoneMemberInterface[] */
+    /**
+     * @var Collection|ZoneMemberInterface[]
+     *
+     * @psalm-var Collection<array-key, ZoneMemberInterface>
+     */
     protected $members;
 
     public function __construct()
     {
+        /** @var ArrayCollection<array-key, ZoneMemberInterface> $this->members */
         $this->members = new ArrayCollection();
     }
 

--- a/src/Sylius/Component/Addressing/Model/ZoneInterface.php
+++ b/src/Sylius/Component/Addressing/Model/ZoneInterface.php
@@ -44,6 +44,8 @@ interface ZoneInterface extends ResourceInterface, CodeAwareInterface
 
     /**
      * @return Collection|ZoneMemberInterface[]
+     *
+     * @psalm-return Collection<array-key, ZoneMemberInterface>
      */
     public function getMembers(): Collection;
 

--- a/src/Sylius/Component/Attribute/Model/AttributeSubjectInterface.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeSubjectInterface.php
@@ -19,11 +19,15 @@ interface AttributeSubjectInterface
 {
     /**
      * @return Collection|AttributeValueInterface[]
+     *
+     * @psalm-return Collection<array-key, AttributeValueInterface>
      */
     public function getAttributes(): Collection;
 
     /**
      * @return Collection|AttributeValueInterface[]
+     *
+     * @psalm-return Collection<array-key, AttributeValueInterface>
      */
     public function getAttributesByLocale(
         string $localeCode,

--- a/src/Sylius/Component/Channel/Context/CompositeChannelContext.php
+++ b/src/Sylius/Component/Channel/Context/CompositeChannelContext.php
@@ -18,7 +18,11 @@ use Zend\Stdlib\PriorityQueue;
 
 final class CompositeChannelContext implements ChannelContextInterface
 {
-    /** @var PriorityQueue|ChannelContextInterface[] */
+    /**
+     * @var PriorityQueue|ChannelContextInterface[]
+     *
+     * @psalm-var PriorityQueue<ChannelContextInterface>
+     */
     private $channelContexts;
 
     public function __construct()

--- a/src/Sylius/Component/Channel/Context/RequestBased/CompositeRequestResolver.php
+++ b/src/Sylius/Component/Channel/Context/RequestBased/CompositeRequestResolver.php
@@ -19,7 +19,11 @@ use Zend\Stdlib\PriorityQueue;
 
 final class CompositeRequestResolver implements RequestResolverInterface
 {
-    /** @var PriorityQueue|RequestResolverInterface[] */
+    /**
+     * @var PriorityQueue|RequestResolverInterface[]
+     *
+     * @psalm-var PriorityQueue<RequestResolverInterface>
+     */
     private $requestResolvers;
 
     public function __construct()

--- a/src/Sylius/Component/Channel/Model/ChannelsAwareInterface.php
+++ b/src/Sylius/Component/Channel/Model/ChannelsAwareInterface.php
@@ -19,6 +19,8 @@ interface ChannelsAwareInterface
 {
     /**
      * @return Collection|ChannelInterface[]
+     *
+     * @psalm-return Collection<array-key, ChannelInterface>
      */
     public function getChannels(): Collection;
 

--- a/src/Sylius/Component/Core/Model/Channel.php
+++ b/src/Sylius/Component/Core/Model/Channel.php
@@ -34,10 +34,18 @@ class Channel extends BaseChannel implements ChannelInterface
     /** @var string */
     protected $taxCalculationStrategy;
 
-    /** @var CurrencyInterface[]|Collection */
+    /**
+     * @var Collection|CurrencyInterface[]
+     *
+     * @psalm-var Collection<array-key, CurrencyInterface>
+     */
     protected $currencies;
 
-    /** @var LocaleInterface[]|Collection */
+    /**
+     * @var Collection|LocaleInterface[]
+     *
+     * @psalm-var Collection<array-key, LocaleInterface>
+     */
     protected $locales;
 
     /** @var string */
@@ -62,7 +70,9 @@ class Channel extends BaseChannel implements ChannelInterface
     {
         parent::__construct();
 
+        /** @var ArrayCollection<array-key, CurrencyInterface> $this->currencies */
         $this->currencies = new ArrayCollection();
+        /** @var ArrayCollection<array-key, LocaleInterface> $this->locales */
         $this->locales = new ArrayCollection();
     }
 

--- a/src/Sylius/Component/Core/Model/Customer.php
+++ b/src/Sylius/Component/Core/Model/Customer.php
@@ -21,13 +21,21 @@ use Webmozart\Assert\Assert;
 
 class Customer extends BaseCustomer implements CustomerInterface
 {
-    /** @var Collection|OrderInterface[] */
+    /**
+     * @var Collection|OrderInterface[]
+     *
+     * @psalm-var Collection<array-key, OrderInterface>
+     */
     protected $orders;
 
     /** @var AddressInterface|null */
     protected $defaultAddress;
 
-    /** @var Collection|AddressInterface[] */
+    /**
+     * @var Collection|AddressInterface[]
+     *
+     * @psalm-var Collection<array-key, AddressInterface>
+     */
     protected $addresses;
 
     /** @var ShopUserInterface|null */
@@ -37,7 +45,10 @@ class Customer extends BaseCustomer implements CustomerInterface
     {
         parent::__construct();
 
+        /** @var ArrayCollection<array-key, OrderInterface> $this->orders */
         $this->orders = new ArrayCollection();
+
+        /** @var ArrayCollection<array-key, AddressInterface> $this->addresses */
         $this->addresses = new ArrayCollection();
     }
 

--- a/src/Sylius/Component/Core/Model/CustomerInterface.php
+++ b/src/Sylius/Component/Core/Model/CustomerInterface.php
@@ -22,6 +22,8 @@ interface CustomerInterface extends BaseCustomerInterface, UserAwareInterface, P
 {
     /**
      * @return Collection|OrderInterface[]
+     *
+     * @psalm-return Collection<array-key, OrderInterface>
      */
     public function getOrders(): Collection;
 
@@ -37,6 +39,8 @@ interface CustomerInterface extends BaseCustomerInterface, UserAwareInterface, P
 
     /**
      * @return Collection|AddressInterface[]
+     *
+     * @psalm-return Collection<array-key, AddressInterface>
      */
     public function getAddresses(): Collection;
 

--- a/src/Sylius/Component/Core/Model/ImagesAwareInterface.php
+++ b/src/Sylius/Component/Core/Model/ImagesAwareInterface.php
@@ -19,11 +19,15 @@ interface ImagesAwareInterface
 {
     /**
      * @return Collection|ImageInterface[]
+     *
+     * @psalm-return Collection<array-key, ImageInterface>
      */
     public function getImages(): Collection;
 
     /**
      * @return Collection|ImageInterface[]
+     *
+     * @psalm-return Collection<array-key, ImageInterface>
      */
     public function getImagesByType(string $type): Collection;
 

--- a/src/Sylius/Component/Core/Model/Order.php
+++ b/src/Sylius/Component/Core/Model/Order.php
@@ -20,7 +20,6 @@ use Sylius\Component\Core\OrderCheckoutStates;
 use Sylius\Component\Core\OrderPaymentStates;
 use Sylius\Component\Core\OrderShippingStates;
 use Sylius\Component\Customer\Model\CustomerInterface as BaseCustomerInterface;
-use Sylius\Component\Order\Model\AdjustmentInterface as BaseAdjustmentInterface;
 use Sylius\Component\Order\Model\Order as BaseOrder;
 use Sylius\Component\Payment\Model\PaymentInterface as BasePaymentInterface;
 use Sylius\Component\Promotion\Model\PromotionCouponInterface as BaseCouponInterface;
@@ -42,10 +41,18 @@ class Order extends BaseOrder implements OrderInterface
     /** @var AddressInterface|null */
     protected $billingAddress;
 
-    /** @var Collection|BasePaymentInterface[] */
+    /**
+     * @var Collection|PaymentInterface[]
+     *
+     * @psalm-var Collection<array-key, PaymentInterface>
+     */
     protected $payments;
 
-    /** @var Collection|ShipmentInterface[] */
+    /**
+     * @var Collection|ShipmentInterface[]
+     *
+     * @psalm-var Collection<array-key, ShipmentInterface>
+     */
     protected $shipments;
 
     /** @var string|null */
@@ -66,7 +73,11 @@ class Order extends BaseOrder implements OrderInterface
     /** @var string */
     protected $shippingState = OrderShippingStates::STATE_CART;
 
-    /** @var Collection|BasePromotionInterface[] */
+    /**
+     * @var Collection|BasePromotionInterface[]
+     *
+     * @psalm-var Collection<array-key, BasePromotionInterface>
+     */
     protected $promotions;
 
     /** @var string|null */
@@ -79,8 +90,13 @@ class Order extends BaseOrder implements OrderInterface
     {
         parent::__construct();
 
+        /** @var ArrayCollection<array-key, PaymentInterface> $this->payments */
         $this->payments = new ArrayCollection();
+
+        /** @var ArrayCollection<array-key, ShipmentInterface> $this->shipments */
         $this->shipments = new ArrayCollection();
+
+        /** @var ArrayCollection<array-key, BasePromotionInterface> $this->promotions */
         $this->promotions = new ArrayCollection();
     }
 
@@ -199,6 +215,7 @@ class Order extends BaseOrder implements OrderInterface
      */
     public function getItemUnits(): Collection
     {
+        /** @var ArrayCollection<int, OrderItemUnitInterface> $units */
         $units = new ArrayCollection();
 
         /** @var OrderItem $item */
@@ -223,6 +240,9 @@ class Order extends BaseOrder implements OrderInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @psalm-suppress InvalidReturnType https://github.com/doctrine/collections/pull/220
+     * @psalm-suppress InvalidReturnStatement https://github.com/doctrine/collections/pull/220
      */
     public function getPayments(): Collection
     {
@@ -291,7 +311,7 @@ class Order extends BaseOrder implements OrderInterface
 
     public function isShippingRequired(): bool
     {
-        foreach ($this->getItems() as $orderItem) {
+        foreach ($this->items as $orderItem) {
             /** @var OrderItemInterface $orderItem */
             Assert::isInstanceOf($orderItem, OrderItemInterface::class);
 

--- a/src/Sylius/Component/Core/Model/OrderInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderInterface.php
@@ -52,11 +52,15 @@ interface OrderInterface extends
 
     /**
      * @return Collection|OrderItemUnitInterface[]
+     *
+     * @psalm-return Collection<array-key, OrderItemUnitInterface>
      */
     public function getItemUnits(): Collection;
 
     /**
      * @return Collection|OrderItemUnitInterface[]
+     *
+     * @psalm-return Collection<array-key, OrderItemUnitInterface>
      */
     public function getItemUnitsByVariant(ProductVariantInterface $variant): Collection;
 
@@ -64,6 +68,8 @@ interface OrderInterface extends
 
     /**
      * @return Collection|ShipmentInterface[]
+     *
+     * @psalm-return Collection<array-key, ShipmentInterface>
      */
     public function getShipments(): Collection;
 
@@ -109,6 +115,10 @@ interface OrderInterface extends
 
     /**
      * @return Collection|OrderItemInterface[]
+     *
+     * @psalm-return Collection<array-key, OrderItemInterface>
+     *
+     * @psalm-suppress ImplementedReturnTypeMismatch
      */
     public function getItems(): Collection;
 

--- a/src/Sylius/Component/Core/Model/PaymentMethod.php
+++ b/src/Sylius/Component/Core/Model/PaymentMethod.php
@@ -22,7 +22,11 @@ use Sylius\Component\Payment\Model\PaymentMethodTranslation;
 
 class PaymentMethod extends BasePaymentMethod implements PaymentMethodInterface
 {
-    /** @var Collection */
+    /**
+     * @var Collection|BaseChannelInterface[]
+     *
+     * @psalm-var Collection<array-key, BaseChannelInterface>
+     */
     protected $channels;
 
     /** @var GatewayConfigInterface */
@@ -32,6 +36,7 @@ class PaymentMethod extends BasePaymentMethod implements PaymentMethodInterface
     {
         parent::__construct();
 
+        /** @var ArrayCollection<array-key, BaseChannelInterface> $this->channels */
         $this->channels = new ArrayCollection();
     }
 

--- a/src/Sylius/Component/Core/Model/Product.php
+++ b/src/Sylius/Component/Core/Model/Product.php
@@ -28,31 +28,54 @@ class Product extends BaseProduct implements ProductInterface, ReviewableProduct
     /** @var string */
     protected $variantSelectionMethod = self::VARIANT_SELECTION_CHOICE;
 
-    /** @var Collection|ProductTaxonInterface[] */
+    /**
+     * @var Collection|ProductTaxonInterface[]
+     *
+     * @psalm-var Collection<array-key, ProductTaxonInterface>
+     */
     protected $productTaxons;
 
-    /** @var Collection|ChannelInterface[] */
+    /**
+     * @var Collection|ChannelInterface[]
+     *
+     * @psalm-var Collection<array-key, ChannelInterface>
+     */
     protected $channels;
 
     /** @var BaseTaxonInterface */
     protected $mainTaxon;
 
-    /** @var Collection|ReviewInterface[] */
+    /**
+     * @var Collection|ReviewInterface[]
+     *
+     * @psalm-var Collection<array-key, ReviewInterface>
+     */
     protected $reviews;
 
     /** @var float */
     protected $averageRating = 0;
 
-    /** @var Collection|ImageInterface[] */
+    /**
+     * @var Collection|ImageInterface[]
+     *
+     * @psalm-var Collection<array-key, ImageInterface>
+     */
     protected $images;
 
     public function __construct()
     {
         parent::__construct();
 
+        /** @var ArrayCollection<array-key, ProductTaxonInterface> $this->productTaxons */
         $this->productTaxons = new ArrayCollection();
+
+        /** @var ArrayCollection<array-key, ChannelInterface> $this->channels */
         $this->channels = new ArrayCollection();
+
+        /** @var ArrayCollection<array-key, ReviewInterface> $this->reviews */
         $this->reviews = new ArrayCollection();
+
+        /** @var ArrayCollection<array-key, ImageInterface> $this->images */
         $this->images = new ArrayCollection();
     }
 
@@ -153,6 +176,9 @@ class Product extends BaseProduct implements ProductInterface, ReviewableProduct
 
     /**
      * {@inheritdoc}
+     *
+     * @psalm-suppress InvalidReturnType https://github.com/doctrine/collections/pull/220
+     * @psalm-suppress InvalidReturnStatement https://github.com/doctrine/collections/pull/220
      */
     public function getChannels(): Collection
     {

--- a/src/Sylius/Component/Core/Model/ProductImage.php
+++ b/src/Sylius/Component/Core/Model/ProductImage.php
@@ -18,11 +18,16 @@ use Doctrine\Common\Collections\Collection;
 
 class ProductImage extends Image implements ProductImageInterface
 {
-    /** @var Collection|ProductVariantInterface[] */
+    /**
+     * @var Collection|ProductVariantInterface[]
+     *
+     * @psalm-var Collection<array-key, ProductVariantInterface>
+     */
     protected $productVariants;
 
     public function __construct()
     {
+        /** @var ArrayCollection<array-key, ProductVariantInterface> $this->productVaraints */
         $this->productVariants = new ArrayCollection();
     }
 

--- a/src/Sylius/Component/Core/Model/ProductImageInterface.php
+++ b/src/Sylius/Component/Core/Model/ProductImageInterface.php
@@ -21,6 +21,8 @@ interface ProductImageInterface extends ImageInterface
 
     /**
      * @return Collection|ProductVariantInterface[]
+     *
+     * @psalm-return Collection<array-key, ProductVariantInterface>
      */
     public function getProductVariants(): Collection;
 

--- a/src/Sylius/Component/Core/Model/ProductImagesAwareInterface.php
+++ b/src/Sylius/Component/Core/Model/ProductImagesAwareInterface.php
@@ -19,11 +19,15 @@ interface ProductImagesAwareInterface
 {
     /**
      * @return Collection|ImageInterface[]
+     *
+     * @psalm-return Collection<array-key, ImageInterface>
      */
     public function getImages(): Collection;
 
     /**
      * @return Collection|ImageInterface[]
+     *
+     * @psalm-return Collection<array-key, ImageInterface>
      */
     public function getImagesByType(string $type): Collection;
 

--- a/src/Sylius/Component/Core/Model/ProductInterface.php
+++ b/src/Sylius/Component/Core/Model/ProductInterface.php
@@ -60,6 +60,8 @@ interface ProductInterface extends
 
     /**
      * @return Collection|ReviewInterface[]
+     *
+     * @psalm-return Collection<array-key, ReviewInterface>
      */
     public function getAcceptedReviews(): Collection;
 

--- a/src/Sylius/Component/Core/Model/ProductTaxonsAwareInterface.php
+++ b/src/Sylius/Component/Core/Model/ProductTaxonsAwareInterface.php
@@ -19,6 +19,8 @@ interface ProductTaxonsAwareInterface
 {
     /**
      * @return Collection|ProductTaxonInterface[]
+     *
+     * @psalm-return Collection<array-key, ProductTaxonInterface>
      */
     public function getProductTaxons(): Collection;
 
@@ -30,6 +32,8 @@ interface ProductTaxonsAwareInterface
 
     /**
      * @return Collection|TaxonInterface[]
+     *
+     * @psalm-return Collection<array-key, TaxonInterface>
      */
     public function getTaxons(): Collection;
 

--- a/src/Sylius/Component/Core/Model/ProductVariant.php
+++ b/src/Sylius/Component/Core/Model/ProductVariant.php
@@ -51,20 +51,28 @@ class ProductVariant extends BaseVariant implements ProductVariantInterface
     /** @var ShippingCategoryInterface */
     protected $shippingCategory;
 
-    /** @var Collection */
+    /**
+     * @var Collection */
     protected $channelPricings;
 
     /** @var bool */
     protected $shippingRequired = true;
 
-    /** @var Collection|ProductImageInterface[] */
+    /**
+     * @var Collection|ProductImageInterface[]
+     *
+     * @psalm-var Collection<array-key, ProductImageInterface>
+     */
     protected $images;
 
     public function __construct()
     {
         parent::__construct();
 
+        /** @var ArrayCollection<array-key, ChannelPricingInterface> $this->channelPricings */
         $this->channelPricings = new ArrayCollection();
+
+        /** @var ArrayCollection<array-key, ProductImageInterface> $this->images */
         $this->images = new ArrayCollection();
     }
 
@@ -377,6 +385,9 @@ class ProductVariant extends BaseVariant implements ProductVariantInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @psalm-suppress InvalidReturnType https://github.com/doctrine/collections/pull/220
+     * @psalm-suppress InvalidReturnStatement https://github.com/doctrine/collections/pull/220
      */
     public function getImages(): Collection
     {
@@ -385,6 +396,9 @@ class ProductVariant extends BaseVariant implements ProductVariantInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @psalm-suppress InvalidReturnType https://github.com/doctrine/collections/pull/220
+     * @psalm-suppress InvalidReturnStatement https://github.com/doctrine/collections/pull/220
      */
     public function getImagesByType(string $type): Collection
     {

--- a/src/Sylius/Component/Core/Model/ProductVariantInterface.php
+++ b/src/Sylius/Component/Core/Model/ProductVariantInterface.php
@@ -52,6 +52,8 @@ interface ProductVariantInterface extends
 
     /**
      * @return Collection|ChannelPricingInterface[]
+     *
+     * @psalm-return Collection<array-key, ChannelPricingInterface>
      */
     public function getChannelPricings(): Collection;
 

--- a/src/Sylius/Component/Core/Model/Promotion.php
+++ b/src/Sylius/Component/Core/Model/Promotion.php
@@ -20,18 +20,26 @@ use Sylius\Component\Promotion\Model\Promotion as BasePromotion;
 
 class Promotion extends BasePromotion implements PromotionInterface
 {
-    /** @var ChannelInterface[]|Collection */
+    /**
+     * @var Collection|ChannelInterface[]
+     *
+     * @psalm-var Collection<array-key, ChannelInterface>
+     */
     protected $channels;
 
     public function __construct()
     {
         parent::__construct();
 
+        /** @var ArrayCollection<array-key, ChannelInterface> $this->channels */
         $this->channels = new ArrayCollection();
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @psalm-suppress InvalidReturnType https://github.com/doctrine/collections/pull/220
+     * @psalm-suppress InvalidReturnStatement https://github.com/doctrine/collections/pull/220
      */
     public function getChannels(): Collection
     {

--- a/src/Sylius/Component/Core/Model/ShippingMethod.php
+++ b/src/Sylius/Component/Core/Model/ShippingMethod.php
@@ -29,13 +29,18 @@ class ShippingMethod extends BaseShippingMethod implements ShippingMethodInterfa
     /** @var TaxCategoryInterface */
     protected $taxCategory;
 
-    /** @var Collection */
+    /**
+     * @var Collection|ChannelInterface[]
+     *
+     * @psalm-var Collection<array-key, ChannelInterface>
+     */
     protected $channels;
 
     public function __construct()
     {
         parent::__construct();
 
+        /** @var ArrayCollection<array-key, ChannelInterface> $this->channels */
         $this->channels = new ArrayCollection();
     }
 
@@ -73,6 +78,9 @@ class ShippingMethod extends BaseShippingMethod implements ShippingMethodInterfa
 
     /**
      * {@inheritdoc}
+     *
+     * @psalm-suppress InvalidReturnType https://github.com/doctrine/collections/pull/220
+     * @psalm-suppress InvalidReturnStatement https://github.com/doctrine/collections/pull/220
      */
     public function getChannels(): Collection
     {

--- a/src/Sylius/Component/Core/Model/Taxon.php
+++ b/src/Sylius/Component/Core/Model/Taxon.php
@@ -23,7 +23,11 @@ class Taxon extends BaseTaxon implements TaxonInterface
 {
     use TimestampableTrait;
 
-    /** @var Collection|ImageInterface[] */
+    /**
+     * @var Collection|ImageInterface[]
+     *
+     * @psalm-var Collection<array-key, ImageInterface>
+     */
     protected $images;
 
     public function __construct()
@@ -31,6 +35,8 @@ class Taxon extends BaseTaxon implements TaxonInterface
         parent::__construct();
 
         $this->createdAt = new \DateTime();
+
+        /** @var ArrayCollection<array-key, ImageInterface> $this->images */
         $this->images = new ArrayCollection();
     }
 

--- a/src/Sylius/Component/Core/OrderProcessing/OrderPricesRecalculator.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderPricesRecalculator.php
@@ -15,6 +15,7 @@ namespace Sylius\Component\Core\OrderProcessing;
 
 use Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Order\Model\OrderInterface as BaseOrderInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Webmozart\Assert\Assert;
@@ -36,9 +37,13 @@ final class OrderPricesRecalculator implements OrderProcessorInterface
     {
         /** @var OrderInterface $order */
         Assert::isInstanceOf($order, OrderInterface::class);
+
         $channel = $order->getChannel();
 
         foreach ($order->getItems() as $item) {
+            /** @var OrderItemInterface $item */
+            Assert::isInstanceOf($item, OrderItemInterface::class);
+
             if ($item->isImmutable()) {
                 continue;
             }

--- a/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
@@ -110,9 +110,6 @@ final class OrderShipmentProcessor implements OrderProcessorInterface
         Assert::isInstanceOf($order, OrderInterface::class);
 
         foreach ($order->getItemUnits() as $itemUnit) {
-            /** @var OrderItemUnitInterface $itemUnit */
-            Assert::isInstanceOf($itemUnit, OrderItemUnitInterface::class);
-
             if (null === $itemUnit->getShipment()) {
                 $shipment->addUnit($itemUnit);
             }

--- a/src/Sylius/Component/Core/StateResolver/OrderPaymentStateResolver.php
+++ b/src/Sylius/Component/Core/StateResolver/OrderPaymentStateResolver.php
@@ -111,6 +111,8 @@ final class OrderPaymentStateResolver implements StateResolverInterface
 
     /**
      * @return Collection|PaymentInterface[]
+     *
+     * @psalm-return Collection<array-key, PaymentInterface>
      */
     private function getPaymentsWithState(OrderInterface $order, string $state): Collection
     {

--- a/src/Sylius/Component/Currency/Context/CompositeCurrencyContext.php
+++ b/src/Sylius/Component/Currency/Context/CompositeCurrencyContext.php
@@ -17,7 +17,11 @@ use Zend\Stdlib\PriorityQueue;
 
 final class CompositeCurrencyContext implements CurrencyContextInterface
 {
-    /** @var PriorityQueue|CurrencyContextInterface[] */
+    /**
+     * @var PriorityQueue|CurrencyContextInterface[]
+     *
+     * @psalm-var PriorityQueue<CurrencyContextInterface>
+     */
     private $currencyContexts;
 
     public function __construct()

--- a/src/Sylius/Component/Currency/Model/CurrenciesAwareInterface.php
+++ b/src/Sylius/Component/Currency/Model/CurrenciesAwareInterface.php
@@ -19,6 +19,8 @@ interface CurrenciesAwareInterface
 {
     /**
      * @return Collection|CurrencyInterface[]
+     *
+     * @psalm-return Collection<array-key, CurrencyInterface>
      */
     public function getCurrencies(): Collection;
 

--- a/src/Sylius/Component/Locale/Context/CompositeLocaleContext.php
+++ b/src/Sylius/Component/Locale/Context/CompositeLocaleContext.php
@@ -17,7 +17,11 @@ use Zend\Stdlib\PriorityQueue;
 
 final class CompositeLocaleContext implements LocaleContextInterface
 {
-    /** @var PriorityQueue|LocaleContextInterface[] */
+    /**
+     * @var PriorityQueue|LocaleContextInterface[]
+     *
+     * @psalm-var PriorityQueue<LocaleContextInterface>
+     */
     private $localeContexts;
 
     public function __construct()

--- a/src/Sylius/Component/Locale/Model/LocalesAwareInterface.php
+++ b/src/Sylius/Component/Locale/Model/LocalesAwareInterface.php
@@ -19,6 +19,8 @@ interface LocalesAwareInterface
 {
     /**
      * @return Collection|LocaleInterface[]
+     *
+     * @psalm-return Collection<array-key, LocaleInterface>
      */
     public function getLocales(): Collection;
 

--- a/src/Sylius/Component/Order/Context/CompositeCartContext.php
+++ b/src/Sylius/Component/Order/Context/CompositeCartContext.php
@@ -18,7 +18,11 @@ use Zend\Stdlib\PriorityQueue;
 
 final class CompositeCartContext implements CartContextInterface
 {
-    /** @var PriorityQueue|CartContextInterface[] */
+    /**
+     * @var PriorityQueue|CartContextInterface[]
+     *
+     * @psalm-var PriorityQueue<CartContextInterface>
+     */
     private $cartContexts;
 
     public function __construct()

--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -33,13 +33,21 @@ class Order implements OrderInterface
     /** @var string|null */
     protected $notes;
 
-    /** @var Collection<array-key, OrderItemInterface> */
+    /**
+     * @var Collection|OrderItemInterface[]
+     *
+     * @psalm-var Collection<array-key, OrderItemInterface>
+     */
     protected $items;
 
     /** @var int */
     protected $itemsTotal = 0;
 
-    /** @var Collection<array-key, AdjustmentInterface> */
+    /**
+     * @var Collection|AdjustmentInterface[]
+     *
+     * @psalm-var Collection<array-key, AdjustmentInterface>
+     */
     protected $adjustments;
 
     /** @var int */
@@ -57,8 +65,12 @@ class Order implements OrderInterface
 
     public function __construct()
     {
+        /** @var ArrayCollection<array-key, OrderItemInterface> $this->items */
         $this->items = new ArrayCollection();
+
+        /** @var ArrayCollection<array-key, AdjustmentInterface> $this->adjustments */
         $this->adjustments = new ArrayCollection();
+
         $this->createdAt = new \DateTime();
     }
 

--- a/src/Sylius/Component/Order/Model/OrderInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderInterface.php
@@ -45,6 +45,8 @@ interface OrderInterface extends AdjustableInterface, ResourceInterface, Timesta
 
     /**
      * @return Collection|OrderItemInterface[]
+     *
+     * @psalm-return Collection<array-key, OrderItemInterface>
      */
     public function getItems(): Collection;
 
@@ -74,6 +76,8 @@ interface OrderInterface extends AdjustableInterface, ResourceInterface, Timesta
 
     /**
      * @return Collection|AdjustmentInterface[]
+     *
+     * @psalm-return Collection<array-key, AdjustmentInterface>
      */
     public function getAdjustmentsRecursively(?string $type = null): Collection;
 

--- a/src/Sylius/Component/Order/Model/OrderItem.php
+++ b/src/Sylius/Component/Order/Model/OrderItem.php
@@ -36,13 +36,21 @@ class OrderItem implements OrderItemInterface
     /** @var bool */
     protected $immutable = false;
 
-    /** @var Collection<array-key, OrderItemUnitInterface> */
+    /**
+     * @var Collection|OrderItemUnitInterface[]
+     *
+     * @psalm-var Collection<array-key, OrderItemUnitInterface>
+     */
     protected $units;
 
     /** @var int */
     protected $unitsTotal = 0;
 
-    /** @var Collection<array-key, AdjustmentInterface> */
+    /**
+     * @var Collection|AdjustmentInterface[]
+     *
+     * @psalm-var Collection<array-key, AdjustmentInterface>
+     */
     protected $adjustments;
 
     /** @var int */
@@ -50,7 +58,10 @@ class OrderItem implements OrderItemInterface
 
     public function __construct()
     {
+        /** @var ArrayCollection<array-key, AdjustmentInterface> $this->adjustments */
         $this->adjustments = new ArrayCollection();
+
+        /** @var ArrayCollection<array-key, OrderItemUnitInterface> $this->units */
         $this->units = new ArrayCollection();
     }
 

--- a/src/Sylius/Component/Order/Model/OrderItemInterface.php
+++ b/src/Sylius/Component/Order/Model/OrderItemInterface.php
@@ -43,6 +43,8 @@ interface OrderItemInterface extends AdjustableInterface, OrderAwareInterface, R
 
     /**
      * @return Collection|OrderItemUnitInterface[]
+     *
+     * @psalm-return Collection<array-key, OrderItemUnitInterface>
      */
     public function getUnits(): Collection;
 
@@ -54,6 +56,8 @@ interface OrderItemInterface extends AdjustableInterface, OrderAwareInterface, R
 
     /**
      * @return Collection|AdjustmentInterface[]
+     *
+     * @psalm-return Collection<array-key, AdjustmentInterface>
      */
     public function getAdjustmentsRecursively(?string $type = null): Collection;
 

--- a/src/Sylius/Component/Order/Model/OrderItemUnit.php
+++ b/src/Sylius/Component/Order/Model/OrderItemUnit.php
@@ -24,7 +24,11 @@ class OrderItemUnit implements OrderItemUnitInterface
     /** @var OrderItemInterface */
     protected $orderItem;
 
-    /** @var Collection<array-key, AdjustmentInterface> */
+    /**
+     * @var Collection|AdjustmentInterface[]
+     *
+     * @psalm-var Collection<array-key, AdjustmentInterface>
+     */
     protected $adjustments;
 
     /** @var int */
@@ -35,6 +39,7 @@ class OrderItemUnit implements OrderItemUnitInterface
         $this->orderItem = $orderItem;
         $this->orderItem->addUnit($this);
 
+        /** @var ArrayCollection<array-key, AdjustmentInterface> $this->adjustments */
         $this->adjustments = new ArrayCollection();
     }
 

--- a/src/Sylius/Component/Order/Processor/CompositeOrderProcessor.php
+++ b/src/Sylius/Component/Order/Processor/CompositeOrderProcessor.php
@@ -18,7 +18,11 @@ use Zend\Stdlib\PriorityQueue;
 
 final class CompositeOrderProcessor implements OrderProcessorInterface
 {
-    /** @var PriorityQueue|OrderProcessorInterface[] */
+    /**
+     * @var PriorityQueue|OrderProcessorInterface[]
+     *
+     * @psalm-var PriorityQueue<OrderProcessorInterface>
+     */
     private $orderProcessors;
 
     public function __construct()

--- a/src/Sylius/Component/Payment/Model/PaymentsSubjectInterface.php
+++ b/src/Sylius/Component/Payment/Model/PaymentsSubjectInterface.php
@@ -19,6 +19,8 @@ interface PaymentsSubjectInterface
 {
     /**
      * @return Collection|PaymentInterface[]
+     *
+     * @psalm-return Collection<array-key, PaymentInterface>
      */
     public function getPayments(): Collection;
 

--- a/src/Sylius/Component/Product/Model/Product.php
+++ b/src/Sylius/Component/Product/Model/Product.php
@@ -36,16 +36,32 @@ class Product implements ProductInterface
     /** @var string */
     protected $code;
 
-    /** @var Collection|AttributeValueInterface[] */
+    /**
+     * @var Collection|AttributeValueInterface[]
+     *
+     * @psalm-var Collection<array-key, AttributeValueInterface>
+     */
     protected $attributes;
 
-    /** @var Collection|ProductVariantInterface[] */
+    /**
+     * @var Collection|ProductVariantInterface[]
+     *
+     * @psalm-var Collection<array-key, ProductVariantInterface>
+     */
     protected $variants;
 
-    /** @var Collection|ProductOptionInterface[] */
+    /**
+     * @var Collection|ProductOptionInterface[]
+     *
+     * @psalm-var Collection<array-key, ProductOptionInterface>
+     */
     protected $options;
 
-    /** @var Collection|ProductAssociationInterface[] */
+    /**
+     * @var Collection|ProductAssociationInterface[]
+     *
+     * @psalm-var Collection<array-key, ProductAssociationInterface>
+     */
     protected $associations;
 
     public function __construct()
@@ -53,9 +69,17 @@ class Product implements ProductInterface
         $this->initializeTranslationsCollection();
 
         $this->createdAt = new \DateTime();
+
+        /** @var ArrayCollection<array-key, AttributeValueInterface> $this->attributes */
         $this->attributes = new ArrayCollection();
+
+        /** @var ArrayCollection<array-key, ProductAssociationInterface> $this->associations */
         $this->associations = new ArrayCollection();
+
+        /** @var ArrayCollection<array-key, ProductVariantInterface> $this->variants */
         $this->variants = new ArrayCollection();
+
+        /** @var ArrayCollection<array-key, ProductOptionInterface> $this->options */
         $this->options = new ArrayCollection();
     }
 

--- a/src/Sylius/Component/Product/Model/ProductAssociation.php
+++ b/src/Sylius/Component/Product/Model/ProductAssociation.php
@@ -30,13 +30,19 @@ class ProductAssociation implements ProductAssociationInterface
     /** @var ProductInterface */
     protected $owner;
 
-    /** @var Collection|ProductInterface[] */
+    /**
+     * @var Collection|ProductInterface[]
+     *
+     * @psalm-var Collection<array-key, ProductInterface>
+     */
     protected $associatedProducts;
 
     public function __construct()
     {
         $this->createdAt = new \DateTime();
         $this->updatedAt = new \DateTime();
+
+        /** @var ArrayCollection<array-key, ProductInterface> $this->associatedProducts */
         $this->associatedProducts = new ArrayCollection();
     }
 

--- a/src/Sylius/Component/Product/Model/ProductAssociationInterface.php
+++ b/src/Sylius/Component/Product/Model/ProductAssociationInterface.php
@@ -29,6 +29,8 @@ interface ProductAssociationInterface extends TimestampableInterface, ResourceIn
 
     /**
      * @return Collection|ProductInterface[]
+     *
+     * @psalm-return Collection<array-key, ProductInterface>
      */
     public function getAssociatedProducts(): Collection;
 

--- a/src/Sylius/Component/Product/Model/ProductInterface.php
+++ b/src/Sylius/Component/Product/Model/ProductInterface.php
@@ -52,6 +52,8 @@ interface ProductInterface extends
 
     /**
      * @return Collection|ProductVariantInterface[]
+     *
+     * @psalm-return Collection<array-key, ProductVariantInterface>
      */
     public function getVariants(): Collection;
 
@@ -65,6 +67,8 @@ interface ProductInterface extends
 
     /**
      * @return Collection|ProductOptionInterface[]
+     *
+     * @psalm-return Collection<array-key, ProductOptionInterface>
      */
     public function getOptions(): Collection;
 
@@ -76,6 +80,8 @@ interface ProductInterface extends
 
     /**
      * @return Collection|ProductAssociationInterface[]
+     *
+     * @psalm-return Collection<array-key, ProductAssociationInterface>
      */
     public function getAssociations(): Collection;
 

--- a/src/Sylius/Component/Product/Model/ProductOption.php
+++ b/src/Sylius/Component/Product/Model/ProductOption.php
@@ -36,14 +36,20 @@ class ProductOption implements ProductOptionInterface
     /** @var int */
     protected $position;
 
-    /** @var Collection|ProductOptionValueInterface[] */
+    /**
+     * @var Collection|ProductOptionValueInterface[]
+     *
+     * @psalm-var Collection<array-key, ProductOptionValueInterface>
+     */
     protected $values;
 
     public function __construct()
     {
         $this->initializeTranslationsCollection();
 
+        /** @var ArrayCollection<array-key, ProductOptionValueInterface> $this->values */
         $this->values = new ArrayCollection();
+
         $this->createdAt = new \DateTime();
     }
 

--- a/src/Sylius/Component/Product/Model/ProductOptionInterface.php
+++ b/src/Sylius/Component/Product/Model/ProductOptionInterface.php
@@ -48,6 +48,8 @@ interface ProductOptionInterface extends
 
     /**
      * @return Collection|ProductOptionValueInterface[]
+     *
+     * @psalm-return Collection<array-key, ProductOptionValueInterface>
      */
     public function getValues(): Collection;
 

--- a/src/Sylius/Component/Product/Model/ProductVariant.php
+++ b/src/Sylius/Component/Product/Model/ProductVariant.php
@@ -36,7 +36,11 @@ class ProductVariant implements ProductVariantInterface
     /** @var ProductInterface */
     protected $product;
 
-    /** @var Collection|ProductOptionValueInterface[] */
+    /**
+     * @var Collection|ProductOptionValueInterface[]
+     *
+     * @psalm-var Collection<array-key, ProductOptionValueInterface>
+     */
     protected $optionValues;
 
     /** @var int */
@@ -45,6 +49,8 @@ class ProductVariant implements ProductVariantInterface
     public function __construct()
     {
         $this->initializeTranslationsCollection();
+
+        /** @var ArrayCollection<array-key, ProductOptionValueInterface> $this->optionValues */
         $this->optionValues = new ArrayCollection();
 
         $this->createdAt = new \DateTime();

--- a/src/Sylius/Component/Product/Model/ProductVariantInterface.php
+++ b/src/Sylius/Component/Product/Model/ProductVariantInterface.php
@@ -34,6 +34,8 @@ interface ProductVariantInterface extends
 
     /**
      * @return Collection|ProductOptionValueInterface[]
+     *
+     * @psalm-return Collection<array-key, ProductOptionValueInterface>
      */
     public function getOptionValues(): Collection;
 

--- a/src/Sylius/Component/Promotion/Model/Promotion.php
+++ b/src/Sylius/Component/Promotion/Model/Promotion.php
@@ -62,21 +62,38 @@ class Promotion implements PromotionInterface
     /** @var bool */
     protected $couponBased = false;
 
-    /** @var Collection|PromotionCouponInterface[] */
+    /**
+     * @var Collection|PromotionCouponInterface[]
+     *
+     * @psalm-var Collection<array-key, PromotionCouponInterface>
+     */
     protected $coupons;
 
-    /** @var Collection|PromotionRuleInterface[] */
+    /**
+     * @var Collection|PromotionRuleInterface[]
+     *
+     * @psalm-var Collection<array-key, PromotionRuleInterface>
+     */
     protected $rules;
 
-    /** @var Collection|PromotionActionInterface[] */
+    /**
+     * @var Collection|PromotionActionInterface[]
+     *
+     * @psalm-var Collection<array-key, PromotionActionInterface>
+     */
     protected $actions;
 
     public function __construct()
     {
         $this->createdAt = new \DateTime();
 
+        /** @var ArrayCollection<array-key, PromotionCouponInterface> $this->coupons */
         $this->coupons = new ArrayCollection();
+
+        /** @var ArrayCollection<array-key, PromotionRuleInterface> $this->rules */
         $this->rules = new ArrayCollection();
+
+        /** @var ArrayCollection<array-key, PromotionActionInterface> $this->actions */
         $this->actions = new ArrayCollection();
     }
 

--- a/src/Sylius/Component/Promotion/Model/PromotionInterface.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionInterface.php
@@ -62,6 +62,8 @@ interface PromotionInterface extends CodeAwareInterface, TimestampableInterface,
 
     /**
      * @return Collection|PromotionCouponInterface[]
+     *
+     * @psalm-return Collection<array-key, PromotionCouponInterface>
      */
     public function getCoupons(): Collection;
 
@@ -75,6 +77,8 @@ interface PromotionInterface extends CodeAwareInterface, TimestampableInterface,
 
     /**
      * @return Collection|PromotionRuleInterface[]
+     *
+     * @psalm-return Collection<array-key, PromotionRuleInterface>
      */
     public function getRules(): Collection;
 
@@ -88,6 +92,8 @@ interface PromotionInterface extends CodeAwareInterface, TimestampableInterface,
 
     /**
      * @return Collection|PromotionActionInterface[]
+     *
+     * @psalm-return Collection<array-key, PromotionActionInterface>
      */
     public function getActions(): Collection;
 

--- a/src/Sylius/Component/Promotion/Model/PromotionSubjectInterface.php
+++ b/src/Sylius/Component/Promotion/Model/PromotionSubjectInterface.php
@@ -21,6 +21,8 @@ interface PromotionSubjectInterface
 
     /**
      * @return Collection|PromotionInterface[]
+     *
+     * @psalm-return Collection<array-key, PromotionInterface>
      */
     public function getPromotions(): Collection;
 

--- a/src/Sylius/Component/Review/Model/ReviewableInterface.php
+++ b/src/Sylius/Component/Review/Model/ReviewableInterface.php
@@ -24,6 +24,8 @@ interface ReviewableInterface
 
     /**
      * @return Collection|ReviewInterface[]
+     *
+     * @psalm-return Collection<array-key, ReviewInterface>
      */
     public function getReviews(): Collection;
 

--- a/src/Sylius/Component/Shipping/Model/Shipment.php
+++ b/src/Sylius/Component/Shipping/Model/Shipment.php
@@ -30,7 +30,11 @@ class Shipment implements ShipmentInterface
     /** @var ShippingMethodInterface|null */
     protected $method;
 
-    /** @var Collection|ShipmentUnitInterface[] */
+    /**
+     * @var Collection|ShipmentUnitInterface[]
+     *
+     * @psalm-var Collection<array-key, ShipmentUnitInterface>
+     */
     protected $units;
 
     /** @var string|null */
@@ -38,6 +42,7 @@ class Shipment implements ShipmentInterface
 
     public function __construct()
     {
+        /** @var ArrayCollection<array-key, ShipmentUnitInterface> $this->units */
         $this->units = new ArrayCollection();
         $this->createdAt = new \DateTime();
     }
@@ -154,6 +159,7 @@ class Shipment implements ShipmentInterface
      */
     public function getShippables(): Collection
     {
+        /** @var ArrayCollection<array-key, ShippableInterface> $shippables */
         $shippables = new ArrayCollection();
 
         foreach ($this->units as $unit) {

--- a/src/Sylius/Component/Shipping/Model/ShipmentInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShipmentInterface.php
@@ -37,6 +37,8 @@ interface ShipmentInterface extends ResourceInterface, ShippingSubjectInterface,
 
     /**
      * @return Collection|ShipmentUnitInterface[]
+     *
+     * @psalm-return Collection<array-key, ShipmentUnitInterface>
      */
     public function getUnits(): Collection;
 

--- a/src/Sylius/Component/Shipping/Model/ShippingSubjectInterface.php
+++ b/src/Sylius/Component/Shipping/Model/ShippingSubjectInterface.php
@@ -27,6 +27,8 @@ interface ShippingSubjectInterface
 
     /**
      * @return Collection|ShippableInterface[]
+     *
+     * @psalm-return Collection<array-key, ShippableInterface>
      */
     public function getShippables(): Collection;
 }

--- a/src/Sylius/Component/Taxation/Model/TaxCategory.php
+++ b/src/Sylius/Component/Taxation/Model/TaxCategory.php
@@ -33,11 +33,16 @@ class TaxCategory implements TaxCategoryInterface
     /** @var string */
     protected $description;
 
-    /** @var Collection|TaxRateInterface[] */
+    /**
+     * @var Collection|TaxRateInterface[]
+     *
+     * @psalm-var Collection<array-key, TaxRateInterface>
+     */
     protected $rates;
 
     public function __construct()
     {
+        /** @var ArrayCollection<array-key, TaxRateInterface> $this->rates */
         $this->rates = new ArrayCollection();
         $this->createdAt = new \DateTime();
     }

--- a/src/Sylius/Component/Taxation/Model/TaxCategoryInterface.php
+++ b/src/Sylius/Component/Taxation/Model/TaxCategoryInterface.php
@@ -30,6 +30,8 @@ interface TaxCategoryInterface extends CodeAwareInterface, TimestampableInterfac
 
     /**
      * @return Collection|TaxRateInterface[]
+     *
+     * @psalm-return Collection<array-key, TaxRateInterface>
      */
     public function getRates(): Collection;
 

--- a/src/Sylius/Component/Taxonomy/Model/Taxon.php
+++ b/src/Sylius/Component/Taxonomy/Model/Taxon.php
@@ -37,7 +37,11 @@ class Taxon implements TaxonInterface
     /** @var TaxonInterface|null */
     protected $parent;
 
-    /** @var Collection|TaxonInterface[] */
+    /**
+     * @var Collection|TaxonInterface[]
+     *
+     * @psalm-var Collection<array-key, TaxonInterface>
+     */
     protected $children;
 
     /** @var int|null */
@@ -56,6 +60,7 @@ class Taxon implements TaxonInterface
     {
         $this->initializeTranslationsCollection();
 
+        /** @var ArrayCollection<array-key, TaxonInterface> $this->children */
         $this->children = new ArrayCollection();
     }
 

--- a/src/Sylius/Component/Taxonomy/Model/TaxonInterface.php
+++ b/src/Sylius/Component/Taxonomy/Model/TaxonInterface.php
@@ -41,11 +41,15 @@ interface TaxonInterface extends CodeAwareInterface, TranslatableInterface, Reso
 
     /**
      * @return Collection|TaxonInterface[]
+     *
+     * @psalm-return Collection<array-key, TaxonInterface>
      */
     public function getAncestors(): Collection;
 
     /**
      * @return Collection|TaxonInterface[]
+     *
+     * @psalm-return Collection<array-key, TaxonInterface>
      */
     public function getChildren(): Collection;
 

--- a/src/Sylius/Component/Taxonomy/Model/TaxonsAwareInterface.php
+++ b/src/Sylius/Component/Taxonomy/Model/TaxonsAwareInterface.php
@@ -19,6 +19,8 @@ interface TaxonsAwareInterface
 {
     /**
      * @return Collection|TaxonInterface[]
+     *
+     * @psalm-return Collection<array-key, TaxonInterface>
      */
     public function getTaxons(): Collection;
 

--- a/src/Sylius/Component/User/Model/User.php
+++ b/src/Sylius/Component/User/Model/User.php
@@ -95,7 +95,8 @@ class User implements UserInterface
      */
     protected $roles = [UserInterface::DEFAULT_ROLE];
 
-    /** @var Collection|UserOAuth[] */
+    /**
+     * @var Collection<int, UserOAuthInterface> */
     protected $oauthAccounts;
 
     /** @var string|null */
@@ -110,7 +111,10 @@ class User implements UserInterface
     public function __construct()
     {
         $this->salt = base_convert(bin2hex(random_bytes(20)), 16, 36);
+
+        /** @var ArrayCollection<array-key, UserOAuthInterface> $this->oauthAccounts */
         $this->oauthAccounts = new ArrayCollection();
+
         $this->createdAt = new \DateTime();
 
         // Set here to overwrite default value from trait

--- a/src/Sylius/Component/User/Model/UserInterface.php
+++ b/src/Sylius/Component/User/Model/UserInterface.php
@@ -101,6 +101,8 @@ interface UserInterface extends
 
     /**
      * @return Collection|UserOAuthInterface[]
+     *
+     * @psalm-return Collection<array-key, UserOAuthInterface>
      */
     public function getOAuthAccounts(): Collection;
 


### PR DESCRIPTION
Getting some proper docblocks in place. Lots of `@psalm-suppress` annotations, but those can be removed after fixing them upstream (and there's a Psalm CLI flag to find those unnecessary).