### PR TITLE
[UI] add form helper

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -4,6 +4,7 @@
     <div class="{% if required %}required {% endif %}field{% if (not compound or force_error|default(false)) and not valid %} error{% endif %}">
         {{- form_label(form) -}}
         {{- form_widget(form) -}}
+        {{- form_help(form) -}}
         {{- form_errors(form) -}}
     </div>
 {%- endblock form_row %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #10466
| License         | MIT

I suggest adding support for form helpers.

**By adding a helper in a back office form**

```php
->add('plainPassword', PasswordType::class, [
    'label' => 'sylius.form.user.password.label',
    'help' => 'sylius.form.user.password.help',
])
```
Look like (Without any other changes, css, ...)
![image](https://user-images.githubusercontent.com/6593252/83339372-74cfeb00-a2cd-11ea-9ba5-ea9fb7a2bda4.png)

**By adding a helper in a front office form**

```php
->add('newPassword', RepeatedType::class, [
    'type' => PasswordType::class,
    'first_options' => [
        'label' => 'sylius.form.user_change_password.new',
        'help' => 'sylius.form.user_change_password.help',
    ],
    'second_options' => ['label' => 'sylius.form.user_change_password.confirmation'],
    'invalid_message' => 'sylius.user.plainPassword.mismatch',
])
```

Look like (Without any other changes, css, ...)
![image](https://user-images.githubusercontent.com/6593252/83339413-d2643780-a2cd-11ea-8578-a9e29c257b86.png)

WDYT ?