### PR TITLE
Add Important information in documentation when change name of plugin

### DIFF
--- a/docs/plugin-development-guide/naming.rst
+++ b/docs/plugin-development-guide/naming.rst
@@ -57,3 +57,15 @@ You should also delete Behat suite named ``greeting_customer`` from ``tests/Beha
     You **don't have to** remove all these files mentioned above. They can be adapted to suit your plugin functionality. However, as
     they provide default, dummy features only for the presentation reasons, it's just easier to delete them and implement new ones on
     your own.
+    
+.. important::
+    After you have change name of plugin, please run in your main directory of plugin (cd MyPlugin/ && composer install). 
+    If you don't       rerun this command you can have this error : 
+    ```bash
+    $ (cd tests/Application && bin/console assets:install public -e test)
+    PHP Fatal error: Uncaught Symfony\Component\Debug\Exception\ClassNotFoundException: Attempted to load class "Kernel" from namespace "Tests\FMDD\SyliusEmailOrderAdminPlugin\Application".
+    Did you forget a "use" statement for e.g. "Symfony\Component\HttpKernel\Kernel" or "Sylius\Bundle\CoreBundle\Application\Kernel"? in C:\Users\FMDD\Plugins\SyliusEmailOrderAdminPlugin\tests\Application\bin\console:36
+    Stack trace:
+    #0 {main}
+    thrown in C:\Users\FMDD\Plugins\SyliusEmailOrderAdminPlugin\tests\Application\bin\console on line 36
+    ```

--- a/docs/plugin-development-guide/naming.rst
+++ b/docs/plugin-development-guide/naming.rst
@@ -60,7 +60,7 @@ You should also delete Behat suite named ``greeting_customer`` from ``tests/Beha
     
 .. important::
     After you have change name of plugin, please run in your main directory of plugin (cd MyPlugin/ && composer install). 
-    If you don't       rerun this command you can have this error : 
+    If you don't rerun this command you may have this error : 
     ```bash
     $ (cd tests/Application && bin/console assets:install public -e test)
     PHP Fatal error: Uncaught Symfony\Component\Debug\Exception\ClassNotFoundException: Attempted to load class "Kernel" from namespace "Tests\FMDD\SyliusEmailOrderAdminPlugin\Application".


### PR DESCRIPTION
After you have change name of plugin, please run composer install in your main directory. Else you have this error :  PHP Fatal error: Uncaught Symfony\Component\Debug\Exception\ClassNotFoundException: Attempted to load class "Kernel" from namespace

| Q               | A
| --------------- | -----
| Branch?         | 1.6
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.6 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
