### PR TITLE
Add slick-carousel to ShopBundle entry.js

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/entry.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/entry.js
@@ -4,6 +4,7 @@ import './js/shim/shim-semantic-ui';
 
 import 'semantic-ui-css/semantic.css';
 import 'lightbox2/dist/css/lightbox.min.css';
+import 'slick-carousel/slick/slick.css';
 
 import 'sylius/ui-resources/js/app';
 import './js/app';


### PR DESCRIPTION
Commit f3e5661476d1ca5d03658ed2267ebf5492c5ec21 added slick-carousel/slick/slick.css to src/Sylius/Bundle/ShopBundle/gulpfile.babel.js

If you want to use webpack encore, you should add slick-carousel/slick/slick.css to entry.js too

Related to https://github.com/Sylius/Sylius/pull/11631

| Q               | A
| --------------- | -----
| Branch?              | 1.7 or master <!-- see the comment below -->
| Bug fix?              | yes
| New feature?     | no
| BC breaks?        | no
| Deprecations?   | no
| Related tickets  | 
| License              | MIT
