### PR TITLE
[WIP] Default shipping and payment method resolver

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -103,6 +103,7 @@
             <argument type="service" id="sylius.repository.shipping_method" />
             <argument type="service" id="sylius.shipping_method_eligibility_checker" />
             <argument type="service" id="sylius.zone_matcher" />
+            <argument type="service" id="sylius.shipping_methods_resolver" />
         </service>
         <service id="Sylius\Component\Shipping\Resolver\DefaultShippingMethodResolverInterface" alias="sylius.shipping_method_resolver.default" />
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -95,6 +95,7 @@
 
         <service id="sylius.payment_method_resolver.default" class="Sylius\Component\Core\Resolver\DefaultPaymentMethodResolver">
             <argument type="service" id="sylius.repository.payment_method" />
+            <argument type="service" id="sylius.payment_methods_resolver" />
         </service>
         <service id="Sylius\Component\Payment\Resolver\DefaultPaymentMethodResolverInterface" alias="sylius.payment_method_resolver.default" />
 

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/services.xml
@@ -49,6 +49,7 @@
         <service id="sylius.shipping_method_resolver.default"
                  class="Sylius\Component\Shipping\Resolver\DefaultShippingMethodResolver">
             <argument type="service" id="sylius.repository.shipping_method"/>
+            <argument type="service" id="sylius.shipping_methods_resolver" />
         </service>
         <service id="Sylius\Component\Shipping\Resolver\DefaultShippingMethodResolverInterface"
                  alias="sylius.shipping_method_resolver.default"/>

--- a/src/Sylius/Component/Core/Resolver/DefaultPaymentMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/DefaultPaymentMethodResolver.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Resolver;
 
-use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Repository\PaymentMethodRepositoryInterface;
 use Sylius\Component\Payment\Exception\UnresolvedDefaultPaymentMethodException;
 use Sylius\Component\Payment\Model\PaymentInterface as BasePaymentInterface;
 use Sylius\Component\Payment\Model\PaymentMethodInterface;
 use Sylius\Component\Payment\Resolver\DefaultPaymentMethodResolverInterface;
+use Sylius\Component\Payment\Resolver\PaymentMethodsResolverInterface;
 use Webmozart\Assert\Assert;
 
 class DefaultPaymentMethodResolver implements DefaultPaymentMethodResolverInterface
@@ -27,23 +27,45 @@ class DefaultPaymentMethodResolver implements DefaultPaymentMethodResolverInterf
     /** @var PaymentMethodRepositoryInterface */
     protected $paymentMethodRepository;
 
-    public function __construct(PaymentMethodRepositoryInterface $paymentMethodRepository)
-    {
+    /** @var PaymentMethodsResolverInterface|null */
+    private $paymentMethodsResolver;
+
+    public function __construct(
+        PaymentMethodRepositoryInterface $paymentMethodRepository,
+        ?PaymentMethodsResolverInterface $paymentMethodsResolver = null
+    ) {
         $this->paymentMethodRepository = $paymentMethodRepository;
+
+        if (null === $paymentMethodsResolver) {
+            @trigger_error(
+                sprintf(
+                    'Not passing an $paymentMethodsResolver to "%s" constructor is deprecated since Sylius 1.8 and will be impossible in Sylius 2.0.',
+                    self::class
+                ),
+                \E_USER_DEPRECATED
+            );
+        }
+
+        $this->paymentMethodsResolver = $paymentMethodsResolver;
     }
 
     /**
+     * @param BasePaymentInterface|PaymentInterface $payment
+     *
      * @throws UnresolvedDefaultPaymentMethodException
      */
-    public function getDefaultPaymentMethod(BasePaymentInterface $subject): PaymentMethodInterface
+    public function getDefaultPaymentMethod(BasePaymentInterface $payment): PaymentMethodInterface
     {
-        /** @var PaymentInterface $subject */
-        Assert::isInstanceOf($subject, PaymentInterface::class);
+        Assert::isInstanceOf($payment, PaymentInterface::class);
 
-        /** @var ChannelInterface $channel */
-        $channel = $subject->getOrder()->getChannel();
+        $channel = $payment->getOrder()->getChannel();
 
-        $paymentMethods = $this->paymentMethodRepository->findEnabledForChannel($channel);
+        if (null !== $this->paymentMethodsResolver) {
+            $paymentMethods = $this->paymentMethodsResolver->getSupportedMethods($payment);
+        } else {
+            $paymentMethods = $this->paymentMethodRepository->findEnabledForChannel($channel);
+        }
+
         if (empty($paymentMethods)) {
             throw new UnresolvedDefaultPaymentMethodException();
         }

--- a/src/Sylius/Component/Core/Resolver/DefaultPaymentMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/DefaultPaymentMethodResolver.php
@@ -34,6 +34,14 @@ class DefaultPaymentMethodResolver implements DefaultPaymentMethodResolverInterf
     ) {
         $this->paymentMethodRepository = $paymentMethodRepository;
 
+        Assert::false(
+            null === $paymentMethodRepository && null === $paymentMethodsResolver,
+            sprintf(
+                'You must pass to "%s" constructor either a $paymentMethodRepository, or a $paymentMethodsResolver, or both.',
+                __CLASS__,
+            )
+        );
+
         if (null !== $paymentMethodRepository) {
             @trigger_error(
                 sprintf(

--- a/src/Sylius/Component/Core/Resolver/DefaultPaymentMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/DefaultPaymentMethodResolver.php
@@ -24,11 +24,9 @@ use Webmozart\Assert\Assert;
 
 class DefaultPaymentMethodResolver implements DefaultPaymentMethodResolverInterface
 {
-    /** @var PaymentMethodRepositoryInterface */
-    protected $paymentMethodRepository;
+    protected PaymentMethodRepositoryInterface $paymentMethodRepository;
 
-    /** @var PaymentMethodsResolverInterface|null */
-    private $paymentMethodsResolver;
+    protected ?PaymentMethodsResolverInterface $paymentMethodsResolver;
 
     public function __construct(
         PaymentMethodRepositoryInterface $paymentMethodRepository,

--- a/src/Sylius/Component/Core/Resolver/DefaultPaymentMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/DefaultPaymentMethodResolver.php
@@ -24,15 +24,25 @@ use Webmozart\Assert\Assert;
 
 class DefaultPaymentMethodResolver implements DefaultPaymentMethodResolverInterface
 {
-    protected PaymentMethodRepositoryInterface $paymentMethodRepository;
+    protected ?PaymentMethodRepositoryInterface $paymentMethodRepository;
 
     protected ?PaymentMethodsResolverInterface $paymentMethodsResolver;
 
     public function __construct(
-        PaymentMethodRepositoryInterface $paymentMethodRepository,
+        ?PaymentMethodRepositoryInterface $paymentMethodRepository = null,
         ?PaymentMethodsResolverInterface $paymentMethodsResolver = null
     ) {
         $this->paymentMethodRepository = $paymentMethodRepository;
+
+        if (null !== $paymentMethodRepository) {
+            @trigger_error(
+                sprintf(
+                    'Passing an $paymentMethodRepository to "%s" constructor is deprecated since Sylius 1.9 and the argument will be removed in Sylius 2.0.',
+                    self::class
+                ),
+                \E_USER_DEPRECATED
+            );
+        }
 
         if (null === $paymentMethodsResolver) {
             @trigger_error(

--- a/src/Sylius/Component/Core/Resolver/EligibleDefaultShippingMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/EligibleDefaultShippingMethodResolver.php
@@ -29,17 +29,13 @@ use Webmozart\Assert\Assert;
 
 final class EligibleDefaultShippingMethodResolver implements DefaultShippingMethodResolverInterface
 {
-    /** @var ShippingMethodRepositoryInterface */
-    private $shippingMethodRepository;
+    private ?ShippingMethodRepositoryInterface $shippingMethodRepository;
 
-    /** @var ShippingMethodEligibilityCheckerInterface */
-    private $shippingMethodEligibilityChecker;
+    private ShippingMethodEligibilityCheckerInterface $shippingMethodEligibilityChecker;
 
-    /** @var ZoneMatcherInterface */
-    private $zoneMatcher;
+    private ZoneMatcherInterface $zoneMatcher;
 
-    /** @var ShippingMethodsResolverInterface|null */
-    private $shippingMethodsResolver;
+    private ?ShippingMethodsResolverInterface $shippingMethodsResolver;
 
     public function __construct(
         ?ShippingMethodRepositoryInterface $shippingMethodRepository = null,

--- a/src/Sylius/Component/Core/Resolver/EligibleDefaultShippingMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/EligibleDefaultShippingMethodResolver.php
@@ -17,7 +17,6 @@ use Sylius\Component\Addressing\Matcher\ZoneMatcherInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
-use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface as CoreShipmentInterface;
 use Sylius\Component\Core\Repository\ShippingMethodRepositoryInterface;
 use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface;
@@ -25,6 +24,7 @@ use Sylius\Component\Shipping\Exception\UnresolvedDefaultShippingMethodException
 use Sylius\Component\Shipping\Model\ShipmentInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Sylius\Component\Shipping\Resolver\DefaultShippingMethodResolverInterface;
+use Sylius\Component\Shipping\Resolver\ShippingMethodsResolverInterface;
 use Webmozart\Assert\Assert;
 
 final class EligibleDefaultShippingMethodResolver implements DefaultShippingMethodResolverInterface
@@ -38,27 +38,71 @@ final class EligibleDefaultShippingMethodResolver implements DefaultShippingMeth
     /** @var ZoneMatcherInterface */
     private $zoneMatcher;
 
+    /** @var ShippingMethodsResolverInterface|null */
+    private $shippingMethodsResolver;
+
     public function __construct(
         ShippingMethodRepositoryInterface $shippingMethodRepository,
         ShippingMethodEligibilityCheckerInterface $shippingMethodEligibilityChecker,
-        ZoneMatcherInterface $zoneMatcher
+        ZoneMatcherInterface $zoneMatcher,
+        ?ShippingMethodsResolverInterface $shippingMethodsResolver = null
     ) {
         $this->shippingMethodRepository = $shippingMethodRepository;
         $this->shippingMethodEligibilityChecker = $shippingMethodEligibilityChecker;
         $this->zoneMatcher = $zoneMatcher;
+
+        if (null === $shippingMethodsResolver) {
+            @trigger_error(
+                sprintf(
+                    'Not passing an $shippingMethodsResolver to "%s" constructor is deprecated since Sylius 1.8 and will be impossible in Sylius 2.0.',
+                    self::class
+                ),
+                \E_USER_DEPRECATED
+            );
+        }
+
+        $this->shippingMethodsResolver = $shippingMethodsResolver;
     }
 
+    /**
+     * @param ShipmentInterface|CoreShipmentInterface $shipment
+     *
+     * @throws UnresolvedDefaultShippingMethodException
+     */
     public function getDefaultShippingMethod(ShipmentInterface $shipment): ShippingMethodInterface
     {
-        /** @var CoreShipmentInterface $shipment */
         Assert::isInstanceOf($shipment, CoreShipmentInterface::class);
 
-        /** @var OrderInterface $order */
-        $order = $shipment->getOrder();
-        /** @var ChannelInterface $channel */
-        $channel = $order->getChannel();
+        if (null !== $this->shippingMethodsResolver) {
+            return $this->getFromResolver($shipment);
+        }
 
-        $shippingMethods = $this->getShippingMethods($channel, $order->getShippingAddress());
+        return $this->getFromRepository($shipment);
+    }
+
+    /**
+     * @throws UnresolvedDefaultShippingMethodException
+     */
+    private function getFromResolver(CoreShipmentInterface $shipment): ShippingMethodInterface
+    {
+        $shippingMethods = $this->shippingMethodsResolver->getSupportedMethods($shipment);
+
+        if (empty($shippingMethods)) {
+            throw new UnresolvedDefaultShippingMethodException();
+        }
+
+        return $shippingMethods[0];
+    }
+
+    /**
+     * @deprecated
+     *
+     * @throws UnresolvedDefaultShippingMethodException
+     */
+    private function getFromRepository(CoreShipmentInterface $shipment): ShippingMethodInterface
+    {
+        $order = $shipment->getOrder();
+        $shippingMethods = $this->getShippingMethods($order->getChannel(), $order->getShippingAddress());
 
         foreach ($shippingMethods as $shippingMethod) {
             if ($this->shippingMethodEligibilityChecker->isEligible($shipment, $shippingMethod)) {
@@ -70,6 +114,8 @@ final class EligibleDefaultShippingMethodResolver implements DefaultShippingMeth
     }
 
     /**
+     * @deprecated
+     *
      * @return array|ShippingMethodInterface[]
      */
     private function getShippingMethods(ChannelInterface $channel, ?AddressInterface $address): array

--- a/src/Sylius/Component/Core/Resolver/EligibleDefaultShippingMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/EligibleDefaultShippingMethodResolver.php
@@ -54,7 +54,7 @@ final class EligibleDefaultShippingMethodResolver implements DefaultShippingMeth
         if (null === $shippingMethodsResolver) {
             @trigger_error(
                 sprintf(
-                    'Not passing an $shippingMethodsResolver to "%s" constructor is deprecated since Sylius 1.8 and will be impossible in Sylius 2.0.',
+                    'Not passing an $shippingMethodsResolver to "%s" constructor is deprecated since Sylius 1.9 and will be impossible in Sylius 2.0.',
                     self::class
                 ),
                 \E_USER_DEPRECATED

--- a/src/Sylius/Component/Core/Resolver/EligibleDefaultShippingMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/EligibleDefaultShippingMethodResolver.php
@@ -95,8 +95,6 @@ final class EligibleDefaultShippingMethodResolver implements DefaultShippingMeth
     }
 
     /**
-     * @deprecated
-     *
      * @throws UnresolvedDefaultShippingMethodException
      */
     private function getFromRepository(CoreShipmentInterface $shipment): ShippingMethodInterface
@@ -114,8 +112,6 @@ final class EligibleDefaultShippingMethodResolver implements DefaultShippingMeth
     }
 
     /**
-     * @deprecated
-     *
      * @return array|ShippingMethodInterface[]
      */
     private function getShippingMethods(ChannelInterface $channel, ?AddressInterface $address): array

--- a/src/Sylius/Component/Core/Resolver/EligibleDefaultShippingMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/EligibleDefaultShippingMethodResolver.php
@@ -51,6 +51,14 @@ final class EligibleDefaultShippingMethodResolver implements DefaultShippingMeth
         $this->shippingMethodEligibilityChecker = $shippingMethodEligibilityChecker;
         $this->zoneMatcher = $zoneMatcher;
 
+        Assert::false(
+            null === $shippingMethodRepository && null === $shippingMethodsResolver,
+            sprintf(
+                'You must pass to "%s" constructor either a $shippingMethodRepository, or a $shippingMethodsResolver, or both.',
+                __CLASS__,
+            )
+        );
+
         if (null !== $shippingMethodRepository) {
             @trigger_error(
                 sprintf(

--- a/src/Sylius/Component/Core/Resolver/EligibleDefaultShippingMethodResolver.php
+++ b/src/Sylius/Component/Core/Resolver/EligibleDefaultShippingMethodResolver.php
@@ -42,7 +42,7 @@ final class EligibleDefaultShippingMethodResolver implements DefaultShippingMeth
     private $shippingMethodsResolver;
 
     public function __construct(
-        ShippingMethodRepositoryInterface $shippingMethodRepository,
+        ?ShippingMethodRepositoryInterface $shippingMethodRepository = null,
         ShippingMethodEligibilityCheckerInterface $shippingMethodEligibilityChecker,
         ZoneMatcherInterface $zoneMatcher,
         ?ShippingMethodsResolverInterface $shippingMethodsResolver = null
@@ -51,11 +51,21 @@ final class EligibleDefaultShippingMethodResolver implements DefaultShippingMeth
         $this->shippingMethodEligibilityChecker = $shippingMethodEligibilityChecker;
         $this->zoneMatcher = $zoneMatcher;
 
+        if (null !== $shippingMethodRepository) {
+            @trigger_error(
+                sprintf(
+                    'Passing an $shippingMethodRepository to "%s" constructor is deprecated since Sylius 1.9 and the argument will be removed in Sylius 2.0.',
+                    self::class
+                ),
+                \E_USER_DEPRECATED
+            );
+        }
+
         if (null === $shippingMethodsResolver) {
             @trigger_error(
                 sprintf(
-                    'Not passing an $shippingMethodsResolver to "%s" constructor is deprecated since Sylius 1.9 and will be impossible in Sylius 2.0.',
-                    self::class
+                    'Not passing a $shippingMethodsResolver to "%s" constructor is deprecated since Sylius 1.9 and the argument will be required starting with Sylius 2.0.',
+                    __CLASS__
                 ),
                 \E_USER_DEPRECATED
             );

--- a/src/Sylius/Component/Core/spec/Resolver/DefaultPaymentMethodResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/Resolver/DefaultPaymentMethodResolverSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Component\Core\Resolver;
 
+use InvalidArgumentException;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -39,7 +40,7 @@ final class DefaultPaymentMethodResolverSpec extends ObjectBehavior
     function it_throws_an_invalid_argument_exception_if_subject_not_implements_core_payment_interface(
         PaymentInterface $payment
     ): void {
-        $this->shouldThrow(\InvalidArgumentException::class)->during('getDefaultPaymentMethod', [$payment]);
+        $this->shouldThrow(InvalidArgumentException::class)->during('getDefaultPaymentMethod', [$payment]);
     }
 
     function it_throws_an_unresolved_default_payment_method_exception_if_there_is_no_enabled_payment_methods_in_database(
@@ -96,5 +97,12 @@ final class DefaultPaymentMethodResolverSpec extends ObjectBehavior
         $paymentMethodsResolver->getSupportedMethods($payment)->willReturn([$secondPaymentMethod]);
 
         $this->getDefaultPaymentMethod($payment)->shouldReturn($secondPaymentMethod);
+    }
+
+    function it_throws_an_exception_if_neither_a_repository_nor_a_resolver_is_passed_to_the_constructor(): void
+    {
+        $this->beConstructedWith();
+
+        $this->shouldThrow(InvalidArgumentException::class)->duringInstantiation();
     }
 }

--- a/src/Sylius/Component/Core/spec/Resolver/EligibleDefaultShippingMethodResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/Resolver/EligibleDefaultShippingMethodResolverSpec.php
@@ -176,4 +176,17 @@ final class EligibleDefaultShippingMethodResolverSpec extends ObjectBehavior
 
         $this->getDefaultShippingMethod($shipment)->shouldReturn($thirdShippingMethod);
     }
+
+    function it_throws_an_exception_if_neither_a_repository_nor_a_resolver_is_passed_to_the_constructor(
+        ShippingMethodEligibilityCheckerInterface $shippingMethodEligibilityChecker,
+        ZoneMatcherInterface $zoneMatcher
+    ): void {
+        $this->beConstructedWith(
+            null,
+            $shippingMethodEligibilityChecker,
+            $zoneMatcher
+        );
+
+        $this->shouldThrow(InvalidArgumentException::class)->duringInstantiation();
+    }
 }


### PR DESCRIPTION
Default shipping method resolver and default payment method resolver should use the corresponding collection resolver to get available methods to choose from.

Right now the logic is duplicated and in case a custom collection resolver uses a different logic it might happen that the default resolver will return a method which is not available.

Need suggestions for tests and on how to deprecate the current logic, especially the constructor arguments. Also, should I split it 2 PRs?

TODO:
- [x] Tests
- [x] Deprecation of current logic, including constructor arguments
- [ ] UPGRADE-*.md