### PR TITLE
Schema.org compatible breadcrumbs

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/AddressBook/layout.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/AddressBook/layout.html.twig
@@ -1,11 +1,11 @@
 {% extends '@SyliusShop/Account/layout.html.twig' %}
 
 {% block breadcrumb %}
-    <div class="ui breadcrumb">
-        <a href="{{ path('sylius_shop_homepage') }}" class="section">{{ 'sylius.ui.home'|trans }}</a>
-        <div class="divider"> / </div>
-        <a href="{{ path('sylius_shop_account_dashboard') }}" class="section">{{ 'sylius.ui.my_account'|trans }}</a>
-        <div class="divider"> / </div>
-        <div class="active section">{{ 'sylius.ui.address_book'|trans }}</div>
-    </div>
+    {% from '@SyliusShop/Common/Macro/breadcrumb.html.twig' import breadcrumb %}
+    {{ breadcrumb([{
+        url: path('sylius_shop_account_dashboard'),
+        name: 'sylius.ui.my_account'|trans
+    }, {
+        name: 'sylius.ui.address_book'|trans
+    }]) }}
 {% endblock %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/Order/Index/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/Order/Index/_breadcrumb.html.twig
@@ -1,7 +1,7 @@
-<div class="ui breadcrumb">
-    <a href="{{ path('sylius_shop_homepage') }}" class="section">{{ 'sylius.ui.home'|trans }}</a>
-    <div class="divider"> / </div>
-    <a href="{{ path('sylius_shop_account_dashboard') }}" class="section">{{ 'sylius.ui.my_account'|trans }}</a>
-    <div class="divider"> / </div>
-    <div class="active section">{{ 'sylius.ui.order_history'|trans }}</div>
-</div>
+{% from '@SyliusShop/Common/Macro/breadcrumb.html.twig' import breadcrumb %}
+{{ breadcrumb([{
+    url: path('sylius_shop_account_dashboard'),
+    name: 'sylius.ui.my_account'|trans
+}, {
+    name: 'sylius.ui.order_history'|trans
+}]) }}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/Order/Show/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/Order/Show/_breadcrumb.html.twig
@@ -1,11 +1,11 @@
-<div class="ui breadcrumb">
-    <a href="{{ path('sylius_shop_homepage') }}" class="section">{{ 'sylius.ui.home'|trans }}</a>
-    <div class="divider"> / </div>
-    <a href="{{ path('sylius_shop_account_dashboard') }}" class="section">{{ 'sylius.ui.my_account'|trans }}</a>
-    <div class="divider"> / </div>
-    <a href="{{ path('sylius_shop_account_order_index') }}" class="section">{{ 'sylius.ui.order_history'|trans }}</a>
-    <div class="divider"> / </div>
-    <div class="active section">
-        {{ 'sylius.ui.order'|trans }} <span id="number" {{ sylius_test_html_attribute('order-number') }}>#{{ order.number }}</span>
-    </div>
-</div>
+{% from '@SyliusShop/Common/Macro/breadcrumb.html.twig' import breadcrumb %}
+{% set current_crumb_name %}{{ 'sylius.ui.order'|trans }} <span id="number" {{ sylius_test_html_attribute('order-number') }}>#{{ order.number }}</span>{% endset %}
+{{ breadcrumb([{
+    url: path('sylius_shop_account_dashboard'),
+    name: 'sylius.ui.my_account'|trans
+}, {
+    url: path('sylius_shop_account_order_index'),
+    name: 'sylius.ui.order_history'|trans
+}, {
+    name: current_crumb_name
+}]) }}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/changePassword.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/changePassword.html.twig
@@ -5,13 +5,13 @@
 {% block title %}{{ 'sylius.ui.change_password'|trans }} | {{ parent() }}{% endblock %}
 
 {% block breadcrumb %}
-    <div class="ui breadcrumb">
-        <a href="{{ path('sylius_shop_homepage') }}" class="section">{{ 'sylius.ui.home'|trans }}</a>
-        <div class="divider"> / </div>
-        <a href="{{ path('sylius_shop_account_dashboard') }}" class="section">{{ 'sylius.ui.my_account'|trans }}</a>
-        <div class="divider"> / </div>
-        <div class="active section">{{ 'sylius.ui.change_password'|trans }}</div>
-    </div>
+    {% from '@SyliusShop/Common/Macro/breadcrumb.html.twig' import breadcrumb %}
+    {{ breadcrumb([{
+        url: path('sylius_shop_account_dashboard'),
+        name: 'sylius.ui.my_account'|trans
+    }, {
+        name: 'sylius.ui.change_password'|trans
+    }]) }}
 {% endblock %}
 
 {% block subcontent %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/dashboard.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/dashboard.html.twig
@@ -3,11 +3,10 @@
 {% block title %}{{ 'sylius.ui.my_account'|trans }} | {{ parent() }}{% endblock %}
 
 {% block breadcrumb %}
-    <div class="ui breadcrumb">
-        <a href="{{ path('sylius_shop_homepage') }}" class="section">{{ 'sylius.ui.home'|trans }}</a>
-        <div class="divider"> / </div>
-        <div class="active section">{{ 'sylius.ui.my_account'|trans }}</div>
-    </div>
+    {% from '@SyliusShop/Common/Macro/breadcrumb.html.twig' import breadcrumb %}
+    {{ breadcrumb([{
+        name: 'sylius.ui.my_account'|trans
+    }]) }}
 {% endblock %}
 
 {% block subcontent %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Account/profileUpdate.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Account/profileUpdate.html.twig
@@ -5,13 +5,13 @@
 {% block title %}{{ 'sylius.ui.your_profile'|trans }} | {{ parent() }}{% endblock %}
 
 {% block breadcrumb %}
-    <div class="ui breadcrumb">
-        <a href="{{ path('sylius_shop_homepage') }}" class="section">{{ 'sylius.ui.home'|trans }}</a>
-        <div class="divider"> / </div>
-        <a href="{{ path('sylius_shop_account_dashboard') }}" class="section">{{ 'sylius.ui.my_account'|trans }}</a>
-        <div class="divider"> / </div>
-        <div class="active section">{{ 'sylius.ui.personal_information'|trans }}</div>
-    </div>
+    {% from '@SyliusShop/Common/Macro/breadcrumb.html.twig' import breadcrumb %}
+    {{ breadcrumb([{
+        url: path('sylius_shop_account_dashboard'),
+        name: 'sylius.ui.my_account'|trans
+    }, {
+        name: 'sylius.ui.personal_information'|trans
+    }]) }}
 {% endblock %}
 
 {% block subcontent %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Macro/breadcrumb.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Common/Macro/breadcrumb.html.twig
@@ -1,0 +1,31 @@
+{% macro breadcrumb(crumbs = {}, prependHome = true) %}
+    {% from _self import breadcrumb_current_crumb, breadcrumb_crumb %}
+    {% if prependHome %}
+        {% set crumbs = [
+            {
+                url: path('sylius_shop_homepage'),
+                name: 'sylius.ui.home'|trans
+            }
+        ]|merge(crumbs) %}
+    {% endif %}
+    {% if crumbs|length %}
+    <div class="ui breadcrumb" itemscope itemtype="https://schema.org/BreadcrumbList">
+        {% for crumb in crumbs %}
+            {% if loop.last %}
+                <span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+                    <strong class="active section" itemprop="name">{{ crumb.name }}</strong>
+                    <meta itemprop="position" content="{{ loop.index }}">
+                </span>
+            {% else %}
+                <span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+                    <a class="section" href="{{ crumb.url }}" itemprop="item">
+                        <span itemprop="name">{{ crumb.name }}</span>
+                    </a>
+                    <meta itemprop="position" content="{{ loop.index }}">
+                </span>
+                <div class="divider"> / </div>
+            {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+{% endmacro %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_breadcrumb.html.twig
@@ -1,21 +1,23 @@
-<div class="ui breadcrumb">
-    <a href="{{ path('sylius_shop_homepage') }}" class="section">{{ 'sylius.ui.home'|trans }}</a>
-    <div class="divider"> / </div>
-    {% if product.mainTaxon is not null %}
-        {% set taxon = product.mainTaxon %}
-        {% set ancestors = taxon.ancestors|reverse %}
+{% from '@SyliusShop/Common/Macro/breadcrumb.html.twig' import breadcrumb %}
+{% set crumbs = [] %}
+{% if product.mainTaxon is not null %}
+    {% set taxon = product.mainTaxon %}
+    {% set ancestors = taxon.ancestors|reverse %}
 
-        {% for ancestor in ancestors %}
-            {% if ancestor.isRoot() %}
-                <div class="section">{{ ancestor.name }}</div>
-            {% else %}
-                <a href="{{ path('sylius_shop_product_index', {'slug': ancestor.slug, '_locale': ancestor.translation.locale}) }}" class="section">{{ ancestor.name }}</a>
-            {% endif %}
-            <div class="divider"> / </div>
-        {% endfor %}
-
-        <a href="{{ path('sylius_shop_product_index', {'slug': taxon.slug, '_locale': taxon.translation.locale}) }}" class="section">{{ taxon.name }}</a>
-        <div class="divider"> / </div>
-    {% endif %}
-    <div class="active section">{{ product.name }}</div>
-</div>
+    {% for ancestor in ancestors %}
+        {% if not ancestor.isRoot() %}
+            {% set crumbs = crumbs|merge([{
+                url: path('sylius_shop_product_index', {'slug': ancestor.slug, '_locale': ancestor.translation.locale}),
+                name: ancestor.name
+            }]) %}
+        {% endif %}
+    {% endfor %}
+    {% set crumbs = crumbs|merge([{
+        url: path('sylius_shop_product_index', {'slug': taxon.slug, '_locale': taxon.translation.locale}),
+        name: taxon.name
+    }]) %}
+{% endif %}
+{% set crumbs = crumbs|merge([{
+    name: product.name
+}]) %}
+{{ breadcrumb(crumbs) }}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Taxon/_breadcrumb.html.twig
@@ -1,15 +1,15 @@
+{% from '@SyliusShop/Common/Macro/breadcrumb.html.twig' import breadcrumb %}
 {% set ancestors = taxon.ancestors|reverse %}
-
-<div class="ui breadcrumb">
-    <a href="{{ path('sylius_shop_homepage') }}" class="section">{{ 'sylius.ui.home'|trans }}</a>
-    <div class="divider"> / </div>
-    {% for ancestor in ancestors %}
-        {% if ancestor.isRoot() or not ancestor.enabled %}
-            <div class="section">{{ ancestor.name }}</div>
-        {% else %}
-            <a href="{{ path('sylius_shop_product_index', {'slug': ancestor.slug, '_locale': ancestor.translation.locale}) }}" class="section">{{ ancestor.name }}</a>
-        {% endif %}
-    <div class="divider"> / </div>
-    {% endfor %}
-    <div class="active section">{{ taxon.name }}</div>
-</div>
+{% set crumbs = [] %}
+{% for ancestor in ancestors %}
+    {% if not ancestor.isRoot() and ancestor.enabled %}
+        {% set crumbs = crumbs|merge([{
+            url: path('sylius_shop_product_index', {'slug': ancestor.slug, '_locale': ancestor.translation.locale}),
+            name: ancestor.name
+        }]) %}
+    {% endif %}
+{% endfor %}
+{% set crumbs = crumbs|merge([{
+    name: taxon.name
+}]) %}
+{{ breadcrumb(crumbs) }}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

I find it not very useful to have multiple places to look out for the
breadcrumbs in the templates.

So I've added here a new macro `breadcrumb` and I've updated the templates
so it can be used properly.

Also, the macro changes a little bit the HTML because I've added the corresponding
microdata for the breadcrumb to be compatible with rich results.  
It can be verified here: https://search.google.com/test/rich-results with the content of the page.

In order to have correct rich results I had to remove the name of the root taxon.  
Since we just display the name of the root taxon and it doesn't have a link, it cannot
be used as an item in the middle of the breadcrumb.  
And I find it better this way since in all our projects we had to remove it.

**Before:**  
![image](https://user-images.githubusercontent.com/858611/85945790-539c0200-b940-11ea-862b-90e9f8a2b10e.png)

**After:**  
![image](https://user-images.githubusercontent.com/858611/85945796-5c8cd380-b940-11ea-83d0-47f8a2f576d1.png)


