### PR TITLE
Expose payment and shipping state

### DIFF
--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/serializer/Model.Order.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/serializer/Model.Order.yml
@@ -6,6 +6,14 @@ Sylius\Component\Core\Model\Order:
             expose: true
             type: string
             groups: [Default, Detailed, DetailedCart]
+        paymentState:
+            expose: true
+            type: string
+            groups: [Default, Detailed, DetailedCart]
+        shippingState:
+            expose: true
+            type: string
+            groups: [Default, Detailed, DetailedCart]
         currencyCode:
             expose: true
             type: string


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Adds two fields to the API response: `paymentState` and `shippingState`
