### PR TITLE
allow sonata block bundle v3

### DIFF
--- a/src/Sylius/Bundle/UiBundle/composer.json
+++ b/src/Sylius/Bundle/UiBundle/composer.json
@@ -25,7 +25,7 @@
         "doctrine/collections": "^1.3",
         "knplabs/knp-menu": "^3.1",
         "knplabs/knp-menu-bundle": "^3.0",
-        "sonata-project/block-bundle": "^4.0",
+        "sonata-project/block-bundle": "^3.20|^4.0",
         "sylius/grid-bundle": "^1.6",
         "symfony/framework-bundle": "^4.4",
         "symfony/security": "^4.4",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7 (will target 1.8 also later)
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

there is no v4 need and it limits compatibility with other bundles, I believe this was mainly done to achieve compatibility with
symfony 5, but if you are still on symfony 4 its fine to use sonata-project/block-bundle: 3