### PR TITLE
Mark new template events implementation as experimental

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Block/BlockEventListener.php
+++ b/src/Sylius/Bundle/UiBundle/Block/BlockEventListener.php
@@ -16,6 +16,9 @@ namespace Sylius\Bundle\UiBundle\Block;
 use Sonata\BlockBundle\Event\BlockEvent;
 use Sonata\BlockBundle\Model\Block;
 
+/**
+ * @deprecated
+ */
 final class BlockEventListener
 {
     /** @var string */

--- a/src/Sylius/Bundle/UiBundle/Command/DebugTemplateEventCommand.php
+++ b/src/Sylius/Bundle/UiBundle/Command/DebugTemplateEventCommand.php
@@ -21,6 +21,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+/**
+ * @experimental
+ */
 final class DebugTemplateEventCommand extends Command
 {
     protected static $defaultName = 'sylius:debug:template-event';

--- a/src/Sylius/Bundle/UiBundle/DataCollector/TemplateBlockDataCollector.php
+++ b/src/Sylius/Bundle/UiBundle/DataCollector/TemplateBlockDataCollector.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 
 /**
  * @internal
+ * @experimental
  */
 final class TemplateBlockDataCollector extends DataCollector
 {

--- a/src/Sylius/Bundle/UiBundle/DataCollector/TemplateBlockRenderingHistory.php
+++ b/src/Sylius/Bundle/UiBundle/DataCollector/TemplateBlockRenderingHistory.php
@@ -17,6 +17,7 @@ use Sylius\Bundle\UiBundle\Registry\TemplateBlock;
 
 /**
  * @internal
+ * @experimental
  */
 final class TemplateBlockRenderingHistory
 {

--- a/src/Sylius/Bundle/UiBundle/DataCollector/TraceableTemplateBlockRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/DataCollector/TraceableTemplateBlockRenderer.php
@@ -18,6 +18,7 @@ use Sylius\Bundle\UiBundle\Renderer\TemplateBlockRendererInterface;
 
 /**
  * @internal
+ * @experimental
  */
 final class TraceableTemplateBlockRenderer implements TemplateBlockRendererInterface
 {

--- a/src/Sylius/Bundle/UiBundle/DataCollector/TraceableTemplateEventRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/DataCollector/TraceableTemplateEventRenderer.php
@@ -17,6 +17,7 @@ use Sylius\Bundle\UiBundle\Renderer\TemplateEventRendererInterface;
 
 /**
  * @internal
+ * @experimental
  */
 final class TraceableTemplateEventRenderer implements TemplateEventRendererInterface
 {

--- a/src/Sylius/Bundle/UiBundle/DependencyInjection/Compiler/LegacySonataBlockPass.php
+++ b/src/Sylius/Bundle/UiBundle/DependencyInjection/Compiler/LegacySonataBlockPass.php
@@ -9,6 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @internal
+ * @experimental
  */
 final class LegacySonataBlockPass implements CompilerPassInterface
 {

--- a/src/Sylius/Bundle/UiBundle/DependencyInjection/SyliusUiExtension.php
+++ b/src/Sylius/Bundle/UiBundle/DependencyInjection/SyliusUiExtension.php
@@ -39,6 +39,8 @@ final class SyliusUiExtension extends Extension
     }
 
     /**
+     * @experimental
+     *
      * @psalm-param array<string, array{blocks: array<string, array{template: string, context: array, priority: int, enabled: bool}>}> $eventsConfig
      */
     private function loadEvents(array $eventsConfig, ContainerBuilder $container): void

--- a/src/Sylius/Bundle/UiBundle/Registry/TemplateBlock.php
+++ b/src/Sylius/Bundle/UiBundle/Registry/TemplateBlock.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\UiBundle\Registry;
 
+/**
+ * @experimental
+ */
 final class TemplateBlock
 {
     /** @var string */

--- a/src/Sylius/Bundle/UiBundle/Registry/TemplateBlockRegistry.php
+++ b/src/Sylius/Bundle/UiBundle/Registry/TemplateBlockRegistry.php
@@ -15,6 +15,9 @@ namespace Sylius\Bundle\UiBundle\Registry;
 
 use Zend\Stdlib\SplPriorityQueue;
 
+/**
+ * @experimental
+ */
 final class TemplateBlockRegistry implements TemplateBlockRegistryInterface
 {
     /**

--- a/src/Sylius/Bundle/UiBundle/Registry/TemplateBlockRegistryInterface.php
+++ b/src/Sylius/Bundle/UiBundle/Registry/TemplateBlockRegistryInterface.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\UiBundle\Registry;
 
+/**
+ * @experimental
+ */
 interface TemplateBlockRegistryInterface
 {
     /**

--- a/src/Sylius/Bundle/UiBundle/Renderer/DelegatingTemplateEventRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/DelegatingTemplateEventRenderer.php
@@ -15,6 +15,9 @@ namespace Sylius\Bundle\UiBundle\Renderer;
 
 use Sylius\Bundle\UiBundle\Registry\TemplateBlockRegistryInterface;
 
+/**
+ * @experimental
+ */
 final class DelegatingTemplateEventRenderer implements TemplateEventRendererInterface
 {
     /** @var TemplateBlockRegistryInterface */

--- a/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateBlockRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateBlockRenderer.php
@@ -15,6 +15,9 @@ namespace Sylius\Bundle\UiBundle\Renderer;
 
 use Sylius\Bundle\UiBundle\Registry\TemplateBlock;
 
+/**
+ * @experimental
+ */
 final class HtmlDebugTemplateBlockRenderer implements TemplateBlockRendererInterface
 {
     /** @var TemplateBlockRendererInterface */

--- a/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateEventRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/HtmlDebugTemplateEventRenderer.php
@@ -16,6 +16,9 @@ namespace Sylius\Bundle\UiBundle\Renderer;
 use Sylius\Bundle\UiBundle\Registry\TemplateBlock;
 use Sylius\Bundle\UiBundle\Registry\TemplateBlockRegistryInterface;
 
+/**
+ * @experimental
+ */
 final class HtmlDebugTemplateEventRenderer implements TemplateEventRendererInterface
 {
     /** @var TemplateEventRendererInterface */

--- a/src/Sylius/Bundle/UiBundle/Renderer/TemplateBlockRendererInterface.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/TemplateBlockRendererInterface.php
@@ -15,6 +15,9 @@ namespace Sylius\Bundle\UiBundle\Renderer;
 
 use Sylius\Bundle\UiBundle\Registry\TemplateBlock;
 
+/**
+ * @experimental
+ */
 interface TemplateBlockRendererInterface
 {
     public function render(TemplateBlock $templateBlock, array $context = []): string;

--- a/src/Sylius/Bundle/UiBundle/Renderer/TemplateEventRendererInterface.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/TemplateEventRendererInterface.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\UiBundle\Renderer;
 
+/**
+ * @experimental
+ */
 interface TemplateEventRendererInterface
 {
     /**

--- a/src/Sylius/Bundle/UiBundle/Renderer/TwigTemplateBlockRenderer.php
+++ b/src/Sylius/Bundle/UiBundle/Renderer/TwigTemplateBlockRenderer.php
@@ -16,6 +16,9 @@ namespace Sylius\Bundle\UiBundle\Renderer;
 use Sylius\Bundle\UiBundle\Registry\TemplateBlock;
 use Twig\Environment;
 
+/**
+ * @experimental
+ */
 final class TwigTemplateBlockRenderer implements TemplateBlockRendererInterface
 {
     /** @var Environment */

--- a/src/Sylius/Bundle/UiBundle/Twig/LegacySonataBlockExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/LegacySonataBlockExtension.php
@@ -9,6 +9,7 @@ use Twig\TwigFunction;
 
 /**
  * @internal
+ * @experimental
  */
 final class LegacySonataBlockExtension extends AbstractExtension
 {

--- a/src/Sylius/Bundle/UiBundle/Twig/TemplateEventExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/TemplateEventExtension.php
@@ -17,6 +17,9 @@ use Sylius\Bundle\UiBundle\Renderer\TemplateEventRendererInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
+/**
+ * @experimental
+ */
 final class TemplateEventExtension extends AbstractExtension
 {
     /** @var TemplateEventRendererInterface */


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | yes
| Related tickets | related to #10997
| License         | MIT

Marking the implementation of template events as experimental, so that some changes can be made in 1.8 release (not too much probably). The end-user API (`sylius_template_event` Twig method and `sylius_ui` configuration) will always stay the same.
