### PR TITLE
[API] Unify interface parameters

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Command/Checkout/AddressOrder.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Checkout/AddressOrder.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\Command\Checkout;
 
 use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
-use Sylius\Component\Core\Model\AddressInterface;
+use Sylius\Component\Addressing\Model\AddressInterface;
 
 /** @experimental */
 class AddressOrder implements OrderTokenValueAwareInterface

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -20,8 +20,7 @@
     </imports>
 
     <parameters>
-        <parameter key="sylius.model.address.class.api.denormalize">%sylius.model.address.class%</parameter>
-        <parameter key="sylius.model.address.interface.api.denormalize">Sylius\Component\Core\Model\AddressInterface</parameter>
+        <parameter key="sylius.model.address.interface">Sylius\Component\Addressing\Model\AddressInterface</parameter>
     </parameters>
 
     <services>
@@ -107,8 +106,8 @@
 
         <service id="Sylius\Bundle\ApiBundle\Serializer\AddressDenormalizer">
             <argument type="service" id="serializer.normalizer.object" />
-            <argument type="string">%sylius.model.address.class.api.denormalize%</argument>
-            <argument type="string">%sylius.model.address.interface.api.denormalize%</argument>
+            <argument type="string">%sylius.model.address.class%</argument>
+            <argument type="string">%sylius.model.address.interface%</argument>
             <tag name="serializer.normalizer" priority="64" />
         </service>
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/Sylius/pull/11693/files#r468483392
| License         | MIT

I was sure, that the parameter exists, however it is a missing feature from ResourceBundle: 
![image](https://user-images.githubusercontent.com/6213903/92580151-56936700-f28e-11ea-9288-00e54e152a9c.png)

Still, the refactored version will be more coherent with Doctrine behavior and attribute bundle definition: 
![image](https://user-images.githubusercontent.com/6213903/92580405-9bb79900-f28e-11ea-9bd8-d8f479b1c3ec.png)

Current addressing serialization:
![image](https://user-images.githubusercontent.com/6213903/92605078-928bf380-f2b1-11ea-9d44-90e3970f0870.png)
