### PR TITLE
fix code generation with too long code length

### DIFF
--- a/features/promotion/managing_coupons/generating_coupon.feature
+++ b/features/promotion/managing_coupons/generating_coupon.feature
@@ -30,3 +30,12 @@ Feature: Generating new coupons
         And I generate these coupons
         Then I should be notified that they have been successfully generated
         And there should be 5 coupons related to this promotion
+
+    @ui
+    Scenario: Generating new coupons with too long code length
+        When I want to generate new coupons for this promotion
+        And I choose the amount of 5 coupons to be generated
+        And I specify their code length as 16
+        And I generate it
+        Then I should be notified that generating 5 coupons with code length equal to 16 is not possible
+        And there should be 0 coupon related to this promotion

--- a/src/Sylius/Bundle/PromotionBundle/Resources/config/validation/PromotionCouponGeneratorInstruction.xml
+++ b/src/Sylius/Bundle/PromotionBundle/Resources/config/validation/PromotionCouponGeneratorInstruction.xml
@@ -33,7 +33,7 @@
             <constraint name="Range">
                 <option name="min">1</option>
                 <option name="minMessage">sylius.promotion_coupon_generator_instruction.code_length.min</option>
-                <option name="max">40</option>
+                <option name="max">15</option>
                 <option name="maxMessage">sylius.promotion_coupon_generator_instruction.code_length.max</option>
             </constraint>
             <constraint name="NotBlank">

--- a/src/Sylius/Component/Promotion/Generator/PercentageGenerationPolicy.php
+++ b/src/Sylius/Component/Promotion/Generator/PercentageGenerationPolicy.php
@@ -68,6 +68,11 @@ final class PercentageGenerationPolicy implements GenerationPolicyInterface
             $instruction->getSuffix()
         );
 
-        return (int) floor((16 ** $expectedCodeLength) * $this->ratio - $generatedAmount);
+        $codeCombination = 16 ** $expectedCodeLength;
+        if ($codeCombination > PHP_INT_MAX) {
+            $codeCombination = 0;
+        }
+
+        return (int) floor($codeCombination * $this->ratio - $generatedAmount);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6 and after
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #10912 
| License         | MIT

Fix error when amount of code combination is greater than the value of PHP_INT_MAX.
