### PR TITLE
Typo in UPGRADE-1.8.md

### DIFF
--- a/UPGRADE-1.8.md
+++ b/UPGRADE-1.8.md
@@ -93,7 +93,7 @@ The later is being decorated by `sylius.context.channel.cached` which caches the
 time out during this ajax request (previously no serialization group was defined on this route).
 
 1. We now use the parameter `sylius_admin.path_name` to retrieve the admin routes prefix. If you used the `/admin` prefix
-in some admin URLs you can now replace `/admin` by `/%sylius_admin.path_prefix%`.  
+in some admin URLs you can now replace `/admin` by `/%sylius_admin.path_name%`.  
 Also the route is now dynamic. You can change the `SYLIUS_ADMIN_ROUTING_PATH_NAME` environment variable to custom the admin's URL.
 
 1. Replace the DoctrineMigrationsBundle configuration in `config/packages/doctrine_migrations.yaml`:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes, because people will have an issue if they follow the typo…
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

The parameter `sylius_admin.path_prefix` doesn't exist.