### PR TITLE
[API] disable input on stateMachine transition endpoints

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
@@ -38,6 +38,7 @@
                     <attribute name="summary">Cancels Order</attribute>
                 </attribute>
                 <attribute name="method">PATCH</attribute>
+                <attribute name="input">false</attribute>
                 <attribute name="path">/orders/{id}/cancel</attribute>
                 <attribute name="controller">sylius.api.order_state_machine_transition_applicator:cancel</attribute>
                 <attribute name="denormalization_context">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Payment.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Payment.xml
@@ -45,6 +45,7 @@
                     <attribute name="summary">Completes Payment</attribute>
                 </attribute>
                 <attribute name="method">PATCH</attribute>
+                <attribute name="input">false</attribute>
                 <attribute name="path">/payments/{id}/complete</attribute>
                 <attribute name="controller">sylius.api.payment_state_machine_transition_applicator:complete</attribute>
             </itemOperation>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductReview.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductReview.xml
@@ -50,6 +50,7 @@
                     <attribute name="summary">Accepts Product Review</attribute>
                 </attribute>
                 <attribute name="method">PATCH</attribute>
+                <attribute name="input">false</attribute>
                 <attribute name="path">/product-reviews/{id}/accept</attribute>
                 <attribute name="controller">sylius.api.product_review_state_machine_transition_applicator:accept</attribute>
             </itemOperation>
@@ -59,6 +60,7 @@
                     <attribute name="summary">Rejects Product Review</attribute>
                 </attribute>
                 <attribute name="method">PATCH</attribute>
+                <attribute name="input">false</attribute>
                 <attribute name="path">/product-reviews/{id}/reject</attribute>
                 <attribute name="controller">sylius.api.product_review_state_machine_transition_applicator:reject</attribute>
             </itemOperation>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
@@ -44,6 +44,7 @@
                     <attribute name="summary">Archives Shipping Method</attribute>
                 </attribute>
                 <attribute name="method">PATCH</attribute>
+                <attribute name="input">false</attribute>
                 <attribute name="path">/shipping-methods/{id}/archive</attribute>
                 <attribute name="controller">sylius.api.archiving_shipping_method_applicator:archive</attribute>
             </itemOperation>
@@ -53,6 +54,7 @@
                     <attribute name="summary">Restores archived Shipping Method</attribute>
                 </attribute>
                 <attribute name="method">PATCH</attribute>
+                <attribute name="input">false</attribute>
                 <attribute name="path">/shipping-methods/{id}/restore</attribute>
                 <attribute name="controller">sylius.api.archiving_shipping_method_applicator:restore</attribute>
             </itemOperation>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | part of #11250 
| License         | MIT

before you can add some request, after this change is will be impossible
before:
<img width="1396" alt="Screenshot 2020-04-06 at 11 37 33" src="https://user-images.githubusercontent.com/29897151/78544956-3cdf8680-77fb-11ea-8f3e-f5d59058e394.png">

after:
<img width="1390" alt="Screenshot 2020-04-06 at 11 38 32" src="https://user-images.githubusercontent.com/29897151/78544973-436dfe00-77fb-11ea-8546-7071be379c08.png">

 it looks the same on all edited resources