### PR TITLE
Don't call the backend if the notification bar is disabled

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-notification.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-notification.js
@@ -33,6 +33,11 @@ const getDismissedSyliusVersion = function getDismissedSyliusVersion() {
 $.fn.extend({
   notification() {
     const notificationMenu = $('#sylius-version-notification');
+
+    if (0 === notificationMenu.length) {
+      return;
+    }
+
     const askFrequency = notificationMenu.attr('data-frequency') * MILISECONDS_MULTIPLIER;
 
     const getCurrentSyliusVersion = function getCurrentSyliusVersion() {


### PR DESCRIPTION
Don't make unnecessary backend calls if the notification bar is missing (eg. disabled).

| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #11604
| License         | MIT
