### PR TITLE
Bug #9738 Fix nested form collections

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-form-collection.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-form-collection.js
@@ -44,8 +44,9 @@ class CollectionForm {
     event.preventDefault();
 
     let prototype = this.$element.data('prototype');
+    let prototypeName = new RegExp(this.$element.data('prototype-name'), 'g');
 
-    prototype = prototype.replace(/__name__/g, this.count);
+    prototype = prototype.replace(prototypeName, this.count);
 
     this.$list.append(prototype);
     this.count = this.count + 1;
@@ -68,9 +69,10 @@ class CollectionForm {
     if (url) {
       $container.load(url, { id: value, position });
     } else {
-      let prototype = this.$element.find(`[data-form-prototype="${value}"]`).val();
+      let $prototype = this.$element.find(`[data-form-prototype="${value}"]`);
+      let prototypeName = new RegExp($prototype.data('subprototype-name'), 'g');
 
-      prototype = prototype.replace(/__name__/g, index);
+      let prototype = $prototype.val().replace(prototypeName, index);
 
       $container.replaceWith(prototype);
     }

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/imagesTheme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/imagesTheme.html.twig
@@ -7,15 +7,19 @@
 
     {% spaceless %}
         <div data-form-type="collection" {{ block('widget_container_attributes') }}
-                {% if prototype is defined and allow_add %}
-                    data-prototype='{{ self.collection_item(prototype, allow_delete, button_delete_label, '__name__')|e }}'
-                {%- endif -%}
+            {% if prototype is defined and allow_add %}
+                data-prototype='{{ self.collection_item(prototype, allow_delete, button_delete_label, prototype.vars.name)|e }}'
+                data-prototype-name='{{ prototype.vars.name }}'
+            {%- endif -%}
         >
             {{ error(form.vars.errors) }}
 
             {% if prototypes|default is iterable %}
                 {% for key, subPrototype in prototypes %}
-                    <input type="hidden" data-form-prototype="{{ key }}" value="{{ self.collection_item(subPrototype, allow_delete, button_delete_label, '__name__')|e }}" />
+                    <input type="hidden" data-form-prototype="{{ key }}"
+                           value="{{ self.collection_item(subPrototype, allow_delete, button_delete_label, subPrototype.vars.name)|e }}"
+                           data-subprototype-name="{{ subPrototype.vars.name }}"
+                    />
                 {% endfor %}
             {% endif %}
 

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -84,14 +84,18 @@
     {% spaceless %}
         <div data-form-type="collection" {{ block('widget_container_attributes') }}
             {% if prototype is defined and allow_add %}
-                data-prototype='{{ self.collection_item(prototype, allow_delete, button_delete_label, '__name__')|e }}'
+                data-prototype='{{ self.collection_item(prototype, allow_delete, button_delete_label, prototype.vars.name)|e }}'
+                data-prototype-name='{{ prototype.vars.name }}'
             {%- endif -%}
         >
             {{ error(form.vars.errors) }}
 
             {% if prototypes|default is iterable %}
                 {% for key, subPrototype in prototypes %}
-                    <input type="hidden" data-form-prototype="{{ key }}" value="{{ self.collection_item(subPrototype, allow_delete, button_delete_label, '__name__')|e }}" />
+                    <input type="hidden" data-form-prototype="{{ key }}"
+                           value="{{ self.collection_item(subPrototype, allow_delete, button_delete_label, subPrototype.vars.name)|e }}"
+                           data-subprototype-name="{{ subPrototype.vars.name }}"
+                    />
                 {% endfor %}
             {% endif %}
 


### PR DESCRIPTION
If there are nested form collections, the value `__name__` of the sub
collection is being replaced by the parent collection index.
Which makes every new sub collection items having the same index.

| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #9738
| License         | MIT