### PR TITLE
Add missing new method into form extensions

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CartItemTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CartItemTypeExtension.php
@@ -70,4 +70,9 @@ final class CartItemTypeExtension extends AbstractTypeExtension
     {
         return CartItemType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [CartItemType::class];
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CartTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CartTypeExtension.php
@@ -54,4 +54,9 @@ final class CartTypeExtension extends AbstractTypeExtension
     {
         return CartType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [CartType::class];
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ChannelTypeExtension.php
@@ -102,4 +102,9 @@ final class ChannelTypeExtension extends AbstractTypeExtension
     {
         return ChannelType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [ChannelType::class];
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CountryTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CountryTypeExtension.php
@@ -74,6 +74,11 @@ final class CountryTypeExtension extends AbstractTypeExtension
         return CountryType::class;
     }
 
+    public static function getExtendedTypes(): iterable
+    {
+        return [CountryType::class];
+    }
+
     private function getCountryName(string $code): string
     {
         return Countries::getName($code);

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CustomerTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CustomerTypeExtension.php
@@ -30,4 +30,9 @@ final class CustomerTypeExtension extends AbstractTypeExtension
     {
         return CustomerType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [CustomerType::class];
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/LocaleTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/LocaleTypeExtension.php
@@ -59,6 +59,11 @@ final class LocaleTypeExtension extends AbstractTypeExtension
         return LocaleType::class;
     }
 
+    public static function getExtendedTypes(): iterable
+    {
+        return [LocaleType::class];
+    }
+
     private function getLocaleName(string $code): ?string
     {
         return Intl::getLocaleBundle()->getLocaleName($code);

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/OrderTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/OrderTypeExtension.php
@@ -32,4 +32,9 @@ final class OrderTypeExtension extends AbstractTypeExtension
     {
         return OrderType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [OrderType::class];
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/PaymentMethodTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/PaymentMethodTypeExtension.php
@@ -59,4 +59,9 @@ final class PaymentMethodTypeExtension extends AbstractTypeExtension
     {
         return PaymentMethodType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [PaymentMethodType::class];
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductTranslationTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductTranslationTypeExtension.php
@@ -34,4 +34,9 @@ final class ProductTranslationTypeExtension extends AbstractTypeExtension
     {
         return ProductTranslationType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [ProductTranslationType::class];
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductTypeExtension.php
@@ -69,4 +69,9 @@ final class ProductTypeExtension extends AbstractTypeExtension
     {
         return ProductType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [ProductType::class];
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantGenerationTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantGenerationTypeExtension.php
@@ -46,4 +46,9 @@ final class ProductVariantGenerationTypeExtension extends AbstractTypeExtension
     {
         return ProductVariantGenerationType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [ProductVariantGenerationType::class];
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ProductVariantTypeExtension.php
@@ -97,4 +97,9 @@ final class ProductVariantTypeExtension extends AbstractTypeExtension
     {
         return ProductVariantType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [ProductVariantType::class];
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionCouponTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionCouponTypeExtension.php
@@ -39,4 +39,9 @@ final class PromotionCouponTypeExtension extends AbstractTypeExtension
     {
         return PromotionCouponType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [PromotionCouponType::class];
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionFilterCollectionTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionFilterCollectionTypeExtension.php
@@ -37,4 +37,9 @@ final class PromotionFilterCollectionTypeExtension extends AbstractTypeExtension
     {
         return PromotionFilterCollectionType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [PromotionFilterCollectionType::class];
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/PromotionTypeExtension.php
@@ -35,4 +35,9 @@ final class PromotionTypeExtension extends AbstractTypeExtension
     {
         return PromotionType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [PromotionType::class];
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/ShippingMethodTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/ShippingMethodTypeExtension.php
@@ -47,4 +47,9 @@ final class ShippingMethodTypeExtension extends AbstractTypeExtension
     {
         return ShippingMethodType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [ShippingMethodType::class];
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/TaxRateTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/TaxRateTypeExtension.php
@@ -30,4 +30,9 @@ final class TaxRateTypeExtension extends AbstractTypeExtension
     {
         return TaxRateType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [TaxRateType::class];
+    }
 }

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/TaxonTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/TaxonTypeExtension.php
@@ -38,4 +38,9 @@ final class TaxonTypeExtension extends AbstractTypeExtension
     {
         return TaxonType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [TaxonType::class];
+    }
 }

--- a/src/Sylius/Bundle/PayumBundle/Form/Extension/CryptedGatewayConfigTypeExtension.php
+++ b/src/Sylius/Bundle/PayumBundle/Form/Extension/CryptedGatewayConfigTypeExtension.php
@@ -67,4 +67,9 @@ final class CryptedGatewayConfigTypeExtension extends AbstractTypeExtension
     {
         return GatewayConfigType::class;
     }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [GatewayConfigType::class];
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related #10928 
| License         | MIT

Error with newer Symfony:
```bash
PHP Fatal error:  Class Sylius\Bundle\CoreBundle\Form\Extension\ChannelTypeExtension contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Symfony\Component\Form\FormTypeExtensionInterface::getExtendedTypes)
```

<!--
 - Bug fixes must be submitted against the 1.7 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
