### PR TITLE
Fix wrong translation

### DIFF
--- a/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.fr.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/translations/messages.fr.yml
@@ -38,7 +38,7 @@ sylius:
             enabled: Activé
             match_all_category_requirement: Tous les produits doivent correspondre à la catégorie d'expédition
             match_any_category_requirement: Au moins un des produits doivent correspondre à la catégorie d'expédition
-            match_none_category_requirement: Aucune contrainte de correspondance à la catégorie d'expédition
+            match_none_category_requirement: Aucun produit doit correspondre à la catégorie d'expédition
             name: Nom
             position: Emplacement
             tax_category: Catégorie de taxe


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

The french sentence sense of "None of the units have to match the method category" is wrong and assumes no verification is performed.



