### PR TITLE
[Docs] Enable redirections on ReadTheDocs

### DIFF
--- a/docs/_exts/sphinxcontrib-redirects/__init__.py
+++ b/docs/_exts/sphinxcontrib-redirects/__init__.py
@@ -16,7 +16,6 @@
 
 import os
 
-from sphinx.builders import html as builders
 from sphinx.util import logging;
 
 TEMPLATE = """<html>
@@ -36,7 +35,7 @@ def generate_redirects(app):
     in_suffix = next(iter(app.config.source_suffix))
 
     # TODO(stephenfin): Add support for DirectoryHTMLBuilder
-    if not type(app.builder) == builders.StandaloneHTMLBuilder:
+    if not app.builder.name in ["html", "readthedocs"]:
         logger.warn("The 'sphinxcontib-redirects' plugin is only supported "
                      "by the 'html' builder. Skipping...")
         return


### PR DESCRIPTION
The redirections map defined in `docs/redirection_map` works correctly for local builds but is skipped for docs hosted on ReadTheDocs because they use `readthedocs` builder instead of `html` one.

<img width="794" alt="CleanShot 2020-05-11 at 13 16 36@2x" src="https://user-images.githubusercontent.com/1897953/81555991-d9acbb00-9389-11ea-81d6-eb23b8209542.png">

This PR should fix that (I hope so). Aiming at 1.6 because it's the earliest branch in which we wanted to create redirections.