### PR TITLE
[Documentation] fix typo in fixture docs

### DIFF
--- a/docs/customization/fixtures.rst
+++ b/docs/customization/fixtures.rst
@@ -119,7 +119,7 @@ How to customize fixtures for customized models?
     The following example is based on `other example of extending an entity with a new field <https://github.com/Sylius/Customizations/pull/7>`_.
     You can browse the full implementation of this example on `this GitHub Pull Request <https://github.com/Sylius/Customizations/pull/23>`__.
 
-Let's suppose you have extended ``App\Entity\Shipping\ShippingMethod`` extended with a new field ``deliveryConditions``,
+Let's suppose you have extended ``App\Entity\Shipping\ShippingMethod`` with a new field ``deliveryConditions``,
 just like in the example mentioned above.
 
 **1.** To cover that in fixtures, you will need to override the ``ShippingMethodExampleFactory`` and add this field:


### PR DESCRIPTION
Removed the word "extended" that was used twice

| Q               | A
| --------------- | -----
| Branch?         | 1.5
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT