### PR TITLE
Require PHP ^7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,23 +36,6 @@ matrix:
                 apt:
                     packages:
                         - parallel
-        -
-            php: 7.2
-            env:
-                - SYLIUS_SUITE="application"
-                - SYMFONY_VERSION="4.3.*"
-            services:
-                - memcached
-                - mysql
-        -
-            php: 7.2
-            env:
-                - SYLIUS_SUITE="packages"
-                - SYMFONY_VERSION="4.3.*"
-            addons:
-                apt:
-                    packages:
-                        - parallel
 
 cache:
     yarn: true

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "ext-exif": "*",
         "ext-fileinfo": "*",
         "ext-gd": "*",

--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/addressing": "^1.2",

--- a/src/Sylius/Bundle/AdminApiBundle/composer.json
+++ b/src/Sylius/Bundle/AdminApiBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "friendsofsymfony/oauth-server-bundle": "^1.6",
         "sylius/core-bundle": "^1.2",

--- a/src/Sylius/Bundle/AdminBundle/composer.json
+++ b/src/Sylius/Bundle/AdminBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/core-bundle": "^1.2",
         "sylius/ui-bundle": "^1.2",

--- a/src/Sylius/Bundle/AttributeBundle/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "ramsey/uuid": "^3.7",
         "stof/doctrine-extensions-bundle": "^1.2",

--- a/src/Sylius/Bundle/ChannelBundle/composer.json
+++ b/src/Sylius/Bundle/ChannelBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/channel": "^1.2",
         "sylius/resource-bundle": "^1.2",

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
 		"egulias/email-validator": "~2.0",
         "fzaninotto/faker": "^1.6",

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/currency": "^1.2",
         "sylius/resource-bundle": "^1.2",

--- a/src/Sylius/Bundle/CustomerBundle/composer.json
+++ b/src/Sylius/Bundle/CustomerBundle/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "doctrine/orm": "^2.5",
 		"egulias/email-validator": "~2.0",

--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/inventory": "^1.2",
         "sylius/resource-bundle": "^1.2",

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/locale": "^1.2",
         "sylius/resource-bundle": "^1.2",

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/resource-bundle": "^1.2",
         "symfony/framework-bundle": "^4.3",

--- a/src/Sylius/Bundle/OrderBundle/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/money-bundle": "^1.2",

--- a/src/Sylius/Bundle/PaymentBundle/composer.json
+++ b/src/Sylius/Bundle/PaymentBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/payment": "^1.2",
         "sylius/resource-bundle": "^1.2",

--- a/src/Sylius/Bundle/PayumBundle/composer.json
+++ b/src/Sylius/Bundle/PayumBundle/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "payum/payum": "^1.4",
         "payum/payum-bundle": "^2.2",

--- a/src/Sylius/Bundle/ProductBundle/composer.json
+++ b/src/Sylius/Bundle/ProductBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/attribute-bundle": "^1.2",

--- a/src/Sylius/Bundle/PromotionBundle/composer.json
+++ b/src/Sylius/Bundle/PromotionBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/money-bundle": "^1.2",

--- a/src/Sylius/Bundle/ReviewBundle/composer.json
+++ b/src/Sylius/Bundle/ReviewBundle/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/mailer-bundle": "^1.2",

--- a/src/Sylius/Bundle/ShippingBundle/composer.json
+++ b/src/Sylius/Bundle/ShippingBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/money-bundle": "^1.2",

--- a/src/Sylius/Bundle/ShopBundle/composer.json
+++ b/src/Sylius/Bundle/ShopBundle/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/core-bundle": "^1.2",
         "sylius/ui-bundle": "^1.2",

--- a/src/Sylius/Bundle/TaxationBundle/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/registry": "^1.2",

--- a/src/Sylius/Bundle/TaxonomyBundle/composer.json
+++ b/src/Sylius/Bundle/TaxonomyBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "stof/doctrine-extensions-bundle": "^1.2",
         "sylius/resource-bundle": "^1.2",

--- a/src/Sylius/Bundle/UiBundle/composer.json
+++ b/src/Sylius/Bundle/UiBundle/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "doctrine/collections": "^1.3",
         "knplabs/knp-menu": "^3.1",

--- a/src/Sylius/Bundle/UserBundle/composer.json
+++ b/src/Sylius/Bundle/UserBundle/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "doctrine/orm": "^2.5",
 		"egulias/email-validator": "~2.0",

--- a/src/Sylius/Component/Addressing/composer.json
+++ b/src/Sylius/Component/Addressing/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/registry": "^1.2",
         "sylius/resource": "^1.2",

--- a/src/Sylius/Component/Attribute/composer.json
+++ b/src/Sylius/Component/Attribute/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "doctrine/collections": "^1.3",
         "sylius/registry": "^1.2",

--- a/src/Sylius/Component/Channel/composer.json
+++ b/src/Sylius/Component/Channel/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/resource": "^1.2",
         "symfony/form": "^4.3",

--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "knplabs/gaufrette": "^0.8",
         "payum/payum": "^1.3",

--- a/src/Sylius/Component/Currency/composer.json
+++ b/src/Sylius/Component/Currency/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/resource": "^1.2",
         "symfony/intl": "^4.3",

--- a/src/Sylius/Component/Customer/composer.json
+++ b/src/Sylius/Component/Customer/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "doctrine/collections": "^1.3",
         "sylius/resource": "^1.0"

--- a/src/Sylius/Component/Inventory/composer.json
+++ b/src/Sylius/Component/Inventory/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/resource": "^1.2",
         "webmozart/assert": "^1.0"

--- a/src/Sylius/Component/Locale/composer.json
+++ b/src/Sylius/Component/Locale/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/resource": "^1.2",
         "symfony/intl": "^4.3",

--- a/src/Sylius/Component/Order/composer.json
+++ b/src/Sylius/Component/Order/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "webmozart/assert": "^1.1",
         "sylius/resource": "^1.2",

--- a/src/Sylius/Component/Payment/composer.json
+++ b/src/Sylius/Component/Payment/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/registry": "^1.2",
         "sylius/resource": "^1.0"

--- a/src/Sylius/Component/Product/composer.json
+++ b/src/Sylius/Component/Product/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "behat/transliterator": "^1.1",
         "sylius/attribute": "^1.2",

--- a/src/Sylius/Component/Promotion/composer.json
+++ b/src/Sylius/Component/Promotion/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "doctrine/orm": "^2.5",
         "sylius/registry": "^1.2",

--- a/src/Sylius/Component/Review/composer.json
+++ b/src/Sylius/Component/Review/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/resource": "^1.2",
         "doctrine/collections": "^1.3"

--- a/src/Sylius/Component/Shipping/composer.json
+++ b/src/Sylius/Component/Shipping/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/resource": "^1.2",
         "sylius/registry": "^1.2",

--- a/src/Sylius/Component/Taxation/composer.json
+++ b/src/Sylius/Component/Taxation/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "sylius/registry": "^1.2",
         "sylius/resource": "^1.0"

--- a/src/Sylius/Component/Taxonomy/composer.json
+++ b/src/Sylius/Component/Taxonomy/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "behat/transliterator": "^1.1",
         "sylius/resource": "^1.2",

--- a/src/Sylius/Component/User/composer.json
+++ b/src/Sylius/Component/User/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
         "doctrine/collections": "^1.1",
         "sylius/resource": "^1.2",


### PR DESCRIPTION
Similar story to #9498. PHP 7.2 is not supported by PHP itself and PHP 7.4 was published a few months ago. Therefore, Sylius 1.7 released in February 2020 will support PHP ^7.3, dropping the maintenance burden.