### PR TITLE
Fixed deprecated option usage on Email validator

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/validation/RegisterShopUser.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/validation/RegisterShopUser.xml
@@ -62,7 +62,7 @@
             </constraint>
             <constraint name="Email">
                 <option name="message">sylius.customer.email.invalid</option>
-                <option name="strict">true</option>
+                <option name="mode">strict</option>
                 <option name="groups">
                     <value>sylius</value>
                 </option>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation/AdminUser.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation/AdminUser.xml
@@ -30,7 +30,7 @@
             </constraint>
             <constraint name="Email">
                 <option name="message">sylius.user.email.invalid</option>
-                <option name="strict">true</option>
+                <option name="mode">strict</option>
                 <option name="groups">sylius</option>
             </constraint>
         </property>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/validation/Channel.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/validation/Channel.xml
@@ -48,7 +48,7 @@
             </constraint>
             <constraint name="Email">
                 <option name="message">sylius.channel.contact_email.invalid</option>
-                <option name="strict">true</option>
+                <option name="mode">strict</option>
                 <option name="groups">
                     <value>sylius</value>
                 </option>

--- a/src/Sylius/Bundle/CustomerBundle/Resources/config/validation/Customer.xml
+++ b/src/Sylius/Bundle/CustomerBundle/Resources/config/validation/Customer.xml
@@ -71,7 +71,7 @@
             </constraint>
             <constraint name="Email">
                 <option name="message">sylius.customer.email.invalid</option>
-                <option name="strict">true</option>
+                <option name="mode">strict</option>
                 <option name="groups">
                     <value>sylius</value>
                     <value>sylius_customer_guest</value>

--- a/src/Sylius/Bundle/UserBundle/Resources/config/validation/PasswordResetRequest.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/validation/PasswordResetRequest.xml
@@ -27,7 +27,7 @@
             </constraint>
             <constraint name="Email">
                 <option name="message">sylius.user.email.invalid</option>
-                <option name="strict">true</option>
+                <option name="mode">strict</option>
                 <option name="groups">sylius</option>
             </constraint>
         </property>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related #10928 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
