### PR TITLE
Use https instead of http for Channel's hostname in form

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Channel/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Channel/_form.html.twig
@@ -22,7 +22,7 @@
             <div class="field">
                 {{ form_label(form.hostname) }}
                 <div class="ui labeled input">
-                    <div class="ui label">http://</div>
+                    <div class="ui label">https://</div>
                     {{ form_widget(form.hostname) }}
                 </div>
                 {{ form_errors(form.hostname) }}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | ^1.0 I think, master otherwise <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

I really prefer to show `https://` instead of `http://` in the Channel form, it's a way to say "Hey, keep the web secure!".

And it doesn't change that much.

It could be `http(s)://` as well…

As you prefer!