### PR TITLE
Fixed wrongly calculated order-item subtotal

### DIFF
--- a/features/order/managing_orders/seeing_order_with_different_promotions.feature
+++ b/features/order/managing_orders/seeing_order_with_different_promotions.feature
@@ -28,10 +28,10 @@ Feature: Seeing order with different promotions
         And the "PHP T-Shirt" product's order discount should be "~ -$3.34"
         And the "PHP T-Shirt" product's discounted unit price should be "$36.66"
         And the "PHP T-Shirt" product's quantity should be 2
-        And the "PHP T-Shirt" product's subtotal should be "$73.32"
+        And the "PHP T-Shirt" product's subtotal should be "$73.33"
         And the "Symfony Mug" product's unit price should be "$40.00"
         And the "Symfony Mug" product's item discount should be "$0.00"
-        And the "Symfony Mug" product's order discount should be "-$3.33"
+        And the "Symfony Mug" product's order discount should be "~ -$3.33"
         And the "Symfony Mug" product's discounted unit price should be "$36.67"
         And the "Symfony Mug" product's quantity should be 1
         And the "Symfony Mug" product's subtotal should be "$36.67"

--- a/features/order/managing_orders/seeing_order_with_different_promotions.feature
+++ b/features/order/managing_orders/seeing_order_with_different_promotions.feature
@@ -25,7 +25,7 @@ Feature: Seeing order with different promotions
         When I view the summary of the order "#00000666"
         Then the "PHP T-Shirt" product's unit price should be "$60.00"
         And the "PHP T-Shirt" product's item discount should be "-$20.00"
-        And the "PHP T-Shirt" product's order discount should be "-$3.34"
+        And the "PHP T-Shirt" product's order discount should be "~ -$3.34"
         And the "PHP T-Shirt" product's discounted unit price should be "$36.66"
         And the "PHP T-Shirt" product's quantity should be 2
         And the "PHP T-Shirt" product's subtotal should be "$73.32"

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
@@ -199,7 +199,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
 
             $quantity = $row->find('css', 'td:nth-child(6)')->getText();
 
-            $orderPromotionTotal = (float) trim(str_replace('-$', '', $unitOrderPromotion)) * $quantity;
+            $orderPromotionTotal = (float) trim(str_replace('~ -$', '', $unitOrderPromotion)) * $quantity;
             $unitOrderPromotionTotal = (float) trim(str_replace('-$', '', $orderPromotion)) * $quantity;
 
             $promotionTotal += (int) ($orderPromotionTotal * 100);

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_item.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_item.html.twig
@@ -25,7 +25,7 @@
         {{ money.format(item.units.first.adjustmentsTotal(unitPromotionAdjustment), order.currencyCode) }}
     </td>
     <td class="right aligned unit-order-discount">
-        <span style="font-style: italic;">~{{ money.format(item.units.first.adjustmentsTotal(orderPromotionAdjustment), order.currencyCode) }}</span>
+        <span style="font-style: italic;">~ {{ money.format(item.units.first.adjustmentsTotal(orderPromotionAdjustment), order.currencyCode) }}</span>
     </td>
     <td class="right aligned discounted-unit-price">
         {{ money.format(item.fullDiscountedUnitPrice, order.currencyCode) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_item.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_item.html.twig
@@ -7,7 +7,9 @@
 
 {% set variant = item.variant %}
 {% set product = variant.product %}
-{% set subtotal = item.quantity * (item.unitPrice + item.units.first.adjustmentsTotal(unitPromotionAdjustment) + item.units.first.adjustmentsTotal(orderPromotionAdjustment)) %}
+
+{% set aggregatedUnitPromotionAdjustments = item.getAdjustmentsTotalRecursively(unitPromotionAdjustment) + item.getAdjustmentsTotalRecursively(orderPromotionAdjustment) %}
+{% set subtotal = (item.unitPrice * item.quantity) + aggregatedUnitPromotionAdjustments %}
 
 {% set taxIncluded = sylius_admin_order_unit_tax_included(item) %}
 {% set taxExcluded = sylius_admin_order_unit_tax_excluded(item) %}
@@ -23,7 +25,7 @@
         {{ money.format(item.units.first.adjustmentsTotal(unitPromotionAdjustment), order.currencyCode) }}
     </td>
     <td class="right aligned unit-order-discount">
-        <span style="font-style: italic;">{{ money.format(item.units.first.adjustmentsTotal(orderPromotionAdjustment), order.currencyCode) }}</span>
+        <span style="font-style: italic;">~{{ money.format(item.units.first.adjustmentsTotal(orderPromotionAdjustment), order.currencyCode) }}</span>
     </td>
     <td class="right aligned discounted-unit-price">
         {{ money.format(item.fullDiscountedUnitPrice, order.currencyCode) }}


### PR DESCRIPTION
Since adjustments can have different value, picking just the first one may yield wrong results. Hence, I use the recursively fetched adjustments. Also, I added a ~ before the distributed amount to signify its variance. See #11112 for more details

| Q               | A
| --------------- | -----
| Branch?         | 1.6 or master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no/
| Related tickets | fixes #11112
| License         | MIT
