### PR TITLE
[Admin] Convert newlines in product description to breaklines 

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_moreDetails.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_moreDetails.html.twig
@@ -18,7 +18,7 @@
                 </tr>
                 <tr>
                     <td class="three wide"><strong class="gray text">{{ 'sylius.ui.description'|trans }}</strong></td>
-                    <td>{{ translation.description }}</td>
+                    <td>{{ translation.description|nl2br }}</td>
                 </tr>
                 <tr>
                     <td class="three wide"><strong class="gray text">{{ 'sylius.ui.meta_keywords'|trans }}</strong></td>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7 
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

To be consistent with https://github.com/Sylius/Sylius/pull/8347 administrative interface should convert newlines in product description to breaklines in product details view  

