### PR TITLE
[Docs] Fix build - Downgrade sphinx to v1.8.5

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx==1.8.5
 pyOpenSSL
 requests[security]
 sphinx-copybutton


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

After release new version of https://github.com/fabpot/sphinx-php we must downgrade sphinx to `1.8.5` through fault: https://github.com/fabpot/sphinx-php/issues/46

<!--
 - Bug fixes must be submitted against the 1.7 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set
-->
