### PR TITLE
Fix migration

### DIFF
--- a/app/migrations/Version20171003103916.php
+++ b/app/migrations/Version20171003103916.php
@@ -37,7 +37,18 @@ class Version20171003103916 extends AbstractMigration implements ContainerAwareI
         $defaultLocale = $this->container->getParameter('locale');
         $productAttributeRepository = $this->container->get('sylius.repository.product_attribute');
 
-        $productAttributes = $productAttributeRepository->findBy(['type' => SelectAttributeType::TYPE]);
+        $productAttributes = $productAttributeRepository
+            ->createQueryBuilder('o')
+                ->select([
+                    'o.id',
+                    'o.configuration',
+                ])
+                ->where('o.type = :type')
+                ->setParameter('type', SelectAttributeType::TYPE)
+                ->getQuery()
+            ->getResult()
+        ;
+
         /** @var ProductAttributeInterface $productAttribute */
         foreach ($productAttributes as $productAttribute) {
             $configuration = $productAttribute->getConfiguration();


### PR DESCRIPTION
_Previous title: Add method findTypeForMigration to ProductAttributeRepository_

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #11592
| License         | MIT

I don't know how to test these except by running the database migrations.  
So…

I've added the repository in Core because I think it is where it belongs since
the Migrations are in the main App.


