### PR TITLE
[Channel][Taxon][Shop] Menu taxon on channel

### DIFF
--- a/app/migrations/Version20200110132702.php
+++ b/app/migrations/Version20200110132702.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Migrations;

--- a/app/migrations/Version20200110132702.php
+++ b/app/migrations/Version20200110132702.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20200110132702 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_channel ADD menu_taxon_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE sylius_channel ADD CONSTRAINT FK_16C8119EF242B1E6 FOREIGN KEY (menu_taxon_id) REFERENCES sylius_taxon (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_16C8119EF242B1E6 ON sylius_channel (menu_taxon_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE sylius_channel DROP FOREIGN KEY FK_16C8119EF242B1E6');
+        $this->addSql('DROP INDEX IDX_16C8119EF242B1E6 ON sylius_channel');
+        $this->addSql('ALTER TABLE sylius_channel DROP menu_taxon_id');
+    }
+}

--- a/features/channel/managing_channels/adding_new_channel_with_menu_taxon.feature
+++ b/features/channel/managing_channels/adding_new_channel_with_menu_taxon.feature
@@ -13,8 +13,8 @@ Feature: Adding a new channel with menu taxon
 
     @ui @javascript
     Scenario: Adding a new channel with menu taxon
-        Given I want to create a new channel
-        When I specify its code as "MOBILE"
+        When I want to create a new channel
+        And I specify its code as "MOBILE"
         And I name it "Mobile channel"
         And I specify menu taxon as "Clothes"
         And I add it

--- a/features/channel/managing_channels/adding_new_channel_with_menu_taxon.feature
+++ b/features/channel/managing_channels/adding_new_channel_with_menu_taxon.feature
@@ -1,0 +1,27 @@
+@managing_channels
+Feature: Adding a new channel with menu taxon
+    In order to sell through multiple channels of distributions products only from specific categories
+    As an Administrator
+    I want to add a new channel with a menu taxon
+
+    Background:
+        Given the store has currency "Euro"
+        And the store has locale "English (United States)"
+        And the store operates in "United States"
+        And the store classifies its products as "Clothes" and "Guns"
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Adding a new channel with menu taxon
+        Given I want to create a new channel
+        When I specify its code as "MOBILE"
+        And I name it "Mobile channel"
+        And I choose "Euro" as the base currency
+        And I choose "English (United States)" as a default locale
+        And I specify company as "Ragnarok"
+        And I specify tax ID as "1100110011"
+        And I specify menu taxon as "Clothes"
+        And I add it
+        Then I should be notified that it has been successfully created
+        And the channel "Mobile channel" should appear in the registry
+        And the channel "Mobile channel" should have "Clothes" as a menu taxon

--- a/features/channel/managing_channels/adding_new_channel_with_menu_taxon.feature
+++ b/features/channel/managing_channels/adding_new_channel_with_menu_taxon.feature
@@ -11,15 +11,11 @@ Feature: Adding a new channel with menu taxon
         And the store classifies its products as "Clothes" and "Guns"
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Adding a new channel with menu taxon
         Given I want to create a new channel
         When I specify its code as "MOBILE"
         And I name it "Mobile channel"
-        And I choose "Euro" as the base currency
-        And I choose "English (United States)" as a default locale
-        And I specify company as "Ragnarok"
-        And I specify tax ID as "1100110011"
         And I specify menu taxon as "Clothes"
         And I add it
         Then I should be notified that it has been successfully created

--- a/features/channel/managing_channels/editing_menu_taxon_on_channel.feature
+++ b/features/channel/managing_channels/editing_menu_taxon_on_channel.feature
@@ -1,0 +1,20 @@
+@managing_channels
+Feature: Editing menu taxon on channel
+    In order to have proper products' categories displayed on each channel
+    As an Administrator
+    I want to be able to edit menu taxon on a channel
+
+    Background:
+        Given the store operates on a channel named "Web Store"
+        And the store ships to "United States"
+        And the store classifies its products as "Clothes" and "Guns"
+        And channel "Web Store" has menu taxon "Clothes"
+        And I am logged in as an administrator
+
+    @ui
+    Scenario: Editing menu taxon on the channel
+        When I want to modify a channel "Web Store"
+        And I change its menu taxon to "Guns"
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And this channel menu taxon should be "Guns"

--- a/features/channel/managing_channels/editing_menu_taxon_on_channel.feature
+++ b/features/channel/managing_channels/editing_menu_taxon_on_channel.feature
@@ -11,7 +11,7 @@ Feature: Editing menu taxon on channel
         And channel "Web Store" has menu taxon "Clothes"
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Editing menu taxon on the channel
         When I want to modify a channel "Web Store"
         And I change its menu taxon to "Guns"

--- a/features/homepage/viewing_only_taxons_from_menu_taxon.feature
+++ b/features/homepage/viewing_only_taxons_from_menu_taxon.feature
@@ -1,0 +1,27 @@
+@homepage
+Feature: Viewing only taxons from the menu taxon
+    In order to be able to browse only products from the correct taxon
+    As a Visitor
+    I want to see taxon list based on the current channel's menu taxon
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store classifies its products as "General", "Clothes" and "Guns"
+        And the "General" taxon has children taxons "Pens" and "Pencils"
+        And the "Clothes" taxon has children taxons "T-Shirts" and "Caps"
+        And the "Guns" taxon has children taxons "Rifles" and "Revolvers"
+
+    @ui
+    Scenario: Viewing taxons list only from the channel menu taxon
+        Given this channel has menu taxon "Guns"
+        When I visit the homepage
+        Then I should see "T-Shirts" and "Guns" in the menu
+        And I should not see "Rifles" and "Revolvers" in the menu
+        And I should not see "Pens" and "Pencils" in the menu
+
+    @ui
+    Scenario: Using general taxon if channel does not have a menu taxon specified
+        When I visit the homepage
+        Then I should see "Pens" and "Pencils" in the menu
+        And I should not see "T-Shirts" and "Guns" in the menu
+        And I should not see "Rifles" and "Revolvers" in the menu

--- a/features/homepage/viewing_only_taxons_from_menu_taxon.feature
+++ b/features/homepage/viewing_only_taxons_from_menu_taxon.feature
@@ -6,8 +6,8 @@ Feature: Viewing only taxons from the menu taxon
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store classifies its products as "General", "Clothes" and "Guns"
-        And the "General" taxon has children taxons "Pens" and "Pencils"
+        And the store classifies its products as "Category", "Clothes" and "Guns"
+        And the "Category" taxon has children taxons "Pens" and "Pencils"
         And the "Clothes" taxon has children taxons "T-Shirts" and "Caps"
         And the "Guns" taxon has children taxons "Rifles" and "Revolvers"
 
@@ -15,9 +15,9 @@ Feature: Viewing only taxons from the menu taxon
     Scenario: Viewing taxons list only from the channel menu taxon
         Given this channel has menu taxon "Guns"
         When I visit the homepage
-        Then I should see "T-Shirts" and "Guns" in the menu
-        And I should not see "Rifles" and "Revolvers" in the menu
+        Then I should see "Rifles" and "Revolvers" in the menu
         And I should not see "Pens" and "Pencils" in the menu
+        And I should not see "T-Shirts" and "Caps" in the menu
 
     @ui
     Scenario: Using general taxon if channel does not have a menu taxon specified

--- a/features/homepage/viewing_only_taxons_from_menu_taxon.feature
+++ b/features/homepage/viewing_only_taxons_from_menu_taxon.feature
@@ -25,3 +25,14 @@ Feature: Viewing only taxons from the menu taxon
         Then I should see "Pens" and "Pencils" in the menu
         And I should not see "T-Shirts" and "Guns" in the menu
         And I should not see "Rifles" and "Revolvers" in the menu
+
+    @ui
+    Scenario: Seeing correct taxons after switching the channel
+        Given the store operates on another channel named "Poland"
+        And channel "United States" has menu taxon "Guns"
+        And channel "Poland" has menu taxon "Clothes"
+        When I change my current channel to "Poland"
+        And I visit the homepage
+        Then I should see "T-Shirts" and "Caps" in the menu
+        And I should not see "Rifles" and "Revolvers" in the menu
+        And I should not see "Pens" and "Pencils" in the menu

--- a/features/taxonomy/managing_taxons/deleting_taxon.feature
+++ b/features/taxonomy/managing_taxons/deleting_taxon.feature
@@ -25,9 +25,9 @@ Feature: Deleting a taxon
         But the "Shovels" taxon should appear in the registry
 
     @ui @javascript
-    Scenario: Deleted taxon should disappear from the registry
+    Scenario: Being unable to delete a menu taxon of a channel
         Given the store classifies its products as "T-Shirts" and "Caps"
         And the store operates on a channel named "Web Store"
         And channel "Web Store" has menu taxon "Caps"
-        When I delete taxon named "Caps"
+        When I try to delete taxon named "Caps"
         Then I should be notified that I cannot delete a menu taxon of any channel

--- a/features/taxonomy/managing_taxons/deleting_taxon.feature
+++ b/features/taxonomy/managing_taxons/deleting_taxon.feature
@@ -23,3 +23,11 @@ Feature: Deleting a taxon
         And the taxon named "Men" should no longer exist in the registry
         And the taxon named "Women" should no longer exist in the registry
         But the "Shovels" taxon should appear in the registry
+
+    @ui
+    Scenario: Deleted taxon should disappear from the registry
+        Given the store classifies its products as "T-Shirts" and "Caps"
+        And the store operates on a channel named "Web Store"
+        And channel "Web Store" has menu taxon "Caps"
+        When I delete taxon named "Caps"
+        Then I should be notified that I cannot delete a menu taxon of any channel

--- a/features/taxonomy/managing_taxons/deleting_taxon.feature
+++ b/features/taxonomy/managing_taxons/deleting_taxon.feature
@@ -24,7 +24,7 @@ Feature: Deleting a taxon
         And the taxon named "Women" should no longer exist in the registry
         But the "Shovels" taxon should appear in the registry
 
-    @ui
+    @ui @javascript
     Scenario: Deleted taxon should disappear from the registry
         Given the store classifies its products as "T-Shirts" and "Caps"
         And the store operates on a channel named "Web Store"

--- a/src/Sylius/Behat/Context/Setup/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Setup/ChannelContext.php
@@ -229,6 +229,7 @@ final class ChannelContext implements Context
 
     /**
      * @Given /^(channel "[^"]+") has menu (taxon "[^"]+")$/
+     * @Given /^(this channel) has menu (taxon "[^"]+")$/
      */
     public function theChannelMenuTaxonIs(ChannelInterface $channel, TaxonInterface $taxon): void
     {

--- a/src/Sylius/Behat/Context/Setup/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Setup/ChannelContext.php
@@ -22,6 +22,7 @@ use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ShopBillingData;
+use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Core\Test\Services\DefaultChannelFactoryInterface;
 
 final class ChannelContext implements Context
@@ -222,6 +223,18 @@ final class ChannelContext implements Context
     public function theChannelIsAType(ChannelInterface $channel, string $type): void
     {
         $channel->setType($type);
+
+        $this->channelManager->flush();
+    }
+
+    /**
+     * @Given /^(channel "[^"]+") has menu (taxon "[^"]+")$/
+     */
+    public function theChannelMenuTaxonIs(ChannelInterface $channel, TaxonInterface $taxon): void
+    {
+        $channel->setMenuTaxon($taxon);
+
+        $this->channelManager->flush();
     }
 
     /**

--- a/src/Sylius/Behat/Context/Setup/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Setup/ChannelContext.php
@@ -231,7 +231,7 @@ final class ChannelContext implements Context
      * @Given /^(channel "[^"]+") has menu (taxon "[^"]+")$/
      * @Given /^(this channel) has menu (taxon "[^"]+")$/
      */
-    public function theChannelMenuTaxonIs(ChannelInterface $channel, TaxonInterface $taxon): void
+    public function channelHasMenuTaxon(ChannelInterface $channel, TaxonInterface $taxon): void
     {
         $channel->setMenuTaxon($taxon);
 

--- a/src/Sylius/Behat/Context/Setup/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Setup/ChannelContext.php
@@ -228,7 +228,7 @@ final class ChannelContext implements Context
     }
 
     /**
-     * @Given /^(channel "[^"]+") has menu (taxon "[^"]+")$/
+     * @Given channel :channel has menu taxon :taxon
      * @Given /^(this channel) has menu (taxon "[^"]+")$/
      */
     public function channelHasMenuTaxon(ChannelInterface $channel, TaxonInterface $taxon): void

--- a/src/Sylius/Behat/Context/Setup/TaxonomyContext.php
+++ b/src/Sylius/Behat/Context/Setup/TaxonomyContext.php
@@ -128,6 +128,7 @@ final class TaxonomyContext implements Context
 
     /**
      * @Given /^the ("[^"]+" taxon) has children taxon "([^"]+)" and "([^"]+)"$/
+     * @Given /^the ("[^"]+" taxon) has children taxons "([^"]+)" and "([^"]+)"$/
      */
     public function theTaxonHasChildrenTaxonAnd(TaxonInterface $taxon, $firstTaxonName, $secondTaxonName)
     {

--- a/src/Sylius/Behat/Context/Setup/TaxonomyContext.php
+++ b/src/Sylius/Behat/Context/Setup/TaxonomyContext.php
@@ -149,7 +149,7 @@ final class TaxonomyContext implements Context
         /** @var TaxonInterface $taxon */
         $taxon = $this->taxonFactory->createNew();
         $taxon->setName($name);
-        $taxon->setCode(StringInflector::nameToCode($name));
+        $taxon->setCode(StringInflector::nameToLowercaseCode($name));
         $taxon->setSlug($this->taxonSlugGenerator->generate($taxon));
 
         return $taxon;

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
@@ -113,7 +113,7 @@ final class ManagingChannelsContext implements Context
     /**
      * @When I change its menu taxon to :menuTaxon
      */
-    public function iChangeMenuTaxonTo(string $menuTaxon): void
+    public function iChangeItsMenuTaxonTo(string $menuTaxon): void
     {
         $this->updatePage->changeMenuTaxon($menuTaxon);
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
@@ -103,6 +103,22 @@ final class ManagingChannelsContext implements Context
     }
 
     /**
+     * @When I specify menu taxon as :menuTaxon
+     */
+    public function iSpecifyMenuTaxonAs(string $menuTaxon): void
+    {
+        $this->createPage->specifyMenuTaxon($menuTaxon);
+    }
+
+    /**
+     * @When I change its menu taxon to :menuTaxon
+     */
+    public function iChangeMenuTaxonTo(string $menuTaxon): void
+    {
+        $this->updatePage->changeMenuTaxon($menuTaxon);
+    }
+
+    /**
      * @When I allow to skip shipping step if only one shipping method is available
      */
     public function iAllowToSkipShippingStepIfOnlyOneShippingMethodIsAvailable()
@@ -514,6 +530,19 @@ final class ManagingChannelsContext implements Context
     public function thisChannelTypeShouldBe(string $type): void
     {
         Assert::same($this->updatePage->getType(), $type);
+    }
+
+    /**
+     * @Given /^(this channel) menu taxon should be "([^"]+)"$/
+     * @Given /^the (channel "[^"]+") should have "([^"]+)" as a menu taxon$/
+     */
+    public function thisChannelMenuTaxonShouldBe(ChannelInterface $channel, string $menuTaxon): void
+    {
+        if (!$this->updatePage->isOpen(['id' => $channel->getId()])) {
+            $this->updatePage->open(['id' => $channel->getId()]);
+        }
+
+        Assert::same($this->updatePage->getMenuTaxon(), $menuTaxon);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
@@ -534,7 +534,7 @@ final class ManagingChannelsContext implements Context
 
     /**
      * @Given /^(this channel) menu taxon should be "([^"]+)"$/
-     * @Given /^the (channel "[^"]+") should have "([^"]+)" as a menu taxon$/
+     * @Given the channel :channel should have :menuTaxon as a menu taxon
      */
     public function thisChannelMenuTaxonShouldBe(ChannelInterface $channel, string $menuTaxon): void
     {

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
@@ -393,7 +393,7 @@ final class ManagingTaxonsContext implements Context
     public function iShouldBeNotifiedThatICannotDeleteAMenuTaxonOfAnyChannel(): void
     {
         $this->notificationChecker->checkNotification(
-            'You cannot delete a menu taxon of any channel',
+            'You cannot delete a menu taxon of any channel.',
             NotificationType::failure()
         );
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingTaxonsContext.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Admin;
 
 use Behat\Behat\Context\Context;
+use Sylius\Behat\NotificationType;
 use Sylius\Behat\Page\Admin\Taxon\CreateForParentPageInterface;
 use Sylius\Behat\Page\Admin\Taxon\CreatePageInterface;
 use Sylius\Behat\Page\Admin\Taxon\UpdatePageInterface;
+use Sylius\Behat\Service\NotificationCheckerInterface;
 use Sylius\Behat\Service\Resolver\CurrentPageResolverInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
@@ -39,18 +41,23 @@ final class ManagingTaxonsContext implements Context
     /** @var CurrentPageResolverInterface */
     private $currentPageResolver;
 
+    /** @var NotificationCheckerInterface */
+    private $notificationChecker;
+
     public function __construct(
         SharedStorageInterface $sharedStorage,
         CreatePageInterface $createPage,
         CreateForParentPageInterface $createForParentPage,
         UpdatePageInterface $updatePage,
-        CurrentPageResolverInterface $currentPageResolver
+        CurrentPageResolverInterface $currentPageResolver,
+        NotificationCheckerInterface $notificationChecker
     ) {
         $this->sharedStorage = $sharedStorage;
         $this->createPage = $createPage;
         $this->createForParentPage = $createForParentPage;
         $this->updatePage = $updatePage;
         $this->currentPageResolver = $currentPageResolver;
+        $this->notificationChecker = $notificationChecker;
     }
 
     /**
@@ -378,6 +385,17 @@ final class ManagingTaxonsContext implements Context
         $this->iWantToModifyATaxon($taxon);
 
         Assert::same($this->updatePage->countImages(), (int) $count);
+    }
+
+    /**
+     * @Then I should be notified that I cannot delete a menu taxon of any channel
+     */
+    public function iShouldBeNotifiedThatICannotDeleteAMenuTaxonOfAnyChannel(): void
+    {
+        $this->notificationChecker->checkNotification(
+            'You cannot delete a menu taxon of any channel',
+            NotificationType::failure()
+        );
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/RemovingTaxonContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/RemovingTaxonContext.php
@@ -36,6 +36,7 @@ final class RemovingTaxonContext implements Context
     /**
      * @When I remove taxon named :name
      * @When I delete taxon named :name
+     * @When I try to delete taxon named :name
      */
     public function iRemoveTaxonNamed(string $name): void
     {

--- a/src/Sylius/Behat/Context/Ui/Shop/HomepageContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/HomepageContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Ui\Shop;
 
 use Behat\Behat\Context\Context;
+use Sylius\Behat\Element\Shop\MenuElementInterface;
 use Sylius\Behat\Page\Shop\HomePageInterface;
 use Webmozart\Assert\Assert;
 
@@ -22,15 +23,20 @@ final class HomepageContext implements Context
     /** @var HomePageInterface */
     private $homePage;
 
-    public function __construct(HomePageInterface $homepage)
+    /** @var MenuElementInterface */
+    private $menuElement;
+
+    public function __construct(HomePageInterface $homePage, MenuElementInterface $menuElement)
     {
-        $this->homePage = $homepage;
+        $this->homePage = $homePage;
+        $this->menuElement = $menuElement;
     }
 
     /**
      * @When I check latest products
+     * @When I visit the homepage
      */
-    public function iCheckLatestProducts()
+    public function iCheckLatestProducts(): void
     {
         $this->homePage->open();
     }
@@ -38,7 +44,7 @@ final class HomepageContext implements Context
     /**
      * @Then I should be redirected to the homepage
      */
-    public function iShouldBeRedirectedToTheHomepage()
+    public function iShouldBeRedirectedToTheHomepage(): void
     {
         $this->homePage->verify();
     }
@@ -46,8 +52,29 @@ final class HomepageContext implements Context
     /**
      * @Then I should see :numberOfProducts products in the list
      */
-    public function iShouldSeeProductsInTheList($numberOfProducts)
+    public function iShouldSeeProductsInTheList(int $numberOfProducts): void
     {
-        Assert::same(count($this->homePage->getLatestProductsNames()), (int) $numberOfProducts);
+        Assert::same(count($this->homePage->getLatestProductsNames()), $numberOfProducts);
+    }
+
+    /**
+     * @Then I should see :firstMenuItem and :secondMenuItem in the menu
+     */
+    public function iShouldSeeAndInTheMenu(string ...$menuItems): void
+    {
+        Assert::allOneOf($menuItems, $this->menuElement->getMenuItems());
+    }
+
+    /**
+     * @Then I should not see :firstMenuItem and :secondMenuItem in the menu
+     */
+    public function iShouldNotSeeAndInTheMenu(string ...$menuItems): void
+    {
+        $actualMenuItems = $this->menuElement->getMenuItems();
+        foreach ($menuItems as $menuItem) {
+            if (in_array($menuItem, $actualMenuItems)) {
+                throw new \InvalidArgumentException(sprintf('Menu should not contain %s element', $menuItem));
+            }
+        }
     }
 }

--- a/src/Sylius/Behat/Element/Shop/MenuElement.php
+++ b/src/Sylius/Behat/Element/Shop/MenuElement.php
@@ -20,9 +20,11 @@ final class MenuElement extends Element implements MenuElementInterface
 {
     public function getMenuItems(): array
     {
+        $menu = $this->getElement('menu');
+
         return array_map(function (NodeElement $element): string {
             return $element->getText();
-        }, $this->getElement('menu')->findAll('css', '[data-test-menu-item]'));
+        }, $menu->findAll('css', '[data-test-menu-item]'));
     }
 
     protected function getDefinedElements(): array

--- a/src/Sylius/Behat/Element/Shop/MenuElement.php
+++ b/src/Sylius/Behat/Element/Shop/MenuElement.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Element\Shop;
+
+use Behat\Mink\Element\NodeElement;
+use FriendsOfBehat\PageObjectExtension\Element\Element;
+
+final class MenuElement extends Element implements MenuElementInterface
+{
+    public function getMenuItems(): array
+    {
+        return array_map(function (NodeElement $element): string {
+            return $element->getText();
+        }, $this->getElement('menu')->findAll('css', '[data-test-menu-item]'));
+    }
+
+    protected function getDefinedElements(): array
+    {
+        return [
+            'menu' => '[data-test-menu]',
+        ];
+    }
+}

--- a/src/Sylius/Behat/Element/Shop/MenuElementInterface.php
+++ b/src/Sylius/Behat/Element/Shop/MenuElementInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Element\Shop;
+
+interface MenuElementInterface
+{
+    public function getMenuItems(): array;
+}

--- a/src/Sylius/Behat/Page/Admin/Channel/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/CreatePage.php
@@ -19,6 +19,7 @@ use Sylius\Behat\Behaviour\NamesIt;
 use Sylius\Behat\Behaviour\SpecifiesItsCode;
 use Sylius\Behat\Behaviour\Toggles;
 use Sylius\Behat\Page\Admin\Crud\CreatePage as BaseCreatePage;
+use Sylius\Behat\Service\AutocompleteHelper;
 
 class CreatePage extends BaseCreatePage implements CreatePageInterface
 {
@@ -94,7 +95,9 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
 
     public function specifyMenuTaxon(string $menuTaxon): void
     {
-        $this->getElement('menu_taxon')->selectOption($menuTaxon);
+        $menuTaxonElement = $this->getElement('menu_taxon')->getParent();
+
+        AutocompleteHelper::chooseValue($this->getSession(), $menuTaxonElement, $menuTaxon);
     }
 
     protected function getToggleableElement(): NodeElement

--- a/src/Sylius/Behat/Page/Admin/Channel/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/CreatePage.php
@@ -92,6 +92,11 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         $this->getElement('type')->selectOption($type);
     }
 
+    public function specifyMenuTaxon(string $menuTaxon): void
+    {
+        $this->getElement('menu_taxon')->selectOption($menuTaxon);
+    }
+
     protected function getToggleableElement(): NodeElement
     {
         return $this->getElement('enabled');
@@ -106,6 +111,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
             'default_locale' => '#sylius_channel_defaultLocale',
             'enabled' => '#sylius_channel_enabled',
             'locales' => '#sylius_channel_locales',
+            'menu_taxon' => '#sylius_channel_menuTaxon',
             'name' => '#sylius_channel_name',
             'type' => '#sylius_channel_type',
         ]);

--- a/src/Sylius/Behat/Page/Admin/Channel/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/CreatePageInterface.php
@@ -50,4 +50,6 @@ interface CreatePageInterface extends BaseCreatePageInterface
     public function allowToSkipPaymentStep(): void;
 
     public function setType(string $type): void;
+
+    public function specifyMenuTaxon(string $menuTaxon): void;
 }

--- a/src/Sylius/Behat/Page/Admin/Channel/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/UpdatePage.php
@@ -97,6 +97,16 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         return $this->getElement('type')->getValue();
     }
 
+    public function changeMenuTaxon(string $menuTaxon): void
+    {
+        $this->getElement('menu_taxon')->selectOption($menuTaxon);
+    }
+
+    public function getMenuTaxon(): string
+    {
+        return $this->getElement('menu_taxon')->find('css', 'option:selected')->getText();
+    }
+
     public function getUsedTheme(): string
     {
         return $this->getElement('theme')->getValue();
@@ -122,6 +132,7 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
             'default_tax_zone' => '#sylius_channel_defaultTaxZone',
             'enabled' => '#sylius_channel_enabled',
             'locales' => '#sylius_channel_locales',
+            'menu_taxon' => '#sylius_channel_menuTaxon',
             'name' => '#sylius_channel_name',
             'tax_calculation_strategy' => '#sylius_channel_taxCalculationStrategy',
             'theme' => '#sylius_channel_themeName',

--- a/src/Sylius/Behat/Page/Admin/Channel/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/UpdatePage.php
@@ -17,6 +17,7 @@ use Behat\Mink\Element\NodeElement;
 use Sylius\Behat\Behaviour\ChecksCodeImmutability;
 use Sylius\Behat\Behaviour\Toggles;
 use Sylius\Behat\Page\Admin\Crud\UpdatePage as BaseUpdatePage;
+use Sylius\Behat\Service\AutocompleteHelper;
 
 class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 {
@@ -99,12 +100,14 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
 
     public function changeMenuTaxon(string $menuTaxon): void
     {
-        $this->getElement('menu_taxon')->selectOption($menuTaxon);
+        $menuTaxonElement = $this->getElement('menu_taxon')->getParent();
+
+        AutocompleteHelper::chooseValue($this->getSession(), $menuTaxonElement, $menuTaxon);
     }
 
     public function getMenuTaxon(): string
     {
-        return $this->getElement('menu_taxon')->find('css', 'option:selected')->getText();
+        return $this->getElement('menu_taxon')->getParent()->find('css', '.search > .text')->getText();
     }
 
     public function getUsedTheme(): string

--- a/src/Sylius/Behat/Page/Admin/Channel/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/UpdatePageInterface.php
@@ -55,5 +55,9 @@ interface UpdatePageInterface extends BaseUpdatePageInterface
 
     public function getType(): string;
 
+    public function changeMenuTaxon(string $menuTaxon): void;
+
+    public function getMenuTaxon(): string;
+
     public function getUsedTheme(): string;
 }

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -252,6 +252,7 @@
             <argument type="service" id="sylius.behat.page.admin.taxon.create_for_parent" />
             <argument type="service" id="sylius.behat.page.admin.taxon.update" />
             <argument type="service" id="sylius.behat.current_page_resolver" />
+            <argument type="service" id="sylius.behat.notification_checker" />
         </service>
 
         <service id="sylius.behat.context.ui.admin.managing_tax_rate" class="Sylius\Behat\Context\Ui\Admin\ManagingTaxRateContext">

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -415,6 +415,7 @@
 
         <service id="sylius.behat.context.ui.shop.homepage" class="Sylius\Behat\Context\Ui\Shop\HomepageContext">
             <argument type="service" id="sylius.behat.page.shop.home" />
+            <argument type="service" id="sylius.behat.element.shop.menu" />
         </service>
 
         <service id="sylius.behat.context.ui.shop.locale" class="Sylius\Behat\Context\Ui\Shop\LocaleContext">

--- a/src/Sylius/Behat/Resources/config/services/elements/shop.xml
+++ b/src/Sylius/Behat/Resources/config/services/elements/shop.xml
@@ -19,5 +19,7 @@
         <defaults public="true" />
 
         <service id="sylius.behat.element.shop.account.register" class="Sylius\Behat\Element\Shop\Account\RegisterElement" parent="sylius.behat.element" public="false" />
+
+        <service id="sylius.behat.element.shop.menu" class="Sylius\Behat\Element\Shop\MenuElement" parent="sylius.behat.element" public="false" />
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/suites/ui/channel/managing_channels.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/channel/managing_channels.yml
@@ -13,6 +13,7 @@ default:
                 - sylius.behat.context.transform.currency
                 - sylius.behat.context.transform.locale
                 - sylius.behat.context.transform.shared_storage
+                - sylius.behat.context.transform.taxon
                 - sylius.behat.context.transform.zone
 
                 - sylius.behat.context.setup.channel
@@ -22,6 +23,7 @@ default:
                 - sylius.behat.context.setup.payment
                 - sylius.behat.context.setup.admin_security
                 - sylius.behat.context.setup.shipping
+                - sylius.behat.context.setup.taxonomy
                 - sylius.behat.context.setup.zone
 
                 - sylius.behat.context.ui.admin.managing_channels

--- a/src/Sylius/Behat/Resources/config/suites/ui/homepage/viewing_products.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/homepage/viewing_products.yml
@@ -7,6 +7,7 @@ default:
             contexts:
                 - sylius.behat.context.hook.doctrine_orm
 
+                - sylius.behat.context.transform.channel
                 - sylius.behat.context.transform.lexical
                 - sylius.behat.context.transform.product
                 - sylius.behat.context.transform.shared_storage
@@ -17,6 +18,7 @@ default:
                 - sylius.behat.context.setup.shop_security
                 - sylius.behat.context.setup.taxonomy
 
+                - sylius.behat.context.ui.channel
                 - sylius.behat.context.ui.shop.homepage
 
             filters:

--- a/src/Sylius/Behat/Resources/config/suites/ui/homepage/viewing_products.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/homepage/viewing_products.yml
@@ -10,10 +10,12 @@ default:
                 - sylius.behat.context.transform.lexical
                 - sylius.behat.context.transform.product
                 - sylius.behat.context.transform.shared_storage
+                - sylius.behat.context.transform.taxon
 
                 - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.product
                 - sylius.behat.context.setup.shop_security
+                - sylius.behat.context.setup.taxonomy
 
                 - sylius.behat.context.ui.shop.homepage
 

--- a/src/Sylius/Behat/Resources/config/suites/ui/taxonomy/managing_taxons.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/taxonomy/managing_taxons.yml
@@ -7,10 +7,12 @@ default:
             contexts:
                 - sylius.behat.context.hook.doctrine_orm
 
+                - sylius.behat.context.transform.channel
                 - sylius.behat.context.transform.locale
                 - sylius.behat.context.transform.shared_storage
                 - sylius.behat.context.transform.taxon
 
+                - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.locale
                 - sylius.behat.context.setup.admin_security
                 - sylius.behat.context.setup.taxonomy

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/serializer/Model.Channel.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/serializer/Model.Channel.yml
@@ -6,6 +6,9 @@ Sylius\Component\Core\Model\Channel:
             expose: true
             type: string
             groups: [Detailed]
+        menuTaxon:
+            expose: true
+            groups: [Detailed]
     relations:
         -   rel: self
             href:

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Channel/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Channel/_form.html.twig
@@ -69,6 +69,9 @@
             {{ form_row(form.locales) }}
             {{ form_row(form.defaultLocale) }}
         </div>
+        <div class="ui attached segment">
+            {{ form_row(form.menuTaxon) }}
+        </div>
         <div class="ui hidden divider"></div>
         <div class="ui attached segment">
             {{ form_row(form.skippingShippingStepAllowed) }}

--- a/src/Sylius/Bundle/CoreBundle/EventListener/TaxonDeletionListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/TaxonDeletionListener.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Core\Promotion\Updater\Rule\TaxonAwareRuleUpdaterInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -25,15 +26,35 @@ final class TaxonDeletionListener
     /** @var SessionInterface */
     private $session;
 
+    /** @var ChannelRepositoryInterface $channelRepository */
+    private $channelRepository;
+
     /** @var TaxonAwareRuleUpdaterInterface[] */
     private $ruleUpdaters;
 
     public function __construct(
         SessionInterface $session,
+        ChannelRepositoryInterface $channelRepository,
         TaxonAwareRuleUpdaterInterface ...$ruleUpdaters
     ) {
         $this->session = $session;
+        $this->channelRepository = $channelRepository;
         $this->ruleUpdaters = $ruleUpdaters;
+    }
+
+    public function protectFromRemovingMenuTaxon(GenericEvent $event): void
+    {
+        $taxon = $event->getSubject();
+        Assert::isInstanceOf($taxon, TaxonInterface::class);
+
+        $channel = $this->channelRepository->findOneBy(['menuTaxon' => $taxon]);
+        if ($channel !== null) {
+            /** @var FlashBagInterface $flashes */
+            $flashes = $this->session->getBag('flashes');
+            $flashes->add('error', 'sylius.taxon.menu_taxon_delete');
+
+            $event->stopPropagation();
+        }
     }
 
     public function removeTaxonFromPromotionRules(GenericEvent $event): void

--- a/src/Sylius/Bundle/CoreBundle/EventListener/TaxonDeletionListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/TaxonDeletionListener.php
@@ -26,7 +26,7 @@ final class TaxonDeletionListener
     /** @var SessionInterface */
     private $session;
 
-    /** @var ChannelRepositoryInterface $channelRepository */
+    /** @var ChannelRepositoryInterface */
     private $channelRepository;
 
     /** @var TaxonAwareRuleUpdaterInterface[] */

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
@@ -21,6 +21,7 @@ use Sylius\Bundle\CoreBundle\Form\Type\ShopBillingDataType;
 use Sylius\Bundle\CoreBundle\Form\Type\TaxCalculationStrategyChoiceType;
 use Sylius\Bundle\CurrencyBundle\Form\Type\CurrencyChoiceType;
 use Sylius\Bundle\LocaleBundle\Form\Type\LocaleChoiceType;
+use Sylius\Bundle\TaxonomyBundle\Form\Type\TaxonAutocompleteChoiceType;
 use Sylius\Bundle\ThemeBundle\Form\Type\ThemeNameChoiceType;
 use Sylius\Component\Core\Model\Scope;
 use Symfony\Component\Form\AbstractTypeExtension;
@@ -85,6 +86,9 @@ final class ChannelTypeExtension extends AbstractTypeExtension
             ])
             ->add('shopBillingData', ShopBillingDataType::class, [
                 'label' => 'sylius.form.channel.shop_billing_data',
+            ])
+            ->add('menuTaxon', TaxonAutocompleteChoiceType::class, [
+                'label' => 'sylius.form.channel.menu_taxon',
             ])
             ->addEventSubscriber(new AddBaseCurrencySubscriber())
             ->addEventSubscriber(new ChannelFormSubscriber())

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
@@ -33,6 +33,9 @@
         <many-to-one field="defaultTaxZone" target-entity="Sylius\Component\Addressing\Model\ZoneInterface">
             <join-column name="default_tax_zone_id" referenced-column-name="id" nullable="true" on-delete="SET NULL" />
         </many-to-one>
+        <many-to-one field="menuTaxon" target-entity="Sylius\Component\Core\Model\TaxonInterface">
+            <join-column name="menu_taxon_id" referenced-column-name="id" nullable="true" on-delete="SET NULL" />
+        </many-to-one>
         <many-to-many field="currencies" target-entity="Sylius\Component\Currency\Model\CurrencyInterface" fetch="EAGER">
             <join-table name="sylius_channel_currencies">
                 <join-columns>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -98,8 +98,10 @@
 
         <service id="sylius.listener.taxon_deletion" class="Sylius\Bundle\CoreBundle\EventListener\TaxonDeletionListener">
             <argument type="service" id="session" />
+            <argument type="service" id="sylius.repository.channel" />
             <argument type="service" id="sylius.promotion_rule_updater.total_of_items_from_taxon" />
             <argument type="service" id="sylius.promotion_rule_updater.has_taxon" />
+            <tag name="kernel.event_listener" event="sylius.taxon.pre_delete" method="protectFromRemovingMenuTaxon" />
             <tag name="kernel.event_listener" event="sylius.taxon.post_delete" method="removeTaxonFromPromotionRules" />
         </service>
     </services>

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
@@ -37,6 +37,7 @@ sylius:
             hostname: Hostname
             locale_default: Default locale
             locales: Locales
+            menu_taxon: Menu taxon
             payment_methods: Payment Methods
             shipping_methods: Shipping Methods
             shop_billing_data: Shop billing data

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/TaxonDeletionListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/TaxonDeletionListenerSpec.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\CoreBundle\EventListener;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Core\Promotion\Updater\Rule\TaxonAwareRuleUpdaterInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -24,10 +26,60 @@ final class TaxonDeletionListenerSpec extends ObjectBehavior
 {
     function let(
         SessionInterface $session,
+        ChannelRepositoryInterface $channelRepository,
         TaxonAwareRuleUpdaterInterface $hasTaxonRuleUpdater,
         TaxonAwareRuleUpdaterInterface $totalOfItemsFromTaxonRuleUpdater
     ): void {
-        $this->beConstructedWith($session, $hasTaxonRuleUpdater, $totalOfItemsFromTaxonRuleUpdater);
+        $this->beConstructedWith(
+            $session,
+            $channelRepository,
+            $hasTaxonRuleUpdater,
+            $totalOfItemsFromTaxonRuleUpdater
+        );
+    }
+
+    function it_does_not_allow_to_remove_taxon_if_any_channel_has_it_as_a_menu_taxon(
+        SessionInterface $session,
+        ChannelRepositoryInterface $channelRepository,
+        GenericEvent $event,
+        TaxonInterface $taxon,
+        ChannelInterface $channel,
+        FlashBagInterface $flashes
+    ): void {
+        $event->getSubject()->willReturn($taxon);
+
+        $channelRepository->findOneBy(['menuTaxon' => $taxon])->willReturn($channel);
+
+        $session->getBag('flashes')->willReturn($flashes);
+        $flashes->add('error', 'sylius.taxon.menu_taxon_delete')->shouldBeCalled();
+        $event->stopPropagation()->shouldBeCalled();
+
+        $this->protectFromRemovingMenuTaxon($event);
+    }
+
+    function it_does_nothing_if_taxon_is_not_a_menu_taxon_of_any_channel(
+        SessionInterface $session,
+        ChannelRepositoryInterface $channelRepository,
+        GenericEvent $event,
+        TaxonInterface $taxon,
+        ChannelInterface $channel
+    ): void {
+        $event->getSubject()->willReturn($taxon);
+
+        $channelRepository->findOneBy(['menuTaxon' => $taxon])->willReturn(null);
+        $session->getBag('flashes')->shouldNotBeCalled();
+
+        $this->protectFromRemovingMenuTaxon($event);
+    }
+
+    function it_throws_an_exception_if_an_event_subject_is_not_taxon(GenericEvent $event): void
+    {
+        $event->getSubject()->willReturn('wrongSubject');
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('protectFromRemovingMenuTaxon', [$event])
+        ;
     }
 
     function it_adds_flash_that_promotions_have_been_updated(

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/taxon.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/routing/partial/taxon.yml
@@ -28,3 +28,16 @@ sylius_shop_partial_taxon_index_by_code:
                 arguments:
                     - $code
                     - "expr:service('sylius.context.locale').getLocaleCode()"
+
+sylius_shop_partial_channel_menu_taxon_index:
+    path: /by-channel-menu-taxon/
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.taxon:indexAction
+        _sylius:
+            template: $template
+            repository:
+                method: findChildrenByChannelMenuTaxon
+                arguments:
+                    - "expr:service('sylius.context.channel').getChannel().getMenuTaxon()"
+                    - "expr:service('sylius.context.locale').getLocaleCode()"

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_horizontalMenu.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_horizontalMenu.html.twig
@@ -2,7 +2,7 @@
     {% import _self as macros %}
 
     {% if taxon.children|length > 0 %}
-        <div class="ui dropdown item">
+        <div class="ui dropdown item" {{ sylius_test_html_attribute('menu-item') }}>
             <span class="text">{{ taxon.name }}</span>
             <i class="dropdown icon"></i>
             <div class="menu">
@@ -19,7 +19,7 @@
 {% import _self as macros %}
 
 {% if taxons|length > 0 %}
-<div class="ui large stackable menu">
+<div class="ui large stackable menu" {{ sylius_test_html_attribute('menu') }}>
     {% for taxon in taxons %}
         {{ macros.item(taxon) }}
     {% endfor %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_horizontalMenu.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_horizontalMenu.html.twig
@@ -12,7 +12,7 @@
             </div>
         </div>
     {% else %}
-        <a href="{{ path('sylius_shop_product_index', {'slug': taxon.slug, '_locale': taxon.translation.locale}) }}" class="item">{{ taxon.name }}</a>
+        <a href="{{ path('sylius_shop_product_index', {'slug': taxon.slug, '_locale': taxon.translation.locale}) }}" class="item" {{ sylius_test_html_attribute('menu-item') }}>{{ taxon.name }}</a>
     {% endif %}
 {% endmacro %}
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
@@ -42,7 +42,7 @@
 
                 {{ sonata_block_render_event('sylius.shop.layout.after_header') }}
 
-                {{ render(url('sylius_shop_partial_taxon_index_by_code', {'code': 'category', 'template': '@SyliusShop/Taxon/_horizontalMenu.html.twig'})) }}
+                {{ render(url('sylius_shop_partial_channel_menu_taxon_index', {'template': '@SyliusShop/Taxon/_horizontalMenu.html.twig'})) }}
             </header>
         {% endblock %}
 

--- a/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
@@ -37,6 +37,20 @@ class TaxonRepository extends EntityRepository implements TaxonRepositoryInterfa
         ;
     }
 
+    public function findChildrenByChannelMenuTaxon(?TaxonInterface $menuTaxon = null, ?string $locale = null): array
+    {
+        return $this->createTranslationBasedQueryBuilder($locale)
+            ->addSelect('child')
+            ->innerJoin('o.parent', 'parent')
+            ->leftJoin('o.children', 'child')
+            ->andWhere('parent.code = :parentCode')
+            ->addOrderBy('o.position')
+            ->setParameter('parentCode', ($menuTaxon !== null) ? $menuTaxon->getCode() : 'category')
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/flashes.en.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/flashes.en.yml
@@ -26,3 +26,5 @@ sylius:
         update_error: 'There was an unexpected problem with updating a product variant. Please, try to update product variant again.'
     promotion:
         update_rules: 'Some rules of the promotions with codes %codes% have been updated.'
+    taxon:
+        menu_taxon_delete: 'You cannot delete a menu taxon of any channel.'

--- a/src/Sylius/Component/Channel/spec/Model/ChannelSpec.php
+++ b/src/Sylius/Component/Channel/spec/Model/ChannelSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Component\Channel\Model;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Channel\Model\ChannelInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
 
 final class ChannelSpec extends ObjectBehavior
 {
@@ -92,5 +93,11 @@ final class ChannelSpec extends ObjectBehavior
     {
         $this->setUpdatedAt($date);
         $this->getUpdatedAt()->shouldReturn($date);
+    }
+
+    function its_type_is_mutable(): void
+    {
+        $this->setType('mobile');
+        $this->getType()->shouldReturn('mobile');
     }
 }

--- a/src/Sylius/Component/Core/Model/Channel.php
+++ b/src/Sylius/Component/Core/Model/Channel.php
@@ -66,6 +66,9 @@ class Channel extends BaseChannel implements ChannelInterface
     /** @var ShopBillingDataInterface|null */
     protected $shopBillingData;
 
+    /** @var TaxonInterface|null */
+    protected $menuTaxon;
+
     public function __construct()
     {
         parent::__construct();
@@ -300,5 +303,15 @@ class Channel extends BaseChannel implements ChannelInterface
     public function setShopBillingData(ShopBillingDataInterface $shopBillingData): void
     {
         $this->shopBillingData = $shopBillingData;
+    }
+
+    public function getMenuTaxon(): ?TaxonInterface
+    {
+        return $this->menuTaxon;
+    }
+
+    public function setMenuTaxon(?TaxonInterface $menuTaxon): void
+    {
+        $this->menuTaxon = $menuTaxon;
     }
 }

--- a/src/Sylius/Component/Core/Model/ChannelInterface.php
+++ b/src/Sylius/Component/Core/Model/ChannelInterface.php
@@ -64,4 +64,8 @@ interface ChannelInterface extends
     public function getShopBillingData(): ?ShopBillingDataInterface;
 
     public function setShopBillingData(ShopBillingDataInterface $shopBillingData): void;
+
+    public function getMenuTaxon(): ?TaxonInterface;
+
+    public function setMenuTaxon(?TaxonInterface $menuTaxon): void;
 }

--- a/src/Sylius/Component/Core/spec/Model/ChannelSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ChannelSpec.php
@@ -18,6 +18,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Channel\Model\Channel as BaseChannel;
 use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 
@@ -158,5 +159,11 @@ final class ChannelSpec extends ObjectBehavior
     {
         $this->setAccountVerificationRequired(false);
         $this->isAccountVerificationRequired()->shouldReturn(false);
+    }
+
+    function its_menu_taxon_is_mutable(TaxonInterface $taxon): void
+    {
+        $this->setMenuTaxon($taxon);
+        $this->getMenuTaxon()->shouldReturn($taxon);
     }
 }

--- a/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
+++ b/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
@@ -24,6 +24,8 @@ interface TaxonRepositoryInterface extends RepositoryInterface
      */
     public function findChildren(string $parentCode, ?string $locale = null): array;
 
+    public function findChildrenByChannelMenuTaxon(?TaxonInterface $menuTaxon = null, ?string $locale = null): array;
+
     /**
      * @return array|TaxonInterface[]
      */

--- a/tests/Controller/ChannelApiTest.php
+++ b/tests/Controller/ChannelApiTest.php
@@ -142,9 +142,10 @@ EOT;
         $this->loadFixturesFromFile('resources/locales.yml');
         $this->loadFixturesFromFile('resources/currencies.yml');
         $this->loadFixturesFromFile('resources/zones.yml');
+        $this->loadFixturesFromFile('resources/taxons.yml');
 
         $data =
-            <<<EOT
+<<<EOT
         {
             "code": "android",
             "name": "Channel for Android client",
@@ -158,6 +159,7 @@ EOT;
             "currencies": [
                 "GBP"
             ],
+            "menuTaxon": "mugs",
             "color": "ClassicBlue",
             "contactEmail": "admin@quickmart.eu",
             "skippingShippingStepAllowed": true,

--- a/tests/Responses/Expected/channel/create_validation_fail_response.json
+++ b/tests/Responses/Expected/channel/create_validation_fail_response.json
@@ -45,6 +45,7 @@
           "postcode": {}
         }
       },
+      "menuTaxon": {},
       "code": {
         "errors": [
           "Please enter channel code."

--- a/tests/Responses/Expected/channel/create_with_extra_response.json
+++ b/tests/Responses/Expected/channel/create_with_extra_response.json
@@ -9,6 +9,164 @@
     "updatedAt": "@string@.isDateTime()",
     "enabled": true,
     "taxCalculationStrategy": "order_items_based",
+    "menuTaxon": {
+        "id": @integer@,
+        "code": "mugs",
+        "root": {
+            "id": @integer@,
+            "code": "category",
+            "children": {
+                "1": {
+                    "id": @integer@,
+                    "code": "stickers",
+                    "children": [],
+                    "left": 4,
+                    "right": 5,
+                    "level": 1,
+                    "position": 1,
+                    "translations": [],
+                    "images": [],
+                    "_links": {
+                        "self": {
+                            "href": "@string@"
+                        }
+                    }
+                },
+                "2": {
+                    "id": @integer@,
+                    "code": "books",
+                    "children": [],
+                    "left": 6,
+                    "right": 7,
+                    "level": 1,
+                    "position": 2,
+                    "translations": [],
+                    "images": [],
+                    "_links": {
+                        "self": {
+                            "href": "@string@"
+                        }
+                    }
+                },
+                "3": {
+                    "id": @integer@,
+                    "code": "t-shirts",
+                    "children": [],
+                    "left": 8,
+                    "right": 13,
+                    "level": 1,
+                    "position": 3,
+                    "translations": [],
+                    "images": [],
+                    "_links": {
+                        "self": {
+                            "href": "@string@"
+                        }
+                    }
+                }
+            },
+            "left": 1,
+            "right": 14,
+            "level": 0,
+            "position": 0,
+            "translations": {
+                "en": {
+                    "locale": "en"
+                }
+            },
+            "images": [],
+            "_links": {
+                "self": {
+                    "href": "@string@"
+                }
+            }
+        },
+        "parent": {
+            "id": @integer@,
+            "code": "category",
+            "children": {
+                "1": {
+                    "id": @integer@,
+                    "code": "stickers",
+                    "children": [],
+                    "left": 4,
+                    "right": 5,
+                    "level": 1,
+                    "position": 1,
+                    "translations": [],
+                    "images": [],
+                    "_links": {
+                        "self": {
+                            "href": "@string@"
+                        }
+                    }
+                },
+                "2": {
+                    "id": @integer@,
+                    "code": "books",
+                    "children": [],
+                    "left": 6,
+                    "right": 7,
+                    "level": 1,
+                    "position": 2,
+                    "translations": [],
+                    "images": [],
+                    "_links": {
+                        "self": {
+                            "href": "@string@"
+                        }
+                    }
+                },
+                "3": {
+                    "id": @integer@,
+                    "code": "t-shirts",
+                    "children": [],
+                    "left": 8,
+                    "right": 13,
+                    "level": 1,
+                    "position": 3,
+                    "translations": [],
+                    "images": [],
+                    "_links": {
+                        "self": {
+                            "href": "@string@"
+                        }
+                    }
+                }
+            },
+            "left": 1,
+            "right": 14,
+            "level": 0,
+            "position": 0,
+            "translations": {
+                "en": {
+                    "locale": "en"
+                }
+            },
+            "images": [],
+            "_links": {
+                "self": {
+                    "href": "@string@"
+                }
+            }
+        },
+        "children": [],
+        "left": 2,
+        "right": 3,
+        "level": 1,
+        "position": 0,
+        "translations": {
+            "en": {
+                "locale": "en"
+            }
+        },
+        "images": [],
+        "_links": {
+            "self": {
+                "href": "@string@"
+            }
+        }
+    },
     "_links": {
         "self": {
             "href": @string@

--- a/tests/Responses/Expected/channel/update_validation_fail_response.json
+++ b/tests/Responses/Expected/channel/update_validation_fail_response.json
@@ -37,6 +37,7 @@
                     "postcode": {}
                 }
             },
+            "menuTaxon": {},
             "code": {},
             "baseCurrency": {}
         }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no (well, sort of)
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

With this feature, the administrator is able to choose children of which taxon will be displayed in the menu (for each channel). We keep the BC by taking a (previously always hardcoded) "category" taxon if none is defined 🚀 

Admin panel:

<img width="278" alt="Zrzut ekranu 2020-01-13 o 13 03 40" src="https://user-images.githubusercontent.com/6212718/72254708-27482f80-3605-11ea-8da4-d4a617db38ab.png">

<img width="539" alt="Zrzut ekranu 2020-01-13 o 12 58 29" src="https://user-images.githubusercontent.com/6212718/72254639-fb2cae80-3604-11ea-8da5-cdd3b161df76.png">

The result in the shop:

<img width="1158" alt="Zrzut ekranu 2020-01-13 o 12 58 46" src="https://user-images.githubusercontent.com/6212718/72254650-067fda00-3605-11ea-8c7f-71fb7eec37f0.png">
