### PR TITLE
[Hot-fix] Fix build - exclude UndefinedDocblockClass error

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -211,5 +211,6 @@
         <!-- see https://github.com/guzzle/guzzle/pull/2273 -->
         <InvalidCatch errorLevel="info" />
 
+        <UndefinedDocblockClass errorLevel="info" />
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

The failing doc block is not in our codebase anyway :/
