### PR TITLE
[Hot-fix] Handle extra docblocks in Psalm

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -78,7 +78,7 @@
     </projectFiles>
 
     <issueHandlers>
-        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
+        <!-- level 3 issues - slightly lazy code writing, but probably low false-negatives -->
 
         <DeprecatedClass>
             <errorLevel type="info">
@@ -137,6 +137,8 @@
             </errorLevel>
         </MissingConstructor>
         <MissingParamType errorLevel="info" />
+
+        <RedundantConditionGivenDocblockType errorLevel="info" />
 
         <!-- level 4 issues - points to possible deficiencies in logic, higher false-positives -->
 

--- a/src/Sylius/Bundle/PayumBundle/Extension/UpdatePaymentStateExtension.php
+++ b/src/Sylius/Bundle/PayumBundle/Extension/UpdatePaymentStateExtension.php
@@ -71,7 +71,6 @@ final class UpdatePaymentStateExtension implements ExtensionInterface
 
         $payment = $request->getFirstModel();
 
-        /** @var PaymentInterface $payment */
         if (!$payment instanceof PaymentInterface) {
             return;
         }

--- a/src/Sylius/Bundle/ProductBundle/EventListener/SelectProductAttributeChoiceRemoveListener.php
+++ b/src/Sylius/Bundle/ProductBundle/EventListener/SelectProductAttributeChoiceRemoveListener.php
@@ -34,7 +34,6 @@ final class SelectProductAttributeChoiceRemoveListener
     {
         $productAttribute = $event->getEntity();
 
-        /** @var ProductAttributeInterface $productAttribute */
         if (!$productAttribute instanceof ProductAttributeInterface) {
             return;
         }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I've removed two unneeded docblocks, but most of the problems were caused by the `Assert::` methods usage. We could, in theory, remove the docblocks there as well, but it would result in the PHPStorm (or some other IDE) not detecting the types properly... That's why it's a hot-fix 💃 