### PR TITLE
[Maintenance][Travis] Upgrade php memory to 6G

### DIFF
--- a/etc/travis/suites/application/before_install.sh
+++ b/etc/travis/suites/application/before_install.sh
@@ -5,7 +5,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../../../bash/application.
 
 print_header "Activating memcached extension" "Sylius"
 run_command "echo \"extension = memcached.so\" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini" || exit $?
-run_command "echo \"memory_limit=4096M\" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini" || exit $?
+run_command "echo \"memory_limit=6144M\" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini" || exit $?
 
 print_header "Updating Composer" "Sylius"
 run_command "composer self-update --preview"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Temporary solution, to make build green again. However, we should take a look into memory consumption in our builds and reduce it. 
<!--
 - Bug fixes must be submitted against the 1.6 or 1.7 branches (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
