### PR TITLE
Add priority to payment gateways

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/DependencyInjection/Compiler/RegisterGatewayConfigTypePass.php
+++ b/src/Sylius/Bundle/PayumBundle/DependencyInjection/Compiler/RegisterGatewayConfigTypePass.php
@@ -56,11 +56,11 @@ final class RegisterGatewayConfigTypePass implements CompilerPassInterface
             return $secondGateway['priority'] - $firstGateway['priority'];
         });
 
+        $sortedGatewayFactories = [];
         foreach ($gatewayFactories as $key => $factory) {
-            $gatewayFactories[$factory['type']] = $factory['label'];
-            unset($gatewayFactories[$key]);
+            $sortedGatewayFactories[$factory['type']] = $factory['label'];
         }
 
-        $container->setParameter('sylius.gateway_factories', $gatewayFactories);
+        $container->setParameter('sylius.gateway_factories', $sortedGatewayFactories);
     }
 }

--- a/src/Sylius/Bundle/PayumBundle/DependencyInjection/Compiler/RegisterGatewayConfigTypePass.php
+++ b/src/Sylius/Bundle/PayumBundle/DependencyInjection/Compiler/RegisterGatewayConfigTypePass.php
@@ -28,7 +28,7 @@ final class RegisterGatewayConfigTypePass implements CompilerPassInterface
         }
 
         $formRegistry = $container->findDefinition('sylius.form_registry.payum_gateway_config');
-        $gatewayFactories = [];
+        $gatewayFactories = [['priority' => 0, 'label' => 'sylius.payum_gateway_factory.offline', 'type' => 'offline']];
 
         $gatewayConfigurationTypes = $container->findTaggedServiceIds('sylius.gateway_configuration_type');
 
@@ -38,7 +38,11 @@ final class RegisterGatewayConfigTypePass implements CompilerPassInterface
                     throw new \InvalidArgumentException('Tagged gateway configuration type needs to have `type` and `label` attributes.');
                 }
 
-                $gatewayFactories[$attribute['type']] = $attribute['label'];
+                $gatewayFactories[] = [
+                    'label' => $attribute['label'],
+                    'priority' => $attribute['priority'] ?? 0,
+                    'type' => $attribute['type'],
+                ];
 
                 $formRegistry->addMethodCall(
                     'add',
@@ -47,8 +51,15 @@ final class RegisterGatewayConfigTypePass implements CompilerPassInterface
             }
         }
 
-        $gatewayFactories = array_merge($gatewayFactories, ['offline' => 'sylius.payum_gateway_factory.offline']);
-        ksort($gatewayFactories);
+
+        usort($gatewayFactories, function (array $firstGateway, array $secondGateway): int {
+            return $secondGateway['priority'] - $firstGateway['priority'];
+        });
+
+        foreach ($gatewayFactories as $key => $factory) {
+            $gatewayFactories[$factory['type']] = $factory['label'];
+            unset($gatewayFactories[$key]);
+        }
 
         $container->setParameter('sylius.gateway_factories', $gatewayFactories);
     }

--- a/src/Sylius/Bundle/PayumBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/config/services/form.xml
@@ -33,11 +33,12 @@
         </service>
 
         <service id="sylius.form.type.gateway_configuration.paypal" class="Sylius\Bundle\PayumBundle\Form\Type\PaypalGatewayConfigurationType">
-            <tag name="sylius.gateway_configuration_type" type="paypal_express_checkout" label="sylius.payum_gateway_factory.paypal_express_checkout" />
+            <tag name="sylius.gateway_configuration_type" type="paypal_express_checkout" label="sylius.payum_gateway_factory.paypal_express_checkout" priority="100" />
             <tag name="form.type" />
         </service>
+
         <service id="sylius.form.type.gateway_configuration.stripe" class="Sylius\Bundle\PayumBundle\Form\Type\StripeGatewayConfigurationType">
-            <tag name="sylius.gateway_configuration_type" type="stripe_checkout" label="sylius.payum_gateway_factory.stripe_checkout" />
+            <tag name="sylius.gateway_configuration_type" type="stripe_checkout" label="sylius.payum_gateway_factory.stripe_checkout" priority="50" />
             <tag name="form.type" />
         </service>
     </services>

--- a/src/Sylius/Bundle/PayumBundle/Tests/DependencyInjection/Compiler/RegisterGatewayConfigTypePassTest.php
+++ b/src/Sylius/Bundle/PayumBundle/Tests/DependencyInjection/Compiler/RegisterGatewayConfigTypePassTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\PayumBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sylius\Bundle\PayumBundle\DependencyInjection\Compiler\RegisterGatewayConfigTypePass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class RegisterGatewayConfigTypePassTest extends AbstractCompilerPassTestCase
+{
+    /** @test */
+    public function it_registers_payment_gateways_configs_by_their_priority_in_the_registry(): void
+    {
+        $this->setDefinition('sylius.form_registry.payum_gateway_config', new Definition());
+        $this->setDefinition('custom_low_priority_gateway',
+            (new Definition('LowGatewayClass'))->addTag(
+                'sylius.gateway_configuration_type',
+                ['type' => 'low_gateway', 'label' => 'Low Gateway', 'priority' => 10]
+            )
+        );
+        $this->setDefinition('custom_high_priority_gateway',
+            (new Definition('HighGatewayClass'))->addTag(
+                'sylius.gateway_configuration_type',
+                ['type' => 'high_gateway', 'label' => 'High Gateway', 'priority' => 1000]
+            )
+        );
+        $this->setDefinition('custom_medium_priority_gateway',
+            (new Definition('MediumGatewayClass'))->addTag(
+                'sylius.gateway_configuration_type',
+                ['type' => 'medium_gateway', 'label' => 'Medium Gateway', 'priority' => 300]
+            )
+        );
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sylius.form_registry.payum_gateway_config',
+            'add',
+            ['gateway_config', 'low_gateway', 'LowGatewayClass']
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sylius.form_registry.payum_gateway_config',
+            'add',
+            ['gateway_config', 'high_gateway', 'HighGatewayClass']
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sylius.form_registry.payum_gateway_config',
+            'add',
+            ['gateway_config', 'medium_gateway', 'MediumGatewayClass']
+        );
+
+        $this->assertSame(
+            [
+                'high_gateway' => 'High Gateway',
+                'medium_gateway' => 'Medium Gateway',
+                'low_gateway' => 'Low Gateway',
+                'offline' => 'sylius.payum_gateway_factory.offline',
+            ],
+            $this->container->getParameter('sylius.gateway_factories')
+        );
+    }
+
+    /** @test */
+    public function it_registers_payment_gateways_configs_with_default_priorities_in_the_registry(): void
+    {
+        $this->setDefinition('sylius.form_registry.payum_gateway_config', new Definition());
+        $this->setDefinition('custom_low_priority_gateway',
+            (new Definition('LowGatewayClass'))->addTag(
+                'sylius.gateway_configuration_type',
+                ['type' => 'low_gateway', 'label' => 'Low Gateway', 'priority' => 10]
+            )
+        );
+        $this->setDefinition('custom_regular_priority_gateway',
+            (new Definition('RegularGatewayClass'))->addTag(
+                'sylius.gateway_configuration_type',
+                ['type' => 'regular_gateway', 'label' => 'Regular Gateway']
+            )
+        );
+        $this->setDefinition('custom_medium_priority_gateway',
+            (new Definition('MediumGatewayClass'))->addTag(
+                'sylius.gateway_configuration_type',
+                ['type' => 'medium_gateway', 'label' => 'Medium Gateway', 'priority' => 300]
+            )
+        );
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sylius.form_registry.payum_gateway_config',
+            'add',
+            ['gateway_config', 'low_gateway', 'LowGatewayClass']
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sylius.form_registry.payum_gateway_config',
+            'add',
+            ['gateway_config', 'regular_gateway', 'RegularGatewayClass']
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sylius.form_registry.payum_gateway_config',
+            'add',
+            ['gateway_config', 'medium_gateway', 'MediumGatewayClass']
+        );
+
+        $this->assertSame(
+            [
+                'medium_gateway' => 'Medium Gateway',
+                'low_gateway' => 'Low Gateway',
+                'offline' => 'sylius.payum_gateway_factory.offline',
+                'regular_gateway' => 'Regular Gateway',
+            ],
+            $this->container->getParameter('sylius.gateway_factories')
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new RegisterGatewayConfigTypePass());
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

`sylius.gateway_factories` parameter stays the same, priority is only used to order gateways - and therefore to display them in proper order in the admin panel.

<img width="258" alt="Zrzut ekranu 2020-06-3 o 16 45 41" src="https://user-images.githubusercontent.com/6212718/83651388-b7d5db00-a5b9-11ea-9e2a-f964a1fb99c2.png">

If priority is not set, it's `0` by default.