### PR TITLE
Separated order items subtotal calculation logic from twig extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 dist: trusty
 
-sudo: false
+sudo: true
 
 env:
     global:

--- a/composer.json
+++ b/composer.json
@@ -125,6 +125,7 @@
         "phpstan/phpstan-doctrine": "^0.11",
         "phpstan/phpstan-webmozart-assert": "^0.11",
         "phpunit/phpunit": "^7.0",
+        "psalm/plugin-mockery": "^0.3.0",
         "psr/event-dispatcher": "^1.0",
         "sensiolabs/security-checker": "^5.0",
         "sspooky13/yaml-standards": "^5.0",

--- a/etc/travis/suites/packages/before_install.sh
+++ b/etc/travis/suites/packages/before_install.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
+# Make swap
+#https://getcomposer.org/doc/articles/troubleshooting.md#proc-open-fork-failed-errors
+sudo fallocate -l 4G /var/swap.1
+sudo /sbin/mkswap /var/swap.1
+sudo /sbin/swapon /var/swap.1
+
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../bash/common.lib.sh"
 
 # To be able to install sylius/* packages by symlinking

--- a/psalm.xml
+++ b/psalm.xml
@@ -212,4 +212,8 @@
         <InvalidCatch errorLevel="info" />
 
     </issueHandlers>
+
+    <plugins>
+        <pluginClass class="Psalm\MockeryPlugin\Plugin" />
+    </plugins>
 </psalm>

--- a/src/Sylius/Bundle/ShopBundle/Calculator/OrderItemsSubtotalCalculator.php
+++ b/src/Sylius/Bundle/ShopBundle/Calculator/OrderItemsSubtotalCalculator.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShopBundle\Calculator;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+
+final class OrderItemsSubtotalCalculator implements OrderItemsSubtotalCalculatorInterface
+{
+    public function getSubtotal(OrderInterface $order): int
+    {
+        return array_reduce(
+            $order->getItems()->toArray(),
+            static function (int $subtotal, OrderItemInterface $item): int {
+                return $subtotal + $item->getSubtotal();
+            },
+            0
+        );
+    }
+}

--- a/src/Sylius/Bundle/ShopBundle/Calculator/OrderItemsSubtotalCalculatorInterface.php
+++ b/src/Sylius/Bundle/ShopBundle/Calculator/OrderItemsSubtotalCalculatorInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShopBundle\Calculator;
+
+use Sylius\Component\Core\Model\OrderInterface;
+
+interface OrderItemsSubtotalCalculatorInterface
+{
+    public function getSubtotal(OrderInterface $order): int;
+}

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services.xml
@@ -46,5 +46,9 @@
         <service id="sylius.grid_filter.shop_string" class="Sylius\Component\Grid\Filter\StringFilter">
             <tag name="sylius.grid_filter" type="shop_string" form-type="Sylius\Bundle\GridBundle\Form\Type\Filter\StringFilterType" />
         </service>
+
+        <service id="sylius.calculator.order_items_subtotal" class="Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculator" />
+
+        <service id="Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculatorInterface" alias="sylius.calculator.order_items_subtotal" />
     </services>
 </container>

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services/twig.xml
@@ -20,6 +20,7 @@
         </service>
 
         <service id="sylius.twig.extension.subtotal" class="Sylius\Bundle\ShopBundle\Twig\OrderItemsSubtotalExtension" public="false">
+            <argument type="service" id="sylius.calculator.order_items_subtotal" />
             <tag name="twig.extension" />
         </service>
     </services>

--- a/src/Sylius/Bundle/ShopBundle/Tests/Calculator/OrderItemsSubtotalCalculatorTest.php
+++ b/src/Sylius/Bundle/ShopBundle/Tests/Calculator/OrderItemsSubtotalCalculatorTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ShopBundle\Tests\Calculator;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculator;
+use Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculatorInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+
+final class OrderItemsSubtotalCalculatorTest extends TestCase
+{
+    private function getOrderItemMock(int $subTotal): OrderItemInterface
+    {
+        $orderItem = Mockery::mock(OrderItemInterface::class);
+        $orderItem
+            ->shouldReceive('getSubTotal')
+            ->once()
+            ->andReturn($subTotal)
+        ;
+
+        return $orderItem;
+    }
+
+    private function getOrderMock(array $orderItems): OrderInterface
+    {
+        $order = Mockery::mock(OrderInterface::class);
+        $order
+            ->shouldReceive('getItems->toArray')
+            ->once()
+            ->andReturn($orderItems);
+
+        return $order;
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_instantiated(): OrderItemsSubtotalCalculator
+    {
+        $calculator = new OrderItemsSubtotalCalculator();
+        $this->assertInstanceOf(OrderItemsSubtotalCalculatorInterface::class, $calculator);
+
+        return $calculator;
+    }
+
+    /**
+     * @test
+     * @depends it_can_be_instantiated
+     * @param OrderItemsSubtotalCalculator $calculator
+     */
+    public function it_can_calculate_the_subtotal_of_order_items(OrderItemsSubtotalCalculator $calculator): void
+    {
+        $subTotal = $calculator->getSubtotal($this->getOrderMock([
+            $this->getOrderItemMock(1000),
+            $this->getOrderItemMock(1000)
+        ]));
+        $this->assertEquals(2000, $subTotal);
+    }
+
+    /**
+     * @test
+     * @depends it_can_be_instantiated
+     * @param OrderItemsSubtotalCalculator $calculator
+     */
+    public function it_can_calculate_a_subtotal_if_there_are_no_order_items(
+        OrderItemsSubtotalCalculator $calculator
+    ): void {
+        $subTotal = $calculator->getSubtotal($this->getOrderMock([]));
+        $this->assertEquals(0, $subTotal);
+    }
+
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+}

--- a/src/Sylius/Bundle/ShopBundle/Tests/Calculator/OrderItemsSubtotalCalculatorTest.php
+++ b/src/Sylius/Bundle/ShopBundle/Tests/Calculator/OrderItemsSubtotalCalculatorTest.php
@@ -14,37 +14,14 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ShopBundle\Tests\Calculator;
 
 use Mockery;
-use PHPUnit\Framework\TestCase;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculator;
 use Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculatorInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 
-final class OrderItemsSubtotalCalculatorTest extends TestCase
+final class OrderItemsSubtotalCalculatorTest extends MockeryTestCase
 {
-    private function getOrderItemMock(int $subTotal): OrderItemInterface
-    {
-        $orderItem = Mockery::mock(OrderItemInterface::class);
-        $orderItem
-            ->shouldReceive('getSubTotal')
-            ->once()
-            ->andReturn($subTotal)
-        ;
-
-        return $orderItem;
-    }
-
-    private function getOrderMock(array $orderItems): OrderInterface
-    {
-        $order = Mockery::mock(OrderInterface::class);
-        $order
-            ->shouldReceive('getItems->toArray')
-            ->once()
-            ->andReturn($orderItems);
-
-        return $order;
-    }
-
     /**
      * @test
      */
@@ -82,8 +59,26 @@ final class OrderItemsSubtotalCalculatorTest extends TestCase
         $this->assertEquals(0, $subTotal);
     }
 
-    public function tearDown()
+    private function getOrderItemMock(int $subTotal): OrderItemInterface
     {
-        Mockery::close();
+        $orderItem = Mockery::mock(OrderItemInterface::class);
+        $orderItem
+            ->shouldReceive('getSubTotal')
+            ->once()
+            ->andReturn($subTotal)
+        ;
+
+        return $orderItem;
+    }
+
+    private function getOrderMock(array $orderItems): OrderInterface
+    {
+        $order = Mockery::mock(OrderInterface::class);
+        $order
+            ->shouldReceive('getItems->toArray')
+            ->once()
+            ->andReturn($orderItems);
+
+        return $order;
     }
 }

--- a/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
@@ -26,7 +26,7 @@ class OrderItemsSubtotalExtension extends \Twig_Extension
      * @param OrderItemsSubtotalCalculatorInterface|null $calculator This argument is optional for backwards
      *                                                               compatibility. If null is passed then an instance
      *                                                               of OrderItemsSubtotalCalculator is used.
-     * @todo Make $calculator argument mandatory in version 2.0
+     * @deprecated  Not passing a calculator is deprecated since 1.6. Argument will no longer be optional from 2.0
      */
     public function __construct(?OrderItemsSubtotalCalculatorInterface $calculator = null)
     {

--- a/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
@@ -26,7 +26,7 @@ class OrderItemsSubtotalExtension extends \Twig_Extension
      * @param OrderItemsSubtotalCalculatorInterface|null $calculator This argument is optional for backwards
      *                                                               compatibility. If null is passed then an instance
      *                                                               of OrderItemsSubtotalCalculator is used.
-     * @deprecated  Not passing a calculator is deprecated since 1.6. Argument will no longer be optional from 2.0
+     * @deprecated Not passing a calculator is deprecated since 1.6. Argument will no longer be optional from 2.0.
      */
     public function __construct(?OrderItemsSubtotalCalculatorInterface $calculator = null)
     {
@@ -34,6 +34,11 @@ class OrderItemsSubtotalExtension extends \Twig_Extension
             $this->calculator = $calculator;
         } else {
             $this->calculator = new OrderItemsSubtotalCalculator();
+
+            @trigger_error(
+                'Not passing a calculator is deprecated since 1.6. Argument will no longer be optional from 2.0.',
+                \E_USER_DEPRECATED
+            );
         }
     }
 

--- a/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ShopBundle\Twig;
 
+use Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculator;
 use Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculatorInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 
@@ -21,9 +22,19 @@ class OrderItemsSubtotalExtension extends \Twig_Extension
     /** @var OrderItemsSubtotalCalculatorInterface */
     private $calculator;
 
-    public function __construct(OrderItemsSubtotalCalculatorInterface $calculator)
+    /**
+     * @param OrderItemsSubtotalCalculatorInterface|null $calculator This argument is optional for backwards
+     *                                                               compatibility. If null is passed then an instance
+     *                                                               of OrderItemsSubtotalCalculator is used.
+     * @todo Make $calculator argument mandatory in version 2.0
+     */
+    public function __construct(?OrderItemsSubtotalCalculatorInterface $calculator = null)
     {
-        $this->calculator = $calculator;
+        if (null !== $calculator) {
+            $this->calculator = $calculator;
+        } else {
+            $this->calculator = new OrderItemsSubtotalCalculator();
+        }
     }
 
     public function getFunctions(): array

--- a/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
@@ -22,12 +22,6 @@ class OrderItemsSubtotalExtension extends \Twig_Extension
     /** @var OrderItemsSubtotalCalculatorInterface */
     private $calculator;
 
-    /**
-     * @param OrderItemsSubtotalCalculatorInterface|null $calculator This argument is optional for backwards
-     *                                                               compatibility. If null is passed then an instance
-     *                                                               of OrderItemsSubtotalCalculator is used.
-     * @deprecated Not passing a calculator is deprecated since 1.6. Argument will no longer be optional from 2.0.
-     */
     public function __construct(?OrderItemsSubtotalCalculatorInterface $calculator = null)
     {
         if (null !== $calculator) {

--- a/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
+++ b/src/Sylius/Bundle/ShopBundle/Twig/OrderItemsSubtotalExtension.php
@@ -13,11 +13,19 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ShopBundle\Twig;
 
+use Sylius\Bundle\ShopBundle\Calculator\OrderItemsSubtotalCalculatorInterface;
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Core\Model\OrderItemInterface;
 
 class OrderItemsSubtotalExtension extends \Twig_Extension
 {
+    /** @var OrderItemsSubtotalCalculatorInterface */
+    private $calculator;
+
+    public function __construct(OrderItemsSubtotalCalculatorInterface $calculator)
+    {
+        $this->calculator = $calculator;
+    }
+
     public function getFunctions(): array
     {
         return [
@@ -27,12 +35,6 @@ class OrderItemsSubtotalExtension extends \Twig_Extension
 
     public function getSubtotal(OrderInterface $order): int
     {
-        return array_reduce(
-            $order->getItems()->toArray(),
-            static function (int $subtotal, OrderItemInterface $item) {
-                return $subtotal + $item->getSubtotal();
-            },
-            0
-        );
+        return $this->calculator->getSubtotal($order);
     }
 }

--- a/src/Sylius/Bundle/ShopBundle/composer.json
+++ b/src/Sylius/Bundle/ShopBundle/composer.json
@@ -40,7 +40,8 @@
         "matthiasnoback/symfony-dependency-injection-test": "^3.0",
         "phpspec/phpspec": "^5.0",
         "phpunit/phpunit": "^7.0",
-        "symfony/dependency-injection": "^3.4|^4.3"
+        "symfony/dependency-injection": "^3.4|^4.3",
+        "mockery/mockery": "^1.3"
     },
     "config": {
         "bin-dir": "bin"

--- a/symfony.lock
+++ b/symfony.lock
@@ -437,6 +437,9 @@
     "polishsymfonycommunity/symfony-mocker-container": {
         "version": "v1.0.2"
     },
+    "psalm/plugin-mockery": {
+        "version": "0.3.0"
+    },
     "psr/cache": {
         "version": "1.0.1"
     },


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

I'd like to be able to use the logic for calculating the subtotal of all order items outside of Twig templates, hence this separation.
