### PR TITLE
Add translations issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,9 +1,11 @@
 ---
-name: "Bug Report 🐛"
+name: "Bug Report \U0001F41B"
 about: Report a problem or error
+title: ''
+labels: ''
+assignees: ''
 
 ---
-
 
 **Sylius version affected**: 1.x.y
 

--- a/.github/ISSUE_TEMPLATE/documentation-issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.md
@@ -1,6 +1,9 @@
 ---
-name: "Documentation Issue 📖"
+name: "Documentation Issue \U0001F4D6"
 about: Report missing or bugged documentation
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,6 +1,9 @@
 ---
 name: Feature request ✅
 about: Suggest an idea for a feature or improvement
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/security-issue.md
+++ b/.github/ISSUE_TEMPLATE/security-issue.md
@@ -1,6 +1,9 @@
 ---
-name: "Security Issue 🔐"
+name: "Security Issue \U0001F510"
 about: Please contact us at security@sylius.com
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/support-question.md
+++ b/.github/ISSUE_TEMPLATE/support-question.md
@@ -1,7 +1,10 @@
 ---
-name: "Support Question 🚫"
+name: "Support Question \U0001F6AB"
 about: See http://docs.sylius.com/en/latest/support/index.html for questions about
   using Sylius
+title: ''
+labels: ''
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/translations-----.md
+++ b/.github/ISSUE_TEMPLATE/translations-----.md
@@ -1,0 +1,12 @@
+---
+name: "Translations \U0001F1EC\U0001F1E7"
+about: See http://translate.sylius.com/ to add or fix Sylius translations.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+We use GitHub issues only to discuss Sylius bugs, new features and documentation.
+
+In order to add or fix translations in Sylius please follow [this guide](https://docs.sylius.com/en/latest/contributing/translations/) or go directly to [Crowdin](http://translate.sylius.com/).


### PR DESCRIPTION
Hi!
For a long time I've felt a tension, that so many of our contributors do not know how to fix/add translations to Sylius, that I've decided to add a new issue template for it :) a one that redirects to the proper place -> our [Crowdin](http://translate.sylius.com/). 🎉 

Sorry for the form of this PR, it was done through GitHub UI 😩 