### PR TITLE
Fixed compatibility with newer version of data collectors

### DIFF
--- a/src/Sylius/Bundle/ChannelBundle/Collector/ChannelCollector.php
+++ b/src/Sylius/Bundle/ChannelBundle/Collector/ChannelCollector.php
@@ -58,7 +58,7 @@ final class ChannelCollector extends DataCollector
         return $this->data['channel_change_support'];
     }
 
-    public function collect(Request $request, Response $response, \Exception $exception = null): void
+    public function collect(Request $request, Response $response, \Throwable $exception = null): void
     {
         try {
             $this->data['channel'] = $this->pluckChannel($this->channelContext->getChannel());

--- a/src/Sylius/Bundle/CoreBundle/Collector/CartCollector.php
+++ b/src/Sylius/Bundle/CoreBundle/Collector/CartCollector.php
@@ -80,7 +80,7 @@ final class CartCollector extends DataCollector
         return $this->data['states'];
     }
 
-    public function collect(Request $request, Response $response, \Exception $exception = null): void
+    public function collect(Request $request, Response $response, \Throwable $exception = null): void
     {
         try {
             /** @var OrderInterface $cart */

--- a/src/Sylius/Bundle/CoreBundle/Collector/SyliusCollector.php
+++ b/src/Sylius/Bundle/CoreBundle/Collector/SyliusCollector.php
@@ -97,7 +97,7 @@ final class SyliusCollector extends DataCollector
         return $this->data['default_locale_code'];
     }
 
-    public function collect(Request $request, Response $response, \Exception $exception = null): void
+    public function collect(Request $request, Response $response, \Throwable $exception = null): void
     {
         try {
             /** @var ChannelInterface $channel */

--- a/src/Sylius/Bundle/UiBundle/DataCollector/TemplateBlockDataCollector.php
+++ b/src/Sylius/Bundle/UiBundle/DataCollector/TemplateBlockDataCollector.php
@@ -32,7 +32,7 @@ final class TemplateBlockDataCollector extends DataCollector
         $this->reset();
     }
 
-    public function collect(Request $request, Response $response): void
+    public function collect(Request $request, Response $response, \Throwable $exception = null): void
     {
         $this->data['renderedEvents'] = $this->templateBlockRenderingHistory->getRenderedEvents();
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related #10928 
| License         | MIT

Error without this change:
```bash
HP Fatal error:  Declaration of Sylius\Bundle\ChannelBundle\Collector\ChannelCollector::collect(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpFoundation\Response $response, ?Exception $exception = NULL): void must be compatible with Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface::collect(Symfony\Component\HttpFoundation\Request $request, Symfony\Component\HttpFoundation\Response $response, ?Throwable $exception = NULL) in /var/www/dimedic-reports/current/vendor/sylius/sylius/src/Sylius/Bundle/ChannelBundle/Collector/ChannelCollector.php on line 61
```

<!--
 - Bug fixes must be submitted against the 1.7 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
