### PR TITLE
Avoid getting the theme if we have it already

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Theme/ChannelBasedThemeContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Theme/ChannelBasedThemeContext.php
@@ -28,28 +28,34 @@ final class ChannelBasedThemeContext implements ThemeContextInterface
     /** @var ThemeRepositoryInterface */
     private $themeRepository;
 
+    /** @var null|false|ThemeInterface */
+    private $theme = false;
+
     public function __construct(ChannelContextInterface $channelContext, ThemeRepositoryInterface $themeRepository)
     {
         $this->channelContext = $channelContext;
         $this->themeRepository = $themeRepository;
     }
 
+    /**
+     * @psalm-suppress InvalidReturnType
+     */
     public function getTheme(): ?ThemeInterface
     {
-        try {
-            /** @var ChannelInterface $channel */
-            $channel = $this->channelContext->getChannel();
-            $themeName = $channel->getThemeName();
-
-            if (null === $themeName) {
+        if (false === $this->theme) {
+            try {
+                /** @var ChannelInterface $channel */
+                $channel = $this->channelContext->getChannel();
+                $themeName = $channel->getThemeName();
+                $this->theme = null === $themeName
+                    ? null
+                    : $this->themeRepository->findOneByName($themeName);
+            } catch (ChannelNotFoundException $exception) {
+                return null;
+            } catch (\Exception $exception) {
                 return null;
             }
-
-            return $this->themeRepository->findOneByName($themeName);
-        } catch (ChannelNotFoundException $exception) {
-            return null;
-        } catch (\Exception $exception) {
-            return null;
         }
+        return $this->theme;
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

I've always had a pretty slow development environment.
So I decided to run a blackfire profile on it and found out that the Debug Toolbar was running a tons of SQL requests (thousands).

After a moment into the blackfire's graph, I found out this simple solution to avoid all these SQL requests (one per twig template, which leads to A LOT of SQL requests).

### On my homepage in dev mode

![image](https://user-images.githubusercontent.com/858611/90897438-6a515900-e3c5-11ea-9766-20c3842dad54.png)
