### PR TITLE
[Countries]Add fixes for broken edit channel page and add product to cart

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/shop_configuration.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/shop_configuration.yaml
@@ -46,7 +46,7 @@ sylius_fixtures:
                             - 'PT'
                             - 'ES'
                             - 'CN'
-                            - 'UK'
+                            - 'GB'
                         zones:
                             US:
                                 name: 'United States of America'
@@ -65,7 +65,7 @@ sylius_fixtures:
                                     - 'PT'
                                     - 'ES'
                                     - 'CN'
-                                    - 'UK'
+                                    - 'GB'
 
                 menu_taxon:
                     name: taxon

--- a/src/Sylius/Component/Core/spec/Locale/Context/StorageBasedLocaleContextSpec.php
+++ b/src/Sylius/Component/Core/spec/Locale/Context/StorageBasedLocaleContextSpec.php
@@ -61,7 +61,7 @@ final class StorageBasedLocaleContextSpec extends ObjectBehavior
 
         $localeStorage->get($channel)->willReturn('pl_PL');
 
-        $localeProvider->getAvailableLocalesCodes()->willReturn(['en_US', 'en_UK']);
+        $localeProvider->getAvailableLocalesCodes()->willReturn(['en_US', 'en_GB']);
 
         $this->shouldThrow(LocaleNotFoundException::class)->during('getLocaleCode');
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

After changes from this pr: https://github.com/Sylius/Sylius/pull/10565
Fix broken edit channel page and add product to cart page
Problem was in fixtures, in resolving locales and countries, for United Kingdom locale `en_UK` not working properly.  For properly working it need `en_GB`

<img width="1060" alt="Screenshot 2020-05-20 at 10 47 06" src="https://user-images.githubusercontent.com/39232096/82428137-57f41600-9a8a-11ea-8f2e-17e8b4ac9031.png">
<img width="1179" alt="Screenshot 2020-05-20 at 11 01 31" src="https://user-images.githubusercontent.com/39232096/82428143-59bdd980-9a8a-11ea-8a9e-60567ecb0a86.png">
<img width="1425" alt="Screenshot 2020-05-20 at 11 02 00" src="https://user-images.githubusercontent.com/39232096/82428144-5a567000-9a8a-11ea-8d25-ae5080c9a74f.png">
<img width="1300" alt="Screenshot 2020-05-20 at 11 22 58" src="https://user-images.githubusercontent.com/39232096/82429576-70fdc680-9a8c-11ea-82c1-4c1ef173b9f2.png">
