### PR TITLE
Error on show product without pricing

### DIFF
--- a/features/product/viewing_product_in_admin_panel/viewing_details_of_simple_product.feature
+++ b/features/product/viewing_product_in_admin_panel/viewing_details_of_simple_product.feature
@@ -25,6 +25,14 @@ Feature: Viewing details of a simple product
         And I should see original price "$25.00" for channel "United States"
 
     @ui
+    Scenario: Viewing price block without channel enable
+        Given this product is unavailable in "United States" channel
+        When I access "Iron shield" product page
+        Then I should see product name "Iron shield"
+        And I should see the product in neither channel
+        And I should not see price for channel "United States"
+
+    @ui
     Scenario: Viewing details block
         Given the store has a tax category "No tax" with a code "nt"
         And product's "Iron shield" code is "123456789"

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -173,6 +173,15 @@ final class ProductContext implements Context
     }
 
     /**
+     * @Given /^(this product) is(?:| also) unavailable in ("[^"]+" channel)$/
+     */
+    public function thisProductIsAlsoUnavailableInChannel(ProductInterface $product, ChannelInterface $channel): void
+    {
+        $product->removeChannel($channel);
+        $this->objectManager->flush();
+    }
+
+    /**
      * @Given the store( also) has a product :productName with code :code
      * @Given the store( also) has a product :productName with code :code, created at :date
      */

--- a/src/Sylius/Behat/Context/Ui/Admin/ProductShowPageContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ProductShowPageContext.php
@@ -185,6 +185,14 @@ final class ProductShowPageContext implements Context
     }
 
     /**
+     * @Then I should not see price for channel :channelName
+     */
+    public function iShouldNotSeePriceForChannel(string $channelName)
+    {
+        Assert::same($this->pricingElement->getPriceForChannel($channelName), '');
+    }
+
+    /**
      * @Then I should see original price :price for channel :channelName
      */
     public function iShouldSeeOrginalPriceForChannel(string $orginalPrice, string $channelName): void
@@ -206,6 +214,14 @@ final class ProductShowPageContext implements Context
     public function iShouldSeeProductIsEnabledForChannels(string $channel): void
     {
         Assert::true($this->detailsElement->hasChannel($channel));
+    }
+
+    /**
+     * @Then I should see the product in neither channel
+     */
+    public function iShouldSeeTheProductInNeitherChannel(): void
+    {
+        Assert::same($this->detailsElement->countChannels(), 0);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Admin/ProductShowPageContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ProductShowPageContext.php
@@ -187,7 +187,7 @@ final class ProductShowPageContext implements Context
     /**
      * @Then I should not see price for channel :channelName
      */
-    public function iShouldNotSeePriceForChannel(string $channelName)
+    public function iShouldNotSeePriceForChannel(string $channelName): void
     {
         Assert::same($this->pricingElement->getPriceForChannel($channelName), '');
     }

--- a/src/Sylius/Behat/Element/Product/ShowPage/DetailsElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/DetailsElement.php
@@ -37,6 +37,17 @@ final class DetailsElement extends Element implements DetailsElementInterface
         return false;
     }
 
+    public function countChannels(): int
+    {
+        if (! $this->hasElement('channels')) {
+            return 0;
+        }
+
+        $channels = $this->getElement('channels')->findAll('css', 'span.channel-name');
+
+        return \count($channels);
+    }
+
     public function getProductCurrentStock(): int
     {
         return (int) $this->getElement('current_stock')->getText();

--- a/src/Sylius/Behat/Element/Product/ShowPage/DetailsElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/DetailsElement.php
@@ -39,7 +39,7 @@ final class DetailsElement extends Element implements DetailsElementInterface
 
     public function countChannels(): int
     {
-        if (! $this->hasElement('channels')) {
+        if (!$this->hasElement('channels')) {
             return 0;
         }
 

--- a/src/Sylius/Behat/Element/Product/ShowPage/DetailsElementInterface.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/DetailsElementInterface.php
@@ -19,6 +19,8 @@ interface DetailsElementInterface
 
     public function hasChannel(string $channelName): bool;
 
+    public function countChannels(): int;
+
     public function getProductCurrentStock(): int;
 
     public function getProductTaxCategory(): string;

--- a/src/Sylius/Behat/Element/Product/ShowPage/PricingElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/PricingElement.php
@@ -22,6 +22,10 @@ final class PricingElement extends Element implements PricingElementInterface
         /** @var NodeElement $priceForChannel */
         $channelPriceRow = $this->getDocument()->find('css', sprintf('#pricing tr:contains("%s")', $channelName));
 
+        if (null === $channelPriceRow) {
+            return '';
+        }
+
         $priceForChannel = $channelPriceRow->find('css', 'td:nth-child(2)');
 
         return $priceForChannel->getText();

--- a/src/Sylius/Behat/Element/Product/ShowPage/PricingElement.php
+++ b/src/Sylius/Behat/Element/Product/ShowPage/PricingElement.php
@@ -13,13 +13,14 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Element\Product\ShowPage;
 
+use Behat\Mink\Element\NodeElement;
 use FriendsOfBehat\PageObjectExtension\Element\Element;
 
 final class PricingElement extends Element implements PricingElementInterface
 {
     public function getPriceForChannel(string $channelName): string
     {
-        /** @var NodeElement $priceForChannel */
+        /** @var NodeElement|null $priceForChannel */
         $channelPriceRow = $this->getDocument()->find('css', sprintf('#pricing tr:contains("%s")', $channelName));
 
         if (null === $channelPriceRow) {

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_pricing.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_pricing.html.twig
@@ -12,17 +12,19 @@
             </thead>
             <tbody>
             {% for channelPricing in product.variants.first.channelPricings %}
-                <tr>
-                    <td class="five wide gray text">
-                        <strong>{{ channelPricing.channelCode|sylius_channel_name }} </strong>
-                    </td>
-                    <td>{{ money.format(channelPricing.price, product.channels.first.baseCurrency) }}</td>
-                    {% if channelPricing.originalPrice != null %}
-                        <td>{{ money.format(channelPricing.originalPrice, product.channels.first.baseCurrency) }}</td>
-                    {% else %}
-                        <td>-</td>
-                    {% endif %}
-                </tr>
+                {% if product.channels.first != false %}
+                    <tr>
+                        <td class="five wide gray text">
+                            <strong>{{ channelPricing.channelCode|sylius_channel_name }} </strong>
+                        </td>
+                        <td>{{ money.format(channelPricing.price, product.channels.first.baseCurrency) }}</td>
+                        {% if channelPricing.originalPrice != null %}
+                            <td>{{ money.format(channelPricing.originalPrice, product.channels.first.baseCurrency) }}</td>
+                        {% else %}
+                            <td>-</td>
+                        {% endif %}
+                    </tr>
+                {% endif %}
             {% endfor %}
             </tbody>
         </table>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6 and after
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #11399 
| License         | MIT

Behat :

    @ui
    Scenario: Viewing price block without channel enable
        Given this product is unavailable in "United States" channel
        When I access "Iron shield" product page
        Then I should see product name "Iron shield"
        And I should see the product in neither channel
        And I should not see price for channel "United States"

Before fix step `Then I should see product name "Iron shield"` throw error in cause of error 500 in page.

After fix, all steps are green :heavy_check_mark: 
