### PR TITLE
Disabled all buttons from the column after click

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/app.js
@@ -62,4 +62,9 @@ $(document).ready(() => {
   });
 
   $('[data-form-type="collection"]').CollectionForm();
+
+  $('[data-js-disable]').on('click', (e) => {
+    const $current = $(e.currentTarget);
+    $(document).find($current.attr('data-js-disable')).not($current).addClass('disabled').prop('disabled', true);
+  });
 });

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/applyTransition.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/applyTransition.html.twig
@@ -2,6 +2,8 @@
     <form action="{{ path(options.link.route, options.link.parameters) }}" method="post">
         <input type="hidden" name="_csrf_token" value="{{ csrf_token(data.id) }}">
         <input type="hidden" name="_method" value="PUT">
-        <button class="ui loadable {{ options.class|default }} labeled icon button" type="submit"><i class="{{ action.icon }} icon"></i> {{ action.label|trans }}</button>
+        <button class="ui loadable {{ options.class|default }} labeled icon button" type="submit" data-js-disable=".sylius-grid-table-wrapper button, .sylius-grid-table-wrapper a">
+            <i class="{{ action.icon }} icon"></i> {{ action.label|trans }}
+        </button>
     </form>
 {% endif %}


### PR DESCRIPTION

![Nagranie z ekranu 2020-01-22 o 12 49 32](https://user-images.githubusercontent.com/15385420/72897231-c960c980-3d21-11ea-81df-0f7e182272f3.gif)

works the same on all index pages with a "transition" buttons (payments, shipments, product reviews...)
