### PR TITLE
[User] Remove usage of deprecated `AdvancedUserInterface`

### DIFF
--- a/UPGRADE-1.8.md
+++ b/UPGRADE-1.8.md
@@ -274,6 +274,8 @@ time out during this ajax request (previously no serialization group was defined
 in some admin URLs you can now replace `/admin` by `/%sylius_admin.path_name%`.  
 Also the route is now dynamic. You can change the `SYLIUS_ADMIN_ROUTING_PATH_NAME` environment variable to custom the admin's URL.
 
+1. Due to its deprecation, we removed the usage of `Symfony\Component\Security\Core\User\AdvancedUserInterface` in `Sylius\Component\User\Model\UserInterface` (the missing methods were added to the latter). If you target the `AdvancedUserInterface` anywhere in your code, extend it again in your interface or switch the type hint.
+
 ## Special attention
 
 ### Migrations

--- a/src/Sylius/Bundle/CoreBundle/Security/UserChecker.php
+++ b/src/Sylius/Bundle/CoreBundle/Security/UserChecker.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Security;
+
+use Sylius\Component\User\Model\UserInterface as SyliusUserInterface;
+use Symfony\Component\Security\Core\Exception\AccountExpiredException;
+use Symfony\Component\Security\Core\Exception\CredentialsExpiredException;
+use Symfony\Component\Security\Core\Exception\DisabledException;
+use Symfony\Component\Security\Core\Exception\LockedException;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+final class UserChecker implements UserCheckerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function checkPreAuth(UserInterface $user)
+    {
+        if (!$user instanceof SyliusUserInterface) {
+            return;
+        }
+
+        if (!$user->isAccountNonLocked()) {
+            $ex = new LockedException('User account is locked.');
+            $ex->setUser($user);
+
+            throw $ex;
+        }
+
+        if (!$user->isEnabled()) {
+            $ex = new DisabledException('User account is disabled.');
+            $ex->setUser($user);
+
+            throw $ex;
+        }
+
+        if (!$user->isAccountNonExpired()) {
+            $ex = new AccountExpiredException('User account has expired.');
+            $ex->setUser($user);
+
+            throw $ex;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkPostAuth(UserInterface $user)
+    {
+        if (!$user instanceof SyliusUserInterface) {
+            return;
+        }
+
+        if (!$user->isCredentialsNonExpired()) {
+            $ex = new CredentialsExpiredException('User credentials have expired.');
+            $ex->setUser($user);
+
+            throw $ex;
+        }
+    }
+}

--- a/src/Sylius/Component/User/Model/UserInterface.php
+++ b/src/Sylius/Component/User/Model/UserInterface.php
@@ -18,10 +18,8 @@ use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Model\TimestampableInterface;
 use Sylius\Component\Resource\Model\ToggleableInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderAwareInterface;
-use Symfony\Component\Security\Core\User\AdvancedUserInterface;
 
 interface UserInterface extends
-    AdvancedUserInterface,
     CredentialsHolderInterface,
     ResourceInterface,
     \Serializable,
@@ -111,4 +109,12 @@ interface UserInterface extends
     public function addOAuthAccount(UserOAuthInterface $oauth): void;
 
     public function setEncoderName(?string $encoderName): void;
+
+    public function isAccountNonExpired(): bool;
+
+    public function isAccountNonLocked(): bool;
+
+    public function isCredentialsNonExpired(): bool;
+
+    public function isEnabled(): bool;
 }


### PR DESCRIPTION
That class was remove in Symfony 5, re-added its method into `UserInterface` instead to prevent fatal errors.

| Q               | A
| --------------- | -----
| Branch?         | 1.8(?)
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no(?)
| Deprecations?   | no
| Related tickets | related to #10928 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
