### PR TITLE
Use !default for SCSS variables to allow overriding them

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_ui.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_ui.scss
@@ -1,7 +1,7 @@
-$sylius-brand-color: #1abb9c;
-$segment-spacing: 1.8em;
-$segment-title-spacing: 1.2em 1.8em;
-$accordion-title-spacing: 1.2em 1.8em;
+$sylius-brand-color: #1abb9c !default;
+$segment-spacing: 1.8em !default;
+$segment-title-spacing: 1.2em 1.8em !default;
+$accordion-title-spacing: 1.2em 1.8em !default;
 
 // ----------------------------------
 // ------------ Globals

--- a/src/Sylius/Bundle/UiBundle/Resources/private/sass/_variables.scss
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/sass/_variables.scss
@@ -1,11 +1,11 @@
 // Sylius colors.
-$color-sylius: #1abb9c;
-$color-sylius-dark: darken($color-sylius, 5%);
-$color-sylius-light: lighten($color-sylius, 5%);
+$color-sylius: #1abb9c !default;
+$color-sylius-dark: darken($color-sylius, 5%) !default;
+$color-sylius-light: lighten($color-sylius, 5%) !default;
 
 // Background colors.
-$color-background: #f9fAfb;
-$color-header-background: #f9fAfb;
+$color-background: #f9fAfb !default;
+$color-header-background: #f9fAfb !default;
 
 // Links.
-$color-link: rgba(0,0,0,.87);
+$color-link: rgba(0,0,0,.87) !default;


### PR DESCRIPTION
Without `!default` it's not possible to override those variables in SCSS.