### PR TITLE
[Plugins][Docs] Plugin technical requirements changes

### DIFF
--- a/docs/book/plugins/approved-plugins.rst
+++ b/docs/book/plugins/approved-plugins.rst
@@ -34,7 +34,7 @@ and general feeling. They will also ask you to provide some changes in the code 
 Technical requirements
 ----------------------
 
-Below you can find a list of requirements that your plugin needs to fulfill to be approved by Sylius core-team. Try to follow
+Below you can find a list of requirements that your plugin needs to fulfill to be approved by Sylius Core Team. Try to follow
 them, and your plugin's approval process will be faster and more efficient!
 
 Must have
@@ -74,7 +74,7 @@ Could have
 
 **Coding standards:**
 
-* Are there any apparent violations of one or more SOLID principles?
+* Does the code follow SOLID principles?
 * Are conventions in the code consistent with each other (are the same conventions used for the same concepts)?
 * Does the code apply some other `PSR's <https://www.php-fig.org/psr/>`_?
 

--- a/docs/book/plugins/approved-plugins.rst
+++ b/docs/book/plugins/approved-plugins.rst
@@ -58,19 +58,12 @@ Must have
 * Is it possible to install the plugin on a fresh Sylius-Standard application with no problems?
 * Is every step needed for installation and configuration explained in the documentation? Are there any assumptions that could be confusing for less experienced developers?
 
-**Tests:**
-
-* Are there any unit tests for the plugin's classes? They can be written in PHPSpec, PHPUnit or any other working and reliable unit testing library
-* Does the unit tests cover at least the most crucial classes in the plugin (those which contain important business logic)?
-* Does the plugin contain some functional/acceptance tests (written in Behat/PHPUnit or similar tool)?
-* Are the core features of the plugin described and tests by them?
-
 **Coding standards:**
 
 * Does the code apply at least `PSR-1 <https://www.php-fig.org/psr/psr-1/>`_?
 
-Could have
-##########
+Should have
+###########
 
 **Coding standards:**
 
@@ -80,7 +73,10 @@ Could have
 
 **Tests:**
 
-* Do unit tests cover most of the application classes?
+* Are there any unit tests for the plugin's classes? They can be written in PHPSpec, PHPUnit or any other working and reliable unit testing library
+* Does the unit tests cover at least the most crucial classes in the plugin (those which contain important business logic)?
+* Does the plugin contain some functional/acceptance tests (written in Behat/PHPUnit or similar tool)?
+* Are the core features of the plugin described and tests by them?
 * Do the functional/acceptance tests describe most of the application business-related features?
 
 **Continuous integration:**

--- a/docs/book/plugins/approved-plugins.rst
+++ b/docs/book/plugins/approved-plugins.rst
@@ -62,7 +62,7 @@ Must have
 
 * Are there any unit tests for the plugin's classes? They can be written in PHPSpec, PHPUnit or any other working and reliable unit testing library
 * Does the unit tests cover at least the most crucial classes in the plugin (those which contain important business logic)?
-* Does the plugin contain some functional/acceptation tests (written in Behat/PHPUnit or similar tool)?
+* Does the plugin contain some functional/acceptance tests (written in Behat/PHPUnit or similar tool)?
 * Are the core features of the plugin described and tests by them?
 
 **Coding standards:**

--- a/docs/book/plugins/approved-plugins.rst
+++ b/docs/book/plugins/approved-plugins.rst
@@ -20,7 +20,7 @@ Since Sylius is an open-source platform, there is a certain flow in order for th
 
 **1.** Develop the plugin using :doc:`the official Plugin Development guide </book/plugins/creating-plugin>`.
 
-**2.** Remember about the tests and code quality!
+**2.** Remember about the tests and code quality! Check out :ref:`book_plugins_technical_requirements` for more details.
 
 **3.** Send it to the project maintainers. It can be via email to any member of the Sylius Core team, or `the official Sylius Slack <http://sylius.com/slack>`_.
 
@@ -28,3 +28,61 @@ Since Sylius is an open-source platform, there is a certain flow in order for th
 and general feeling. They will also ask you to provide some changes in the code (if needed) to make this plugin approved.
 
 **5.** Wait for your Plugin to be featured in `the list of plugins <http://sylius.com/developers/store/plugins>`_ on the Sylius website.
+
+.. _book_plugins_technical_requirements:
+
+Technical requirements
+----------------------
+
+Below you can find a list of requirements that your plugin needs to fulfill to be approved by Sylius core-team. Try to follow
+them, and your plugin's approval process will be faster and more efficient!
+
+Must have
+#########
+
+**Name of the plugin:**
+
+* Does the name clearly say what kind of feature the plugin provides?
+* Does the plugin name contain the vendor's name?
+* Are all configuration roots and all classes appropriately named?
+* Generally, does the plugin fulfills :ref:`naming conventions <book_plugins_creating_plugin_naming_conventions>`?
+
+**Documentation:**
+
+* Does the plugin contain a description of its features?
+* Is there a description of the plugin installation?
+* Does the documentation consist of any screenshots (if the plugin provides any visual content)?
+
+**Installation:**
+
+* Is it possible to install the plugin on a fresh Sylius-Standard application with no problems?
+* Is every step needed for installation and configuration explained in the documentation? Are there any assumptions that could be confusing for less experienced developers?
+
+**Tests:**
+
+* Are there any unit tests for the plugin's classes? They can be written in PHPSpec, PHPUnit or any other working and reliable unit testing library
+* Does the unit tests cover at least the most crucial classes in the plugin (those which contain important business logic)?
+* Does the plugin contain some functional/acceptation tests (written in Behat/PHPUnit or similar tool)?
+* Are the core features of the plugin described and tests by them?
+
+**Coding standards:**
+
+* Does the code apply at least `PSR-1 <https://www.php-fig.org/psr/psr-1/>`_?
+
+Could have
+##########
+
+**Coding standards:**
+
+* Are there any apparent violations of one or more SOLID principles?
+* Are conventions in the code consistent with each other (are the same conventions used for the same concepts)?
+* Does the code apply some other `PSR's <https://www.php-fig.org/psr/>`_?
+
+**Tests:**
+
+* Do unit tests cover most of the application classes?
+* Do the functional/acceptance tests describe most of the application business-related features?
+
+**Continuous integration:**
+
+* Is there any CI tool used in the plugin's repository (CircleCI, Travis CI, Jenkins)?

--- a/docs/book/plugins/creating-plugin.rst
+++ b/docs/book/plugins/creating-plugin.rst
@@ -69,6 +69,8 @@ to ensure your plugin's extraordinary quality.
 .. _`phpspec`: http://www.phpspec.net/en/stable/
 .. _`PHPUnit`: https://phpunit.de/
 
+.. _book_plugins_creating_plugin_naming_conventions:
+
 5. Naming conventions
 ---------------------
 

--- a/docs/book/plugins/index.rst
+++ b/docs/book/plugins/index.rst
@@ -22,6 +22,6 @@ Exemplary features may be: Social media buttons, newsletter, wishlists, payment 
 
     creating-plugin
     official-plugins
-    approved-plugins
+    sylius-store
 
 .. include:: /book/plugins/map.rst.inc

--- a/docs/book/plugins/map.rst.inc
+++ b/docs/book/plugins/map.rst.inc
@@ -1,4 +1,4 @@
 * :doc:`/book/plugins/index`
 * :doc:`/book/plugins/creating-plugin`
 * :doc:`/book/plugins/official-plugins`
-* :doc:`/book/plugins/approved-plugins`
+* :doc:`/book/plugins/sylius-store`

--- a/docs/book/plugins/sylius-store.rst
+++ b/docs/book/plugins/sylius-store.rst
@@ -1,44 +1,39 @@
-Plugins Approved by Sylius
-==========================
+Sylius Store
+============
 
-As the Sylius eCommerce framework is an open source project it has an awesome community of users and developers.
-Therefore our ecosystem flourishes with plugins created outside of our organization. These plugins can become officially
-approved by us, when they meet certain requirements. Then, when accepted, they will land on the `official list of plugins
-on our website <https://sylius.com/plugins/>`_.
+As the Sylius is an open-source project, it has an awesome community of users and developers.
+Therefore our ecosystem flourishes with plugins created outside of our organization. These plugins can be listed in our
+`Sylius Store <https://sylius.com/plugins/>`_ or even become officially approved by us when they meet specific requirements.
 
-When a plugin is approved by Sylius, you can recognize it also by this badge below in its readme file:
+How to have a Plugin listed on Sylius Store?
+--------------------------------------------
 
-.. image:: ../../_images/approved_plugin.png
-    :scale: 50%
-
-|
-
-How to have a Plugin approved by Sylius?
-----------------------------------------
-
-Since Sylius is an open-source platform, there is a certain flow in order for the plugin to become officially adopted by the community.
+Since Sylius is an open-source platform, there is a precise flow for the plugin to become officially adopted by the community.
 
 **1.** Develop the plugin using :doc:`the official Plugin Development guide </book/plugins/creating-plugin>`.
 
 **2.** Remember about the tests and code quality! Check out :ref:`book_plugins_technical_requirements` for more details.
 
-**3.** Send it to the project maintainers. It can be via email to any member of the Sylius Core team, or `the official Sylius Slack <http://sylius.com/slack>`_.
+**3.** Send it to the project maintainers. The preferred way is to use `plugin request submit form <https://store.sylius.com/submit>`_.
 
 **4.** One of our Plugin Curators will contact you with the feedback regarding your plugin's code quality, test suite,
-and general feeling. They will also ask you to provide some changes in the code (if needed) to make this plugin approved.
+and general feeling. They will also ask you to provide some changes in the code (if needed) to make this plugin visible in the Sylius Store.
 
-**5.** Wait for your Plugin to be featured in `the list of plugins <http://sylius.com/developers/store/plugins>`_ on the Sylius website.
+**5.** Wait for your Plugin to be featured in `the list of plugins <http://sylius.com/plugins/>`_ on the Sylius website.
 
 .. _book_plugins_technical_requirements:
 
 Technical requirements
 ----------------------
 
-Below you can find a list of requirements that your plugin needs to fulfill to be approved by Sylius Core Team. Try to follow
-them, and your plugin's approval process will be faster and more efficient!
+Below you can find a list of requirements that your plugin needs to fulfill to pass the Sylius Core Team review. Try to follow
+them and your plugin's approval process will be faster and more efficient!
 
 Must have
 #########
+
+Every plugin must fulfill these requirements to be listed on the Sylius Store. We're happy to accept new extensions to our platform,
+but it's also crucial for us to keep their high standards.
 
 **Name of the plugin:**
 
@@ -65,6 +60,16 @@ Must have
 Should have
 ###########
 
+If you want your plugin to be officially approved by Sylius Core Team, there are more things to do. Only plugins with the
+highest standards of code and properly developed test suite could get the "Approved by Sylius" mark, which makes them more
+visible in the community and ensures users about their quality.
+When Sylius approve a plugin, you can recognize it also by this badge below in its readme file:
+
+.. image:: ../../_images/approved_plugin.png
+    :scale: 30%
+
+|
+
 **Coding standards:**
 
 * Does the code follow SOLID principles?
@@ -75,7 +80,7 @@ Should have
 
 * Are there any unit tests for the plugin's classes? They can be written in PHPSpec, PHPUnit or any other working and reliable unit testing library
 * Does the unit tests cover at least the most crucial classes in the plugin (those which contain important business logic)?
-* Does the plugin contain some functional/acceptance tests (written in Behat/PHPUnit or similar tool)?
+* Does the plugin include some functional/acceptance tests (written in Behat/PHPUnit or similar tool)?
 * Are the core features of the plugin described and tests by them?
 * Do the functional/acceptance tests describe most of the application business-related features?
 

--- a/docs/plugin-development-guide/summary.rst
+++ b/docs/plugin-development-guide/summary.rst
@@ -26,7 +26,7 @@ and even more. The limit is only your imagination (and business value, of course
 our :doc:`customizing guide</customization/index>`.
 
 At the end, do not hesitate to contact us at contact@sylius.com when you manage to implement a new plugin.
-We would be happy to check it out and add it to our `official plugins list`_!
+We would be happy to check it out and add it to our `approved plugins list`_!
 
 .. note::
 
@@ -40,5 +40,5 @@ We are working hard to make creating Sylius plugins even more developer- and use
 `PluginSkeleton`_ notifications and other announcements from Sylius community.
 Our plugins base is growing fast - why not be a part of it?
 
-.. _`official plugins list`: https://sylius.com/plugins/
+.. _`approved plugins list`: https://sylius.com/plugins/
 .. _`PluginSkeleton`: https://github.com/Sylius/PluginSkeleton


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This PR contains changes from https://github.com/Sylius/Sylius/pull/10731, which in fact should be from the beginning opened to `1.6` 😄 

Due to the release of Sylius Store, I propose a slightly new approach to approving/accepting plugins. We want to develop our plugins ecosystem, but on the other hand, we still want to keep the high quality of these extensions. There is also a new way to propose plugins to our plugins list - a [plugin request submit form](https://store.sylius.com/submit).

So my proposal is to accept all the plugins that work, provide a valuable extension to Sylius features and is documented enough to make installation as less problematic as possible. On the other hand, only plugins that fulfill more strict requirements from the "Should have" section, can get an "Approved by Sylius" badge. I believe it will be a better change for both Sylius users and developers 🏅 Let me know what you think about it 🖖 