### PR TITLE
Use env(SYLIUS_ADMIN_ROUTING_PATH_NAME) as admin's route name

### DIFF
--- a/UPGRADE-1.8.md
+++ b/UPGRADE-1.8.md
@@ -91,6 +91,10 @@ The later is being decorated by `sylius.context.channel.cached` which caches the
 1. A serialization group has been added to the route `sylius_admin_ajax_product_index` to avoid an infinite loop, or a
 time out during this ajax request (previously no serialization group was defined on this route).
 
+1. We now use the parameter `sylius_admin.path_name` to retrieve the admin routes prefix. If you used the `/admin` prefix
+in some admin URLs you can now replace `/admin` by `/%sylius_admin.path_prefix%`.  
+Also the route is now dynamic. You can change the `SYLIUS_ADMIN_ROUTING_PATH_NAME` environment variable to custom the admin's URL. 
+
 ## Special attention
 
 ### Translations

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,7 +1,7 @@
 parameters:
-    sylius.security.admin_regex: "^/admin"
+    sylius.security.admin_regex: "^/%sylius_admin.path_name%"
     sylius.security.api_regex: "^/api"
-    sylius.security.shop_regex: "^/(?!admin|new-api|api/.*|api$|media/.*)[^/]++"
+    sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|new-api|api/.*|api$|media/.*)[^/]++"
     sylius.security.new_api_route: "/new-api"
     sylius.security.new_api_regex: "^%sylius.security.new_api_route%"
 
@@ -41,7 +41,7 @@ security:
                 csrf_token_id: admin_authenticate
             remember_me:
                 secret: "%env(APP_SECRET)%"
-                path: /admin
+                path: "/%sylius_admin.path_name%"
                 name: APP_ADMIN_REMEMBER_ME
                 lifetime: 31536000
                 remember_me_parameter: _remember_me

--- a/config/routes/sylius_admin.yaml
+++ b/config/routes/sylius_admin.yaml
@@ -1,3 +1,3 @@
 sylius_admin:
     resource: "@SyliusAdminBundle/Resources/config/routing.yml"
-    prefix: /admin
+    prefix: '/%sylius_admin.path_name%'

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
@@ -33,6 +33,10 @@ imports:
     - { resource: "@SyliusAdminBundle/Resources/config/grids/taxon.yml" }
     - { resource: "@SyliusAdminBundle/Resources/config/grids/zone.yml" }
 
+parameters:
+    env(SYLIUS_ADMIN_ROUTING_PATH_NAME): admin
+    sylius_admin.path_name: '%env(resolve:SYLIUS_ADMIN_ROUTING_PATH_NAME)%'
+
 sylius_grid:
     templates:
         action:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes, kind of
| BC breaks?      | I'm not sure. This PR doesn't change the routes but it allows it…
| Deprecations?   | no
| Related tickets |
| License         | MIT

We always change the admin route URL. By default `/admin` is unsecure, it's too
easy to guess.

We wanted to ease this change by using an environment variable.

All plugins using `/admin` hard coded will have to use the dynamic `/%sylius_admin.path_name%` value instead.


