### PR TITLE
Fix UPGRADE-1.7 file

### DIFF
--- a/UPGRADE-1.7.md
+++ b/UPGRADE-1.7.md
@@ -3,7 +3,7 @@
 1. Require upgraded Sylius version using Composer:
 
     ```bash
-    composer require sylius/sylius:~1.7.0
+    composer require sylius/sylius:~1.7.0 --update-with-dependencies
     ```
    
    You might need to adjust your `config.platform.php` setting in `composer.json`, because Sylius 1.7 requires PHP 7.3 or higher.
@@ -26,10 +26,12 @@
    
    Run `yarn install && yarn build` to use them.
 
-3. Remove `SonataCoreBundle` from your list of used bundles in `config/bundles.php` if you are not using it apart from Sylius:
+3. Remove not needed bundles from your list of used bundles in `config/bundles.php` if you are not using it apart from Sylius:
 
     ```diff
     -   Sonata\CoreBundle\SonataCoreBundle::class => ['all' => true],
+    -   Sonata\IntlBundle\SonataIntlBundle::class => ['all' => true],
+    -   Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['all' => true],
     ```
     
     You should remove `config/packages/sonata_core.yaml` as well.


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I believe we should also delete [this migration file](https://github.com/Sylius/Sylius-Standard/blob/1.7/src/Migrations/Version20191119131635.php) due to https://github.com/Sylius/Sylius/pull/11053