### PR TITLE
Making error messages in example factories more descriptive

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AddressExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/AddressExampleFactory.php
@@ -136,7 +136,7 @@ class AddressExampleFactory extends AbstractExampleFactory
     private function assertCountryCodeIsValid(string $code): void
     {
         $country = $this->countryRepository->findOneBy(['code' => $code]);
-        Assert::notNull($country);
+        Assert::notNull($country, sprintf('Trying to create address with invalid country code: "%s"', $code));
     }
 
     /**

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
@@ -379,7 +379,7 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
         /** @var ProductAttributeInterface|null $productAttribute */
         $productAttribute = $this->productAttributeRepository->findOneBy(['code' => $code]);
 
-        Assert::notNull($productAttribute);
+        Assert::notNull($productAttribute, sprintf('Can not find product attribute with code: "%s"', $code));
 
         /** @var ProductAttributeValueInterface $productAttributeValue */
         $productAttributeValue = $this->productAttributeValueFactory->createNew();


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

When loading of a fixture fails because the factory can not find the objects it should attach to  precise error messages are very helpful.

Before:
![image](https://user-images.githubusercontent.com/14860264/82560206-46d20480-9b71-11ea-9dbe-819c64daeace.png)

After:
![image](https://user-images.githubusercontent.com/14860264/82560104-0e322b00-9b71-11ea-91d4-3c37fb7e7ed7.png)

