### PR TITLE
Loop.first is easier to 0 == loop.index0

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/Statistics/_perChannel.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Show/Statistics/_perChannel.html.twig
@@ -1,10 +1,10 @@
 {% import '@SyliusAdmin/Common/Macro/money.html.twig' as money %}
 
-<div class="title{% if 0 == loop.index0 %} active{% endif %}">
+<div class="title{% if loop.first %} active{% endif %}">
     <i class="dropdown icon"></i>
     {{ statistic.channel.name }}
 </div>
-<div class="content{% if 0 == loop.index0 %} active{% endif %}">
+<div class="content{% if loop.first %} active{% endif %}">
     <div class="ui center aligned stackable divided grid">
         <div class="four column row">
             <div class="column middle aligned">

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Form/theme.html.twig
@@ -6,11 +6,11 @@
     <div class="ui styled fluid accordion">
         {% for translation in form %}
             <div data-locale="{{ translation.vars.name }}">
-                <div class="title{% if 0 == loop.index0 %} active{% endif %}">
+                <div class="title{% if loop.first %} active{% endif %}">
                     <i class="dropdown icon"></i>
                     {{ flags.fromLocaleCode(translation.vars.name) }} {{ translation.vars.name|sylius_locale_name }}
                 </div>
-                <div class="ui content{% if 0 == loop.index0 %} active{% endif %}">
+                <div class="ui content{% if loop.first %} active{% endif %}">
                     {{ form_widget(translation) }}
                     {{- form_errors(form) -}}
                 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Macro/translationForm.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Macro/translationForm.html.twig
@@ -4,11 +4,11 @@
     <div class="ui styled fluid accordion">
         {% for locale, translationForm in translations %}
             <div data-locale="{{ locale }}">
-                <div class="title{% if 0 == loop.index0 %} active{% endif %}">
+                <div class="title{% if loop.first %} active{% endif %}">
                     <i class="dropdown icon"></i>
                     {{ flags.fromLocaleCode(locale) }} {{ locale|sylius_locale_name }}
                 </div>
-                <div class="ui content{% if 0 == loop.index0 %} active{% endif %}">
+                <div class="ui content{% if loop.first %} active{% endif %}">
                     {% for field in translationForm %}
                         {{ form_row(field) }}
                     {% endfor %}
@@ -24,11 +24,11 @@
     <div class="ui styled fluid accordion">
         {% for locale, translationForm in translations %}
             <div data-locale="{{ locale }}">
-                <div class="title{% if 0 == loop.index0 %} active{% endif %}">
+                <div class="title{% if loop.first %} active{% endif %}">
                     <i class="dropdown icon"></i>
                     {{ flags.fromLocaleCode(locale) }} {{ locale|sylius_locale_name }}
                 </div>
-                <div class="ui content{% if 0 == loop.index0 %} active{% endif %}">
+                <div class="ui content{% if loop.first %} active{% endif %}">
                     {% for field in translationForm %}
                         {% if field.vars.name != 'slug' %}
                             {{ form_row(field) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PaymentMethod/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PaymentMethod/_form.html.twig
@@ -41,11 +41,11 @@
 
 <div class="ui styled fluid accordion">
     {% for locale, translationForm in form.translations %}
-        <div class="title{% if 0 == loop.index0 %} active{% endif %}">
+        <div class="title{% if loop.first %} active{% endif %}">
             <i class="dropdown icon"></i>
             {{ flags.fromLocaleCode(locale) }} {{ locale|sylius_locale_name }}
         </div>
-        <div class="content{% if 0 == loop.index0 %} active{% endif %}">
+        <div class="content{% if loop.first %} active{% endif %}">
             {{ form_row(translationForm.name) }}
             {{ form_row(translationForm.description) }}
             <div class="ui compact message">

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
@@ -6,14 +6,14 @@
 
     <div class="ui top attached tabular menu">
         {% for localeCode, translationForm in attr.translations %}
-            <a class="item{% if 0 == loop.index0 %} active{% endif %}" data-tab="{{ localeCode }}">
+            <a class="item{% if loop.first %} active{% endif %}" data-tab="{{ localeCode }}">
                 {{ flags.fromLocaleCode(localeCode) }} {{ localeCode|sylius_locale_name }}
             </a>
         {% endfor %}
     </div>
 
     {% for localeCode, translationForm in attr.translations %}
-        <div class="ui bottom attached tab segment{% if 0 == loop.index0 %} active{% endif %}" data-tab="{{ localeCode }}">
+        <div class="ui bottom attached tab segment{% if loop.first %} active{% endif %}" data-tab="{{ localeCode }}">
             {% apply spaceless %}
                 {% for child in form %}
                     {% if localeCode == child.localeCode.vars.value %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

I just found this and I think it's easier to read `loop.first` than `0 == loop.index0`…


