### PR TITLE
[Payum][Paypal] Use full price instead of discounted one

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Action/Paypal/ExpressCheckout/ConvertPaymentAction.php
+++ b/src/Sylius/Bundle/PayumBundle/Action/Paypal/ExpressCheckout/ConvertPaymentAction.php
@@ -54,7 +54,7 @@ final class ConvertPaymentAction implements ActionInterface
         $m = 0;
         foreach ($order->getItems() as $item) {
             $details['L_PAYMENTREQUEST_0_NAME' . $m] = $item->getVariant()->getProduct()->getName();
-            $details['L_PAYMENTREQUEST_0_AMT' . $m] = $this->formatPrice($item->getDiscountedUnitPrice());
+            $details['L_PAYMENTREQUEST_0_AMT' . $m] = $this->formatPrice($item->getUnitPrice());
             $details['L_PAYMENTREQUEST_0_QTY' . $m] = $item->getQuantity();
 
             ++$m;

--- a/src/Sylius/Bundle/PayumBundle/spec/Action/Paypal/ExpressCheckout/ConvertPaymentActionSpec.php
+++ b/src/Sylius/Bundle/PayumBundle/spec/Action/Paypal/ExpressCheckout/ConvertPaymentActionSpec.php
@@ -61,7 +61,7 @@ final class ConvertPaymentActionSpec extends ObjectBehavior
         $order->getShippingTotal()->willReturn(8000);
 
         $orderItem->getVariant()->willReturn($productVariant);
-        $orderItem->getDiscountedUnitPrice()->willReturn(80000);
+        $orderItem->getUnitPrice()->willReturn(80000);
         $orderItem->getQuantity()->willReturn(1);
 
         $productVariant->getProduct()->willReturn($product);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.4 to master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | unknown
| License         | MIT

I was having trouble with many PayPal errors during the black friday and the error was :
`"The totals of the cart item amounts do not match order amounts."`

The bug was caused by the fact that PayPal make a validation of the total price with the sum of each item lines we build. This bug appear because all discounted prices are regrouped into an item line named "Discount" so all other lines shouldn't be filled with something related with discounts.