### PR TITLE
Resolve awaiting_payment state in resolver

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_payment.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_payment.yml
@@ -42,6 +42,6 @@ winzou_state_machine:
                     do: ["@sylius.order_processing.order_payment_processor.after_checkout", "process"]
                     args: ["object.getOrder()"]
                 sylius_resolve_state:
-                    on: ["complete", "refund", "authorize"]
+                    on: ["complete", "process", "refund", "authorize"]
                     do: ["@sylius.state_resolver.order_payment", "resolve"]
                     args: ["object.getOrder()"]

--- a/src/Sylius/Component/Core/StateResolver/OrderPaymentStateResolver.php
+++ b/src/Sylius/Component/Core/StateResolver/OrderPaymentStateResolver.php
@@ -91,6 +91,7 @@ final class OrderPaymentStateResolver implements StateResolverInterface
             return OrderPaymentTransitions::TRANSITION_PARTIALLY_PAY;
         }
 
+        // Authorized payments
         $authorizedPaymentTotal = 0;
         $authorizedPayments = $this->getPaymentsWithState($order, PaymentInterface::STATE_AUTHORIZED);
 
@@ -104,6 +105,18 @@ final class OrderPaymentStateResolver implements StateResolverInterface
 
         if ($authorizedPaymentTotal < $order->getTotal() && 0 < $authorizedPaymentTotal) {
             return OrderPaymentTransitions::TRANSITION_PARTIALLY_AUTHORIZE;
+        }
+
+        // Processing payments
+        $processingPaymentTotal = 0;
+        $processingPayments = $this->getPaymentsWithState($order, PaymentInterface::STATE_PROCESSING);
+
+        foreach ($processingPayments as $payment) {
+            $processingPaymentTotal += $payment->getAmount();
+        }
+
+        if (0 < $processingPayments->count() && $processingPaymentTotal >= $order->getTotal()) {
+            return OrderPaymentTransitions::TRANSITION_REQUEST_PAYMENT;
         }
 
         return null;

--- a/src/Sylius/Component/Core/spec/StateResolver/OrderPaymentStateResolverSpec.php
+++ b/src/Sylius/Component/Core/spec/StateResolver/OrderPaymentStateResolverSpec.php
@@ -268,4 +268,26 @@ final class OrderPaymentStateResolverSpec extends ObjectBehavior
 
         $this->resolve($order);
     }
+
+    function it_marks_an_order_as_awaiting_payment_if_payments_is_processing(
+        FactoryInterface $stateMachineFactory,
+        StateMachineInterface $stateMachine,
+        OrderInterface $order,
+        PaymentInterface $firstPayment
+    ): void {
+        $firstPayment->getAmount()->willReturn(6000);
+        $firstPayment->getState()->willReturn(PaymentInterface::STATE_PROCESSING);
+
+        $order
+            ->getPayments()
+            ->willReturn(new ArrayCollection([$firstPayment->getWrappedObject()]))
+        ;
+        $order->getTotal()->willReturn(6000);
+
+        $stateMachineFactory->get($order, OrderPaymentTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->can(OrderPaymentTransitions::TRANSITION_REQUEST_PAYMENT)->willReturn(true);
+        $stateMachine->apply(OrderPaymentTransitions::TRANSITION_REQUEST_PAYMENT)->shouldBeCalled();
+
+        $this->resolve($order);
+    }
 }


### PR DESCRIPTION
OrderPaymentStateResolver should resolve awaiting_payment state when there is payment under processing. This is needed to handle asynchronous payment confirmation.

> For asynchronous payment methods, it can take up to several days to confirm whether the payment has been successful. During this time, the payment cannot be guaranteed. The status of the payment’s Charge object is initially set to pending, until the payment has been confirmed as successful or failed. ACH debits are an example of an asynchronous method: with these debits, it takes a few days to confirm that the payment has succeeded.

https://stripe.com/docs/sources#synchronous-or-asynchronous-confirmation

| Q               | A
| --------------- | -----
| Branch?         | 1.6
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT
