### PR TITLE
Adding help to the tracking

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_inventory.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_inventory.html.twig
@@ -6,7 +6,9 @@
             <br />
 
             {{ form_row(form.variant.tracked) }}
-            <div style="color: rgba(0, 0, 0, .6)">{{ form_help(form.variant.tracked) }}</div>
+            <div class="ui pointing above ignored label">
+                {{ form_help(form.variant.tracked) }}
+            </div>
 
             {{ form_row(form.variant.version) }}
         {% endif %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_inventory.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Tab/_inventory.html.twig
@@ -3,7 +3,11 @@
     <div class="ui attached segment">
         {% if product.simple %}
             {{ form_row(form.variant.onHand) }}
+            <br />
+
             {{ form_row(form.variant.tracked) }}
+            <div style="color: rgba(0, 0, 0, .6)">{{ form_help(form.variant.tracked) }}</div>
+
             {{ form_row(form.variant.version) }}
         {% endif %}
     </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_inventory.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_inventory.html.twig
@@ -2,9 +2,11 @@
     <h3 class="ui dividing header">{{ 'sylius.ui.inventory'|trans }}</h3>
     <div class="ui segment">
         {{ form_row(form.onHand) }}
-
         {{ form_row(form.tracked) }}
-        <div style="color: rgba(0, 0, 0, .6)">{{ form_help(form.tracked) }}</div>
+
+        <div class="ui pointing above ignored label">
+            {{ form_help(form.tracked) }}
+        </div>
 
         {{ form_row(form.version) }}
     </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_inventory.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductVariant/Tab/_inventory.html.twig
@@ -2,7 +2,10 @@
     <h3 class="ui dividing header">{{ 'sylius.ui.inventory'|trans }}</h3>
     <div class="ui segment">
         {{ form_row(form.onHand) }}
+
         {{ form_row(form.tracked) }}
+        <div style="color: rgba(0, 0, 0, .6)">{{ form_help(form.tracked) }}</div>
+
         {{ form_row(form.version) }}
     </div>
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantTypeExtension.php
@@ -36,6 +36,7 @@ final class ProductVariantTypeExtension extends AbstractTypeExtension
             ->add('version', HiddenType::class)
             ->add('tracked', CheckboxType::class, [
                 'label' => 'sylius.form.variant.tracked',
+                'help' => 'sylius.form.variant.tracked_help'
             ])
             ->add('shippingRequired', CheckboxType::class, [
                 'label' => 'sylius.form.variant.shipping_required',

--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.en.yml
@@ -122,6 +122,7 @@ sylius:
             shipping_required: Is shipping required?
             weight: Weight
             width: Width
+            tracked_help: If this option is enabled Sylius will keep track of the stock and will stop selling the product once stock reaches 0.
         attribute:
             product_attribute_value:
                 attribute: Attribute


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #11518
| License         | MIT

Adding a little help text to the tracked flag of Sylius inventory.
![screenshot](https://user-images.githubusercontent.com/14860264/86533277-55317100-bed0-11ea-8367-a2fd0bfb9a6d.png)

