### PR TITLE
Fallback to the locale code if the associated name isn't found

### DIFF
--- a/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
+++ b/src/Sylius/Bundle/LocaleBundle/Templating/Helper/LocaleHelper.php
@@ -41,7 +41,11 @@ final class LocaleHelper extends Helper implements LocaleHelperInterface
      */
     public function convertCodeToName(string $code, ?string $localeCode = null): ?string
     {
-        return $this->localeConverter->convertCodeToName($code, $this->getLocaleCode($localeCode));
+        try {
+            return $this->localeConverter->convertCodeToName($code, $this->getLocaleCode($localeCode));
+        } catch (\InvalidArgumentException $e) {
+            return $code;
+        }
     }
 
     /**

--- a/src/Sylius/Bundle/LocaleBundle/spec/Templating/Helper/LocaleHelperSpec.php
+++ b/src/Sylius/Bundle/LocaleBundle/spec/Templating/Helper/LocaleHelperSpec.php
@@ -77,6 +77,13 @@ final class LocaleHelperSpec extends ObjectBehavior
         $this->convertCodeToName('en')->shouldReturn('English');
     }
 
+    function it_fallbacks_to_the_code_if_the_name_is_not_in_the_database(LocaleConverterInterface $localeConverter): void
+    {
+        $localeConverter->convertCodeToName('en_DG', null)->willThrow(new \InvalidArgumentException());
+
+        $this->convertCodeToName('en_DG')->shouldReturn('en_DG');
+    }
+
     function it_has_a_name(): void
     {
         $this->getName()->shouldReturn('sylius_locale');


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

Prevents a 500 error if the locale code has no associated name in the Intl database. Example with `en_DG`:

<img width="1552" alt="Capture d’écran 2020-04-23 à 11 19 45" src="https://user-images.githubusercontent.com/57224/80082253-60713380-8554-11ea-955d-2766ccd5d519.png">
