### PR TITLE
fix #11362 : ignore channel locale listener on profiler routes

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/EventListener/NonChannelLocaleListener.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/NonChannelLocaleListener.php
@@ -64,7 +64,7 @@ final class NonChannelLocaleListener
         }
 
         $request = $event->getRequest();
-        if (in_array($request->attributes->get('_route'), ['_wdt', '_profiler'])) {
+        if (in_array($request->attributes->get('_route'), ['_wdt', '_profiler', '_profiler_search', '_profiler_search_results'])) {
             return;
         }
 
@@ -91,6 +91,6 @@ final class NonChannelLocaleListener
         return
             null !== $firewall &&
             in_array($firewall->getName(), $this->firewallNames)
-        ;
+            ;
     }
 }


### PR DESCRIPTION
fix #11362 on branch 1.7 : ignore channel locale listener on profiler search & results routes

| Q               | A
| --------------- | -----
| Branch?         | 1.7 or master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #11362
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.6 or 1.7 branches (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
