### PR TITLE
update guzzle6-adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "ocramius/proxy-manager": "^2.1",
         "payum/payum": "^1.4",
         "payum/payum-bundle": "^2.2",
-        "php-http/guzzle6-adapter": "^1.1",
+        "php-http/guzzle6-adapter": "^1.1|^2.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "ramsey/uuid": "^3.7",
         "sonata-project/block-bundle": "^3.3",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Allow to use php-http/guzzle6-adapter v2.

