### PR TITLE
Add missing images in entry.js

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/entry.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/entry.js
@@ -14,3 +14,6 @@ import './scss/style.scss';
 
 import 'sylius/ui-resources/img/logo.png';
 import 'sylius/ui-resources/img/avatar.png';
+
+import './img/homepage-banner.jpg';
+import './img/sylius-plus-banner.png';


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes, kind of…
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

These two lines are really missing if you want to build the theme with webpack.