### PR TITLE
Add metatags event in layout's block

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/layout.html.twig
@@ -10,6 +10,7 @@
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
 
     {% block metatags %}
+        {{ sonata_block_render_event('sylius.shop.layout.metatags') }}
     {% endblock %}
 
     {% block stylesheets %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT

Add event to be able to append some data in metatags block.
