### PR TITLE
[Attribute] Bring back attribute types templates after BC break in 1.7

### DIFF
--- a/UPGRADE-1.7.md
+++ b/UPGRADE-1.7.md
@@ -1,3 +1,7 @@
+# UPGRADE FROM `v1.7.4` TO `v1.7.5`
+
+We've brought back the attribute types templates to SyliusAttributeBundle after BC break in v1.7.0.
+
 # UPGRADE FROM `v1.6.X` TO `v1.7.0`
 
 1. Require upgraded Sylius version using Composer:

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/Types/boolean.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/Types/boolean.html.twig
@@ -1,5 +1,1 @@
-{% if attribute.value %}
-    {{ 'sylius.ui.yes_label'|trans }}
-{% else %}
-    {{ 'sylius.ui.no_label'|trans }}
-{% endif %}
+{% extends '@SyliusAttribute/Types/checkbox.html.twig' %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/Types/date.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/Types/date.html.twig
@@ -1,5 +1,1 @@
-{% if attribute.attribute.configuration['format'] is defined %}
-    {{ attribute.value|format_date(attribute.attribute.configuration['format']) }}
-{% else %}
-    {{ attribute.value|format_date }}
-{% endif %}
+{% extends '@SyliusAttribute/Types/date.html.twig' %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/Types/datetime.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/Types/datetime.html.twig
@@ -1,5 +1,1 @@
-{% if attribute.attribute.configuration['format'] is defined %}
-    {{ attribute.value|format_datetime(attribute.attribute.configuration['format']) }}
-{% else %}
-    {{ attribute.value|format_datetime }}
-{% endif %}
+{% extends '@SyliusAttribute/Types/datetime.html.twig' %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/Types/default.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/Types/default.html.twig
@@ -1,1 +1,1 @@
-{{ attribute.value }}
+{% extends '@SyliusAttribute/Types/default.html.twig' %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/Types/percent.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/Types/percent.html.twig
@@ -1,1 +1,1 @@
-{{ attribute.value|sylius_percentage }}
+{% extends '@SyliusAttribute/Types/percent.html.twig' %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/Types/text.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/Types/text.html.twig
@@ -1,1 +1,1 @@
-{{ attribute.value|nl2br }}
+{% extends '@SyliusAttribute/Types/textarea.html.twig' %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_attributes.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_attributes.html.twig
@@ -20,7 +20,15 @@
                                 <strong class="gray text">{{ attributeValue.name }}</strong>
                             </td>
                             <td>
-                                {% include [('@SyliusAdmin/Product/Show/Types/'~attributeValue.type~'.html.twig'), '@SyliusAdmin/Product/Show/Types/default.html.twig'] with {'attribute': attributeValue, 'locale': configuration.request.locale, 'fallbackLocale': configuration.request.defaultLocale} %}
+                                {% include [
+                                    '@SyliusAdmin/Product/Show/Types/'~attributeValue.type~'.html.twig',
+                                    '@SyliusAttribute/Types/'~attributeValue.type~'.html.twig',
+                                    '@SyliusAdmin/Product/Show/Types/default.html.twig'
+                                ] with {
+                                    'attribute': attributeValue,
+                                    'locale': configuration.request.locale,
+                                    'fallbackLocale': configuration.request.defaultLocale
+                                } %}
                             </td>
                         </tr>
                     {% endfor %}

--- a/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/checkbox.html.twig
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/checkbox.html.twig
@@ -1,0 +1,5 @@
+{% if attribute.value %}
+    {{ 'sylius.ui.yes_label'|trans }}
+{% else %}
+    {{ 'sylius.ui.no_label'|trans }}
+{% endif %}

--- a/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/date.html.twig
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/date.html.twig
@@ -1,0 +1,5 @@
+{% if attribute.attribute.configuration['format'] is defined %}
+    {{ attribute.value|format_date(attribute.attribute.configuration['format']) }}
+{% else %}
+    {{ attribute.value|format_date }}
+{% endif %}

--- a/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/datetime.html.twig
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/datetime.html.twig
@@ -1,0 +1,5 @@
+{% if attribute.attribute.configuration['format'] is defined %}
+    {{ attribute.value|format_datetime(attribute.attribute.configuration['format']) }}
+{% else %}
+    {{ attribute.value|format_datetime }}
+{% endif %}

--- a/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/default.html.twig
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/default.html.twig
@@ -1,0 +1,1 @@
+{{ attribute.value }}

--- a/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/percent.html.twig
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/percent.html.twig
@@ -1,0 +1,1 @@
+{{ attribute.value|sylius_percentage }}

--- a/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/select.html.twig
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/select.html.twig
@@ -1,0 +1,18 @@
+{% if attribute.value is not null %}
+    {% set values = attribute.attribute.configuration.choices %}
+    {% if attribute.value is iterable %}
+        {% for value in attribute.value %}
+            {% if locale in values[value]|keys and values[value][locale] is not empty %}
+                {{ values[value][locale] }}{% if loop.last == false %}, {% endif %}
+            {% else %}
+                {{ values[value][fallbackLocale] }}{% if loop.last == false %}, {% endif %}
+            {% endif %}
+        {% endfor %}
+    {% else %}
+        {% if values[attribute.value][locale] is not empty %}
+            {{ values[attribute.value][locale] }}
+        {% elseif values[attribute.value][fallbackLocale] is not empty %}
+            {{ values[attribute.value][fallbackLocale] }}
+        {% endif %}
+    {% endif %}
+{% endif %}

--- a/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/textarea.html.twig
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/views/Types/textarea.html.twig
@@ -1,0 +1,1 @@
+{{ attribute.value|nl2br }}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/Attributes/_list.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Tabs/Attributes/_list.html.twig
@@ -4,7 +4,15 @@
         <tr>
             <td class="sylius-product-attribute-name" {{ sylius_test_html_attribute('product-attribute-name', attribute.name) }}>{{ attribute.name }}</td>
             <td class="sylius-product-attribute-value" {{ sylius_test_html_attribute('product-attribute-value', attribute.name) }}>
-                {% include [('@SyliusShop/Product/Show/Types/'~attribute.attribute.type~'.html.twig'), '@SyliusShop/Product/Show/Types/default.html.twig'] with {'attribute': attribute, 'locale': configuration.request.locale, 'fallbackLocale': configuration.request.defaultLocale} %}
+                {% include [
+                    '@SyliusShop/Product/Show/Types/'~attribute.attribute.type~'.html.twig',
+                    '@SyliusAttribute/Types/'~attribute.attribute.type~'.html.twig',
+                    '@SyliusShop/Product/Show/Types/default.html.twig'
+                ] with {
+                    'attribute': attribute,
+                    'locale': configuration.request.locale,
+                    'fallbackLocale': configuration.request.defaultLocale
+                } %}
             </td>
         </tr>
     {% endfor %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Types/checkbox.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Types/checkbox.html.twig
@@ -1,5 +1,1 @@
-{% if attribute.value %}
-    {{ 'sylius.ui.yes_label'|trans }}
-{% else %}
-    {{ 'sylius.ui.no_label'|trans }}
-{% endif %}
+{% extends '@SyliusAttribute/Types/checkbox.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Types/date.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Types/date.html.twig
@@ -1,5 +1,1 @@
-{% if attribute.attribute.configuration['format'] is defined %}
-    {{ attribute.value|format_date(attribute.attribute.configuration['format']) }}
-{% else %}
-    {{ attribute.value|format_date }}
-{% endif %}
+{% extends '@SyliusAttribute/Types/date.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Types/datetime.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Types/datetime.html.twig
@@ -1,5 +1,1 @@
-{% if attribute.attribute.configuration['format'] is defined %}
-    {{ attribute.value|format_datetime(attribute.attribute.configuration['format']) }}
-{% else %}
-    {{ attribute.value|format_datetime }}
-{% endif %}
+{% extends '@SyliusAttribute/Types/datetime.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Types/default.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Types/default.html.twig
@@ -1,1 +1,1 @@
-{{ attribute.value }}
+{% extends '@SyliusAttribute/Types/default.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Types/percent.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Types/percent.html.twig
@@ -1,1 +1,1 @@
-{{ attribute.value|sylius_percentage }}
+{% extends '@SyliusAttribute/Types/percent.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Types/select.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Types/select.html.twig
@@ -1,18 +1,1 @@
-{% if attribute.value is not null %}
-    {% set values = attribute.attribute.configuration.choices %}
-    {% if attribute.value is iterable %}
-        {% for value in attribute.value %}
-            {% if locale in values[value]|keys and values[value][locale] is not empty %}
-                {{ values[value][locale] }}{% if loop.last == false %}, {% endif %}
-            {% else %}
-                {{ values[value][fallbackLocale] }}{% if loop.last == false %}, {% endif %}
-            {% endif %}
-        {% endfor %}
-    {% else %}
-        {% if values[attribute.value][locale] is not empty %}
-            {{ values[attribute.value][locale] }}
-        {% elseif values[attribute.value][fallbackLocale] is not empty %}
-            {{ values[attribute.value][fallbackLocale] }}
-        {% endif %}
-    {% endif %}
-{% endif %}
+{% extends '@SyliusAttribute/Types/select.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Types/textarea.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/Types/textarea.html.twig
@@ -1,1 +1,1 @@
-{{ attribute.value|nl2br }}
+{% extends '@SyliusAttribute/Types/textarea.html.twig' %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #11365
| License         | MIT
