### PR TITLE
[sylius_ui] Use default context instead of a custom one

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Twig/TemplateEventExtension.php
+++ b/src/Sylius/Bundle/UiBundle/Twig/TemplateEventExtension.php
@@ -30,18 +30,25 @@ final class TemplateEventExtension extends AbstractExtension
         $this->templateEventRenderer = $templateEventRenderer;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('sylius_template_event', [$this, 'render'], ['is_safe' => ['html']]),
+            new TwigFunction('sylius_template_event', [$this, 'render'], ['is_safe' => ['html'], 'needs_context' => true]),
         ];
     }
 
     /**
-     * @param string|string[] $eventName
+     * @param array $context
+     * @param string[]|string $eventName
+     * @param array $customContext
+     *
+     * @return string
      */
-    public function render($eventName, array $context = []): string
+    public function render(array $context, $eventName, array $customContext = null): string
     {
-        return $this->templateEventRenderer->render((array) $eventName, $context);
+        return $this->templateEventRenderer->render((array) $eventName, $customContext ?? $context);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no, yes, maybe
| Deprecations?   | no
| Related tickets | none
| License         | MIT

Maybe my idea is wrong but plugin devs need more controls on what `sylius_template_event` twig function is giving, that's why I propose to add the possibility to get the current context and not no context when no second parameter is given to this twig function.