### PR TITLE
Revert "[Behat] Remove js requirement for bulk delete scenarios"

### DIFF
--- a/features/addressing/managing_zones/deleting_multiple_zones.feature
+++ b/features/addressing/managing_zones/deleting_multiple_zones.feature
@@ -8,7 +8,7 @@ Feature: Deleting multiple zones
         Given the store has zones "North America", "South America" and "Europe"
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple zones at once
         When I browse zones
         And I check the "North America" zone

--- a/features/channel/managing_channels/deleting_multiple_channels.feature
+++ b/features/channel/managing_channels/deleting_multiple_channels.feature
@@ -10,7 +10,7 @@ Feature: Deleting multiple channels
         And the store operates on another channel named "DE Store"
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple channels at once
         When I browse channels
         And I check the "PL Store" channel

--- a/features/currency/managing_exchange_rates/deleting_multiple_exchange_rates.feature
+++ b/features/currency/managing_exchange_rates/deleting_multiple_exchange_rates.feature
@@ -11,7 +11,7 @@ Feature: Deleting multiple exchange rates
         And the exchange rate of "Polish Zloty" to "Euro" is 0.22
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple exchange rates at once
         When I browse exchange rates
         And I check the exchange rate between "Euro" and "British Pound"

--- a/features/payment/managing_payment_methods/deleting_multiple_payment_methods.feature
+++ b/features/payment/managing_payment_methods/deleting_multiple_payment_methods.feature
@@ -10,7 +10,7 @@ Feature: Deleting multiple payment methods
         And the store has also a payment method "PayPal Express Checkout" with a code "paypal" and Paypal Express Checkout gateway
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple payment methods at once
         When I browse payment methods
         And I check the "Offline" payment method

--- a/features/product/managing_product_association_types/deleting_multiple_product_association_types.feature
+++ b/features/product/managing_product_association_types/deleting_multiple_product_association_types.feature
@@ -10,7 +10,7 @@ Feature: Deleting multiple product association types
         And the store has also a product association type "Accessories"
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple product association types at once
         When I browse product association types
         And I check the "Cross sell" product association type

--- a/features/product/managing_product_attributes/deleting_multiple_product_attributes.feature
+++ b/features/product/managing_product_attributes/deleting_multiple_product_attributes.feature
@@ -10,7 +10,7 @@ Feature: Deleting multiple product attributes
         And the store has a integer product attribute "Pages"
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple product attributes at once
         When I browse product attributes
         And I check the "Publisher" product attribute

--- a/features/product/managing_product_options/deleting_multiple_product_options.feature
+++ b/features/product/managing_product_options/deleting_multiple_product_options.feature
@@ -10,7 +10,7 @@ Feature: Deleting multiple product options
         And the store has also a product option "T-Shirt brand"
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple product options at once
         When I browse product options
         And I check the "T-Shirt size" product option

--- a/features/product/managing_product_reviews/deleting_multiple_product_reviews.feature
+++ b/features/product/managing_product_reviews/deleting_multiple_product_reviews.feature
@@ -11,7 +11,7 @@ Feature: Deleting multiple product reviews
         And this product has also a review titled "Cool" and rated 4 with a comment "Quite cool" added by customer "aquaman@dc.com"
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple product reviews at once
         When I browse product reviews
         And I check the "Awesome" product review

--- a/features/product/managing_product_variants/deleting_multiple_product_variants.feature
+++ b/features/product/managing_product_variants/deleting_multiple_product_variants.feature
@@ -10,7 +10,7 @@ Feature: Deleting multiple product variants
         And this product has "Small PHP Mug", "Medium PHP Mug" and "Big PHP Mug" variants
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple product variants at once
         When I browse variants of this product
         And I check the "Small PHP Mug" product variant

--- a/features/product/managing_products/deleting_multiple_products.feature
+++ b/features/product/managing_products/deleting_multiple_products.feature
@@ -8,7 +8,7 @@ Feature: Deleting multiple products
         Given the store has "Audi RS5 model", "Audi RS6 model" and "Audi RS7 model" products
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple products at once
         When I browse products
         And I check the "Audi RS5 model" product

--- a/features/promotion/managing_coupons/deleting_multiple_coupons.feature
+++ b/features/promotion/managing_coupons/deleting_multiple_coupons.feature
@@ -10,7 +10,7 @@ Feature: Deleting multiple coupons
         And this promotion has "SANTA1", "SANTA2" and "SANTA3" coupons
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple coupons at once
         When I browse coupons of this promotion
         And I check the "SANTA1" coupon

--- a/features/promotion/managing_promotions/deleting_multiple_promotions.feature
+++ b/features/promotion/managing_promotions/deleting_multiple_promotions.feature
@@ -11,7 +11,7 @@ Feature: Deleting multiple promotions
         And there is also a promotion "Easter sale"
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple promotions at once
         When I browse promotions
         And I check the "Christmas sale" promotion

--- a/features/shipping/managing_shipping_categories/deleting_multiple_shipping_categories.feature
+++ b/features/shipping/managing_shipping_categories/deleting_multiple_shipping_categories.feature
@@ -9,7 +9,7 @@ Feature: Deleting multiple shipping categories
         And the store has "Big" and "Small" shipping category
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple shipping categories at once
         When I browse shipping categories
         And I check the "Big" shipping category

--- a/features/shipping/managing_shipping_methods/deleting_multiple_shipping_methods.feature
+++ b/features/shipping/managing_shipping_methods/deleting_multiple_shipping_methods.feature
@@ -9,7 +9,7 @@ Feature: Deleting multiple shipping methods
         And the store allows shipping with "UPS", "FedEx" and "DHL"
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple shipping methods at once
         When I browse shipping methods
         And I check the "UPS" shipping method

--- a/features/taxation/managing_tax_categories/deleting_multiple_tax_categories.feature
+++ b/features/taxation/managing_tax_categories/deleting_multiple_tax_categories.feature
@@ -8,7 +8,7 @@ Feature: Deleting multiple tax categories
         Given the store has tax categories "Alcohol", "Food" and "Books"
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple tax categories at once
         When I browse tax categories
         And I check the "Alcohol" tax category

--- a/features/taxation/managing_tax_rates/deleting_multiple_tax_rates.feature
+++ b/features/taxation/managing_tax_rates/deleting_multiple_tax_rates.feature
@@ -11,7 +11,7 @@ Feature: Deleting multiple tax rates
         And the store has "High VAT" tax rate of 40% for "Food" for the rest of the world
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple tax rates at once
         When I browse tax rates
         And I check the "Low VAT" tax rate

--- a/features/user/managing_administrators/deleting_multiple_administrators.feature
+++ b/features/user/managing_administrators/deleting_multiple_administrators.feature
@@ -10,7 +10,7 @@ Feature: Deleting multiple administrators
         And there is also an administrator "watermelon@example.com"
         And I am logged in as "watermelon@example.com" administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple administrators at once
         Given I browse administrators
         And I check the "banana@example.com" administrator

--- a/features/user/managing_customer_groups/deleting_multiple_customer_groups.feature
+++ b/features/user/managing_customer_groups/deleting_multiple_customer_groups.feature
@@ -8,7 +8,7 @@ Feature: Deleting multiple customer groups
         Given the store has customer groups "Retail", "Wholesale" and "General"
         And I am logged in as an administrator
 
-    @ui
+    @ui @javascript
     Scenario: Deleting multiple customer groups at once
         When I browse customer groups
         And I check the "Retail" customer group

--- a/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
+++ b/src/Sylius/Behat/Page/Admin/Crud/IndexPage.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\Behat\Page\Admin\Crud;
 
-use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;
@@ -138,9 +137,7 @@ class IndexPage extends SymfonyPage implements IndexPageInterface
     public function bulkDelete(): void
     {
         $this->getElement('bulk_actions')->pressButton('Delete');
-        if ($this->getDriver() instanceof Selenium2Driver || $this->getDriver() instanceof ChromeDriver) {
-            $this->getElement('confirmation_button')->click();
-        }
+        $this->getElement('confirmation_button')->click();
     }
 
     public function sort(string $order): void

--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-bulk-action-require-confirmation.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-bulk-action-require-confirmation.js
@@ -27,6 +27,10 @@ $.fn.extend({
             event.preventDefault();
 
             const form = actionButton.closest('form');
+            $('input.bulk-select-checkbox:checked').each((index, element) => {
+              $(`<input type="hidden" name="ids[]" value="${element.value}">`).appendTo(form);
+            });
+
             form.submit();
           });
         }

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Macro/buttons.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Macro/buttons.html.twig
@@ -62,7 +62,7 @@
 {% endmacro %}
 
 {% macro bulkDelete(url, message, labeled = true) %}
-    <form action="{{ url }}" method="post" id="bulk-delete">
+    <form action="{{ url }}" method="post">
         <input type="hidden" name="_method" value="DELETE">
         <button class="ui red {% if labeled %}labeled {% endif %}icon button" type="submit" data-bulk-action-requires-confirmation disabled>
             <i class="icon trash"></i> {{ ((message is empty and labeled) ? 'sylius.ui.delete' : message)|trans }}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Macro/table.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Macro/table.html.twig
@@ -24,7 +24,7 @@
 {% macro row(grid, definition, row) %}
     <tr class="item" {{ sylius_test_html_attribute('row') }}>
     {% if definition.actionGroups.bulk is defined and definition.getEnabledActions('bulk')|length > 0 %}
-        <td class="center aligned"><input class="bulk-select-checkbox" form="bulk-delete" type="checkbox" name="ids[]" value="{{ row.id }}" /></td>
+        <td class="center aligned"><input class="bulk-select-checkbox" type="checkbox" value="{{ row.id }}" /></td>
     {% endif %}
     {% for field in definition.enabledFields|sort_by('position') %}
         <td>{{ sylius_grid_render_field(grid, field, row) }}</td>


### PR DESCRIPTION
This reverts commit 4013e51dfdd3ff7d5bd00f2751308eac2bb3149a.

| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

Related to this issue https://github.com/Sylius/Sylius/issues/11324
Custom bulk action can't work cause of the id #bulk-delete wich has been had in the reverted commit.
