### PR TITLE
Bug #10951 [Account] fix sync username with customer email

### DIFF
--- a/features/user/managing_customers/adding_customer_account.feature
+++ b/features/user/managing_customers/adding_customer_account.feature
@@ -26,5 +26,6 @@ Feature: Adding a new customer account
         And I specify their password as "killSauron"
         And I save my changes
         Then I should be notified that it has been successfully edited
+        And I should not see create account option
         And the customer "f.baggins@example.com" should appear in the store
         And this customer should have an account created

--- a/src/Sylius/Bundle/CoreBundle/EventListener/DefaultUsernameORMListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/DefaultUsernameORMListener.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\UnitOfWork;
 use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Core\Model\ShopUserInterface;
 
 /**
  * Keeps user's username synchronized with email.
@@ -35,13 +36,20 @@ final class DefaultUsernameORMListener
 
     private function processEntities(array $entities, EntityManagerInterface $entityManager, UnitOfWork $unitOfWork): void
     {
-        foreach ($entities as $customer) {
-            if (!$customer instanceof CustomerInterface) {
+        foreach ($entities as $entity) {
+            if (!$entity instanceof ShopUserInterface && !$entity instanceof CustomerInterface) {
                 continue;
             }
 
-            $user = $customer->getUser();
-            if (null === $user) {
+            if ($entity instanceof ShopUserInterface) {
+                $user = $entity;
+                $customer = $user->getCustomer();
+            } else {
+                $customer = $entity;
+                $user = $customer->getUser();
+            }
+
+            if (!$customer || !$user) {
                 continue;
             }
 


### PR DESCRIPTION
If applied, this commit will

-make sync behavior works on both customer and shop user,
resulting in username will never by setting username value whenever
shop user or customer is inserted or updated.

| Q               | A
| --------------- | -----
| Branch?         | 1.6 or master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #10951
| License         | MIT

I could have used the solution proposed here 
https://github.com/Sylius/Sylius/issues/10951#issuecomment-566190560
but it might be better if the username is always in sync with customer email