### PR TITLE
Allow plugins to move forward with the admin route

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
@@ -33,6 +33,9 @@ imports:
     - { resource: "@SyliusAdminBundle/Resources/config/grids/taxon.yml" }
     - { resource: "@SyliusAdminBundle/Resources/config/grids/zone.yml" }
 
+parameters:
+    sylius_admin.path_name: admin
+
 sylius_grid:
     templates:
         action:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

If a plugin wants to stay compatible with 1.7 and 1.8 and has controllers in admin… then they need to change their admin route to contain the 'sylius_admin.path_name` parameter.

But since it's not present in older versions it'll fail.
The other possibility is to setup this parameter in every plugin ([like here…](https://github.com/monsieurbiz/SyliusSettingsPlugin/pull/14/files#diff-732ea71904b614568caacf326d011419R1-R4)), but I feel like it should be a backward compatibility without a lot of effort from Sylius side.

What do you think?