### PR TITLE
[Docs] Remove experimental badges mentioning "master" branch from theming guide

### DIFF
--- a/docs/theming/bootstrap-theme.rst
+++ b/docs/theming/bootstrap-theme.rst
@@ -1,9 +1,3 @@
-.. raw:: html
-
-    <div style="padding: 20px; background: #ffedcc; border-radius: 4px; margin-bottom: 20px;">
-    <strong>EXPERIMENTAL.</strong> This guide is based on "Sylius" and "Sylius-Standard" master branches.
-    </div>
-
 Theming with BootstrapTheme
 ---------------------------
 

--- a/docs/theming/index.rst
+++ b/docs/theming/index.rst
@@ -1,9 +1,3 @@
-.. raw:: html
-
-    <div style="padding: 20px; background: #ffedcc; border-radius: 4px; margin-bottom: 20px;">
-    <strong>EXPERIMENTAL.</strong> This guide is based on "Sylius" and "Sylius-Standard" master branches.
-    </div>
-
 🎨 Theming Guide
 ================
 

--- a/docs/theming/webpack.rst
+++ b/docs/theming/webpack.rst
@@ -1,9 +1,3 @@
-.. raw:: html
-
-    <div style="padding: 20px; background: #ffedcc; border-radius: 4px; margin-bottom: 20px;">
-    <strong>EXPERIMENTAL.</strong> This guide is based on "Sylius" and "Sylius-Standard" master branches.
-    </div>
-
 Using Webpack Encore in Sylius
 ------------------------------
 


### PR DESCRIPTION
Mentioned "master" branch is now "v1.7.x" tag.