### PR TITLE
Add lint:container command to the build & fix errors reported by it

### DIFF
--- a/etc/travis/suites/application/script/validate-container
+++ b/etc/travis/suites/application/script/validate-container
@@ -3,4 +3,9 @@
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../../bash/common.lib.sh"
 
 print_header "Validating (DI Container)" "Sylius"
-run_command "bin/console lint:container"
+
+if [ "$(bin/console list | grep lint:container -c)" = 1 ]; then
+    run_command "bin/console lint:container"
+else
+    print_info "lint:container command not found, skipped"
+fi

--- a/etc/travis/suites/application/script/validate-container
+++ b/etc/travis/suites/application/script/validate-container
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../../bash/common.lib.sh"
+
+print_header "Validating (DI Container)" "Sylius"
+run_command "bin/console lint:container"

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
@@ -172,25 +172,12 @@
             <argument type="service" id="sylius.form.type.data_transformer.products_to_codes" />
             <tag name="form.type" />
         </service>
-        <service id="sylius.form.event_subscriber.build_promotion_action" class="Sylius\Bundle\CoreBundle\Form\EventSubscriber\BuildChannelBasedPromotionActionFormSubscriber">
-            <argument type="service" id="sylius.registry_promotion_action" />
-            <argument type="service" id="form.factory" />
-            <argument type="service" id="sylius.repository.channel" />
-        </service>
-        <service id="sylius.form.event_subscriber.build_promotion_rule" class="Sylius\Bundle\CoreBundle\Form\EventSubscriber\BuildChannelBasedPromotionRuleFormSubscriber">
-            <argument type="service" id="sylius.registry_promotion_rule_checker" />
-            <argument type="service" id="form.factory" />
-            <argument type="service" id="sylius.repository.channel" />
-        </service>
 
         <service id="sylius.form.type.data_transformer.taxons_to_codes" class="Sylius\Bundle\CoreBundle\Form\DataTransformer\TaxonsToCodesTransformer">
             <argument type="service" id="sylius.repository.taxon" />
         </service>
         <service id="sylius.form.type.data_transformer.products_to_codes" class="Sylius\Bundle\CoreBundle\Form\DataTransformer\ProductsToCodesTransformer">
             <argument type="service" id="sylius.repository.product" />
-        </service>
-        <service id="sylius.form.type.data_transformer.product_variants_to_codes" class="Sylius\Bundle\CoreBundle\Form\DataTransformer\ProductVariantsToCodesTransformer">
-            <argument type="service" id="sylius.repository.product_variant" />
         </service>
 
         <service id="sylius.form.type.customer_guest" class="Sylius\Bundle\CoreBundle\Form\Type\Customer\CustomerGuestType">

--- a/src/Sylius/Bundle/PayumBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/config/services/controller.xml
@@ -9,7 +9,12 @@
         <service id="sylius.controller.payum" class="Sylius\Bundle\PayumBundle\Controller\PayumController" public="true">
             <argument type="service" id="payum" />
             <argument type="service" id="sylius.repository.order" />
-            <argument type="expression">service('sylius.resource_registry').get('sylius.order')</argument>
+            <argument type="service">
+                <service class="Sylius\Component\Resource\Metadata\MetadataInterface">
+                    <factory service="sylius.resource_registry" method="get" />
+                    <argument type="string">sylius.order</argument>
+                </service>
+            </argument>
             <argument type="service" id="sylius.resource_controller.request_configuration_factory" />
             <argument type="service" id="sylius.resource_controller.view_handler" />
             <argument type="service" id="router" />


### PR DESCRIPTION
| Q               | A 
| --------------- | ----- 
| Branch?         | 1.5 
| Bug fix?        | yes 
| New feature?    | no 
| BC breaks?      | no 
| Deprecations?   | no 
| Related tickets | - 
| License         | MIT

Removes services defined for nonexisting classes and fixes other container-related errors.
Adds `lint:container` command to the build.

https://symfony.com/blog/new-in-symfony-4-4-service-container-linter