### PR TITLE
Symfony Update | Remove unused Hateos bundle & library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,8 +99,6 @@
         "twig/twig": "^2.12",
         "webmozart/assert": "^1.9",
         "white-october/pagerfanta-bundle": "^1.3",
-        "willdurand/hateoas": "^2.12",
-        "willdurand/hateoas-bundle": "^1.4",
         "winzou/state-machine-bundle": "^0.3",
         "zendframework/zend-hydrator": "^2.4",
         "zendframework/zend-stdlib": "^3.2"

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -32,7 +32,6 @@ return [
     Sylius\Bundle\GridBundle\SyliusGridBundle::class => ['all' => true],
     winzou\Bundle\StateMachineBundle\winzouStateMachineBundle::class => ['all' => true],
     Sonata\BlockBundle\SonataBlockBundle::class => ['all' => true],
-    Bazinga\Bundle\HateoasBundle\BazingaHateoasBundle::class => ['all' => true],
     JMS\SerializerBundle\JMSSerializerBundle::class => ['all' => true],
     FOS\RestBundle\FOSRestBundle::class => ['all' => true],
     Knp\Bundle\GaufretteBundle\KnpGaufretteBundle::class => ['all' => true],


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8 / master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes(?)
| Deprecations?   | no
| Related tickets | partially #10928 
| License         | MIT

Remove unused Hateos bundle & library as they are not used anymore in Sylius.
