### PR TITLE
Remove the doc reference to a promotion action that no longer exists in Core.

### DIFF
--- a/docs/book/orders/promotions.rst
+++ b/docs/book/orders/promotions.rst
@@ -118,7 +118,6 @@ There are a few kinds of actions in **Sylius**:
 * percentage discount on the order (for example: -10% on the whole order)
 * fixed unit discount (for example: -1$ off the order total but *distributed and applied on each order item unit*)
 * percentage unit discount (for example: -10% off the order total but *distributed and applied on each order item unit*)
-* add product (for example: gives a free bonus sticker)
 * shipping discount (for example: -6$ on the costs of shipping)
 
 .. tip::


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #9689 
| License         | MIT
