### PR TITLE
Fixed: Calculator at TaxRate fixtures

### DIFF
--- a/tests/DataFixtures/ORM/resources/tax_rates.yml
+++ b/tests/DataFixtures/ORM/resources/tax_rates.yml
@@ -3,11 +3,11 @@ Sylius\Component\Core\Model\TaxRate:
         code: sales_tax
         name: "Sales Tax 20\\%"
         zone: "@zone_eu"
-        calculator: "flat_rate"
+        calculator: "default"
         category: "@tax_category_1"
     regular_tax:
         code: regular_tax
         name: "Regular Tax 20\\%"
         zone: "@zone_eu"
-        calculator: "flat_rate"
+        calculator: "default"
         category: "@tax_category_2"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | any
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT

Not sure it that matter, but for taxes there is only one calculator - `default`.
`flat_rate` is for shipping I guess.