### PR TITLE
Update custom-redirect-after-cart-add-action.rst

### DIFF
--- a/docs/cookbook/shop/custom-redirect-after-cart-add-action.rst
+++ b/docs/cookbook/shop/custom-redirect-after-cart-add-action.rst
@@ -90,7 +90,7 @@ Let's assume that you would like such a feature in your system:
         {
             if (!$event->getSubject() instanceof OrderItemInterface) {
                 throw new \LogicException(
-                    sprintf('This listener operates only on order item, got "$s"', get_class($event->getSubject()))
+                    sprintf('This listener operates only on order item, got "%s"', get_class($event->getSubject()))
                 );
             }
 


### PR DESCRIPTION
Fixed a typo in sprintf format ("$s" instead of "%s") in the "custom-redirect-after-cart-add-action" cookbook.

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

