### PR TITLE
Define countries for a channel

### DIFF
--- a/app/migrations/Version20200122082429.php
+++ b/app/migrations/Version20200122082429.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200122082429 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE sylius_channel_countries (channel_id INT NOT NULL, country_id INT NOT NULL, INDEX IDX_D96E51AE72F5A1AA (channel_id), INDEX IDX_D96E51AEF92F3E70 (country_id), PRIMARY KEY(channel_id, country_id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE sylius_channel_countries ADD CONSTRAINT FK_D96E51AE72F5A1AA FOREIGN KEY (channel_id) REFERENCES sylius_channel (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE sylius_channel_countries ADD CONSTRAINT FK_D96E51AEF92F3E70 FOREIGN KEY (country_id) REFERENCES sylius_country (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP TABLE sylius_channel_countries');
+    }
+}

--- a/docs/book/configuration/channels.rst
+++ b/docs/book/configuration/channels.rst
@@ -19,6 +19,7 @@ Or pretty much any other channel type you can imagine.
 * products,
 * currencies,
 * locales (language),
+* countries,
 * themes,
 * hostnames,
 * taxes,

--- a/features/channel/managing_channels/adding_channel.feature
+++ b/features/channel/managing_channels/adding_channel.feature
@@ -7,6 +7,7 @@ Feature: Adding a new channel
     Background:
         Given the store has currency "Euro"
         And the store has locale "English (United States)"
+        And the store operates in "United States" and "Poland"
         And I am logged in as an administrator
 
     @ui
@@ -32,6 +33,7 @@ Feature: Adding a new channel
         And I define its type as mobile
         And I choose "Euro" as the base currency
         And I choose "English (United States)" as a default locale
+        And I choose "United States" and "Poland" as operating countries
         And I allow to skip shipping step if only one shipping method is available
         And I allow to skip payment step if only one payment method is available
         And I add it

--- a/features/checkout/addressing_order/restricting_list_of_countries_available_for_addressing.feature
+++ b/features/checkout/addressing_order/restricting_list_of_countries_available_for_addressing.feature
@@ -1,0 +1,26 @@
+@checkout
+Feature: Restricting list of countries available for addressing
+    In order to make choosing countries easier
+    As a Customer
+    I want to have only available countries listed
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store operates in "Poland"
+        And the store has a product "PHP T-Shirt" priced at "$19.99"
+        And the store ships everywhere for free
+        And I am a logged in customer
+
+    @ui
+    Scenario: Having only countries available for current channel listed
+        Given this channel operates in the "United States" country
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
+        Then I should have only "United States" country available to choose from
+
+    @ui
+    Scenario: Having all the countries listed if channel does not define available ones
+        Given this channel does not define operating countries
+        When I add product "PHP T-Shirt" to the cart
+        And I go to the checkout addressing step
+        Then I should have both "United States" and "Poland" countries available to choose from

--- a/src/Sylius/Behat/Context/Setup/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Setup/ChannelContext.php
@@ -239,6 +239,28 @@ final class ChannelContext implements Context
     }
 
     /**
+     * @Given /^(this channel) operates in the ("[^"]+" country)$/
+     */
+    public function channelOperatesInCountry(ChannelInterface $channel, CountryInterface $country): void
+    {
+        $channel->addCountry($country);
+
+        $this->channelManager->flush();
+    }
+
+    /**
+     * @Given /^(this channel) does not define operating countries$/
+     */
+    public function channelDoesNotDefineOperatingCountries(ChannelInterface $channel): void
+    {
+        foreach ($channel->getCountries() as $country) {
+            $channel->removeCountry($country);
+        }
+
+        $this->channelManager->flush();
+    }
+
+    /**
      * @param bool $state
      */
     private function changeChannelState(ChannelInterface $channel, $state)

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingChannelsContext.php
@@ -103,6 +103,14 @@ final class ManagingChannelsContext implements Context
     }
 
     /**
+     * @When I choose :firstCountry and :secondCountry as operating countries
+     */
+    public function iChooseOperatingCountries(string ...$countries): void
+    {
+        $this->createPage->chooseOperatingCountries($countries);
+    }
+
+    /**
      * @When I specify menu taxon as :menuTaxon
      */
     public function iSpecifyMenuTaxonAs(string $menuTaxon): void

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
@@ -56,9 +56,10 @@ final class CheckoutAddressingContext implements Context
 
     /**
      * @Given I am at the checkout addressing step
+     * @When I go to the checkout addressing step
      * @When I go back to addressing step of the checkout
      */
-    public function iAmAtTheCheckoutAddressingStep()
+    public function iAmAtTheCheckoutAddressingStep(): void
     {
         $this->addressPage->open();
     }
@@ -383,6 +384,23 @@ final class CheckoutAddressingContext implements Context
     {
         $this->assertElementValidationMessage($type, $firstElement, sprintf('Please enter %s.', $firstElement));
         $this->assertElementValidationMessage($type, $secondElement, sprintf('Please enter %s.', $secondElement));
+    }
+
+    /**
+     * @Then I should have only :firstCountry country available to choose from
+     * @Then I should have both :firstCountry and :secondCountry countries available to choose from
+     */
+    public function shouldHaveCountriesToChooseFrom(string ...$countries): void
+    {
+        $availableShippingCountries = $this->addressPage->getAvailableShippingCountries();
+        $availableBillingCountries = $this->addressPage->getAvailableBillingCountries();
+
+        sort($countries);
+        sort($availableShippingCountries);
+        sort($availableBillingCountries);
+
+        Assert::same($availableShippingCountries, $countries);
+        Assert::same($availableBillingCountries, $countries);
     }
 
     /**

--- a/src/Sylius/Behat/Page/Admin/Channel/CreatePage.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/CreatePage.php
@@ -65,6 +65,13 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         }
     }
 
+    public function chooseOperatingCountries(array $countries): void
+    {
+        foreach ($countries as $country) {
+            $this->getElement('countries')->selectOption($country, true);
+        }
+    }
+
     public function chooseBaseCurrency(?string $currency): void
     {
         if (null !== $currency) {
@@ -110,6 +117,7 @@ class CreatePage extends BaseCreatePage implements CreatePageInterface
         return array_merge(parent::getDefinedElements(), [
             'base_currency' => '#sylius_channel_baseCurrency',
             'code' => '#sylius_channel_code',
+            'countries' => '#sylius_channel_countries',
             'currencies' => '#sylius_channel_currencies',
             'default_locale' => '#sylius_channel_defaultLocale',
             'enabled' => '#sylius_channel_enabled',

--- a/src/Sylius/Behat/Page/Admin/Channel/CreatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Channel/CreatePageInterface.php
@@ -41,6 +41,9 @@ interface CreatePageInterface extends BaseCreatePageInterface
 
     public function chooseDefaultLocale(?string $locale): void;
 
+    /** @param string[] $countries */
+    public function chooseOperatingCountries(array $countries): void;
+
     public function chooseBaseCurrency(?string $currency): void;
 
     public function chooseTaxCalculationStrategy(string $taxCalculationStrategy): void;

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPage.php
@@ -250,6 +250,16 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
         return $this->getPreFilledAddress(self::TYPE_BILLING);
     }
 
+    public function getAvailableShippingCountries(): array
+    {
+        return $this->getOptionsFromSelect($this->getElement('shipping_country'));
+    }
+
+    public function getAvailableBillingCountries(): array
+    {
+        return $this->getOptionsFromSelect($this->getElement('billing_country'));
+    }
+
     protected function getDefinedElements(): array
     {
         return array_merge(parent::getDefinedElements(), [
@@ -281,6 +291,18 @@ class AddressPage extends SymfonyPage implements AddressPageInterface
             'shipping_province' => '[data-test-shipping-address] [data-test-province-name]',
             'shipping_street' => '[data-test-shipping-street]',
         ]);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getOptionsFromSelect(NodeElement $element): array
+    {
+        return array_map(
+            /** @return string[] */
+            static function (NodeElement $element): string { return $element->getText(); },
+            $element->findAll('css', 'option[value!=""]')
+        );
     }
 
     private function getPreFilledAddress(string $type): AddressInterface

--- a/src/Sylius/Behat/Page/Shop/Checkout/AddressPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/AddressPageInterface.php
@@ -65,4 +65,10 @@ interface AddressPageInterface extends SymfonyPageInterface
     public function getPreFilledShippingAddress(): AddressInterface;
 
     public function getPreFilledBillingAddress(): AddressInterface;
+
+    /** @return string[] */
+    public function getAvailableShippingCountries(): array;
+
+    /** @return string[] */
+    public function getAvailableBillingCountries(): array;
 }

--- a/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/Type/CountryChoiceType.php
@@ -15,8 +15,10 @@ namespace Sylius\Bundle\AddressingBundle\Form\Type;
 
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Symfony\Bridge\Doctrine\Form\DataTransformer\CollectionToArrayTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -28,6 +30,13 @@ final class CountryChoiceType extends AbstractType
     public function __construct(RepositoryInterface $countryRepository)
     {
         $this->countryRepository = $countryRepository;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        if ($options['multiple']) {
+            $builder->addModelTransformer(new CollectionToArrayTransformer());
+        }
     }
 
     /**
@@ -45,14 +54,6 @@ final class CountryChoiceType extends AbstractType
                         $countries = $this->countryRepository->findBy(['enabled' => $options['enabled']]);
                     }
 
-                    if ($options['choice_filter']) {
-                        $countries = array_filter($countries, $options['choice_filter']);
-                    }
-
-                    usort($countries, function (CountryInterface $a, CountryInterface $b): int {
-                        return $a->getName() <=> $b->getName();
-                    });
-
                     return $countries;
                 },
                 'choice_value' => 'code',
@@ -63,6 +64,17 @@ final class CountryChoiceType extends AbstractType
                 'placeholder' => 'sylius.form.country.select',
             ])
             ->setAllowedTypes('choice_filter', ['null', 'callable'])
+            ->setNormalizer('choices', static function (Options $options, array $countries): array {
+                if ($options['choice_filter']) {
+                    $countries = array_filter($countries, $options['choice_filter']);
+                }
+
+                usort($countries, static function (CountryInterface $firstCountry, CountryInterface $secondCountry): int {
+                    return $firstCountry->getName() <=> $secondCountry->getName();
+                });
+
+                return $countries;
+            })
         ;
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Channel/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Channel/_form.html.twig
@@ -31,6 +31,9 @@
             {{ form_row(form.contactEmail) }}
             {{ form_row(form.description, {'attr': {'rows' : '3'}}) }}
         </div>
+        <div class="ui attached segment">
+            {{ form_row(form.countries) }}
+        </div>
         <div class="ui hidden divider"></div>
         <h4 class="ui top attached large header">{{ 'sylius.ui.money'|trans }}</h4>
         <div class="ui attached segment">

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/AddressTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/AddressTypeExtension.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Form\Extension;
+
+use Sylius\Bundle\AddressingBundle\Form\Type\AddressType;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class AddressTypeExtension extends AbstractTypeExtension
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver
+            ->setDefault('channel', null)
+            ->setAllowedTypes('channel', ['null', ChannelInterface::class])
+        ;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        /** @var ChannelInterface|null $channel */
+        $channel = $options['channel'];
+
+        if ($channel === null || $channel->getCountries()->count() === 0) {
+            return;
+        }
+
+        $oldCountryCodeField = $builder->get('countryCode');
+
+        $countryCodeField = $builder->create(
+            $oldCountryCodeField->getName(),
+            get_class($oldCountryCodeField->getType()->getInnerType()),
+            array_replace($oldCountryCodeField->getOptions(), ['choices' => $channel->getCountries()->toArray()])
+        );
+
+        $builder->add($countryCodeField);
+    }
+
+    public static function getExtendedTypes(): array
+    {
+        return [AddressType::class];
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Form\Extension;
 
+use Sylius\Bundle\AddressingBundle\Form\Type\CountryChoiceType;
 use Sylius\Bundle\AddressingBundle\Form\Type\ZoneChoiceType;
 use Sylius\Bundle\ChannelBundle\Form\Type\ChannelType;
 use Sylius\Bundle\CoreBundle\Form\EventSubscriber\AddBaseCurrencySubscriber;
@@ -51,6 +52,11 @@ final class ChannelTypeExtension extends AbstractTypeExtension
             ])
             ->add('currencies', CurrencyChoiceType::class, [
                 'label' => 'sylius.form.channel.currencies',
+                'required' => false,
+                'multiple' => true,
+            ])
+            ->add('countries', CountryChoiceType::class, [
+                'label' => 'sylius.form.channel.countries',
                 'required' => false,
                 'multiple' => true,
             ])

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
@@ -56,6 +56,16 @@
                 </inverse-join-columns>
             </join-table>
         </many-to-many>
+        <many-to-many field="countries" target-entity="Sylius\Component\Addressing\Model\CountryInterface" fetch="EAGER">
+            <join-table name="sylius_channel_countries">
+                <join-columns>
+                    <join-column name="channel_id" nullable="false" on-delete="CASCADE" />
+                </join-columns>
+                <inverse-join-columns>
+                    <join-column name="country_id" nullable="false" on-delete="CASCADE" />
+                </inverse-join-columns>
+            </join-table>
+        </many-to-many>
 
         <one-to-one field="shopBillingData" target-entity="Sylius\Component\Core\Model\ShopBillingData">
             <join-column name="shop_billing_data_id" on-delete="CASCADE"/>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
@@ -54,6 +54,9 @@
     <services>
         <defaults public="true" />
 
+        <service id="sylius.form.extension.type.address" class="Sylius\Bundle\CoreBundle\Form\Extension\AddressTypeExtension">
+            <tag name="form.type_extension" extended-type="Sylius\Bundle\AddressingBundle\Form\Type\AddressType" />
+        </service>
         <service id="sylius.form.extension.type.country" class="Sylius\Bundle\CoreBundle\Form\Extension\CountryTypeExtension">
             <argument type="service" id="sylius.repository.country" />
             <tag name="form.type_extension" extended-type="Sylius\Bundle\AddressingBundle\Form\Type\CountryType" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
@@ -32,6 +32,7 @@ sylius:
                 street: Street
                 tax_id: Tax ID
             contact_email: Contact email
+            countries: Countries
             currencies: Currencies
             currency_base: Base currency
             account_verification_required: Is account verification required?

--- a/src/Sylius/Component/Core/Model/Channel.php
+++ b/src/Sylius/Component/Core/Model/Channel.php
@@ -15,6 +15,7 @@ namespace Sylius\Component\Core\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Channel\Model\Channel as BaseChannel;
 use Sylius\Component\Currency\Model\CurrencyInterface;
@@ -48,6 +49,13 @@ class Channel extends BaseChannel implements ChannelInterface
      */
     protected $locales;
 
+    /**
+     * @var Collection|CountryInterface[]
+     *
+     * @psalm-var Collection<array-key, CountryInterface>
+     */
+    protected $countries;
+
     /** @var string */
     protected $themeName;
 
@@ -77,6 +85,8 @@ class Channel extends BaseChannel implements ChannelInterface
         $this->currencies = new ArrayCollection();
         /** @var ArrayCollection<array-key, LocaleInterface> $this->locales */
         $this->locales = new ArrayCollection();
+        /** @var ArrayCollection<array-key, CountryInterface> $this->countries */
+        $this->countries = new ArrayCollection();
     }
 
     /**
@@ -213,6 +223,30 @@ class Channel extends BaseChannel implements ChannelInterface
     public function hasLocale(LocaleInterface $locale): bool
     {
         return $this->locales->contains($locale);
+    }
+
+    public function getCountries(): Collection
+    {
+        return $this->countries;
+    }
+
+    public function addCountry(CountryInterface $country): void
+    {
+        if (!$this->hasCountry($country)) {
+            $this->countries->add($country);
+        }
+    }
+
+    public function removeCountry(CountryInterface $country): void
+    {
+        if ($this->hasCountry($country)) {
+            $this->countries->removeElement($country);
+        }
+    }
+
+    public function hasCountry(CountryInterface $country): bool
+    {
+        return $this->countries->contains($country);
     }
 
     /**

--- a/src/Sylius/Component/Core/Model/ChannelInterface.php
+++ b/src/Sylius/Component/Core/Model/ChannelInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Model;
 
+use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Channel\Model\ChannelInterface as BaseChannelInterface;
 use Sylius\Component\Currency\Model\CurrenciesAwareInterface;
@@ -68,4 +70,17 @@ interface ChannelInterface extends
     public function getMenuTaxon(): ?TaxonInterface;
 
     public function setMenuTaxon(?TaxonInterface $menuTaxon): void;
+
+    /**
+     * @return Collection|CountryInterface[]
+     *
+     * @psalm-return Collection<array-key, CountryInterface>
+     */
+    public function getCountries(): Collection;
+
+    public function addCountry(CountryInterface $country): void;
+
+    public function removeCountry(CountryInterface $country): void;
+
+    public function hasCountry(CountryInterface $country): bool;
 }

--- a/tests/Responses/Expected/channel/create_validation_fail_response.json
+++ b/tests/Responses/Expected/channel/create_validation_fail_response.json
@@ -24,6 +24,7 @@
         ]
       },
       "currencies": {},
+      "countries": {},
       "defaultTaxZone": {},
       "taxCalculationStrategy": {
         "errors": [

--- a/tests/Responses/Expected/channel/update_validation_fail_response.json
+++ b/tests/Responses/Expected/channel/update_validation_fail_response.json
@@ -16,6 +16,7 @@
             "locales": {},
             "defaultLocale": {},
             "currencies": {},
+            "countries": {},
             "defaultTaxZone": {},
             "taxCalculationStrategy": {
                 "errors": [


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #9122 
| License         | MIT

Currently used only in checkout addressing to limit the list of countries. If not defined, fallbacks to the previous behaviour - all enabled countries.

<img width="672" alt="Screenshot 2020-01-22 at 20 10 51" src="https://user-images.githubusercontent.com/1897953/72925676-65ef8f80-3d53-11ea-831c-25fad0973a83.png">

