### PR TITLE
[HotFix] SyliusGridBundle downgrade to 1.7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -177,6 +177,7 @@
         "sylius/user-bundle": "self.version"
     },
     "conflict": {
+        "sylius/grid-bundle": "1.7.4",
         "symfony/symfony": "3.4.7",
         "twig/twig": "2.6.1"
     },


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

New version GridBundle(1.7.4) need fixes because sorting by names doesn't work properly 

<!--
 - Bug fixes must be submitted against the 1.5 or 1.6 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
