### PR TITLE
[ShopBundle] Add missing form_theme declaration

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Order/show.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Order/show.html.twig
@@ -2,6 +2,8 @@
 
 {% import '@SyliusUi/Macro/messages.html.twig' as messages %}
 
+{% form_theme form '@SyliusShop/Form/theme.html.twig' %}
+
 {% block content %}
     <div class="ui segment">
         {% include '@SyliusShop/Order/_summary.html.twig' %}


### PR DESCRIPTION
Fix missing form style declaration "form_theme" in Order/show.html.twig for "@SyliusShop/Checkout/SelectPayment/_form.html.twig" include.
This file is also included in the Checkout/selectPayment.html.twig file, where "form_theme" is declared correctly.

| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT