### PR TITLE
Introduce Probot Autolabeler

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,0 +1,4 @@
+Documentation: ['docs/']
+Maintenance: ['etc/', '.travis.yml', '.symfony.insight.yaml', 'UPGRADE-*', 'README.md']
+Admin: ['src/Bundle/AdminBundle/']
+Shop: ['src/Bundle/ShopBundle/']


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

As a _General Hater of Not-labeled Pull Requests_, to help our work easier, I would like to introduce a https://github.com/apps/probot-autolabeler.

I'm not sure if it's **the best** choice from auto labelling bots, but it has one big advantage - can label PRs from forked repositories (which is crucial for Sylius). It has also a very simple configuration (which is both ➕ and ➖), so maybe we would have to modify it (or replace with something better) to handle some more sophisticated algorithms for labels 🏇 

This is just a first version of configuration - when it's merged, I would love to see some more lines there (for example for `API` label on `master` branch 💃)