### PR TITLE
Fixed Twig translate extension not working with `null` values

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_headerTitle.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_headerTitle.html.twig
@@ -1,3 +1,3 @@
 {% import '@SyliusUi/Macro/headers.html.twig' as headers %}
 
-{{ headers.default(header|trans, configuration.vars.icon|default('plus'), configuration.vars.subheader|default(null)|trans) }}
+{{ headers.default(header|trans, configuration.vars.icon|default('plus'), configuration.vars.subheader|default('')|trans) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Index/_headerTitle.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Index/_headerTitle.html.twig
@@ -1,3 +1,3 @@
 {% import '@SyliusUi/Macro/headers.html.twig' as headers %}
 
-{{ headers.default(header|trans, configuration.vars.icon|default('list'), configuration.vars.subheader|default(null)|trans) }}
+{{ headers.default(header|trans, configuration.vars.icon|default('list'), configuration.vars.subheader|default('')|trans) }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_headerTitle.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_headerTitle.html.twig
@@ -1,3 +1,3 @@
 {% import '@SyliusUi/Macro/headers.html.twig' as headers %}
 
-{{ headers.default(header|trans, configuration.vars.icon|default('pencil'), configuration.vars.subheader|default(null)|trans) }}
+{{ headers.default(header|trans, configuration.vars.icon|default('pencil'), configuration.vars.subheader|default('')|trans) }}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related #10928 
| License         | MIT

@lchrusciel I think this is one of most unexpected BC breaks.

Fatal error due to type-hint change:
```
# Before
/**
 * @param string $id
 */
public function trans($id, array $parameters = [], string $domain = null, string $locale = null);
# Now
public function trans(string $id, array $parameters = [], string $domain = null, string $locale = null);
```

<!--
 - Bug fixes must be submitted against the 1.7 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
