### PR TITLE
Initializing adjustments before the order item is processed

### DIFF
--- a/src/Sylius/Component/Order/Model/OrderItemUnit.php
+++ b/src/Sylius/Component/Order/Model/OrderItemUnit.php
@@ -36,11 +36,11 @@ class OrderItemUnit implements OrderItemUnitInterface
 
     public function __construct(OrderItemInterface $orderItem)
     {
-        $this->orderItem = $orderItem;
-        $this->orderItem->addUnit($this);
-
         /** @var ArrayCollection<array-key, AdjustmentInterface> $this->adjustments */
         $this->adjustments = new ArrayCollection();
+
+        $this->orderItem = $orderItem;
+        $this->orderItem->addUnit($this);
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no (kinda)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | ----
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.6 or 1.7 branches (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->

This pull request moves the initialization of the object's property before the logic that this object executes. The reason for this change is if the methods that are called because of the `addUnit` function require the adjustments to be set, then those will crash because the property has not been initialized yet.