### PR TITLE
[HOTFIX] Travis memory upgrade & turned off composer scripts

### DIFF
--- a/etc/travis/suites/application/before_install.sh
+++ b/etc/travis/suites/application/before_install.sh
@@ -5,6 +5,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../bash/application.
 
 print_header "Activating memcached extension" "Sylius"
 run_command "echo \"extension = memcached.so\" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini" || exit $?
+run_command "echo \"memory_limit=4096M\" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini" || exit $?
 
 print_header "Updating Composer" "Sylius"
 run_command "composer self-update --preview"

--- a/etc/travis/suites/application/install.sh
+++ b/etc/travis/suites/application/install.sh
@@ -5,7 +5,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../bash/application.
 
 print_header "Installing dependencies" "Sylius"
 run_command "if [ ! -z \"${SYMFONY_VERSION}\" ]; then bin/require-symfony-version composer.json \"${SYMFONY_VERSION}\"; fi" || exit $?
-run_command "composer install --no-interaction --prefer-dist" || exit $?
+run_command "composer install --no-interaction --no-scripts --prefer-dist" || exit $?
 run_command "composer dump-env test_cached" || exit $?
 
 print_header "Warming up dependencies" "Sylius"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Recently, flex started to install additional recipes([here](https://travis-ci.org/github/Sylius/Sylius/jobs/673443197#L780-L838)) what ended up with the broken build. I've turned off composer scripts, as it is probably not a CI duty to update them.(or clearing cache at this stage)

Nevertheless, this problem may be propagated into clear Sylius-Standard installation and we should investigate, what has changed in the new recipes as well. 
<!--
 - Bug fixes must be submitted against the 1.6 or 1.7 branches (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
