### PR TITLE
[API] Product options (with values) creation and index

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -5,3 +5,9 @@ framework:
     templating: { engines: ["twig"] }
     session:
         handler_id: ~
+    serializer:
+        enabled: true
+        enable_annotations: false
+        mapping:
+            paths:
+                - '%kernel.project_dir%/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/'

--- a/features/product/managing_product_options/adding_product_option.feature
+++ b/features/product/managing_product_options/adding_product_option.feature
@@ -29,7 +29,7 @@ Feature: Adding a new product option
         Then I should be notified that it has been successfully created
         And the product option "T-Shirt size" should appear in the registry
 
-    @ui @javascript
+    @ui @javascript @api
     Scenario: Adding a new product option with one option value
         Given I want to create a new product option
         When I name it "T-Shirt size" in "English (United States)"

--- a/features/product/managing_product_options/adding_product_option.feature
+++ b/features/product/managing_product_options/adding_product_option.feature
@@ -8,7 +8,7 @@ Feature: Adding a new product option
         Given the store is available in "English (United States)"
         And I am logged in as an administrator
 
-    @ui @javascript
+    @api
     Scenario: Adding a new product option with two required option values
         Given I want to create a new product option
         When I name it "T-Shirt size" in "English (United States)"
@@ -19,7 +19,7 @@ Feature: Adding a new product option
         Then I should be notified that it has been successfully created
         And the product option "T-Shirt size" should appear in the registry
 
-    @ui
+    @ui @api
     Scenario: Adding a new product option without any option values
         Given I want to create a new product option
         When I name it "T-Shirt size" in "English (United States)"

--- a/features/product/managing_product_options/adding_product_option.feature
+++ b/features/product/managing_product_options/adding_product_option.feature
@@ -8,7 +8,7 @@ Feature: Adding a new product option
         Given the store is available in "English (United States)"
         And I am logged in as an administrator
 
-    @api
+    @ui @javascript @api
     Scenario: Adding a new product option with two required option values
         Given I want to create a new product option
         When I name it "T-Shirt size" in "English (United States)"

--- a/features/product/managing_product_options/adding_product_option.feature
+++ b/features/product/managing_product_options/adding_product_option.feature
@@ -18,6 +18,8 @@ Feature: Adding a new product option
         And I add it
         Then I should be notified that it has been successfully created
         And the product option "T-Shirt size" should appear in the registry
+        And product option "T-Shirt size" should have the "OV1" option value
+        And product option "T-Shirt size" should have the "OV2" option value
 
     @ui @api
     Scenario: Adding a new product option without any option values
@@ -38,3 +40,4 @@ Feature: Adding a new product option
         And I try to add it
         Then I should be notified that it has been successfully created
         And the product option "T-Shirt size" should appear in the registry
+        And product option "T-Shirt size" should have the "OV1" option value

--- a/features/product/managing_product_options/browsing_product_options.feature
+++ b/features/product/managing_product_options/browsing_product_options.feature
@@ -4,7 +4,7 @@ Feature: Browsing product options
     As an Administrator
     I want to be able to browse product options
 
-    @ui
+    @api
     Scenario: Browsing defined product options
         Given I am logged in as an administrator
         And the store has a product option "T-Shirt size" with a code "t_shirt_size"

--- a/features/product/managing_product_options/browsing_product_options.feature
+++ b/features/product/managing_product_options/browsing_product_options.feature
@@ -4,7 +4,7 @@ Feature: Browsing product options
     As an Administrator
     I want to be able to browse product options
 
-    @api
+    @ui @api
     Scenario: Browsing defined product options
         Given I am logged in as an administrator
         And the store has a product option "T-Shirt size" with a code "t_shirt_size"

--- a/src/Sylius/Behat/Client/ApiClientInterface.php
+++ b/src/Sylius/Behat/Client/ApiClientInterface.php
@@ -30,4 +30,6 @@ interface ApiClientInterface
     public function getError(): string;
 
     public function isCreationSuccessful(): bool;
+
+    public function hasItemWithValue(string $key, string $value): bool;
 }

--- a/src/Sylius/Behat/Client/ApiClientInterface.php
+++ b/src/Sylius/Behat/Client/ApiClientInterface.php
@@ -17,6 +17,8 @@ interface ApiClientInterface
 {
     public function index(string $resource): void;
 
+    public function subResourceIndex(string $resource, string $subResource, string $id): void;
+
     public function buildCreateRequest(string $resource): void;
 
     public function addRequestData(string $key, string $value): void;

--- a/src/Sylius/Behat/Client/ApiClientInterface.php
+++ b/src/Sylius/Behat/Client/ApiClientInterface.php
@@ -21,6 +21,8 @@ interface ApiClientInterface
 
     public function addRequestData(string $key, string $value): void;
 
+    public function addCompoundRequestData(array $data): void;
+
     public function create(): void;
 
     public function countCollectionItems(): int;

--- a/src/Sylius/Behat/Client/ApiPlatformClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformClient.php
@@ -72,6 +72,17 @@ final class ApiPlatformClient implements ApiClientInterface
         return $this->client->getResponse()->getStatusCode() === Response::HTTP_CREATED;
     }
 
+    public function hasItemWithValue(string $key, string $value): bool
+    {
+        foreach ($this->getCollection() as $resource) {
+            if ($resource[$key] === $value) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private function request(string $method, string $url, array $headers, string $content = null): void
     {
         $this->client->request(

--- a/src/Sylius/Behat/Client/ApiPlatformClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformClient.php
@@ -35,6 +35,13 @@ final class ApiPlatformClient implements ApiClientInterface
         $this->client->request('GET', '/new-api/'.$resource, [], [], ['HTTP_ACCEPT' => 'application/ld+json']);
     }
 
+    public function subResourceIndex(string $resource, string $subResource, string $id): void
+    {
+        $url = sprintf('/new-api/%s/%s/%s', $resource, $id, $subResource);
+
+        $this->client->request('GET', $url, [], [], ['HTTP_ACCEPT' => 'application/ld+json']);
+    }
+
     public function buildCreateRequest(string $resource): void
     {
         $this->request['url'] = '/new-api/'.$resource;

--- a/src/Sylius/Behat/Client/ApiPlatformClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformClient.php
@@ -23,7 +23,7 @@ final class ApiPlatformClient implements ApiClientInterface
     private $client;
 
     /** @var array */
-    private $request;
+    private $request = ['url' => null, 'body' => []];
 
     public function __construct(AbstractBrowser $client)
     {
@@ -37,12 +37,17 @@ final class ApiPlatformClient implements ApiClientInterface
 
     public function buildCreateRequest(string $resource): void
     {
-        $this->request = ['url' => '/new-api/'.$resource];
+        $this->request['url'] = '/new-api/'.$resource;
     }
 
     public function addRequestData(string $key, string $value): void
     {
         $this->request['body'][$key] = $value;
+    }
+
+    public function addCompoundRequestData(array $data): void
+    {
+        $this->request['body'] = array_merge_recursive($this->request['body'], $data);
     }
 
     public function create(): void

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCurrenciesContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCurrenciesContext.php
@@ -77,7 +77,10 @@ final class ManagingCurrenciesContext implements Context
     public function currencyShouldAppearInTheStore(string $currencyName): void
     {
         $this->client->index('currencies');
-        $this->assertCurrencyWithData('name', $currencyName);
+        Assert::true(
+            $this->client->hasItemWithValue('name', $currencyName),
+            sprintf('There is no currency with name "%s"', $currencyName)
+        );
     }
 
     /**
@@ -87,7 +90,7 @@ final class ManagingCurrenciesContext implements Context
     {
         $this->client->index('currencies');
         Assert::eq(1, $this->client->countCollectionItems());
-        $this->assertCurrencyWithData('code', $code);
+        Assert::true($this->client->hasItemWithValue('code', $code), sprintf('There is no currency with code "%s"', $code));
     }
 
     /**
@@ -97,20 +100,5 @@ final class ManagingCurrenciesContext implements Context
     {
         Assert::false($this->client->isCreationSuccessful(), 'Currency has been created successfully, but it should not');
         Assert::same($this->client->getError(), 'code: Currency code must be unique.');
-    }
-
-    private function assertCurrencyWithData(string $element, string $currencyName): void
-    {
-        $currencies = $this->client->getCollection();
-
-        foreach ($currencies as $currency) {
-            if ($currency[$element] === $currencyName) {
-                return;
-            }
-        }
-
-        throw new \InvalidArgumentException(
-            sprintf('There is no currency with %s "%s" in the list', $element, $currencyName)
-        );
     }
 }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductOptionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductOptionsContext.php
@@ -32,7 +32,7 @@ final class ManagingProductOptionsContext implements Context
      */
     public function iBrowseProductOptions(): void
     {
-        $this->client->index('product-options');
+        $this->client->index('product_options');
     }
 
     /**
@@ -50,7 +50,7 @@ final class ManagingProductOptionsContext implements Context
      */
     public function theProductOptionShouldAppearInTheRegistry(string $productOptionName): void
     {
-        $this->client->index('product-options');
+        $this->client->index('product_options');
         $this->assertProductOptionWithData('name', $productOptionName);
     }
 

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductOptionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductOptionsContext.php
@@ -15,6 +15,8 @@ namespace Sylius\Behat\Context\Api\Admin;
 
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
+use Sylius\Behat\Page\Admin\ProductOption\CreatePageInterface;
+use Sylius\Behat\Page\Admin\ProductOption\UpdatePageInterface;
 use Webmozart\Assert\Assert;
 
 final class ManagingProductOptionsContext implements Context
@@ -36,6 +38,55 @@ final class ManagingProductOptionsContext implements Context
     }
 
     /**
+     * @Given I want to create a new product option
+     */
+    public function iWantToCreateANewProductOption(): void
+    {
+        $this->client->buildCreateRequest('product_options');
+    }
+
+    /**
+     * @When I name it :name in :language
+     */
+    public function iNameItInLanguage(string $name, string $language): void
+    {
+        $this->client->addCompoundRequestData(['translations' => [['name' => $name, 'locale' => $language]]]);
+    }
+
+    /**
+     * @When I specify its code as :code
+     */
+    public function iSpecifyItsCodeAs(string $code): void
+    {
+        $this->client->addRequestData('code', $code);
+    }
+
+    /**
+     * @When I add the :value option value identified by :code
+     */
+    public function iAddTheOptionValueWithCodeAndValue(string $value, string $code): void
+    {
+        $this->client->addCompoundRequestData(['values' => [['code' => $code, 'value' => $value]]]);
+    }
+
+    /**
+     * @When I do not add an option value
+     */
+    public function iDoNotAddAnOptionValue(): void
+    {
+        // Intentionally left blank to fulfill context expectation
+    }
+
+    /**
+     * @When I add it
+     * @When I try to add it
+     */
+    public function iAddIt(): void
+    {
+        $this->client->create();
+    }
+
+    /**
      * @Then I should see :count product options in the list
      */
     public function iShouldSeeProductOptionsInTheList(int $count): void
@@ -47,6 +98,7 @@ final class ManagingProductOptionsContext implements Context
 
     /**
      * @Then the product option :productOptionName should be in the registry
+     * @Then the product option :productOptionName should appear in the registry
      */
     public function theProductOptionShouldAppearInTheRegistry(string $productOptionName): void
     {

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductOptionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductOptionsContext.php
@@ -51,19 +51,6 @@ final class ManagingProductOptionsContext implements Context
     public function theProductOptionShouldAppearInTheRegistry(string $productOptionName): void
     {
         $this->client->index('product_options');
-        $this->assertProductOptionWithData('name', $productOptionName);
-    }
-
-    private function assertProductOptionWithData(string $element, string $currencyName): void
-    {
-        $currencies = $this->client->getCollection();
-
-        foreach ($currencies as $currency) {
-            if ($currency[$element] === $currencyName) {
-                return;
-            }
-        }
-
-        throw new \Exception(sprintf('There is no product option with %s "%s" in the list', $element, $currencyName));
+        Assert::true($this->client->hasItemWithValue('name', $productOptionName));
     }
 }

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductOptionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductOptionsContext.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Api\Admin;
+
+use Behat\Behat\Context\Context;
+use Sylius\Behat\Client\ApiClientInterface;
+use Webmozart\Assert\Assert;
+
+final class ManagingProductOptionsContext implements Context
+{
+    /** @var ApiClientInterface */
+    private $client;
+
+    public function __construct(ApiClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * @When I browse product options
+     */
+    public function iBrowseProductOptions(): void
+    {
+        $this->client->index('product-options');
+    }
+
+    /**
+     * @Then I should see :count product options in the list
+     */
+    public function iShouldSeeProductOptionsInTheList(int $count): void
+    {
+        $itemsCount = $this->client->countCollectionItems();
+
+        Assert::eq($count, $itemsCount, sprintf('Expected %d product options, but got %d', $count, $itemsCount));
+    }
+
+    /**
+     * @Then the product option :productOptionName should be in the registry
+     */
+    public function theProductOptionShouldAppearInTheRegistry(string $productOptionName): void
+    {
+        $this->client->index('product-options');
+        $this->assertProductOptionWithData('name', $productOptionName);
+    }
+
+    private function assertProductOptionWithData(string $element, string $currencyName): void
+    {
+        $currencies = $this->client->getCollection();
+
+        foreach ($currencies as $currency) {
+            if ($currency[$element] === $currencyName) {
+                return;
+            }
+        }
+
+        throw new \Exception(sprintf('There is no product option with %s "%s" in the list', $element, $currencyName));
+    }
+}

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingProductOptionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingProductOptionsContext.php
@@ -66,7 +66,11 @@ final class ManagingProductOptionsContext implements Context
      */
     public function iAddTheOptionValueWithCodeAndValue(string $value, string $code): void
     {
-        $this->client->addCompoundRequestData(['values' => [['code' => $code, 'value' => $value]]]);
+        $this->client->addCompoundRequestData([
+            'values' => [
+                ['code' => $code, 'translations' => [['value' => $value, 'locale' => 'en_US']]]
+            ]
+        ]);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Admin/NotificationContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/NotificationContext.php
@@ -32,6 +32,6 @@ final class NotificationContext implements Context
      */
     public function iShouldBeNotifiedThatSomethingHappened(): void
     {
-        Assert::true($this->client->isCreationSuccessful(), 'Currency could not be created');
+        Assert::true($this->client->isCreationSuccessful(), 'Resource could not be created');
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductOptionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductOptionsContext.php
@@ -247,6 +247,7 @@ final class ManagingProductOptionsContext implements Context
 
     /**
      * @Then /^(this product option) should have the "([^"]*)" option value$/
+     * @Then /^(product option "[^"]+") should have the "([^"]*)" option value$/
      */
     public function thisProductOptionShouldHaveTheOptionValue(ProductOptionInterface $productOption, $optionValue)
     {

--- a/src/Sylius/Behat/Resources/config/services/contexts/api.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api.xml
@@ -21,6 +21,7 @@
 
         <service id="sylius.behat.context.api.admin.managing_product_options" class="Sylius\Behat\Context\Api\Admin\ManagingProductOptionsContext">
             <argument type="service" id="Sylius\Behat\Client\ApiClientInterface" />
+            <argument type="service" id="sylius.behat.shared_storage" />
         </service>
 
         <service id="sylius.behat.context.api.admin.managing_taxons" class="Sylius\Behat\Context\Api\Admin\ManagingTaxonsContext">

--- a/src/Sylius/Behat/Resources/config/services/contexts/api.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api.xml
@@ -19,6 +19,10 @@
             <argument type="service" id="Sylius\Behat\Client\ApiClientInterface" />
         </service>
 
+        <service id="sylius.behat.context.api.admin.managing_product_options" class="Sylius\Behat\Context\Api\Admin\ManagingProductOptionsContext">
+            <argument type="service" id="Sylius\Behat\Client\ApiClientInterface" />
+        </service>
+
         <service id="sylius.behat.context.api.admin.managing_taxons" class="Sylius\Behat\Context\Api\Admin\ManagingTaxonsContext">
             <argument type="service" id="test.client" />
             <argument type="service" id="session" />

--- a/src/Sylius/Behat/Resources/config/suites.yml
+++ b/src/Sylius/Behat/Resources/config/suites.yml
@@ -2,7 +2,9 @@
 # (c) Paweł Jędrzejewski
 
 imports:
+    - suites/api/currency/managing_currencies.yml
     - suites/api/product/managing_product_variants.yml
+    - suites/api/product/managing_product_options.yml
     - suites/api/taxon/managing_taxons.yml
 
     - suites/cli/installer.yml

--- a/src/Sylius/Behat/Resources/config/suites/api/currency/managing_currencies.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/currency/managing_currencies.yml
@@ -3,7 +3,7 @@
 
 default:
     suites:
-        ui_managing_currencies:
+        api_managing_currencies:
             contexts:
                 - sylius.behat.context.hook.doctrine_orm
 
@@ -11,12 +11,12 @@ default:
                 - sylius.behat.context.transform.shared_storage
                 - sylius.behat.context.transform.lexical
 
+                - sylius.behat.context.setup.admin_api_security
                 - sylius.behat.context.setup.channel
-                - sylius.behat.context.setup.admin_security
                 - sylius.behat.context.setup.currency
 
-                - sylius.behat.context.ui.admin.managing_currencies
-                - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.api.admin.managing_currencies
+                - sylius.behat.context.api.admin.notification
 
             filters:
-                tags: "@managing_currencies && @ui"
+                tags: "@managing_currencies && @api"

--- a/src/Sylius/Behat/Resources/config/suites/api/product/managing_product_options.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/product/managing_product_options.yml
@@ -3,7 +3,7 @@
 
 default:
     suites:
-        ui_managing_product_options:
+        api_managing_product_options:
             contexts:
                 - sylius.behat.context.hook.doctrine_orm
 
@@ -16,8 +16,9 @@ default:
                 - sylius.behat.context.setup.product_option
                 - sylius.behat.context.setup.admin_security
 
-                - sylius.behat.context.ui.admin.managing_product_options
-                - sylius.behat.context.ui.admin.notification
+                - sylius.behat.context.api.admin.managing_product_options
+                - sylius.behat.context.api.admin.notification
 
             filters:
-                tags: "@managing_product_options && @ui"
+                tags: "@managing_product_options && @api"
+            javascript: false

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_options.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_options.yml
@@ -3,6 +3,23 @@
 
 default:
     suites:
+        api_managing_product_options:
+            contexts:
+                - sylius.behat.context.hook.doctrine_orm
+
+                - sylius.behat.context.transform.lexical
+                - sylius.behat.context.transform.locale
+                - sylius.behat.context.transform.product_option
+                - sylius.behat.context.transform.shared_storage
+
+                - sylius.behat.context.setup.locale
+                - sylius.behat.context.setup.product_option
+                - sylius.behat.context.setup.admin_security
+
+                - sylius.behat.context.api.admin.managing_product_options
+
+            filters:
+                tags: "@managing_product_options && @api"
         ui_managing_product_options:
             contexts:
                 - sylius.behat.context.hook.doctrine_orm

--- a/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_options.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/product/managing_product_options.yml
@@ -17,6 +17,7 @@ default:
                 - sylius.behat.context.setup.admin_security
 
                 - sylius.behat.context.api.admin.managing_product_options
+                - sylius.behat.context.api.admin.notification
 
             filters:
                 tags: "@managing_product_options && @api"

--- a/src/Sylius/Bundle/ApiBundle/Behat/Extension/SyliusApiBundleExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Behat/Extension/SyliusApiBundleExtension.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Behat\Extension;
@@ -13,6 +22,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
+/**
+ * This extension disables javascript session when running api scenarios
+ */
 final class SyliusApiBundleExtension implements Extension
 {
     public function process(ContainerBuilder $container): void

--- a/src/Sylius/Bundle/ApiBundle/Behat/Extension/SyliusApiBundleExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Behat/Extension/SyliusApiBundleExtension.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Behat\Extension;
+
+use Behat\Testwork\ServiceContainer\Extension;
+use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Behat\Behat\Tester\ServiceContainer\TesterExtension;
+use Sylius\Bundle\ApiBundle\Behat\Tester\ApiScenarioEventDispatchingScenarioTester;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class SyliusApiBundleExtension implements Extension
+{
+    public function process(ContainerBuilder $container): void
+    {
+    }
+
+    public function getConfigKey(): string
+    {
+        return 'sylius_api';
+    }
+
+    public function initialize(ExtensionManager $extensionManager): void
+    {
+    }
+
+    public function configure(ArrayNodeDefinition $builder): void
+    {
+    }
+
+    public function load(ContainerBuilder $container, array $config): void
+    {
+        $definition = new Definition(ApiScenarioEventDispatchingScenarioTester::class, [
+            new Reference(TesterExtension::EXAMPLE_TESTER_ID)
+        ]);
+        $definition->addTag(TesterExtension::SCENARIO_TESTER_WRAPPER_TAG, array('priority' => -100000));
+
+        $container->setDefinition(ApiScenarioEventDispatchingScenarioTester::class, $definition);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Behat/Tester/ApiScenarioEventDispatchingScenarioTester.php
+++ b/src/Sylius/Bundle/ApiBundle/Behat/Tester/ApiScenarioEventDispatchingScenarioTester.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Behat\Tester;
+
+use Behat\Behat\Tester\ScenarioTester;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\ScenarioInterface as Scenario;
+use Behat\Gherkin\Node\ScenarioNode;
+use Behat\Testwork\Environment\Environment;
+use Behat\Testwork\Suite\Exception\ParameterNotFoundException;
+use Behat\Testwork\Tester\Result\TestResult;
+use Behat\Testwork\Tester\Setup\Setup;
+use Behat\Testwork\Tester\Setup\Teardown;
+
+final class ApiScenarioEventDispatchingScenarioTester implements ScenarioTester
+{
+    /** @var ScenarioTester */
+    private $baseTester;
+
+    public function __construct(ScenarioTester $baseTester)
+    {
+        $this->baseTester = $baseTester;
+    }
+
+    public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, $skip): Setup
+    {
+        try {
+            $javascript = $env->getSuite()->getSetting('javascript');
+        } catch (ParameterNotFoundException $exception) {
+            return $this->baseTester->setUp($env, $feature, $scenario, $skip);
+        }
+
+        if (!$javascript) {
+            $tags = $scenario->getTags();
+            if (($key = array_search('javascript', $tags)) !== false) {
+                unset($tags[$key]);
+            }
+
+            $scenario = new ScenarioNode(
+                $scenario->getTitle(),
+                $tags,
+                $scenario->getSteps(),
+                $scenario->getKeyword(),
+                $scenario->getLine()
+            );
+        }
+
+        return $this->baseTester->setUp($env, $feature, $scenario, $skip);
+    }
+
+    public function test(Environment $env, FeatureNode $feature, Scenario $scenario, $skip): TestResult
+    {
+        return $this->baseTester->test($env, $feature, $scenario, $skip);
+    }
+
+    public function tearDown(Environment $env, FeatureNode $feature, Scenario $scenario, $skip, TestResult $result): Teardown
+    {
+        return $this->baseTester->tearDown($env, $feature, $scenario, $skip, $result);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Behat/Tester/ApiScenarioEventDispatchingScenarioTester.php
+++ b/src/Sylius/Bundle/ApiBundle/Behat/Tester/ApiScenarioEventDispatchingScenarioTester.php
@@ -27,25 +27,25 @@ final class ApiScenarioEventDispatchingScenarioTester implements ScenarioTester
     public function setUp(Environment $env, FeatureNode $feature, Scenario $scenario, $skip): Setup
     {
         try {
-            $javascript = $env->getSuite()->getSetting('javascript');
+            if ($env->getSuite()->getSetting('javascript')) {
+                return $this->baseTester->setUp($env, $feature, $scenario, $skip);
+            }
         } catch (ParameterNotFoundException $exception) {
             return $this->baseTester->setUp($env, $feature, $scenario, $skip);
         }
 
-        if (!$javascript) {
-            $tags = $scenario->getTags();
-            if (($key = array_search('javascript', $tags)) !== false) {
-                unset($tags[$key]);
-            }
-
-            $scenario = new ScenarioNode(
-                $scenario->getTitle(),
-                $tags,
-                $scenario->getSteps(),
-                $scenario->getKeyword(),
-                $scenario->getLine()
-            );
+        $tags = $scenario->getTags();
+        if (($key = array_search('javascript', $tags)) !== false) {
+            unset($tags[$key]);
         }
+
+        $scenario = new ScenarioNode(
+            $scenario->getTitle(),
+            $tags,
+            $scenario->getSteps(),
+            $scenario->getKeyword(),
+            $scenario->getLine()
+        );
 
         return $this->baseTester->setUp($env, $feature, $scenario, $skip);
     }

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
@@ -33,4 +33,5 @@
         <property name="values" readable="true" writable="true" />
         <property name="translations" readable="true" writable="true" />
     </resource>
+
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+
+<resources xmlns="https://api-platform.com/schema/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd">
+
+    <resource
+        class="Sylius\Component\Product\Model\ProductOption"
+        shortName="ProductOption"
+    >
+        <attribute name="validation_groups">sylius</attribute>
+        <collectionOperations>
+            <collectionOperation name="get" />
+        </collectionOperations>
+        <itemOperations>
+            <itemOperation name="get" />
+        </itemOperations>
+        <property name="id" identifier="false" writable="false" />
+        <property name="code" identifier="true" required="true" />
+        <property name="createdAt" writable="false" />
+        <property name="updatedAt" writable="false" />
+        <property name="values" readable="false" writable="false" />
+        <property name="translations" readable="false" writable="false" />
+    </resource>
+</resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
@@ -30,7 +30,9 @@
         <property name="code" identifier="true" required="true" />
         <property name="createdAt" writable="false" />
         <property name="updatedAt" writable="false" />
-        <property name="values" readable="true" writable="true" />
+        <property name="values" readable="true" writable="true">
+            <subresource resourceClass="Sylius\Component\Product\Model\ProductOptionValue" collection="true" />
+        </property>
         <property name="translations" readable="true" writable="true" />
     </resource>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
@@ -11,6 +11,7 @@
         <attribute name="validation_groups">sylius</attribute>
         <collectionOperations>
             <collectionOperation name="get" />
+            <collectionOperation name="post" />
         </collectionOperations>
         <itemOperations>
             <itemOperation name="get" />
@@ -19,7 +20,7 @@
         <property name="code" identifier="true" required="true" />
         <property name="createdAt" writable="false" />
         <property name="updatedAt" writable="false" />
-        <property name="values" readable="false" writable="false" />
-        <property name="translations" readable="false" writable="false" />
+        <property name="values" readable="true" writable="true" />
+        <property name="translations" readable="true" writable="true" />
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
@@ -5,32 +5,26 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd">
 
     <resource
-        class="Sylius\Component\Product\Model\ProductOption"
-        shortName="ProductOption"
+        class="Sylius\Component\Product\Model\ProductOptionValue"
+        shortName="ProductOptionValue"
     >
         <attribute name="normalization_context">
             <attribute name="groups">
-                <attribute>product_option:read</attribute>
+                <attribute>product_option_value:read</attribute>
             </attribute>
         </attribute>
         <attribute name="denormalization_context">
             <attribute name="groups">
-                <attribute>product_option:write</attribute>
+                <attribute>product_option_value:write</attribute>
             </attribute>
         </attribute>
-        <attribute name="validation_groups">sylius</attribute>
-        <collectionOperations>
-            <collectionOperation name="get" />
-            <collectionOperation name="post" />
-        </collectionOperations>
+        <collectionOperations />
         <itemOperations>
             <itemOperation name="get" />
         </itemOperations>
+        <attribute name="validation_groups">sylius</attribute>
         <property name="id" identifier="false" writable="false" />
         <property name="code" identifier="true" required="true" />
-        <property name="createdAt" writable="false" />
-        <property name="updatedAt" writable="false" />
-        <property name="values" readable="true" writable="true" />
         <property name="translations" readable="true" writable="true" />
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
@@ -10,12 +10,12 @@
     >
         <attribute name="normalization_context">
             <attribute name="groups">
-                <attribute>product_option:read</attribute>
+                <attribute>product_option_value:read</attribute>
             </attribute>
         </attribute>
         <attribute name="denormalization_context">
             <attribute name="groups">
-                <attribute>product_option:write</attribute>
+                <attribute>product_option_value:write</attribute>
             </attribute>
         </attribute>
         <collectionOperations />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
@@ -10,12 +10,12 @@
     >
         <attribute name="normalization_context">
             <attribute name="groups">
-                <attribute>product_option_value:read</attribute>
+                <attribute>product_option:read</attribute>
             </attribute>
         </attribute>
         <attribute name="denormalization_context">
             <attribute name="groups">
-                <attribute>product_option_value:write</attribute>
+                <attribute>product_option:write</attribute>
             </attribute>
         </attribute>
         <collectionOperations />
@@ -27,4 +27,5 @@
         <property name="code" identifier="true" required="true" />
         <property name="translations" readable="true" writable="true" />
     </resource>
+
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOption.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">
+
+    <class name="Sylius\Component\Product\Model\ProductOption">
+        <attribute name="id">
+            <group>product_option:read</group>
+        </attribute>
+        <attribute name="code">
+            <group>product_option:read</group>
+            <group>product_option:write</group>
+        </attribute>
+        <attribute name="name">
+            <group>product_option:read</group>
+        </attribute>
+        <attribute name="createdAt">
+            <group>product_option:read</group>
+        </attribute>
+        <attribute name="updatedAt">
+            <group>product_option:read</group>
+        </attribute>
+        <attribute name="values">
+            <group>product_option:read</group>
+            <group>product_option:write</group>
+        </attribute>
+        <attribute name="translations">
+            <group>product_option:read</group>
+            <group>product_option:write</group>
+        </attribute>
+    </class>
+
+</serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOptionTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOptionTranslation.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">
+
+    <class name="Sylius\Component\Product\Model\ProductOptionTranslation">
+        <attribute name="id">
+            <group>product_option:read</group>
+        </attribute>
+        <attribute name="name">
+            <group>product_option:read</group>
+            <group>product_option:write</group>
+        </attribute>
+        <attribute name="locale">
+            <group>product_option:write</group>
+        </attribute>
+    </class>
+
+</serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOptionValue.xml
@@ -6,15 +6,17 @@
 
     <class name="Sylius\Component\Product\Model\ProductOptionValue">
         <attribute name="id">
-            <group>product_option:read</group>
+            <group>product_option_value:read</group>
         </attribute>
         <attribute name="code">
-            <group>product_option:read</group>
             <group>product_option:write</group>
+            <group>product_option_value:read</group>
+            <group>product_option_value:write</group>
         </attribute>
         <attribute name="translations">
             <group>product_option:write</group>
-            <group>product_option:read</group>
+            <group>product_option_value:read</group>
+            <group>product_option_value:write</group>
         </attribute>
     </class>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOptionValue.xml
@@ -6,19 +6,15 @@
 
     <class name="Sylius\Component\Product\Model\ProductOptionValue">
         <attribute name="id">
-            <group>product_option_value:read</group>
+            <group>product_option:read</group>
         </attribute>
         <attribute name="code">
             <group>product_option:read</group>
             <group>product_option:write</group>
-            <group>product_option_value:read</group>
-            <group>product_option_value:write</group>
         </attribute>
         <attribute name="translations">
             <group>product_option:write</group>
             <group>product_option:read</group>
-            <group>product_option_value:read</group>
-            <group>product_option_value:write</group>
         </attribute>
     </class>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOptionValue.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">
+
+    <class name="Sylius\Component\Product\Model\ProductOptionValue">
+        <attribute name="id">
+            <group>product_option_value:read</group>
+        </attribute>
+        <attribute name="code">
+            <group>product_option:read</group>
+            <group>product_option:write</group>
+            <group>product_option_value:read</group>
+            <group>product_option_value:write</group>
+        </attribute>
+        <attribute name="translations">
+            <group>product_option:write</group>
+            <group>product_option:read</group>
+            <group>product_option_value:read</group>
+            <group>product_option_value:write</group>
+        </attribute>
+    </class>
+
+</serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOptionValueTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOptionValueTranslation.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">
+
+    <class name="Sylius\Component\Product\Model\ProductOptionValueTranslation">
+        <attribute name="id">
+            <group>product_option_value:read</group>
+        </attribute>
+        <attribute name="value">
+            <group>product_option:read</group>
+            <group>product_option:write</group>
+            <group>product_option_value:read</group>
+            <group>product_option_value:write</group>
+        </attribute>
+        <attribute name="locale">
+            <group>product_option:write</group>
+            <group>product_option_value:write</group>
+        </attribute>
+    </class>
+
+</serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOptionValueTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOptionValueTranslation.xml
@@ -6,14 +6,16 @@
 
     <class name="Sylius\Component\Product\Model\ProductOptionValueTranslation">
         <attribute name="id">
-            <group>product_option:read</group>
+            <group>product_option_value:read</group>
         </attribute>
         <attribute name="value">
-            <group>product_option:read</group>
             <group>product_option:write</group>
+            <group>product_option_value:read</group>
+            <group>product_option_value:write</group>
         </attribute>
         <attribute name="locale">
             <group>product_option:write</group>
+            <group>product_option_value:write</group>
         </attribute>
     </class>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOptionValueTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serializer/ProductOptionValueTranslation.xml
@@ -6,17 +6,14 @@
 
     <class name="Sylius\Component\Product\Model\ProductOptionValueTranslation">
         <attribute name="id">
-            <group>product_option_value:read</group>
+            <group>product_option:read</group>
         </attribute>
         <attribute name="value">
             <group>product_option:read</group>
             <group>product_option:write</group>
-            <group>product_option_value:read</group>
-            <group>product_option_value:write</group>
         </attribute>
         <attribute name="locale">
             <group>product_option:write</group>
-            <group>product_option_value:write</group>
         </attribute>
     </class>
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | api
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

PR consists of API for creation and indexing product options (with product option values as sub-resources):

<img width="1353" alt="Zrzut ekranu 2020-02-25 o 12 36 00" src="https://user-images.githubusercontent.com/6212718/75244118-79b36900-57cb-11ea-8ccc-bb590c67a7c7.png">


It also contains a PoC of the Behat extension, that does not allow to run a javascript session for API scenarios with multiple tags (like `@ui @javascript @api`) 💃 