### PR TITLE
[API]add to swagger documentation missing locale code in translations

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
@@ -68,7 +68,18 @@
         <property name="code" identifier="true" required="true" />
         <property name="createdAt" writable="false" />
         <property name="updatedAt" writable="false" />
-        <property name="translations" readable="true" writable="true" />
+        <property name="translations" readable="true" writable="true">
+            <attribute name="openapi_context">
+                <attribute name="type">object</attribute>
+                <attribute name="example">
+                    <attribute name="en_US">
+                        <attribute name="name">string</attribute>
+                        <attribute name="slug">string</attribute>
+                        <attribute name="locale">string</attribute>
+                    </attribute>
+                </attribute>
+            </attribute>
+        </property>
         <property name="productTaxons" readable="true" writable="true" />
         <property name="reviews" required="false" />
         <property name="options" required="false" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAssociationType.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductAssociationType.xml
@@ -53,6 +53,17 @@
         <property name="code" identifier="true" required="true" />
         <property name="createdAt" writable="false" />
         <property name="updatedAt" writable="false" />
-        <property name="translations" readable="true" writable="true" />
+        <property name="translations" readable="true" writable="true">
+            <attribute name="openapi_context">
+                <attribute name="type">object</attribute>
+                <attribute name="example">
+                    <attribute name="en_US">
+                        <attribute name="name">string</attribute>
+                        <attribute name="description">string</attribute>
+                        <attribute name="locale">string</attribute>
+                    </attribute>
+                </attribute>
+            </attribute>
+        </property>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOption.xml
@@ -59,7 +59,17 @@
         <property name="values" readable="true" writable="true">
             <subresource resourceClass="%sylius.model.product_option_value.class%" collection="true" />
         </property>
-        <property name="translations" readable="true" writable="true" />
+        <property name="translations" readable="true" writable="true">
+            <attribute name="openapi_context">
+                <attribute name="type">object</attribute>
+                <attribute name="example">
+                    <attribute name="en_US">
+                        <attribute name="name">string</attribute>
+                        <attribute name="locale">string</attribute>
+                    </attribute>
+                </attribute>
+            </attribute>
+        </property>
     </resource>
 
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
@@ -46,7 +46,17 @@
 
         <property name="id" identifier="false" writable="false" />
         <property name="code" identifier="true" required="true" />
-        <property name="translations" readable="true" writable="true" />
+        <property name="translations" readable="true" writable="true" >
+            <attribute name="openapi_context">
+                <attribute name="type">array</attribute>
+                <attribute name="example">
+                    <attribute name="en_US">
+                        <attribute name="value">string</attribute>
+                        <attribute name="locale">string</attribute>
+                    </attribute>
+                </attribute>
+            </attribute>
+        </property>
     </resource>
 
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" ?>
 
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
 <resources xmlns="https://api-platform.com/schema/metadata"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
@@ -19,5 +30,17 @@
         <property name="id" identifier="false" writable="false" />
         <property name="code" identifier="true" required="true" />
         <property name="product" />
+        <property name="translations">
+            <attribute name="openapi_context">
+                <attribute name="type">array</attribute>
+                <attribute name="example">
+                    <attribute name="en_US">
+                        <attribute name="name">string</attribute>
+                        <attribute name="slug">string</attribute>
+                        <attribute name="locale">string</attribute>
+                    </attribute>
+                </attribute>
+            </attribute>
+        </property>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
@@ -87,6 +87,17 @@
         <property name="channels" writable="true" />
         <property name="calculator" writable="true" />
         <property name="configuration" writable="true" />
-        <property name="translations" readable="true" writable="true" />
+        <property name="translations" readable="true" writable="true">
+            <attribute name="openapi_context">
+                <attribute name="type">object</attribute>
+                <attribute name="example">
+                    <attribute name="en_US">
+                        <attribute name="name">string</attribute>
+                        <attribute name="description">string</attribute>
+                        <attribute name="locale">string</attribute>
+                    </attribute>
+                </attribute>
+            </attribute>
+        </property>
     </resource>
 </resources>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Example on "Product" resource
Before changes:
![Zrzut ekranu 2020-09-9 o 14 22 34](https://user-images.githubusercontent.com/35863747/92597594-eb568e80-f2a7-11ea-8495-9ffc2458e298.png)

After changes:
![Zrzut ekranu 2020-09-9 o 14 21 53](https://user-images.githubusercontent.com/35863747/92597539-d37f0a80-f2a7-11ea-9898-fb80f8c434cd.png)
