### PR TITLE
[Maintenance] Remove shipping bundle from spec namespace config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -239,7 +239,6 @@
             "spec\\Sylius\\Bundle\\ProductBundle\\": "src/Sylius/Bundle/ProductBundle/spec/",
             "spec\\Sylius\\Bundle\\PromotionBundle\\": "src/Sylius/Bundle/PromotionBundle/spec/",
             "spec\\Sylius\\Bundle\\ReviewBundle\\": "src/Sylius/Bundle/ReviewBundle/spec/",
-            "spec\\Sylius\\Bundle\\ShippingBundle\\": "src/Sylius/Bundle/ShippingBundle",
             "spec\\Sylius\\Bundle\\ShopBundle\\": "src/Sylius/Bundle/ShopBundle/spec/",
             "spec\\Sylius\\Bundle\\TaxationBundle\\": "src/Sylius/Bundle/TaxationBundle/spec/",
             "spec\\Sylius\\Bundle\\TaxonomyBundle\\": "src/Sylius/Bundle/TaxonomyBundle/spec/",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.5
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

There are no specs for shipping bundle, therefore this namespace is not needed.
<!--
 - Bug fixes must be submitted against the 1.5 or 1.6 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->