### PR TITLE
[SyliusUserBundle] Improve output of Promote/DemoteUserCommand

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Command/DemoteUserCommand.php
+++ b/src/Sylius/Bundle/UserBundle/Command/DemoteUserCommand.php
@@ -49,21 +49,25 @@ EOT
     protected function executeRoleCommand(InputInterface $input, OutputInterface $output, UserInterface $user, array $securityRoles): void
     {
         $error = false;
+        $successMessages = [];
 
         foreach ($securityRoles as $securityRole) {
             if (!$user->hasRole($securityRole)) {
-                $output->writeln(sprintf('<error>User "%s" didn\'t have "%s" Security role.</error>', $user->getEmail(), $securityRole));
+                $output->writeln(sprintf('<error>User "%s" doesn\'t have "%s" Security role.</error>', $user->getEmail(), $securityRole));
                 $error = true;
 
                 continue;
             }
 
             $user->removeRole($securityRole);
-            $output->writeln(sprintf('Security role <comment>%s</comment> has been removed from user <comment>%s</comment>', $securityRole, $user->getEmail()));
+            $successMessages[] = sprintf('Security role <comment>%s</comment> has been removed from user <comment>%s</comment>', $securityRole, $user->getEmail());
         }
 
         if (!$error) {
+            $output->writeln($successMessages);
             $this->getEntityManager($input->getOption('user-type'))->flush();
+        } else {
+            $output->writeln(sprintf('<error>No roles removed from User "%s".</error>', $user->getEmail()));
         }
     }
 }

--- a/src/Sylius/Bundle/UserBundle/Command/PromoteUserCommand.php
+++ b/src/Sylius/Bundle/UserBundle/Command/PromoteUserCommand.php
@@ -49,21 +49,25 @@ EOT
     protected function executeRoleCommand(InputInterface $input, OutputInterface $output, UserInterface $user, array $securityRoles): void
     {
         $error = false;
+        $successMessages = [];
 
         foreach ($securityRoles as $securityRole) {
             if ($user->hasRole($securityRole)) {
-                $output->writeln(sprintf('<error>User "%s" did already have "%s" security role.</error>', $user->getEmail(), $securityRole));
+                $output->writeln(sprintf('<error>User "%s" already has "%s" security role.</error>', $user->getEmail(), $securityRole));
                 $error = true;
 
                 continue;
             }
 
             $user->addRole($securityRole);
-            $output->writeln(sprintf('Security role <comment>%s</comment> has been added to user <comment>%s</comment>', $securityRole, $user->getEmail()));
+            $successMessages[] = sprintf('Security role <comment>%s</comment> has been added to user <comment>%s</comment>', $securityRole, $user->getEmail());
         }
 
         if (!$error) {
+            $output->writeln($successMessages);
             $this->getEntityManager($input->getOption('user-type'))->flush();
+        } else {
+            $output->writeln(sprintf('<error>No roles added to User "%s".</error>', $user->getEmail()));
         }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.5
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #10862
| License         | MIT

A quick fix to make it clearer to users that if an error happens the user's roles are unchanged. Previously it was showing both success and error messages which gave the impression other role changes that didn't trigger an error had been applied when they hadn't (the entity is only flushed if no errors happen).

<!--
 - Bug fixes must be submitted against the 1.4, 1.5 or 1.6 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
