### PR TITLE
Fix typo in french translation for core bundle

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.fr.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.fr.yml
@@ -100,7 +100,7 @@ sylius:
             file: Sélectionnez une image
         user:
             billing_address: Adresse de facturation
-            different_billing_address: Utiliser une adresse différente pour la facturation ?
+            different_shipping_address: Utiliser une adresse différente pour la livraison ?
             enabled: Activé
             first_name: Prénom
             groups: Groupes


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.6, 1.7 or master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

See https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml#L106 for reference