### PR TITLE
[Hot-fix] Conflict API Platform 2.5.5 to fix the build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -185,7 +185,8 @@
     "conflict": {
         "sylius/grid-bundle": "1.7.4",
         "symfony/symfony": "3.4.7",
-        "twig/twig": "2.6.1"
+        "twig/twig": "2.6.1",
+        "api-platform/core": "2.5.5"
     },
     "suggest": {
         "ext-iconv": "For better performance than using Symfony Polyfill Component",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Should fix the build for now, until some braking changes would be fixed on API Platform itself.