### PR TITLE
[Documentation][Cookbook] Fix login & failure path

### DIFF
--- a/docs/cookbook/shop/facebook-login.rst
+++ b/docs/cookbook/shop/facebook-login.rst
@@ -92,9 +92,9 @@ Under the ``security: firewalls: shop:`` keys in the ``security.yaml`` configure
                 oauth:
                     resource_owners:
                         facebook: "/login/check-facebook"
-                    login_path: /login
+                    login_path: sylius_shop_login
                     use_forward: false
-                    failure_path: /login
+                    failure_path: sylius_shop_login
 
                     oauth_user_provider:
                         service: sylius.oauth.user_provider


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | At least from 1.6
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.6 or 1.7 branches (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
Hello,

I'm working on a website in Sylius 1.6 with one locale (mywebsite.com/fr_FR), and I want to add Facebook login.
If I put the path `/login`, Facebook will redirect to mywebsite.com/login which fail (blank page with only a link to facebook).
But if I put the route name, the path will be `/fr_FR/login`, which works fine (for me at least)

