### PR TITLE
Fixing the ChannelContext deprecations

### DIFF
--- a/src/Sylius/Component/Channel/Context/RequestBased/ChannelContext.php
+++ b/src/Sylius/Component/Channel/Context/RequestBased/ChannelContext.php
@@ -38,7 +38,7 @@ final class ChannelContext implements ChannelContextInterface
         try {
             return $this->getChannelForRequest($this->getMasterRequest());
         } catch (\UnexpectedValueException $exception) {
-            throw new ChannelNotFoundException($exception);
+            throw new ChannelNotFoundException(null, $exception);
         }
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no (fixing them)
| Related tickets | -none-
| License         | MIT

When resolving the hostname in dev-mode it generates a lot of calls to exceptions:
![image](https://user-images.githubusercontent.com/14860264/88923541-2f4e8080-d272-11ea-8750-2add9edce069.png)

This will keep the same error message but uses the new function signiture.