### PR TITLE
[Admin][Order] Add resending a shipment confirmation email

### DIFF
--- a/features/order/managing_orders/resending_shipment_confirmation_email.feature
+++ b/features/order/managing_orders/resending_shipment_confirmation_email.feature
@@ -1,0 +1,33 @@
+@managing_orders
+Feature: Resending a shipment confirmation email for a chosen order
+    In order to be able to send a lost email again
+    As an Administrator
+    I want to have the shipment confirmation email for a chosen order sent to the customer
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And that channel allows to shop using "English (United States)" and "Polish (Poland)" locales
+        And the store has a product "Angel T-Shirt"
+        And the store ships everywhere for free
+        And the store allows paying with "Cash on Delivery"
+        And there is a customer "lucy@teamlucifer.com" that placed an order "#00000666"
+        And the customer bought a single "Angel T-Shirt"
+        And the customer "Lucifer Morningstar" addressed it to "Seaside Fwy", "90802" "Los Angeles" in the "United States" with identical billing address
+        And the customer chose "Free" shipping method with "Cash on Delivery" payment
+        And this order has already been shipped
+        And I am logged in as an administrator
+
+    @ui @email
+    Scenario: Resending a shipment confirmation email for a given order
+        When I view the summary of the order "#00000666"
+        And I resend the shipment confirmation email
+        Then I should be notified that the shipment confirmation email has been successfully resent to the customer
+        And an email with the shipment's confirmation of the order "#00000666" should be sent to "lucy@teamlucifer.com"
+
+    @ui @email
+    Scenario: Resending a shipment confirmation email after shipping an order in different locale than the default one
+        Given the order "#00000666" has been placed in "Polish (Poland)" locale
+        When I view the summary of the order "#00000666"
+        And I resend the shipment confirmation email
+        Then I should be notified that the shipment confirmation email has been successfully resent to the customer
+        And an email with the shipment's confirmation of the order "#00000666" should be sent to "lucy@teamlucifer.com" in "Polish (Poland)" locale

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -201,6 +201,14 @@ final class ManagingOrdersContext implements Context
     }
 
     /**
+     * @When I resend the shipment confirmation email
+     */
+    public function iResendTheShipmentConfirmationEmail(): void
+    {
+        $this->showPage->resendShipmentConfirmationEmail();
+    }
+
+    /**
      * @Then I should see a single order from customer :customer
      */
     public function iShouldSeeASingleOrderFromCustomer(CustomerInterface $customer)
@@ -890,12 +898,12 @@ final class ManagingOrdersContext implements Context
     }
 
     /**
-     * @Then I should be notified that the order confirmation email has been successfully resent to the customer
+     * @Then /^I should be notified that the (order|shipment) confirmation email has been successfully resent to the customer$/
      */
-    public function iShouldBeNotifiedThatTheOrderConfirmationEmailHasBeenSuccessfullyResentToTheCustomer(): void
+    public function iShouldBeNotifiedThatTheOrderConfirmationEmailHasBeenSuccessfullyResentToTheCustomer(string $type): void
     {
         $this->notificationChecker->checkNotification(
-            'Order confirmation has been successfully resent to the customer.',
+            sprintf('%s confirmation has been successfully resent to the customer.', ucfirst($type)),
             NotificationType::success()
         );
     }

--- a/src/Sylius/Behat/Context/Ui/EmailContext.php
+++ b/src/Sylius/Behat/Context/Ui/EmailContext.php
@@ -130,6 +130,8 @@ final class EmailContext implements Context
     /**
      * @Then /^an email with shipment's details of (this order) should be sent to "([^"]+)"$/
      * @Then /^an email with shipment's details of (this order) should be sent to "([^"]+)" in ("([^"]+)" locale)$/
+     * @Then an email with the shipment's confirmation of the order :order should be sent to :recipient
+     * @Then an email with the shipment's confirmation of the order :order should be sent to :recipient in :localeCode locale
      */
     public function anEmailWithShipmentDetailsOfOrderShouldBeSentTo(
         OrderInterface $order,
@@ -147,16 +149,19 @@ final class EmailContext implements Context
             ),
             $recipient
         );
-        $this->assertEmailContainsMessageTo(
-            sprintf(
-                '%s %s %s',
-                $this->sharedStorage->get('tracking_code'),
-                $this->translator->trans('sylius.email.shipment_confirmation.tracking_code', [], null, $localeCode),
-                $this->translator->trans('sylius.email.shipment_confirmation.thank_you_for_transaction', [], null, $localeCode)
 
-            ),
-            $recipient
-        );
+        if ($this->sharedStorage->has('tracking_code')) {
+            $this->assertEmailContainsMessageTo(
+                sprintf(
+                    '%s %s %s',
+                    $this->sharedStorage->get('tracking_code'),
+                    $this->translator->trans('sylius.email.shipment_confirmation.tracking_code', [], null, $localeCode),
+                    $this->translator->trans('sylius.email.shipment_confirmation.thank_you_for_transaction', [], null, $localeCode)
+
+                ),
+                $recipient
+            );
+        }
     }
 
     private function assertEmailContainsMessageTo(string $message, string $recipient): void

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
@@ -372,6 +372,11 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         $this->getElement('resend_order_confirmation_email')->click();
     }
 
+    public function resendShipmentConfirmationEmail(): void
+    {
+        $this->getElement('resend_shipment_confirmation_email')->click();
+    }
+
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -389,6 +394,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
             'promotion_shipping_discounts' => '#shipping-discount-value',
             'promotion_total' => '#promotion-total',
             'resend_order_confirmation_email' => '[data-test-resend-order-confirmation-email]',
+            'resend_shipment_confirmation_email' => '[data-test-resend-shipment-confirmation-email]',
             'shipments' => '#sylius-shipments',
             'shipping_address' => '#shipping-address',
             'shipping_adjustment_name' => '#shipping-adjustment-label',

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
@@ -117,4 +117,6 @@ interface ShowPageInterface extends SymfonyPageInterface
     public function hasInformationAboutNoPayment(): bool;
 
     public function resendOrderConfirmationEmail(): void;
+
+    public function resendShipmentConfirmationEmail(): void;
 }

--- a/src/Sylius/Bundle/AdminBundle/Action/ResendShipmentConfirmationEmailAction.php
+++ b/src/Sylius/Bundle/AdminBundle/Action/ResendShipmentConfirmationEmailAction.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Action;
+
+use Sylius\Bundle\AdminBundle\EmailManager\ShipmentEmailManagerInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+use Sylius\Component\Core\Repository\ShipmentRepositoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+final class ResendShipmentConfirmationEmailAction
+{
+    /** @var ShipmentRepositoryInterface */
+    private $shipmentRepository;
+
+    /** @var ShipmentEmailManagerInterface */
+    private $shipmentEmailManager;
+
+    /** @var CsrfTokenManagerInterface */
+    private $csrfTokenManager;
+
+    /** @var Session */
+    private $session;
+
+    public function __construct(
+        ShipmentRepositoryInterface $shipmentRepository,
+        ShipmentEmailManagerInterface $shipmentEmailManager,
+        CsrfTokenManagerInterface $csrfTokenManager,
+        SessionInterface $session
+    ) {
+        $this->shipmentRepository = $shipmentRepository;
+        $this->shipmentEmailManager = $shipmentEmailManager;
+        $this->csrfTokenManager = $csrfTokenManager;
+        $this->session = $session;
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        $shipmentId = $request->attributes->get('id');
+
+        if (!$this->csrfTokenManager->isTokenValid(new CsrfToken($shipmentId, $request->query->get('_csrf_token')))) {
+            throw new HttpException(Response::HTTP_FORBIDDEN, 'Invalid csrf token.');
+        }
+
+        /** @var ShipmentInterface|null $shipment */
+        $shipment = $this->shipmentRepository->find($shipmentId);
+        if ($shipment === null) {
+            throw new NotFoundHttpException(sprintf('The shipment with id %s has not been found', $shipmentId));
+        }
+
+        $this->shipmentEmailManager->sendConfirmationEmail($shipment);
+
+        $this->session->getFlashBag()->add(
+            'success',
+            'sylius.email.shipment_confirmation_resent'
+        );
+
+        return new RedirectResponse($request->headers->get('referer'));
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shipment.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/shipment.yml
@@ -27,3 +27,9 @@ sylius_admin_shipment_ship:
                 transition: ship
             redirect: referer
             flash: sylius.shipment.shipped
+
+sylius_admin_shipment_resend_confirmation_email:
+    path: /shipments/{id}/resend-confirmation-email
+    methods: [GET]
+    defaults:
+        _controller: Sylius\Bundle\AdminBundle\Action\ResendShipmentConfirmationEmailAction

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
@@ -32,6 +32,13 @@
             <argument type="service" id="session" />
         </service>
 
+        <service id="Sylius\Bundle\AdminBundle\Action\ResendShipmentConfirmationEmailAction" public="true">
+            <argument type='service' id="sylius.repository.shipment" />
+            <argument type="service" id="Sylius\Bundle\AdminBundle\EmailManager\ShipmentEmailManagerInterface" />
+            <argument type="service" id="security.csrf.token_manager" />
+            <argument type="service" id="session" />
+        </service>
+
         <service id="sylius.controller.admin.dashboard" class="Sylius\Bundle\AdminBundle\Controller\DashboardController" public="true">
             <argument type="service" id="sylius.dashboard.statistics_provider" />
             <argument type="service" id="sylius.repository.channel" />

--- a/src/Sylius/Bundle/AdminBundle/Resources/translations/flashes.en.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/translations/flashes.en.yml
@@ -4,5 +4,6 @@
 sylius:
     email:
         order_confirmation_resent: 'Order confirmation has been successfully resent to the customer.'
+        shipment_confirmation_resent: 'Shipment confirmation has been successfully resent to the customer.'
     product_variant:
         cannot_generate_variants: 'Cannot generate variants for a product without options values.'

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_shipment.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_shipment.html.twig
@@ -1,5 +1,7 @@
 {% import '@SyliusUi/Macro/labels.html.twig' as label %}
 
+{% set shipped = constant('Sylius\\Component\\Shipping\\Model\\Shipment::STATE_SHIPPED') %}
+
 <div class="item">
     <div class="right floated content">
         {% include '@SyliusAdmin/Common/Label/shipmentState.html.twig' with {'data': shipment.state} %}
@@ -21,5 +23,12 @@
             <span class="ui top attached icon label"><i class="plane icon"></i> {{ 'sylius.ui.tracking_code'|trans|upper }}</span>
             <p>{{ shipment.tracking }}</p>
         </div>
+    {% endif %}
+
+    {% if shipment.state == shipped %}
+        {% set path = path('sylius_admin_shipment_resend_confirmation_email', {'id': shipment.id, '_csrf_token': csrf_token(shipment.id)}) %}
+        <a href="{{ path }}" class="ui icon labeled tiny fluid button" {{ sylius_test_html_attribute('resend-shipment-confirmation-email') }}>
+            <i class="send icon"></i> {{ 'sylius.ui.resend_the_shipment_confirmation_email'|trans }}
+        </a>
     {% endif %}
 </div>

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
@@ -699,6 +699,7 @@ sylius:
         report_details: 'Report details'
         reports: 'Reports'
         resend_the_order_confirmation_email: 'Resend the order confirmation email'
+        resend_the_shipment_confirmation_email: 'Resend the shipment confirmation email'
         reserved: 'Reserved'
         reset: 'Reset'
         reset_button: 'Reset'


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

When the shipment is in `ready` state:
![screencapture-127-0-0-1-8007-admin-orders-19-2019-12-16-15_17_46](https://user-images.githubusercontent.com/6140884/70914341-17462b80-2018-11ea-823f-e6cfce86eb52.png)

When the shipment is in `shipped` state:
![screencapture-127-0-0-1-8007-admin-orders-19-2019-12-16-15_18_10](https://user-images.githubusercontent.com/6140884/70914333-157c6800-2018-11ea-83d9-fddeff01b773.png)
