### PR TITLE
Add crowdin proofreaders in documentation

### DIFF
--- a/docs/book/organization/team.rst
+++ b/docs/book/organization/team.rst
@@ -38,6 +38,15 @@ This role is currently held by:
 
 * **Adam Kasperczak** (`AdamKasp`_)
 
+Community Proofreaders
+~~~~~~~~~~~~~~~~~~~~~~
+
+* Maintains translations directly on `Crowdin`_.
+
+This role is currently held by:
+
+* **Jacques Bodin-Hullin** (`jacquesbh`_): French (fr)
+
 Demon
 -----
 
@@ -123,3 +132,4 @@ This role is currently held by:
 .. _`the Sylius Roadmap`: https://sylius.com/roadmap/
 .. _`Tomanhez`: https://github.com/Tomanhez/
 .. _`Zales0123`: https://github.com/Zales0123/
+.. _`jacquesbh`: https://github.com/jacquesbh/

--- a/docs/book/organization/team.rst
+++ b/docs/book/organization/team.rst
@@ -4,7 +4,7 @@ Sylius Team
 Sylius Team members have the following roles (in an alphabetical order):
 
 Architect
-~~~~~~~~~
+---------
 
 * Defines and publishes :doc:`the Release Cycle <release-cycle>`
 * Contributes to the roadmap with architectural issues
@@ -14,7 +14,7 @@ This role is currently held by:
 * **Kamil Kokot** (`pamil`_)
 
 Core Team Member
-~~~~~~~~~~~~~~~~
+----------------
 
 * Reviews and merges pull requests
 * Triages and reacts to issues
@@ -29,7 +29,7 @@ This role is currently held by:
 * **Mateusz Zalewski** (`Zales0123`_)
 
 CrowdIn Magician
-~~~~~~~~~~~~~~~~
+----------------
 
 * Maintains translations and integration with `CrowdIn`_
 * Curates proofreaders team
@@ -39,7 +39,7 @@ This role is currently held by:
 * **Adam Kasperczak** (`AdamKasp`_)
 
 Demon
-~~~~~
+-----
 
 * Deploys and maintains our public demos (`demo.sylius.com`_, `master.demo.sylius.com`_)
 
@@ -49,7 +49,7 @@ This role is currently held by:
 * **Mateusz Zalewski** (`Zales0123`_)
 
 Documentation Mechanic
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
 * Maintains and configures documentation setup on Read The Docs
 
@@ -58,7 +58,7 @@ This role is currently held by:
 * **Tomasz Sut** (`Tomanhez`_)
 
 Documentation Warden
-~~~~~~~~~~~~~~~~~~~~
+--------------------
 
 * Reacts to documentation-related issues and pull requests
 * Writes and updates the documentation
@@ -70,7 +70,7 @@ This role is currently held by:
 * **Magdalena Sadowska** (`CoderMaggie`_)
 
 Gardener
-~~~~~~~~
+--------
 
 * Releases new versions of Sylius (`Sylius`_, `Sylius-Standard`_, `PluginSkeleton`_ repositories)
 
@@ -79,7 +79,7 @@ This role is currently held by:
 * **Kamil Kokot** (`pamil`_)
 
 Product Owner
-~~~~~~~~~~~~~
+-------------
 
 * Builds and refines the Product Backlog
 * Gathers feedback from all stakeholders
@@ -89,7 +89,7 @@ This role is currently held by:
 * **Magdalena Sadowska** (`CoderMaggie`_)
 
 Protector of the Realm
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
 * Creates and publishes security procedures
 * Handles and evaluates security issues
@@ -99,7 +99,7 @@ This role is currently held by:
 * **Kamil Kokot** (`pamil`_)
 
 Roadmapper
-~~~~~~~~~~
+----------
 
 * Creates and iterates over `the Sylius Roadmap`_
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

Add a section for the proofreaders on Sylius.

I would like to be contacted more easily by french people when they need.

So, one thing is missing here: who are the other proofreaders?  
I think we have many!

What do you think?

