### PR TITLE
Use https instead of http for all (almost) links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,10 +5,10 @@ Sylius is a Open Source project driven by the community.
 Join our amazing adventure and we promise to be nice and welcoming to everyone. 
 Remember, you do not have to be a Symfony guru or even a programmer to help!
 
-You can learn [how to contribute the patches](http://docs.sylius.com/en/latest/contributing/code/patches.html)
-in our [Contributing Guide](http://docs.sylius.com/en/latest/contributing/index.html).
+You can learn [how to contribute the patches](https://docs.sylius.com/en/latest/contributing/code/patches.html)
+in our [Contributing Guide](https://docs.sylius.com/en/latest/contributing/index.html).
 
 Security Issues
 ---------------
 
-We treat security very seriously, you can read about security procedures [here](http://docs.sylius.com/en/latest/contributing/code/security.html).
+We treat security very seriously, you can read about security procedures [here](https://docs.sylius.com/en/latest/contributing/code/security.html).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,5 +7,5 @@
 | Sylius version   | 1.x.y
 
 <!--
- - For support requests and how-tos, visit http://docs.sylius.com/en/latest/support/
+ - For support requests and how-tos, visit https://docs.sylius.com/en/latest/support/
 -->

--- a/.github/ISSUE_TEMPLATE/support-question.md
+++ b/.github/ISSUE_TEMPLATE/support-question.md
@@ -1,6 +1,6 @@
 ---
 name: "Support Question \U0001F6AB"
-about: See http://docs.sylius.com/en/latest/support/index.html for questions about
+about: See https://docs.sylius.com/en/latest/support/index.html for questions about
   using Sylius
 title: ''
 labels: ''
@@ -10,6 +10,6 @@ assignees: ''
 
 We use GitHub issues only to discuss about Sylius bugs, new features and documentation. 
 For this kind of questions about Sylius usage, please use
-any of the support alternatives described here: http://docs.sylius.com/en/latest/support/index.html
+any of the support alternatives described here: https://docs.sylius.com/en/latest/support/index.html
 
 Thank you!

--- a/CHANGELOG-1.1.md
+++ b/CHANGELOG-1.1.md
@@ -103,7 +103,7 @@
 
 #### TL;DR
 
-- There's a new [plugin development guide](http://docs.sylius.com/en/1.1/plugins/plugin-development-guide/index.html) ([#9592](https://github.com/Sylius/Sylius/pull/9592))
+- There's a new [plugin development guide](https://docs.sylius.com/en/1.1/plugins/plugin-development-guide/index.html) ([#9592](https://github.com/Sylius/Sylius/pull/9592))
 - Fixed compatibility with PHP-PM ([#9613](https://github.com/Sylius/Sylius/pull/9613), [#9608](https://github.com/Sylius/Sylius/pull/9608))
 - Fixed buggy shop user removal in the admin panel ([#9618](https://github.com/Sylius/Sylius/pull/9618))
 

--- a/CHANGELOG-1.2.md
+++ b/CHANGELOG-1.2.md
@@ -228,7 +228,7 @@
 
 #### TL;DR
 
-- There's a new [plugin development guide](http://docs.sylius.com/en/1.1/plugins/plugin-development-guide/index.html) ([#9592](https://github.com/Sylius/Sylius/pull/9592))
+- There's a new [plugin development guide](https://docs.sylius.com/en/1.1/plugins/plugin-development-guide/index.html) ([#9592](https://github.com/Sylius/Sylius/pull/9592))
 - Fixed compatibility with PHP-PM ([#9613](https://github.com/Sylius/Sylius/pull/9613), [#9608](https://github.com/Sylius/Sylius/pull/9608))
 - Fixed buggy shop user removal in the admin panel ([#9618](https://github.com/Sylius/Sylius/pull/9618))
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Sylius is an Open Source eCommerce platform on top of [**Symfony**](https://symf
 The highest quality of code, strong testing culture, built-in Agile (BDD) workflow and exceptional flexibility make it the best solution for application tailored to your business requirements. 
 Powerful REST API allows for easy integrations and creating unique customer experience on any device.
 
-We're using full-stack Behavior-Driven-Development, with [phpspec](http://phpspec.net) and [Behat](http://behat.org).
+We're using full-stack Behavior-Driven-Development, with [phpspec](https://phpspec.net) and [Behat](http://behat.org).
 
 Enjoy being an eCommerce Developer again!
 

--- a/UPGRADE-1.0.md
+++ b/UPGRADE-1.0.md
@@ -48,7 +48,7 @@
 
 * Scalar and return typehints have been introduced in the codebase. Please introduce these in your codebase for classes 
   that implement Sylius interfaces or extend Sylius classes. It is also highly recommended to add `declare(strict_types=1);` declaration to your PHP files.
-  Learn more about PHP 7.1 features here: http://php.net/manual/de/migration71.new-features.php
+  Learn more about PHP 7.1 features here: https://php.net/manual/de/migration71.new-features.php
 
 * Starting with Symfony version 3.3.8, the custom autoloader is not needed anymore and therefore it has been removed in favour of the Composer
   autoloader. Apply the following changes (reference: https://github.com/Sylius/Sylius/pull/8340):
@@ -276,7 +276,7 @@
 * ImagineBundle has been upgraded from ^1.6 to ^1.9.1 to move past a BC break in console commands: https://github.com/liip/LiipImagineBundle/releases/tag/1.9.1.
 
 * If `sylius_shop.locale_switcher` is set to `storage`, `LocaleStrippingRouter` is loaded, which strips out `_locale` parameter
-  from the URL if it's the same as the one already in the storage. In order to disable localized urls, follow this cookbook entry: http://docs.sylius.com/en/latest/cookbook/disabling-localised-urls.html
+  from the URL if it's the same as the one already in the storage. In order to disable localized urls, follow this cookbook entry: https://docs.sylius.com/en/latest/cookbook/disabling-localised-urls.html
  
 * `ShopUserLogoutHandler` has different parameters in constructor:
     * `HttpUtils $httpUtils`

--- a/composer.json
+++ b/composer.json
@@ -3,19 +3,19 @@
     "type": "project",
     "description": "E-Commerce platform for PHP, based on Symfony framework.",
     "license": "MIT",
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 Sylius Documentation
 ====================
 
-This directory contains documentation for Sylius - Decoupled eCommerce Platform, available on [**docs.sylius.com**](http://docs.sylius.com). 
+This directory contains documentation for Sylius - Decoupled eCommerce Platform, available on [**docs.sylius.com**](https://docs.sylius.com). 
 
 It is hosted by the great [readthedocs.org](http://readthedocs.org).
 
@@ -37,4 +37,4 @@ To test the documentation before a commit:
 Authors
 -------
 
-See the list of [our amazing contributors](http://github.com/Sylius/Sylius/contributors).
+See the list of [our amazing contributors](https://github.com/Sylius/Sylius/contributors).

--- a/docs/book/architecture/architecture.rst
+++ b/docs/book/architecture/architecture.rst
@@ -22,7 +22,7 @@ Fullstack Symfony
 developers to work better and faster by providing them with certainty of developing an application that is fully compatible
 with the business rules, that is structured, maintainable and upgradable, but also it allows to save time by providing generic re-usable modules.
 
-`Learn more about Symfony <http://symfony.com/what-is-symfony>`_.
+`Learn more about Symfony <https://symfony.com/what-is-symfony>`_.
 
 Doctrine
 --------
@@ -141,7 +141,7 @@ Third Party Libraries
 Sylius uses a lot of libraries for various tasks:
 
 * `Payum <https://github.com/Payum/Payum>`_ for payments
-* `KnpMenu <http://symfony.com/doc/current/bundles/KnpMenuBundle/index.html>`_ - for shop and admin menus
+* `KnpMenu <https://symfony.com/doc/current/bundles/KnpMenuBundle/index.html>`_ - for shop and admin menus
 * `Gaufrette <https://github.com/KnpLabs/Gaufrette>`_ for filesystem abstraction (store images locally, Amazon S3 or external server)
 * `Imagine <https://github.com/liip/LiipImagineBundle>`_ for images processing, generating thumbnails and cropping
 * `Pagerfanta <https://github.com/whiteoctober/Pagerfanta>`_ for pagination

--- a/docs/book/architecture/emails.rst
+++ b/docs/book/architecture/emails.rst
@@ -175,7 +175,7 @@ Parameters:
 
 .. image:: ../../_images/sylius_plus/banner.png
    :align: center
-   :target: http://sylius.com/plus/?utm_source=docs
+   :target: https://sylius.com/plus/?utm_source=docs
 
 How to send an Email programmatically?
 --------------------------------------

--- a/docs/book/architecture/events.rst
+++ b/docs/book/architecture/events.rst
@@ -6,7 +6,7 @@ Events
 
 .. tip::
 
-    You can learn more about events in general in `the Symfony documentation <http://symfony.com/doc/current/event_dispatcher.html>`_.
+    You can learn more about events in general in `the Symfony documentation <https://symfony.com/doc/current/event_dispatcher.html>`_.
 
 What is the naming convention of Sylius events?
 -----------------------------------------------

--- a/docs/book/configuration/channels.rst
+++ b/docs/book/configuration/channels.rst
@@ -109,7 +109,7 @@ on the Channel form.
 
 .. image:: ../../_images/sylius_plus/banner.png
     :align: center
-    :target: http://sylius.com/plus/?utm_source=docs
+    :target: https://sylius.com/plus/?utm_source=docs
 
 Learn more
 ----------

--- a/docs/book/contributing/documentation/standards.rst
+++ b/docs/book/contributing/documentation/standards.rst
@@ -43,7 +43,7 @@ Example
 
         echo 'You cannot use the :: shortcut here';
 
-    .. _`Sylius Documentation`: http://docs.sylius.com/en/latest/contributing/documentation/standards.html
+    .. _`Sylius Documentation`: https://docs.sylius.com/en/latest/contributing/documentation/standards.html
 
 Code Examples
 -------------

--- a/docs/book/contributing/index.rst
+++ b/docs/book/contributing/index.rst
@@ -3,7 +3,7 @@ Contributing
 
 .. note::
 
-    This section is based on the great `Symfony documentation <http://symfony.com/doc/current>`_.
+    This section is based on the great `Symfony documentation <https://symfony.com/doc/current>`_.
 
 Install to Contribute
 ---------------------
@@ -51,7 +51,7 @@ And now you can use gulp for installing views, by just running a simple command:
 
     yarn build
 
-For the contributing process questions, please refer to the `Contributing Guide <http://docs.sylius.com/en/latest/contributing/index.html>`_ that comes up in the following chapters:
+For the contributing process questions, please refer to the `Contributing Guide <https://docs.sylius.com/en/latest/contributing/index.html>`_ that comes up in the following chapters:
 
 .. toctree::
     :maxdepth: 1

--- a/docs/book/customers/admin_user.rst
+++ b/docs/book/customers/admin_user.rst
@@ -231,7 +231,7 @@ They can be configured as below:
 
 .. image:: ../../_images/sylius_plus/banner.png
    :align: center
-   :target: http://sylius.com/plus/?utm_source=docs
+   :target: https://sylius.com/plus/?utm_source=docs
 
 Learn more
 ----------

--- a/docs/book/customers/customer_pools.rst
+++ b/docs/book/customers/customer_pools.rst
@@ -103,4 +103,4 @@ Learn more
 
 .. image:: ../../_images/sylius_plus/banner.png
    :align: center
-   :target: http://sylius.com/plus/?utm_source=docs
+   :target: https://sylius.com/plus/?utm_source=docs

--- a/docs/book/index.rst
+++ b/docs/book/index.rst
@@ -134,7 +134,7 @@ Documentation sections of The Book referring to Sylius Plus features are:
 
 .. image:: ../_images/sylius_plus/banner.png
     :align: center
-    :target: http://sylius.com/plus/?utm_source=docs
+    :target: https://sylius.com/plus/?utm_source=docs
 
 Sylius Plugins
 --------------

--- a/docs/book/installation/installation.rst
+++ b/docs/book/installation/installation.rst
@@ -88,7 +88,7 @@ command and then accessing ``http://127.0.0.1:8000`` in your web browser to see 
 
 .. note::
     Get to know more about using Symfony Local Web Server `in the Symfony server documentation <https://symfony.com/doc/current/setup/symfony_server.html>`_.
-    If you are using a built-in server check `here <http://symfony.com/doc/current/cookbook/web_server/built_in.html>`_.
+    If you are using a built-in server check `here <https://symfony.com/doc/current/cookbook/web_server/built_in.html>`_.
 
 You can log to the administrator panel located at ``/admin`` with the credentials you have provided during the installation process.
 
@@ -107,8 +107,8 @@ In the root directory of your project you will find these important subdirectori
 
 .. tip::
 
-    As it was mentioned before we are basing on Symfony, that is why we've adopted its approach to architecture. Read more `in the Symfony documentation <http://symfony.com/doc/current/quick_tour/the_architecture.html>`_.
-    Read also about the `best practices while structuring your project <http://symfony.com/doc/current/best_practices/creating-the-project.html#structuring-the-application>`_.
+    As it was mentioned before we are basing on Symfony, that is why we've adopted its approach to architecture. Read more `in the Symfony documentation <https://symfony.com/doc/current/quick_tour/the_architecture.html>`_.
+    Read also about the `best practices while structuring your project <https://symfony.com/doc/current/best_practices/creating-the-project.html#structuring-the-application>`_.
 
 Contributing
 ------------

--- a/docs/book/installation/requirements.rst
+++ b/docs/book/installation/requirements.rst
@@ -5,7 +5,7 @@ System Requirements
 ===================
 
 Here you will find the list of system requirements that have to be adhered to be able to use **Sylius**.
-First of all have a look at the `requirements for running Symfony <http://symfony.com/doc/current/reference/requirements.html>`_.
+First of all have a look at the `requirements for running Symfony <https://symfony.com/doc/current/reference/requirements.html>`_.
 
 Read about the `LAMP stack <https://en.wikipedia.org/wiki/LAMP_(software_bundle)>`_ and the `MAMP stack <https://en.wikipedia.org/wiki/MAMP>`_.
 
@@ -21,7 +21,7 @@ In the production environment we do recommend using Apache web server ≥ 2.2.
 
 While developing the recommended way to work with your Symfony application is to use PHP's built-in web server.
 
-`Go there <http://symfony.com/doc/current/cookbook/configuration/web_server_configuration.html>`_ to see the full reference to the web server configuration.
+`Go there <https://symfony.com/doc/current/cookbook/configuration/web_server_configuration.html>`_ to see the full reference to the web server configuration.
 
 PHP required modules and configuration
 --------------------------------------
@@ -54,7 +54,7 @@ PHP required modules and configuration
 
 .. warning::
 
-    Use your local timezone, for example America/Los_Angeles or Europe/Berlin. See http://php.net/manual/en/timezones.php for the list of all available timezones.
+    Use your local timezone, for example America/Los_Angeles or Europe/Berlin. See https://php.net/manual/en/timezones.php for the list of all available timezones.
 
 Database
 --------
@@ -78,9 +78,9 @@ Most of the application folders and files require only read access, but a few fo
 * ``var/log``
 * ``public/media``
 
-You can read how to set these permissions in the `Symfony - setting up permissions <http://symfony.com/doc/current/setup/file_permissions.html>`_ section.
+You can read how to set these permissions in the `Symfony - setting up permissions <https://symfony.com/doc/current/setup/file_permissions.html>`_ section.
 
-.. _`gd`: http://php.net/manual/en/book.fileinfo.php
-.. _`exif`: http://php.net/manual/en/book.exif.php
-.. _`fileinfo`: http://php.net/manual/en/book.fileinfo.php
-.. _`intl`: http://php.net/manual/en/book.intl.php
+.. _`gd`: https://php.net/manual/en/book.fileinfo.php
+.. _`exif`: https://php.net/manual/en/book.exif.php
+.. _`fileinfo`: https://php.net/manual/en/book.fileinfo.php
+.. _`intl`: https://php.net/manual/en/book.intl.php

--- a/docs/book/installation/sylius_plus_installation.rst
+++ b/docs/book/installation/sylius_plus_installation.rst
@@ -354,4 +354,4 @@ To upgrade Sylius Plus in an existing application, please follow upgrade instruc
 
 .. image:: ../../_images/sylius_plus/banner.png
     :align: center
-    :target: http://sylius.com/plus/?utm_source=docs
+    :target: https://sylius.com/plus/?utm_source=docs

--- a/docs/book/installation/sylius_plus_upgrading.rst
+++ b/docs/book/installation/sylius_plus_upgrading.rst
@@ -36,4 +36,4 @@ Each release comes with an ``UPGRADE.md`` file, which is meant to help in the up
 
 .. image:: ../../_images/sylius_plus/banner.png
    :align: center
-   :target: http://sylius.com/plus/?utm_source=docs
+   :target: https://sylius.com/plus/?utm_source=docs

--- a/docs/book/introduction/environments.rst
+++ b/docs/book/introduction/environments.rst
@@ -41,4 +41,4 @@ To run Sylius console in ``test`` environment, add the following parameters to e
 Final Thoughts
 --------------
 
-You can read more about Symfony environments in `this cookbook article <http://symfony.com/doc/current/cookbook/configuration/environments.html>`_.
+You can read more about Symfony environments in `this cookbook article <https://symfony.com/doc/current/cookbook/configuration/environments.html>`_.

--- a/docs/book/orders/returns.rst
+++ b/docs/book/orders/returns.rst
@@ -182,4 +182,4 @@ Learn more
 
 .. image:: ../../_images/sylius_plus/banner.png
   :align: center
-  :target: http://sylius.com/plus/?utm_source=docs
+  :target: https://sylius.com/plus/?utm_source=docs

--- a/docs/book/orders/shipments.rst
+++ b/docs/book/orders/shipments.rst
@@ -28,7 +28,7 @@ there remains one shipment in state ``ready``.
 
 .. image:: ../../_images/sylius_plus/banner.png
     :align: center
-    :target: http://sylius.com/plus/?utm_source=docs
+    :target: https://sylius.com/plus/?utm_source=docs
 
 The Shipment State Machine
 --------------------------

--- a/docs/book/orders/taxation.rst
+++ b/docs/book/orders/taxation.rst
@@ -93,7 +93,7 @@ How to create a TaxRate programmatically?
 .. note::
 
    Before creating a tax rate you need to know that you can have different tax zones, in order to apply correct taxes for customers coming from any country in the world.
-   To understand how zones work, please refer to the `Zones <http://docs.sylius.com/en/latest/book/customers/addresses/zones.html>`_ chapter of this book.
+   To understand how zones work, please refer to the `Zones <https://docs.sylius.com/en/latest/book/customers/addresses/zones.html>`_ chapter of this book.
 
 Use a factory to create a new, empty TaxRate. Provide a ``code``, a ``name``. Set the amount of charge in float.
 Then choose a calculator and zone (retrieved from the repository beforehand).
@@ -134,7 +134,7 @@ Since we are using the concept of :doc:`Channels </book/configuration/channels>`
 
 .. note::
 
-   To understand how zones work, please refer to the `Zones <http://docs.sylius.com/en/latest/book/customers/addresses/zones.html>`_ chapter of this book.
+   To understand how zones work, please refer to the `Zones <https://docs.sylius.com/en/latest/book/customers/addresses/zones.html>`_ chapter of this book.
 
 Applying Taxes
 --------------

--- a/docs/book/plugins/index.rst
+++ b/docs/book/plugins/index.rst
@@ -14,7 +14,7 @@ Exemplary features may be: Social media buttons, newsletter, wishlists, payment 
 
 .. tip::
 
-    **The list of all Sylius Plugins (official and approved) is available on the Sylius website** `here <http://sylius.com/developers/store/plugins>`_.
+    **The list of all Sylius Plugins (official and approved) is available on the Sylius website** `here <https://sylius.com/developers/store/plugins>`_.
 
 .. toctree::
     :hidden:

--- a/docs/book/plugins/official-plugins.rst
+++ b/docs/book/plugins/official-plugins.rst
@@ -2,7 +2,7 @@ Official Sylius Plugins
 =======================
 
 Sylius as an organization is providing some of its own plugins in the open source model. All the official plugins
-developed by Sylius can be found in the `github organization <http://github.com/Sylius>`_ (just like the main repository).
+developed by Sylius can be found in the `github organization <https://github.com/Sylius>`_ (just like the main repository).
 
 You can recognize a Sylius official plugin by this badge in its readme:
 

--- a/docs/book/plugins/sylius-store.rst
+++ b/docs/book/plugins/sylius-store.rst
@@ -24,7 +24,7 @@ Since Sylius is an open-source platform, there is a precise flow for the plugin 
 **4.** One of our Plugin Curators will contact you with the feedback regarding your plugin's code quality, test suite,
 and general feeling. They will also ask you to provide some changes in the code (if needed) to make this plugin visible in the Sylius Store.
 
-**5.** Wait for your Plugin to be featured in `the list of plugins <http://sylius.com/plugins/>`_ on the Sylius website.
+**5.** Wait for your Plugin to be featured in `the list of plugins <https://sylius.com/plugins/>`_ on the Sylius website.
 
 .. _book_plugins_technical_requirements:
 

--- a/docs/book/products/multi_source_inventory.rst
+++ b/docs/book/products/multi_source_inventory.rst
@@ -174,4 +174,4 @@ Learn more
 
 .. image:: ../../_images/sylius_plus/banner.png
    :align: center
-   :target: http://sylius.com/plus/?utm_source=docs
+   :target: https://sylius.com/plus/?utm_source=docs

--- a/docs/book/support/index.rst
+++ b/docs/book/support/index.rst
@@ -22,7 +22,7 @@ The most important rooms for newcomers are:
 But there are many more specific channels also.
 If you have any suggestions regarding its organization, please let us know on Slack!
 
-Slack requires inviting new members, but this can be done automatically, just go to `sylius.com/slack <http://sylius.com/slack>`_,
+Slack requires inviting new members, but this can be done automatically, just go to `sylius.com/slack <https://sylius.com/slack>`_,
 enter your email and you will get an invitation.
 If possible, please use your GitHub username - it will help us to recognize each other easily!
 

--- a/docs/components_and_bundles/components/Addressing/basic_usage.rst
+++ b/docs/components_and_bundles/components/Addressing/basic_usage.rst
@@ -90,4 +90,4 @@ narrow the search only to zones with same corresponding property.
 .. caution::
    Throws `\\InvalidArgumentException`_.
 
-.. _\\InvalidArgumentException: http://php.net/manual/en/class.invalidargumentexception.php
+.. _\\InvalidArgumentException: https://php.net/manual/en/class.invalidargumentexception.php

--- a/docs/components_and_bundles/components/Currency/basic_usage.rst
+++ b/docs/components_and_bundles/components/Currency/basic_usage.rst
@@ -11,7 +11,7 @@ Basic Usage
 Getting a Currency name
 -----------------------
 
-.. _Intl: http://symfony.com/doc/current/components/intl.html
+.. _Intl: https://symfony.com/doc/current/components/intl.html
 
 .. code-block:: php
 

--- a/docs/components_and_bundles/components/Currency/unavailable_currency_exception.rst
+++ b/docs/components_and_bundles/components/Currency/unavailable_currency_exception.rst
@@ -10,4 +10,4 @@ to a currency which is not present in the provided repository.
 .. note::
    This exception extends the `\\InvalidArgumentException`_.
 
-.. _\\InvalidArgumentException: http://php.net/manual/en/class.invalidargumentexception.php
+.. _\\InvalidArgumentException: https://php.net/manual/en/class.invalidargumentexception.php

--- a/docs/components_and_bundles/components/Inventory/basic_usage.rst
+++ b/docs/components_and_bundles/components/Inventory/basic_usage.rst
@@ -167,7 +167,7 @@ Decrease
 
 .. _InsufficientStockException: http://api.sylius.com/Sylius/Component/Inventory/Operator/InsufficientStockException.html
 
-.. _InvalidArgumentException: http://php.net/manual/en/class.invalidargumentexception.php
+.. _InvalidArgumentException: https://php.net/manual/en/class.invalidargumentexception.php
 
 .. note::
     For more detailed information go to `Sylius API InventoryOperator`_.
@@ -177,7 +177,7 @@ Decrease
 .. hint::
     To understand how events work check `Symfony EventDispatcher`_.
 
-.. _Symfony EventDispatcher: http://symfony.com/doc/current/components/event_dispatcher/introduction.html
+.. _Symfony EventDispatcher: https://symfony.com/doc/current/components/event_dispatcher/introduction.html
 
 .. _component_inventory_operator_noop-inventory-operator:
 

--- a/docs/components_and_bundles/components/Locale/models.rst
+++ b/docs/components_and_bundles/components/Locale/models.rst
@@ -38,4 +38,4 @@ Locale has the following properties:
 
 .. _Sylius API Locale: http://api.sylius.com/Sylius/Component/Locale/Model/Locale.html
 
-.. _Symfony Intl component: http://symfony.com/doc/current/components/intl.html
+.. _Symfony Intl component: https://symfony.com/doc/current/components/intl.html

--- a/docs/components_and_bundles/components/Shipping/basic_usage.rst
+++ b/docs/components_and_bundles/components/Shipping/basic_usage.rst
@@ -373,7 +373,7 @@ container. The calculators are retrieved by name.
 .. hint::
     You can read more about each of the available calculators in the :doc:`calculators` chapter.
 
-.. _InvalidArgumentException: http://php.net/manual/en/class.invalidargumentexception.php
+.. _InvalidArgumentException: https://php.net/manual/en/class.invalidargumentexception.php
 .. _UndefinedShippingMethodException: http://api.sylius.com/Sylius/Component/Shipping/Calculator/UndefinedShippingMethodException.html
 
 Resolvers

--- a/docs/components_and_bundles/components/Shipping/checkers.rst
+++ b/docs/components_and_bundles/components/Shipping/checkers.rst
@@ -93,4 +93,4 @@ This class checks if shipping method rules are capable of shipping given subject
     For more detailed information go to `Sylius API ShippingMethodEligibilityChecker`_.
 
 .. _Sylius API ShippingMethodEligibilityChecker: http://api.sylius.com/Sylius/Component/Shipping/Checker/ShippingMethodEligibilityChecker.html
-.. _InvalidArgumentException: http://php.net/manual/en/class.invalidargumentexception.php
+.. _InvalidArgumentException: https://php.net/manual/en/class.invalidargumentexception.php

--- a/docs/cookbook/deployment/platform-sh.rst
+++ b/docs/cookbook/deployment/platform-sh.rst
@@ -4,7 +4,7 @@ How to deploy Sylius to Platform.sh?
 .. tip::
 
     Start with reading `Platform.sh documentation <https://docs.platform.sh/frameworks/symfony.html>`_.
-    Also Symfony provides `a guide on deploying projects to Platform.sh <http://symfony.com/doc/current/deployment/platformsh.html>`_.
+    Also Symfony provides `a guide on deploying projects to Platform.sh <https://symfony.com/doc/current/deployment/platformsh.html>`_.
 
 The process of deploying Sylius to Platform.sh is based on the guidelines prepared for Symfony projects in general.
 In this guide you will find sufficient instructions to have your application up and running on Platform.sh.
@@ -235,5 +235,5 @@ Learn more
 ----------
 
 * Platform.sh documentation: `Configuring Symfony projects for Platform.sh <https://docs.platform.sh/frameworks/symfony.html>`_
-* Symfony documentation: `Deploying Symfony to Platform.sh <http://symfony.com/doc/current/deployment/platformsh.html>`_
+* Symfony documentation: `Deploying Symfony to Platform.sh <https://symfony.com/doc/current/deployment/platformsh.html>`_
 * :doc:`Installation Guide </book/installation/installation>`

--- a/docs/cookbook/emails/custom-email-template-per-channel.rst
+++ b/docs/cookbook/emails/custom-email-template-per-channel.rst
@@ -5,7 +5,7 @@ How to customize email templates per channel?
 
     This cookbook is suitable for a clean :doc:`sylius-standard installation </book/installation/installation>`.
     For more general tips, while using `SyliusMailerBundle <https://github.com/Sylius/SyliusMailerBundle/blob/master/docs/index.md>`_
-    go to `Sending configurable e-mails in Symfony Blogpost <http://sylius.com/blog/sending-configurable-e-mails-in-symfony>`_.
+    go to `Sending configurable e-mails in Symfony Blogpost <https://sylius.com/blog/sending-configurable-e-mails-in-symfony>`_.
 
 It is a common use-case to customize email templates depending on a channel in which an action was performed.
 

--- a/docs/cookbook/emails/custom-email.rst
+++ b/docs/cookbook/emails/custom-email.rst
@@ -5,7 +5,7 @@ How to send a custom e-mail?
 
     This cookbook is suitable for a clean :doc:`sylius-standard installation </book/installation/installation>`.
     For more general tips, while using `SyliusMailerBundle <https://github.com/Sylius/SyliusMailerBundle/blob/master/docs/index.md>`_
-    go to `Sending configurable e-mails in Symfony Blogpost <http://sylius.com/blog/sending-configurable-e-mails-in-symfony>`_.
+    go to `Sending configurable e-mails in Symfony Blogpost <https://sylius.com/blog/sending-configurable-e-mails-in-symfony>`_.
 
 Currently **Sylius** is sending e-mails only in a few "must-have" cases - see :doc:`E-mails documentation </book/architecture/emails>`.
 Of course these cases may not be sufficient for your business needs. If so, you will need to create your own custom e-mails inside the system.
@@ -147,4 +147,4 @@ Learn More
 * :doc:`Emails Concept </book/architecture/emails>`
 * :doc:`State Machine Concept </book/architecture/state_machine>`
 * :doc:`Customization Guide - State Machine </customization/state_machine>`
-* `Sending configurable e-mails in Symfony Blogpost <http://sylius.com/blog/sending-configurable-e-mails-in-symfony>`_
+* `Sending configurable e-mails in Symfony Blogpost <https://sylius.com/blog/sending-configurable-e-mails-in-symfony>`_

--- a/docs/cookbook/emails/disabling-order-confirmation-email.rst
+++ b/docs/cookbook/emails/disabling-order-confirmation-email.rst
@@ -76,4 +76,4 @@ That's it, we have removed the definition of the listener that is responsible fo
 Learn more
 ----------
 
-* `Compiler passes in the Symfony documentation <http://symfony.com/doc/current/service_container/compiler_passes.html>`_
+* `Compiler passes in the Symfony documentation <https://symfony.com/doc/current/service_container/compiler_passes.html>`_

--- a/docs/cookbook/emails/mailer.rst
+++ b/docs/cookbook/emails/mailer.rst
@@ -29,4 +29,4 @@ Learn More
 ----------
 
 * :doc:`Emails Concept </book/architecture/emails>`
-* `Sending configurable e-mails in Symfony Blogpost <http://sylius.com/blog/sending-configurable-e-mails-in-symfony>`_
+* `Sending configurable e-mails in Symfony Blogpost <https://sylius.com/blog/sending-configurable-e-mails-in-symfony>`_

--- a/docs/cookbook/entities/custom-model.rst
+++ b/docs/cookbook/entities/custom-model.rst
@@ -14,7 +14,7 @@ A Supplier needs three essential fields: ``name``, ``description`` and ``enabled
 2. Generate the entity
 ----------------------
 
-Symfony, the framework Sylius uses, provides the `SensioGeneratorBundle <http://symfony.com/doc/current/bundles/SensioGeneratorBundle/index.html>`_,
+Symfony, the framework Sylius uses, provides the `SensioGeneratorBundle <https://symfony.com/doc/current/bundles/SensioGeneratorBundle/index.html>`_,
 that simplifies the process of adding a model, or the `SymfonyMakerBundle <https://symfony.com/doc/current/bundles/SymfonyMakerBundle/index.html>`_ for Symfony 4.
 
 .. warning::

--- a/docs/cookbook/entities/custom-translatable-model.rst
+++ b/docs/cookbook/entities/custom-translatable-model.rst
@@ -15,7 +15,7 @@ The **name and description** fields need to be translatable.
 2. Generate the SupplierTranslation entity
 ------------------------------------------
 
-Symfony, the framework Sylius uses, provides the `SensioGeneratorBundle <http://symfony.com/doc/current/bundles/SensioGeneratorBundle/index.html>`_,
+Symfony, the framework Sylius uses, provides the `SensioGeneratorBundle <https://symfony.com/doc/current/bundles/SensioGeneratorBundle/index.html>`_,
 that simplifies the process of adding a model.
 
 .. warning::

--- a/docs/cookbook/images/images.rst
+++ b/docs/cookbook/images/images.rst
@@ -1,12 +1,12 @@
 How to resize images?
 =====================
 
-In Sylius we are using the `LiipImagineBundle <http://symfony.com/doc/current/bundles/LiipImagineBundle/index.html>`_
+In Sylius we are using the `LiipImagineBundle <https://symfony.com/doc/current/bundles/LiipImagineBundle/index.html>`_
 for handling images.
 
 .. tip::
 
-    You will find a reference to the types of filters in the LiipImagineBundle `in their documentation <http://symfony.com/doc/current/bundles/LiipImagineBundle/filters.html>`_.
+    You will find a reference to the types of filters in the LiipImagineBundle `in their documentation <https://symfony.com/doc/current/bundles/LiipImagineBundle/filters.html>`_.
 
 There are three places in the Sylius platform where the configuration for images can be found:
 
@@ -88,4 +88,4 @@ For example you can create a filter for advertisement banners:
 Learn more
 ----------
 
-* `The LiipImagineBundle documentation <http://symfony.com/doc/current/bundles/LiipImagineBundle/index.html>`_
+* `The LiipImagineBundle documentation <https://symfony.com/doc/current/bundles/LiipImagineBundle/index.html>`_

--- a/docs/cookbook/inventory/custom-inventory-sources-filter.rst
+++ b/docs/cookbook/inventory/custom-inventory-sources-filter.rst
@@ -98,4 +98,4 @@ Learn more
 
 .. image:: ../../_images/sylius_plus/banner.png
     :align: center
-    :target: http://sylius.com/plus/?utm_source=docs
+    :target: https://sylius.com/plus/?utm_source=docs

--- a/docs/cookbook/payments/stripe.rst
+++ b/docs/cookbook/payments/stripe.rst
@@ -45,7 +45,7 @@ Go to the ``http://localhost:8000/admin/payment-methods/new/stripe_checkout`` ur
 
 .. warning::
 
-    When your project is behind a loadbalancer and uses https you probably need to configure `trusted proxies <http://symfony.com/doc/current/deployment/proxies.html>`_. Otherwise the payment will not succeed and the user will endlessly loopback to the payment page without any notice.
+    When your project is behind a loadbalancer and uses https you probably need to configure `trusted proxies <https://symfony.com/doc/current/deployment/proxies.html>`_. Otherwise the payment will not succeed and the user will endlessly loopback to the payment page without any notice.
 
 Choosing Stripe Credit Card method in Checkout
 ----------------------------------------------

--- a/docs/cookbook/shop/checkout.rst
+++ b/docs/cookbook/shop/checkout.rst
@@ -33,7 +33,7 @@ Overwrite the state machine of Checkout
 
 Open the `CoreBundle/Resources/config/app/state_machine/sylius_order_checkout.yml <https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order_checkout.yml>`_
 and place its content in the ``src/Resources/SyliusCoreBundle/config/app/state_machine/sylius_order_checkout.yml``
-which is a `standard procedure of overriding configs in Symfony <http://symfony.com/doc/current/bundles/inheritance.html#overriding-resources-templates-routing-etc>`_.
+which is a `standard procedure of overriding configs in Symfony <https://symfony.com/doc/current/bundles/inheritance.html#overriding-resources-templates-routing-etc>`_.
 Remove the ``shipping_selected`` and ``shipping_skipped`` states, ``select_shipping`` and ``skip_shipping`` transitions.
 Remove the ``select_shipping`` and ``skip_shipping`` transition from the ``sylius_process_cart`` callback.
 

--- a/docs/customization/form.rst
+++ b/docs/customization/form.rst
@@ -124,7 +124,7 @@ Need more information?
 
 .. warning::
 
-    Some of the forms already have extensions in Sylius. Learn more about Extensions `here <http://symfony.com/doc/current/form/create_form_type_extension.html>`_.
+    Some of the forms already have extensions in Sylius. Learn more about Extensions `here <https://symfony.com/doc/current/form/create_form_type_extension.html>`_.
 
 For instance the ``ProductVariant`` admin form is defined under ``Sylius/Bundle/ProductBundle/Form/Type/ProductVariantType.php`` and later extended in
 ``Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantTypeExtension.php``. If you again extend the base type form like this:
@@ -269,6 +269,6 @@ Overriding forms completely
 .. tip::
 
     If you need to create a new form type on top of an existing one -  create this new alternative form type and define `getParent()`
-    to the old one. `See details in the Symfony docs <http://symfony.com/doc/current/form/create_custom_field_type.html>`_.
+    to the old one. `See details in the Symfony docs <https://symfony.com/doc/current/form/create_custom_field_type.html>`_.
 
 .. include:: /customization/plugins.rst.inc

--- a/docs/customization/model.rst
+++ b/docs/customization/model.rst
@@ -137,7 +137,7 @@ Which we strongly recommend over updating the schema.
 
 .. tip::
 
-    Read more about the database modifications and migrations in the `Symfony documentation here <http://symfony.com/doc/current/book/doctrine.html#creating-the-database-tables-schema>`_.
+    Read more about the database modifications and migrations in the `Symfony documentation here <https://symfony.com/doc/current/book/doctrine.html#creating-the-database-tables-schema>`_.
 
 **4.** Additionally if you want to give the administrator an ability to add the ``flag`` to any of countries,
 you'll need to update its form type. Check how to do it :doc:`here </customization/form>`.
@@ -253,7 +253,7 @@ Which we strongly recommend over updating the schema.
 
 .. tip::
 
-    Read more about the database modifications and migrations in the `Symfony documentation here <http://symfony.com/doc/current/book/doctrine.html#creating-the-database-tables-schema>`_.
+    Read more about the database modifications and migrations in the `Symfony documentation here <https://symfony.com/doc/current/book/doctrine.html#creating-the-database-tables-schema>`_.
 
 **4.** Additionally if you need  to add the ``estimatedDeliveryTime`` to any of your shipping methods in the admin panel,
 you'll need to update its form type. Check how to do it :doc:`here </customization/form>`.
@@ -395,7 +395,7 @@ Which we strongly recommend over updating the schema.
 
 .. tip::
 
-    Read more about the database modifications and migrations in the `Symfony documentation here <http://symfony.com/doc/current/book/doctrine.html#creating-the-database-tables-schema>`_.
+    Read more about the database modifications and migrations in the `Symfony documentation here <https://symfony.com/doc/current/book/doctrine.html#creating-the-database-tables-schema>`_.
 
 **5.** If you need to add delivery conditions to your shipping methods in the admin panel,
 you'll need to update its form type. Check how to do it :doc:`here </customization/form>`.

--- a/docs/customization/validation.rst
+++ b/docs/customization/validation.rst
@@ -40,7 +40,7 @@ Give it a new, custom validation group - ``[app_product]``.
 
 .. tip::
 
-    When using custom validation messages see `here how to add them <http://symfony.com/doc/current/validation/translations.html>`_.
+    When using custom validation messages see `here how to add them <https://symfony.com/doc/current/validation/translations.html>`_.
 
 **2.** Configure the new validation group in the ``config/services.yaml``.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -107,6 +107,6 @@ Components & Bundles
 
 .. include:: /components_and_bundles/map.rst.inc
 
-.. _Sylius: http://sylius.com
-.. _`Symfony Framework`: http://symfony.com
-.. _`Quick Tour`: http://symfony.com/doc/current/quick_tour
+.. _Sylius: https://sylius.com
+.. _`Symfony Framework`: https://symfony.com
+.. _`Quick Tour`: https://symfony.com/doc/current/quick_tour

--- a/src/Sylius/Bundle/AddressingBundle/README.md
+++ b/src/Sylius/Bundle/AddressingBundle/README.md
@@ -17,17 +17,17 @@ Sylius
 
 ![Sylius](http://demo.sylius.com/assets/admin/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusAddressingBundle/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusAddressingBundle/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -52,5 +52,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/AddressingBundle/composer.json
+++ b/src/Sylius/Bundle/AddressingBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Addressing and zone management for Symfony applications.",
     "keywords": ["shop", "ecommerce", "address", "addressing", "zones"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/AdminApiBundle/README.md
+++ b/src/Sylius/Bundle/AdminApiBundle/README.md
@@ -8,17 +8,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/api/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/api/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/AdminApiBundle/composer.json
+++ b/src/Sylius/Bundle/AdminApiBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "APIs management for Symfony projects.",
     "keywords": ["api", "rest"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/AdminBundle/README.md
+++ b/src/Sylius/Bundle/AdminBundle/README.md
@@ -8,17 +8,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/layout.html.twig
@@ -27,7 +27,7 @@
 {% endblock %}
 
 {% block footer %}
-{{ 'sylius.ui.powered_by'|trans }} <a href="http://sylius.com" target="_blank">Sylius v{{ sylius_meta.version }}</a>. {{ 'sylius.ui.see_issue'|trans }}? <a href="https://github.com/Sylius/Sylius/issues" target="_blank">{{ 'sylius.ui.report_it'|trans }}!</a>
+{{ 'sylius.ui.powered_by'|trans }} <a href="https://sylius.com" target="_blank">Sylius v{{ sylius_meta.version }}</a>. {{ 'sylius.ui.see_issue'|trans }}? <a href="https://github.com/Sylius/Sylius/issues" target="_blank">{{ 'sylius.ui.report_it'|trans }}!</a>
 {% endblock %}
 
 {% block javascripts %}

--- a/src/Sylius/Bundle/AdminBundle/composer.json
+++ b/src/Sylius/Bundle/AdminBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Sylius eCommerce administration panel component.",
     "keywords": ["shop", "ecommerce", "store", "webshop", "sylius", "ui", "admin interface", "admin", "backend"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "APIs management for Symfony projects.",
     "keywords": ["api", "rest"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/AttributeBundle/README.md
+++ b/src/Sylius/Bundle/AttributeBundle/README.md
@@ -8,17 +8,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusAttributeBundle/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusAttributeBundle/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/AttributeBundle/composer.json
+++ b/src/Sylius/Bundle/AttributeBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Managing object attributes for Symfony applications.",
     "keywords": ["shop", "ecommerce", "products", "product", "assortment"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/ChannelBundle/README.md
+++ b/src/Sylius/Bundle/ChannelBundle/README.md
@@ -8,17 +8,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/ChannelBundle/composer.json
+++ b/src/Sylius/Bundle/ChannelBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Currencies and channel formatting engine bundle for Symfony.",
     "keywords": ["cash", "currency", "channel", "currencies"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/CoreBundle/README.md
+++ b/src/Sylius/Bundle/CoreBundle/README.md
@@ -1,24 +1,24 @@
 SyliusCoreBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusCoreBundle.png?branch=master)](http://travis-ci.org/Sylius/SyliusCoreBundle)
 ================
 
-Sylius Core Bundle integrates all other bundles into complete eCommerce solution for [Symfony2](http://symfony.com).
+Sylius Core Bundle integrates all other bundles into complete eCommerce solution for [Symfony2](https://symfony.com).
 
 Sylius
 ------
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/CoreBundle/Resources/views/Collector/sylius.html.twig
+++ b/src/Sylius/Bundle/CoreBundle/Resources/views/Collector/sylius.html.twig
@@ -9,7 +9,7 @@
         <div class="sf-toolbar-info-group">
             <div class="sf-toolbar-info-piece">
                 <b>Sylius</b>
-                <span><a href="http://sylius.com">{{ collector.version }}</a></span>
+                <span><a href="https://sylius.com">{{ collector.version }}</a></span>
             </div>
             <div class="sf-toolbar-info-piece">
                 <b>Extensions</b>
@@ -55,7 +55,7 @@
         <div class="sf-toolbar-info-group">
             <div class="sf-toolbar-info-piece">
                 <b>Resources</b>
-                <span><a href="http://docs.sylius.com/en/latest/" rel="help">Sylius Documentation</a></span>
+                <span><a href="https://docs.sylius.com/en/latest/" rel="help">Sylius Documentation</a></span>
             </div>
         </div>
     {% endset %}

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Sylius core bundle. It integrates all other bundles into full stack Symfony ecommerce solution.",
     "keywords": ["shop", "ecommerce", "store", "webshop", "sylius"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/CurrencyBundle/README.md
+++ b/src/Sylius/Bundle/CurrencyBundle/README.md
@@ -1,24 +1,24 @@
 SyliusCurrencyBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusCurrencyBundle.png?branch=master)](http://travis-ci.org/Sylius/SyliusCurrencyBundle)
 ====================
 
-[**Symfony2**](http://symfony.com) integration of Sylius Currency processing component.
+[**Symfony2**](https://symfony.com) integration of Sylius Currency processing component.
 
 Sylius
 ------
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/CurrencyBundle/composer.json
+++ b/src/Sylius/Bundle/CurrencyBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Currencies processing for Symfony.",
     "keywords": ["cash", "currency", "money", "currencies"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/CustomerBundle/README.md
+++ b/src/Sylius/Bundle/CustomerBundle/README.md
@@ -1,24 +1,24 @@
 SyliusCustomerBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusCustomerBundle.png?branch=master)](http://travis-ci.org/Sylius/SyliusCustomerBundle)
 ==================
 
-[**Symfony2**](http://symfony.com) integration of Sylius Customer management component.
+[**Symfony2**](https://symfony.com) integration of Sylius Customer management component.
 
 Sylius
 ------
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/CustomerBundle/composer.json
+++ b/src/Sylius/Bundle/CustomerBundle/composer.json
@@ -3,12 +3,12 @@
     "type": "symfony-bundle",
     "description": "Customers management for Symfony projects.",
     "keywords": ["customer", "groups"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Michał Marcinkowski",
@@ -24,11 +24,11 @@
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/InventoryBundle/README.md
+++ b/src/Sylius/Bundle/InventoryBundle/README.md
@@ -1,7 +1,7 @@
 SyliusInventoryBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusInventoryBundle.png?branch=master)](http://travis-ci.org/Sylius/SyliusInventoryBundle)
 =====================
 
-Flexible inventory management for [**Symfony2**](http://symfony.com) eCommerce applications.
+Flexible inventory management for [**Symfony2**](https://symfony.com) eCommerce applications.
 
 It was heavily inspired by [Spree inventory system](http://guides.spreecommerce.org/developer/inventory.html).
 
@@ -10,17 +10,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusInventoryBundle/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusInventoryBundle/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -45,5 +45,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/InventoryBundle/composer.json
+++ b/src/Sylius/Bundle/InventoryBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Flexible inventory management for Symfony applications.",
     "keywords": ["shop", "ecommerce", "stock", "inventory", "sylius"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/LocaleBundle/README.md
+++ b/src/Sylius/Bundle/LocaleBundle/README.md
@@ -1,24 +1,24 @@
 SyliusLocaleBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusLocaleBundle.png?branch=master)](http://travis-ci.org/Sylius/SyliusLocaleBundle)
 ==================
 
-[**Symfony2**](http://symfony.com) integration of Sylius Locale management component.
+[**Symfony2**](https://symfony.com) integration of Sylius Locale management component.
 
 Sylius
 ------
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/LocaleBundle/composer.json
+++ b/src/Sylius/Bundle/LocaleBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Locales management for Symfony projects.",
     "keywords": ["language", "localization", "locale", "i18n", "internationalization"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/MoneyBundle/README.md
+++ b/src/Sylius/Bundle/MoneyBundle/README.md
@@ -1,24 +1,24 @@
 SyliusMoneyBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusMoneyBundle.png?branch=master)](http://travis-ci.org/Sylius/SyliusMoneyBundle)
 =================
 
-[**Symfony2**](http://symfony.com) integration with PHP Money library.
+[**Symfony2**](https://symfony.com) integration with PHP Money library.
 
 Sylius
 ------
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/MoneyBundle/composer.json
+++ b/src/Sylius/Bundle/MoneyBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Currencies and money formatting engine bundle for Symfony.",
     "keywords": ["cash", "currency", "money", "currencies"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/OrderBundle/README.md
+++ b/src/Sylius/Bundle/OrderBundle/README.md
@@ -1,7 +1,7 @@
 SyliusOrderBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusOrderBundle.png?branch=master)](http://travis-ci.org/Sylius/SyliusOrderBundle)
 =================
 
-Sales order bundle for [**Symfony2**](http://symfony.com) ecommerce applications. It allows you to start building you application with sensible and flexible models.
+Sales order bundle for [**Symfony2**](https://symfony.com) ecommerce applications. It allows you to start building you application with sensible and flexible models.
 Provides default forms, controllers, entities, mappings and everything that can help you building your perfect solution.
 
 Includes order and order item total value adjustments system based on ideas from [Spree adjustments](http://guides.spreecommerce.org/developer/adjustments.html).
@@ -11,17 +11,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusOrderBundle/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusOrderBundle/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -46,5 +46,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/OrderBundle/composer.json
+++ b/src/Sylius/Bundle/OrderBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Sales order management for Symfony applications.",
     "keywords": ["shop", "ecommerce", "sales", "orders", "order", "sylius"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/PaymentBundle/README.md
+++ b/src/Sylius/Bundle/PaymentBundle/README.md
@@ -1,24 +1,24 @@
 SyliusPaymentBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusPaymentBundle.png)](http://travis-ci.org/Sylius/SyliusPaymentBundle)
 ====================
 
-Payments component integration for [**Symfony2**](http://symfony.com) eCommerce applications.
+Payments component integration for [**Symfony2**](https://symfony.com) eCommerce applications.
 
 Sylius
 ------
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/PaymentBundle/composer.json
+++ b/src/Sylius/Bundle/PaymentBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Flexible payments system for Symfony e-commerce applications.",
     "keywords": ["payments", "payment", "shop", "webshop", "ecommerce"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/PayumBundle/README.md
+++ b/src/Sylius/Bundle/PayumBundle/README.md
@@ -8,17 +8,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/PayumBundle/composer.json
+++ b/src/Sylius/Bundle/PayumBundle/composer.json
@@ -3,12 +3,12 @@
     "type": "symfony-bundle",
     "description": "Payum integration for Symfony e-commerce applications.",
     "keywords": ["payments", "payment", "payum"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Kotlyar Maksim",
@@ -16,11 +16,11 @@
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/ProductBundle/README.md
+++ b/src/Sylius/Bundle/ProductBundle/README.md
@@ -1,7 +1,7 @@
 SyliusProductBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusProductBundle.png?branch=master)](http://travis-ci.org/Sylius/SyliusProductBundle)
 ===================
 
-Products system for [**Symfony2**](http://symfony.com) applications.
+Products system for [**Symfony2**](https://symfony.com) applications.
 It supports simple product catalogs, as well as stores with requirement for fully customizable variants, options and properties.
 
 Its initial version was inspired by [Spree product and variants system](http://guides.spreecommerce.org/developer/products.html).
@@ -11,17 +11,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusProductBundle/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusProductBundle/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -46,5 +46,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/ProductBundle/composer.json
+++ b/src/Sylius/Bundle/ProductBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Product catalog for your Symfony applications.",
     "keywords": ["shop", "ecommerce", "products", "product", "assortment"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/PromotionBundle/README.md
+++ b/src/Sylius/Bundle/PromotionBundle/README.md
@@ -1,24 +1,24 @@
 SyliusPromotionBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusPromotionBundle.png?branch=master)](http://travis-ci.org/Sylius/SyliusPromotionBundle)
 ===================
 
-Promotions engine for [**Symfony2**](http://symfony.com) eCommerce applications.
+Promotions engine for [**Symfony2**](https://symfony.com) eCommerce applications.
 
 Sylius
 ------
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusPromotionBundle/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusPromotionBundle/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Sylius/contributors).

--- a/src/Sylius/Bundle/PromotionBundle/composer.json
+++ b/src/Sylius/Bundle/PromotionBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Manage ecommerce promotions system in your Symfony application.",
     "keywords": ["shop", "ecommerce", "promotions", "coupons", "discounts", "sylius"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/ReviewBundle/README.md
+++ b/src/Sylius/Bundle/ReviewBundle/README.md
@@ -6,17 +6,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------

--- a/src/Sylius/Bundle/ReviewBundle/composer.json
+++ b/src/Sylius/Bundle/ReviewBundle/composer.json
@@ -3,12 +3,12 @@
     "type": "symfony-bundle",
     "description": "Review system for Symfony ecommerce applications.",
     "keywords": ["review", "shop", "webshop", "ecommerce", "sylius"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Mateusz Zalewski",
@@ -24,11 +24,11 @@
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/ShippingBundle/README.md
+++ b/src/Sylius/Bundle/ShippingBundle/README.md
@@ -1,7 +1,7 @@
 SyliusShippingBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusShippingBundle.png?branch=master)](http://travis-ci.org/Sylius/SyliusShippingBundle)
 ====================
 
-Shipping component integration for [**Symfony2**](http://symfony.com) eCommerce applications.
+Shipping component integration for [**Symfony2**](https://symfony.com) eCommerce applications.
 It provides architecture for shipment management system.
 
 It includes flexible calculators engine, which already contains default
@@ -18,17 +18,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusShippingBundle/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusShippingBundle/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -53,5 +53,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/SyliusShippingBundle/contributors).

--- a/src/Sylius/Bundle/ShippingBundle/composer.json
+++ b/src/Sylius/Bundle/ShippingBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Flexible shipping system for Symfony ecommerce applications.",
     "keywords": ["shipping", "delivery", "shipments", "shop", "webshop", "ecommerce", "sylius"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/ShopBundle/README.md
+++ b/src/Sylius/Bundle/ShopBundle/README.md
@@ -8,17 +8,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/SyliusShopBundle/contributors).

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Layout/Footer/_content.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Layout/Footer/_content.html.twig
@@ -1,5 +1,5 @@
 <div class="ui center aligned inverted basic segment">
-    <p>&copy; {{ 'sylius.ui.your_store'|trans }}, {{ 'sylius.ui.powered_by'|trans }} <a href="http://sylius.com" target="_blank" style="color: #1abb9c;">Sylius</a>.</p>
+    <p>&copy; {{ 'sylius.ui.your_store'|trans }}, {{ 'sylius.ui.powered_by'|trans }} <a href="https://sylius.com" target="_blank" style="color: #1abb9c;">Sylius</a>.</p>
     <a target="_blank" href="//facebook.com/SyliusEcommerce/"><i class="big grey facebook icon"></i></a>
     <a target="_blank" href="//instagram.com/sylius.team/"><i class="big grey instagram icon"></i></a>
     <a target="_blank" href="//twitter.com/sylius"><i class="big grey twitter card icon"></i></a>

--- a/src/Sylius/Bundle/ShopBundle/composer.json
+++ b/src/Sylius/Bundle/ShopBundle/composer.json
@@ -9,20 +9,20 @@
         "webshop",
         "sylius"
     ],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/TaxationBundle/README.md
+++ b/src/Sylius/Bundle/TaxationBundle/README.md
@@ -1,24 +1,24 @@
 SyliusTaxationBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusTaxationBundle.png?branch=master)](http://travis-ci.org/Sylius/SyliusTaxationBundle)
 ====================
 
-Customizable taxation system for [**Symfony2**](http://symfony.com) e-commerce applications.
+Customizable taxation system for [**Symfony2**](https://symfony.com) e-commerce applications.
 
 Sylius
 ------
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusTaxationBundle/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusTaxationBundle/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/SyliusTaxationBundle/contributors).

--- a/src/Sylius/Bundle/TaxationBundle/composer.json
+++ b/src/Sylius/Bundle/TaxationBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Flexible taxation system for Symfony ecommerce applications.",
     "keywords": ["tax", "taxes", "taxation", "shop", "webshop", "ecommerce"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/TaxonomyBundle/README.md
+++ b/src/Sylius/Bundle/TaxonomyBundle/README.md
@@ -1,24 +1,24 @@
 SyliusTaxonomyBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusTaxonomyBundle.png?branch=master)](http://travis-ci.org/Sylius/SyliusTaxonomyBundle)
 ======================
 
-Flexible categorization system based on [Spree Taxonomies system](http://guides.spreecommerce.org/user/configuring_taxonomies.html) for [**Symfony2**](http://symfony.com) eCommerce applications.
+Flexible categorization system based on [Spree Taxonomies system](http://guides.spreecommerce.org/user/configuring_taxonomies.html) for [**Symfony2**](https://symfony.com) eCommerce applications.
 
 Sylius
 ------
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusTaxonomyBundle/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/bundles/SyliusTaxonomyBundle/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/SyliusTaxonomyBundle/contributors).

--- a/src/Sylius/Bundle/TaxonomyBundle/composer.json
+++ b/src/Sylius/Bundle/TaxonomyBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Flexible categorization system for Symfony.",
     "keywords": ["shop", "ecommerce", "taxonomies", "taxonomy", "category", "categorization", "sylius"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/UiBundle/README.md
+++ b/src/Sylius/Bundle/UiBundle/README.md
@@ -6,17 +6,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -41,5 +41,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/SyliusUiBundle/contributors).

--- a/src/Sylius/Bundle/UiBundle/composer.json
+++ b/src/Sylius/Bundle/UiBundle/composer.json
@@ -3,20 +3,20 @@
     "type": "symfony-bundle",
     "description": "Generic UI bundle for Sylius eCommerce components.",
     "keywords": ["shop", "ecommerce", "store", "webshop", "sylius", "ui", "user interface"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Bundle/UserBundle/README.md
+++ b/src/Sylius/Bundle/UserBundle/README.md
@@ -1,24 +1,24 @@
 SyliusUserBundle [![Build status...](https://secure.travis-ci.org/Sylius/SyliusUserBundle.png?branch=master)](http://travis-ci.org/Sylius/SyliusUserBundle)
 ==================
 
-[**Symfony2**](http://symfony.com) integration of Sylius User management component.
+[**Symfony2**](https://symfony.com) integration of Sylius User management component.
 
 Sylius
 ------
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The bundle was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The bundle was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/SyliusUserBundle/contributors).

--- a/src/Sylius/Bundle/UserBundle/composer.json
+++ b/src/Sylius/Bundle/UserBundle/composer.json
@@ -3,12 +3,12 @@
     "type": "symfony-bundle",
     "description": "Users management for Symfony projects.",
     "keywords": ["user", "registration", "login", "groups"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Michał Marcinkowski",
@@ -24,11 +24,11 @@
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Addressing/README.md
+++ b/src/Sylius/Component/Addressing/README.md
@@ -15,17 +15,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/components/Addressing/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/components/Addressing/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -50,5 +50,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Addressing/contributors).

--- a/src/Sylius/Component/Addressing/composer.json
+++ b/src/Sylius/Component/Addressing/composer.json
@@ -3,20 +3,20 @@
     "type": "library",
     "description": "Addressing and zone management for PHP applications.",
     "keywords": ["shop", "ecommerce", "address", "addressing", "zones"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Attribute/README.md
+++ b/src/Sylius/Component/Attribute/README.md
@@ -8,17 +8,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/components/Attribute/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/components/Attribute/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Attribute/contributors).

--- a/src/Sylius/Component/Attribute/composer.json
+++ b/src/Sylius/Component/Attribute/composer.json
@@ -3,20 +3,20 @@
     "type": "library",
     "description": "Component for handling object attributes in PHP projects.",
     "keywords": ["shop", "ecommerce", "attribute", "feature"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Channel/README.md
+++ b/src/Sylius/Component/Channel/README.md
@@ -8,17 +8,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/components/Channel/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/components/Channel/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Channel/contributors).

--- a/src/Sylius/Component/Channel/composer.json
+++ b/src/Sylius/Component/Channel/composer.json
@@ -3,20 +3,20 @@
     "type": "library",
     "description": "E-Commerce PHP component for managing different sales channels.",
     "keywords": ["channel", "multichannel", "multistore", "stores", "ecommerce", "sylius"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Core/README.md
+++ b/src/Sylius/Component/Core/README.md
@@ -8,17 +8,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Core/contributors).

--- a/src/Sylius/Component/Core/composer.json
+++ b/src/Sylius/Component/Core/composer.json
@@ -3,20 +3,20 @@
     "type": "library",
     "description": "Sylius e-commerce core. It integrates all components.",
     "keywords": ["shop", "ecommerce", "core", "store", "sylius"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Currency/README.md
+++ b/src/Sylius/Component/Currency/README.md
@@ -8,17 +8,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/components/Currency/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/components/Currency/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Currency/contributors).

--- a/src/Sylius/Component/Currency/composer.json
+++ b/src/Sylius/Component/Currency/composer.json
@@ -3,20 +3,20 @@
     "type": "library",
     "description": "Currency handling for PHP applications.",
     "keywords": ["cash", "currency", "money", "currencies"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Customer/README.md
+++ b/src/Sylius/Component/Customer/README.md
@@ -8,17 +8,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Customer/contributors).

--- a/src/Sylius/Component/Customer/composer.json
+++ b/src/Sylius/Component/Customer/composer.json
@@ -3,12 +3,12 @@
     "type": "library",
     "description": "Customer handling for PHP applications.",
     "keywords": ["customer", "groups"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Michał Marcinkowski",
@@ -20,11 +20,11 @@
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Inventory/README.md
+++ b/src/Sylius/Component/Inventory/README.md
@@ -8,17 +8,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/components/Inventory/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/components/Inventory/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Inventory/contributors).

--- a/src/Sylius/Component/Inventory/composer.json
+++ b/src/Sylius/Component/Inventory/composer.json
@@ -3,20 +3,20 @@
     "type": "library",
     "description": "Flexible inventory management for PHP applications.",
     "keywords": ["shop", "ecommerce", "stock", "inventory", "sylius"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Locale/README.md
+++ b/src/Sylius/Component/Locale/README.md
@@ -8,17 +8,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/components/Locale/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/components/Locale/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Locale/contributors).

--- a/src/Sylius/Component/Locale/composer.json
+++ b/src/Sylius/Component/Locale/composer.json
@@ -3,20 +3,20 @@
     "type": "library",
     "description": "Locale handling for PHP applications.",
     "keywords": ["language", "localization", "locale", "i18n", "internationalization"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Order/README.md
+++ b/src/Sylius/Component/Order/README.md
@@ -12,17 +12,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/components/Order/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/components/Order/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -47,5 +47,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Order/contributors).

--- a/src/Sylius/Component/Order/composer.json
+++ b/src/Sylius/Component/Order/composer.json
@@ -3,20 +3,20 @@
     "type": "library",
     "description": "Orders management library for PHP.",
     "keywords": ["order", "sales", "shop", "webshop", "ecommerce"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Payment/README.md
+++ b/src/Sylius/Component/Payment/README.md
@@ -10,17 +10,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/components/Payment/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/components/Payment/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -45,5 +45,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Payment/contributors).

--- a/src/Sylius/Component/Payment/composer.json
+++ b/src/Sylius/Component/Payment/composer.json
@@ -3,20 +3,20 @@
     "type": "library",
     "description": "Flexible payments system for PHP e-commerce applications.",
     "keywords": ["payments", "payment", "shop", "webshop", "ecommerce"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Product/README.md
+++ b/src/Sylius/Component/Product/README.md
@@ -12,17 +12,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/components/Product/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/components/Product/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -47,5 +47,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Product/contributors).

--- a/src/Sylius/Component/Product/composer.json
+++ b/src/Sylius/Component/Product/composer.json
@@ -3,20 +3,20 @@
     "type": "library",
     "description": "Product catalog system with support for product options and variants.",
     "keywords": ["shop", "ecommerce", "products", "product", "assortment", "options", "variants"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Promotion/README.md
+++ b/src/Sylius/Component/Promotion/README.md
@@ -16,17 +16,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/components/Promotion/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/components/Promotion/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -51,5 +51,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Promotion/contributors).

--- a/src/Sylius/Component/Promotion/composer.json
+++ b/src/Sylius/Component/Promotion/composer.json
@@ -3,20 +3,20 @@
     "type": "library",
     "description": "Flexible promotion management for PHP applications.",
     "keywords": ["shop", "ecommerce", "promotion", "sylius"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Review/README.md
+++ b/src/Sylius/Component/Review/README.md
@@ -8,17 +8,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------

--- a/src/Sylius/Component/Review/composer.json
+++ b/src/Sylius/Component/Review/composer.json
@@ -3,12 +3,12 @@
     "type": "library",
     "description": "Review system, for commenting and rating shop components.",
     "keywords": ["shop", "ecommerce", "review", "rating"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Mateusz Zalewski",
@@ -24,11 +24,11 @@
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Shipping/README.md
+++ b/src/Sylius/Component/Shipping/README.md
@@ -17,17 +17,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/components/Shipping/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/components/Shipping/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -52,5 +52,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Shipping/contributors).

--- a/src/Sylius/Component/Shipping/composer.json
+++ b/src/Sylius/Component/Shipping/composer.json
@@ -3,20 +3,20 @@
     "type": "library",
     "description": "Flexible shipping component for PHP e-commerce projects.",
     "keywords": ["shipping", "delivery", "shipments", "shop", "webshop", "ecommerce", "sylius"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Taxation/README.md
+++ b/src/Sylius/Component/Taxation/README.md
@@ -10,17 +10,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/components/Taxation/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/components/Taxation/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -45,5 +45,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Taxation/contributors).

--- a/src/Sylius/Component/Taxation/composer.json
+++ b/src/Sylius/Component/Taxation/composer.json
@@ -3,20 +3,20 @@
     "type": "library",
     "description": "Flexible taxation system for PHP ecommerce applications.",
     "keywords": ["shop", "ecommerce", "tax", "taxes", "taxation", "vat", "sylius"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/Taxonomy/README.md
+++ b/src/Sylius/Component/Taxonomy/README.md
@@ -29,17 +29,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/components/Taxonomy/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/components/Taxonomy/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -64,5 +64,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/Taxonomy/contributors).

--- a/src/Sylius/Component/Taxonomy/composer.json
+++ b/src/Sylius/Component/Taxonomy/composer.json
@@ -3,20 +3,20 @@
     "type": "library",
     "description": "Taxonomies - categorization of domain models in PHP projects.",
     "keywords": ["taxonomy", "ecommerce", "categorization", "taxon", "classification"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {

--- a/src/Sylius/Component/User/README.md
+++ b/src/Sylius/Component/User/README.md
@@ -8,17 +8,17 @@ Sylius
 
 ![Sylius](https://demo.sylius.com/assets/shop/img/logo.png)
 
-Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](http://sylius.com).
+Sylius is an Open Source eCommerce solution built from decoupled components with powerful API and the highest quality code. [Read more on sylius.com](https://sylius.com).
 
 Documentation
 -------------
 
-Documentation is available on [**docs.sylius.com**](http://docs.sylius.com/en/latest/components_and_bundles/components/User/index.html).
+Documentation is available on [**docs.sylius.com**](https://docs.sylius.com/en/latest/components_and_bundles/components/User/index.html).
 
 Contributing
 ------------
 
-[This page](http://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
+[This page](https://docs.sylius.com/en/latest/contributing/index.html) contains all the information about contributing to Sylius.
 
 Follow Sylius' Development
 --------------------------
@@ -43,5 +43,5 @@ License can be found [here](https://github.com/Sylius/Sylius/blob/master/LICENSE
 Authors
 -------
 
-The component was originally created by [Paweł Jędrzejewski](http://pjedrzejewski.com).
+The component was originally created by [Paweł Jędrzejewski](https://pjedrzejewski.com).
 See the list of [contributors](https://github.com/Sylius/User/contributors).

--- a/src/Sylius/Component/User/composer.json
+++ b/src/Sylius/Component/User/composer.json
@@ -3,12 +3,12 @@
     "type": "library",
     "description": "User handling for PHP applications.",
     "keywords": ["user", "registration", "login", "groups"],
-    "homepage": "http://sylius.com",
+    "homepage": "https://sylius.com",
     "license": "MIT",
     "authors": [
         {
             "name": "Paweł Jędrzejewski",
-            "homepage": "http://pjedrzejewski.com"
+            "homepage": "https://pjedrzejewski.com"
         },
         {
             "name": "Michał Marcinkowski",
@@ -20,11 +20,11 @@
         },
         {
             "name": "Sylius project",
-            "homepage": "http://sylius.com"
+            "homepage": "https://sylius.com"
         },
         {
             "name": "Community contributions",
-            "homepage": "http://github.com/Sylius/Sylius/contributors"
+            "homepage": "https://github.com/Sylius/Sylius/contributors"
         }
     ],
     "require": {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

Use https for:
- github.com
- symfony.com
- sylius.com
- docs.sylius.com
- php.net
- pjedrzejewski.com
- phpspec.net

No change in translation files because it's managed by crowdin.
No change in XML files or XML code blocks.

