### PR TITLE
Making the error message on fixutre load helpful

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/OptionsResolver/LazyOption.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/OptionsResolver/LazyOption.php
@@ -45,7 +45,7 @@ final class LazyOption
                 $objects = $objects->toArray();
             }
 
-            Assert::notEmpty($objects);
+            Assert::notEmpty($objects, 'No entities found of type ' . $repository->getClassName());
 
             return $objects[array_rand($objects)];
         };


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | (none)
| License         | MIT

## Proposal
Making the error message more helpful. When running the fixtures you might run into this error: 
```                                 
  [InvalidArgumentException]              
  Expected a non-empty value. Got: array  
```
Which is very undescriptive. But looking at the stacktrace it is clear that it's from the LazyOption. And would be much more helpful with this:
```
  [InvalidArgumentException]
  No items found for Sylius\Component\Core\Model\Promotion
```

What do you think?