### PR TITLE
Make console commands lazy

### DIFF
--- a/src/Sylius/Bundle/AdminApiBundle/Command/CreateClientCommand.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Command/CreateClientCommand.php
@@ -28,6 +28,8 @@ final class CreateClientCommand extends ContainerAwareCommand
     /** @var ClientManagerInterface|null */
     private $clientManager;
 
+    protected static $defaultName = 'sylius:oauth-server:create-client';
+
     public function __construct(?string $name = null, ClientManagerInterface $clientManager = null)
     {
         parent::__construct($name);
@@ -38,7 +40,6 @@ final class CreateClientCommand extends ContainerAwareCommand
     protected function configure(): void
     {
         $this
-            ->setName('sylius:oauth-server:create-client')
             ->setDescription('Creates a new client')
             ->addOption(
                 'redirect-uri',

--- a/src/Sylius/Bundle/CoreBundle/Command/CancelUnpaidOrdersCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/CancelUnpaidOrdersCommand.php
@@ -22,10 +22,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class CancelUnpaidOrdersCommand extends ContainerAwareCommand
 {
+    protected static $defaultName = 'sylius:cancel-unpaid-orders';
+
     protected function configure(): void
     {
         $this
-            ->setName('sylius:cancel-unpaid-orders')
             ->setDescription(
                 'Removes order that have been unpaid for a configured period. Configuration parameter - sylius_order.order_expiration_period.'
             );

--- a/src/Sylius/Bundle/CoreBundle/Command/CheckRequirementsCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/CheckRequirementsCommand.php
@@ -19,10 +19,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class CheckRequirementsCommand extends AbstractInstallCommand
 {
+    protected static $defaultName = 'sylius:install:check-requirements';
+
     protected function configure(): void
     {
         $this
-            ->setName('sylius:install:check-requirements')
             ->setDescription('Checks if all Sylius requirements are satisfied.')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command checks system requirements.

--- a/src/Sylius/Bundle/CoreBundle/Command/InformAboutGUSCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InformAboutGUSCommand.php
@@ -20,9 +20,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class InformAboutGUSCommand extends Command
 {
+    protected static $defaultName = 'sylius:inform-about-gus';
+
     protected function configure(): void
     {
-        $this->setName('sylius:inform-about-gus');
         $this->setDescription('Informs about Sylius internal statistical service');
     }
 

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallAssetsCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallAssetsCommand.php
@@ -18,10 +18,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class InstallAssetsCommand extends AbstractInstallCommand
 {
+    protected static $defaultName = 'sylius:install:assets';
+
     protected function configure(): void
     {
         $this
-            ->setName('sylius:install:assets')
             ->setDescription('Installs all Sylius assets.')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command downloads and installs all Sylius media assets.

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallCommand.php
@@ -21,6 +21,8 @@ use Symfony\Component\Process\Exception\RuntimeException;
 
 final class InstallCommand extends AbstractInstallCommand
 {
+    protected static $defaultName = 'sylius:install';
+
     /**
      * @var array
      *
@@ -48,7 +50,6 @@ final class InstallCommand extends AbstractInstallCommand
     protected function configure(): void
     {
         $this
-            ->setName('sylius:install')
             ->setDescription('Installs Sylius in your preferred environment.')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command installs Sylius.

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallDatabaseCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallDatabaseCommand.php
@@ -20,10 +20,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class InstallDatabaseCommand extends AbstractInstallCommand
 {
+    protected static $defaultName = 'sylius:install:database';
+
     protected function configure(): void
     {
         $this
-            ->setName('sylius:install:database')
             ->setDescription('Install Sylius database.')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command creates Sylius database.

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
@@ -22,10 +22,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class InstallSampleDataCommand extends AbstractInstallCommand
 {
+    protected static $defaultName = 'sylius:install:sample-data';
+
     protected function configure(): void
     {
         $this
-            ->setName('sylius:install:sample-data')
             ->setDescription('Install sample data into Sylius.')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command loads the sample data for Sylius.

--- a/src/Sylius/Bundle/CoreBundle/Command/SetupCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/SetupCommand.php
@@ -27,10 +27,11 @@ use Webmozart\Assert\Assert;
 
 final class SetupCommand extends AbstractInstallCommand
 {
+    protected static $defaultName = 'sylius:install:setup';
+
     protected function configure(): void
     {
         $this
-            ->setName('sylius:install:setup')
             ->setDescription('Sylius configuration setup.')
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command allows user to configure basic Sylius data.

--- a/src/Sylius/Bundle/CoreBundle/Command/ShowAvailablePluginsCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/ShowAvailablePluginsCommand.php
@@ -22,6 +22,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class ShowAvailablePluginsCommand extends Command
 {
+    protected static $defaultName = 'sylius:show-available-plugins';
+
     /**
      * @var iterable<PluginInfo>
      *
@@ -32,7 +34,6 @@ final class ShowAvailablePluginsCommand extends Command
 
     protected function configure(): void
     {
-        $this->setName('sylius:show-available-plugins');
         $this->setDescription('Shows official Sylius Plugins');
         $this->configurePlugins();
     }

--- a/src/Sylius/Bundle/OrderBundle/Command/RemoveExpiredCartsCommand.php
+++ b/src/Sylius/Bundle/OrderBundle/Command/RemoveExpiredCartsCommand.php
@@ -22,10 +22,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class RemoveExpiredCartsCommand extends ContainerAwareCommand
 {
+    protected static $defaultName = 'sylius:remove-expired-carts';
+
     protected function configure(): void
     {
         $this
-            ->setName('sylius:remove-expired-carts')
             ->setDescription('Removes carts that have been idle for a period set in `sylius_order.expiration.cart` configuration key.')
         ;
     }

--- a/src/Sylius/Bundle/PromotionBundle/Command/GenerateCouponsCommand.php
+++ b/src/Sylius/Bundle/PromotionBundle/Command/GenerateCouponsCommand.php
@@ -26,6 +26,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class GenerateCouponsCommand extends Command
 {
+    protected static $defaultName = 'sylius:promotion:generate-coupons';
+
     /** @var PromotionRepositoryInterface */
     private $promotionRepository;
 
@@ -45,7 +47,6 @@ final class GenerateCouponsCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('sylius:promotion:generate-coupons')
             ->setDescription('Generates coupons for a given promotion')
             ->addArgument('promotion-code', InputArgument::REQUIRED, 'Code of the promotion')
             ->addArgument('count', InputArgument::REQUIRED, 'Amount of coupons to generate')

--- a/src/Sylius/Bundle/UserBundle/Command/DemoteUserCommand.php
+++ b/src/Sylius/Bundle/UserBundle/Command/DemoteUserCommand.php
@@ -21,10 +21,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class DemoteUserCommand extends AbstractRoleCommand
 {
+    protected static $defaultName = 'sylius:user:demote';
+
     protected function configure(): void
     {
         $this
-            ->setName('sylius:user:demote')
             ->setDescription('Demotes a user by removing a role.')
             ->setDefinition([
                 new InputArgument('email', InputArgument::REQUIRED, 'Email'),

--- a/src/Sylius/Bundle/UserBundle/Command/PromoteUserCommand.php
+++ b/src/Sylius/Bundle/UserBundle/Command/PromoteUserCommand.php
@@ -21,10 +21,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class PromoteUserCommand extends AbstractRoleCommand
 {
+    protected static $defaultName = 'sylius:user:promote';
+
     protected function configure(): void
     {
         $this
-            ->setName('sylius:user:promote')
             ->setDescription('Promotes a user by adding roles.')
             ->setDefinition([
                 new InputArgument('email', InputArgument::REQUIRED, 'Email'),


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This commit is about of a little optimisation to avoid initialisation of all command services on each executing `bin/console` command.
Since Symfony 3.4 console commands can be lazy thanks to [a static name property](https://github.com/symfony/symfony/pull/23887).
This change does not break BC because the BC layer is already [in the base command's constructor](https://github.com/symfony/symfony/pull/23887/files#diff-8e80595663798837db1b033187835535R75).