### PR TITLE
Introduce `DashboardStatisticsInterface`

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Provider/StatisticsDataProvider.php
+++ b/src/Sylius/Bundle/AdminBundle/Provider/StatisticsDataProvider.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\AdminBundle\Provider;
 
 use Sylius\Bundle\MoneyBundle\Formatter\MoneyFormatterInterface;
-use Sylius\Component\Core\Dashboard\DashboardStatistics;
+use Sylius\Component\Core\Dashboard\DashboardStatisticsInterface;
 use Sylius\Component\Core\Dashboard\DashboardStatisticsProviderInterface;
 use Sylius\Component\Core\Dashboard\Interval;
 use Sylius\Component\Core\Dashboard\SalesDataProviderInterface;
@@ -43,7 +43,7 @@ class StatisticsDataProvider implements StatisticsDataProviderInterface
 
     public function getRawData(ChannelInterface $channel, \DateTimeInterface $startDate, \DateTimeInterface $endDate, string $interval): array
     {
-        /** @var DashboardStatistics $statistics */
+        /** @var DashboardStatisticsInterface $statistics */
         $statistics = $this->statisticsProvider->getStatisticsForChannelInPeriod($channel, $startDate, $endDate);
 
         $salesSummary = $this->salesDataProvider->getSalesSummary(

--- a/src/Sylius/Bundle/AdminBundle/spec/Provider/StatisticsDataProviderSpec.php
+++ b/src/Sylius/Bundle/AdminBundle/spec/Provider/StatisticsDataProviderSpec.php
@@ -17,7 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\AdminBundle\Provider\StatisticsDataProvider;
 use Sylius\Bundle\AdminBundle\Provider\StatisticsDataProviderInterface;
 use Sylius\Bundle\MoneyBundle\Formatter\MoneyFormatterInterface;
-use Sylius\Component\Core\Dashboard\DashboardStatistics;
+use Sylius\Component\Core\Dashboard\DashboardStatisticsInterface;
 use Sylius\Component\Core\Dashboard\DashboardStatisticsProviderInterface;
 use Sylius\Component\Core\Dashboard\Interval;
 use Sylius\Component\Core\Dashboard\SalesDataProviderInterface;
@@ -49,7 +49,7 @@ class StatisticsDataProviderSpec extends ObjectBehavior
         ChannelInterface $channel,
         DashboardStatisticsProviderInterface $statisticsProvider,
         SalesDataProviderInterface $salesDataProvider,
-        DashboardStatistics $statistics,
+        DashboardStatisticsInterface $statistics,
         SalesSummaryInterface $salesSummary,
         CurrencyInterface $currency,
         MoneyFormatterInterface $moneyFormatter
@@ -99,7 +99,7 @@ class StatisticsDataProviderSpec extends ObjectBehavior
         ChannelInterface $channel,
         DashboardStatisticsProviderInterface $statisticsProvider,
         SalesDataProviderInterface $salesDataProvider,
-        DashboardStatistics $statistics,
+        DashboardStatisticsInterface $statistics,
         SalesSummaryInterface $salesSummary,
         CurrencyInterface $currency,
         MoneyFormatterInterface $moneyFormatter
@@ -181,7 +181,7 @@ class StatisticsDataProviderSpec extends ObjectBehavior
         ChannelInterface $channel,
         DashboardStatisticsProviderInterface $statisticsProvider,
         SalesDataProviderInterface $salesDataProvider,
-        DashboardStatistics $statistics,
+        DashboardStatisticsInterface $statistics,
         SalesSummaryInterface $salesSummary,
         CurrencyInterface $currency,
         MoneyFormatterInterface $moneyFormatter

--- a/src/Sylius/Component/Core/Dashboard/DashboardStatistics.php
+++ b/src/Sylius/Component/Core/Dashboard/DashboardStatistics.php
@@ -15,7 +15,7 @@ namespace Sylius\Component\Core\Dashboard;
 
 use Sylius\Component\Core\Model\ChannelInterface;
 
-class DashboardStatistics
+class DashboardStatistics implements DashboardStatisticsInterface
 {
     /** @var int */
     private $totalSales;

--- a/src/Sylius/Component/Core/Dashboard/DashboardStatisticsInterface.php
+++ b/src/Sylius/Component/Core/Dashboard/DashboardStatisticsInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Dashboard;
+
+use Sylius\Component\Core\Model\ChannelInterface;
+
+interface DashboardStatisticsInterface
+{
+    public function getChannel(): ?ChannelInterface;
+
+    public function getTotalSales(): int;
+
+    public function getNumberOfNewOrders(): int;
+
+    public function getNumberOfNewCustomers(): int;
+
+    public function getAverageOrderValue(): int;
+}

--- a/src/Sylius/Component/Core/Dashboard/DashboardStatisticsProvider.php
+++ b/src/Sylius/Component/Core/Dashboard/DashboardStatisticsProvider.php
@@ -33,7 +33,10 @@ class DashboardStatisticsProvider implements DashboardStatisticsProviderInterfac
         $this->customerRepository = $customerRepository;
     }
 
-    public function getStatisticsForChannel(ChannelInterface $channel): DashboardStatistics
+    /**
+     * {@inheritdoc}
+     */
+    public function getStatisticsForChannel(ChannelInterface $channel)
     {
         return new DashboardStatistics(
             $this->orderRepository->getTotalPaidSalesForChannel($channel),
@@ -43,11 +46,14 @@ class DashboardStatisticsProvider implements DashboardStatisticsProviderInterfac
         );
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getStatisticsForChannelInPeriod(
         ChannelInterface $channel,
         \DateTimeInterface $startDate,
         \DateTimeInterface $endDate
-    ): DashboardStatistics {
+    ) {
         return new DashboardStatistics(
             $this->orderRepository->getTotalPaidSalesForChannelInPeriod($channel, $startDate, $endDate),
             $this->orderRepository->countPaidForChannelInPeriod($channel, $startDate, $endDate),

--- a/src/Sylius/Component/Core/Dashboard/DashboardStatisticsProviderInterface.php
+++ b/src/Sylius/Component/Core/Dashboard/DashboardStatisticsProviderInterface.php
@@ -17,11 +17,19 @@ use Sylius\Component\Core\Model\ChannelInterface;
 
 interface DashboardStatisticsProviderInterface
 {
-    public function getStatisticsForChannel(ChannelInterface $channel): DashboardStatistics;
+    // Use typehint instead of PHPDoc once PHP <= 7.3 support is dropped.
+    /**
+     * @return DashboardStatisticsInterface
+     */
+    public function getStatisticsForChannel(ChannelInterface $channel);
 
+    // Use typehint instead of PHPDoc once PHP <= 7.3 support is dropped.
+    /**
+     * @return DashboardStatisticsInterface
+     */
     public function getStatisticsForChannelInPeriod(
         ChannelInterface $channel,
         \DateTimeInterface $startDate,
         \DateTimeInterface $endDate
-    ): DashboardStatistics;
+    );
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes (excluded from the BC promise?)
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

To allow modifying the `DashboardStatistics` model, for instance to add more statistics.
The interface was missing to do so.

Potentially a BC break if the `DashboardStatisticsProvider` has been extended (but excluded from the BC promise?).