### PR TITLE
Reorder order's sidebar in admin

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
@@ -670,39 +670,39 @@ sylius_ui:
             blocks:
                 before_customer_information_legacy:
                     template: "@SyliusUi/Block/_legacySonataEvent.html.twig"
-                    priority: 55
+                    priority: 90
                     context:
                         event: sylius.admin.order.show.before_customer_information
                 customer:
                     template: "@SyliusAdmin/Order/Show/_customer.html.twig"
-                    priority: 50
-                before_addresses_legacy:
-                    template: "@SyliusUi/Block/_legacySonataEvent.html.twig"
-                    priority: 45
-                    context:
-                        event: sylius.admin.order.show.before_addresses
-                addresses:
-                    template: "@SyliusAdmin/Order/Show/_addresses.html.twig"
-                    priority: 40
+                    priority: 80
                 before_payments_legacy:
                     template: "@SyliusUi/Block/_legacySonataEvent.html.twig"
-                    priority: 35
+                    priority: 70
                     context:
                         event: sylius.admin.order.show.before_payments
                 payments:
                     template: "@SyliusAdmin/Order/Show/_payments.html.twig"
-                    priority: 30
+                    priority: 60
                 shipments:
                     template: "@SyliusAdmin/Order/Show/_shipments.html.twig"
+                    priority: 50
+                after_shipments_legacy:
+                    template: "@SyliusUi/Block/_legacySonataEvent.html.twig"
+                    priority: 40
+                    context:
+                        event: sylius.admin.order.show.after_shipments
+                before_addresses_legacy:
+                    template: "@SyliusUi/Block/_legacySonataEvent.html.twig"
+                    priority: 30
+                    context:
+                        event: sylius.admin.order.show.before_addresses
+                addresses:
+                    template: "@SyliusAdmin/Order/Show/_addresses.html.twig"
                     priority: 20
                 resend_email:
                     template: "@SyliusAdmin/Order/Show/_resendEmail.html.twig"
                     priority: 10
-                after_shipments_legacy:
-                    template: "@SyliusUi/Block/_legacySonataEvent.html.twig"
-                    priority: 5
-                    context:
-                        event: sylius.admin.order.show.after_shipments
 
         sylius.admin.customer.show.information:
             blocks:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

According to our experience in e-commerce payment and shipping are more important than the addresses when we look at an order.

Now we can see these informations first.
![image](https://user-images.githubusercontent.com/858611/79739308-4ccc8f80-82fe-11ea-894a-5f5271d3ed3e.png)
