### PR TITLE
[1.8][Bugfix] Rework commands to match Symfony 5 changes & requirements

### DIFF
--- a/src/Sylius/Bundle/AdminApiBundle/Command/CreateClientCommand.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Command/CreateClientCommand.php
@@ -15,24 +15,21 @@ namespace Sylius\Bundle\AdminApiBundle\Command;
 
 use FOS\OAuthServerBundle\Model\ClientManagerInterface;
 use Sylius\Bundle\AdminApiBundle\Model\Client;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * @deprecated Fetching dependencies directly from container is not recommended from Symfony 3.4. Extending `ContainerAwareCommand` will be removed in 2.0
- */
-final class CreateClientCommand extends ContainerAwareCommand
+final class CreateClientCommand extends Command
 {
-    /** @var ClientManagerInterface|null */
+    /** @var ClientManagerInterface */
     private $clientManager;
 
     protected static $defaultName = 'sylius:oauth-server:create-client';
 
-    public function __construct(?string $name = null, ClientManagerInterface $clientManager = null)
+    public function __construct(ClientManagerInterface $clientManager)
     {
-        parent::__construct($name);
+        parent::__construct();
 
         $this->clientManager = $clientManager;
     }
@@ -62,11 +59,6 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if (null === $this->clientManager) {
-            @trigger_error('Fetching services directly from the container is deprecated since Sylius 1.2 and will be removed in 2.0.', \E_USER_DEPRECATED);
-            $this->clientManager = $this->getContainer()->get('fos_oauth_server.client_manager.default');
-        }
-
         /** @var Client $client */
         $client = $this->clientManager->createClient();
         $client->setRedirectUris($input->getOption('redirect-uri'));

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/services.xml
@@ -23,7 +23,6 @@
         <defaults public="true" />
 
         <service id="Sylius\Bundle\AdminApiBundle\Command\CreateClientCommand">
-            <argument>null</argument>
             <argument type="service" id="fos_oauth_server.client_manager.default" />
             <tag name="console.command" />
         </service>

--- a/src/Sylius/Bundle/AdminApiBundle/spec/Command/CreateClientCommandSpec.php
+++ b/src/Sylius/Bundle/AdminApiBundle/spec/Command/CreateClientCommandSpec.php
@@ -17,36 +17,37 @@ use FOS\OAuthServerBundle\Model\ClientManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\AdminApiBundle\Model\Client;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 final class CreateClientCommandSpec extends ObjectBehavior
 {
-    public function it_is_a_container_aware_command()
+    public function it_is_a_command(ClientManager $clientManager)
     {
-        $this->shouldHaveType(ContainerAwareCommand::class);
+        $this->beConstructedWith($clientManager);
+        $this->shouldHaveType(Command::class);
     }
 
-    public function it_has_a_name()
+    public function it_has_a_name(ClientManager $clientManager)
     {
+        $this->beConstructedWith($clientManager);
         $this->getName()->shouldReturn('sylius:oauth-server:create-client');
     }
 
     public function it_creates_a_client_without_client_manager(
-        ContainerInterface $container,
         InputInterface $input,
         OutputInterface $output,
         ClientManager $clientManager,
         Client $client
     ) {
+        $this->beConstructedWith($clientManager);
+
         $input->bind(Argument::any())->shouldBeCalled();
         $input->isInteractive()->shouldBeCalled();
         $input->validate()->shouldBeCalled();
         $input->hasArgument('command')->willReturn(false);
 
-        $container->get('fos_oauth_server.client_manager.default')->willReturn($clientManager);
         $clientManager->createClient()->willReturn($client);
 
         $input->getOption('redirect-uri')->willReturn(['redirect-uri']);
@@ -62,25 +63,22 @@ final class CreateClientCommandSpec extends ObjectBehavior
 
         $output->writeln(Argument::type('string'))->shouldBeCalled();
 
-        $this->setContainer($container);
         $this->run($input, $output);
     }
 
     public function it_creates_a_client(
-        ContainerInterface $container,
         InputInterface $input,
         OutputInterface $output,
         ClientManager $clientManager,
         Client $client
     ) {
-        $this->beConstructedWith(null, $clientManager);
+        $this->beConstructedWith($clientManager);
 
         $input->bind(Argument::any())->shouldBeCalled();
         $input->isInteractive()->shouldBeCalled();
         $input->validate()->shouldBeCalled();
         $input->hasArgument('command')->willReturn(false);
 
-        $container->get('fos_oauth_server.client_manager.default')->willReturn($clientManager);
         $clientManager->createClient()->willReturn($client);
 
         $input->getOption('redirect-uri')->willReturn(['redirect-uri']);
@@ -96,7 +94,6 @@ final class CreateClientCommandSpec extends ObjectBehavior
 
         $output->writeln(Argument::type('string'))->shouldBeCalled();
 
-        $this->setContainer($container);
         $this->run($input, $output);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Command/AbstractInstallCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/AbstractInstallCommand.php
@@ -14,16 +14,21 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
+use Sylius\Bundle\CoreBundle\Installer\Checker\CommandDirectoryChecker;
 use Sylius\Bundle\CoreBundle\Installer\Executor\CommandExecutor;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-abstract class AbstractInstallCommand extends ContainerAwareCommand
+abstract class AbstractInstallCommand extends Command implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /** @deprecated */
     public const WEB_ASSETS_DIRECTORY = 'web/assets/';
 
@@ -52,17 +57,17 @@ abstract class AbstractInstallCommand extends ContainerAwareCommand
      */
     protected function get(string $id)
     {
-        return $this->getContainer()->get($id);
+        return $this->container->get($id);
     }
 
     protected function getEnvironment(): string
     {
-        return (string) $this->getContainer()->getParameter('kernel.environment');
+        return (string) $this->container->getParameter('kernel.environment');
     }
 
     protected function isDebug(): bool
     {
-        return (bool) $this->getContainer()->getParameter('kernel.debug');
+        return (bool) $this->container->getParameter('kernel.debug');
     }
 
     protected function renderTable(array $headers, array $rows, OutputInterface $output): void
@@ -106,7 +111,7 @@ abstract class AbstractInstallCommand extends ContainerAwareCommand
             // PDO does not always close the connection after Doctrine commands.
             // See https://github.com/symfony/symfony/issues/11750.
             /** @var EntityManagerInterface $entityManager */
-            $entityManager = $this->getContainer()->get('doctrine')->getManager();
+            $entityManager = $this->container->get('doctrine')->getManager();
             $entityManager->getConnection()->close();
 
             $progress->advance();
@@ -117,7 +122,8 @@ abstract class AbstractInstallCommand extends ContainerAwareCommand
 
     protected function ensureDirectoryExistsAndIsWritable(string $directory, OutputInterface $output): void
     {
-        $checker = $this->getContainer()->get('sylius.installer.checker.command_directory');
+        /** @var CommandDirectoryChecker $checker */
+        $checker = $this->container->get('sylius.installer.checker.command_directory');
         $checker->setCommandName($this->getName());
 
         $checker->ensureDirectoryExists($directory, $output);

--- a/src/Sylius/Bundle/CoreBundle/Command/CheckRequirementsCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/CheckRequirementsCommand.php
@@ -34,7 +34,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $fulfilled = $this->getContainer()->get('sylius.installer.checker.sylius_requirements')->check($input, $output);
+        $fulfilled = $this->get('sylius.installer.checker.sylius_requirements')->check($input, $output);
 
         if (!$fulfilled) {
             throw new RuntimeException(

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallAssetsCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallAssetsCommand.php
@@ -31,7 +31,7 @@ EOT
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln(sprintf(
             'Installing Sylius assets for environment <info>%s</info>.',
@@ -39,7 +39,7 @@ EOT
         ));
 
         try {
-            $publicDir = $this->getContainer()->getParameter('sylius_core.public_dir');
+            $publicDir = $this->container->getParameter('sylius_core.public_dir');
 
             $this->ensureDirectoryExistsAndIsWritable($publicDir . '/assets/', $output);
             $this->ensureDirectoryExistsAndIsWritable($publicDir . '/bundles/', $output);
@@ -55,6 +55,6 @@ EOT
 
         $this->runCommands($commands, $output);
 
-        return null;
+        return 0;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallCommand.php
@@ -67,7 +67,7 @@ EOT
         $outputStyle->writeln('<info>Installing Sylius...</info>');
         $outputStyle->writeln($this->getSyliusLogo());
 
-        $this->ensureDirectoryExistsAndIsWritable($this->getContainer()->getParameter('kernel.cache_dir'), $output);
+        $this->ensureDirectoryExistsAndIsWritable($this->container->getParameter('kernel.cache_dir'), $output);
 
         $errored = false;
         foreach ($this->commands as $step => $command) {

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallDatabaseCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallDatabaseCommand.php
@@ -45,7 +45,6 @@ EOT
         ));
 
         $commands = $this
-            ->getContainer()
             ->get('sylius.commands_provider.database_setup')
             ->getCommands($input, $output, $this->getHelper('question'))
         ;

--- a/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/InstallSampleDataCommand.php
@@ -36,7 +36,7 @@ EOT
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var QuestionHelper $questionHelper */
         $questionHelper = $this->getHelper('question');
@@ -58,7 +58,7 @@ EOT
         }
 
         try {
-            $publicDir = $this->getContainer()->getParameter('sylius_core.public_dir');
+            $publicDir = $this->container->getParameter('sylius_core.public_dir');
 
             $this->ensureDirectoryExistsAndIsWritable($publicDir . '/media/', $output);
             $this->ensureDirectoryExistsAndIsWritable($publicDir . '/media/image/', $output);
@@ -80,6 +80,6 @@ EOT
         $this->runCommands($commands, $output);
         $outputStyle->newLine(2);
 
-        return null;
+        return 0;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Command/SetupCommand.php
+++ b/src/Sylius/Bundle/CoreBundle/Command/SetupCommand.php
@@ -42,9 +42,9 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $currency = $this->getContainer()->get('sylius.setup.currency')->setup($input, $output, $this->getHelper('question'));
-        $locale = $this->getContainer()->get('sylius.setup.locale')->setup($input, $output, $this->getHelper('question'));
-        $this->getContainer()->get('sylius.setup.channel')->setup($locale, $currency);
+        $currency = $this->get('sylius.setup.currency')->setup($input, $output, $this->getHelper('question'));
+        $locale = $this->get('sylius.setup.locale')->setup($input, $output, $this->getHelper('question'));
+        $this->get('sylius.setup.channel')->setup($locale, $currency);
         $this->setupAdministratorUser($input, $output, $locale->getCode());
 
         return 0;
@@ -55,8 +55,8 @@ EOT
         $outputStyle = new SymfonyStyle($input, $output);
         $outputStyle->writeln('Create your administrator account.');
 
-        $userManager = $this->getContainer()->get('sylius.manager.admin_user');
-        $userFactory = $this->getContainer()->get('sylius.factory.admin_user');
+        $userManager = $this->get('sylius.manager.admin_user');
+        $userFactory = $this->get('sylius.factory.admin_user');
 
         try {
             $user = $this->configureNewUser($userFactory->createNew(), $input, $output);
@@ -79,8 +79,7 @@ EOT
         InputInterface $input,
         OutputInterface $output
     ): AdminUserInterface {
-        /** @var UserRepositoryInterface $userRepository */
-        $userRepository = $this->getAdminUserRepository();
+        $userRepository = $this->get('sylius.repository.admin_user');
 
         if ($input->getOption('no-interaction')) {
             Assert::null($userRepository->findOneByEmail('sylius@example.com'));
@@ -109,7 +108,7 @@ EOT
                  */
                 function ($value): string {
                     /** @var ConstraintViolationListInterface $errors */
-                    $errors = $this->getContainer()->get('validator')->validate((string) $value, [new Email(), new NotBlank()]);
+                    $errors = $this->get('validator')->validate((string) $value, [new Email(), new NotBlank()]);
                     foreach ($errors as $error) {
                         throw new \DomainException($error->getMessage());
                     }
@@ -125,8 +124,7 @@ EOT
     {
         /** @var QuestionHelper $questionHelper */
         $questionHelper = $this->getHelper('question');
-        /** @var UserRepositoryInterface $userRepository */
-        $userRepository = $this->getAdminUserRepository();
+        $userRepository = $this->get('sylius.repository.admin_user');
 
         do {
             $question = $this->createEmailQuestion();
@@ -145,8 +143,7 @@ EOT
     {
         /** @var QuestionHelper $questionHelper */
         $questionHelper = $this->getHelper('question');
-        /** @var UserRepositoryInterface $userRepository */
-        $userRepository = $this->getAdminUserRepository();
+        $userRepository = $this->get('sylius.repository.admin_user');
 
         do {
             $question = new Question('Username (press enter to use email): ', $email);
@@ -188,7 +185,7 @@ EOT
             /** @param mixed $value */
             function ($value): string {
                 /** @var ConstraintViolationListInterface $errors */
-                $errors = $this->getContainer()->get('validator')->validate($value, [new NotBlank()]);
+                $errors = $this->get('validator')->validate($value, [new NotBlank()]);
                 foreach ($errors as $error) {
                     throw new \DomainException($error->getMessage());
                 }
@@ -206,10 +203,5 @@ EOT
             ->setHidden(true)
             ->setHiddenFallback(false)
         ;
-    }
-
-    private function getAdminUserRepository(): UserRepositoryInterface
-    {
-        return $this->getContainer()->get('sylius.repository.admin_user');
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/commands.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/commands.xml
@@ -16,6 +16,9 @@
         <defaults public="true" />
 
         <service id="Sylius\Bundle\CoreBundle\Command\CancelUnpaidOrdersCommand">
+            <argument>%sylius_order.order_expiration_period%</argument>
+            <argument type="service" id="sylius.unpaid_orders_state_updater" />
+            <argument type="service" id="sylius.manager.order" />
             <tag name="console.command" />
         </service>
 

--- a/src/Sylius/Bundle/OrderBundle/Command/RemoveExpiredCartsCommand.php
+++ b/src/Sylius/Bundle/OrderBundle/Command/RemoveExpiredCartsCommand.php
@@ -13,16 +13,37 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\OrderBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Sylius\Bundle\OrderBundle\Remover\ExpiredCartsRemover;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @final
  */
-class RemoveExpiredCartsCommand extends ContainerAwareCommand
+class RemoveExpiredCartsCommand extends Command
 {
     protected static $defaultName = 'sylius:remove-expired-carts';
+
+    /**
+     * @var string
+     */
+    private $orderExpirationPeriod;
+
+    /**
+     * @var ExpiredCartsRemover
+     */
+    private $expiredCartsRemover;
+
+    public function __construct(
+        string $orderExpirationPeriod,
+        ExpiredCartsRemover $expiredCartsRemover
+    ) {
+        parent::__construct();
+
+        $this->orderExpirationPeriod = $orderExpirationPeriod;
+        $this->expiredCartsRemover = $expiredCartsRemover;
+    }
 
     protected function configure(): void
     {
@@ -31,15 +52,13 @@ class RemoveExpiredCartsCommand extends ContainerAwareCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $expirationTime = $this->getContainer()->getParameter('sylius_order.cart_expiration_period');
         $output->writeln(
-            sprintf('Command will remove carts that have been idle for <info>%s</info>.', $expirationTime)
+            sprintf('Command will remove carts that have been idle for <info>%s</info>.', $this->orderExpirationPeriod)
         );
 
-        $expiredCartsRemover = $this->getContainer()->get('sylius.expired_carts_remover');
-        $expiredCartsRemover->remove();
+        $this->expiredCartsRemover->remove();
 
         return 0;
     }

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/services.xml
@@ -22,6 +22,8 @@
         <defaults public="true" />
 
         <service id="Sylius\Bundle\OrderBundle\Command\RemoveExpiredCartsCommand">
+            <argument>%sylius_order.cart_expiration_period%</argument>
+            <argument type="service" id="sylius.expired_carts_remover" />
             <tag name="console.command" />
         </service>
 

--- a/src/Sylius/Bundle/UserBundle/Command/AbstractRoleCommand.php
+++ b/src/Sylius/Bundle/UserBundle/Command/AbstractRoleCommand.php
@@ -16,14 +16,18 @@ namespace Sylius\Bundle\UserBundle\Command;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\User\Model\UserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-abstract class AbstractRoleCommand extends ContainerAwareCommand
+abstract class AbstractRoleCommand extends Command implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     protected function interact(InputInterface $input, OutputInterface $output): void
     {
         // User types configured in the Bundle
@@ -74,7 +78,7 @@ abstract class AbstractRoleCommand extends ContainerAwareCommand
         }
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $email = $input->getArgument('email');
         $securityRoles = $input->getArgument('roles');
@@ -112,7 +116,7 @@ abstract class AbstractRoleCommand extends ContainerAwareCommand
     {
         $class = $this->getUserModelClass($userType);
 
-        return $this->getContainer()->get('doctrine')->getManagerForClass($class);
+        return $this->container->get('doctrine')->getManagerForClass($class);
     }
 
     protected function getUserRepository(string $userType): UserRepositoryInterface
@@ -124,7 +128,7 @@ abstract class AbstractRoleCommand extends ContainerAwareCommand
 
     protected function getAvailableUserTypes(): array
     {
-        $config = $this->getContainer()->getParameter('sylius.user.users');
+        $config = $this->container->getParameter('sylius.user.users');
 
         // Keep only users types which implement \Sylius\Component\User\Model\UserInterface
         $userTypes = array_filter($config, function (array $userTypeConfig): bool {
@@ -139,7 +143,7 @@ abstract class AbstractRoleCommand extends ContainerAwareCommand
      */
     protected function getUserModelClass(string $userType): string
     {
-        $config = $this->getContainer()->getParameter('sylius.user.users');
+        $config = $this->container->getParameter('sylius.user.users');
         if (empty($config[$userType]['user']['classes']['model'])) {
             throw new \InvalidArgumentException(sprintf('User type %s misconfigured.', $userType));
         }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no(?)
| Deprecations?   | no
| Related tickets | related #10928 
| License         | MIT

Class `ContainerAwareCommand` was removed (added BC layer for now). Also all commands must return `int`, not `null` or `void`.
