### PR TITLE
Fix Customer form_errors display

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/_form.html.twig
@@ -1,5 +1,5 @@
+{{ form_errors(form) }}
 <div class="ui two column stackable grid">
-    {{ form_errors(form) }}
     <div class="column">
         <div class="ui segment">
             <h4 class="ui dividing header">{{ 'sylius.ui.customer_details'|trans }}</h4>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| License         | MIT

Edit the form_errors location to fix the display on Customer/_form.html.twig

Before:
![before](https://user-images.githubusercontent.com/20583699/90312101-0d0b6280-df02-11ea-96ee-fb1f2884eca7.png)

After:
![after](https://user-images.githubusercontent.com/20583699/90312105-109ee980-df02-11ea-829b-48a17955f6a7.png)



