### PR TITLE
Add notice about moved templates during upgrade

### DIFF
--- a/UPGRADE-1.7.md
+++ b/UPGRADE-1.7.md
@@ -69,6 +69,15 @@ Those are excluded from our BC promise:
 
 - `Sylius\Bundle\ShopBundle\EventListener\UserMailerListener` has been removed and replaced with `Sylius\Bundle\CoreBundle\EventListener\MailerListener`
 
+## Templates moved
+
+We've moved the following templates:
+
+- `@SyliusAttribute/Types/*.html.twig`  
+    You should search for `SyliusAttribute/Types` and `SyliusAttributeBundle:Types` in your templates and make the changes accordingly:
+    - in the Admin area: `@SyliusAdmin/Product/Show/Types/*.html.twig`
+    - in the Shop area: `@SyliusShop/Product/Show/Types/*.html.twig`
+
 ## Billing and shipping addresses have been switched with one another
 
 Until now shipping address used to be the default address of an Order. We have changed that, so now the billing address 


### PR DESCRIPTION
Using the old files leads to a not found template error in Front or Admin.

| Q               | A
| --------------- | -----
| Branch?         | 1.7 or master, I don't know if we consider this as a bug fix or not :p 
| Bug fix?        | yes or no… for me yes, for others no.
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

This PR is quite simple. I've just added some information about the move of some templates.  
I was using these templates and faced the issue in production since it was an edge case.  
Better to tell than sorry.