### PR TITLE
Use env:SYLIUS_FIXTURES_THEME_NAME to set the theme in fixtures

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures.yml
@@ -11,3 +11,4 @@ imports:
 
 parameters:
     env(SYLIUS_FIXTURES_HOSTNAME): 'localhost'
+    env(SYLIUS_FIXTURES_THEME_NAME): ~

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/shop_configuration.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/fixtures/shop_configuration.yaml
@@ -92,6 +92,7 @@ sylius_fixtures:
                                     - 'USD'
                                 enabled: true
                                 hostname: '%env(resolve:SYLIUS_FIXTURES_HOSTNAME)%'
+                                theme_name: '%env(resolve:SYLIUS_FIXTURES_THEME_NAME)%'
                                 shop_billing_data:
                                     company: 'Sylius'
                                     tax_id: '0001112222'


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

We are currently building some themes and having this could be very useful.

The previous behavior is kept.

