### PR TITLE
Typo in code block in documentation

### DIFF
--- a/docs/cookbook/shop/disabling-localised-urls.rst
+++ b/docs/cookbook/shop/disabling-localised-urls.rst
@@ -51,7 +51,7 @@ Replace:
 
     parameters:
         # ...
-        sylius.security.shop_regex: "^/(?!admin|api/.*|api$|media/.*)[^/]++""
+        sylius.security.shop_regex: "^/(?!admin|api/.*|api$|media/.*)[^/]++"
 
 With:
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | >1.6
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

SImple typo in documentation. The last `"` shouldn't be here.