### PR TITLE
Remove useless interface in custom_fixture.rst

### DIFF
--- a/docs/components_and_bundles/bundles/SyliusFixturesBundle/custom_fixture.rst
+++ b/docs/components_and_bundles/bundles/SyliusFixturesBundle/custom_fixture.rst
@@ -11,7 +11,7 @@ to skip the configuration part for now:
 
     namespace App\Fixture;
 
-    use use Doctrine\Persistence\ObjectManager;
+    use Doctrine\Persistence\ObjectManager;
     use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
 
     final class CountryFixture extends AbstractFixture

--- a/docs/components_and_bundles/bundles/SyliusFixturesBundle/custom_fixture.rst
+++ b/docs/components_and_bundles/bundles/SyliusFixturesBundle/custom_fixture.rst
@@ -12,9 +12,8 @@ to skip the configuration part for now:
     namespace App\Fixture;
 
     use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
-    use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
 
-    final class CountryFixture extends AbstractFixture implements FixtureInterface
+    final class CountryFixture extends AbstractFixture
     {
         private $countryManager;
 

--- a/docs/components_and_bundles/bundles/SyliusFixturesBundle/custom_fixture.rst
+++ b/docs/components_and_bundles/bundles/SyliusFixturesBundle/custom_fixture.rst
@@ -11,6 +11,7 @@ to skip the configuration part for now:
 
     namespace App\Fixture;
 
+    use use Doctrine\Persistence\ObjectManager;
     use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
 
     final class CountryFixture extends AbstractFixture


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

The interface is already implemented by the abstract class. Also add a missing use statement.
