### PR TITLE
Decrement length constraint on postcode

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/validation/Address.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/validation/Address.xml
@@ -114,7 +114,7 @@
                 </option>
             </constraint>
             <constraint name="Length">
-                <option name="min">2</option>
+                <option name="min">1</option>
                 <option name="max">255</option>
                 <option name="minMessage">sylius.address.postcode.min_length</option>
                 <option name="maxMessage">sylius.address.postcode.max_length</option>


### PR DESCRIPTION
In Oslo, Norway there is a postal code `1`. See https://worldpostalcode.com/norway/hordaland/oslo

| Q               | A
| --------------- | -----
| Branch?         | All
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

