### PR TITLE
Add warning on tax calculation in 1.7's upgrade

### DIFF
--- a/UPGRADE-1.7.md
+++ b/UPGRADE-1.7.md
@@ -87,6 +87,8 @@ We've moved the following templates:
 Until now shipping address used to be the default address of an Order. We have changed that, so now the billing address 
 became the default address during checkout. It is an important change in our checkout process, please have that in mind.
 
+⚠️ This change also implies that the Tax calculation is now done on the billing address and not on the shipping address anymore.
+
 ## Postgres support
 
 In case when you are using Postgres in your project, function `DATE_FORMAT` should be overridden.


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

This change (using the billing address instead of shipping address to calculate taxes) is actually a BIG change. It changed all our tax calculation and we didn't see that coming. 😭 