### PR TITLE
ensure swagger docs route matches the configured new api route

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -45,6 +45,7 @@
             decoration-priority="20"
         >
             <argument type="service" id="sylius.api.swagger_admin_authentication_documentation_normalizer.inner" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service
@@ -56,6 +57,7 @@
             decoration-priority="10"
         >
             <argument type="service" id="sylius.api.swagger_shop_authentication_documentation_normalizer.inner" />
+            <argument>%sylius.security.new_api_route%</argument>
         </service>
 
         <service id="sylius.api.api_platform.metadata.property.metadata_factory.xml" decorates="api_platform.metadata.property.metadata_factory.xml" class="Sylius\Bundle\ApiBundle\ApiPlatform\Metadata\Property\Factory\ExtractorPropertyMetadataFactory" public="false">

--- a/src/Sylius/Bundle/ApiBundle/Swagger/AdminAuthenticationTokenDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/AdminAuthenticationTokenDocumentationNormalizer.php
@@ -20,9 +20,8 @@ final class AdminAuthenticationTokenDocumentationNormalizer implements Normalize
 {
     /** @var NormalizerInterface */
     private $decoratedNormalizer;
-    /**
-     * @var string
-     */
+
+    /** @var string */
     private $apiRoute;
 
     public function __construct(NormalizerInterface $decoratedNormalizer, string $apiRoute)

--- a/src/Sylius/Bundle/ApiBundle/Swagger/AdminAuthenticationTokenDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/AdminAuthenticationTokenDocumentationNormalizer.php
@@ -20,10 +20,15 @@ final class AdminAuthenticationTokenDocumentationNormalizer implements Normalize
 {
     /** @var NormalizerInterface */
     private $decoratedNormalizer;
+    /**
+     * @var string
+     */
+    private $apiRoute;
 
-    public function __construct(NormalizerInterface $decoratedNormalizer)
+    public function __construct(NormalizerInterface $decoratedNormalizer, string $apiRoute)
     {
         $this->decoratedNormalizer = $decoratedNormalizer;
+        $this->apiRoute = $apiRoute;
     }
 
     public function supportsNormalization($data, string $format = null): bool
@@ -61,7 +66,7 @@ final class AdminAuthenticationTokenDocumentationNormalizer implements Normalize
 
         $tokenDocumentation = [
             'paths' => [
-                '/new-api/admin-user-authentication-token' => [
+                $this->apiRoute .'/admin-user-authentication-token' => [
                     'post' => [
                         'tags' => ['AdminUserToken'],
                         'operationId' => 'postCredentialsItem',

--- a/src/Sylius/Bundle/ApiBundle/Swagger/ShopAuthenticationTokenDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/ShopAuthenticationTokenDocumentationNormalizer.php
@@ -20,10 +20,15 @@ final class ShopAuthenticationTokenDocumentationNormalizer implements Normalizer
 {
     /** @var NormalizerInterface */
     private $decoratedNormalizer;
+    /**
+     * @var string
+     */
+    private $apiRoute;
 
-    public function __construct(NormalizerInterface $decoratedNormalizer)
+    public function __construct(NormalizerInterface $decoratedNormalizer, string $apiRoute)
     {
         $this->decoratedNormalizer = $decoratedNormalizer;
+        $this->apiRoute = $apiRoute;
     }
 
     public function supportsNormalization($data, string $format = null): bool
@@ -61,7 +66,7 @@ final class ShopAuthenticationTokenDocumentationNormalizer implements Normalizer
 
         $tokenDocumentation = [
             'paths' => [
-                '/new-api/shop-user-authentication-token' => [
+                $this->apiRoute .'/shop-user-authentication-token' => [
                     'post' => [
                         'tags' => ['ShopUserToken'],
                         'operationId' => 'postCredentialsItem',

--- a/src/Sylius/Bundle/ApiBundle/Swagger/ShopAuthenticationTokenDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/ShopAuthenticationTokenDocumentationNormalizer.php
@@ -20,9 +20,8 @@ final class ShopAuthenticationTokenDocumentationNormalizer implements Normalizer
 {
     /** @var NormalizerInterface */
     private $decoratedNormalizer;
-    /**
-     * @var string
-     */
+
+    /** @var string */
     private $apiRoute;
 
     public function __construct(NormalizerInterface $decoratedNormalizer, string $apiRoute)


### PR DESCRIPTION
fixes #11483

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #11483
| License         | MIT

when you change the new api route in the parameters, it will now correctly reflect in the documentation