### PR TITLE
user provider fix exception

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/spec/OAuth/UserProviderSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/OAuth/UserProviderSpec.php
@@ -29,7 +29,9 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\User\Canonicalizer\CanonicalizerInterface;
 use Sylius\Component\User\Model\UserOAuthInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 final class UserProviderSpec extends ObjectBehavior
 {
@@ -222,5 +224,11 @@ final class UserProviderSpec extends ObjectBehavior
         $userRepository->findOneByEmail(Argument::any())->shouldNotBeCalled();
 
         $this->shouldThrow(UsernameNotFoundException::class)->during('loadUserByOAuthUserResponse', [$response]);
+    }
+
+    function it_should_throw_exception_when_unsupported_user_is_used(
+        UserInterface $user
+    ):void {
+        $this->shouldThrow(UnsupportedUserException::class)->during('refreshUser', [$user]);
     }
 }

--- a/src/Sylius/Bundle/UserBundle/Provider/AbstractUserProvider.php
+++ b/src/Sylius/Bundle/UserBundle/Provider/AbstractUserProvider.php
@@ -19,7 +19,6 @@ use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Webmozart\Assert\Assert;
 
 abstract class AbstractUserProvider implements UserProviderInterface
 {
@@ -67,8 +66,11 @@ abstract class AbstractUserProvider implements UserProviderInterface
      */
     public function refreshUser(UserInterface $user): UserInterface
     {
-        /** @var SyliusUserInterface $user */
-        Assert::isInstanceOf($user, SyliusUserInterface::class);
+        if(!$user instanceof SyliusUserInterface) {
+            throw new UnsupportedUserException(
+                sprintf('User must implement "%s".', SyliusUserInterface::class)
+            );
+        }
 
         if (!$this->supportsClass(get_class($user))) {
             throw new UnsupportedUserException(

--- a/src/Sylius/Bundle/UserBundle/spec/Provider/EmailProviderSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/Provider/EmailProviderSpec.php
@@ -18,6 +18,8 @@ use Sylius\Bundle\UserBundle\Provider\AbstractUserProvider;
 use Sylius\Component\User\Canonicalizer\CanonicalizerInterface;
 use Sylius\Component\User\Model\User;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 final class EmailProviderSpec extends ObjectBehavior
@@ -61,5 +63,11 @@ final class EmailProviderSpec extends ObjectBehavior
         $user->getId()->willReturn(1);
 
         $this->refreshUser($user)->shouldReturn($user);
+    }
+
+    function it_should_throw_exception_when_unsupported_user_is_used(
+        UserInterface $user
+    ):void {
+        $this->shouldThrow(UnsupportedUserException::class)->during('refreshUser', [$user]);
     }
 }

--- a/src/Sylius/Bundle/UserBundle/spec/Provider/UsernameOrEmailProviderSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/Provider/UsernameOrEmailProviderSpec.php
@@ -19,7 +19,9 @@ use Sylius\Component\User\Canonicalizer\CanonicalizerInterface;
 use Sylius\Component\User\Model\User;
 use Sylius\Component\User\Model\UserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\UserInterface as CoreUserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 final class UsernameOrEmailProviderSpec extends ObjectBehavior
@@ -93,5 +95,11 @@ final class UsernameOrEmailProviderSpec extends ObjectBehavior
         $user->getId()->willReturn(1);
 
         $this->refreshUser($user)->shouldReturn($refreshedUser);
+    }
+
+    function it_should_throw_exception_when_unsupported_user_is_used(
+        CoreUserInterface $user
+    ):void {
+        $this->shouldThrow(UnsupportedUserException::class)->during('refreshUser', [$user]);
     }
 }

--- a/src/Sylius/Bundle/UserBundle/spec/Provider/UsernameProviderSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/Provider/UsernameProviderSpec.php
@@ -18,6 +18,8 @@ use Sylius\Bundle\UserBundle\Provider\AbstractUserProvider;
 use Sylius\Component\User\Canonicalizer\CanonicalizerInterface;
 use Sylius\Component\User\Model\User;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 final class UsernameProviderSpec extends ObjectBehavior
@@ -61,5 +63,11 @@ final class UsernameProviderSpec extends ObjectBehavior
         $user->getId()->willReturn(1);
 
         $this->refreshUser($user)->shouldReturn($user);
+    }
+
+    function it_should_throw_exception_when_unsupported_user_is_used(
+        UserInterface $user
+    ):void {
+        $this->shouldThrow(UnsupportedUserException::class)->during('refreshUser', [$user]);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.5 and more
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #10879 
| License         | MIT

UserProvider should throw UnsupportedUserException and not UnexpectedValueException.
