### PR TITLE
[Email][Shipment] Fix shipment confirmation email to send information about tracking only if it is provided

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Email/shipmentConfirmation.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Email/shipmentConfirmation.html.twig
@@ -12,11 +12,13 @@
             {{ 'sylius.email.shipment_confirmation.has_been_sent_using'|trans({}, null, localeCode) }}
             <span style="color: #1abb9c;">{{ shipment.method }}</span>.
         </div>
-        <div style="margin-bottom: 20px;">
-            {{ 'sylius.email.shipment_confirmation.you_can_check_its_location'|trans({}, null, localeCode) }}
-            <span style="color: #1abb9c;">{{ shipment.tracking }}</span>
-            {{ 'sylius.email.shipment_confirmation.tracking_code'|trans({}, null, localeCode) }}
-        </div>
+        {% if shipment.tracking is not null %}
+            <div style="margin-bottom: 20px;">
+                {{ 'sylius.email.shipment_confirmation.you_can_check_its_location'|trans({}, null, localeCode) }}
+                <span style="color: #1abb9c;">{{ shipment.tracking }}</span>
+                {{ 'sylius.email.shipment_confirmation.tracking_code'|trans({}, null, localeCode) }}
+            </div>
+        {% endif %}
         <div>
             {{ 'sylius.email.shipment_confirmation.thank_you_for_transaction'|trans({}, null, localeCode) }}
         </div>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

![image](https://user-images.githubusercontent.com/6140884/71002534-c1d55180-20df-11ea-9ec9-a53fbe876068.png)
![image](https://user-images.githubusercontent.com/6140884/71002552-cd287d00-20df-11ea-9fa7-b0c66d5f317a.png)
