### PR TITLE
[RFC][DX] Open consts holder classes

### DIFF
--- a/UPGRADE-1.8.md
+++ b/UPGRADE-1.8.md
@@ -8,14 +8,14 @@
     +   Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
     ```
 
-2. Add configuration of ApiBundle in your `config/packages/_sylius.yaml` file:
+1. Add configuration of ApiBundle in your `config/packages/_sylius.yaml` file:
 
     ```diff
         imports:
     +       - { resource: "@SyliusApiBundle/Resources/config/app/config.yaml" }
     ```
 
-3. Add configuration of new ApiBundle in your `config/packages/security.yaml` file:
+1. Add configuration of new ApiBundle in your `config/packages/security.yaml` file:
 
     ```diff
         parameters:
@@ -71,10 +71,12 @@
     +           - { path: "%sylius.security.new_api_route%/docs", role: IS_AUTHENTICATED_ANONYMOUSLY }
     ```
 
-4. Add `sylius_api.yaml` file to `config/routes/` directory:
+1. Add `sylius_api.yaml` file to `config/routes/` directory:
 
     ```yaml
        sylius_api:
            resource: "@SyliusApiBundle/Resources/config/routing.yml"
            prefix: "%sylius.security.new_api_route%"
     ```
+
+1. All consts classes has been changed from final classes to interfaces. As a result initialization of `\Sylius\Bundle\UserBundle\UserEvents` is not longer possible. The whole list of changed classes can be found [here](https://github.com/Sylius/Sylius/pull/11347).

--- a/src/Sylius/Bundle/CoreBundle/Mailer/Emails.php
+++ b/src/Sylius/Bundle/CoreBundle/Mailer/Emails.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Mailer;
 
-final class Emails
+interface Emails
 {
     public const CONTACT_REQUEST = 'contact_request';
 
@@ -24,8 +24,4 @@ final class Emails
     public const SHIPMENT_CONFIRMATION = 'shipment_confirmation';
 
     public const USER_REGISTRATION = 'user_registration';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Bundle/OrderBundle/SyliusExpiredCartsEvents.php
+++ b/src/Sylius/Bundle/OrderBundle/SyliusExpiredCartsEvents.php
@@ -13,13 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\OrderBundle;
 
-final class SyliusExpiredCartsEvents
+interface SyliusExpiredCartsEvents
 {
     public const PRE_REMOVE = 'sylius.carts.pre_remove';
 
     public const POST_REMOVE = 'sylius.carts.post_remove';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Bundle/UserBundle/UserEvents.php
+++ b/src/Sylius/Bundle/UserBundle/UserEvents.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\UserBundle;
 
-final class UserEvents
+interface UserEvents
 {
     public const REQUEST_RESET_PASSWORD_TOKEN = 'sylius.user.password_reset.request.token';
 

--- a/src/Sylius/Component/Addressing/Model/Scope.php
+++ b/src/Sylius/Component/Addressing/Model/Scope.php
@@ -13,11 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Addressing\Model;
 
-final class Scope
+interface Scope
 {
     public const ALL = 'all';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Component/Core/Model/Scope.php
+++ b/src/Sylius/Component/Core/Model/Scope.php
@@ -13,13 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Model;
 
-final class Scope
+use Sylius\Component\Addressing\Model\Scope as BaseScope;
+
+interface Scope extends BaseScope
 {
     public const SHIPPING = 'shipping';
 
     public const TAX = 'tax';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Component/Core/OrderCheckoutStates.php
+++ b/src/Sylius/Component/Core/OrderCheckoutStates.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core;
 
-final class OrderCheckoutStates
+interface OrderCheckoutStates
 {
     public const STATE_ADDRESSED = 'addressed';
 
@@ -28,8 +28,4 @@ final class OrderCheckoutStates
     public const STATE_SHIPPING_SELECTED = 'shipping_selected';
 
     public const STATE_SHIPPING_SKIPPED = 'shipping_skipped';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Component/Core/OrderCheckoutTransitions.php
+++ b/src/Sylius/Component/Core/OrderCheckoutTransitions.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core;
 
-final class OrderCheckoutTransitions
+interface OrderCheckoutTransitions
 {
     public const GRAPH = 'sylius_order_checkout';
 
@@ -28,8 +28,4 @@ final class OrderCheckoutTransitions
     public const TRANSITION_SKIP_PAYMENT = 'skip_payment';
 
     public const TRANSITION_SKIP_SHIPPING = 'skip_shipping';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Component/Core/OrderPaymentStates.php
+++ b/src/Sylius/Component/Core/OrderPaymentStates.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core;
 
-final class OrderPaymentStates
+interface OrderPaymentStates
 {
     public const STATE_CART = 'cart';
 
@@ -32,8 +32,4 @@ final class OrderPaymentStates
     public const STATE_PARTIALLY_REFUNDED = 'partially_refunded';
 
     public const STATE_REFUNDED = 'refunded';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Component/Core/OrderPaymentTransitions.php
+++ b/src/Sylius/Component/Core/OrderPaymentTransitions.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core;
 
-final class OrderPaymentTransitions
+interface OrderPaymentTransitions
 {
     public const GRAPH = 'sylius_order_payment';
 
@@ -32,8 +32,4 @@ final class OrderPaymentTransitions
     public const TRANSITION_PARTIALLY_REFUND = 'partially_refund';
 
     public const TRANSITION_REFUND = 'refund';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Component/Core/OrderShippingStates.php
+++ b/src/Sylius/Component/Core/OrderShippingStates.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core;
 
-final class OrderShippingStates
+interface OrderShippingStates
 {
     public const STATE_CART = 'cart';
 
@@ -24,8 +24,4 @@ final class OrderShippingStates
     public const STATE_PARTIALLY_SHIPPED = 'partially_shipped';
 
     public const STATE_SHIPPED = 'shipped';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Component/Core/OrderShippingTransitions.php
+++ b/src/Sylius/Component/Core/OrderShippingTransitions.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core;
 
-final class OrderShippingTransitions
+interface OrderShippingTransitions
 {
     public const GRAPH = 'sylius_order_shipping';
 
@@ -24,8 +24,4 @@ final class OrderShippingTransitions
     public const TRANSITION_SHIP = 'ship';
 
     public const TRANSITION_CANCEL = 'cancel';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Component/Core/ProductReviewTransitions.php
+++ b/src/Sylius/Component/Core/ProductReviewTransitions.php
@@ -13,15 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core;
 
-final class ProductReviewTransitions
+interface ProductReviewTransitions
 {
     public const GRAPH = 'sylius_product_review';
 
     public const TRANSITION_ACCEPT = 'accept';
 
     public const TRANSITION_REJECT = 'reject';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Component/Core/SyliusLocaleEvents.php
+++ b/src/Sylius/Component/Core/SyliusLocaleEvents.php
@@ -13,11 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core;
 
-final class SyliusLocaleEvents
+interface SyliusLocaleEvents
 {
     public const CODE_CHANGED = 'sylius.locale.code_changed';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Component/Order/CartActions.php
+++ b/src/Sylius/Component/Order/CartActions.php
@@ -13,13 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Order;
 
-final class CartActions
+interface CartActions
 {
     public const ADD = 'add';
 
     public const REMOVE = 'remove';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Component/Order/OrderTransitions.php
+++ b/src/Sylius/Component/Order/OrderTransitions.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Order;
 
-final class OrderTransitions
+interface OrderTransitions
 {
     public const GRAPH = 'sylius_order';
 
@@ -22,8 +22,4 @@ final class OrderTransitions
     public const TRANSITION_CANCEL = 'cancel';
 
     public const TRANSITION_FULFILL = 'fulfill';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Component/Order/SyliusCartEvents.php
+++ b/src/Sylius/Component/Order/SyliusCartEvents.php
@@ -13,11 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Order;
 
-final class SyliusCartEvents
+interface SyliusCartEvents
 {
     public const CART_CHANGE = 'sylius.cart_change';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Component/Payment/PaymentTransitions.php
+++ b/src/Sylius/Component/Payment/PaymentTransitions.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Payment;
 
-final class PaymentTransitions
+interface PaymentTransitions
 {
     public const GRAPH = 'sylius_payment';
 
@@ -32,8 +32,4 @@ final class PaymentTransitions
     public const TRANSITION_REFUND = 'refund';
 
     public const TRANSITION_VOID = 'void';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Component/Shipping/Calculator/DefaultCalculators.php
+++ b/src/Sylius/Component/Shipping/Calculator/DefaultCalculators.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Shipping\Calculator;
 
-final class DefaultCalculators
+interface DefaultCalculators
 {
     /**
      * Flat rate per shipment calculator.
@@ -24,8 +24,4 @@ final class DefaultCalculators
      * Fixed price per unit calculator.
      */
     public const PER_UNIT_RATE = 'per_unit_rate';
-
-    private function __construct()
-    {
-    }
 }

--- a/src/Sylius/Component/Shipping/ShipmentTransitions.php
+++ b/src/Sylius/Component/Shipping/ShipmentTransitions.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Shipping;
 
-final class ShipmentTransitions
+interface ShipmentTransitions
 {
     public const GRAPH = 'sylius_shipment';
 
@@ -22,8 +22,4 @@ final class ShipmentTransitions
     public const TRANSITION_SHIP = 'ship';
 
     public const TRANSITION_CANCEL = 'cancel';
-
-    private function __construct()
-    {
-    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Final classes, which holds consts has been changed to interfaces. Therefore, still, no one is able to initialize them, while we are open to multi inheritance.  This should remove the problem of adding new values to them in plugins and end applications.  
<!--
 - Bug fixes must be submitted against the 1.6 or 1.7 branches (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
