### PR TITLE
Handle pluralisation in translations with Intl ICU

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/Provider/PaymentDescriptionProvider.php
+++ b/src/Sylius/Bundle/PayumBundle/Provider/PaymentDescriptionProvider.php
@@ -35,9 +35,8 @@ final class PaymentDescriptionProvider implements PaymentDescriptionProviderInte
         /** @var OrderInterface $order */
         $order = $payment->getOrder();
 
-        return $this->translator->transChoice(
+        return $this->translator->trans(
             'sylius.payum_action.payment.description',
-            $order->getItems()->count(),
             [
                 '%items%' => $order->getItems()->count(),
                 '%total%' => round($payment->getAmount() / 100, 2),

--- a/src/Sylius/Bundle/PayumBundle/Resources/translations/messages+intl-icu.en.yml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/translations/messages+intl-icu.en.yml
@@ -1,0 +1,4 @@
+sylius:
+    payum_action:
+        payment:
+            description: '{items, plural, one {Payment contains # item for a total of {total}} other {Payment contains # items for a total of {total}}}'

--- a/src/Sylius/Bundle/PayumBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/translations/messages.en.yml
@@ -15,6 +15,3 @@ sylius:
         offline: Offline
         paypal_express_checkout: Paypal express checkout
         stripe_checkout: Stripe checkout (no SCA support)
-    payum_action:
-        payment:
-            description: Payment contains %items% item for a total of %total%|Payment contains %items% items for a total of %total%

--- a/src/Sylius/Bundle/PayumBundle/spec/Provider/PaymentDescriptionProviderSpec.php
+++ b/src/Sylius/Bundle/PayumBundle/spec/Provider/PaymentDescriptionProviderSpec.php
@@ -24,7 +24,7 @@ final class PaymentDescriptionProviderSpec extends ObjectBehavior
 {
     function let(TranslatorInterface $translator): void
     {
-        $translator->transChoice('sylius.payum_action.payment.description', 2, [
+        $translator->trans('sylius.payum_action.payment.description', [
             '%items%' => 2,
             '%total%' => 100.00,
         ])->willReturn('Payment contains 2 items for a total of 100');

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/_widget.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Cart/_widget.html.twig
@@ -5,9 +5,9 @@
 
     <i class="cart icon"></i>
     <span id="sylius-cart-total">
-        {{ money.convertAndFormat(cart.itemsTotal) }}
+        {{- money.convertAndFormat(cart.itemsTotal) -}}
     </span>
-    {% transchoice cart.items|length %}sylius.ui.item.choice{% endtranschoice %}
+    {{- 'sylius.ui.item.choice'|trans({'%count%': cart.items|length}) }}
 
     {{ sonata_block_render_event('sylius.shop.partial.cart.summary.after_widget_content', {'cart': cart}) }}
 </div>

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages+intl-icu.en.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages+intl-icu.en.yml
@@ -1,0 +1,4 @@
+sylius:
+    ui:
+        item.choice: '{count, plural, =0 {} one {, 1 item} other {, # items}}'
+        overall_this_customer_has_placed_orders_across_all_channels.choice: '{count, plural, =0 {This customer has not placed any order} one {This customer has placed one order} other {Overall, this customer has placed # orders across all channels}}'

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
@@ -401,7 +401,6 @@ sylius:
         is_enabled: 'Is enabled'
         issue_tracker: 'Issue tracker'
         it_seems_you_have_an_account_already: 'It seems you have an account already'
-        item.choice: "{0} |{1}, 1 item|]1,Inf], %count% items"
         item: 'Item'
         item_discount: 'Item discount'
         items: 'Items'
@@ -598,7 +597,6 @@ sylius:
         orders_statistics: 'Orders statistics'
         original_price: 'Original price'
         out_of_stock: 'Out of stock'
-        overall_this_customer_has_placed_orders_across_all_channels.choice: '{0}|{1}This customer has placed one order|]1,Inf]Overall, this customer has placed %count% orders across all channels'
         overview_of_your_store: 'Overview of your store'
         page: 'Page'
         pages: 'Pages'


### PR DESCRIPTION
Symfony 5.0 removes `transchoice` filter and recommends using Intl ICU to handle pluralisation - https://symfony.com/doc/4.4/translation/message_format.html.

Referencing mega-issue #10928.