### PR TITLE
Reset credentials expiration on password reset

### DIFF
--- a/src/Sylius/Bundle/UserBundle/EventListener/PasswordUpdaterListener.php
+++ b/src/Sylius/Bundle/UserBundle/EventListener/PasswordUpdaterListener.php
@@ -60,5 +60,9 @@ class PasswordUpdaterListener
         if (null !== $user->getPlainPassword()) {
             $this->passwordUpdater->updatePassword($user);
         }
+        
+        if (null !== $user->getCredentialsExpireAt()) {
+            $user->setCredentialsExpireAt(null);
+        }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no/yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

I am not sure _if_ you want this, or where, but in our use case we want customers to reset their password when their credentials have expired. And therefore, when the password is updated, this expiration date should be removed. Let me know what you think!