### PR TITLE
[Taxation] [Shipping] Fixed issue with shipping zones available to select in tax rate form (and the other way)

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/ZoneChoiceType.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AddressingBundle\Form\Type;
 
+use Sylius\Component\Addressing\Model\Scope as AddressingScope;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -24,9 +25,17 @@ final class ZoneChoiceType extends AbstractType
     /** @var RepositoryInterface */
     private $zoneRepository;
 
-    public function __construct(RepositoryInterface $zoneRepository)
+    /** @var string[] */
+    private $scopeTypes;
+
+    public function __construct(RepositoryInterface $zoneRepository, array $scopeTypes = [])
     {
         $this->zoneRepository = $zoneRepository;
+        $this->scopeTypes = $scopeTypes;
+
+        if (count($scopeTypes) === 0) {
+            @trigger_error('Not passing scopeTypes thru constructor is deprecated in Sylius 1.5 and it will be removed in Sylius 2.0');
+        }
     }
 
     /**
@@ -36,14 +45,22 @@ final class ZoneChoiceType extends AbstractType
     {
         $resolver->setDefaults([
             'choices' => function (Options $options): iterable {
-                return $this->zoneRepository->findAll();
+                $zoneCriteria = [];
+                if ($options['zone_scope'] !== AddressingScope::ALL) {
+                    $zoneCriteria['scope'] = [$options['zone_scope'], AddressingScope::ALL];
+                }
+
+                return $this->zoneRepository->findBy($zoneCriteria);
             },
             'choice_value' => 'code',
             'choice_label' => 'name',
             'choice_translation_domain' => false,
             'label' => 'sylius.form.address.zone',
             'placeholder' => 'sylius.form.zone.select',
+            'zone_scope' => AddressingScope::ALL,
         ]);
+
+        $resolver->setAllowedValues('zone_scope', array_keys($this->scopeTypes));
     }
 
     /**

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/services/form.xml
@@ -86,6 +86,7 @@
 
         <service id="sylius.form.type.zone_choice" class="Sylius\Bundle\AddressingBundle\Form\Type\ZoneChoiceType">
             <argument type="service" id="sylius.repository.zone" />
+            <argument>%sylius.scope.zone%</argument>
             <tag name="form.type" />
         </service>
 

--- a/src/Sylius/Bundle/AddressingBundle/Tests/Form/Type/ZoneChoiceTypeTest.php
+++ b/src/Sylius/Bundle/AddressingBundle/Tests/Form/Type/ZoneChoiceTypeTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AddressingBundle\Tests\Form\Type;
+
+use PHPUnit\Framework\Assert;
+use Prophecy\Prophecy\ProphecyInterface;
+use Sylius\Bundle\AddressingBundle\Form\Type\ZoneChoiceType;
+use Sylius\Component\Addressing\Model\ZoneInterface;
+use Sylius\Component\Addressing\Model\Scope as AddressingScope;
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Component\Form\ChoiceList\View\ChoiceView;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+final class ZoneChoiceTypeTest extends TypeTestCase
+{
+    /** @var ProphecyInterface|RepositoryInterface */
+    private $zoneRepository;
+
+    /** @var ProphecyInterface|ZoneInterface */
+    private $zoneAllScopes;
+
+    /** @var ProphecyInterface|ZoneInterface */
+    private $zoneTaxScope;
+
+    /** @var ProphecyInterface|ZoneInterface */
+    private $zoneShippingScope;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->zoneRepository = $this->prophesize(RepositoryInterface::class);
+
+        /** @var ProphecyInterface|ZoneInterface $zoneAllScopes */
+        $zoneAllScopes = $this->prophesize(ZoneInterface::class);
+        $zoneAllScopes->getCode()->willReturn('all');
+        $zoneAllScopes->getName()->willReturn('All');
+        $this->zoneAllScopes = $zoneAllScopes;
+
+        /** @var ProphecyInterface|ZoneInterface $zoneTaxScope */
+        $zoneTaxScope = $this->prophesize(ZoneInterface::class);
+        $zoneTaxScope->getCode()->willReturn('tax');
+        $zoneTaxScope->getName()->willReturn('Tax');
+        $this->zoneTaxScope = $zoneTaxScope;
+
+        /** @var ProphecyInterface|ZoneInterface $zoneShippingScope */
+        $zoneShippingScope = $this->prophesize(ZoneInterface::class);
+        $zoneShippingScope->getCode()->willReturn('shipping');
+        $zoneShippingScope->getName()->willReturn('Shipping');
+        $this->zoneShippingScope = $zoneShippingScope;
+
+        parent::setUp();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getExtensions()
+    {
+        $scopeTypes = [
+            AddressingScope::ALL => 'All',
+            'tax' => 'Tax',
+            'shipping' => 'Shipping'
+        ];
+
+        $type = new ZoneChoiceType($this->zoneRepository->reveal(), $scopeTypes);
+
+        return [
+            new PreloadedExtension([$type], []),
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_all_scopes_by_default()
+    {
+        $this->zoneRepository->findBy([])->willReturn([
+            $this->zoneAllScopes->reveal(),
+            $this->zoneTaxScope->reveal(),
+            $this->zoneShippingScope->reveal(),
+        ]);
+
+        $this->assertChoicesLabels(['All', 'Tax', 'Shipping']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_all_scopes_when_zone_scope_set_to_all()
+    {
+        $this->zoneRepository->findBy([])->willReturn([
+            $this->zoneAllScopes->reveal(),
+            $this->zoneTaxScope->reveal(),
+            $this->zoneShippingScope->reveal(),
+        ]);
+
+        $this->assertChoicesLabels(['All', 'Tax', 'Shipping'], [ 'zone_scope' => AddressingScope::ALL ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_tax_scopes_when_zone_scope_set_to_tax()
+    {
+        $this->zoneRepository->findBy([ 'scope' => ['tax', AddressingScope::ALL]])->willReturn([
+            $this->zoneAllScopes->reveal(),
+            $this->zoneTaxScope->reveal(),
+        ]);
+
+        $this->assertChoicesLabels(['All', 'Tax'], [ 'zone_scope' => 'tax' ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_shipping_scopes_when_zone_scope_set_to_shipping()
+    {
+        $this->zoneRepository->findBy([ 'scope' => ['shipping', AddressingScope::ALL]])->willReturn([
+            $this->zoneAllScopes->reveal(),
+            $this->zoneShippingScope->reveal(),
+        ]);
+
+        $this->assertChoicesLabels(['All', 'Shipping'], [ 'zone_scope' => 'shipping' ]);
+    }
+
+    /**
+     * @param array $expectedLabels
+     * @param array $formConfiguration
+     */
+    private function assertChoicesLabels(array $expectedLabels, array $formConfiguration = []): void
+    {
+        $form = $this->factory->create(ZoneChoiceType::class, null, $formConfiguration);
+        $view = $form->createView();
+
+        Assert::assertSame($expectedLabels, array_map(function (ChoiceView $choiceView): string {
+            return $choiceView->label;
+        }, $view->vars['choices']));
+    }
+}

--- a/src/Sylius/Bundle/AddressingBundle/Tests/Form/Type/ZoneChoiceTypeTest.php
+++ b/src/Sylius/Bundle/AddressingBundle/Tests/Form/Type/ZoneChoiceTypeTest.php
@@ -99,7 +99,7 @@ final class ZoneChoiceTypeTest extends TypeTestCase
             $this->zoneShippingScope->reveal(),
         ]);
 
-        $this->assertChoicesLabels(['All', 'Tax', 'Shipping'], [ 'zone_scope' => AddressingScope::ALL ]);
+        $this->assertChoicesLabels(['All', 'Tax', 'Shipping'], ['zone_scope' => AddressingScope::ALL]);
     }
 
     /**

--- a/src/Sylius/Bundle/AddressingBundle/Tests/Form/Type/ZoneChoiceTypeTest.php
+++ b/src/Sylius/Bundle/AddressingBundle/Tests/Form/Type/ZoneChoiceTypeTest.php
@@ -125,7 +125,7 @@ final class ZoneChoiceTypeTest extends TypeTestCase
             $this->zoneShippingScope->reveal(),
         ]);
 
-        $this->assertChoicesLabels(['All', 'Shipping'], [ 'zone_scope' => 'shipping' ]);
+        $this->assertChoicesLabels(['All', 'Shipping'], ['zone_scope' => 'shipping']);
     }
 
     /**

--- a/src/Sylius/Bundle/AddressingBundle/Tests/Form/Type/ZoneChoiceTypeTest.php
+++ b/src/Sylius/Bundle/AddressingBundle/Tests/Form/Type/ZoneChoiceTypeTest.php
@@ -112,7 +112,7 @@ final class ZoneChoiceTypeTest extends TypeTestCase
             $this->zoneTaxScope->reveal(),
         ]);
 
-        $this->assertChoicesLabels(['All', 'Tax'], [ 'zone_scope' => 'tax' ]);
+        $this->assertChoicesLabels(['All', 'Tax'], ['zone_scope' => 'tax']);
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ShippingMethodTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ShippingMethodTypeExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Form\Extension;
 
+use Sylius\Component\Core\Model\Scope;
 use Sylius\Bundle\AddressingBundle\Form\Type\ZoneChoiceType;
 use Sylius\Bundle\ChannelBundle\Form\Type\ChannelChoiceType;
 use Sylius\Bundle\ShippingBundle\Form\Type\ShippingMethodType;
@@ -30,6 +31,7 @@ final class ShippingMethodTypeExtension extends AbstractTypeExtension
         $builder
             ->add('zone', ZoneChoiceType::class, [
                 'label' => 'sylius.form.shipping_method.zone',
+                'zone_scope' => Scope::SHIPPING,
             ])
             ->add('taxCategory', TaxCategoryChoiceType::class, [
                 'required' => false,

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/TaxRateTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/TaxRateTypeExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Form\Extension;
 
+use Sylius\Component\Core\Model\Scope;
 use Sylius\Bundle\AddressingBundle\Form\Type\ZoneChoiceType;
 use Sylius\Bundle\TaxationBundle\Form\Type\TaxRateType;
 use Symfony\Component\Form\AbstractTypeExtension;
@@ -25,7 +26,7 @@ final class TaxRateTypeExtension extends AbstractTypeExtension
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder->add('zone', ZoneChoiceType::class);
+        $builder->add('zone', ZoneChoiceType::class, [ 'zone_scope' => Scope::TAX ]);
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/TaxRateTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/TaxRateTypeExtension.php
@@ -26,7 +26,7 @@ final class TaxRateTypeExtension extends AbstractTypeExtension
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder->add('zone', ZoneChoiceType::class, [ 'zone_scope' => Scope::TAX ]);
+        $builder->add('zone', ZoneChoiceType::class, ['zone_scope' => Scope::TAX]);
     }
 
     /**


### PR DESCRIPTION
Fixed issue with shipping zones available to select in tax rate form (and the other way)
- added zone_scope option to ZoneChoiceType to pass desired scope
- for BC default scope is "ALL"
- modified ShippingMethodTypeExtension and TaxRateTypeExtension to pass correct zone_scope option
- form type test for ZoneChoiceType

| Q               | A
| --------------- | -----
| Branch?         | 1.6 
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes 
| Related tickets | 
| License         | MIT

btw. Maybe this is not something that people usually write in PRs, but it is actually my first contribution to Sylius, so I feel that I should write something more in this important moment... I would like to dedicate this PR to my wife who always supports me and never complains about coding till late :-) 