### PR TITLE
[WIP] Add option to set theme via parameters

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -2,3 +2,4 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     locale: en_US
+    default_theme: null

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/context.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/context.xml
@@ -23,6 +23,7 @@
         <service id="sylius.theme.context.channel_based" class="Sylius\Bundle\CoreBundle\Theme\ChannelBasedThemeContext" public="false">
             <argument type="service" id="sylius.context.channel" />
             <argument type="service" id="sylius.repository.theme" />
+            <argument>%default_theme%</argument>
         </service>
 
         <service id="sylius.context.shopper" class="Sylius\Component\Core\Context\ShopperContext" lazy="true">

--- a/src/Sylius/Bundle/CoreBundle/spec/Theme/ChannelBasedThemeContextSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Theme/ChannelBasedThemeContextSpec.php
@@ -25,7 +25,7 @@ final class ChannelBasedThemeContextSpec extends ObjectBehavior
 {
     function let(ChannelContextInterface $channelContext, ThemeRepositoryInterface $themeRepository): void
     {
-        $this->beConstructedWith($channelContext, $themeRepository);
+        $this->beConstructedWith($channelContext, $themeRepository, null);
     }
 
     function it_implements_theme_context_interface(): void
@@ -33,7 +33,7 @@ final class ChannelBasedThemeContextSpec extends ObjectBehavior
         $this->shouldImplement(ThemeContextInterface::class);
     }
 
-    function it_returns_a_theme(
+    function it_returns_a_theme_if_channel_has_theme(
         ChannelContextInterface $channelContext,
         ThemeRepositoryInterface $themeRepository,
         ChannelInterface $channel,
@@ -46,19 +46,43 @@ final class ChannelBasedThemeContextSpec extends ObjectBehavior
         $this->getTheme()->shouldReturn($theme);
     }
 
-    function it_returns_null_if_channel_has_no_theme(
+    function it_returns_a_theme_if_channel_has_no_theme_but_default_theme_is_set(
         ChannelContextInterface $channelContext,
         ThemeRepositoryInterface $themeRepository,
+        ChannelInterface $channel,
+        ThemeInterface $theme
+    ): void {
+        $this->beConstructedWith($channelContext, $themeRepository, 'theme/name');
+        $channelContext->getChannel()->willReturn($channel);
+        $channel->getThemeName()->willReturn(null);
+        $themeRepository->findOneByName('theme/name')->willReturn($theme);
+
+        $this->getTheme()->shouldReturn($theme);
+    }
+
+    function it_returns_null_if_channel_has_no_theme_and_default_theme_is_not_set(
+        ChannelContextInterface $channelContext,
         ChannelInterface $channel
     ): void {
         $channelContext->getChannel()->willReturn($channel);
         $channel->getThemeName()->willReturn(null);
-        $themeRepository->findOneByName(null)->willReturn(null);
 
         $this->getTheme()->shouldReturn(null);
     }
 
-    function it_returns_null_if_there_is_no_channel(
+    function it_returns_a_theme_if_there_is_no_channel_but_default_theme_is_set(
+        ChannelContextInterface $channelContext,
+        ThemeRepositoryInterface $themeRepository,
+        ThemeInterface $theme
+    ): void {
+        $this->beConstructedWith($channelContext, $themeRepository, 'theme/name');
+        $channelContext->getChannel()->willThrow(ChannelNotFoundException::class);
+        $themeRepository->findOneByName('theme/name')->willReturn($theme);
+
+        $this->getTheme()->shouldReturn($theme);
+    }
+
+    function it_returns_null_if_there_is_no_channel_and_default_theme_is_not_set(
         ChannelContextInterface $channelContext
     ): void {
         $channelContext->getChannel()->willThrow(ChannelNotFoundException::class);
@@ -66,7 +90,19 @@ final class ChannelBasedThemeContextSpec extends ObjectBehavior
         $this->getTheme()->shouldReturn(null);
     }
 
-    function it_returns_null_if_any_exception_is_thrown_during_getting_the_channel(
+    function it_returns_a_theme_if_any_exception_is_thrown_during_getting_the_channel_but_default_theme_is_set(
+        ChannelContextInterface $channelContext,
+        ThemeRepositoryInterface $themeRepository,
+        ThemeInterface $theme
+    ): void {
+        $this->beConstructedWith($channelContext, $themeRepository, 'theme/name');
+        $channelContext->getChannel()->willThrow(\Exception::class);
+        $themeRepository->findOneByName('theme/name')->willReturn($theme);
+
+        $this->getTheme()->shouldReturn($theme);
+    }
+
+    function it_returns_null_if_any_exception_is_thrown_during_getting_the_channel_and_default_theme_is_not_set(
         ChannelContextInterface $channelContext
     ): void {
         $channelContext->getChannel()->willThrow(\Exception::class);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | partially #11622
| License         | MIT

With the current implementation, the only option to set themes is selecting channel theme via admin panel. This is not optimal when we want to test themes (set theme; clear cache; run tests).

One possible solution is to set a `default_theme` via parameters. This `default_theme` will only be loaded if there is no channel theme defined. It is like a fallback option and its default value should be `null`. That way we can install a new theme, set as `default_theme`, clear cache and run tests against it.

The **[WIP]** label is because there are many ways to implement this functionality and at the end it is a core decission. For example `default_theme` probably should belong to `sylius_theme` and not `parameters`, but I put it here to make it understandable.
