### PR TITLE
[AttributeBundle] Non translatable attributes

### DIFF
--- a/features/product/managing_products/adding_non_translatable_attributes_to_existing_product.feature
+++ b/features/product/managing_products/adding_non_translatable_attributes_to_existing_product.feature
@@ -1,0 +1,50 @@
+@managing_products
+Feature: Adding non translatable attributes to an existing product
+    In order to reduce configuration overhead
+    As an administrator
+    I want to be able to add non translatable attributes to an existing product
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "44 Magnum"
+        And the store has a non translatable text product attribute "Overall length"
+        And I am logged in as an administrator
+
+    @ui @javascript
+    Scenario: Adding a non translatable text attribute to an existing product
+        When I want to modify the "44 Magnum" product
+        And I set its non translatable "Overall length" attribute to "30.5 cm"
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And non translatable attribute "Overall length" of product "44 Magnum" should be "30.5 cm"
+
+    @ui @javascript
+    Scenario: Adding a non translatable text attribute to an existing product with a translatable attribute
+        Given this product has text attribute "Gun caliber" with value "11 mm" in "English (United States)" locale
+        When I want to modify the "44 Magnum" product
+        And I set its non translatable "Overall length" attribute to "30.5 cm"
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And attribute "Gun caliber" of product "44 Magnum" should be "11 mm"
+        And non translatable attribute "Overall length" of product "44 Magnum" should be "30.5 cm"
+
+    @ui @javascript
+    Scenario: Adding and removing non translatable text attributes on product update page
+        When I want to modify the "44 Magnum" product
+        And I set its non translatable "Overall length" attribute to "30.5 cm"
+        And I remove its non translatable "Overall length" attribute
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And product "44 Magnum" should not have a "Overall length" attribute
+
+    @ui @javascript
+    Scenario: Adding and removing after saving text attributes on product update page
+        Given this product has text attribute "Gun caliber" with value "11 mm" in "English (United States)" locale
+        When I want to modify the "44 Magnum" product
+        And I set its non translatable "Overall length" attribute to "30.5 cm"
+        And I save my changes
+        And I remove its "Gun caliber" attribute
+        And I save my changes
+        Then I should be notified that it has been successfully edited
+        And non translatable attribute "Overall length" of product "44 Magnum" should be "30.5 cm"
+        And product "44 Magnum" should not have a "Gun caliber" attribute

--- a/src/Sylius/Behat/Context/Setup/ProductAttributeContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductAttributeContext.php
@@ -93,6 +93,16 @@ final class ProductAttributeContext implements Context
     }
 
     /**
+     * @Given /^the store has(?:| also)(?:| a) non translatable (text|textarea|integer|percent) product attribute "([^"]+)"$/
+     */
+    public function theStoreHasANonTranslatableProductAttribute(string $type, string $name): void
+    {
+        $productAttribute = $this->createProductAttribute($type, $name, null, false);
+
+        $this->saveProductAttribute($productAttribute);
+    }
+
+    /**
      * @Given /^(this product attribute) has(?:| also) a value "([^"]+)" in ("[^"]+" locale)$/
      */
     public function thisProductAttributeHasAValueInLocale(

--- a/src/Sylius/Behat/Context/Setup/ProductAttributeContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductAttributeContext.php
@@ -289,7 +289,7 @@ final class ProductAttributeContext implements Context
      *
      * @return ProductAttributeInterface
      */
-    private function createProductAttribute($type, $name, $code = null)
+    private function createProductAttribute($type, $name, $code = null, bool $translatable = true)
     {
         $productAttribute = $this->productAttributeFactory->createTyped($type);
 
@@ -297,6 +297,7 @@ final class ProductAttributeContext implements Context
 
         $productAttribute->setCode($code);
         $productAttribute->setName($name);
+        $productAttribute->setTranslatable($translatable);
 
         return $productAttribute;
     }

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -520,12 +520,28 @@ final class ManagingProductsContext implements Context
     }
 
     /**
+     * @When I set its non translatable :attribute attribute to :value
+     */
+    public function iSetItsNonTranslatableAttributeTo($attribute, $value = null)
+    {
+        $this->createSimpleProductPage->addAttribute($attribute, $value ?? '', '__not_translatable__');
+    }
+
+    /**
      * @When I remove its :attribute attribute
      * @When I remove its :attribute attribute from :language
      */
     public function iRemoveItsAttribute($attribute, $language = 'en_US')
     {
         $this->createSimpleProductPage->removeAttribute($attribute, $language);
+    }
+
+    /**
+     * @When I remove its non translatable :attribute attribute
+     */
+    public function iRemoveItsNonTranslatableAttribute($attribute)
+    {
+        $this->createSimpleProductPage->removeAttribute($attribute, '__not_translatable__');
     }
 
     /**
@@ -553,6 +569,16 @@ final class ManagingProductsContext implements Context
         $this->updateSimpleProductPage->open(['id' => $product->getId()]);
 
         Assert::same($this->updateSimpleProductPage->getAttributeValue($attributeName, $language), $value);
+    }
+
+    /**
+     * @Then non translatable attribute :attributeName of product :product should be :value
+     */
+    public function itsNonTranslatableAttributeShouldBe($attributeName, ProductInterface $product, $value)
+    {
+        $this->updateSimpleProductPage->open(['id' => $product->getId()]);
+
+        Assert::same($this->updateSimpleProductPage->getAttributeValue($attributeName, '__not_translatable__'), $value);
     }
 
     /**

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product_attribute.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/product_attribute.yml
@@ -25,10 +25,19 @@ sylius_grid:
                     sortable: ~
                     options:
                         template: "@SyliusUi/Grid/Field/label.html.twig"
+                translatable:
+                    type: twig
+                    label: sylius.ui.translatable
+                    sortable: ~
+                    options:
+                        template: "@SyliusUi/Grid/Field/enabled.html.twig"
             filters:
                 code:
                     type: string
                     label: sylius.ui.code
+                translatable:
+                    type: boolean
+                    label: sylius.ui.translatable
             actions:
                 main:
                     create:

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributeValues.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributeValues.html.twig
@@ -3,7 +3,7 @@
 {% set subject = metadata.name|replace({'_attribute': ''}) %}
 {% for code, localeCodes in forms %}
     {% for localeCode, form in localeCodes %}
-        <div class="attribute" data-id="{{ code }}">
+        <div class="attribute" data-id="{{ code }}" data-localecode="{{ localeCode }}">
             {% set id = form.vars.label|replace({' ': '_'})|lower %}
             {% if 'type_checkbox' in form.vars.cache_key %}
                 {{ self.checkboxField(form, count, id, subject, metadata.applicationName) }}
@@ -14,10 +14,12 @@
                    name="{{ metadata.applicationName }}_{{ subject }}[attributes][{{ count }}][attribute]"
                    id="{{ metadata.applicationName }}_{{ subject }}_attributes_{{ count }}_attribute"
                    value="{{ code }}"/>
-            <input type="hidden"
-                   name="{{ metadata.applicationName }}_{{ subject }}[attributes][{{ count }}][localeCode]"
-                   id="{{ metadata.applicationName }}_{{ subject }}_attributes_{{ count }}_localeCode"
-                   value="{{ localeCode }}"/>
+            {% if localeCode != '__not_translatable__' %}
+                <input type="hidden"
+                       name="{{ metadata.applicationName }}_{{ subject }}[attributes][{{ count }}][localeCode]"
+                       id="{{ metadata.applicationName }}_{{ subject }}_attributes_{{ count }}_localeCode"
+                       value="{{ localeCode }}"/>
+            {% endif %}
             {% set count = count + 1 %}
         </div>
     {% endfor %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
@@ -6,7 +6,7 @@
 
     <div class="ui top attached tabular menu">
 
-        <a class="item active" data-tab="__not_translatable__">Not translatable</a>
+        <a class="item active" data-tab="__not_translatable__">{{ 'sylius.ui.not_translatable'|trans }}</a>
         {% for localeCode, translationForm in attr.translations %}
             <a class="item" data-tab="{{ localeCode }}">
                 {{ flags.fromLocaleCode(localeCode) }} {{ localeCode|sylius_locale_name }}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
@@ -5,22 +5,34 @@
     {% import _self as self %}
 
     <div class="ui top attached tabular menu">
+
+        <a class="item active" data-tab="__not_translatable__">Not translatable</a>
         {% for localeCode, translationForm in attr.translations %}
-            <a class="item{% if loop.first %} active{% endif %}" data-tab="{{ localeCode }}">
+            <a class="item" data-tab="{{ localeCode }}">
                 {{ flags.fromLocaleCode(localeCode) }} {{ localeCode|sylius_locale_name }}
             </a>
         {% endfor %}
     </div>
 
-    {% for localeCode, translationForm in attr.translations %}
-        <div class="ui bottom attached tab segment{% if loop.first %} active{% endif %}" data-tab="{{ localeCode }}">
-            {% apply spaceless %}
-                {% for child in form %}
-                    {% if localeCode == child.localeCode.vars.value %}
-                        {{ self.collection_item(child, allow_delete, button_delete_label, loop.index0) }}
-                    {% endif %}
-                {% endfor %}
-            {% endapply %}
+    <div class="ui bottom attached tab segment active" data-tab="__not_translatable__">
+        {% apply spaceless %}
+            {% for child in form %}
+                {% if child.localeCode.vars.value is empty %}
+                    {{ self.collection_item(child, allow_delete, button_delete_label, loop.index0) }}
+                {% endif %}
+            {% endfor %}
+        {% endapply %}
+    </div>
+
+    {% for localeCode, translationForm in attr.translations if localeCode is not empty %}
+        <div class="ui bottom attached tab segment" data-tab="{{ localeCode }}">
+        {% apply spaceless %}
+            {% for child in form %}
+                {% if localeCode == child.localeCode.vars.value %}
+                    {{ self.collection_item(child, allow_delete, button_delete_label, loop.index0) }}
+                {% endif %}
+            {% endfor %}
+        {% endapply %}
         </div>
     {% endfor %}
 {%- endblock collection_widget %}
@@ -46,6 +58,9 @@
             {{ form_errors(form.value) }}
         {% endif %}
         <input type="hidden" name="{{ form.attribute.vars.full_name }}" id="{{ form.attribute.vars.id }}" value="{{ form.vars.data.attribute.code }}"/>
-        <input type="hidden" name="{{ form.localeCode.vars.full_name }}" id="{{ form.localeCode.vars.id }}" value="{{ form.localeCode.vars.value }}"/>
+
+        {% if form.localeCode.vars.value is not empty %}
+            <input type="hidden" name="{{ form.localeCode.vars.full_name }}" id="{{ form.localeCode.vars.id }}" value="{{ form.localeCode.vars.value }}"/>
+        {% endif %}
     </div>
 {% endmacro %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Attribute/attributesCollection.html.twig
@@ -5,7 +5,6 @@
     {% import _self as self %}
 
     <div class="ui top attached tabular menu">
-
         <a class="item active" data-tab="__not_translatable__">{{ 'sylius.ui.not_translatable'|trans }}</a>
         {% for localeCode, translationForm in attr.translations %}
             <a class="item" data-tab="{{ localeCode }}">

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ProductAttribute/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ProductAttribute/_form.html.twig
@@ -8,6 +8,7 @@
         {{ form_row(form.position) }}
         {{ form_row(form.type) }}
     </div>
+    {{ form_row(form.translatable) }}
 </div>
 {% if form.configuration is defined %}
 <div class="ui segment">

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeType.php
@@ -18,6 +18,7 @@ use Sylius\Bundle\ResourceBundle\Form\Registry\FormTypeRegistryInterface;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Bundle\ResourceBundle\Form\Type\ResourceTranslationsType;
 use Sylius\Component\Attribute\Model\AttributeInterface;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -54,6 +55,7 @@ abstract class AttributeType extends AbstractResourceType
                 'label' => 'sylius.form.attribute.type',
                 'disabled' => true,
             ])
+            ->add('translatable', CheckboxType::class, ['label' => 'sylius.form.attribute.translatable'])
         ;
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {

--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeValueType.php
@@ -19,6 +19,7 @@ use Sylius\Bundle\ResourceBundle\Form\Registry\FormTypeRegistryInterface;
 use Sylius\Bundle\ResourceBundle\Form\Type\AbstractResourceType;
 use Sylius\Component\Attribute\Model\AttributeInterface;
 use Sylius\Component\Attribute\Model\AttributeValueInterface;
+use Sylius\Component\Locale\Model\Locale;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -59,7 +60,7 @@ abstract class AttributeValueType extends AbstractResourceType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('localeCode', LocaleChoiceType::class)
+            ->add('localeCode', LocaleChoiceType::class, ['required' => false])
             ->add('attribute', $this->attributeChoiceType)
             ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
                 $attributeValue = $event->getData();

--- a/src/Sylius/Bundle/AttributeBundle/Resources/config/doctrine/model/Attribute.orm.xml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/config/doctrine/model/Attribute.orm.xml
@@ -32,5 +32,7 @@
         <field name="position" type="integer">
             <gedmo:sortable-position />
         </field>
+
+        <field name="translatable" column="translatable" type="boolean" />
     </mapped-superclass>
 </doctrine-mapping>

--- a/src/Sylius/Bundle/AttributeBundle/Resources/config/doctrine/model/AttributeValue.orm.xml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/config/doctrine/model/AttributeValue.orm.xml
@@ -21,7 +21,7 @@
             <generator strategy="AUTO" />
         </id>
 
-        <field type="string" name="localeCode" column="locale_code" />
+        <field type="string" name="localeCode" column="locale_code" nullable="true" />
 
         <field name="text" column="text_value" type="text" nullable="true" />
         <field name="boolean" column="boolean_value" type="boolean" nullable="true" />

--- a/src/Sylius/Bundle/AttributeBundle/Resources/config/serializer/Model.Attribute.yml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/config/serializer/Model.Attribute.yml
@@ -35,3 +35,7 @@ Sylius\Component\Attribute\Model\Attribute:
             expose: true
             type: array
             groups: [Detailed]
+        translatable:
+            expose: true
+            type: boolean
+            groups: [Default, Detailed]

--- a/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.en.yml
@@ -6,6 +6,7 @@ sylius:
             choices: Choices
             code: Code
             name: Name
+            translatable: Translatable
             translations: Translations
             type: Type
         attribute_type:

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAttributeExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAttributeExampleFactory.php
@@ -92,9 +92,7 @@ class ProductAttributeExampleFactory extends AbstractExampleFactory implements E
             ->setDefault('configuration', function (Options $options): array {
                 return [];
             })
-            ->setDefault('translatable', function (Options $options): bool {
-                return $this->faker->boolean;
-            })
+            ->setDefault('translatable', true)
             ->setAllowedValues('type', array_keys($this->attributeTypes))
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAttributeExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductAttributeExampleFactory.php
@@ -69,6 +69,7 @@ class ProductAttributeExampleFactory extends AbstractExampleFactory implements E
         }
 
         $productAttribute->setConfiguration($options['configuration']);
+        $productAttribute->setTranslatable($options['translatable']);
 
         return $productAttribute;
     }
@@ -90,6 +91,9 @@ class ProductAttributeExampleFactory extends AbstractExampleFactory implements E
             })
             ->setDefault('configuration', function (Options $options): array {
                 return [];
+            })
+            ->setDefault('translatable', function (Options $options): bool {
+                return $this->faker->boolean;
             })
             ->setAllowedValues('type', array_keys($this->attributeTypes))
         ;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ProductExampleFactory.php
@@ -360,21 +360,24 @@ class ProductExampleFactory extends AbstractExampleFactory implements ExampleFac
     {
         $productAttributesValues = [];
         foreach ($productAttributes as $code => $value) {
-            foreach ($this->getLocales() as $localeCode) {
-                $productAttributesValues[] = $this->configureProductAttributeValue($code, $localeCode, $value);
+            /** @var ProductAttributeInterface|null $productAttribute */
+            $productAttribute = $this->productAttributeRepository->findOneBy(['code' => $code]);
+            Assert::notNull($productAttribute, sprintf('Can not find product attribute with code: "%s"', $code));
+
+            if ($productAttribute->isTranslatable()) {
+                foreach ($this->getLocales() as $localeCode) {
+                    $productAttributesValues[] = $this->configureProductAttributeValue($productAttribute, $localeCode, $value);
+                }
+            } else {
+                $productAttributesValues[] = $this->configureProductAttributeValue($productAttribute, null, $value);
             }
         }
 
         return $productAttributesValues;
     }
 
-    private function configureProductAttributeValue(string $code, string $localeCode, $value): ProductAttributeValueInterface
+    private function configureProductAttributeValue(ProductAttributeInterface $productAttribute, ?string $localeCode, $value): ProductAttributeValueInterface
     {
-        /** @var ProductAttributeInterface|null $productAttribute */
-        $productAttribute = $this->productAttributeRepository->findOneBy(['code' => $code]);
-
-        Assert::notNull($productAttribute, sprintf('Can not find product attribute with code: "%s"', $code));
-
         /** @var ProductAttributeValueInterface $productAttributeValue */
         $productAttributeValue = $this->productAttributeValueFactory->createNew();
         $productAttributeValue->setAttribute($productAttribute);

--- a/src/Sylius/Bundle/CoreBundle/Fixture/ProductAttributeFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ProductAttributeFixture.php
@@ -42,6 +42,7 @@ class ProductAttributeFixture extends AbstractResourceFixture
                 ->scalarNode('code')->cannotBeEmpty()->end()
                 ->enumNode('type')->values($this->attributeTypes)->cannotBeEmpty()->end()
                 ->variableNode('configuration')->end()
+                ->booleanNode('translatable')->end()
         ;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20200910074029.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20200910074029.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200910074029 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_product_attribute ADD translatable TINYINT(1) NOT NULL');
+        $this->addSql('ALTER TABLE sylius_product_attribute_value CHANGE locale_code locale_code VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_product_attribute DROP translatable');
+        $this->addSql('ALTER TABLE sylius_product_attribute_value CHANGE locale_code locale_code VARCHAR(255) CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/LocalesAwareValidAttributeValueValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/LocalesAwareValidAttributeValueValidator.php
@@ -45,7 +45,7 @@ final class LocalesAwareValidAttributeValueValidator extends ConstraintValidator
         $defaultLocale = $this->localeProvider->getDefaultLocaleCode();
         $configuration = $value->getAttribute()->getConfiguration();
 
-        if ($defaultLocale === $value->getLocaleCode()) {
+        if ($defaultLocale === $value->getLocaleCode() || null === $value->getLocaleCode()) {
             $configuration = array_merge($configuration, ['required' => true]);
         }
 

--- a/src/Sylius/Bundle/ProductBundle/Controller/ProductAttributeController.php
+++ b/src/Sylius/Bundle/ProductBundle/Controller/ProductAttributeController.php
@@ -89,12 +89,15 @@ class ProductAttributeController extends ResourceController
         $attributeForm = $this->get('sylius.form_registry.attribute_type')->get($attribute->getType(), 'default');
 
         $forms = [];
+        if (!$attribute->isTranslatable()) {
+            $localeCodes = ['__not_translatable__'];
+        }
+
         foreach ($localeCodes as $localeCode) {
             $forms[$localeCode] = $this
                 ->get('form.factory')
                 ->createNamed('value', $attributeForm, null, ['label' => $attribute->getName(), 'configuration' => $attribute->getConfiguration()])
-                ->createView()
-            ;
+                ->createView();
         }
 
         return $forms;

--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-product-attributes.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-product-attributes.js
@@ -93,7 +93,7 @@ const setAttributeChoiceListener = function setAttributeChoiceListener() {
         const attributeFormElements = modifyAttributeFormElements($(response));
 
         attributeFormElements.each((index, element) => {
-          const localeCode = $(element).find('input[type="hidden"]').last().val();
+          const localeCode = $(element).data('localecode');
           $(`#attributesContainer > div[data-tab="${localeCode}"]`).append(element);
         });
 

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
@@ -882,6 +882,7 @@ sylius:
         tracked: 'Tracked'
         tracking_code: 'Tracking code'
         tracking_number: 'Tracking number'
+        translatable: 'Translatable'
         translations: 'Translations'
         type: 'Type'
         unavailable: 'Unavailable'

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.en.yml
@@ -569,6 +569,7 @@ sylius:
         not_equal: 'Not equal'
         not_in: 'Not in'
         not_tracked: 'Not tracked'
+        not_translatable: 'Not translatable'
         not_verified: 'Not verified'
         notes: 'Notes'
         notify_customer: 'Notify Customer'

--- a/src/Sylius/Component/Attribute/Model/Attribute.php
+++ b/src/Sylius/Component/Attribute/Model/Attribute.php
@@ -44,6 +44,9 @@ class Attribute implements AttributeInterface
     /** @var int */
     protected $position;
 
+    /** @var bool */
+    protected $translatable = false;
+
     public function __construct()
     {
         $this->initializeTranslationsCollection();
@@ -119,6 +122,16 @@ class Attribute implements AttributeInterface
     public function setPosition(?int $position): void
     {
         $this->position = $position;
+    }
+
+    public function isTranslatable(): bool
+    {
+        return $this->translatable;
+    }
+
+    public function setTranslatable(bool $translatable): void
+    {
+        $this->translatable = $translatable;
     }
 
     /**

--- a/src/Sylius/Component/Attribute/Model/AttributeInterface.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeInterface.php
@@ -45,6 +45,10 @@ interface AttributeInterface extends
 
     public function setPosition(?int $position): void;
 
+    public function isTranslatable(): bool;
+
+    public function setTranslatable(bool $translatable): void;
+
     /**
      * @return AttributeTranslationInterface
      */

--- a/src/Sylius/Component/Attribute/Model/AttributeValue.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeValue.php
@@ -82,8 +82,6 @@ class AttributeValue implements AttributeValueInterface
 
     public function setLocaleCode(?string $localeCode): void
     {
-        Assert::string($localeCode);
-
         $this->localeCode = $localeCode;
     }
 

--- a/src/Sylius/Component/Attribute/Model/AttributeValueInterface.php
+++ b/src/Sylius/Component/Attribute/Model/AttributeValueInterface.php
@@ -49,9 +49,6 @@ interface AttributeValueInterface extends ResourceInterface
 
     public function getType(): ?string;
 
-    /**
-     * @throws \InvalidArgumentException
-     */
     public function getLocaleCode(): ?string;
 
     public function setLocaleCode(?string $localeCode): void;

--- a/src/Sylius/Component/Product/Model/Product.php
+++ b/src/Sylius/Component/Product/Model/Product.php
@@ -176,7 +176,7 @@ class Product implements ProductInterface
 
         $attributes = $this->attributes->filter(
             function (ProductAttributeValueInterface $attribute) use ($baseLocaleCode) {
-                return $attribute->getLocaleCode() === $baseLocaleCode;
+                return $attribute->getLocaleCode() === $baseLocaleCode || null === $attribute->getLocaleCode();
             }
         );
 
@@ -229,7 +229,7 @@ class Product implements ProductInterface
 
         foreach ($this->attributes as $attribute) {
             if ($attribute->getAttribute()->getCode() === $attributeCode
-                && $attribute->getLocaleCode() === $localeCode) {
+                && ($attribute->getLocaleCode() === $localeCode || null === $attribute->getLocaleCode())) {
                 return true;
             }
         }
@@ -245,7 +245,7 @@ class Product implements ProductInterface
 
         foreach ($this->attributes as $attribute) {
             if ($attribute->getAttribute()->getCode() === $attributeCode &&
-                $attribute->getLocaleCode() === $localeCode) {
+                ($attribute->getLocaleCode() === $localeCode || null === $attribute->getLocaleCode())) {
                 return $attribute;
             }
         }

--- a/tests/Controller/ProductApiTest.php
+++ b/tests/Controller/ProductApiTest.php
@@ -416,6 +416,11 @@ EOT;
                     "attribute": "mug_collection",
                     "localeCode": "en_US",
                     "value": "make life harder"
+                },
+                {
+                    "attribute": "mug_size",
+                    "localeCode": null,
+                    "value": "L"
                 }
             ],
             "translations": {
@@ -451,7 +456,7 @@ EOT;
                     "attribute": "mug_color",
                     "localeCode": "en_US",
                     "value": [
-                        "7a968ac4-a1e3-4a37-a707-f22a839130c4", 
+                        "7a968ac4-a1e3-4a37-a707-f22a839130c4",
                         "ff62a939-d946-4d6b-b742-b7115875ae75"
                     ]
                 }

--- a/tests/Controller/ProductAttributeApiTest.php
+++ b/tests/Controller/ProductAttributeApiTest.php
@@ -132,6 +132,7 @@ final class ProductAttributeApiTest extends JsonApiTestCase
 <<<EOT
         {
             "code": "mug_material",
+            "translatable": true,
             "translations": {
                 "de_CH": {
                     "name": "Becher Material"
@@ -189,6 +190,7 @@ EOT;
 <<<EOT
         {
             "position": 2,
+            "translatable": true,
             "translations": {
                 "de_CH": {
                     "name": "Becher Material"
@@ -286,6 +288,7 @@ EOT;
 <<<EOT
         {
             "code": "mug_color",
+            "translatable": true,
             "configuration": {
                 "choices": [
                     {"en_US": "yellow", "fr_FR": "jaune"},
@@ -311,6 +314,53 @@ EOT;
 
         $response = $this->client->getResponse();
         $this->assertResponse($response, 'product_attribute/create_select_response', Response::HTTP_CREATED);
+
+        $expectedChoiceValues = [
+            ['en_US' => 'yellow', 'fr_FR' => 'jaune'],
+            ['en_US' => 'green'],
+            ['en_US' => 'black'],
+        ];
+        $this->assertSelectChoicesInResponse($response, $expectedChoiceValues);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_to_create_non_translatable_product_attribute()
+    {
+        $this->loadFixturesFromFile('authentication/api_administrator.yml');
+        $this->loadFixturesFromFile('resources/locales.yml');
+
+        $data =
+<<<EOT
+        {
+            "code": "mug_color",
+            "translatable": false,
+            "configuration": {
+                "choices": [
+                    {"en_US": "yellow", "fr_FR": "jaune"},
+                    {"en_US": "green"},
+                    {"en_US": "black"}
+                ],
+                "multiple": true,
+                "min": 1,
+                "max": 2
+            },
+            "translations": {
+                "de_CH": {
+                    "name": "Becher Farbe"
+                },
+                "en_US": {
+                    "name": "Mug color"
+                }
+            }
+        }
+EOT;
+
+        $this->client->request('POST', '/api/v1/product-attributes/select', [], [], static::$authorizedHeaderWithContentType, $data);
+
+        $response = $this->client->getResponse();
+        $this->assertResponse($response, 'product_attribute/create_non_translatable_response', Response::HTTP_CREATED);
 
         $expectedChoiceValues = [
             ['en_US' => 'yellow', 'fr_FR' => 'jaune'],

--- a/tests/DataFixtures/ORM/resources/product_attributes.yml
+++ b/tests/DataFixtures/ORM/resources/product_attributes.yml
@@ -19,9 +19,14 @@ Sylius\Component\Product\Model\ProductAttributeTranslation:
         locale: en_US
         name: "Mug color"
         translatable: "@productAttributeSelect"
+    attributeTranslation6:
+        locale: en_US
+        name: "Mug size"
+        translatable: "@productAttributeSelect"
 
 Sylius\Component\Product\Model\ProductAttribute:
     productAttribute1:
+        translatable: true
         fallbackLocale: en_US
         currentLocale: de
         code: mug_material
@@ -31,6 +36,7 @@ Sylius\Component\Product\Model\ProductAttribute:
             - "@attributeTranslation1"
             - "@attributeTranslation3"
     productAttribute2:
+        translatable: true
         fallbackLocale: en_US
         currentLocale: de
         code: mug_collection
@@ -40,6 +46,7 @@ Sylius\Component\Product\Model\ProductAttribute:
             - "@attributeTranslation2"
             - "@attributeTranslation4"
     productAttributeSelect:
+        translatable: true
         fallbackLocale: en_US
         currentLocale: de
         code: mug_color
@@ -54,3 +61,12 @@ Sylius\Component\Product\Model\ProductAttribute:
             multiple: true
         translations:
             - "@attributeTranslation5"
+    productAttributeNonTranslatable:
+        translatable: false
+        fallbackLocale: en_US
+        currentLocale: de
+        code: mug_size
+        type: text
+        storage_type: text
+        translations:
+            - "@attributeTranslation6"

--- a/tests/Responses/product/create_with_attributes_response.json
+++ b/tests/Responses/product/create_with_attributes_response.json
@@ -18,6 +18,13 @@
             "value": "make life harder",
             "type": "text",
             "localeCode": "en_US"
+        },
+        {
+            "id": @integer@,
+            "code": "mug_size",
+            "name": "Mug size",
+            "value": "L",
+            "type": "text"
         }
     ],
     "options": [],

--- a/tests/Responses/product_attribute/create_non_translatable_response.json
+++ b/tests/Responses/product_attribute/create_non_translatable_response.json
@@ -11,7 +11,7 @@
     "position": 0,
     "createdAt": "@string@.isDateTime()",
     "updatedAt": "@string@.isDateTime()",
-    "translatable": true,
+    "translatable": false,
     "translations": {
         "en_US": {
             "id": @integer@,

--- a/tests/Responses/product_attribute/create_response.json
+++ b/tests/Responses/product_attribute/create_response.json
@@ -6,6 +6,7 @@
     "configuration": [],
     "createdAt": "@string@.isDateTime()",
     "updatedAt": "@string@.isDateTime()",
+    "translatable": true,
     "translations": {
         "de_CH": {
             "id": @integer@,

--- a/tests/Responses/product_attribute/create_validation_fail_response.json
+++ b/tests/Responses/product_attribute/create_validation_fail_response.json
@@ -6,6 +6,7 @@
             "type": {},
             "position": {},
             "translations": {},
+            "translatable": {},
             "code": {
                 "errors": [
                     "Please enter attribute code."

--- a/tests/Responses/product_attribute/index_response.json
+++ b/tests/Responses/product_attribute/index_response.json
@@ -2,7 +2,7 @@
     "page": 1,
     "limit": 10,
     "pages": 1,
-    "total": 3,
+    "total": 4,
     "_links": {
         "self": {
             "href": "\/api\/v1\/product-attributes\/?page=1&limit=10"
@@ -21,6 +21,7 @@
                 "code": "mug_material",
                 "type": "text",
                 "position": 0,
+                "translatable": true,
                 "translations": {
                     "de": {
                         "id": @integer@,
@@ -44,6 +45,7 @@
                 "code": "mug_collection",
                 "type": "text",
                 "position": 1,
+                "translatable": true,
                 "translations": {
                     "de": {
                         "id": @integer@,
@@ -67,6 +69,7 @@
                 "code": "mug_color",
                 "type": "select",
                 "position": 2,
+                "translatable": true,
                 "translations": {
                     "en_US": {
                         "id": @integer@,
@@ -77,6 +80,25 @@
                 "_links": {
                     "self": {
                         "href": "\/api\/v1\/product-attributes\/mug_color"
+                    }
+                }
+            },
+            {
+                "id": @integer@,
+                "code": "mug_size",
+                "type": "text",
+                "position": 3,
+                "translatable": false,
+                "translations": {
+                    "en_US": {
+                        "id": @integer@,
+                        "locale": "en_US",
+                        "name": "Mug size"
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "\/api\/v1\/product-attributes\/mug_size"
                     }
                 }
             }

--- a/tests/Responses/product_attribute/index_response_after_delete.json
+++ b/tests/Responses/product_attribute/index_response_after_delete.json
@@ -2,7 +2,7 @@
     "page": 1,
     "limit": 10,
     "pages": 1,
-    "total": 2,
+    "total": 3,
     "_links": {
         "self": {
             "href": "\/api\/v1\/product-attributes\/?page=1&limit=10"
@@ -21,6 +21,7 @@
                 "code": "mug_collection",
                 "type": "text",
                 "position": 0,
+                "translatable": true,
                 "translations": {
                     "de": {
                         "id": @integer@,
@@ -44,6 +45,7 @@
                 "code": "mug_color",
                 "type": "select",
                 "position": 1,
+                "translatable": true,
                 "translations": {
                       "en_US": {
                           "locale": "en_US",
@@ -54,6 +56,25 @@
                 "_links": {
                       "self": {
                           "href": "\/api\/v1\/product-attributes\/mug_color"
+                    }
+                }
+            },
+            {
+                "id": @integer@,
+                "code": "mug_size",
+                "type": "text",
+                "position": 2,
+                "translatable": false,
+                "translations": {
+                    "en_US": {
+                        "id": @integer@,
+                        "locale": "en_US",
+                        "name": "Mug size"
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "\/api\/v1\/product-attributes\/mug_size"
                     }
                 }
             }

--- a/tests/Responses/product_attribute/show_response.json
+++ b/tests/Responses/product_attribute/show_response.json
@@ -6,6 +6,7 @@
     "position": 0,
     "createdAt": "@string@.isDateTime()",
     "updatedAt": "@string@.isDateTime()",
+    "translatable": true,
     "translations": {
         "de": {
             "id": @integer@,

--- a/tests/Responses/product_attribute/show_response_after_partial_update.json
+++ b/tests/Responses/product_attribute/show_response_after_partial_update.json
@@ -6,6 +6,7 @@
     "configuration": [],
     "createdAt": "@string@.isDateTime()",
     "updatedAt": "@string@.isDateTime()",
+    "translatable": true,
     "translations": {
         "de": {
             "id": @integer@,

--- a/tests/Responses/product_attribute/show_response_after_update.json
+++ b/tests/Responses/product_attribute/show_response_after_update.json
@@ -6,6 +6,7 @@
     "configuration": [],
     "createdAt": "@string@.isDateTime()",
     "updatedAt": "@string@.isDateTime()",
+    "translatable": true,
     "translations": {
         "de": {
             "id": @integer@,


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | #11689
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
Adds a `translatable` flag to attributes. 
Non translatable attributes have *one* value for all locales.

