### PR TITLE
[Checkout] Make billing address the default one

### DIFF
--- a/features/account/customer_account/address_book/deleting_address_created_after_checkout.feature
+++ b/features/account/customer_account/address_book/deleting_address_created_after_checkout.feature
@@ -17,7 +17,7 @@ Feature: Removing an address from my book
     Scenario: Viewing address created after placing an order
         Given I have product "PHP T-Shirt" in the cart
         And I am at the checkout addressing step
-        When I specify the first and last name as "Mike Ross" for shipping address
+        When I specify the first and last name as "Mike Ross" for billing address
         And I complete the addressing step
         And I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order

--- a/features/account/customer_account/address_book/viewing_addresses_created_after_checkout.feature
+++ b/features/account/customer_account/address_book/viewing_addresses_created_after_checkout.feature
@@ -17,7 +17,7 @@ Feature: Viewing addresses created after checkout
     Scenario: Viewing address created after placing an order
         Given I have product "PHP T-Shirt" in the cart
         And I am at the checkout addressing step
-        When I specify the first and last name as "Mike Ross" for shipping address
+        When I specify the first and last name as "Mike Ross" for billing address
         And I complete the addressing step
         And I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order

--- a/features/account/customer_account/viewing_orders_history/order_is_always_placed_in_a_base_currency_of_a_channel.feature
+++ b/features/account/customer_account/viewing_orders_history/order_is_always_placed_in_a_base_currency_of_a_channel.feature
@@ -19,7 +19,7 @@ Feature: Order is always placed in a base currency of a channel
     Scenario: Placing an order with other than base display currency
         Given I changed my currency to "GBP"
         And I had product "Angel T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "DHL" shipping method and "Cash on Delivery" payment
         When I confirm my order
         And I am viewing the summary of my last order

--- a/features/account/customer_account/viewing_orders_history/seeing_customer_orders_placed_as_guest.feature
+++ b/features/account/customer_account/viewing_orders_history/seeing_customer_orders_placed_as_guest.feature
@@ -10,12 +10,12 @@ Feature: Seeing customer's orders placed as guest
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And the store ships everywhere for free
         And the store allows paying offline
-        And the guest customer placed order with "PHP T-Shirt" product for "john@snow.com" and "United States" based shipping address with "Free" shipping method and "Offline" payment
+        And the guest customer placed order with "PHP T-Shirt" product for "john@snow.com" and "United States" based billing address with "Free" shipping method and "Offline" payment
 
     @ui
     Scenario: Not being able to hijack another customer's orders
         Given I have product "PHP T-Shirt" in the cart
-        When I complete addressing step with email "john@snow.com" and "United States" based shipping address
+        When I complete addressing step with email "john@snow.com" and "United States" based billing address
         And I decide to change my address
         And I specify the email as "ned@stark.com"
         And I complete the addressing step

--- a/features/checkout/ability_to_confirm_an_order_with_a_promotion_on_shipping.feature
+++ b/features/checkout/ability_to_confirm_an_order_with_a_promotion_on_shipping.feature
@@ -17,7 +17,7 @@ Feature: Ability to confirm an order with a promotion on shipping
   Scenario: Successfully placing an order
     Given I have product "PHP T-Shirt" in the cart
     And I am at the checkout addressing step
-    When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+    When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
     And I proceed with "DHL" shipping method and "Offline" payment
     Then I should be on the checkout summary step
     And "Holiday promotion" should be applied to my order shipping

--- a/features/checkout/addressing_order/choosing_billing_and_shipping_address_from_address_book.feature
+++ b/features/checkout/addressing_order/choosing_billing_and_shipping_address_from_address_book.feature
@@ -16,13 +16,6 @@ Feature: Choosing an address from address book
         And I have an address "Fletcher Ren", "Upper Barkly Street", "3377", "Ararat", "Australia", "Victoria" in my address book
 
     @ui @javascript
-    Scenario: Choosing shipping address from address book
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I choose "Seaside Fwy" street for shipping address
-        Then address "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States", "Arkansas" should be filled as shipping address
-
-    @ui @javascript
     Scenario: Choosing billing address from address book
         Given I have product "PHP T-Shirt" in the cart
         And I am at the checkout addressing step
@@ -30,16 +23,23 @@ Feature: Choosing an address from address book
         Then address "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States", "Arkansas" should be filled as billing address
 
     @ui @javascript
-    Scenario: Choosing shipping address which contains a country with provinces from my address book
-        Given I have product "PHP T-Shirt" in the cart
-        And I am at the checkout addressing step
-        When I choose "Upper Barkly Street" street for shipping address
-        Then address "Fletcher Ren", "Upper Barkly Street", "3377", "Ararat", "Australia", "Victoria" should be filled as shipping address
-
-    @ui @javascript
-    Scenario: Choosing shipping address from address book and proceed to the next step
+    Scenario: Choosing shipping address from address book
         Given I have product "PHP T-Shirt" in the cart
         And I am at the checkout addressing step
         When I choose "Seaside Fwy" street for shipping address
+        Then address "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States", "Arkansas" should be filled as shipping address
+
+    @ui @javascript
+    Scenario: Choosing billing address which contains a country with provinces from my address book
+        Given I have product "PHP T-Shirt" in the cart
+        And I am at the checkout addressing step
+        When I choose "Upper Barkly Street" street for billing address
+        Then address "Fletcher Ren", "Upper Barkly Street", "3377", "Ararat", "Australia", "Victoria" should be filled as billing address
+
+    @ui @javascript
+    Scenario: Choosing billing address from address book and proceed to the next step
+        Given I have product "PHP T-Shirt" in the cart
+        And I am at the checkout addressing step
+        When I choose "Seaside Fwy" street for billing address
         And I complete the addressing step
         Then I should be on the checkout shipping step

--- a/features/checkout/addressing_order/choosing_province_for_country.feature
+++ b/features/checkout/addressing_order/choosing_province_for_country.feature
@@ -16,8 +16,8 @@ Feature: Choosing province for country
     Scenario: Address an order with country and its province
         Given I have product "The Dark Knight T-Shirt" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Gotham", "Mountain Drive", "1007", "United States" for "Bruce Wayne"
-        And I specify shipping country province as "New York"
+        When I specify the billing address as "Gotham", "Mountain Drive", "1007", "United States" for "Bruce Wayne"
+        And I specify billing country province as "New York"
         And I complete the addressing step
         Then I should be on the checkout shipping step
 
@@ -25,8 +25,8 @@ Feature: Choosing province for country
     Scenario: Address an order with country and its province and different billing address for country without province
         Given I have product "The Dark Knight T-Shirt" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Gotham", "Mountain Drive", "1007", "United States" for "Bruce Wayne"
-        And I specify shipping country province as "New York"
+        When I specify the billing address as "Gotham", "Mountain Drive", "1007", "United States" for "Bruce Wayne"
+        And I specify billing country province as "New York"
         And I specify the billing address as "Nanda Parbat", "League of Assassins House", "11-333", "Nepal" for "Ra's al Ghul"
         And I complete the addressing step
         Then I should be on the checkout shipping step
@@ -35,9 +35,9 @@ Feature: Choosing province for country
     Scenario: Address an order with country with province and different billing address for country with province
         Given I have product "The Dark Knight T-Shirt" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Gotham", "Mountain Drive", "1007", "United States" for "Bruce Wayne"
-        And I specify shipping country province as "New York"
-        And I specify the billing address as "Metropolis", "Clinton Str.", "344", "United States" for "Clark Kent"
+        When I specify the billing address as "Gotham", "Mountain Drive", "1007", "United States" for "Bruce Wayne"
         And I specify billing country province as "New York"
+        And I specify the shipping address as "Metropolis", "Clinton Str.", "344", "United States" for "Clark Kent"
+        And I specify shipping country province as "New York"
         And I complete the addressing step
         Then I should be on the checkout shipping step

--- a/features/checkout/addressing_order/filling_billing_and_shipping_address_details.feature
+++ b/features/checkout/addressing_order/filling_billing_and_shipping_address_details.feature
@@ -11,18 +11,18 @@ Feature: Addressing an order
         And I am a logged in customer
 
     @ui
-    Scenario: Address an order without different billing address
+    Scenario: Address an order without different shipping address
         Given I have product "PHP T-Shirt" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
 
     @ui
-    Scenario: Address an order with different billing address
+    Scenario: Address an order with different shipping address
         Given I have product "PHP T-Shirt" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Eddard Stark"
+        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step

--- a/features/checkout/addressing_order/filling_shipping_address_details_as_guest_with_existing_account.feature
+++ b/features/checkout/addressing_order/filling_shipping_address_details_as_guest_with_existing_account.feature
@@ -17,6 +17,6 @@ Feature: Addressing an order and signing in
         When I specify the email as "francis@underwood.com"
         And I specify the password as "whitehouse"
         And I sign in
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step

--- a/features/checkout/addressing_order/filling_shipping_and_billing_address_details_as_guest.feature
+++ b/features/checkout/addressing_order/filling_shipping_and_billing_address_details_as_guest.feature
@@ -10,21 +10,21 @@ Feature: Addressing an order
         And the store has a product "PHP T-Shirt" priced at "$19.99"
 
     @ui
-    Scenario: Address an order without different billing address
+    Scenario: Address an order without different shipping address
         Given I have product "PHP T-Shirt" in the cart
         And I am at the checkout addressing step
         When I specify the email as "jon.snow@example.com"
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
 
     @ui
-    Scenario: Address an order with different billing address
+    Scenario: Address an order with different shipping address
         Given I have product "PHP T-Shirt" in the cart
         And I am at the checkout addressing step
         When I specify the email as "eddard.stark@example.com"
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Eddard Stark"
+        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
 
@@ -34,6 +34,6 @@ Feature: Addressing an order
         And I have product "PHP T-Shirt" in the cart
         And I am at the checkout addressing step
         When I specify the email as "eddard.stark@example.com"
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step

--- a/features/checkout/addressing_order/having_default_address_preselected.feature
+++ b/features/checkout/addressing_order/having_default_address_preselected.feature
@@ -3,7 +3,7 @@ Feature: Having a default address preselected
     In order to speed up checkout process
     As a Customer
     I want to have my default address preselected on addressing step
-    
+
     Background:
         Given the store operates on a single channel in "United States"
         And I am a logged in customer
@@ -16,11 +16,11 @@ Feature: Having a default address preselected
     Scenario: Having a default address preselected on checkout addressing step
         When I add product "PHP T-Shirt" to the cart
         And I am at the checkout addressing step
-        Then address "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States", "Arkansas" should be filled as shipping address
+        Then address "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States", "Arkansas" should be filled as billing address
 
     @ui
     Scenario: Not modifying a default address in address book after modifying it on addressing step
         Given I have product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         When I am browsing my address book
         Then address "Lucifer Morningstar", "Seaside Fwy", "90802", "Los Angeles", "United States", "Arkansas" should still be marked as my default address

--- a/features/checkout/addressing_order/returning_to_addressing_step_and_changing_address_data.feature
+++ b/features/checkout/addressing_order/returning_to_addressing_step_and_changing_address_data.feature
@@ -14,7 +14,7 @@ Feature: Returning to the addressing step and changing address data
         Given I have product "Apollo 11 T-Shirt" in the cart
         And I am at the checkout addressing step
         When I specify the email as "jon.snow@example.com"
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I decide to change my address
         And I specify the email as "ned.stark@example.com"

--- a/features/checkout/assigning_customer_ip_address_to_placed_order.feature
+++ b/features/checkout/assigning_customer_ip_address_to_placed_order.feature
@@ -3,7 +3,7 @@ Feature: Assigning customer's IP address to a placed order
     In order to know from which IP address a new order has been places
     As an Administrator
     I want to have customer's IP address assigned to their orders
-    
+
     Background:
         Given the store operates on a single channel in "United States"
         And the store has a product "PHP T-Shirt" priced at "$19.99"
@@ -16,7 +16,7 @@ Feature: Assigning customer's IP address to a placed order
     @ui
     Scenario: Assigning customer's IP address to a newly placed order
         Given I have product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order
         Then the administrator should know about IP address of this order made by "customer@example.com"

--- a/features/checkout/being_able_to_modify_remaining_steps.feature
+++ b/features/checkout/being_able_to_modify_remaining_steps.feature
@@ -16,7 +16,7 @@ Feature: Changing checkout steps
     @ui
     Scenario: Changing address of my order
         Given I had product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         When I go back to addressing step of the checkout
         And I change the shipping address to "Ankh Morpork", "Fire Alley", "90350", "United States" for "Jon Snow"
         And I complete the addressing step
@@ -25,7 +25,7 @@ Feature: Changing checkout steps
     @ui
     Scenario: Addressing my order after selecting payment method
         Given I had product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I have proceeded order with "Free" shipping method and "Offline" payment
         When I go back to addressing step of the checkout
         And I change the shipping address to "Ankh Morpork", "Fire Alley", "90350", "United States" for "Jon Snow"
@@ -35,7 +35,7 @@ Feature: Changing checkout steps
     @ui
     Scenario: Addressing my order after selecting shipping method
         Given I had product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I have proceeded selecting "Free" shipping method
         When I go back to addressing step of the checkout
         And I change the shipping address to "Ankh Morpork", "Fire Alley", "90350", "United States" for "Jon Snow"
@@ -45,7 +45,7 @@ Feature: Changing checkout steps
     @ui
     Scenario: Changing shipping method of my order
         Given I had product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I have proceeded selecting "Free" shipping method
         When I go back to shipping step of the checkout
         And I select "Raven Post" shipping method
@@ -55,7 +55,7 @@ Feature: Changing checkout steps
     @ui
     Scenario: Selecting shipping method after selecting payment method
         Given I had product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I have proceeded order with "Free" shipping method and "Offline" payment
         When I go back to shipping step of the checkout
         And I select "Raven Post" shipping method
@@ -65,7 +65,7 @@ Feature: Changing checkout steps
     @ui
     Scenario: Selecting payment method after complete checkout
         Given I had product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I have proceeded order with "Free" shipping method and "Offline" payment
         When I go back to payment step of the checkout
         And I select "PayPal Express Checkout" payment method

--- a/features/checkout/emptying_the_cart_after_checkout.feature
+++ b/features/checkout/emptying_the_cart_after_checkout.feature
@@ -14,7 +14,7 @@ Feature: Emptying the cart after checkout
     @ui
     Scenario: Cart is emptied after the checkout
         Given I have product "Sig Sauer P226" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Cash on Delivery" payment
         When I confirm my order
         Then my cart should be empty

--- a/features/checkout/having_new_addresses_saved_in_address_book.feature
+++ b/features/checkout/having_new_addresses_saved_in_address_book.feature
@@ -15,7 +15,7 @@ Feature: Having new addresses saved in the address book after checkout
     @ui
     Scenario: Having the shipping address saved in my address book
         Given I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I proceed with "Free" shipping method and "Cash on Delivery" payment
         And I confirm my order
@@ -24,8 +24,8 @@ Feature: Having new addresses saved in the address book after checkout
     @ui
     Scenario: Having the shipping and billing addresses saved in my address book
         Given I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I specify the billing address as "Pseudopolis", "Haggard", "00-007", "United States" for "Sarah Connor"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the shipping address as "Pseudopolis", "Haggard", "00-007", "United States" for "Sarah Connor"
         And I complete the addressing step
         And I proceed with "Free" shipping method and "Cash on Delivery" payment
         And I confirm my order
@@ -36,8 +36,8 @@ Feature: Having new addresses saved in the address book after checkout
         Given I have an address "Jon Snow", "Frost Alley", "90210", "Ankh Morpork", "United States" in my address book
         And I have an address "Sarah Connor", "Haggard", "00-007", "Pseudopolis", "United States" in my address book
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I specify the billing address as "Pseudopolis", "Haggard", "00-007", "United States" for "Sarah Connor"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the shipping address as "Pseudopolis", "Haggard", "00-007", "United States" for "Sarah Connor"
         And I complete the addressing step
         And I proceed with "Free" shipping method and "Cash on Delivery" payment
         And I confirm my order

--- a/features/checkout/having_registration_account_form_prefilled_after_checkout.feature
+++ b/features/checkout/having_registration_account_form_prefilled_after_checkout.feature
@@ -13,7 +13,7 @@ Feature: Having registration form prefilled after checkout
     @ui
     Scenario: Having prefilled registration form after checkout
         Given I have product "PHP T-Shirt" in the cart
-        And I complete addressing step with email "john@example.com" and "United States" based shipping address
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
         And I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order
         Then I should see the thank you page
@@ -24,7 +24,7 @@ Feature: Having registration form prefilled after checkout
     Scenario: Not being able to create an account if customer is logged in
         Given I am a logged in customer
         And I have product "PHP T-Shirt" in the cart
-        And I complete addressing step with "United States" based shipping address
+        And I complete addressing step with "United States" based billing address
         And I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order
         Then I should see the thank you page

--- a/features/checkout/leaving_notes_on_order_during_checkout.feature
+++ b/features/checkout/leaving_notes_on_order_during_checkout.feature
@@ -16,7 +16,7 @@ Feature: Leaving additional request notes on my order during checkout
     @ui
     Scenario: Adding note on the checkout summary step
         Given I have product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Offline" payment
         When I provide additional note like "Code to the front gateway is #44*"
         And I confirm my order

--- a/features/checkout/paying_for_order/accessing_order_right_after_completing_checkout.feature
+++ b/features/checkout/paying_for_order/accessing_order_right_after_completing_checkout.feature
@@ -14,7 +14,7 @@ Feature: Having good number of items in changing payment method page
     @ui
     Scenario: Seeing correct quantity on payment retry page
         Given I have added 2 products "PHP T-Shirt" to the cart
-        And I complete addressing step with email "john@example.com" and "United States" based shipping address
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
         And I have proceeded selecting "Cash on delivery" payment method
         And I have confirmed order
         When I go to the change payment method page

--- a/features/checkout/paying_for_order/changing_payment_method_after_order_confirmation.feature
+++ b/features/checkout/paying_for_order/changing_payment_method_after_order_confirmation.feature
@@ -14,7 +14,7 @@ Feature: Changing the method after order confirmation
     @ui
     Scenario: Retrying the payment with offline payment
         Given I added product "PHP T-Shirt" to the cart
-        And I complete addressing step with email "john@example.com" and "United States" based shipping address
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
         And I have proceeded selecting "Cash on delivery" payment method
         And I have confirmed order
         When I go to the change payment method page
@@ -26,7 +26,7 @@ Feature: Changing the method after order confirmation
         Given there is 1 unit of product "PHP T-Shirt" available in the inventory
         And this product is tracked by the inventory
         And I added product "PHP T-Shirt" to the cart
-        And I complete addressing step with email "john@example.com" and "United States" based shipping address
+        And I complete addressing step with email "john@example.com" and "United States" based billing address
         And I have proceeded selecting "Cash on delivery" payment method
         And I have confirmed order
         When I go to the change payment method page

--- a/features/checkout/paying_for_order/inform_customer_about_order_total_changes.feature
+++ b/features/checkout/paying_for_order/inform_customer_about_order_total_changes.feature
@@ -46,7 +46,7 @@ Feature: Inform customer about any order total changes during checkout process
     Scenario: Inform customer about order total change due to shipping method fee change
         Given the store has "UPS" shipping method with "$20.00" fee
         And I added product "PHP T-Shirt" to the cart
-        And I have completed addressing step with email "guest@example.com" and "United States" based shipping address
+        And I have completed addressing step with email "guest@example.com" and "United States" based billing address
         And I have proceeded order with "UPS" shipping method and "Offline" payment
         And the shipping fee for "UPS" shipping method has been changed to "$30.00"
         When I confirm my order

--- a/features/checkout/paying_for_order/paying_offline_during_checkout_as_guest.feature
+++ b/features/checkout/paying_for_order/paying_offline_during_checkout_as_guest.feature
@@ -14,7 +14,7 @@ Feature: Paying offline during checkout as guest
     @ui
     Scenario: Successfully placing an order
         Given I have product "PHP T-Shirt" in the cart
-        When I complete addressing step with email "john@example.com" and "United States" based shipping address
+        When I complete addressing step with email "john@example.com" and "United States" based billing address
         And I select "Free" shipping method
         And I complete the shipping step
         And I choose "Offline" payment method

--- a/features/checkout/paying_for_order/preventing_not_available_payment_method_selection.feature
+++ b/features/checkout/paying_for_order/preventing_not_available_payment_method_selection.feature
@@ -16,7 +16,7 @@ Feature: Preventing not available payment method selection
         Given the payment method "Paypal Express Checkout" is disabled
         And I have product "PHP T-Shirt" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I select "Free" shipping method
         And I complete the shipping step
@@ -27,7 +27,7 @@ Feature: Preventing not available payment method selection
         Given the store has "Cash on delivery" payment method not assigned to any channel
         And I have product "PHP T-Shirt" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I select "Free" shipping method
         And I complete the shipping step

--- a/features/checkout/paying_for_order/preventing_payment_step_completion_without_a_selected_method.feature
+++ b/features/checkout/paying_for_order/preventing_payment_step_completion_without_a_selected_method.feature
@@ -13,7 +13,7 @@ Feature: Preventing payment step completion without a selected method
     @ui @todo
     Scenario: Preventing payment step completion if there are no available methods
         Given I have product "PHP T-Shirt" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed selecting "Free" shipping method
         And I do not select any payment method
         Then I should not be able to complete the payment step
@@ -23,7 +23,7 @@ Feature: Preventing payment step completion without a selected method
     Scenario: Preventing payment step completion if there are no available methods for a channel
         Given the store has "Cash on Delivery" payment method not assigned to any channel
         And I have product "PHP T-Shirt" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed selecting "Free" shipping method
         And I do not select any payment method
         Then I should not be able to complete the payment step
@@ -34,7 +34,7 @@ Feature: Preventing payment step completion without a selected method
         Given the store has a payment method "Offline" with a code "offline"
         And this payment method is disabled
         And I have product "PHP T-Shirt" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed selecting "Free" shipping method
         And I do not select any payment method
         Then I should not be able to complete the payment step
@@ -46,7 +46,7 @@ Feature: Preventing payment step completion without a selected method
         And this payment method is disabled
         And the store has "Cash on Delivery" payment method not assigned to any channel
         And I have product "PHP T-Shirt" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed selecting "Free" shipping method
         And I do not select any payment method
         Then I should not be able to complete the payment step

--- a/features/checkout/paying_for_order/returning_from_payment_step_to_one_of_previous_steps.feature
+++ b/features/checkout/paying_for_order/returning_from_payment_step_to_one_of_previous_steps.feature
@@ -14,7 +14,7 @@ Feature: Returning from payment step to one of previous steps
     @ui
     Scenario: Going back to shipping step with button
         Given I have product "Hulk Mug" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the shipping step
         When I decide to change order shipping method
         Then I should be redirected to the shipping step
@@ -23,7 +23,7 @@ Feature: Returning from payment step to one of previous steps
     @ui
     Scenario: Going back to shipping step with steps panel
         Given I have product "Hulk Mug" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the shipping step
         When I go to the shipping step
         Then I should be redirected to the shipping step
@@ -32,7 +32,7 @@ Feature: Returning from payment step to one of previous steps
     @ui
     Scenario: Going back to addressing step with steps panel
         Given I have product "Hulk Mug" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the shipping step
         When I go to the addressing step
         Then I should be redirected to the addressing step

--- a/features/checkout/paying_for_order/selecting_order_payment_method.feature
+++ b/features/checkout/paying_for_order/selecting_order_payment_method.feature
@@ -14,7 +14,7 @@ Feature: Selecting an order payment method
     @ui
     Scenario: Selecting a payment method
         Given I have product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I select "Free" shipping method
         And I complete the shipping step
         When I select "Paypal Express Checkout" payment method

--- a/features/checkout/paying_for_order/sorting_payment_method_selection.feature
+++ b/features/checkout/paying_for_order/sorting_payment_method_selection.feature
@@ -17,7 +17,7 @@ Feature: Sorting payment method selection
     Scenario: Seeing payment methods sorted
         Given I have product "Targaryen T-Shirt" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I select "Aardvark Stagecoach" shipping method
         And I complete the shipping step

--- a/features/checkout/placing_an_order_with_different_scopes_for_shipping_and_taxes.feature
+++ b/features/checkout/placing_an_order_with_different_scopes_for_shipping_and_taxes.feature
@@ -24,7 +24,7 @@ Feature: Placing an order with different scopes for shipping and taxes
         And this product belongs to "Clothes" tax category
         And I have product "Jane's Vest" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "Germany" for "Patrick Jane"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "Germany" for "Patrick Jane"
         And I complete the addressing step
         And I proceed with "Free" shipping method and "Offline" payment
         Then I should be on the checkout summary step
@@ -40,7 +40,7 @@ Feature: Placing an order with different scopes for shipping and taxes
         And this product belongs to "Clothes" tax category
         And I have product "Jane's Vest" in the cart
         Given I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Patrick Jane"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Patrick Jane"
         And I complete the addressing step
         And I proceed with "Free" shipping method and "Offline" payment
         Then I should be on the checkout summary step
@@ -54,7 +54,7 @@ Feature: Placing an order with different scopes for shipping and taxes
         And the store ships everything for free within the "US" zone
         And I have product "Jane's Vest" in the cart
         Given I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Patrick Jane"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Patrick Jane"
         And I complete the addressing step
         And I proceed with "Free" shipping method and "Offline" payment
         Then I should be on the checkout summary step

--- a/features/checkout/placing_order_on_multi_channel/placing_an_order_on_a_single_channel_store.feature
+++ b/features/checkout/placing_order_on_multi_channel/placing_an_order_on_a_single_channel_store.feature
@@ -19,7 +19,7 @@ Feature: Placing an order on a single channel store
     @ui
     Scenario: Placing an order in a channels base currency
         Given I have product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order
         Then the administrator should see that order placed by "customer@example.com" has "USD" currency
@@ -29,7 +29,7 @@ Feature: Placing an order on a single channel store
         Given that channel also allows to shop using the "CAD" currency
         And I had product "PHP T-Shirt" in the cart
         And I changed my currency to "CAD"
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Offline" payment
         When I confirm my order
         Then the administrator should see that order placed by "customer@example.com" has "USD" currency

--- a/features/checkout/placing_order_on_multi_channel/placing_an_order_on_multiple_channels_with_different_currency.feature
+++ b/features/checkout/placing_order_on_multi_channel/placing_an_order_on_multiple_channels_with_different_currency.feature
@@ -21,7 +21,7 @@ Feature: Placing an order on multiple channels with different currency
     Scenario: Placing an order in a channels base currency
         Given I changed my current channel to "United States"
         And I have product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order
         Then the administrator should see that order placed by "customer@example.com" has "USD" currency
@@ -30,7 +30,7 @@ Feature: Placing an order on multiple channels with different currency
     Scenario: Placing an order on a different channel with same currency
         Given I changed my current channel to "Colombia"
         And I had product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Offline" payment
         When I confirm my order
         Then the administrator should see that order placed by "customer@example.com" has "COP" currency

--- a/features/checkout/placing_order_on_multi_channel/placing_an_order_on_multiple_channels_with_same_currency.feature
+++ b/features/checkout/placing_order_on_multi_channel/placing_an_order_on_multiple_channels_with_same_currency.feature
@@ -21,7 +21,7 @@ Feature: Placing an order on multiple channels with same currency
     Scenario: Placing an order in a channels base currency
         Given I changed my current channel to "Web"
         And I have product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order
         Then the administrator should see that order placed by "customer@example.com" has "USD" currency
@@ -30,7 +30,7 @@ Feature: Placing an order on multiple channels with same currency
     Scenario: Placing an order on a different channel with same currency
         Given I changed my current channel to "Mobile"
         And I had product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Offline" payment
         When I confirm my order
         Then the administrator should see that order placed by "customer@example.com" has "USD" currency

--- a/features/checkout/prevent_skipping_checkout_steps.feature
+++ b/features/checkout/prevent_skipping_checkout_steps.feature
@@ -17,14 +17,14 @@ Feature: Prevent skipping checkout steps
     @ui
     Scenario: Skipping shipping checkout step
         Given I have product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         When I want to complete checkout
         Then I should be on the checkout shipping step
 
     @ui
     Scenario: Skipping payment checkout step
         Given I have product "PHP T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I have selected "Free" shipping method
         And I complete the shipping step
         When I want to complete checkout
@@ -49,7 +49,7 @@ Feature: Prevent skipping checkout steps
     Scenario: Not being able to skip the checkout shipping selection step when order total is zero
         Given I have product "PHP T-Shirt" in the cart
         And I have product "Paganini T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         When I want to complete checkout
         Then I should be on the checkout shipping step
 
@@ -57,7 +57,7 @@ Feature: Prevent skipping checkout steps
     Scenario: Not being able go to payment checkout step when order total is zero and payments not exists
         Given I have product "PHP T-Shirt" in the cart
         And I have product "Paganini T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I have selected "Free" shipping method
         And I complete the shipping step
         When I want to pay for order

--- a/features/checkout/prices_get_updated_throughout_checkout.feature
+++ b/features/checkout/prices_get_updated_throughout_checkout.feature
@@ -24,19 +24,19 @@ Feature: Prices get updated when exchange rate changes during the whole checkout
     Scenario: Prices get updated after the addressing step
         Given I am at the checkout addressing step
         When the exchange rate of "US Dollar" to "British Pound" is 5.0
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         Then the subtotal of "The Pug Mug" item should be "£50.00"
 
     @ui
     Scenario: Prices get updated on readdressing
-        Given I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        Given I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         When the exchange rate of "US Dollar" to "British Pound" is 3.0
         And I decide to change my address
         Then the subtotal of "The Pug Mug" item should be "£30.00"
 
     @ui
     Scenario: Prices get updated after the select shipping step
-        Given I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        Given I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I have selected "Pigeon Mail" shipping method
         When the exchange rate of "US Dollar" to "British Pound" is 2.0
         And I complete the shipping step
@@ -44,7 +44,7 @@ Feature: Prices get updated when exchange rate changes during the whole checkout
 
     @ui
     Scenario: Prices get updated on re-selecting shipping step
-        Given I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        Given I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I have selected "Pigeon Mail" shipping method
         And I complete the shipping step
         When the exchange rate of "US Dollar" to "British Pound" is 3.0
@@ -53,7 +53,7 @@ Feature: Prices get updated when exchange rate changes during the whole checkout
 
     @ui
     Scenario: Prices get updated after the select payment method step
-        Given I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        Given I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I have selected "Pigeon Mail" shipping method
         And I complete the shipping step
         And I select "Offline" payment method
@@ -64,7 +64,7 @@ Feature: Prices get updated when exchange rate changes during the whole checkout
 
     @ui
     Scenario: Prices get updated on re-selecting payment method step
-        Given I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        Given I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Pigeon Mail" shipping method and "Offline" payment
         When the exchange rate of "US Dollar" to "British Pound" is 3.0
         And I decide to change the payment method

--- a/features/checkout/receiving_confirmation_email_after_completing_checkout.feature
+++ b/features/checkout/receiving_confirmation_email_after_completing_checkout.feature
@@ -14,7 +14,7 @@ Feature: Receiving confirmation email after finalizing checkout
     @ui @email
     Scenario: Receiving confirmation email after finalizing checkout
         Given I have product "Sig Sauer P226" in the cart
-        And I have completed addressing step with email "john@example.com" and "United States" based shipping address
+        And I have completed addressing step with email "john@example.com" and "United States" based billing address
         And I have proceeded order with "Free" shipping method and "Offline" payment
         When I confirm my order
         Then an email with the summary of order placed by "john@example.com" should be sent to him

--- a/features/checkout/registering_account_after_checkout.feature
+++ b/features/checkout/registering_account_after_checkout.feature
@@ -13,7 +13,7 @@ Feature: Registering a new account after checkout
     @ui
     Scenario: Registering a new account after checkout
         Given I have product "PHP T-Shirt" in the cart
-        And I have completed addressing step with email "john@example.com" and "United States" based shipping address
+        And I have completed addressing step with email "john@example.com" and "United States" based billing address
         And I have proceeded order with "Free" shipping method and "Offline" payment
         And I have confirmed order
         When I proceed to the registration

--- a/features/checkout/returning_from_order_summary_page_to_one_of_previous_steps.feature
+++ b/features/checkout/returning_from_order_summary_page_to_one_of_previous_steps.feature
@@ -16,7 +16,7 @@ Feature: Returning from order summary page to one of previous steps
     @ui
     Scenario: Going back to payment step
         Given I have product "Stark Robe" in the cart
-        And I complete addressing step with email "jon@snow.wall" and "United States" based shipping address
+        And I complete addressing step with email "jon@snow.wall" and "United States" based billing address
         And I proceed with "Free" shipping method and "Cash on Delivery" payment
         When I decide to change the payment method
         Then I should be redirected to the payment step
@@ -25,7 +25,7 @@ Feature: Returning from order summary page to one of previous steps
     @ui
     Scenario: Going back to shipping step with steps panel
         Given I have product "Stark Robe" in the cart
-        And I complete addressing step with email "jon@snow.wall" and "United States" based shipping address
+        And I complete addressing step with email "jon@snow.wall" and "United States" based billing address
         And I proceed with "Free" shipping method and "Cash on Delivery" payment
         When I go to the shipping step
         Then I should be redirected to the shipping step
@@ -34,7 +34,7 @@ Feature: Returning from order summary page to one of previous steps
     @ui
     Scenario: Going back to addressing step with steps panel
         Given I have product "Stark Robe" in the cart
-        And I complete addressing step with email "jon@snow.wall" and "United States" based shipping address
+        And I complete addressing step with email "jon@snow.wall" and "United States" based billing address
         And I proceed with "Free" shipping method and "Cash on Delivery" payment
         When I go to the addressing step
         Then I should be redirected to the addressing step
@@ -45,7 +45,7 @@ Feature: Returning from order summary page to one of previous steps
         Given the store has customer "jon@snow.wall"
         And this customer has a "United States" based address in their address book
         And I have product "Stark Robe" in the cart
-        And I complete addressing step with email "jon@snow.wall" and "United States" based shipping address
+        And I complete addressing step with email "jon@snow.wall" and "United States" based billing address
         And I proceed with "Free" shipping method and "Cash on Delivery" payment
         When I go to the addressing step
         Then I should be redirected to the addressing step
@@ -55,7 +55,7 @@ Feature: Returning from order summary page to one of previous steps
     Scenario: Going back to shipping step with steps panel when order total is zero
         Given I have product "Stark Robe" in the cart
         And I have product "Paganini T-shirt" in the cart
-        And I complete addressing step with email "jon@snow.wall" and "United States" based shipping address
+        And I complete addressing step with email "jon@snow.wall" and "United States" based billing address
         And I proceed with "Free" shipping method
         When I go to the shipping step
         Then I should be redirected to the shipping step
@@ -65,7 +65,7 @@ Feature: Returning from order summary page to one of previous steps
     Scenario: Going back to addressing step with steps panel when order total is zero
         Given I have product "Stark Robe" in the cart
         And I have product "Paganini T-shirt" in the cart
-        And I complete addressing step with email "jon@snow.wall" and "United States" based shipping address
+        And I complete addressing step with email "jon@snow.wall" and "United States" based billing address
         And I proceed with "Free" shipping method
         When I go to the addressing step
         Then I should be redirected to the addressing step

--- a/features/checkout/seeing_order_summary/seeing_addresses_on_order_summary_page.feature
+++ b/features/checkout/seeing_order_summary/seeing_addresses_on_order_summary_page.feature
@@ -14,7 +14,7 @@ Feature: Seeing order addresses on order summary page
     @ui
     Scenario: Seeing the same shipping and billing address on order summary
         Given I have product "Lannister Coat" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Cash on Delivery" payment
         Then I should be on the checkout summary step
         And address to "Jon Snow" should be used for both shipping and billing of my order
@@ -23,8 +23,8 @@ Feature: Seeing order addresses on order summary page
     Scenario: Seeing different shipping and billing address on order summary
         Given I have product "Lannister Coat" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
-        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Eddard Stark"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Eddard Stark"
+        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I proceed with "Free" shipping method and "Cash on Delivery" payment
         Then I should be on the checkout summary step

--- a/features/checkout/seeing_order_summary/seeing_discount_on_order_item_on_summary_page.feature
+++ b/features/checkout/seeing_order_summary/seeing_discount_on_order_item_on_summary_page.feature
@@ -16,7 +16,7 @@ Feature: Seeing a order item discount
     @ui
     Scenario: Seeing a discounted price on order item
         Given I had product "Lannister Coat" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And the "Lannister Coat" product should have unit price discounted by "$10"

--- a/features/checkout/seeing_order_summary/seeing_items_on_order_summary_page.feature
+++ b/features/checkout/seeing_order_summary/seeing_items_on_order_summary_page.feature
@@ -19,7 +19,7 @@ Feature: Seeing order items on order summary page
         And I have 2 products "Targaryen Jacket" in the cart
         And I have 3 products "Stark T-Shirt" in the cart
         And I am at the checkout addressing step
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And I should have 4 "Lannister Coat" products in the cart

--- a/features/checkout/seeing_order_summary/seeing_province_created_manually_on_order_summary_page.feature
+++ b/features/checkout/seeing_order_summary/seeing_province_created_manually_on_order_summary_page.feature
@@ -18,8 +18,8 @@ Feature: Seeing province created manually on order summary page
     Scenario: Seeing manually defined province on order summary page
         Given I added product "PHP T-Shirt" to the cart
         And I am at the checkout addressing step
-        When I specify the shipping address for "Jon Snow" from "Ankh Morpork", "90210", "London", "United Kingdom", "East of England"
-        And I specify the billing address for "Jon Snow" from "Ankh Morpork", "90210", "London", "United Kingdom", "East of England"
+        When I specify the billing address for "Jon Snow" from "Ankh Morpork", "90210", "London", "United Kingdom", "East of England"
+        And I specify the shipping address for "Jon Snow" from "Ankh Morpork", "90210", "London", "United Kingdom", "East of England"
         And I complete the addressing step
         And I proceed with "DHL" shipping method and "Cash on Delivery" payment
         Then I should be on the checkout summary step

--- a/features/checkout/seeing_order_summary/seeing_shipping_discount_on_order_summary_page.feature
+++ b/features/checkout/seeing_order_summary/seeing_shipping_discount_on_order_summary_page.feature
@@ -17,7 +17,7 @@ Feature: Seeing shipping discount on order summary
     Scenario: Seeing order shipping discount on the order summary page
         Given I have product "PHP T-Shirt" in the cart
         And I am at the checkout addressing step
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "DHL" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And "Holiday promotion" should be applied to my order shipping

--- a/features/checkout/seeing_order_summary/seeing_shipping_method_and_payment_method_on_order_summary_page.feature
+++ b/features/checkout/seeing_order_summary/seeing_shipping_method_and_payment_method_on_order_summary_page.feature
@@ -14,7 +14,7 @@ Feature: Seeing an order shipping method and payment method details on summary p
     @ui
     Scenario: Seeing shipping method and payment method
         Given I have product "Lannister Coat" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Cash on delivery" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And my order's shipping method should be "Cash on delivery"

--- a/features/checkout/seeing_order_summary/seeing_shipping_total_on_order_summary_page.feature
+++ b/features/checkout/seeing_order_summary/seeing_shipping_total_on_order_summary_page.feature
@@ -16,7 +16,7 @@ Feature: Seeing order shipping total on order summary page
     @ui
     Scenario: Seeing the shipping total on order summary
         Given I have "Guards! Guards! - book" variant of product "Guards! Guards!" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "UPS" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And my order shipping should be "$20.00"
@@ -26,7 +26,7 @@ Feature: Seeing order shipping total on order summary page
         Given there is a promotion "Holiday promotion"
         And the promotion gives "50%" discount on shipping to every order
         And I have "Guards! Guards! - book" variant of product "Guards! Guards!" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "UPS" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And my order shipping should be "$10.00"
@@ -34,7 +34,7 @@ Feature: Seeing order shipping total on order summary page
     @ui
     Scenario: Not seeing the shipping total on order summary if none of the order items require shipping
         Given I have "Guards! Guards! - ebook" variant of product "Guards! Guards!" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I choose "Offline" payment method
         Then I should be on the checkout summary step
         And I should not see shipping total

--- a/features/checkout/seeing_order_summary/seeing_summary_order_with_free_product.feature
+++ b/features/checkout/seeing_order_summary/seeing_summary_order_with_free_product.feature
@@ -20,7 +20,7 @@ Feature: Seeing a summary of the order with free product
     @ui
     Scenario: Seeing free order
         Given I have product "Greyjoy Coat" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "DHL" shipping method
         Then I should be on the checkout summary step
         And my order total should be "$0.00"
@@ -31,7 +31,7 @@ Feature: Seeing a summary of the order with free product
     Scenario: Seeing order with both free and paid products
         Given I have product "Greyjoy Coat" in the cart
         And I have product "Lannister Coat" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "DHL" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And my order total should be "$104.50"

--- a/features/checkout/seeing_order_summary/seeing_total_discount_on_order_summary_page.feature
+++ b/features/checkout/seeing_order_summary/seeing_total_discount_on_order_summary_page.feature
@@ -18,7 +18,7 @@ Feature: Seeing order promotion total on order summary page
     @ui
     Scenario: Seeing the total discount on order summary page
         Given I have product "The Sorting Hat" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And my order promotion total should be "-$9.00"

--- a/features/checkout/seeing_order_summary/seeing_total_tax_on_order_summary_page.feature
+++ b/features/checkout/seeing_order_summary/seeing_total_tax_on_order_summary_page.feature
@@ -16,7 +16,7 @@ Feature: Seeing tax total on order summary page
     @ui
     Scenario: Seeing the total discount on order summary page
         Given I have product "The Sorting Hat" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I proceed with "Free" shipping method and "Offline" payment
         Then I should be on the checkout summary step
         And my tax total should be "$23.00"

--- a/features/checkout/shipping_order/preventing_not_available_shipping_method_selection.feature
+++ b/features/checkout/shipping_order/preventing_not_available_shipping_method_selection.feature
@@ -15,7 +15,7 @@ Feature: Preventing not available shipping method selection
         And the store has disabled "Dragon Post" shipping method with "$30.00" fee
         And I have product "Targaryen T-Shirt" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should not be able to select "Dragon Post" shipping method
 
@@ -26,7 +26,7 @@ Feature: Preventing not available shipping method selection
         And the store has "Raven Post" shipping method with "$10.00" fee within the "US" zone
         And I have product "Targaryen T-Shirt" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should not be able to select "Dragon Post" shipping method
 
@@ -36,7 +36,7 @@ Feature: Preventing not available shipping method selection
         And the store has "Dragon Post" shipping method with "$30.00" fee
         And I have product "Targaryen T-Shirt" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should not be able to select "Raven Post" shipping method
 
@@ -47,7 +47,7 @@ Feature: Preventing not available shipping method selection
         And the store has disabled "Raven Post" shipping method with "$10.00" fee
         And I have product "Targaryen T-Shirt" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should not be able to select "Raven Post" shipping method
         And I should not be able to select "Dragon Post" shipping method
@@ -59,6 +59,6 @@ Feature: Preventing not available shipping method selection
         And the store has an archival "Dragon Post" shipping method with "$30.00" fee
         And I have product "Targaryen T-Shirt" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should not be able to select "Dragon Post" shipping method

--- a/features/checkout/shipping_order/preventing_shipping_step_completion_without_a_selected_method.feature
+++ b/features/checkout/shipping_order/preventing_shipping_step_completion_without_a_selected_method.feature
@@ -12,7 +12,7 @@ Feature: Preventing shipping step completion without a selected method
         Given the store operates on a single channel in "United States"
         And the store has a product "PHP T-Shirt" priced at "$19.99"
         And I have product "PHP T-Shirt" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I do not select any shipping method
         Then I should not be able to complete the shipping step
         And there should be information about no shipping methods available for my shipping address
@@ -27,10 +27,10 @@ Feature: Preventing shipping step completion without a selected method
         And this zone has the "France" country member
         And the store has "DHL" shipping method with "$20.00" fee within the "EU" zone
         And I have product "PHP T-Shirt" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         Then I should not be able to complete the shipping step
         And there should be information about no shipping methods available for my shipping address
-      
+
     @ui @todo
     Scenario: Preventing shipping step completion if there are no available shipping methods for selected country
         Given the store operates on a channel named "Web"
@@ -44,7 +44,7 @@ Feature: Preventing shipping step completion without a selected method
         And the store has "DHL" shipping method with "$20.00" fee within the "EU" zone
         And the store has "UPS" shipping method with "$20.00" fee within the "AMR" zone
         And I have product "PHP T-Shirt" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I do not select any shipping method
         And I try to complete the shipping step
         Then I should still be on the shipping step

--- a/features/checkout/shipping_order/returning_from_shipping_step_to_addressing_step.feature
+++ b/features/checkout/shipping_order/returning_from_shipping_step_to_addressing_step.feature
@@ -13,7 +13,7 @@ Feature: Returning from shipping step to addressing step
     @ui
     Scenario: Going back to addressing step with button
         Given I have product "Apollo 11 T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I decide to change my address
         Then I should be redirected to the addressing step
         And I should be able to go to the shipping step again
@@ -21,7 +21,7 @@ Feature: Returning from shipping step to addressing step
     @ui
     Scenario: Going back to the addressing step with steps panel
         Given I have product "Apollo 11 T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I go to the addressing step
         Then I should be redirected to the addressing step
         And I should be able to go to the shipping step again

--- a/features/checkout/shipping_order/seeing_default_shipping_method_selected_based_on_shipping_address.feature
+++ b/features/checkout/shipping_order/seeing_default_shipping_method_selected_based_on_shipping_address.feature
@@ -18,23 +18,23 @@ Feature: Seeing default shipping method selected based on shipping address
         And I am a logged in customer
 
     @ui
-    Scenario: Seeing default shipping method selected based on country from shipping address
+    Scenario: Seeing default shipping method selected based on country from billing address
         Given I have product "Star Trek Ship" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
         And I should see selected "DHL" shipping method
         And I should not see "FedEx" shipping method
 
     @ui
-    Scenario: Seeing default shipping method selected based on country from shipping address after readdressing
+    Scenario: Seeing default shipping method selected based on country from billing address after readdressing
         Given I have product "Star Trek Ship" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I decide to change my address
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United Kingdom" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United Kingdom" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
         And I should see selected "FedEx" shipping method

--- a/features/checkout/shipping_order/seeing_shipping_fee.feature
+++ b/features/checkout/shipping_order/seeing_shipping_fee.feature
@@ -15,7 +15,7 @@ Feature: Seeing detailed shipping fee on selecting shipping method page
     Scenario: Seeing the shipping fee per shipment on selecting shipping method
         Given the store has "UPS" shipping method with "$20.00" fee
         And I have product "The Sorting Hat" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         Then I should be on the checkout shipping step
         And I should see shipping method "UPS" with fee "$20.00"
 
@@ -23,6 +23,6 @@ Feature: Seeing detailed shipping fee on selecting shipping method page
     Scenario: Seeing the shipping fee per unit on selecting shipping method
         Given the store has "UPS" shipping method with "$5.00" fee per unit
         And I have product "The Sorting Hat" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         Then I should be on the checkout shipping step
         And I should see shipping method "UPS" with fee "$5.00"

--- a/features/checkout/shipping_order/seeing_shipping_fee_on_multiple_channels.feature
+++ b/features/checkout/shipping_order/seeing_shipping_fee_on_multiple_channels.feature
@@ -20,7 +20,7 @@ Feature: Seeing detailed shipping fee on multiple channels with different base c
     Scenario: Seeing the shipping fee per shipment on selecting method in a channel's base currency
         Given I changed my current channel to "Web-US"
         And I have product "PHP T-Shirt" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         Then I should be on the checkout shipping step
         And I should see shipping method "UPS" with fee "$15.00"
         And I should see shipping method "FedEx" with fee "$10.00"
@@ -29,7 +29,7 @@ Feature: Seeing detailed shipping fee on multiple channels with different base c
     Scenario: Seeing the shipping fee on selecting shipping method on a different channel in its base currency
         Given I changed my current channel to "Web-GB"
         And I have added 2 products "PHP T-Shirt" in the cart
-        When I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         Then I should be on the checkout shipping step
         And I should see shipping method "UPS" with fee "£12.00"
         And I should see shipping method "FedEx" with fee "£16.00"

--- a/features/checkout/shipping_order/seeing_shipping_method_when_all_units_match_to_shipping_category.feature
+++ b/features/checkout/shipping_order/seeing_shipping_method_when_all_units_match_to_shipping_category.feature
@@ -28,7 +28,7 @@ Feature: Seeing shipping methods which category is same as category of all my un
         Given I have product "Rocket T-shirt" in the cart
         And I have product "Picasso T-shirt" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
         And I should see "Raven Post" shipping method
@@ -38,7 +38,7 @@ Feature: Seeing shipping methods which category is same as category of all my un
     Scenario: Seeing shipping method which category is same as category of my unit
         Given I have product "Star Trek Ship" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
         And I should see "Invisible Post" shipping method
@@ -49,7 +49,7 @@ Feature: Seeing shipping methods which category is same as category of all my un
         And I have product "Rocket T-shirt" in the cart
         And I have product "Star Trek Ship" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then there should be information about no available shipping methods
 
@@ -60,7 +60,7 @@ Feature: Seeing shipping methods which category is same as category of all my un
         And I have "T-shirt banana" with Size "S" in the cart
         And I have "T-shirt banana" with Size "M" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then there should be information about no available shipping methods
 
@@ -71,7 +71,7 @@ Feature: Seeing shipping methods which category is same as category of all my un
         And I have "T-shirt banana" with Size "S" in the cart
         And I have "T-shirt banana" with Size "M" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
         And I should see "Raven Post" shipping method

--- a/features/checkout/shipping_order/seeing_shipping_method_when_at_least_one_unit_match_to_shipping_method.feature
+++ b/features/checkout/shipping_order/seeing_shipping_method_when_at_least_one_unit_match_to_shipping_method.feature
@@ -26,7 +26,7 @@ Feature: Seeing shipping methods compatible with categories of units in my cart
         Given I have product "Star Trek Ship" in the cart
         And I have product "Picasso T-Shirt" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
         And I should see "Raven Post" shipping method
@@ -36,7 +36,7 @@ Feature: Seeing shipping methods compatible with categories of units in my cart
     Scenario: Not seeing shipping method which not match to my units category
         Given I have product "Star Trek Ship" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
         And I should see "Invisible Post" shipping method
@@ -47,7 +47,7 @@ Feature: Seeing shipping methods compatible with categories of units in my cart
         Given the store has a product "Rocket T-shirt" priced at "$20.00"
         And I have product "Rocket T-shirt" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then there should be information about no available shipping methods
 
@@ -56,7 +56,7 @@ Feature: Seeing shipping methods compatible with categories of units in my cart
         Given I have "T-shirt banana" with Size "S" in the cart
         And I have "T-shirt banana" with Size "M" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then there should be information about no available shipping methods
 
@@ -67,7 +67,7 @@ Feature: Seeing shipping methods compatible with categories of units in my cart
         And I have "T-shirt banana" with Size "S" in the cart
         And I have "T-shirt banana" with Size "M" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
         And I should see "Raven Post" shipping method

--- a/features/checkout/shipping_order/seeing_shipping_method_when_no_units_match_to_shipping_category.feature
+++ b/features/checkout/shipping_order/seeing_shipping_method_when_no_units_match_to_shipping_category.feature
@@ -22,7 +22,7 @@ Feature: Seeing shipping methods which category is not same as any category of a
     Scenario: Seeing shipping method which category is not same as category of all my units
         Given I have product "Picasso T-shirt" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
         And I should see "Invisible Post" shipping method
@@ -31,7 +31,7 @@ Feature: Seeing shipping methods which category is not same as any category of a
     Scenario: Seeing no shipping methods if its category is same as category of all my units
         Given I have product "Star Trek Ship" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then there should be information about no available shipping methods
 
@@ -40,7 +40,7 @@ Feature: Seeing shipping methods which category is not same as any category of a
         Given I have product "Picasso T-shirt" in the cart
         And I have product "Star Trek Ship" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then there should be information about no available shipping methods
 
@@ -50,7 +50,7 @@ Feature: Seeing shipping methods which category is not same as any category of a
         And I have "T-shirt banana" with Size "S" in the cart
         And I have "T-shirt banana" with Size "M" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then there should be information about no available shipping methods
 
@@ -59,7 +59,7 @@ Feature: Seeing shipping methods which category is not same as any category of a
         And I have "T-shirt banana" with Size "S" in the cart
         And I have "T-shirt banana" with Size "M" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step
         And I should see "Invisible Post" shipping method

--- a/features/checkout/shipping_order/selecting_order_shipping_method.feature
+++ b/features/checkout/shipping_order/selecting_order_shipping_method.feature
@@ -14,6 +14,6 @@ Feature: Selecting order shipping method
     @ui
     Scenario: Selecting one of available shipping method
         Given I have product "Targaryen T-Shirt" in the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         When I select "Raven Post" shipping method
         And I complete the shipping step

--- a/features/checkout/shipping_order/shipping_method_integrity_validation.feature
+++ b/features/checkout/shipping_order/shipping_method_integrity_validation.feature
@@ -21,7 +21,7 @@ Feature: Order shipping method integrity
     @ui
     Scenario: Validate shipping method after adding item which does not fit shipping method requirements
         Given I added product "Westworld host" to the cart
-        And I have completed addressing step with email "guest@example.com" and "United States" based shipping address
+        And I have completed addressing step with email "guest@example.com" and "United States" based billing address
         And I have proceeded order with "DHL" shipping method and "Offline" payment
         When I add product "T-shirt Breaking Bad" to the cart
         And I want to complete checkout
@@ -32,7 +32,7 @@ Feature: Order shipping method integrity
     Scenario: Validate shipping method after removing item which fits shipping method requirements
         Given I added product "T-shirt Breaking Bad" to the cart
         And I added product "Westworld host" to the cart
-        And I have completed addressing step with email "guest@example.com" and "United States" based shipping address
+        And I have completed addressing step with email "guest@example.com" and "United States" based billing address
         And I have proceeded order with "FedEx" shipping method and "Offline" payment
         When I remove product "T-shirt Breaking Bad" from the cart
         And I want to complete checkout
@@ -42,7 +42,7 @@ Feature: Order shipping method integrity
     @ui
     Scenario: Validate shipping method after administrator changes shipping method requirements
         Given I added product "Westworld host" to the cart
-        And I have completed addressing step with email "guest@example.com" and "United States" based shipping address
+        And I have completed addressing step with email "guest@example.com" and "United States" based billing address
         And I have proceeded order with "DHL" shipping method and "Offline" payment
         And product "Westworld host" shipping category has been changed to "Small stuff"
         When I want to complete checkout

--- a/features/checkout/shipping_order/sorting_shipping_method_selection.feature
+++ b/features/checkout/shipping_order/sorting_shipping_method_selection.feature
@@ -16,7 +16,7 @@ Feature: Sorting shipping method selection
     Scenario: Seeing shipping methods sorted
         Given I have product "Targaryen T-Shirt" in the cart
         When I am at the checkout addressing step
-        And I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should have "Narwhal Submarine" shipping method available as the first choice
         And I should have "Aardvark Stagecoach" shipping method available as the last choice

--- a/features/checkout/skipping_payment_method_step_when_only_one_payment_method_is_available.feature
+++ b/features/checkout/skipping_payment_method_step_when_only_one_payment_method_is_available.feature
@@ -14,7 +14,7 @@ Feature: Skipping payment step when only one payment method is available
     @ui
     Scenario: Seeing checkout completion page after shipping if only one payment method is available
         Given I have product "Guards! Guards!" in the cart
-        And I have completed addressing step with email "guest@example.com" and "United States" based shipping address
+        And I have completed addressing step with email "guest@example.com" and "United States" based billing address
         And I try to complete the shipping step
         Then I should be on the checkout complete step
         And my order's payment method should be "Paypal Express Checkout"
@@ -23,7 +23,7 @@ Feature: Skipping payment step when only one payment method is available
     Scenario: Seeing checkout completion page after shipping if only one payment method is available
         Given the store has "Offline" payment method not assigned to any channel
         And I have product "Guards! Guards!" in the cart
-        And I have completed addressing step with email "guest@example.com" and "United States" based shipping address
+        And I have completed addressing step with email "guest@example.com" and "United States" based billing address
         And I try to complete the shipping step
         Then I should be on the checkout complete step
         And my order's payment method should be "Paypal Express Checkout"
@@ -33,7 +33,7 @@ Feature: Skipping payment step when only one payment method is available
         Given the store allows paying with "Offline"
         And the payment method "Offline" is disabled
         And I have product "Guards! Guards!" in the cart
-        And I have completed addressing step with email "guest@example.com" and "United States" based shipping address
+        And I have completed addressing step with email "guest@example.com" and "United States" based billing address
         And I try to complete the shipping step
         Then I should be on the checkout complete step
         And my order's payment method should be "Paypal Express Checkout"

--- a/features/checkout/skipping_payment_step_when_order_total_is_zero.feature
+++ b/features/checkout/skipping_payment_step_when_order_total_is_zero.feature
@@ -17,7 +17,7 @@ Feature: Skipping payment selection when order total is zero
     Scenario: Seeing order summary after shipping selection when order total is zero
         Given I have product "PHP T-Shirt" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I select "Free" shipping method
         And I complete the shipping step
@@ -28,7 +28,7 @@ Feature: Skipping payment selection when order total is zero
     Scenario: Seeing payment selection after shipping selection when order total is not zero
         Given I have product "PHP T-Shirt" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I select "SHL" shipping method
         And I complete the shipping step

--- a/features/checkout/skipping_payment_step_when_order_total_is_zero_after_applying_coupon.feature
+++ b/features/checkout/skipping_payment_step_when_order_total_is_zero_after_applying_coupon.feature
@@ -19,7 +19,7 @@ Feature: Skipping payment selection when order total is zero after applying coup
         Given I have product "PHP T-Shirt" in the cart
         And I use coupon with code "HOLIDAYPROMO"
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I select "Free" shipping method
         And I complete the shipping step

--- a/features/checkout/skipping_shipping_and_payment_step_when_order_does_not_require_any_shipping_and_its_total_is_zero.feature
+++ b/features/checkout/skipping_shipping_and_payment_step_when_order_does_not_require_any_shipping_and_its_total_is_zero.feature
@@ -17,6 +17,6 @@ Feature: Skipping shipping and payment step when order does not require any ship
     Scenario: Seeing order summary page after addressing if none of order items require shipping and order total is zero
         Given I have "Guards! Guards! - ebook" variant of product "Guards! Guards!" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout summary step

--- a/features/checkout/skipping_shipping_step_when_only_one_shipping_method_is_available.feature
+++ b/features/checkout/skipping_shipping_step_when_only_one_shipping_method_is_available.feature
@@ -16,7 +16,7 @@ Feature: Skipping shipping step when only one shipping method is available
         Given the store has "DHL" shipping method with "$5.00" fee
         And I have product "Guards! Guards!" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I select "Paypal Express Checkout" payment method
         And I complete the payment step
@@ -29,7 +29,7 @@ Feature: Skipping shipping step when only one shipping method is available
         And the store has "FedEx" shipping method with "$15.00" fee not assigned to any channel
         And I have product "Guards! Guards!" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I select "Paypal Express Checkout" payment method
         And I complete the payment step
@@ -42,7 +42,7 @@ Feature: Skipping shipping step when only one shipping method is available
         And the store has disabled "FedEx" shipping method with "$15.00" fee
         And I have product "Guards! Guards!" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         And I select "Paypal Express Checkout" payment method
         And I complete the payment step

--- a/features/checkout/skipping_shipping_step_when_order_does_not_require_any_shipping.feature
+++ b/features/checkout/skipping_shipping_step_when_order_does_not_require_any_shipping.feature
@@ -16,7 +16,7 @@ Feature: Skipping shipping step when order does not require any shipping
     Scenario: Seeing checkout payment page after addressing if none of order items require shipping
         Given I have "Guards! Guards! - ebook" variant of product "Guards! Guards!" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout payment step
 
@@ -25,6 +25,6 @@ Feature: Skipping shipping step when order does not require any shipping
         Given I have "Guards! Guards! - ebook" variant of product "Guards! Guards!" in the cart
         And I have "Guards! Guards! - book" variant of product "Guards! Guards!" in the cart
         And I am at the checkout addressing step
-        When I specify the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        When I specify the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         And I complete the addressing step
         Then I should be on the checkout shipping step

--- a/features/order/managing_orders/seeing_orders_with_different_currency_on_index.feature
+++ b/features/order/managing_orders/seeing_orders_with_different_currency_on_index.feature
@@ -21,7 +21,7 @@ Feature: Seeing orders' total in their currency
     Scenario: List of orders from only one channel
         Given I changed my current channel to "United States"
         And I have product "Angel T-Shirt" in the cart
-        And I specified the shipping address as "Los Angeles", "Frost Alley", "90210", "United States" for "Lucifer Morningstar"
+        And I specified the billing address as "Los Angeles", "Frost Alley", "90210", "United States" for "Lucifer Morningstar"
         And I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order
         Then the administrator should see the order with total "$20.00" in order list
@@ -30,12 +30,12 @@ Feature: Seeing orders' total in their currency
     Scenario: List of orders from different channels
         Given I changed my current channel to "United States"
         And I have product "Angel T-Shirt" in the cart
-        And I specified the shipping address as "Los Angeles", "Frost Alley", "90210", "United States" for "Lucifer Morningstar"
+        And I specified the billing address as "Los Angeles", "Frost Alley", "90210", "United States" for "Lucifer Morningstar"
         And I proceed with "Free" shipping method and "Offline" payment
         And I confirm my order
         And I changed my current channel to "Great Britain"
         And I had product "Angel T-Shirt" in the cart
-        And I specified the shipping address as "Los Angeles", "Frost Alley", "90210", "United States" for "Lucifer Morningstar"
+        And I specified the billing address as "Los Angeles", "Frost Alley", "90210", "United States" for "Lucifer Morningstar"
         And I proceed with "Free" shipping method and "Offline" payment
         When I confirm my order
         Then the administrator should see the order with total "£20.00" in order list

--- a/features/promotion/applying_promotion_rules/receiving_discount_based_on_nth_order_for_guest_customer.feature
+++ b/features/promotion/applying_promotion_rules/receiving_discount_based_on_nth_order_for_guest_customer.feature
@@ -15,7 +15,7 @@ Feature: Receiving discount based on nth order
         Given there is a promotion "1st order promotion"
         And it gives "$20.00" off customer's 1st order
         When I add product "PHP T-Shirt" to the cart
-        And I complete addressing step with email "john.doe@example.com" and "United States" based shipping address
+        And I complete addressing step with email "john.doe@example.com" and "United States" based billing address
         Then my cart total should be "$80.00"
         And my discount should be "-$20.00"
 
@@ -27,7 +27,7 @@ Feature: Receiving discount based on nth order
         And the customer bought a single "PHP T-Shirt"
         And the customer chose "Free" shipping method to "United States" with "Cash on Delivery" payment
         When I add product "PHP T-Shirt" to the cart
-        And I complete addressing step with email "john.doe@example.com" and "United States" based shipping address
+        And I complete addressing step with email "john.doe@example.com" and "United States" based billing address
         Then my cart total should be "$100.00"
         And there should be no discount
 
@@ -36,6 +36,6 @@ Feature: Receiving discount based on nth order
         Given there is a promotion "2nd order promotion"
         And it gives "$10.00" off customer's 2nd order
         When I add product "PHP T-Shirt" to the cart
-        And I complete addressing step with email "john.doe@example.com" and "United States" based shipping address
+        And I complete addressing step with email "john.doe@example.com" and "United States" based billing address
         Then my cart total should be "$100.00"
         And there should be no discount

--- a/features/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_product_taxes_on_order.feature
+++ b/features/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_product_taxes_on_order.feature
@@ -33,7 +33,7 @@ Feature: Apply correct shipping fee with product taxes on order
     @ui
     Scenario: Proper shipping fee, tax and products' taxes after addressing
         Given I have 3 products "PHP T-Shirt" in the cart
-        When I proceed selecting "Germany" as shipping country with "FedEx" method
+        When I proceed selecting "Germany" as billing country with "FedEx" method
         And I choose "Offline" payment method
         Then my cart total should be "$352.00"
         And my cart taxes should be "$32.00"

--- a/features/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_taxes_on_order.feature
+++ b/features/shipping/applying_shipping_fee/applying_correct_shipping_fee_with_taxes_on_order.feature
@@ -32,7 +32,7 @@ Feature: Apply correct shipping fee with taxes on order
     @ui
     Scenario: Proper shipping fee and tax after addressing
         Given I have product "PHP T-Shirt" in the cart
-        When I proceed selecting "Germany" as shipping country with "DHL-World" method
+        When I proceed selecting "Germany" as billing country with "DHL-World" method
         And I choose "Offline" payment method
         Then my cart total should be "$122.00"
         And my cart taxes should be "$2.00"

--- a/features/taxation/applying_taxes/applying_correct_taxes_based_on_customer_data.feature
+++ b/features/taxation/applying_taxes/applying_correct_taxes_based_on_customer_data.feature
@@ -26,7 +26,7 @@ Feature: Apply correct taxes based on customer data
     Scenario: Proper taxes after specifying shipping address
         Given I am a logged in customer
         When I add product "PHP T-Shirt" to the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "United States" for "Jon Snow"
         Then my cart total should be "$123.00"
         And my cart taxes should be "$23.00"
 
@@ -34,6 +34,6 @@ Feature: Apply correct taxes based on customer data
     Scenario: Proper taxes after specifying shipping address
         Given I am a logged in customer
         When I add product "PHP T-Shirt" to the cart
-        And I specified the shipping address as "Ankh Morpork", "Frost Alley", "90210", "Germany" for "Jon Snow"
+        And I specified the billing address as "Ankh Morpork", "Frost Alley", "90210", "Germany" for "Jon Snow"
         Then my cart total should be "$110.00"
         And my cart taxes should be "$10.00"

--- a/features/taxation/applying_taxes/applying_correct_taxes_for_products_with_different_tax_rates_for_different_zones.feature
+++ b/features/taxation/applying_taxes/applying_correct_taxes_for_products_with_different_tax_rates_for_different_zones.feature
@@ -26,16 +26,16 @@ Feature: Apply correct taxes for products with different tax rates for different
         And there should be no taxes charged
 
     @ui
-    Scenario: Displaying correct tax after specifying shipping address
+    Scenario: Displaying correct tax after specifying billing address
         Given I have product "PHP T-Shirt" in the cart
-        When I proceed selecting "Germany" as shipping country
+        When I proceed selecting "Germany" as billing country
         Then my cart total should be "$123.00"
         And my cart taxes should be "$23.00"
 
     @ui
-    Scenario: Displaying correct taxes for multiple products after specifying shipping address
+    Scenario: Displaying correct taxes for multiple products after specifying billing address
         Given I have 3 products "PHP T-Shirt" in the cart
-        When I proceed selecting "Germany" as shipping country
+        When I proceed selecting "Germany" as billing country
         Then my cart total should be "$369.00"
         And my cart taxes should be "$69.00"
 
@@ -47,9 +47,9 @@ Feature: Apply correct taxes for products with different tax rates for different
         And my cart taxes should be "$5.00"
 
     @ui
-    Scenario: Displaying correct taxes for multiple products from different zones after specifying shipping address
+    Scenario: Displaying correct taxes for multiple products from different zones after specifying billing address
         Given I have product "PHP T-Shirt" in the cart
         And I have 2 products "Symfony Mug" in the cart
-        When I proceed selecting "Germany" as shipping country
+        When I proceed selecting "Germany" as billing country
         Then my cart total should be "$223.00"
         And my cart taxes should be "$23.00"

--- a/features/taxation/applying_taxes/applying_correct_taxes_on_visitor_cart.feature
+++ b/features/taxation/applying_taxes/applying_correct_taxes_on_visitor_cart.feature
@@ -24,6 +24,6 @@ Feature: Apply correct taxes on visitor cart
     @ui
     Scenario: Proper taxes after specifying shipping address
         Given I have product "PHP T-Shirt" in the cart
-        When I proceed as guest "john@example.com" with "Austria" as shipping country
+        When I proceed as guest "john@example.com" with "Austria" as billing country
         Then my cart total should be "$110.00"
         And my cart taxes should be "$10.00"

--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -146,7 +146,7 @@ final class OrderContext implements Context
     }
 
     /**
-     * @Given /^the guest customer placed order with ("[^"]+" product) for "([^"]+)" and ("[^"]+" based shipping address) with ("[^"]+" shipping method) and ("[^"]+" payment)$/
+     * @Given /^the guest customer placed order with ("[^"]+" product) for "([^"]+)" and ("[^"]+" based billing address) with ("[^"]+" shipping method) and ("[^"]+" payment)$/
      */
     public function theGuestCustomerPlacedOrderWithForAndBasedShippingAddress(
         ProductInterface $product,

--- a/src/Sylius/Behat/Context/Transform/CountryContext.php
+++ b/src/Sylius/Behat/Context/Transform/CountryContext.php
@@ -38,6 +38,7 @@ final class CountryContext implements Context
      * @Transform /^country "([^"]+)"$/
      * @Transform /^"([^"]+)" country$/
      * @Transform /^"([^"]+)" as shipping country$/
+     * @Transform /^"([^"]+)" as billing country$/
      * @Transform :country
      */
     public function getCountryByName($countryName)

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
@@ -64,24 +64,24 @@ final class CheckoutAddressingContext implements Context
     }
 
     /**
-     * @Given /^I have completed addressing step with email "([^"]+)" and ("[^"]+" based shipping address)$/
-     * @When /^I complete addressing step with email "([^"]+)" and ("[^"]+" based shipping address)$/
+     * @Given /^I have completed addressing step with email "([^"]+)" and ("[^"]+" based billing address)$/
+     * @When /^I complete addressing step with email "([^"]+)" and ("[^"]+" based billing address)$/
      */
-    public function iCompleteAddressingStepWithEmail($email, AddressInterface $address)
+    public function iCompleteAddressingStepWithEmail(string $email, AddressInterface $address): void
     {
         $this->addressPage->open();
         $this->iSpecifyTheEmail($email);
-        $this->iSpecifyTheShippingAddressAs($address);
+        $this->iSpecifyTheBillingAddressAs($address);
         $this->iCompleteTheAddressingStep();
     }
 
     /**
-     * @When /^I complete addressing step with ("[^"]+" based shipping address)$/
+     * @When /^I complete addressing step with ("[^"]+" based billing address)$/
      */
-    public function iCompleteAddressingStepWithBasedShippingAddress(AddressInterface $address): void
+    public function iCompleteAddressingStepWithBasedBillingAddress(AddressInterface $address): void
     {
         $this->addressPage->open();
-        $this->iSpecifyTheShippingAddressAs($address);
+        $this->iSpecifyTheBillingAddressAs($address);
         $this->iCompleteTheAddressingStep();
     }
 
@@ -114,6 +114,7 @@ final class CheckoutAddressingContext implements Context
      */
     public function iChooseForShippingAddress(AddressInterface $address)
     {
+        $this->addressPage->chooseDifferentShippingAddress();
         $this->addressPage->selectShippingAddressFromAddressBook($address);
     }
 
@@ -122,7 +123,6 @@ final class CheckoutAddressingContext implements Context
      */
     public function iChooseForBillingAddress(AddressInterface $address)
     {
-        $this->addressPage->chooseDifferentBillingAddress();
         $this->addressPage->selectBillingAddressFromAddressBook($address);
     }
 
@@ -134,6 +134,8 @@ final class CheckoutAddressingContext implements Context
      */
     public function iSpecifyTheShippingAddressAs(AddressInterface $address)
     {
+        $this->addressPage->chooseDifferentShippingAddress();
+
         $key = sprintf(
             'shipping_address_%s_%s',
             strtolower((string) $address->getFirstName()),
@@ -167,8 +169,6 @@ final class CheckoutAddressingContext implements Context
      */
     public function iSpecifyTheBillingAddressAs(AddressInterface $address)
     {
-        $this->addressPage->chooseDifferentBillingAddress();
-
         $key = sprintf(
             'billing_address_%s_%s',
             strtolower((string) $address->getFirstName()),
@@ -180,18 +180,18 @@ final class CheckoutAddressingContext implements Context
     }
 
     /**
-     * @When /^I specified the shipping (address as "[^"]+", "[^"]+", "[^"]+", "[^"]+" for "[^"]+")$/
+     * @When /^I specified the billing (address as "[^"]+", "[^"]+", "[^"]+", "[^"]+" for "[^"]+")$/
      */
-    public function iSpecifiedTheShippingAddress(AddressInterface $address = null)
+    public function iSpecifiedTheBillingAddress(AddressInterface $address = null)
     {
         if (null === $address) {
             $address = $this->createDefaultAddress();
         }
 
         $this->addressPage->open();
-        $this->iSpecifyTheShippingAddressAs($address);
+        $this->iSpecifyTheBillingAddressAs($address);
 
-        $key = sprintf('billing_address_%s_%s', strtolower((string) $address->getFirstName()), strtolower((string) $address->getLastName()));
+        $key = sprintf('shipping_address_%s_%s', strtolower((string) $address->getFirstName()), strtolower((string) $address->getLastName()));
         $this->sharedStorage->set($key, $address);
 
         $this->iCompleteTheAddressingStep();
@@ -232,9 +232,9 @@ final class CheckoutAddressingContext implements Context
     }
 
     /**
-     * @When /^I proceed selecting ("[^"]+" as shipping country)$/
+     * @When /^I proceed selecting ("[^"]+" as billing country)$/
      */
-    public function iProceedSelectingShippingCountry(
+    public function iProceedSelectingBillingCountry(
         CountryInterface $shippingCountry = null,
         string $localeCode = 'en_US',
         ?string $email = null
@@ -247,7 +247,7 @@ final class CheckoutAddressingContext implements Context
         if (null !== $email) {
             $this->addressPage->specifyEmail($email);
         }
-        $this->addressPage->specifyShippingAddress($shippingAddress);
+        $this->addressPage->specifyBillingAddress($shippingAddress);
         $this->addressPage->nextStep();
     }
 

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
@@ -207,11 +207,11 @@ final class CheckoutAddressingContext implements Context
     }
 
     /**
-     * @When I specify the first and last name as :fullName for shipping address
+     * @When I specify the first and last name as :fullName for billing address
      */
-    public function iSpecifyTheStreetAsForShippingAddress(string $fullName)
+    public function iSpecifyTheStreetAsForBillingAddress(string $fullName): void
     {
-        $this->addressPage->specifyShippingAddressFullName($fullName);
+        $this->addressPage->specifyBillingAddressFullName($fullName);
     }
 
     /**
@@ -252,10 +252,12 @@ final class CheckoutAddressingContext implements Context
     }
 
     /**
-     * @When /^I proceed as guest "([^"]*)" with ("[^"]+" as shipping country)$/
+     * @When /^I proceed as guest "([^"]*)" with ("[^"]+" as billing country)$/
      */
-    public function iProceedLoggingAsGuestWithAsShippingCountry($email, CountryInterface $shippingCountry = null)
-    {
+    public function iProceedLoggingAsGuestWithAsBillingCountry(
+        string $email,
+        CountryInterface $shippingCountry = null
+    ): void {
         $this->addressPage->open();
         $this->addressPage->specifyEmail($email);
         $shippingAddress = $this->createDefaultAddress();
@@ -263,7 +265,7 @@ final class CheckoutAddressingContext implements Context
             $shippingAddress->setCountryCode($shippingCountry->getCode());
         }
 
-        $this->addressPage->specifyShippingAddress($shippingAddress);
+        $this->addressPage->specifyBillingAddress($shippingAddress);
         $this->addressPage->nextStep();
     }
 

--- a/src/Sylius/Behat/Context/Ui/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CheckoutContext.php
@@ -89,7 +89,7 @@ final class CheckoutContext implements Context
      */
     public function iWasAtTheCheckoutSummaryStep()
     {
-        $this->addressingContext->iSpecifiedTheShippingAddress();
+        $this->addressingContext->iSpecifiedTheBillingAddress();
         $this->iProceedOrderWithShippingMethodAndPayment('Free', 'Offline');
     }
 
@@ -99,7 +99,7 @@ final class CheckoutContext implements Context
      */
     public function iProceedSelectingShippingMethod($shippingMethodName)
     {
-        $this->iProceedSelectingShippingCountryAndShippingMethod(null, $shippingMethodName);
+        $this->iProceedSelectingBillingCountryAndShippingMethod(null, $shippingMethodName);
     }
 
     /**
@@ -108,7 +108,7 @@ final class CheckoutContext implements Context
      */
     public function iProceedSelectingPaymentMethod($paymentMethodName)
     {
-        $this->iProceedSelectingShippingCountryAndShippingMethod();
+        $this->iProceedSelectingBillingCountryAndShippingMethod();
         $this->paymentContext->iChoosePaymentMethod($paymentMethodName);
     }
 
@@ -130,17 +130,17 @@ final class CheckoutContext implements Context
      */
     public function iProceedThroughCheckoutProcess(string $localeCode = 'en_US', ?string $email = null): void
     {
-        $this->addressingContext->iProceedSelectingShippingCountry(null, $localeCode, $email);
+        $this->addressingContext->iProceedSelectingBillingCountry(null, $localeCode, $email);
         $this->shippingContext->iCompleteTheShippingStep();
         $this->paymentContext->iCompleteThePaymentStep();
     }
 
     /**
-     * @When /^I proceed selecting ("[^"]+" as shipping country) with "([^"]+)" method$/
+     * @When /^I proceed selecting ("[^"]+" as billing country) with "([^"]+)" method$/
      */
-    public function iProceedSelectingShippingCountryAndShippingMethod(CountryInterface $shippingCountry = null, $shippingMethodName = null)
+    public function iProceedSelectingBillingCountryAndShippingMethod(CountryInterface $shippingCountry = null, $shippingMethodName = null)
     {
-        $this->addressingContext->iProceedSelectingShippingCountry($shippingCountry);
+        $this->addressingContext->iProceedSelectingBillingCountry($shippingCountry);
         $this->shippingContext->iHaveProceededSelectingShippingMethod($shippingMethodName ?: 'Free');
     }
 

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
@@ -271,7 +271,7 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
             'login_button' => '[data-test-login-button]',
             'login_password' => '[data-test-password-input]',
             'next_step' => '[data-test-next-step]',
-            'shipping_address_book' => '[data-test-shipping-address] .ui.dropdown',
+            'shipping_address_book' => '[data-test-shipping-address] [data-test-address-book]',
             'shipping_city' => '[data-test-shipping-city]',
             'shipping_country' => '[data-test-shipping-country]',
             'shipping_country_province' => '[data-test-shipping-address] [data-test-province-code]',

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
@@ -49,16 +49,16 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
         return 'sylius_shop_checkout_address';
     }
 
-    public function chooseDifferentBillingAddress(): void
+    public function chooseDifferentShippingAddress(): void
     {
         $driver = $this->getDriver();
         if ($driver instanceof Selenium2Driver) {
-            $this->getElement('different_billing_address_label')->click();
+            $this->getElement('different_shipping_address_label')->click();
 
             return;
         }
 
-        $billingAddressSwitch = $this->getElement('different_billing_address');
+        $billingAddressSwitch = $this->getElement('different_shipping_address');
         Assert::false(
             $billingAddressSwitch->isChecked(),
             'Previous state of different billing address switch was true expected to be false'
@@ -266,6 +266,8 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
             'customer_email' => '[data-test-login-email]',
             'different_billing_address' => '[data-test-different-billing-address]',
             'different_billing_address_label' => '[data-test-different-billing-address-label]',
+            'different_shipping_address' => '[data-test-different-shipping-address]',
+            'different_shipping_address_label' => '[data-test-different-shipping-address-label]',
             'login_button' => '[data-test-login-button]',
             'login_password' => '[data-test-password-input]',
             'next_step' => '[data-test-next-step]',

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
@@ -123,12 +123,12 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
         $this->getElement('customer_email')->setValue($email);
     }
 
-    public function specifyShippingAddressFullName(string $fullName): void
+    public function specifyBillingAddressFullName(string $fullName): void
     {
         $names = explode(' ', $fullName);
 
-        $this->getElement('shipping_first_name')->setValue($names[0]);
-        $this->getElement('shipping_last_name')->setValue($names[1]);
+        $this->getElement('billing_first_name')->setValue($names[0]);
+        $this->getElement('billing_last_name')->setValue($names[1]);
     }
 
     public function canSignIn(): bool
@@ -219,8 +219,6 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
         }
 
         $addressOption->click();
-
-        JQueryHelper::waitForFormToStopLoading($this->getDocument());
     }
 
     public function selectBillingAddressFromAddressBook(AddressInterface $address): void
@@ -238,6 +236,8 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
         }
 
         $addressOption->click();
+
+        JQueryHelper::waitForFormToStopLoading($this->getDocument());
     }
 
     public function getPreFilledShippingAddress(): AddressInterface
@@ -271,7 +271,7 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
             'login_button' => '[data-test-login-button]',
             'login_password' => '[data-test-password-input]',
             'next_step' => '[data-test-next-step]',
-            'shipping_address_book' => '[data-test-address-book]',
+            'shipping_address_book' => '[data-test-shipping-address] .ui.dropdown',
             'shipping_city' => '[data-test-shipping-city]',
             'shipping_country' => '[data-test-shipping-country]',
             'shipping_country_province' => '[data-test-shipping-address] [data-test-province-code]',

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPageInterface.php
@@ -18,7 +18,7 @@ use Sylius\Component\Core\Model\AddressInterface;
 
 interface AddressPageInterface extends SymfonyPageInterface
 {
-    public function chooseDifferentBillingAddress(): void;
+    public function chooseDifferentShippingAddress(): void;
 
     public function checkInvalidCredentialsValidation(): bool;
 

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPageInterface.php
@@ -34,7 +34,7 @@ interface AddressPageInterface extends SymfonyPageInterface
 
     public function specifyEmail(?string $email): void;
 
-    public function specifyShippingAddressFullName(string $fullName): void;
+    public function specifyBillingAddressFullName(string $fullName): void;
 
     public function canSignIn(): bool;
 

--- a/src/Sylius/Bundle/AdminApiBundle/Form/Type/AddressType.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Form/Type/AddressType.php
@@ -36,16 +36,16 @@ final class AddressType extends AbstractType
             ->add('billingAddress', SyliusAddressType::class, [
                 'constraints' => [new Valid()],
             ])
-            ->add('differentBillingAddress', CheckboxType::class, [
+            ->add('differentShippingAddress', CheckboxType::class, [
                 'mapped' => false,
                 'required' => false,
-                'label' => 'sylius.form.checkout.addressing.different_billing_address',
+                'label' => 'sylius.form.checkout.addressing.different_shipping_address',
             ])
             ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
                 $orderData = $event->getData();
 
-                if (isset($orderData['shippingAddress']) && (!isset($orderData['differentBillingAddress']) || false === $orderData['differentBillingAddress'])) {
-                    $orderData['billingAddress'] = $orderData['shippingAddress'];
+                if (isset($orderData['shippingAddress']) && (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])) {
+                    $orderData['shippingAddress'] = $orderData['billingAddress'];
 
                     $event->setData($orderData);
                 }

--- a/src/Sylius/Bundle/AdminApiBundle/Form/Type/AddressType.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Form/Type/AddressType.php
@@ -49,19 +49,14 @@ final class AddressType extends AbstractType
             ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
                 $orderData = $event->getData();
 
-                if (
-                    isset($orderData['billingAddress']) &&
-                    (!isset($orderData['differentBillingAddress']) || false === $orderData['differentBillingAddress']) &&
-                    (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])
-                ) {
+                $differentBillingAddress = $orderData['differentBillingAddress'] ?? false;
+                $differentShippingAddress = $orderData['differentShippingAddress'] ?? false;
+
+                if (isset($orderData['billingAddress']) && !$differentBillingAddress && !$differentShippingAddress) {
                     $orderData['shippingAddress'] = $orderData['billingAddress'];
                 }
 
-                if (
-                    isset($orderData['shippingAddress']) &&
-                    (!isset($orderData['differentBillingAddress']) || false === $orderData['differentBillingAddress']) &&
-                    (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])
-                ) {
+                if (isset($orderData['shippingAddress']) && !$differentBillingAddress && !$differentShippingAddress) {
                     $orderData['billingAddress'] = $orderData['shippingAddress'];
                 }
 

--- a/src/Sylius/Bundle/AdminApiBundle/Form/Type/AddressType.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Form/Type/AddressType.php
@@ -36,6 +36,11 @@ final class AddressType extends AbstractType
             ->add('billingAddress', SyliusAddressType::class, [
                 'constraints' => [new Valid()],
             ])
+            ->add('differentBillingAddress', CheckboxType::class, [
+                'mapped' => false,
+                'required' => false,
+                'label' => 'sylius.form.checkout.addressing.different_billing_address',
+            ])
             ->add('differentShippingAddress', CheckboxType::class, [
                 'mapped' => false,
                 'required' => false,
@@ -44,11 +49,23 @@ final class AddressType extends AbstractType
             ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
                 $orderData = $event->getData();
 
-                if (isset($orderData['billingAddress']) && (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])) {
+                if (
+                    isset($orderData['billingAddress']) &&
+                    (!isset($orderData['differentBillingAddress']) || false === $orderData['differentBillingAddress']) &&
+                    (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])
+                ) {
                     $orderData['shippingAddress'] = $orderData['billingAddress'];
-
-                    $event->setData($orderData);
                 }
+
+                if (
+                    isset($orderData['shippingAddress']) &&
+                    (!isset($orderData['differentBillingAddress']) || false === $orderData['differentBillingAddress']) &&
+                    (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])
+                ) {
+                    $orderData['billingAddress'] = $orderData['shippingAddress'];
+                }
+
+                $event->setData($orderData);
             })
         ;
     }

--- a/src/Sylius/Bundle/AdminApiBundle/Form/Type/AddressType.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Form/Type/AddressType.php
@@ -44,7 +44,7 @@ final class AddressType extends AbstractType
             ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
                 $orderData = $event->getData();
 
-                if (isset($orderData['shippingAddress']) && (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])) {
+                if (isset($orderData['billingAddress']) && (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])) {
                     $orderData['shippingAddress'] = $orderData['billingAddress'];
 
                     $event->setData($orderData);

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
@@ -41,6 +41,11 @@ final class AddressType extends AbstractResourceType
             ->add('billingAddress', SyliusAddressType::class, [
                 'constraints' => [new Valid()],
             ])
+            ->add('differentBillingAddress', CheckboxType::class, [
+                'mapped' => false,
+                'required' => false,
+                'label' => 'sylius.form.checkout.addressing.different_billing_address',
+            ])
             ->add('differentShippingAddress', CheckboxType::class, [
                 'mapped' => false,
                 'required' => false,
@@ -66,11 +71,23 @@ final class AddressType extends AbstractResourceType
             ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
                 $orderData = $event->getData();
 
-                if (isset($orderData['billingAddress']) && (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])) {
+                if (
+                    isset($orderData['billingAddress']) &&
+                    (!isset($orderData['differentBillingAddress']) || false === $orderData['differentBillingAddress']) &&
+                    (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])
+                ) {
                     $orderData['shippingAddress'] = $orderData['billingAddress'];
-
-                    $event->setData($orderData);
                 }
+
+                if (
+                    isset($orderData['shippingAddress']) &&
+                    (!isset($orderData['differentBillingAddress']) || false === $orderData['differentBillingAddress']) &&
+                    (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])
+                ) {
+                    $orderData['billingAddress'] = $orderData['shippingAddress'];
+                }
+
+                $event->setData($orderData);
             })
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
@@ -66,7 +66,7 @@ final class AddressType extends AbstractResourceType
             ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
                 $orderData = $event->getData();
 
-                if (isset($orderData['shippingAddress']) && (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])) {
+                if (isset($orderData['billingAddress']) && (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])) {
                     $orderData['shippingAddress'] = $orderData['billingAddress'];
 
                     $event->setData($orderData);

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
@@ -41,10 +41,10 @@ final class AddressType extends AbstractResourceType
             ->add('billingAddress', SyliusAddressType::class, [
                 'constraints' => [new Valid()],
             ])
-            ->add('differentBillingAddress', CheckboxType::class, [
+            ->add('differentShippingAddress', CheckboxType::class, [
                 'mapped' => false,
                 'required' => false,
-                'label' => 'sylius.form.checkout.addressing.different_billing_address',
+                'label' => 'sylius.form.checkout.addressing.different_shipping_address',
             ])
             ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($options): void {
                 $form = $event->getForm();
@@ -66,8 +66,8 @@ final class AddressType extends AbstractResourceType
             ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
                 $orderData = $event->getData();
 
-                if (isset($orderData['shippingAddress']) && (!isset($orderData['differentBillingAddress']) || false === $orderData['differentBillingAddress'])) {
-                    $orderData['billingAddress'] = $orderData['shippingAddress'];
+                if (isset($orderData['shippingAddress']) && (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])) {
+                    $orderData['shippingAddress'] = $orderData['billingAddress'];
 
                     $event->setData($orderData);
                 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/Checkout/AddressType.php
@@ -71,19 +71,14 @@ final class AddressType extends AbstractResourceType
             ->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
                 $orderData = $event->getData();
 
-                if (
-                    isset($orderData['billingAddress']) &&
-                    (!isset($orderData['differentBillingAddress']) || false === $orderData['differentBillingAddress']) &&
-                    (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])
-                ) {
+                $differentBillingAddress = $orderData['differentBillingAddress'] ?? false;
+                $differentShippingAddress = $orderData['differentShippingAddress'] ?? false;
+
+                if (isset($orderData['billingAddress']) && !$differentBillingAddress && !$differentShippingAddress) {
                     $orderData['shippingAddress'] = $orderData['billingAddress'];
                 }
 
-                if (
-                    isset($orderData['shippingAddress']) &&
-                    (!isset($orderData['differentBillingAddress']) || false === $orderData['differentBillingAddress']) &&
-                    (!isset($orderData['differentShippingAddress']) || false === $orderData['differentShippingAddress'])
-                ) {
+                if (isset($orderData['shippingAddress']) && !$differentBillingAddress && !$differentShippingAddress) {
                     $orderData['billingAddress'] = $orderData['shippingAddress'];
                 }
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
@@ -8,6 +8,7 @@ sylius:
             coupon: Coupon
         checkout:
             addressing:
+                different_billing_address: Use different address for billing?
                 different_shipping_address: Use different address for shipping?
             payment_method: Payment Method
             shipping_method: Shipping Method

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
@@ -8,7 +8,7 @@ sylius:
             coupon: Coupon
         checkout:
             addressing:
-                different_billing_address: Use different address for billing?
+                different_shipping_address: Use different address for shipping?
             payment_method: Payment Method
             shipping_method: Shipping Method
         promotion:
@@ -101,7 +101,7 @@ sylius:
             file: Select image
         user:
             billing_address: Billing address
-            different_billing_address: Use different address for billing?
+            different_shipping_address: Use different address for shipping?
             enabled: Enabled
             first_name: First name
             groups: Groups

--- a/src/Sylius/Bundle/CustomerBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/CustomerBundle/Resources/translations/messages.en.yml
@@ -9,7 +9,7 @@ sylius:
             gender: Gender
             birthday: Birthday
             billing_address: Billing address
-            different_billing_address: Use different address for billing?
+            different_shipping_address: Use different address for shipping?
             only_customer_registration: Create account?
             subscribed_to_newsletter: Subscribe to the newsletter
         customer_group:

--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-province-field.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-province-field.js
@@ -96,12 +96,12 @@ $.fn.extend({
       $('select.country-select').trigger('change');
     }
 
-    const billingAddressCheckbox = $('input[type="checkbox"][name$="[differentBillingAddress]"]');
-    const billingAddressContainer = $('#sylius-billing-address-container');
-    const toggleBillingAddress = function toggleBillingAddress() {
-      billingAddressContainer.toggle(billingAddressCheckbox.prop('checked'));
+    const shippingAddressCheckbox = $('input[type="checkbox"][name$="[differentShippingAddress]"]');
+    const shippingAddressContainer = $('#sylius-shipping-address-container');
+    const toggleShippingAddress = function toggleShippingAddress() {
+      shippingAddressContainer.toggle(shippingAddressCheckbox.prop('checked'));
     };
-    toggleBillingAddress();
-    billingAddressCheckbox.on('change', toggleBillingAddress);
+    toggleShippingAddress();
+    shippingAddressCheckbox.on('change', toggleShippingAddress);
   },
 });

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_form.html.twig
@@ -1,20 +1,20 @@
-<div id="sylius-shipping-address" {{ sylius_test_html_attribute('shipping-address') }}>
+<div id="sylius-billing-address" {{ sylius_test_html_attribute('billing-address') }}>
     {% include '@SyliusShop/Checkout/Address/_addressBookSelect.html.twig' %}
-    <h3 class="ui dividing header">{{ 'sylius.ui.shipping_address'|trans }}</h3>
+    <h3 class="ui dividing header">{{ 'sylius.ui.billing_address'|trans }}</h3>
     {% if form.customer is defined %}
         {% include '@SyliusShop/Common/Form/_login.html.twig' with {'form': form.customer} %}
     {% endif %}
-    {% include '@SyliusShop/Common/Form/_address.html.twig' with {'form': form.shippingAddress, 'order': order, 'type': 'shipping'} %}
-    {{ form_row(form.differentBillingAddress,sylius_test_form_attribute('different-billing-address')|sylius_merge_recursive({'attr': {'data-toggles': 'sylius-billing-address'}, 'label_attr': {'data-test-different-billing-address-label': ''}} )) }}
-
-    {{ sonata_block_render_event('sylius.shop.checkout.address.shipping_address_form', {'order': order}) }}
-</div>
-
-<div id="sylius-billing-address" {{ sylius_test_html_attribute('billing-address') }}>
-    <div class="ui hidden divider"></div>
-    {% include '@SyliusShop/Checkout/Address/_addressBookSelect.html.twig' %}
-    <h3 class="ui dividing header">{{ 'sylius.ui.billing_address'|trans }}</h3>
     {% include '@SyliusShop/Common/Form/_address.html.twig' with {'form': form.billingAddress, 'order': order, 'type': 'billing'} %}
+    {{ form_row(form.differentShippingAddress, sylius_test_form_attribute('different-shipping-address')|sylius_merge_recursive({'attr': {'data-toggles': 'sylius-shipping-address'}, 'label_attr': {'data-test-different-shipping-address-label': ''}} )) }}
 
     {{ sonata_block_render_event('sylius.shop.checkout.address.billing_address_form', {'order': order}) }}
+</div>
+
+<div id="sylius-shipping-address" {{ sylius_test_html_attribute('shipping-address') }}>
+    <div class="ui hidden divider"></div>
+    {% include '@SyliusShop/Checkout/Address/_addressBookSelect.html.twig' %}
+    <h3 class="ui dividing header">{{ 'sylius.ui.shipping_address'|trans }}</h3>
+    {% include '@SyliusShop/Common/Form/_address.html.twig' with {'form': form.shippingAddress, 'order': order, 'type': 'shipping'} %}
+
+    {{ sonata_block_render_event('sylius.shop.checkout.address.shipping_address_form', {'order': order}) }}
 </div>

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_form.html.twig
@@ -18,3 +18,4 @@
 
     {{ sonata_block_render_event('sylius.shop.checkout.address.shipping_address_form', {'order': order}) }}
 </div>
+features/checkout/addressing_order/choosing_billing_and_shipping_address_from_address_book.feature:40features/checkout/addressing_order/choosing_billing_and_shipping_address_from_address_book.feature:40

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_form.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/Address/_form.html.twig
@@ -18,4 +18,3 @@
 
     {{ sonata_block_render_event('sylius.shop.checkout.address.shipping_address_form', {'order': order}) }}
 </div>
-features/checkout/addressing_order/choosing_billing_and_shipping_address_from_address_book.feature:40features/checkout/addressing_order/choosing_billing_and_shipping_address_from_address_book.feature:40

--- a/src/Sylius/Component/Core/Cart/Context/ShopBasedCartContext.php
+++ b/src/Sylius/Component/Core/Cart/Context/ShopBasedCartContext.php
@@ -86,7 +86,7 @@ final class ShopBasedCartContext implements CartContextInterface
         if (null !== $defaultAddress) {
             $clonedAddress = clone $defaultAddress;
             $clonedAddress->setCustomer(null);
-            $cart->setShippingAddress($clonedAddress);
+            $cart->setBillingAddress($clonedAddress);
         }
     }
 

--- a/src/Sylius/Component/Core/OrderProcessing/OrderTaxesProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderTaxesProcessor.php
@@ -80,11 +80,11 @@ final class OrderTaxesProcessor implements OrderProcessorInterface
 
     private function getTaxZone(OrderInterface $order): ?ZoneInterface
     {
-        $shippingAddress = $order->getShippingAddress();
+        $billingAddress = $order->getBillingAddress();
         $zone = null;
 
-        if (null !== $shippingAddress) {
-            $zone = $this->zoneMatcher->match($shippingAddress, Scope::TAX);
+        if (null !== $billingAddress) {
+            $zone = $this->zoneMatcher->match($billingAddress, Scope::TAX);
         }
 
         return $zone ?: $this->defaultTaxZoneProvider->getZone($order);

--- a/src/Sylius/Component/Core/spec/Cart/Context/ShopBasedCartContextSpec.php
+++ b/src/Sylius/Component/Core/spec/Cart/Context/ShopBasedCartContextSpec.php
@@ -87,7 +87,7 @@ final class ShopBasedCartContextSpec extends ObjectBehavior
         $cart->setCurrencyCode('PLN')->shouldBeCalled();
         $cart->setLocaleCode('pl')->shouldBeCalled();
         $cart->setCustomer($customer)->shouldBeCalled();
-        $cart->setShippingAddress(Argument::that(static function (AddressInterface $address): bool {
+        $cart->setBillingAddress(Argument::that(static function (AddressInterface $address): bool {
             return $address->getCustomer() === null;
         }))->shouldBeCalled();
 

--- a/src/Sylius/Component/Core/spec/OrderProcessing/OrderTaxesProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/OrderTaxesProcessorSpec.php
@@ -55,7 +55,7 @@ final class OrderTaxesProcessorSpec extends ObjectBehavior
     ): void {
         $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
         $order->isEmpty()->willReturn(false);
-        $order->getShippingAddress()->willReturn($address);
+        $order->getBillingAddress()->willReturn($address);
 
         $order->removeAdjustments(AdjustmentInterface::TAX_ADJUSTMENT)->shouldBeCalled();
         $orderItem->removeAdjustmentsRecursively(AdjustmentInterface::TAX_ADJUSTMENT)->shouldBeCalled();
@@ -83,7 +83,7 @@ final class OrderTaxesProcessorSpec extends ObjectBehavior
     ): void {
         $order->getItems()->willReturn(new ArrayCollection([$orderItem->getWrappedObject()]));
         $order->isEmpty()->willReturn(false);
-        $order->getShippingAddress()->willReturn($address);
+        $order->getBillingAddress()->willReturn($address);
 
         $order->removeAdjustments(AdjustmentInterface::TAX_ADJUSTMENT)->shouldBeCalled();
         $orderItem->removeAdjustmentsRecursively(AdjustmentInterface::TAX_ADJUSTMENT)->shouldBeCalled();
@@ -104,7 +104,7 @@ final class OrderTaxesProcessorSpec extends ObjectBehavior
         $order->getItems()->willReturn(new ArrayCollection([]));
         $order->isEmpty()->willReturn(true);
 
-        $order->getShippingAddress()->shouldNotBeCalled();
+        $order->getBillingAddress()->shouldNotBeCalled();
 
         $this->process($order);
     }
@@ -123,7 +123,7 @@ final class OrderTaxesProcessorSpec extends ObjectBehavior
         $order->removeAdjustments(AdjustmentInterface::TAX_ADJUSTMENT)->shouldBeCalled();
         $orderItem->removeAdjustmentsRecursively(AdjustmentInterface::TAX_ADJUSTMENT)->shouldBeCalled();
 
-        $order->getShippingAddress()->willReturn($address);
+        $order->getBillingAddress()->willReturn($address);
 
         $zoneMatcher->match($address, Scope::TAX)->willReturn(null);
 

--- a/tests/Controller/CheckoutAddressingApiTest.php
+++ b/tests/Controller/CheckoutAddressingApiTest.php
@@ -80,7 +80,7 @@ EOT;
         $data =
 <<<EOT
         {
-            "shippingAddress": {
+            "billingAddress": {
                 "firstName": "Hieronim",
                 "lastName": "Bosch",
                 "street": "Surrealism St.",
@@ -114,7 +114,7 @@ EOT;
         $data =
 <<<EOT
         {
-            "shippingAddress": {
+            "billingAddress": {
                 "firstName": "Hieronim",
                 "lastName": "Bosch",
                 "street": "Surrealism St.",
@@ -147,7 +147,7 @@ EOT;
         $data =
 <<<EOT
         {
-            "shippingAddress": {
+            "billingAddress": {
                 "firstName": "Hieronim",
                 "lastName": "Bosch",
                 "street": "Surrealism St.",
@@ -155,7 +155,7 @@ EOT;
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "billingAddress": {
+            "shippingAddress": {
                 "firstName": "Vincent",
                 "lastName": "van Gogh",
                 "street": "Post-Impressionism St.",
@@ -193,7 +193,7 @@ EOT;
         $data =
 <<<EOT
         {
-            "shippingAddress": {
+            "billingAddress": {
                 "firstName": "Vincent",
                 "lastName": "van Gogh",
                 "street": "Post-Impressionism St.",
@@ -210,7 +210,7 @@ EOT;
         $newData =
 <<<EOT
         {
-            "shippingAddress": {
+            "billingAddress": {
                 "firstName": "Hieronim",
                 "lastName": "Bosch",
                 "street": "Surrealism St.",
@@ -243,7 +243,7 @@ EOT;
         $addressData =
 <<<EOT
         {
-            "shippingAddress": {
+            "billingAddress": {
                 "firstName": "Vincent",
                 "lastName": "van Gogh",
                 "street": "Post-Impressionism St.",
@@ -262,7 +262,7 @@ EOT;
         $newAddressData =
 <<<EOT
         {
-            "shippingAddress": {
+            "billingAddress": {
                 "firstName": "Hieronim",
                 "lastName": "Bosch",
                 "street": "Surrealism St.",
@@ -295,7 +295,7 @@ EOT;
         $addressData =
 <<<EOT
         {
-            "shippingAddress": {
+            "billingAddress": {
                 "firstName": "Vincent",
                 "lastName": "van Gogh",
                 "street": "Post-Impressionism St.",
@@ -315,7 +315,7 @@ EOT;
         $newAddressData =
 <<<EOT
         {
-            "shippingAddress": {
+            "billingAddress": {
                 "firstName": "Hieronim",
                 "lastName": "Bosch",
                 "street": "Surrealism St.",

--- a/tests/Controller/CheckoutAddressingApiTest.php
+++ b/tests/Controller/CheckoutAddressingApiTest.php
@@ -55,7 +55,7 @@ final class CheckoutAddressingApiTest extends CheckoutApiTestCase
         $data =
 <<<EOT
         {
-            "differentBillingAddress": false
+            "differentShippingAddress": false
         }
 EOT;
 
@@ -88,7 +88,7 @@ EOT;
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "differentBillingAddress": false
+            "differentShippingAddress": false
         }
 EOT;
 
@@ -122,7 +122,7 @@ EOT;
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "differentBillingAddress": true
+            "differentShippingAddress": true
         }
 EOT;
 
@@ -163,7 +163,7 @@ EOT;
                 "city": "Groot Zundert",
                 "postcode": "88-888"
             },
-            "differentBillingAddress": true
+            "differentShippingAddress": true
         }
 EOT;
 
@@ -201,7 +201,7 @@ EOT;
                 "city": "Groot Zundert",
                 "postcode": "88-888"
             },
-            "differentBillingAddress": false
+            "differentShippingAddress": false
         }
 EOT;
 
@@ -218,7 +218,7 @@ EOT;
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "differentBillingAddress": false
+            "differentShippingAddress": false
         }
 EOT;
 
@@ -251,7 +251,7 @@ EOT;
                 "city": "Groot Zundert",
                 "postcode": "88-888"
             },
-            "differentBillingAddress": false
+            "differentShippingAddress": false
         }
 EOT;
 
@@ -270,7 +270,7 @@ EOT;
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "differentBillingAddress": false
+            "differentShippingAddress": false
         }
 EOT;
 
@@ -303,7 +303,7 @@ EOT;
                 "city": "Groot Zundert",
                 "postcode": "88-888"
             },
-            "differentBillingAddress": false
+            "differentShippingAddress": false
         }
 EOT;
 
@@ -323,7 +323,7 @@ EOT;
                 "city": "’s-Hertogenbosch",
                 "postcode": "99-999"
             },
-            "differentBillingAddress": false
+            "differentShippingAddress": false
         }
 EOT;
 

--- a/tests/Controller/CheckoutAddressingApiTest.php
+++ b/tests/Controller/CheckoutAddressingApiTest.php
@@ -180,6 +180,54 @@ EOT;
 
     /**
      * @test
+     *
+     * It is deprecated since Sylius 1.7 and will be removed in Sylius 2.0
+     */
+    public function it_allows_to_address_order_with_different_shipping_and_billing_address_using_different_billing_address_flag(): void
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/countries.yml');
+        $this->loadFixturesFromFile('resources/checkout.yml');
+
+        $cartId = $this->createCart();
+        $this->addItemToCart($cartId);
+
+        $data =
+<<<EOT
+        {
+            "billingAddress": {
+                "firstName": "Hieronim",
+                "lastName": "Bosch",
+                "street": "Surrealism St.",
+                "countryCode": "NL",
+                "city": "’s-Hertogenbosch",
+                "postcode": "99-999"
+            },
+            "shippingAddress": {
+                "firstName": "Vincent",
+                "lastName": "van Gogh",
+                "street": "Post-Impressionism St.",
+                "countryCode": "NL",
+                "city": "Groot Zundert",
+                "postcode": "88-888"
+            },
+            "differentBillingAddress": true
+        }
+EOT;
+
+        $this->client->request('PUT', $this->getAddressingUrl($cartId), [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponseCode($response, Response::HTTP_NO_CONTENT);
+
+        $this->client->request('GET', $this->getCheckoutSummaryUrl($cartId), [], [], static::$authorizedHeaderWithAccept);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'checkout/addressed_order_response');
+    }
+
+    /**
+     * @test
      */
     public function it_allows_to_change_order_address_after_the_order_has_already_been_addressed()
     {

--- a/tests/Controller/CheckoutApiTestCase.php
+++ b/tests/Controller/CheckoutApiTestCase.php
@@ -89,7 +89,7 @@ EOT;
                 "city": "Groot Zundert",
                 "postcode": "88-888"
             },
-            "differentBillingAddress": true
+            "differentShippingAddress": true
         }
 EOT;
 

--- a/tests/Responses/Expected/checkout/addressed_order_response.json
+++ b/tests/Responses/Expected/checkout/addressed_order_response.json
@@ -37,7 +37,7 @@
             }
         }
     },
-    "shippingAddress": {
+    "billingAddress": {
         "firstName": "Hieronim",
         "lastName": "Bosch",
         "countryCode": "NL",
@@ -45,7 +45,7 @@
         "city": "’s-Hertogenbosch",
         "postcode": "99-999"
     },
-    "billingAddress": {
+    "shippingAddress": {
         "firstName": "Vincent",
         "lastName": "van Gogh",
         "countryCode": "NL",

--- a/tests/Responses/Expected/checkout/addressing_invalid_customer.json
+++ b/tests/Responses/Expected/checkout/addressing_invalid_customer.json
@@ -75,7 +75,7 @@
           }
         }
       },
-      "differentBillingAddress": {}
+      "differentShippingAddress": {}
     }
   }
 }

--- a/tests/Responses/Expected/checkout/addressing_validation_failed_billing_address.json
+++ b/tests/Responses/Expected/checkout/addressing_validation_failed_billing_address.json
@@ -52,6 +52,7 @@
                     }
                 }
             },
+            "differentBillingAddress": {},
             "differentShippingAddress": {}
         }
     }

--- a/tests/Responses/Expected/checkout/addressing_validation_failed_billing_address.json
+++ b/tests/Responses/Expected/checkout/addressing_validation_failed_billing_address.json
@@ -52,7 +52,7 @@
                     }
                 }
             },
-            "differentBillingAddress": {}
+            "differentShippingAddress": {}
         }
     }
 }

--- a/tests/Responses/Expected/checkout/addressing_validation_failed_billing_address.json
+++ b/tests/Responses/Expected/checkout/addressing_validation_failed_billing_address.json
@@ -3,7 +3,7 @@
     "message": "Validation Failed",
     "errors": {
         "children": {
-            "shippingAddress": {
+            "billingAddress": {
                 "children": {
                     "firstName": {},
                     "lastName": {},
@@ -16,7 +16,7 @@
                     "provinceName": {}
                 }
             },
-            "billingAddress": {
+            "shippingAddress": {
                 "children": {
                     "firstName": {
                         "errors": [

--- a/tests/Responses/Expected/checkout/addressing_validation_failed_shipping_address.json
+++ b/tests/Responses/Expected/checkout/addressing_validation_failed_shipping_address.json
@@ -3,7 +3,7 @@
     "message": "Validation Failed",
     "errors": {
         "children": {
-            "shippingAddress": {
+            "billingAddress": {
                 "children": {
                     "firstName": {
                         "errors": [
@@ -39,7 +39,7 @@
                     }
                 }
             },
-            "billingAddress": {
+            "shippingAddress": {
                 "children": {
                     "firstName": {
                         "errors": [

--- a/tests/Responses/Expected/checkout/addressing_validation_failed_shipping_address.json
+++ b/tests/Responses/Expected/checkout/addressing_validation_failed_shipping_address.json
@@ -75,7 +75,7 @@
                     }
                 }
             },
-            "differentBillingAddress": {}
+            "differentShippingAddress": {}
         }
     }
 }

--- a/tests/Responses/Expected/checkout/addressing_validation_failed_shipping_address.json
+++ b/tests/Responses/Expected/checkout/addressing_validation_failed_shipping_address.json
@@ -75,6 +75,7 @@
                     }
                 }
             },
+            "differentBillingAddress": {},
             "differentShippingAddress": {}
         }
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/10575
| License         | MIT

It's the change we need and we deserve 😄 There are a lot of files changed, but it's a change that touches a lot of places in the code.

What needs to be considered - how to keep a BC, as we change the `differentBillingAddress` field to `differentShippingAddress`, which can affect customizations in some Sylius apps.