### PR TITLE
Added expression language support to template event system

### DIFF
--- a/src/Sylius/Bundle/UiBundle/DependencyInjection/SyliusUiExtension.php
+++ b/src/Sylius/Bundle/UiBundle/DependencyInjection/SyliusUiExtension.php
@@ -19,6 +19,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Zend\Stdlib\SplPriorityQueue;
 
@@ -59,6 +60,14 @@ final class SyliusUiExtension extends Extension
             }
 
             foreach ($blocksPriorityQueue->toArray() as $details) {
+                if (\is_array($details['context'])) {
+                    foreach ($details['context'] as $key => &$value) {
+                        if (\is_string($value) && 0 === strpos($value, '@=')) {
+                            $value = new Expression(substr($value, 2));
+                        }
+                    }
+                }
+
                 /** @psalm-var array{name: string, eventName: string, template: string, context: array, priority: int, enabled: bool} $details */
                 $blocksForEvents[$eventName][$details['name']] = new Definition(TemplateBlock::class, [
                     $details['name'],

--- a/src/Sylius/Bundle/UiBundle/Resources/config/services/template_event.xml
+++ b/src/Sylius/Bundle/UiBundle/Resources/config/services/template_event.xml
@@ -17,8 +17,17 @@
             <argument type="collection" />
         </service>
 
+        <service id="sylius.expression_language_provider" class="Symfony\Component\DependencyInjection\ExpressionLanguageProvider" />
+
+        <service id="sylius.expression_language_template_event" class="Sylius\Bundle\ResourceBundle\ExpressionLanguage\ExpressionLanguage">
+            <argument key="$providers" type="collection">
+                <argument>@sylius.expression_language_provider</argument>
+            </argument>
+        </service>
+
         <service id="Sylius\Bundle\UiBundle\Renderer\TemplateBlockRendererInterface" class="Sylius\Bundle\UiBundle\Renderer\TwigTemplateBlockRenderer">
             <argument type="service" id="twig" />
+            <argument type="service" id="sylius.expression_language" />
         </service>
 
         <service id="Sylius\Bundle\UiBundle\Renderer\TemplateEventRendererInterface" class="Sylius\Bundle\UiBundle\Renderer\DelegatingTemplateEventRenderer">


### PR DESCRIPTION
Added expression language support to template event system block contexts

| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no (Unless you count passing values that start with `@=` in the context values)
| Deprecations?   | no
| License         | MIT


