### PR TITLE
Fix for product translation tabs to be folded by default

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_moreDetails.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_moreDetails.html.twig
@@ -1,11 +1,11 @@
 <div id="more-details" class="ui styled fluid accordion">
     {% for translation in product.translations %}
-        <div class="title active">
+        <div class="title">
             <i class="dropdown icon"></i>
             <i class="{{ translation.locale|slice(-2)|lower }} flag"></i>
             {{ translation.locale|sylius_locale_name }}
         </div>
-        <div class="ui content active">
+        <div class="ui content">
             <table class="ui very basic celled table">
                 <tbody>
                 <tr>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT