### PR TITLE
[Behat] Rework behat  - using attributes instead class/id in address and shipping page

### DIFF
--- a/src/Sylius/Behat/Page/Shop/Account/RequestPasswordResetPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/RequestPasswordResetPage.php
@@ -28,10 +28,10 @@ class RequestPasswordResetPage extends SymfonyPage implements RequestPasswordRes
      */
     public function checkValidationMessageFor(string $element, string $message): bool
     {
-        $errorLabel = $this->getElement($element)->getParent()->find('css', '[data-test-sylius-validation-error]');
+        $errorLabel = $this->getElement($element)->getParent()->find('css', '[data-test-validation-error]');
 
         if (null === $errorLabel) {
-            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '[data-test-sylius-validation-error]');
+            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '[data-test-validation-error]');
         }
 
         return $message === $errorLabel->getText();

--- a/src/Sylius/Behat/Page/Shop/Account/ResetPasswordPage.php
+++ b/src/Sylius/Behat/Page/Shop/Account/ResetPasswordPage.php
@@ -40,10 +40,10 @@ class ResetPasswordPage extends SymfonyPage implements ResetPasswordPageInterfac
 
     public function checkValidationMessageFor(string $element, string $message): bool
     {
-        $errorLabel = $this->getElement($element)->getParent()->find('css', '[data-test-sylius-validation-error]');
+        $errorLabel = $this->getElement($element)->getParent()->find('css', '[data-test-validation-error]');
 
         if (null === $errorLabel) {
-            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '[data-test-sylius-validation-error]');
+            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '[data-test-validation-error]');
         }
 
         return $message === $errorLabel->getText();

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
@@ -70,7 +70,7 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
     public function checkInvalidCredentialsValidation(): bool
     {
         $this->getElement('login_password')->waitFor(5, function () {
-            $validationElement = $this->getElement('login_password')->getParent()->find('css', '.red.label');
+            $validationElement = $this->getElement('login_password')->getParent()->find('css', '[data-test-login-errors]');
             if (null === $validationElement) {
                 return false;
             }
@@ -85,12 +85,12 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
     {
         $foundElement = $this->getFieldElement($element);
         if (null === $foundElement) {
-            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '.sylius-validation-error');
+            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '[data-test-validation-error]');
         }
 
         $validationMessage = $foundElement->find('css', '.sylius-validation-error');
         if (null === $validationMessage) {
-            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '.sylius-validation-error');
+            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '[data-test-validation-error]');
         }
 
         return $message === $validationMessage->getText();
@@ -118,7 +118,7 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
         $this->getElement('billing_country_province')->selectOption($province);
     }
 
-    public function specifyEmail(string $email): void
+    public function specifyEmail(?string $email): void
     {
         $this->getElement('customer_email')->setValue($email);
     }
@@ -164,7 +164,7 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
 
         $subtotalTable = $this->getElement('checkout_subtotal');
 
-        return $subtotalTable->find('css', sprintf('#sylius-item-%s-subtotal', $itemSlug))->getText();
+        return $subtotalTable->find('css', sprintf('[data-test-item-subtotal="%s"]', $itemSlug))->getText();
     }
 
     public function getShippingAddressCountry(): string
@@ -253,31 +253,31 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
-            'billing_address_book' => '#sylius-billing-address .ui.dropdown',
-            'billing_first_name' => '#sylius_checkout_address_billingAddress_firstName',
-            'billing_last_name' => '#sylius_checkout_address_billingAddress_lastName',
-            'billing_street' => '#sylius_checkout_address_billingAddress_street',
-            'billing_city' => '#sylius_checkout_address_billingAddress_city',
-            'billing_country' => '#sylius_checkout_address_billingAddress_countryCode',
+            'billing_address_book' => '[data-test-billing-address] .ui.dropdown',
+            'billing_city' => '[data-test-billing-city]',
+            'billing_country' => '[data-test-billing-country]',
             'billing_country_province' => '[name="sylius_checkout_address[billingAddress][provinceCode]"]',
-            'billing_postcode' => '#sylius_checkout_address_billingAddress_postcode',
+            'billing_first_name' => '[data-test-billing-first-name]',
+            'billing_last_name' => '[data-test-billing-last-name]',
+            'billing_postcode' => '[data-test-billing-postcode]',
             'billing_province' => '[name="sylius_checkout_address[billingAddress][provinceName]"]',
-            'checkout_subtotal' => '#sylius-checkout-subtotal',
-            'customer_email' => '#sylius_checkout_address_customer_email',
-            'different_billing_address' => '#sylius_checkout_address_differentBillingAddress',
-            'different_billing_address_label' => '#sylius_checkout_address_differentBillingAddress ~ label',
+            'billing_street' => '[data-test-billing-street]',
+            'checkout_subtotal' => '[data-test-checkout-subtotal]',
+            'customer_email' => '[data-test-login-email]',
+            'different_billing_address' => '[data-test-different-billing-address]',
+            'different_billing_address_label' => '[data-test-different-billing-address-label]',
             'login_button' => '#sylius-api-login-submit',
             'login_password' => 'input[type=\'password\']',
-            'next_step' => '#next-step',
-            'shipping_address_book' => '#sylius-shipping-address .ui.dropdown',
-            'shipping_city' => '#sylius_checkout_address_shippingAddress_city',
-            'shipping_country' => '#sylius_checkout_address_shippingAddress_countryCode',
+            'next_step' => '[data-test-next-step]',
+            'shipping_address_book' => '[data-test-address-book]',
+            'shipping_city' => '[data-test-shipping-city]',
+            'shipping_country' => '[data-test-shipping-country]',
             'shipping_country_province' => '[name="sylius_checkout_address[shippingAddress][provinceCode]"]',
-            'shipping_first_name' => '#sylius_checkout_address_shippingAddress_firstName',
-            'shipping_last_name' => '#sylius_checkout_address_shippingAddress_lastName',
-            'shipping_postcode' => '#sylius_checkout_address_shippingAddress_postcode',
+            'shipping_first_name' => '[data-test-shipping-first-name]',
+            'shipping_last_name' => '[data-test-shipping-last-name]',
+            'shipping_postcode' => '[data-test-shipping-postcode]',
             'shipping_province' => '[name="sylius_checkout_address[shippingAddress][provinceName]"]',
-            'shipping_street' => '#sylius_checkout_address_shippingAddress_street',
+            'shipping_street' => '[data-test-shipping-street]',
         ]);
     }
 

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPageInterface.php
@@ -32,7 +32,7 @@ interface AddressPageInterface extends SymfonyPageInterface
 
     public function selectBillingAddressProvince(string $province): void;
 
-    public function specifyEmail(string $email): void;
+    public function specifyEmail(?string $email): void;
 
     public function specifyShippingAddressFullName(string $fullName): void;
 

--- a/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPage.php
@@ -39,7 +39,7 @@ class SelectShippingPage extends SymfonyPage implements SelectShippingPageInterf
 
     public function getShippingMethods(): array
     {
-        $inputs = $this->getSession()->getPage()->findAll('css', '#sylius-shipping-methods .item .content label');
+        $inputs = $this->getSession()->getPage()->findAll('css', '[data-test-shipping-method-label]');
 
         $shippingMethods = [];
         foreach ($inputs as $input) {
@@ -51,12 +51,12 @@ class SelectShippingPage extends SymfonyPage implements SelectShippingPageInterf
 
     public function getSelectedShippingMethodName(): ?string
     {
-        $shippingMethods = $this->getSession()->getPage()->findAll('css', '#sylius-shipping-methods .item');
+        $shippingMethods = $this->getSession()->getPage()->findAll('css', '[data-test-shipping-item]');
 
         /** @var NodeElement $shippingMethod */
         foreach ($shippingMethods as $shippingMethod) {
             if (null !== $shippingMethod->find('css', 'input:checked')) {
-                return $shippingMethod->find('css', '.content label')->getText();
+                return $shippingMethod->find('css', '[data-test-shipping-method-label]')->getText();
             }
         }
 
@@ -87,7 +87,7 @@ class SelectShippingPage extends SymfonyPage implements SelectShippingPageInterf
 
         $subtotalTable = $this->getElement('checkout_subtotal');
 
-        return $subtotalTable->find('css', sprintf('#sylius-item-%s-subtotal', $itemSlug))->getText();
+        return $subtotalTable->find('css', sprintf('[data-test-item-subtotal="%s"]', $itemSlug))->getText();
     }
 
     public function nextStep(): void
@@ -107,7 +107,7 @@ class SelectShippingPage extends SymfonyPage implements SelectShippingPageInterf
 
     public function getPurchaserEmail(): string
     {
-        return $this->getElement('purchaser-email')->getText();
+        return $this->getElement('purchaser_email')->getText();
     }
 
     public function getValidationMessageForShipment(): string
@@ -117,9 +117,9 @@ class SelectShippingPage extends SymfonyPage implements SelectShippingPageInterf
             throw new ElementNotFoundException($this->getSession(), 'Items element');
         }
 
-        $validationMessage = $foundElement->find('css', '.sylius-validation-error');
+        $validationMessage = $foundElement->find('css', '[data-test-validation-error]');
         if (null === $validationMessage) {
-            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '.sylius-validation-error');
+            throw new ElementNotFoundException($this->getSession(), 'Validation message', 'css', '[data-test-validation-error]');
         }
 
         return $validationMessage->getText();
@@ -137,7 +137,7 @@ class SelectShippingPage extends SymfonyPage implements SelectShippingPageInterf
 
     public function hasShippingMethod(string $shippingMethodName): bool
     {
-        $inputs = $this->getSession()->getPage()->findAll('css', '#sylius-shipping-methods .item .content label');
+        $inputs = $this->getSession()->getPage()->findAll('css', '[data-test-shipping-method-label]');
 
         $shippingMethods = [];
         foreach ($inputs as $input) {
@@ -150,17 +150,17 @@ class SelectShippingPage extends SymfonyPage implements SelectShippingPageInterf
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
-            'address' => '.steps a:contains("Address")',
-            'checkout_subtotal' => '#sylius-checkout-subtotal',
-            'next_step' => '#next-step',
-            'order_cannot_be_shipped_message' => '#sylius-order-cannot-be-shipped',
-            'purchaser-email' => '#purchaser-email',
-            'shipment' => '.items',
+            'address' => '[data-test-step-address]',
+            'checkout_subtotal' => '[data-test-checkout-subtotal]',
+            'next_step' => '[data-test-next-step]',
+            'order_cannot_be_shipped_message' => '[data-test-order-cannot-be-shipped]',
+            'purchaser_email' => '[data-test-purchaser-name-or-email]',
+            'shipment' => '[data-test-shipments]',
             'shipping_method' => '[name="sylius_checkout_select_shipping[shipments][0][method]"]',
-            'shipping_method_fee' => '.item:contains("%shipping_method%") .fee',
-            'shipping_method_select' => '.item:contains("%shipping_method%") > .field > .ui.radio.checkbox',
+            'shipping_method_fee' => '[data-test-shipping-item]:contains("%shipping_method%") [data-test-shipping-method-fee]',
+            'shipping_method_select' => '[data-test-shipping-item]:contains("%shipping_method%") > .field > .ui.radio.checkbox',
             'shipping_method_option' => '.item:contains("%shipping_method%") input',
-            'warning_no_shipping_methods' => '#sylius-order-cannot-be-shipped',
+            'warning_no_shipping_methods' => '[data-test-order-cannot-be-shipped]',
         ]);
     }
 }

--- a/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPage.php
@@ -156,7 +156,7 @@ class SelectShippingPage extends SymfonyPage implements SelectShippingPageInterf
             'order_cannot_be_shipped_message' => '[data-test-order-cannot-be-shipped]',
             'purchaser_email' => '[data-test-purchaser-name-or-email]',
             'shipment' => '[data-test-shipments]',
-            'shipping_method' => '[name="sylius_checkout_select_shipping[shipments][0][method]"]',
+            'shipping_method' => '[data-test-shipping-method-select]',
             'shipping_method_fee' => '[data-test-shipping-item]:contains("%shipping_method%") [data-test-shipping-method-fee]',
             'shipping_method_select' => '[data-test-shipping-item]:contains("%shipping_method%") > .field > .ui.radio.checkbox',
             'shipping_method_option' => '.item:contains("%shipping_method%") input',

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_addressBookSelect.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_addressBookSelect.html.twig
@@ -1,5 +1,5 @@
 {% if app.user is not empty and app.user.customer is not empty and app.user.customer.addresses|length > 0 %}
-    <div class="ui fluid floating dropdown labeled search icon button address-book-select">
+    <div class="ui fluid floating dropdown labeled search icon button address-book-select" {{ sylius_test_html_attribute('address-book') }}>
         <i class="book icon"></i>
         <span class="text">{{ 'sylius.ui.select_address_from_book'|trans }}</span>
         <div class="menu">

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_form.html.twig
@@ -5,7 +5,7 @@
         {% include '@SyliusShop/Common/Form/_login.html.twig' with {'form': form.customer} %}
     {% endif %}
     {% include '@SyliusShop/Common/Form/_address.html.twig' with {'form': form.shippingAddress, 'order': order, 'type': 'shipping'} %}
-    {{ form_row(form.differentBillingAddress,sylius_test_form_attribute('different-billing-address')|merge({'attr': {'data-toggles': 'sylius-billing-address'}, 'label_attr': {'data-test-different-billing-address-label': ''}})) }}
+    {{ form_row(form.differentBillingAddress,sylius_test_form_attribute('different-billing-address')|sylius_merge_recursive({'attr': {'data-toggles': 'sylius-billing-address'}, 'label_attr': {'data-test-different-billing-address-label': ''}} )) }}
 
     {{ sonata_block_render_event('sylius.shop.checkout.address.shipping_address_form', {'order': order}) }}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_form.html.twig
@@ -1,20 +1,20 @@
-<div id="sylius-shipping-address">
+<div id="sylius-shipping-address" {{ sylius_test_html_attribute('shipping-address') }}>
     {% include '@SyliusShop/Checkout/Address/_addressBookSelect.html.twig' %}
     <h3 class="ui dividing header">{{ 'sylius.ui.shipping_address'|trans }}</h3>
     {% if form.customer is defined %}
         {% include '@SyliusShop/Common/Form/_login.html.twig' with {'form': form.customer} %}
     {% endif %}
-    {% include '@SyliusShop/Common/Form/_address.html.twig' with {'form': form.shippingAddress, 'order': order} %}
-    {{ form_row(form.differentBillingAddress, {'attr': {'data-toggles': 'sylius-billing-address'}}) }}
+    {% include '@SyliusShop/Common/Form/_address.html.twig' with {'form': form.shippingAddress, 'order': order, 'type': 'shipping'} %}
+    {{ form_row(form.differentBillingAddress,sylius_test_form_attribute('different-billing-address')|merge({'attr': {'data-toggles': 'sylius-billing-address'}, 'label_attr': {'data-test-different-billing-address-label': ''}})) }}
 
     {{ sonata_block_render_event('sylius.shop.checkout.address.shipping_address_form', {'order': order}) }}
 </div>
 
-<div id="sylius-billing-address">
+<div id="sylius-billing-address" {{ sylius_test_html_attribute('billing-address') }}>
     <div class="ui hidden divider"></div>
     {% include '@SyliusShop/Checkout/Address/_addressBookSelect.html.twig' %}
     <h3 class="ui dividing header">{{ 'sylius.ui.billing_address'|trans }}</h3>
-    {% include '@SyliusShop/Common/Form/_address.html.twig' with {'form': form.billingAddress, 'order': order} %}
+    {% include '@SyliusShop/Common/Form/_address.html.twig' with {'form': form.billingAddress, 'order': order, 'type': 'billing'} %}
 
     {{ sonata_block_render_event('sylius.shop.checkout.address.billing_address_form', {'order': order}) }}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_navigation.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_navigation.html.twig
@@ -3,6 +3,6 @@
         <a href="{{ path('sylius_shop_homepage') }}" class="ui large icon labeled button"><i class="arrow left icon"></i> {{ 'sylius.ui.back_to_store'|trans }}</a>
     </div>
     <div class="right aligned column">
-        <button type="submit" id="next-step" class="ui large primary icon labeled button"><i class="arrow right icon"></i> {{ 'sylius.ui.next'|trans }}</button>
+        <button type="submit" id="next-step" class="ui large primary icon labeled button" {{ sylius_test_html_attribute('next-step') }}><i class="arrow right icon"></i> {{ 'sylius.ui.next'|trans }}</button>
     </div>
 </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_navigation.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectPayment/_navigation.html.twig
@@ -9,7 +9,7 @@
         {% endif %}
     </div>
     <div class="right aligned column">
-        <button type="submit" id="next-step" class="ui large primary icon labeled{% if not enabled %} disabled{% endif %} button">
+        <button type="submit" id="next-step" class="ui large primary icon labeled{% if not enabled %} disabled{% endif %} button" {{ sylius_test_html_attribute('next-step') }}>
             <i class="arrow right icon"></i>
             {{ 'sylius.ui.next'|trans }}
         </button>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_choice.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_choice.html.twig
@@ -1,13 +1,13 @@
 {% import '@SyliusShop/Common/Macro/money.html.twig' as money %}
 
-<div class="item">
+<div class="item" {{ sylius_test_html_attribute('shipping-item') }}>
     <div class="field">
         <div class="ui radio checkbox">
-            {{ form_widget(form) }}
+            {{ form_widget(form, sylius_test_form_attribute('shipping-method-select')) }}
         </div>
     </div>
     <div class="content">
-        <a class="header">{{ form_label(form) }}</a>
+        <a class="header" {{ sylius_test_html_attribute('shipping-method-label') }}>{{ form_label(form) }}</a>
         {% if method.description is not null %}
             <div class="description">
                 <p>{{ method.description }}</p>
@@ -15,7 +15,7 @@
         {% endif %}
     </div>
     <div class="extra">
-        <div class="ui large right floated fee label">
+        <div class="ui large right floated fee label" {{ sylius_test_html_attribute('shipping-method-fee') }}>
             {{ money.convertAndFormat(fee) }}
         </div>
     </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_navigation.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_navigation.html.twig
@@ -5,7 +5,7 @@
         <a href="{{ path('sylius_shop_checkout_address') }}" class="ui large icon labeled button"><i class="arrow left icon"></i> {{ 'sylius.ui.change_address'|trans }}</a>
     </div>
     <div class="right aligned column">
-        <button type="submit" id="next-step" class="ui large primary icon labeled{% if not enabled %} disabled{% endif %} button">
+        <button type="submit" id="next-step" class="ui large primary icon labeled{% if not enabled %} disabled{% endif %} button" {{ sylius_test_html_attribute('next-step') }}>
             <i class="arrow right icon"></i>
             {{ 'sylius.ui.next'|trans }}
         </button>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_shipment.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_shipment.html.twig
@@ -1,6 +1,6 @@
 <div class="ui segment">
     <div class="ui dividing header">{{ 'sylius.ui.shipment'|trans }} #{{ loop.index }}</div>
-    <div class="ui fluid stackable items">
+    <div class="ui fluid stackable items" {{ sylius_test_html_attribute('shipments') }}>
         {{ form_errors(form.method) }}
 
         {% for key, choice_form in form.method %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_unavailable.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/SelectShipping/_unavailable.html.twig
@@ -1,4 +1,4 @@
-<div class="ui icon message" id="sylius-order-cannot-be-shipped">
+<div class="ui icon message" id="sylius-order-cannot-be-shipped" {{ sylius_test_html_attribute('order-cannot-be-shipped') }}>
     <i class="warning sign icon"></i>
     <div class="content">
         <div class="header">{{ 'sylius.ui.warning'|trans }}</div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_header.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_header.html.twig
@@ -5,7 +5,7 @@
         </div>
         <div class="right menu">
             {% if order.customer.id|default(null) is not null %}
-                <div class="item" id="purchaser-email">{{ 'sylius.ui.checking_out_as'|trans }} {{ order.customer.fullName|default(order.customer.email) }}.</div>
+                <div class="item" id="purchaser-email" {{ sylius_test_html_attribute('purchaser-name-or-email') }}>{{ 'sylius.ui.checking_out_as'|trans }} {{ order.customer.fullName|default(order.customer.email) }}.</div>
             {% else %}
                 <a href="{{ path('sylius_shop_login') }}" class="item">{{ 'sylius.ui.sign_in'|trans }}</a>
             {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_steps.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_steps.html.twig
@@ -19,7 +19,7 @@
 {% endif %}
 
 <div class="ui {{ steps_count }} steps">
-    <a class="{{ steps['address'] }} step" href="{{ path('sylius_shop_checkout_address') }}">
+    <a class="{{ steps['address'] }} step" href="{{ path('sylius_shop_checkout_address') }}" {{ sylius_test_html_attribute('step-address') }}>
         <i class="map icon"></i>
         <div class="content">
             <div class="title">{{ 'sylius.ui.address'|trans }}</div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_summary.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_summary.html.twig
@@ -5,7 +5,7 @@
 {% set taxExcluded = sylius_order_tax_excluded(order) %}
 
 <div class="ui segment">
-    <table class="ui very basic table" id="sylius-checkout-subtotal">
+    <table class="ui very basic table" id="sylius-checkout-subtotal" {{ sylius_test_html_attribute('checkout-subtotal') }}>
         <thead>
         <tr>
             <th class="sylius-table-column-item">{{ 'sylius.ui.item'|trans }}</th>
@@ -20,7 +20,9 @@
                 <td class="center aligned">
                     {{ item.quantity }}
                 </td>
-                <td class="right aligned" id="sylius-item-{{ item.variant.product.slug }}-subtotal">{{ money.convertAndFormat(item.subtotal) }}</td>
+                <td class="right aligned" id="sylius-item-{{ item.variant.product.slug }}-subtotal" {{ sylius_test_html_attribute('item-subtotal', item.variant.product.slug) }}>
+                    {{ money.convertAndFormat(item.subtotal) }}
+                </td>
             </tr>
         {% endfor %}
         </tbody>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Form/_address.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Form/_address.html.twig
@@ -1,9 +1,13 @@
+{% if type is not defined %}
+     {% set type = null %}
+{% endif %}
+
 <div class="two fields">
-    {{ form_row(form.firstName) }}
-    {{ form_row(form.lastName) }}
+    {{ form_row(form.firstName, sylius_test_form_attribute(type ~ '-first-name')) }}
+    {{ form_row(form.lastName, sylius_test_form_attribute(type ~ '-last-name')) }}
 </div>
-{{ form_row(form.company) }}
-{{ form_row(form.street) }}
+{{ form_row(form.company, sylius_test_form_attribute(type ~ '-company')) }}
+{{ form_row(form.street, sylius_test_form_attribute(type ~ '-street')) }}
 
 {% include '@SyliusShop/Common/Form/_countryCode.html.twig' with {'form': form.countryCode} %}
 
@@ -15,12 +19,12 @@
     {% endif %}
 </div>
 
-{% if form.provinceCode is defined %}
+{% if form.provinceCode is defined %}a
     {{ form_errors(form) }}
 {% endif %}
 
 <div class="two fields">
-    {{ form_row(form.city) }}
-    {{ form_row(form.postcode) }}
+    {{ form_row(form.city, sylius_test_form_attribute(type ~ '-city')) }}
+    {{ form_row(form.postcode, sylius_test_form_attribute(type ~ '-postcode')) }}
 </div>
 {{ form_row(form.phoneNumber) }}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Form/_address.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Form/_address.html.twig
@@ -19,7 +19,7 @@
     {% endif %}
 </div>
 
-{% if form.provinceCode is defined %}a
+{% if form.provinceCode is defined %}
     {{ form_errors(form) }}
 {% endif %}
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Form/_countryCode.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Form/_countryCode.html.twig
@@ -1,5 +1,5 @@
 {% if form.vars.choices|length == 1 %}
-    {{ form_row(form, {'value': form.vars.choices[0].value}) }}
+    {{ form_row(form, sylius_test_form_attribute(type ~ '-country')|merge({'value': form.vars.choices[0].value})) }}
 {% else %}
-    {{ form_row(form) }}
+    {{ form_row(form, sylius_test_form_attribute(type ~ '-country')) }}
 {% endif %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Form/_login.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Form/_login.html.twig
@@ -1,7 +1,7 @@
 <div class="one field" id="sylius-api-login">
     {{ form_errors(form.email, sylius_test_form_attribute('login-errors')) }}
     {% set path = path('sylius_shop_ajax_user_check_action')  %}
-    {{ form_row(form.email, sylius_test_form_attribute('login-email')|merge({'attr': {'data-url': path}})) }}
+    {{ form_row(form.email, sylius_test_form_attribute('login-email')|sylius_merge_recursive({'attr': {'data-url': path}})) }}
 
     <div class="ui action input" id="sylius-api-login-form">
         <input type="password" placeholder="{{ 'sylius.ui.password'|trans }}">

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Form/_login.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Form/_login.html.twig
@@ -1,6 +1,7 @@
 <div class="one field" id="sylius-api-login">
-    {{ form_errors(form.email) }}
-    {{ form_row(form.email, {'attr': {'data-url': path('sylius_shop_ajax_user_check_action')}}) }}
+    {{ form_errors(form.email, sylius_test_form_attribute('login-errors')) }}
+    {% set path = path('sylius_shop_ajax_user_check_action')  %}
+    {{ form_row(form.email, sylius_test_form_attribute('login-email')|merge({'attr': {'data-url': path}})) }}
 
     <div class="ui action input" id="sylius-api-login-form">
         <input type="password" placeholder="{{ 'sylius.ui.password'|trans }}">

--- a/src/Sylius/Bundle/UiBundle/Resources/config/services/twig.xml
+++ b/src/Sylius/Bundle/UiBundle/Resources/config/services/twig.xml
@@ -38,5 +38,9 @@
             <argument type="collection" />
             <tag name="twig.extension" />
         </service>
+
+        <service id="sylius.twig.extension.merge_recursive" class="Sylius\Bundle\UiBundle\Twig\MergeRecursiveExtension">
+            <tag name="twig.extension" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -11,7 +11,7 @@
 {%- block form_errors -%}
     {%- if errors|length > 0 -%}
         {%- for error in errors -%}
-            <div class="ui red {% if form.parent is not empty %}pointing {% endif %}label sylius-validation-error" {{ sylius_test_html_attribute('sylius-validation-error') }} {% if form.parent is empty %} style="margin-bottom: 10px;"{% endif %}>
+            <div class="ui red {% if form.parent is not empty %}pointing {% endif %}label sylius-validation-error" {{ sylius_test_html_attribute('validation-error') }} {% if form.parent is empty %} style="margin-bottom: 10px;"{% endif %}>
                 {{ error.message }}
             </div>
         {%- endfor -%}

--- a/src/Sylius/Bundle/UiBundle/Twig/MergeRecursiveExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/MergeRecursiveExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\UiBundle\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+final class MergeRecursiveExtension extends AbstractExtension
+{
+    public function  getFilters(): array
+    {
+        return [
+            new TwigFilter(
+                'sylius_merge_recursive',
+                function (array $firstArray, array $secondArray): array {
+                    return array_merge_recursive($firstArray, $secondArray);
+                }
+            ),
+        ];
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         |  master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no/
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.4, 1.5 or 1.6 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
Replacing class/id by attributes in AddressPage, selectShippingPage and related html
for now, I left elements related to JS without changes, because simple attribute generates errors, it will be done in the near feature.