### PR TITLE
Rendering multiple dependent template events at once + admin-side CRUD events

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
@@ -63,3 +63,166 @@ liip_imagine:
 
 sonata_block:
     default_contexts: ~
+
+sylius_ui:
+    events:
+        sylius.admin.index:
+            blocks:
+                before_header_legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    priority: 25
+                    context:
+                        postfix: index.before_header 
+                header:
+                    template: "@SyliusUi/Block/_include.html.twig"
+                    priority: 20
+                    context:
+                        template: "@SyliusAdmin/Crud/Index/_header.html.twig"
+                after_header_legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    priority: 15
+                    context:
+                        postfix: index.after_header
+                content:
+                    template: "@SyliusUi/Block/_include.html.twig"
+                    priority: 10
+                    context:
+                        template: "@SyliusAdmin/Crud/Index/_content.html.twig"
+                after_content: 
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    priority: 5
+                    context:
+                        postfix: index.after_content 
+        
+        sylius.admin.index.stylesheets:
+            blocks:
+                legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    context:
+                        postfix: index.stylesheets
+                        
+        sylius.admin.index.javascripts:
+            blocks:
+                legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    context:
+                        postfix: index.javascripts
+                        
+        sylius.admin.index.header:
+            blocks:
+                legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    context:
+                        postfix: index.header
+                        
+        sylius.admin.create:
+            blocks:
+                before_header_legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    priority: 25
+                    context:
+                        postfix: create.before_header 
+                header:
+                    template: "@SyliusUi/Block/_include.html.twig"
+                    priority: 20
+                    context:
+                        template: "@SyliusAdmin/Crud/Create/_header.html.twig"
+                after_header_legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    priority: 15
+                    context:
+                        postfix: create.after_header
+                content:
+                    template: "@SyliusUi/Block/_include.html.twig"
+                    priority: 10
+                    context:
+                        template: "@SyliusAdmin/Crud/Create/_content.html.twig"
+                after_content: 
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    priority: 5
+                    context:
+                        postfix: create.after_content 
+        
+        sylius.admin.create.stylesheets:
+            blocks:
+                legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    context:
+                        postfix: create.stylesheets
+                        
+        sylius.admin.create.javascripts:
+            blocks:
+                legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    context:
+                        postfix: create.javascripts
+                        
+        sylius.admin.create.header:
+            blocks:
+                legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    context:
+                        postfix: create.header
+                        
+        sylius.admin.create.form:
+            blocks:
+                legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    context:
+                        postfix: create.form
+                        
+        sylius.admin.update:
+            blocks:
+                before_header_legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    priority: 25
+                    context:
+                        postfix: update.before_header 
+                header:
+                    template: "@SyliusUi/Block/_include.html.twig"
+                    priority: 20
+                    context:
+                        template: "@SyliusAdmin/Crud/Update/_header.html.twig"
+                after_header_legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    priority: 15
+                    context:
+                        postfix: update.after_header
+                content:
+                    template: "@SyliusUi/Block/_include.html.twig"
+                    priority: 10
+                    context:
+                        template: "@SyliusAdmin/Crud/Update/_content.html.twig"
+                after_content: 
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    priority: 5
+                    context:
+                        postfix: update.after_content 
+        
+        sylius.admin.update.stylesheets:
+            blocks:
+                legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    context:
+                        postfix: update.stylesheets
+                        
+        sylius.admin.update.javascripts:
+            blocks:
+                legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    context:
+                        postfix: update.javascripts
+                        
+        sylius.admin.update.header:
+            blocks:
+                legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    context:
+                        postfix: update.header
+                        
+        sylius.admin.update.form:
+            blocks:
+                legacy:
+                    template: "@SyliusAdmin/Crud/Block/_legacySonataEvent.html.twig"
+                    context:
+                        postfix: update.form

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Block/_legacySonataEvent.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Block/_legacySonataEvent.html.twig
@@ -1,0 +1,1 @@
+{{ sonata_block_render_event(metadata.applicationName ~ '.admin.' ~ metadata.name ~ '.' ~ postfix, context|default({})) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_content.html.twig
@@ -13,7 +13,7 @@
         {{ form_widget(form) }}
     {% endif %}
 
-    {{ sonata_block_render_event(event_prefix ~ '.form', {'resource': resource, 'form': form}) }}
+    {{ sylius_template_event([event_prefix ~ '.form', 'sylius.admin.create.form'], {'metadata': metadata, 'resource': resource, 'form': form}) }}
 
     {% include '@SyliusUi/Form/Buttons/_create.html.twig' with {'paths': {'cancel': index_url}} %}
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_header.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_header.html.twig
@@ -3,7 +3,7 @@
         {% include configuration.vars.templates.header_title|default('@SyliusAdmin/Crud/Create/_headerTitle.html.twig') %}
         {% include configuration.vars.templates.breadcrumb|default('@SyliusAdmin/Crud/Create/_breadcrumb.html.twig') %}
 
-        {{ sonata_block_render_event(event_prefix ~ '.header', {'resource': resource}) }}
+        {{ sylius_template_event([event_prefix ~ '.header', 'sylius.admin.create.header'], {'metadata': metadata, 'resource': resource}) }}
     </div>
     <div class="middle aligned column">
         {% include configuration.vars.templates.toolbar|default('@SyliusAdmin/Crud/_toolbar.html.twig') ignore missing %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Index/_header.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Index/_header.html.twig
@@ -3,7 +3,7 @@
         {% include configuration.vars.templates.header_title|default('@SyliusAdmin/Crud/Index/_headerTitle.html.twig') %}
         {% include configuration.vars.templates.breadcrumb|default('@SyliusAdmin/Crud/Index/_breadcrumb.html.twig') %}
 
-        {{ sonata_block_render_event(event_prefix ~ '.header', {'resources': resources}) }}
+        {{ sylius_template_event([event_prefix ~ '.header', 'sylius.admin.index.header'], {'metadata': metadata, 'resources': resources}) }}
     </div>
 
     {% include '@SyliusAdmin/Crud/Index/_actions.html.twig' %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
@@ -14,7 +14,7 @@
         {{ form_widget(form) }}
     {% endif %}
 
-    {{ sonata_block_render_event(event_prefix ~ '.form', {'resource': resource, 'form': form}) }}
+    {{ sylius_template_event([event_prefix ~ '.form', 'sylius.admin.update.form'], {'metadata': metadata, 'resource': resource, 'form': form}) }}
 
     {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': index_url}} %}
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_header.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_header.html.twig
@@ -3,7 +3,7 @@
         {% include configuration.vars.templates.header_title|default('@SyliusAdmin/Crud/Update/_headerTitle.html.twig') %}
         {% include configuration.vars.templates.breadcrumb|default('@SyliusAdmin/Crud/Update/_breadcrumb.html.twig') %}
 
-        {{ sonata_block_render_event(event_prefix ~ '.header', {'resource': resource}) }}
+        {{ sylius_template_event([event_prefix ~ '.header', 'sylius.admin.update.header'], {'metadata': metadata, 'resource': resource}) }}
     </div>
     <div class="middle aligned column">
         {% include configuration.vars.templates.toolbar|default('@SyliusAdmin/Crud/_toolbar.html.twig') ignore missing %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/create.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/create.html.twig
@@ -8,25 +8,17 @@
 {% form_theme form '@SyliusAdmin/Form/theme.html.twig' %}
 
 {% block content %}
-{{ sonata_block_render_event(event_prefix ~ '.before_header', {'resource': resource}) }}
-
-{% include '@SyliusAdmin/Crud/Create/_header.html.twig' %}
-
-{{ sonata_block_render_event(event_prefix ~ '.after_header', {'resource': resource}) }}
-
-{% include '@SyliusAdmin/Crud/Create/_content.html.twig' %}
-
-{{ sonata_block_render_event(event_prefix ~ '.after_content', {'resource': resource}) }}
+    {{ sylius_template_event([event_prefix, 'sylius.admin.create'], _context) }}
 {% endblock %}
 
 {% block stylesheets %}
     {{ parent() }}
 
-    {{ sonata_block_render_event(event_prefix ~ '.stylesheets') }}
+    {{ sylius_template_event([event_prefix ~ '.stylesheets', 'sylius.admin.create.stylesheets'], { 'metadata': metadata }) }}
 {% endblock %}
 
 {% block javascripts %}
     {{ parent() }}
 
-    {{ sonata_block_render_event(event_prefix ~ '.javascripts') }}
+    {{ sylius_template_event([event_prefix ~ '.javascripts', 'sylius.admin.create.javascripts'], { 'metadata': metadata }) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/index.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/index.html.twig
@@ -9,25 +9,17 @@
 {% block title %}{{ header|trans }} {{ parent() }}{% endblock %}
 
 {% block content %}
-{{ sonata_block_render_event(event_prefix ~ '.before_header', {'resources': resources}) }}
-
-{% include '@SyliusAdmin/Crud/Index/_header.html.twig' %}
-
-{{ sonata_block_render_event(event_prefix ~ '.after_header', {'resources': resources}) }}
-
-{% include '@SyliusAdmin/Crud/Index/_content.html.twig' %}
-
-{{ sonata_block_render_event(event_prefix ~ '.after_content', {'resources': resources}) }}
+    {{ sylius_template_event([event_prefix, 'sylius.admin.index'], _context) }}
 {% endblock %}
 
 {% block stylesheets %}
     {{ parent() }}
 
-    {{ sonata_block_render_event(event_prefix ~ '.stylesheets') }}
+    {{ sylius_template_event([event_prefix ~ '.stylesheets', 'sylius.admin.index.stylesheets'], { 'metadata': metadata }) }}
 {% endblock %}
 
 {% block javascripts %}
     {{ parent() }}
 
-    {{ sonata_block_render_event(event_prefix ~ '.javascripts') }}
+    {{ sylius_template_event([event_prefix ~ '.javascripts', 'sylius.admin.index.javascripts'], { 'metadata': metadata }) }}
 {% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/update.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/update.html.twig
@@ -8,25 +8,17 @@
 {% form_theme form '@SyliusAdmin/Form/theme.html.twig' %}
 
 {% block content %}
-{{ sonata_block_render_event(event_prefix ~ '.before_header', {'resource': resource}) }}
-
-{% include '@SyliusAdmin/Crud/Update/_header.html.twig' %}
-
-{{ sonata_block_render_event(event_prefix ~ '.after_header', {'resource': resource}) }}
-
-{% include '@SyliusAdmin/Crud/Update/_content.html.twig' %}
-
-{{ sonata_block_render_event(event_prefix ~ '.after_content', {'resource': resource}) }}
+    {{ sylius_template_event([event_prefix, 'sylius.admin.update'], _context) }}
 {% endblock %}
 
 {% block stylesheets %}
     {{ parent() }}
 
-    {{ sonata_block_render_event(event_prefix ~ '.stylesheets') }}
+    {{ sylius_template_event([event_prefix ~ '.stylesheets', 'sylius.admin.update.stylesheets'], { 'metadata': metadata }) }}
 {% endblock %}
 
 {% block javascripts %}
     {{ parent() }}
 
-    {{ sonata_block_render_event(event_prefix ~ '.javascripts') }}
+    {{ sylius_template_event([event_prefix ~ '.javascripts', 'sylius.admin.update.javascripts'], { 'metadata': metadata }) }}
 {% endblock %}

--- a/src/Sylius/Bundle/UiBundle/DataCollector/TemplateBlockRenderingHistory.php
+++ b/src/Sylius/Bundle/UiBundle/DataCollector/TemplateBlockRenderingHistory.php
@@ -29,17 +29,17 @@ final class TemplateBlockRenderingHistory
     /** @psalm-var array{definition: TemplateBlock, start: float, stop?: float, time?: float} */
     private $currentlyRenderedBlock = [];
 
-    public function startRenderingEvent(string $eventName, array $context): void
+    public function startRenderingEvent(array $eventNames, array $context): void
     {
-        $this->currentlyRenderedEvent = ['name' => $eventName, 'start' => microtime(true), 'blocks' => []];
+        $this->currentlyRenderedEvent = ['names' => $eventNames, 'start' => microtime(true), 'blocks' => []];
     }
 
-    public function startRenderingBlock(string $eventName, TemplateBlock $templateBlock, array $context): void
+    public function startRenderingBlock(TemplateBlock $templateBlock, array $context): void
     {
         $this->currentlyRenderedBlock = ['definition' => $templateBlock, 'start' => microtime(true)];
     }
 
-    public function stopRenderingBlock(string $eventName, TemplateBlock $templateBlock, array $context): void
+    public function stopRenderingBlock(TemplateBlock $templateBlock, array $context): void
     {
         $this->currentlyRenderedBlock['stop'] = microtime(true);
         $this->currentlyRenderedBlock['time'] = $this->currentlyRenderedBlock['stop'] - $this->currentlyRenderedBlock['start'];
@@ -47,7 +47,7 @@ final class TemplateBlockRenderingHistory
         $this->currentlyRenderedBlock = [];
     }
 
-    public function stopRenderingEvent(string $eventName, array $context): void
+    public function stopRenderingEvent(array $eventNames, array $context): void
     {
         $this->currentlyRenderedEvent['stop'] = microtime(true);
         $this->currentlyRenderedEvent['time'] = $this->currentlyRenderedEvent['stop'] - $this->currentlyRenderedEvent['start'];

--- a/src/Sylius/Bundle/UiBundle/DataCollector/TraceableTemplateBlockRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/DataCollector/TraceableTemplateBlockRenderer.php
@@ -33,13 +33,13 @@ final class TraceableTemplateBlockRenderer implements TemplateBlockRendererInter
         $this->templateBlockRenderingHistory = $templateBlockRenderingHistory;
     }
 
-    public function render(string $eventName, TemplateBlock $templateBlock, array $context = []): string
+    public function render(TemplateBlock $templateBlock, array $context = []): string
     {
-        $this->templateBlockRenderingHistory->startRenderingBlock($eventName, $templateBlock, $context);
+        $this->templateBlockRenderingHistory->startRenderingBlock($templateBlock, $context);
 
-        $renderedBlock = $this->templateBlockRenderer->render($eventName, $templateBlock, $context);
+        $renderedBlock = $this->templateBlockRenderer->render($templateBlock, $context);
 
-        $this->templateBlockRenderingHistory->stopRenderingBlock($eventName, $templateBlock, $context);
+        $this->templateBlockRenderingHistory->stopRenderingBlock($templateBlock, $context);
 
         return $renderedBlock;
     }

--- a/src/Sylius/Bundle/UiBundle/DataCollector/TraceableTemplateEventRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/DataCollector/TraceableTemplateEventRenderer.php
@@ -32,13 +32,13 @@ final class TraceableTemplateEventRenderer implements TemplateEventRendererInter
         $this->templateBlockRenderingHistory = $templateBlockRenderingHistory;
     }
 
-    public function render(string $eventName, array $context = []): string
+    public function render(array $eventNames, array $context = []): string
     {
-        $this->templateBlockRenderingHistory->startRenderingEvent($eventName, $context);
+        $this->templateBlockRenderingHistory->startRenderingEvent($eventNames, $context);
 
-        $renderedEvent = $this->templateEventRenderer->render($eventName, $context);
+        $renderedEvent = $this->templateEventRenderer->render($eventNames, $context);
 
-        $this->templateBlockRenderingHistory->stopRenderingEvent($eventName, $context);
+        $this->templateBlockRenderingHistory->stopRenderingEvent($eventNames, $context);
 
         return $renderedEvent;
     }

--- a/src/Sylius/Bundle/UiBundle/DependencyInjection/Configuration.php
+++ b/src/Sylius/Bundle/UiBundle/DependencyInjection/Configuration.php
@@ -40,14 +40,15 @@ final class Configuration implements ConfigurationInterface
                                     ->canBeDisabled()
                                     ->beforeNormalization()
                                         ->ifString()
-                                        ->then(static function (string $template): array {
+                                        ->then(static function (?string $template): array {
                                             return ['template' => $template];
                                         })
                                     ->end()
                                     ->children()
+                                        ->booleanNode('enabled')->defaultNull()->end()
                                         ->arrayNode('context')->addDefaultsIfNotSet()->ignoreExtraKeys(false)->end()
-                                        ->scalarNode('template')->isRequired()->cannotBeEmpty()->end()
-                                        ->integerNode('priority')->defaultValue(0)->end()
+                                        ->scalarNode('template')->defaultNull()->end()
+                                        ->integerNode('priority')->defaultNull()->end()
         ;
 
         return $treeBuilder;

--- a/src/Sylius/Bundle/UiBundle/DependencyInjection/SyliusUiExtension.php
+++ b/src/Sylius/Bundle/UiBundle/DependencyInjection/SyliusUiExtension.php
@@ -50,13 +50,23 @@ final class SyliusUiExtension extends Extension
             $blocksPriorityQueue = new SplPriorityQueue();
 
             foreach ($eventConfiguration['blocks'] as $blockName => $details) {
-                $blocksPriorityQueue->insert(
-                    new Definition(TemplateBlock::class, [$blockName, $details['template'], $details['context'], $details['priority'], $details['enabled']]),
-                    $details['priority']
-                );
+                $details['name'] = $blockName;
+                $details['eventName'] = $eventName;
+
+                $blocksPriorityQueue->insert($details, $details['priority'] ?? 0);
             }
 
-            $blocksForEvents[$eventName] = $blocksPriorityQueue->toArray();
+            foreach ($blocksPriorityQueue->toArray() as $details) {
+                /** @psalm-var array{name: string, eventName: string, template: string, context: array, priority: int, enabled: bool} $details */
+                $blocksForEvents[$eventName][$details['name']] = new Definition(TemplateBlock::class, [
+                    $details['name'],
+                    $details['eventName'],
+                    $details['template'],
+                    $details['context'],
+                    $details['priority'],
+                    $details['enabled'],
+                ]);
+            }
         }
 
         $templateBlockRegistryDefinition->setArgument(0, $blocksForEvents);

--- a/src/Sylius/Bundle/UiBundle/Registry/TemplateBlock.php
+++ b/src/Sylius/Bundle/UiBundle/Registry/TemplateBlock.php
@@ -19,25 +19,30 @@ final class TemplateBlock
     private $name;
 
     /** @var string */
+    private $eventName;
+
+    /** @var string|null */
     private $template;
 
-    /** @var array */
+    /** @var array|null */
     private $context;
 
-    /** @var int */
+    /** @var int|null */
     private $priority;
 
-    /** @var bool */
+    /** @var bool|null */
     private $enabled;
 
     public function __construct(
         string $name,
-        string $template,
-        array $context,
-        int $priority,
-        bool $enabled
+        string $eventName,
+        ?string $template,
+        ?array $context,
+        ?int $priority,
+        ?bool $enabled
     ) {
         $this->name = $name;
+        $this->eventName = $eventName;
         $this->template = $template;
         $this->context = $context;
         $this->priority = $priority;
@@ -49,23 +54,56 @@ final class TemplateBlock
         return $this->name;
     }
 
+    public function getEventName(): string
+    {
+        return $this->eventName;
+    }
+
     public function getTemplate(): string
     {
+        if ($this->template === null) {
+            throw new \DomainException(sprintf(
+                'There is no template defined for block "%s" in event "%s".',
+                $this->name,
+                $this->eventName
+            ));
+        }
+
         return $this->template;
     }
 
     public function getContext(): array
     {
-        return $this->context;
+        return $this->context ?? [];
     }
 
     public function getPriority(): int
     {
-        return $this->priority;
+        return $this->priority ?? 0;
     }
 
     public function isEnabled(): bool
     {
-        return $this->enabled;
+        return $this->enabled ?? true;
+    }
+
+    public function overwriteWith(self $block): self
+    {
+        if ($this->name !== $block->name) {
+            throw new \DomainException(sprintf(
+                'Trying to overwrite block "%s" with block "%s".',
+                $this->name,
+                $block->name
+            ));
+        }
+
+        return new self(
+            $this->name,
+            $block->eventName,
+            $block->template ?? $this->template,
+            $block->context ?? $this->context,
+            $block->priority ?? $this->priority,
+            $block->enabled ?? $this->enabled
+        );
     }
 }

--- a/src/Sylius/Bundle/UiBundle/Registry/TemplateBlockRegistryInterface.php
+++ b/src/Sylius/Bundle/UiBundle/Registry/TemplateBlockRegistryInterface.php
@@ -17,15 +17,16 @@ interface TemplateBlockRegistryInterface
 {
     /**
      * @return TemplateBlock[][]
-     *
-     * @psalm-return array<string, list<TemplateBlock>>
+     * @psalm-return array<string, array<string, TemplateBlock>>
      */
     public function all(): array;
 
     /**
-     * @return TemplateBlock[]
+     * @param string[] $eventNames
+     * @psalm-param non-empty-list<string> $eventNames
      *
+     * @return TemplateBlock[]
      * @psalm-return list<TemplateBlock>
      */
-    public function findEnabledForEvent(string $eventName): array;
+    public function findEnabledForEvents(array $eventNames): array;
 }

--- a/src/Sylius/Bundle/UiBundle/Renderer/DelegatingTemplateEventRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/DelegatingTemplateEventRenderer.php
@@ -29,13 +29,13 @@ final class DelegatingTemplateEventRenderer implements TemplateEventRendererInte
         $this->templateBlockRenderer = $templateBlockRenderer;
     }
 
-    public function render(string $eventName, array $context = []): string
+    public function render(array $eventNames, array $context = []): string
     {
-        $templateBlocks = $this->templateBlockRegistry->findEnabledForEvent($eventName);
+        $templateBlocks = $this->templateBlockRegistry->findEnabledForEvents($eventNames);
         $renderedTemplates = [];
 
         foreach ($templateBlocks as $templateBlock) {
-            $renderedTemplates[] = $this->templateBlockRenderer->render($eventName, $templateBlock, $context);
+            $renderedTemplates[] = $this->templateBlockRenderer->render($templateBlock, $context);
         }
 
         return implode("\n", $renderedTemplates);

--- a/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateBlockRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateBlockRenderer.php
@@ -25,7 +25,7 @@ final class HtmlDebugTemplateBlockRenderer implements TemplateBlockRendererInter
         $this->templateBlockRenderer = $templateBlockRenderer;
     }
 
-    public function render(string $eventName, TemplateBlock $templateBlock, array $context = []): string
+    public function render(TemplateBlock $templateBlock, array $context = []): string
     {
         $shouldRenderHtmlDebug = strrpos($templateBlock->getTemplate(), '.html.twig') !== false;
 
@@ -34,19 +34,19 @@ final class HtmlDebugTemplateBlockRenderer implements TemplateBlockRendererInter
         if ($shouldRenderHtmlDebug) {
             $renderedParts[] = sprintf(
                 '<!-- BEGIN BLOCK | event name: "%s", block name: "%s", template: "%s", priority: %d -->',
-                $eventName,
+                $templateBlock->getEventName(),
                 $templateBlock->getName(),
                 $templateBlock->getTemplate(),
                 $templateBlock->getPriority()
             );
         }
 
-        $renderedParts[] = $this->templateBlockRenderer->render($eventName, $templateBlock, $context);
+        $renderedParts[] = $this->templateBlockRenderer->render($templateBlock, $context);
 
         if ($shouldRenderHtmlDebug) {
             $renderedParts[] = sprintf(
                 '<!-- END BLOCK | event name: "%s", block name: "%s" -->',
-                $eventName,
+                $templateBlock->getEventName(),
                 $templateBlock->getName()
             );
         }

--- a/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateEventRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateEventRenderer.php
@@ -30,25 +30,25 @@ final class HtmlDebugTemplateEventRenderer implements TemplateEventRendererInter
         $this->templateBlockRegistry = $templateBlockRegistry;
     }
 
-    public function render(string $eventName, array $context = []): string
+    public function render(array $eventNames, array $context = []): string
     {
-        $shouldRenderHtmlDebug = $this->shouldRenderHtmlDebug($this->templateBlockRegistry->findEnabledForEvent($eventName));
+        $shouldRenderHtmlDebug = $this->shouldRenderHtmlDebug($this->templateBlockRegistry->findEnabledForEvents($eventNames));
 
         $renderedParts = [];
 
         if ($shouldRenderHtmlDebug) {
             $renderedParts[] = sprintf(
                 '<!-- BEGIN EVENT | event name: "%s" -->',
-                $eventName
+                implode(', ', $eventNames)
             );
         }
 
-        $renderedParts[] = $this->templateEventRenderer->render($eventName, $context);
+        $renderedParts[] = $this->templateEventRenderer->render($eventNames, $context);
 
         if ($shouldRenderHtmlDebug) {
             $renderedParts[] = sprintf(
                 '<!-- END EVENT | event name: "%s" -->',
-                $eventName
+                implode(', ', $eventNames)
             );
         }
 

--- a/src/Sylius/Bundle/UiBundle/Renderer/TemplateBlockRendererInterface.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/TemplateBlockRendererInterface.php
@@ -17,5 +17,5 @@ use Sylius\Bundle\UiBundle\Registry\TemplateBlock;
 
 interface TemplateBlockRendererInterface
 {
-    public function render(string $eventName, TemplateBlock $templateBlock, array $context = []): string;
+    public function render(TemplateBlock $templateBlock, array $context = []): string;
 }

--- a/src/Sylius/Bundle/UiBundle/Renderer/TemplateEventRendererInterface.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/TemplateEventRendererInterface.php
@@ -15,5 +15,9 @@ namespace Sylius\Bundle\UiBundle\Renderer;
 
 interface TemplateEventRendererInterface
 {
-    public function render(string $eventName, array $context = []): string;
+    /**
+     * @param string[] $eventNames
+     * @psalm-param non-empty-list<string> $eventNames
+     */
+    public function render(array $eventNames, array $context = []): string;
 }

--- a/src/Sylius/Bundle/UiBundle/Renderer/TwigTemplateBlockRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/TwigTemplateBlockRenderer.php
@@ -26,15 +26,11 @@ final class TwigTemplateBlockRenderer implements TemplateBlockRendererInterface
         $this->twig = $twig;
     }
 
-    public function render(string $eventName, TemplateBlock $templateBlock, array $context = []): string
+    public function render(TemplateBlock $templateBlock, array $context = []): string
     {
         return $this->twig->render(
             $templateBlock->getTemplate(),
-            array_replace(
-                $templateBlock->getContext(),
-                $context,
-                ['_event' => $eventName]
-            )
+            array_replace($templateBlock->getContext(), $context)
         );
     }
 }

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Block/_include.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Block/_include.html.twig
@@ -1,0 +1,1 @@
+{% include template %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/DataCollector/templateBlock.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/DataCollector/templateBlock.html.twig
@@ -66,12 +66,19 @@
 
             {% for event in collector.renderedEvents %}
                 <tr>
-                    <td>{{ event.name }}</td>
+                    <td>
+                        {% for name in event.names %}
+                            {% if loop.first %}<strong>{% endif %}
+                            {{ name }}{% if not loop.last %}, {% endif %}
+                            {% if loop.first %}</strong>{% endif %}
+                        {% endfor %}
+                    </td>
                     <td>{{ '%.0f'|format(event.time * 1000) }}ms</td>
                     <td>
                         {% if event.blocks|length > 0 %}
                             <table>
                                 <tr>
+                                    {% if event.names|length > 1 %}<th>Origin event</th>{% endif %}
                                     <th>Name</th>
                                     <th>Template</th>
                                     <th>Duration</th>
@@ -79,6 +86,7 @@
                                 </tr>
                                 {% for block in event.blocks %}
                                     <tr>
+                                        {% if event.names|length > 1 %}<td>{{ block.definition.eventName }}</td>{% endif %}
                                         <td>{{ block.definition.name }}</td>
                                         <td>{{ block.definition.template }}</td>
                                         <td>{{ '%.0f'|format(block.time * 1000) }}ms</td>

--- a/src/Sylius/Bundle/UiBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Sylius/Bundle/UiBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -77,15 +77,6 @@ final class ConfigurationTest extends TestCase
     }
 
     /** @test */
-    public function block_configuration_requires_template_to_be_defined(): void
-    {
-        $this->assertPartialConfigurationIsInvalid(
-            [['events' => ['event_name' => ['blocks' => ['block_name' => []]]]]],
-            'events.*.blocks'
-        );
-    }
-
-    /** @test */
     public function block_has_default_priority_set_to_zero(): void
     {
         $this->assertProcessedConfigurationEquals(
@@ -106,11 +97,11 @@ final class ConfigurationTest extends TestCase
     }
 
     /** @test */
-    public function block_is_enabled_by_default(): void
+    public function block_is_null_by_default(): void
     {
         $this->assertProcessedConfigurationEquals(
             [['events' => ['event_name' => ['blocks' => ['block_name' => []]]]]],
-            ['events' => ['event_name' => ['blocks' => ['block_name' => ['enabled' => true]]]]],
+            ['events' => ['event_name' => ['blocks' => ['block_name' => ['enabled' => null]]]]],
             'events.*.blocks.*.enabled'
         );
     }

--- a/src/Sylius/Bundle/UiBundle/Tests/DependencyInjection/SyliusUiExtensionTest.php
+++ b/src/Sylius/Bundle/UiBundle/Tests/DependencyInjection/SyliusUiExtensionTest.php
@@ -41,11 +41,11 @@ final class SyliusUiExtensionTest extends AbstractExtensionTestCase
             0,
             [
                 'first_event' => [
-                    new Definition(TemplateBlock::class, ['first_block', 'first.html.twig', [], 0, true]),
-                    new Definition(TemplateBlock::class, ['second_block', 'second.html.twig', ['foo' => 'bar'], 0, true]),
+                    'first_block' => new Definition(TemplateBlock::class, ['first_block', 'first_event', 'first.html.twig', [], 0, true]),
+                    'second_block' => new Definition(TemplateBlock::class, ['second_block', 'first_event', 'second.html.twig', ['foo' => 'bar'], 0, true]),
                 ],
                 'second_event' => [
-                    new Definition(TemplateBlock::class, ['another_block', 'another.html.twig', [], 0, true]),
+                    'another_block' => new Definition(TemplateBlock::class, ['another_block', 'second_event', 'another.html.twig', [], 0, true]),
                 ],
             ]
         );
@@ -69,10 +69,10 @@ final class SyliusUiExtensionTest extends AbstractExtensionTestCase
             TemplateBlockRegistryInterface::class,
             0,
             ['event_name' => [
-                new Definition(TemplateBlock::class, ['first_block', 'first.html.twig', [], 5, true]),
-                new Definition(TemplateBlock::class, ['second_block', 'second.html.twig', [], 0, true]),
-                new Definition(TemplateBlock::class, ['third_block', 'third.html.twig', [], 0, true]),
-                new Definition(TemplateBlock::class, ['fourth_block', 'fourth.html.twig', [], -5, true]),
+                'first_block' => new Definition(TemplateBlock::class, ['first_block', 'event_name', 'first.html.twig', [], 5, true]),
+                'second_block' => new Definition(TemplateBlock::class, ['second_block', 'event_name', 'second.html.twig', [], 0, true]),
+                'third_block' => new Definition(TemplateBlock::class, ['third_block', 'event_name', 'third.html.twig', [], 0, true]),
+                'fourth_block' => new Definition(TemplateBlock::class, ['fourth_block', 'event_name', 'fourth.html.twig', [], -5, true]),
             ]]
         );
     }

--- a/src/Sylius/Bundle/UiBundle/Tests/Functional/Kernel.php
+++ b/src/Sylius/Bundle/UiBundle/Tests/Functional/Kernel.php
@@ -80,6 +80,29 @@ final class Kernel extends HttpKernel
                     ],
                 ],
             ],
+            'multiple_events_generic' => [
+                'blocks' => [
+                    'first' => [
+                        'template' => 'blocks/multipleEvents/genericFirst.txt.twig',
+                    ],
+                    'second' => [
+                        'template' => 'blocks/multipleEvents/genericSecond.txt.twig',
+                        'context' => ['value' => 13],
+                    ],
+                ],
+            ],
+            'multiple_events_specific' => [
+                'blocks' => [
+                    'specific' => [
+                        'template' => 'blocks/multipleEvents/specific.txt.twig',
+                        'priority' => 3,
+                    ],
+                    'second' => [
+                        'context' => ['value' => 42],
+                        'priority' => 5,
+                    ],
+                ],
+            ],
         ]]);
     }
 

--- a/src/Sylius/Bundle/UiBundle/Tests/Functional/TemplateEventTest.php
+++ b/src/Sylius/Bundle/UiBundle/Tests/Functional/TemplateEventTest.php
@@ -34,7 +34,7 @@ final class TemplateEventTest extends KernelTestCase
     {
         // See Kernel.php for the configuration resulting in those lines
         $expectedLines = [
-            'First block (for event: "first_event")',
+            'First block',
             'Second block',
             'Third block',
             'The king is dead, long live the king!',
@@ -71,6 +71,21 @@ final class TemplateEventTest extends KernelTestCase
             'Block: option1=foo, option2=baz',
         ];
         $renderedLines = array_values(array_filter(explode("\n", $this->twig->render('contextTemplateBlock.txt.twig'))));
+
+        Assert::assertSame($expectedLines, $renderedLines);
+    }
+
+    /** @test */
+    public function it_renders_multiple_events_at_once(): void
+    {
+        // See Kernel.php for the configuration resulting in those lines
+        $expectedLines = [
+            'Generic block #2 (value=42)',
+            'Specific block',
+            'Generic block #1',
+        ];
+
+        $renderedLines = array_values(array_filter(explode("\n", $this->twig->render('multipleEvents.txt.twig'))));
 
         Assert::assertSame($expectedLines, $renderedLines);
     }

--- a/src/Sylius/Bundle/UiBundle/Tests/Functional/templates/blocks/multipleEvents/genericFirst.txt.twig
+++ b/src/Sylius/Bundle/UiBundle/Tests/Functional/templates/blocks/multipleEvents/genericFirst.txt.twig
@@ -1,0 +1,1 @@
+Generic block #1

--- a/src/Sylius/Bundle/UiBundle/Tests/Functional/templates/blocks/multipleEvents/genericSecond.txt.twig
+++ b/src/Sylius/Bundle/UiBundle/Tests/Functional/templates/blocks/multipleEvents/genericSecond.txt.twig
@@ -1,0 +1,1 @@
+Generic block #2 (value={{ value }})

--- a/src/Sylius/Bundle/UiBundle/Tests/Functional/templates/blocks/multipleEvents/specific.txt.twig
+++ b/src/Sylius/Bundle/UiBundle/Tests/Functional/templates/blocks/multipleEvents/specific.txt.twig
@@ -1,0 +1,1 @@
+Specific block

--- a/src/Sylius/Bundle/UiBundle/Tests/Functional/templates/blocks/txt/first.txt.twig
+++ b/src/Sylius/Bundle/UiBundle/Tests/Functional/templates/blocks/txt/first.txt.twig
@@ -1,1 +1,1 @@
-First block (for event: "{{ _event }}")
+First block

--- a/src/Sylius/Bundle/UiBundle/Tests/Functional/templates/multipleEvents.txt.twig
+++ b/src/Sylius/Bundle/UiBundle/Tests/Functional/templates/multipleEvents.txt.twig
@@ -1,0 +1,1 @@
+{{ sylius_template_event(['multiple_events_specific', 'multiple_events_generic']) }}

--- a/src/Sylius/Bundle/UiBundle/Twig/TemplateEventExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/TemplateEventExtension.php
@@ -30,7 +30,15 @@ final class TemplateEventExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('sylius_template_event', [$this->templateEventRenderer, 'render'], ['is_safe' => ['html']]),
+            new TwigFunction('sylius_template_event', [$this, 'render'], ['is_safe' => ['html']]),
         ];
+    }
+
+    /**
+     * @param string|string[] $eventName
+     */
+    public function render($eventName, array $context = []): string
+    {
+        return $this->templateEventRenderer->render((array) $eventName, $context);
     }
 }

--- a/src/Sylius/Bundle/UiBundle/spec/Registry/TemplateBlockRegistrySpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Registry/TemplateBlockRegistrySpec.php
@@ -31,21 +31,78 @@ final class TemplateBlockRegistrySpec extends ObjectBehavior
 
     function it_returns_all_template_blocks(): void
     {
-        $templateBlock = new TemplateBlock('block_name', 'block.html.twig', [], 10, true);
+        $templateBlock = new TemplateBlock('block_name', 'event', 'block.html.twig', [], 10, true);
 
-        $this->beConstructedWith(['event' => [$templateBlock]]);
+        $this->beConstructedWith(['event' => ['block_name' => $templateBlock]]);
 
-        $this->all()->shouldReturn(['event' => [$templateBlock]]);
+        $this->all()->shouldReturn(['event' => ['block_name' => $templateBlock]]);
     }
 
     function it_returns_enabled_template_blocks_for_a_given_event(): void
     {
-        $firstTemplateBlock = new TemplateBlock('first_block', 'first.html.twig', [], 0, true);
-        $secondTemplateBlock = new TemplateBlock('second_block', 'second.html.twig', [], 10, false);
-        $thirdTemplateBlock = new TemplateBlock('third_block', 'third.html.twig', [], 50, true);
+        $firstTemplateBlock = new TemplateBlock('first_block', 'event', 'first.html.twig', [], 0, true);
+        $secondTemplateBlock = new TemplateBlock('second_block', 'event', 'second.html.twig', [], 10, false);
+        $thirdTemplateBlock = new TemplateBlock('third_block', 'event', 'third.html.twig', [], 50, true);
 
-        $this->beConstructedWith(['event' => [$firstTemplateBlock, $secondTemplateBlock], 'another_event' => [$thirdTemplateBlock]]);
+        $this->beConstructedWith([
+            'event' => [
+                'first_block' => $firstTemplateBlock,
+                'second_block' => $secondTemplateBlock,
+            ],
+            'another_event' => [
+                'third_block' => $thirdTemplateBlock,
+            ],
+        ]);
 
-        $this->findEnabledForEvent('event')->shouldReturn([$firstTemplateBlock]);
+        $this->findEnabledForEvents(['event'])->shouldReturn([$firstTemplateBlock]);
+    }
+
+    function it_returns_enabled_template_blocks_for_multiple_events(): void
+    {
+        $this->beConstructedWith([
+            'generic_event' => ['block' => new TemplateBlock('block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], 0, true)],
+            'specific_event_template' => ['block' => new TemplateBlock('block', 'specific_event_template', 'specific.html.twig', null, null, null)],
+            'specific_event_context' => ['block' => new TemplateBlock('block', 'specific_event_context', null, ['other' => 'context'], null, null)],
+            'specific_event_priority' => ['block' => new TemplateBlock('block', 'specific_event_priority', null, null, 10, null)],
+            'specific_event_enabled' => ['block' => new TemplateBlock('block', 'specific_event_enabled', null, null, null, false)],
+        ]);
+
+        $this->findEnabledForEvents(['specific_event_template', 'generic_event'])->shouldIterateLike([
+            new TemplateBlock('block', 'specific_event_template', 'specific.html.twig', ['foo' => 'bar'], 0, true),
+        ]);
+        $this->findEnabledForEvents(['specific_event_context', 'generic_event'])->shouldIterateLike([
+            new TemplateBlock('block', 'specific_event_context', 'generic.html.twig', ['other' => 'context'], 0, true),
+        ]);
+        $this->findEnabledForEvents(['specific_event_priority', 'generic_event'])->shouldIterateLike([
+            new TemplateBlock('block', 'specific_event_priority', 'generic.html.twig', ['foo' => 'bar'], 10, true),
+        ]);
+        $this->findEnabledForEvents(['specific_event_enabled', 'generic_event'])->shouldReturn([]);
+        $this->findEnabledForEvents(['specific_event_priority', 'specific_event_template', 'generic_event'])->shouldIterateLike([
+            new TemplateBlock('block', 'specific_event_priority', 'specific.html.twig', ['foo' => 'bar'], 10, true),
+        ]);
+    }
+
+    function it_returns_enabled_template_blocks_sorted_by_priority_for_multiple_events(): void
+    {
+        $this->beConstructedWith([
+            'generic_event' => [
+                'first_block' => new TemplateBlock('first_block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], 50, true),
+                'third_block' => new TemplateBlock('third_block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], -10, true),
+                'second_block' => new TemplateBlock('second_block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], 0, true),
+                'invisible_block' => new TemplateBlock('invisible_block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], 0, false),
+            ],
+            'specific_event' => [
+                'additional_block' => new TemplateBlock('additional_block', 'specific_event', 'specific.html.twig', [], 75, true),
+                'second_block' => new TemplateBlock('second_block', 'specific_event', null, null, null, false),
+                'third_block' => new TemplateBlock('third_block', 'specific_event', null, null, 100, null),
+                'invisible_block' => new TemplateBlock('invisible_block', 'specific_event', null, [], null, null),
+            ],
+        ]);
+
+        $this->findEnabledForEvents(['specific_event', 'generic_event'])->shouldIterateLike([
+            new TemplateBlock('third_block', 'specific_event', 'generic.html.twig', ['foo' => 'bar'], 100, true),
+            new TemplateBlock('additional_block', 'specific_event', 'specific.html.twig', [], 75, true),
+            new TemplateBlock('first_block', 'generic_event', 'generic.html.twig', ['foo' => 'bar'], 50, true),
+        ]);
     }
 }

--- a/src/Sylius/Bundle/UiBundle/spec/Registry/TemplateBlockSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Registry/TemplateBlockSpec.php
@@ -14,17 +14,61 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\UiBundle\Registry;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\UiBundle\Registry\TemplateBlock;
 
 final class TemplateBlockSpec extends ObjectBehavior
 {
     function it_represents_a_template_block(): void
     {
-        $this->beConstructedWith('block_name', 'block.html.twig', ['foo' => 'bar'], 10, false);
+        $this->beConstructedWith('block_name', 'event_name', 'block.html.twig', ['foo' => 'bar'], 10, false);
 
         $this->getName()->shouldReturn('block_name');
+        $this->getEventName()->shouldReturn('event_name');
         $this->getTemplate()->shouldReturn('block.html.twig');
         $this->getContext()->shouldReturn(['foo' => 'bar']);
         $this->getPriority()->shouldReturn(10);
         $this->isEnabled()->shouldReturn(false);
+    }
+
+    function it_overwrites_a_template_block_with_an_another_template_block(): void
+    {
+        $this->beConstructedWith('block_name', 'event_name', 'block.html.twig', ['foo' => 'bar'], 10, false);
+
+        $this
+            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', 'another.html.twig', null, null, null))
+            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'another.html.twig', ['foo' => 'bar'], 10, false))
+        ;
+
+        $this
+            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', null, [], null, null))
+            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'block.html.twig', [], 10, false))
+        ;
+
+        $this
+            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', null, null, -5, null))
+            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'block.html.twig', ['foo' => 'bar'], -5, false))
+        ;
+
+        $this
+            ->overwriteWith(new TemplateBlock('block_name', 'specific_event_name', null, null, null, true))
+            ->shouldBeLike(new TemplateBlock('block_name', 'specific_event_name', 'block.html.twig', ['foo' => 'bar'], 10, true))
+        ;
+    }
+
+    function it_throws_an_exception_if_trying_to_overwrite_with_a_differently_named_block(): void
+    {
+        $this->beConstructedWith('block_name', 'event_name', 'block.html.twig', ['foo' => 'bar'], 10, false);
+
+        $this->shouldThrow(\DomainException::class)->during('overwriteWith', [new TemplateBlock('different_name', 'specific_event_name', null, null, null, null)]);
+    }
+
+    function it_has_sensible_defaults(): void
+    {
+        $this->beConstructedWith('block_name', 'event_name', null, null, null, null);
+
+        $this->shouldThrow(\DomainException::class)->during('getTemplate');
+        $this->getContext()->shouldReturn([]);
+        $this->getPriority()->shouldReturn(0);
+        $this->isEnabled()->shouldReturn(true);
     }
 }

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/DelegatingTemplateEventRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/DelegatingTemplateEventRendererSpec.php
@@ -36,25 +36,25 @@ final class DelegatingTemplateEventRendererSpec extends ObjectBehavior
         TemplateBlockRegistryInterface $templateBlockRegistry,
         TemplateBlockRendererInterface $templateBlockRenderer
     ): void {
-        $firstTemplateBlock = new TemplateBlock('first_block', 'firstBlock.txt.twig', [], 0, true);
-        $secondTemplateBlock = new TemplateBlock('second_block', 'secondBlock.txt.twig', [], 0, true);
+        $firstTemplateBlock = new TemplateBlock('first_block', 'best_event_ever', 'firstBlock.txt.twig', [], 0, true);
+        $secondTemplateBlock = new TemplateBlock('second_block', 'best_event_ever', 'secondBlock.txt.twig', [], 0, true);
 
-        $templateBlockRegistry->findEnabledForEvent('best_event_ever')->willReturn([$firstTemplateBlock, $secondTemplateBlock]);
+        $templateBlockRegistry->findEnabledForEvents(['best_event_ever'])->willReturn([$firstTemplateBlock, $secondTemplateBlock]);
 
-        $templateBlockRenderer->render('best_event_ever', $firstTemplateBlock, ['foo' => 'bar'])->willReturn('First block');
-        $templateBlockRenderer->render('best_event_ever', $secondTemplateBlock, ['foo' => 'bar'])->willReturn('Second block');
+        $templateBlockRenderer->render($firstTemplateBlock, ['foo' => 'bar'])->willReturn('First block');
+        $templateBlockRenderer->render($secondTemplateBlock, ['foo' => 'bar'])->willReturn('Second block');
 
-        $this->render('best_event_ever', ['foo' => 'bar'])->shouldReturn("First block\nSecond block");
+        $this->render(['best_event_ever'], ['foo' => 'bar'])->shouldReturn("First block\nSecond block");
     }
 
     function it_returns_an_empty_string_if_no_blocks_are_found_for_an_event(
         TemplateBlockRegistryInterface $templateBlockRegistry,
         TemplateBlockRendererInterface $templateBlockRenderer
     ): void {
-        $templateBlockRegistry->findEnabledForEvent('best_event_ever')->willReturn([]);
+        $templateBlockRegistry->findEnabledForEvents(['best_event_ever'])->willReturn([]);
 
         $templateBlockRenderer->render(Argument::cetera())->shouldNotBeCalled();
 
-        $this->render('best_event_ever')->shouldReturn('');
+        $this->render(['best_event_ever'])->shouldReturn('');
     }
 }

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/HtmlDebugTemplateBlockRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/HtmlDebugTemplateBlockRendererSpec.php
@@ -33,11 +33,10 @@ final class HtmlDebugTemplateBlockRendererSpec extends ObjectBehavior
     function it_renders_html_debug_comment_prepending_the_block_if_rendering_html_template(
         TemplateBlockRendererInterface $templateBlockRenderer
     ): void {
-        $templateBlockRenderer->render('event_name', Argument::cetera())->willReturn('Block content');
+        $templateBlockRenderer->render(Argument::cetera())->willReturn('Block content');
 
         $this->render(
-            'event_name',
-            new TemplateBlock('block_name', 'block.html.twig', [], 0, true),
+            new TemplateBlock('block_name', 'event_name', 'block.html.twig', [], 0, true),
             ['foo' => 'bar']
         )->shouldReturn(
             '<!-- BEGIN BLOCK | event name: "event_name", block name: "block_name", template: "block.html.twig", priority: 0 -->' . "\n" .
@@ -49,11 +48,10 @@ final class HtmlDebugTemplateBlockRendererSpec extends ObjectBehavior
     function it_does_not_render_html_debug_comment_prepending_the_block_if_rendering_non_html_template(
         TemplateBlockRendererInterface $templateBlockRenderer
     ): void {
-        $templateBlockRenderer->render('event_name', Argument::cetera())->willReturn('Block content');
+        $templateBlockRenderer->render(Argument::cetera())->willReturn('Block content');
 
         $this->render(
-            'event_name',
-            new TemplateBlock('block_name', 'block.txt.twig', [], 0, true),
+            new TemplateBlock('block_name', 'event_name', 'block.txt.twig', [], 0, true),
             ['foo' => 'bar']
         )->shouldReturn('Block content');
     }

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/HtmlDebugTemplateEventRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/HtmlDebugTemplateEventRendererSpec.php
@@ -35,14 +35,14 @@ final class HtmlDebugTemplateEventRendererSpec extends ObjectBehavior
         TemplateEventRendererInterface $templateEventRenderer,
         TemplateBlockRegistryInterface $templateBlockRegistry
     ): void {
-        $firstTemplateBlock = new TemplateBlock('first_block', 'firstBlock.txt.twig', [], 0, true);
-        $secondTemplateBlock = new TemplateBlock('second_block', 'secondBlock.html.twig', [], 0, true);
+        $firstTemplateBlock = new TemplateBlock('first_block', 'event_block', 'firstBlock.txt.twig', [], 0, true);
+        $secondTemplateBlock = new TemplateBlock('second_block', 'event_block', 'secondBlock.html.twig', [], 0, true);
 
-        $templateBlockRegistry->findEnabledForEvent('best_event_ever')->willReturn([$firstTemplateBlock, $secondTemplateBlock]);
+        $templateBlockRegistry->findEnabledForEvents(['best_event_ever'])->willReturn([$firstTemplateBlock, $secondTemplateBlock]);
 
-        $templateEventRenderer->render('best_event_ever', ['foo' => 'bar'])->willReturn("First block\nSecond block");
+        $templateEventRenderer->render(['best_event_ever'], ['foo' => 'bar'])->willReturn("First block\nSecond block");
 
-        $this->render('best_event_ever', ['foo' => 'bar'])->shouldReturn(
+        $this->render(['best_event_ever'], ['foo' => 'bar'])->shouldReturn(
             '<!-- BEGIN EVENT | event name: "best_event_ever" -->' . "\n" .
             'First block' . "\n" .
             'Second block' . "\n" .
@@ -54,25 +54,25 @@ final class HtmlDebugTemplateEventRendererSpec extends ObjectBehavior
         TemplateEventRendererInterface $templateEventRenderer,
         TemplateBlockRegistryInterface $templateBlockRegistry
     ): void {
-        $firstTemplateBlock = new TemplateBlock('first_block', 'firstBlock.txt.twig', [], 0, true);
-        $secondTemplateBlock = new TemplateBlock('second_block', 'secondBlock.txt.twig', [], 0, true);
+        $firstTemplateBlock = new TemplateBlock('first_block', 'event_block', 'firstBlock.txt.twig', [], 0, true);
+        $secondTemplateBlock = new TemplateBlock('second_block', 'event_block', 'secondBlock.txt.twig', [], 0, true);
 
-        $templateBlockRegistry->findEnabledForEvent('best_event_ever')->willReturn([$firstTemplateBlock, $secondTemplateBlock]);
+        $templateBlockRegistry->findEnabledForEvents(['best_event_ever'])->willReturn([$firstTemplateBlock, $secondTemplateBlock]);
 
-        $templateEventRenderer->render('best_event_ever', ['foo' => 'bar'])->willReturn("First block\nSecond block");
+        $templateEventRenderer->render(['best_event_ever'], ['foo' => 'bar'])->willReturn("First block\nSecond block");
 
-        $this->render('best_event_ever', ['foo' => 'bar'])->shouldReturn("First block\nSecond block");
+        $this->render(['best_event_ever'], ['foo' => 'bar'])->shouldReturn("First block\nSecond block");
     }
 
     function it_returns_html_debug_comment_if_no_blocks_are_found_for_an_event(
         TemplateEventRendererInterface $templateEventRenderer,
         TemplateBlockRegistryInterface $templateBlockRegistry
     ): void {
-        $templateBlockRegistry->findEnabledForEvent('best_event_ever')->willReturn([]);
+        $templateBlockRegistry->findEnabledForEvents(['best_event_ever'])->willReturn([]);
 
         $templateEventRenderer->render(Argument::cetera())->willReturn('');
 
-        $this->render('best_event_ever')->shouldReturn(
+        $this->render(['best_event_ever'])->shouldReturn(
             '<!-- BEGIN EVENT | event name: "best_event_ever" -->' . "\n" .
             "\n" .
             '<!-- END EVENT | event name: "best_event_ever" -->'

--- a/src/Sylius/Bundle/UiBundle/spec/Renderer/TwigTemplateBlockRendererSpec.php
+++ b/src/Sylius/Bundle/UiBundle/spec/Renderer/TwigTemplateBlockRendererSpec.php
@@ -32,22 +32,20 @@ final class TwigTemplateBlockRendererSpec extends ObjectBehavior
 
     function it_renders_a_template_block(Environment $twig): void
     {
-        $twig->render('block.txt.twig', ['foo' => 'bar', '_event' => 'event_name'])->willReturn('Block content');
+        $twig->render('block.txt.twig', ['foo' => 'bar'])->willReturn('Block content');
 
         $this->render(
-            'event_name',
-            new TemplateBlock('block_name', 'block.txt.twig', [], 0, true),
+            new TemplateBlock('block_name', 'event_name', 'block.txt.twig', [], 0, true),
             ['foo' => 'bar']
         )->shouldReturn('Block content');
     }
 
     function it_merges_template_block_context_with_passed_context(Environment $twig): void
     {
-        $twig->render('block.txt.twig', ['sample' => 'Hello', 'switch' => true, '_event' => 'event_name'])->willReturn('Block content');
+        $twig->render('block.txt.twig', ['sample' => 'Hello', 'switch' => true])->willReturn('Block content');
 
         $this->render(
-            'event_name',
-            new TemplateBlock('block_name', 'block.txt.twig', ['sample' => 'Hi', 'switch' => true], 0, true),
+            new TemplateBlock('block_name', 'event_name', 'block.txt.twig', ['sample' => 'Hi', 'switch' => true], 0, true),
             ['sample' => 'Hello']
         )->shouldReturn('Block content');
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | a bit
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | -
| Related tickets | related to #10997 
| License         | MIT

_Please review the code commit by commit, it'll be much easier._

Lots of the code added in the Sylius UI bundle configuration is to provide backwards compatibility with Sonata blocks.

<hr/>

This PR adds an ability to render multiple dependent template events at once. What does it mean?

Apart from usual call to render template event using `sylius_template_event('event')`, it is now possible to pass an array with two or more events using `sylius_template_event('first_event', 'second_event')`.

The call mentioned above will merge blocks defined in both `first_event` and `second_event` and render them all. In case the same block is defined, the first event's block configuration overrides the second event's block configuration. 

<hr/>

### Example: Admin CRUD template events

This allows defining two events for generic templates - one event which name is variable, and another one which name is constant. The following example comes from generic CRUD templates in AdminBundle, which was modified in this PR as well:

```twig
{% set event_prefix = metadata.applicationName ~ '.admin.' ~ metadata.name ~ '.create' %}

{{ sylius_template_event([event_prefix, 'sylius.admin.create'], _context) }}
```

In this case, you can manage blocks for all `create` pages:

```yaml
sylius_ui:
  events:
    sylius.admin.create:
      blocks:
        new_block: template.html.twig
```

Or manage blocks only for product create page:

```yaml
sylius_ui:
  events:
    sylius.admin.product.create:
      blocks:
        new_block: template.html.twig
```

<img width="1392" alt="Screenshot 2020-01-23 at 23 51 24" src="https://user-images.githubusercontent.com/1897953/73031403-497b5200-3e3c-11ea-91a6-d8e8ddc0130e.png">

<hr/>

### Example: Equivalent configuration (one event / multiple events)

Given the following basic configuration:

```yaml
# First config file
sylius_ui:
  events:
    event:
      blocks:
        block:
          template: template.html.twig
          priority: 10
          context:
            foo: bar

# Second config file
sylius_ui:
  events:
    event:
      blocks:
        block:
          priority: -5
```

```twig
{{ sylius_template_event('event') }}
```

The equivalent configuration using dependent template events:

```yaml
sylius_ui:
  events:
    first_event:
      blocks:
        block:
          template: template.html.twig
          priority: 10
          context:
            foo: bar
    second_event:
      blocks:
        block:
          priority: -5
```

```twig
{{ sylius_template_event(['second_event', 'first_event']) }}
```