### PR TITLE
Fixed deprecated `Intl` component usage

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/LocaleTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/LocaleTypeExtension.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Intl\Intl;
+use Symfony\Component\Intl\Locales;
 
 final class LocaleTypeExtension extends AbstractTypeExtension
 {
@@ -66,7 +66,7 @@ final class LocaleTypeExtension extends AbstractTypeExtension
 
     private function getLocaleName(string $code): ?string
     {
-        return Intl::getLocaleBundle()->getLocaleName($code);
+        return Locales::getName($code);
     }
 
     /**
@@ -74,7 +74,7 @@ final class LocaleTypeExtension extends AbstractTypeExtension
      */
     private function getAvailableLocales(): array
     {
-        $availableLocales = Intl::getLocaleBundle()->getLocaleNames();
+        $availableLocales = Locales::getNames();
 
         /** @var LocaleInterface[] $definedLocales */
         $definedLocales = $this->localeRepository->findAll();

--- a/src/Sylius/Component/Locale/Converter/LocaleConverter.php
+++ b/src/Sylius/Component/Locale/Converter/LocaleConverter.php
@@ -13,14 +13,15 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Locale\Converter;
 
-use Symfony\Component\Intl\Intl;
+use Symfony\Component\Intl\Exception\MissingResourceException;
+use Symfony\Component\Intl\Locales;
 use Webmozart\Assert\Assert;
 
 final class LocaleConverter implements LocaleConverterInterface
 {
     public function convertNameToCode(string $name, ?string $locale = null): string
     {
-        $names = Intl::getLocaleBundle()->getLocaleNames($locale ?? 'en');
+        $names = Locales::getNames($locale ?? 'en');
         $code = array_search($name, $names, true);
 
         Assert::string($code, sprintf('Cannot find code for "%s" locale name', $name));
@@ -30,10 +31,10 @@ final class LocaleConverter implements LocaleConverterInterface
 
     public function convertCodeToName(string $code, ?string $locale = null): string
     {
-        $name = Intl::getLocaleBundle()->getLocaleName($code, $locale ?? 'en');
-
-        Assert::string($name, sprintf('Cannot find name for "%s" locale code', $code));
-
-        return $name;
+        try {
+            return Locales::getName($code, $locale ?? 'en');
+        } catch (MissingResourceException $e) {
+            throw new \InvalidArgumentException(sprintf('Cannot find name for "%s" locale code', $code), 0, $e);
+        }
     }
 }

--- a/src/Sylius/Component/Locale/Model/Locale.php
+++ b/src/Sylius/Component/Locale/Model/Locale.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Component\Locale\Model;
 
 use Sylius\Component\Resource\Model\TimestampableTrait;
-use Symfony\Component\Intl\Intl;
+use Symfony\Component\Intl\Locales;
 
 class Locale implements LocaleInterface
 {
@@ -53,6 +53,6 @@ class Locale implements LocaleInterface
 
     public function getName(?string $locale = null): ?string
     {
-        return Intl::getLocaleBundle()->getLocaleName($this->getCode(), $locale);
+        return Locales::getName($this->getCode(), $locale);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes(?)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related #10928 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
