### PR TITLE
Update fixtures.rst

### DIFF
--- a/docs/customization/fixtures.rst
+++ b/docs/customization/fixtures.rst
@@ -238,6 +238,8 @@ just like in the example mentioned above.
             resource: '../src/*'
             exclude: '../src/{Entity,Fixture,Migrations,Tests,Kernel.php}'
 
+    If you leave autowiring on, errors like `Fixture with name ""your_cusom_fixture"" is already registered.` will most probably appear. Your fixture service will register twice (as `app.fixture.bla` by you and as `App\Fixture\BlaFixture` by DI autoconfigure).
+
 **4.** Add new Shipping Methods with delivery conditions in ``config/packages/fixtures.yaml``:
 
 .. code-block:: yaml


### PR DESCRIPTION
based on this gist: https://gist.githubusercontent.com/igormukhingmailcom/39edfb74d45d57f97bafadc3bc7d9af6/raw/bdb48156d8cc454d8e7624dc09feae13822fdaa1/sylius-tips.md

I think it will be better to have in Google SERPS the official documentation rather than a random gist on the internet that might be removed.

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT