### PR TITLE
Filter variables passed to legacy Sonata block events

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Block/_legacySonataEvent.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Block/_legacySonataEvent.html.twig
@@ -1,1 +1,4 @@
-{{ sonata_block_render_event(metadata.applicationName ~ '.admin.' ~ metadata.name ~ '.' ~ postfix, _context) }}
+{{ sonata_block_render_event(
+    metadata.applicationName ~ '.admin.' ~ metadata.name ~ '.' ~ postfix,
+    _context|filter((value, key) => key in sonata_block_whitelisted_variables())
+) }}

--- a/src/Sylius/Bundle/UiBundle/DependencyInjection/Compiler/LegacySonataBlockPass.php
+++ b/src/Sylius/Bundle/UiBundle/DependencyInjection/Compiler/LegacySonataBlockPass.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\UiBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @internal
+ */
+final class LegacySonataBlockPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $whitelistedVariables = [];
+        $configs = $container->getExtensionConfig('sonata_block');
+
+        foreach ($configs as $config) {
+            if (!isset($config['blocks']['sonata.block.service.template']['settings'])) {
+                continue;
+            }
+
+            $whitelistedVariables = array_merge(
+                $whitelistedVariables,
+                array_keys($config['blocks']['sonata.block.service.template']['settings'])
+            );
+        }
+
+        $whitelistedVariables = array_unique($whitelistedVariables);
+
+        $container->setParameter('sylius_ui.sonata_block.whitelisted_variables', $whitelistedVariables);
+    }
+}

--- a/src/Sylius/Bundle/UiBundle/Resources/config/services/twig.xml
+++ b/src/Sylius/Bundle/UiBundle/Resources/config/services/twig.xml
@@ -41,5 +41,10 @@
         <service id="sylius.twig.extension.merge_recursive" class="Sylius\Bundle\UiBundle\Twig\MergeRecursiveExtension">
             <tag name="twig.extension" />
         </service>
+
+        <service id="Sylius\Bundle\UiBundle\Twig\LegacySonataBlockExtension">
+            <argument>%sylius_ui.sonata_block.whitelisted_variables%</argument>
+            <tag name="twig.extension" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Block/_legacySonataEvent.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Block/_legacySonataEvent.html.twig
@@ -1,1 +1,4 @@
-{{ sonata_block_render_event(event, _context) }}
+{{ sonata_block_render_event(
+    event,
+    _context|filter((value, key) => key in sonata_block_whitelisted_variables())
+) }}

--- a/src/Sylius/Bundle/UiBundle/SyliusUiBundle.php
+++ b/src/Sylius/Bundle/UiBundle/SyliusUiBundle.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\UiBundle;
 
+use Sylius\Bundle\UiBundle\DependencyInjection\Compiler\LegacySonataBlockPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -20,4 +22,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 final class SyliusUiBundle extends Bundle
 {
+    public function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new LegacySonataBlockPass());
+    }
 }

--- a/src/Sylius/Bundle/UiBundle/Twig/LegacySonataBlockExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/LegacySonataBlockExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\UiBundle\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * @internal
+ */
+final class LegacySonataBlockExtension extends AbstractExtension
+{
+    /** @var array */
+    private $whitelistedVariables;
+
+    public function __construct(array $whitelistedVariables)
+    {
+        $this->whitelistedVariables = $whitelistedVariables;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sonata_block_whitelisted_variables', [$this, 'getWhitelistedVariables']),
+        ];
+    }
+
+    public function getWhitelistedVariables(): array
+    {
+        return $this->whitelistedVariables;
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #11120
| License         | MIT

All classes added as internal, the Twig function is not supposed to be used by end-users.
