### PR TITLE
Use a placeholder in tracking code sentence in shipment email

### DIFF
--- a/UPGRADE-1.8.md
+++ b/UPGRADE-1.8.md
@@ -90,3 +90,14 @@ The later is being decorated by `sylius.context.channel.cached` which caches the
 
 1. A serialization group has been added to the route `sylius_admin_ajax_product_index` to avoid an infinite loop, or a
 time out during this ajax request (previously no serialization group was defined on this route).
+
+## Special attention
+
+### Translations
+
+Some translations have changed, you may want to search for them in your project:
+
+- `sylius.email.shipment_confirmation.tracking_code` has been removed.
+- `sylius.email.shipment_confirmation.you_can_check_its_location` has been removed.
+- `sylius.email.shipment_confirmation.you_can_check_its_location_with_the_tracking_code` has been added instead of the two above.
+

--- a/src/Sylius/Behat/Context/Ui/EmailContext.php
+++ b/src/Sylius/Behat/Context/Ui/EmailContext.php
@@ -151,12 +151,9 @@ final class EmailContext implements Context
 
         if ($this->sharedStorage->has('tracking_code')) {
             $this->assertEmailContainsMessageTo(
-                sprintf(
-                    '%s %s %s',
-                    $this->sharedStorage->get('tracking_code'),
-                    $this->translator->trans('sylius.email.shipment_confirmation.tracking_code', [], null, $localeCode),
-                    $this->translator->trans('sylius.email.shipment_confirmation.thank_you_for_transaction', [], null, $localeCode)
-                ),
+                $this->translator->trans('sylius.email.shipment_confirmation.you_can_check_its_location_with_the_tracking_code', [
+                    '%tracking_code%' => $this->sharedStorage->get('tracking_code'),
+                ], null, $localeCode),
                 $recipient
             );
         }

--- a/src/Sylius/Bundle/AdminBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/translations/messages.en.yml
@@ -4,8 +4,7 @@ sylius:
             has_been_sent_using: 'has been sent using'
             subject: 'Shipment confirmation'
             thank_you_for_transaction: 'Thank you for a successful transaction.'
-            tracking_code: 'tracking code.'
-            you_can_check_its_location: 'You can check it''s location with the'
+            you_can_check_its_location_with_the_tracking_code: 'You can check it''s location with the %tracking_code% tracking code.'
             your_order_with_number: 'Your order with number'
     menu:
         admin:

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Email/shipmentConfirmation.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Email/shipmentConfirmation.html.twig
@@ -14,9 +14,10 @@
         </div>
         {% if shipment.tracking is not null %}
             <div style="margin-bottom: 20px;">
-                {{ 'sylius.email.shipment_confirmation.you_can_check_its_location'|trans({}, null, localeCode) }}
-                <span style="color: #1abb9c;">{{ shipment.tracking }}</span>
-                {{ 'sylius.email.shipment_confirmation.tracking_code'|trans({}, null, localeCode) }}
+                {% set tracking_code %}<span style="color: #1abb9c;">{{ shipment.tracking }}</span>{% endset %}
+                {{ 'sylius.email.shipment_confirmation.you_can_check_its_location_with_the_tracking_code'|trans({
+                    '%tracking_code%': tracking_code
+                }, null, localeCode)|raw }}
             </div>
         {% endif %}
         <div>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7 <!-- see the comment below -->
| Bug fix?        | yes (translation issue in French language…)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

See this discussion on Crowdin: <https://crowdin.com/translate/sylius/981/en-fr#34209>.

The way the sentence was handled gives a bad translation in French since we need to
change the order of the 3 elements previously involved.

Using a placeholder `%tracking_code%` here will allow to have a correct translation
in all languages.



