### PR TITLE
[DOC] Fix webpack usage with appropriate _logo.html.twig template

### DIFF
--- a/docs/theming/webpack.rst
+++ b/docs/theming/webpack.rst
@@ -48,7 +48,11 @@ This is a simple guide on how to start using webpack in Sylius apps. Webpack fin
     {{ encore_entry_link_tags('admin-entry', null, 'admin') }}
 
     // templates/bundles/SyliusAdminBundle/_logo.html.twig
-    {{ asset('build/admin/images/admin-logo.svg', 'admin') }}
+    <a class="item" href="{{ path('sylius_admin_dashboard') }}" style="padding: 13px 0;">
+        <div style="max-width: 90px; margin: 0 auto;">
+            <img src="{{ asset('build/admin/images/admin-logo.svg', 'admin') }}" class="ui fluid image">
+        </div>
+    </a>
 
     // templates/bundles/SyliusShopBundle/_scripts.html.twig
     {{ encore_entry_script_tags('shop-entry', null, 'shop') }}


### PR DESCRIPTION
The file "templates/bundles/SyliusAdminBundle/_logo.html.twig" overrides "src/Sylius/Bundle/AdminBundle/Resources/views/Layout/_logo.html.twig" but only the asset location should change.

Currently the documentation suggests to remove all the HTML of the template and to replace it with only the asset path, this is not correct.

| Q               | A
| --------------- | -----
| Branch?         | 1.7 or master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT
