### PR TITLE
[Admin][Search] added search in admin

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "babel-polyfill": "^6.26.0",
     "chart.js": "^2.9.3",
     "jquery": "^3.5.0",
+    "jquery-address": "^1.6.0",
     "jquery.dirtyforms": "^2.0.0",
     "lightbox2": "^2.9.0",
     "semantic-ui-css": "^2.2.0",

--- a/src/Sylius/Bundle/AdminApiBundle/Migrations/Version20200918223714.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Migrations/Version20200918223714.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminApiBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20200918223714 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE FULLTEXT INDEX IDX_7E82D5E6E7927C74A9D1C132C808BA5A ON sylius_customer (email, first_name, last_name)');
+        $this->addSql('CREATE FULLTEXT INDEX IDX_105A9085E237E066DE44026 ON sylius_product_translation (name, description)');
+        $this->addSql('CREATE FULLTEXT INDEX IDX_1487DFCF5E237E066DE44026 ON sylius_taxon_translation (name, description)');
+        $this->addSql('CREATE FULLTEXT INDEX IDX_CBA491AD5E237E06 ON sylius_product_option_translation (name)');
+        $this->addSql('CREATE FULLTEXT INDEX IDX_93850EBA5E237E06 ON sylius_product_attribute_translation (name)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX IDX_7E82D5E6E7927C74A9D1C132C808BA5A ON sylius_customer');
+        $this->addSql('DROP INDEX IDX_105A9085E237E066DE44026 ON sylius_product_translation');
+        $this->addSql('DROP INDEX IDX_1487DFCF5E237E066DE44026 ON sylius_taxon_translation');
+        $this->addSql('DROP INDEX IDX_CBA491AD5E237E06 ON sylius_product_option_translation');
+        $this->addSql('DROP INDEX IDX_93850EBA5E237E06 ON sylius_product_attribute_translation');
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Controller/SearchController.php
+++ b/src/Sylius/Bundle/AdminBundle/Controller/SearchController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Controller;
+
+use Sylius\Bundle\AdminBundle\Provider\SearchEngineInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class SearchController extends AbstractController
+{
+    /** @var SearchEngineInterface  */
+    private $searchEngine;
+
+    public function __construct(SearchEngineInterface $searchEngine)
+    {
+        $this->searchEngine = $searchEngine;
+    }
+
+    public function search(Request $request): Response
+    {
+        $terms = $request->query->get('terms', '');
+
+        return $this->render('@SyliusAdmin/Search/search.html.twig', [
+            'terms' => $terms,
+            'results' => $this->searchEngine->search($terms, $request->query),
+        ]);
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Provider/SearchEngine.php
+++ b/src/Sylius/Bundle/AdminBundle/Provider/SearchEngine.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Provider;
+
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Sylius\Component\Search\Model\SearchQuery;
+use Sylius\Component\Search\Provider\ResultSetProviderInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+final class SearchEngine implements SearchEngineInterface
+{
+    /** @var LocaleContextInterface */
+    private $localeContext;
+
+    /** @var ResultSetProviderInterface[] */
+    private $resultSetProviders;
+
+    public function __construct(
+        LocaleContextInterface $localeContext,
+        \Traversable $resultSetProviders
+    ) {
+        $this->localeContext = $localeContext;
+        $this->resultSetProviders = iterator_to_array($resultSetProviders);
+    }
+
+    public function search(string $terms, ParameterBag $query): array
+    {
+        $searchQuery = new SearchQuery($terms, $this->localeContext->getLocaleCode(), $query);
+
+        return array_map(function (ResultSetProviderInterface $resultSetProvider) use ($searchQuery) {
+            return $resultSetProvider->getResultSet($searchQuery);
+        }, $this->resultSetProviders);
+    }
+}

--- a/src/Sylius/Bundle/AdminBundle/Provider/SearchEngineInterface.php
+++ b/src/Sylius/Bundle/AdminBundle/Provider/SearchEngineInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminBundle\Provider;
+
+use Sylius\Component\Search\Model\ResultSetInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+interface SearchEngineInterface
+{
+    /**
+     * @param string $terms
+     * @param ParameterBag $query
+     *
+     * @return ResultSetInterface[]
+     */
+    public function search(string $terms, ParameterBag $query): array;
+}

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing.yml
@@ -92,6 +92,9 @@ sylius_admin_promotion_coupon:
     resource: "@SyliusAdminBundle/Resources/config/routing/promotion_coupon.yml"
     prefix: /promotions/{promotionId}/coupons/
 
+sylius_admin_search:
+    resource: "@SyliusAdminBundle/Resources/config/routing/search.yml"
+
 sylius_admin_security:
     resource: "@SyliusAdminBundle/Resources/config/routing/security.yml"
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/routing/search.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/routing/search.yml
@@ -1,0 +1,5 @@
+sylius_admin_search:
+    path: /search
+    methods: [GET]
+    defaults:
+        _controller: sylius.controller.admin.search:search

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services.xml
@@ -19,6 +19,7 @@
         <import resource="services/menu.xml" />
         <import resource="services/form.xml" />
         <import resource="services/provider.xml" />
+        <import resource="services/resultSetProvider.xml" />
     </imports>
 
     <parameters>

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/controller.xml
@@ -64,5 +64,12 @@
             <argument type="string">%sylius.admin.notification.uri%</argument>
             <argument type="string">%kernel.environment%</argument>
         </service>
+
+        <service id="sylius.controller.admin.search" class="Sylius\Bundle\AdminBundle\Controller\SearchController">
+            <argument key="$searchEngine" type="service" id="Sylius\Bundle\AdminBundle\Provider\SearchEngineInterface"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/provider.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/provider.xml
@@ -15,6 +15,11 @@
     <services>
         <defaults public="true" />
 
+        <service id="Sylius\Bundle\AdminBundle\Provider\SearchEngineInterface" class="Sylius\Bundle\AdminBundle\Provider\SearchEngine">
+            <argument key="$localeContext" type="service" id="sylius.context.locale"/>
+            <argument key="$resultSetProviders" type="tagged_iterator" tag="sylius.search.result_set_provider"/>
+        </service>
+
         <service id="Sylius\Bundle\AdminBundle\Provider\StatisticsDataProviderInterface" class="Sylius\Bundle\AdminBundle\Provider\StatisticsDataProvider" >
             <argument type="service" id="Sylius\Component\Core\Dashboard\DashboardStatisticsProviderInterface"/>
             <argument type="service" id="Sylius\Component\Core\Dashboard\SalesDataProviderInterface"/>

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/services/resultSetProvider.xml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/services/resultSetProvider.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+
+        <service id="sylius.search.result_set_provider.product" class="Sylius\Component\Search\Provider\ResultSetProvider">
+            <argument key="$type" type="string">product</argument>
+            <argument key="$searchableRepository" type="service" id="sylius.repository.product"/>
+            <tag name="sylius.search.result_set_provider" priority="100"/>
+        </service>
+
+        <service id="sylius.search.result_set_provider.taxon" class="Sylius\Component\Search\Provider\ResultSetProvider">
+            <argument key="$type" type="string">taxon</argument>
+            <argument key="$searchableRepository" type="service" id="sylius.repository.taxon"/>
+            <tag name="sylius.search.result_set_provider" priority="200"/>
+        </service>
+
+        <service id="sylius.search.result_set_provider.product_attribute" class="Sylius\Component\Search\Provider\ResultSetProvider">
+            <argument key="$type" type="string">product_attribute</argument>
+            <argument key="$searchableRepository" type="service" id="sylius.repository.product_attribute"/>
+            <tag name="sylius.search.result_set_provider" priority="300"/>
+        </service>
+
+        <service id="sylius.search.result_set_provider.product_option" class="Sylius\Component\Search\Provider\ResultSetProvider">
+            <argument key="$type" type="string">product_option</argument>
+            <argument key="$searchableRepository" type="service" id="sylius.repository.product_option"/>
+            <tag name="sylius.search.result_set_provider" priority="400"/>
+        </service>
+
+        <service id="sylius.search.result_set_provider.customer" class="Sylius\Component\Search\Provider\ResultSetProvider">
+            <argument key="$type" type="string">customer</argument>
+            <argument key="$searchableRepository" type="service" id="sylius.repository.customer"/>
+            <tag name="sylius.search.result_set_provider" priority="500"/>
+        </service>
+    </services>
+</container>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Layout/_search.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Layout/_search.html.twig
@@ -1,8 +1,10 @@
-<div class="item">
-    <form method="get" action="{{ path('sylius_admin_product_index') }}">
-        <div class="ui transparent left icon input">
-            <input type="text" name="criteria[search][value]" placeholder="{{ 'sylius.ui.search_products'|trans }}...">
-            <i class="search link icon"></i>
-        </div>
-    </form>
-</div>
+{% if app.request.attributes.get('_route') != 'sylius_admin_search' %}
+    <div class="item">
+        <form method="get" action="{{ path('sylius_admin_search') }}">
+            <div class="ui transparent left icon input">
+                <input type="text" name="terms" autocomplete="off" placeholder="{{ 'sylius.ui.search'|trans }}...">
+                <i class="search link icon"></i>
+            </div>
+        </form>
+    </div>
+{% endif %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row.html.twig
@@ -1,0 +1,9 @@
+<div class="event">
+    <div class="content">
+        <div class="summary">
+            <div class="user">
+                {{ item }}
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row.html.twig
@@ -1,9 +1,7 @@
-<div class="event">
+<div class="item">
     <div class="content">
-        <div class="summary">
-            <div class="user">
-                {{ item }}
-            </div>
+        <div class="header">
+            {{ item }}
         </div>
     </div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_customer.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_customer.html.twig
@@ -1,0 +1,12 @@
+<div class="event">
+    <div class="content">
+        <div class="summary">
+            <a  href="{{ path('sylius_admin_customer_show', {id: item.id}) }}" class="user">
+                {{ item.fullName }}
+            </a>
+            <div class="date">
+                {{ item.email }}
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_customer.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_customer.html.twig
@@ -1,11 +1,41 @@
-<div class="event">
+<div class="item">
     <div class="content">
-        <div class="summary">
-            <a  href="{{ path('sylius_admin_customer_show', {id: item.id}) }}" class="user">
-                {{ item.fullName }}
+        <a href="{{ path('sylius_admin_customer_show', {id: item.id}) }}" class="header">
+            {{ item.fullName }}
+        </a>
+
+        <div class="description">
+            <span class="date">{{ 'sylius.ui.customer_since'|trans }} {{ item.createdAt|date }}</span>
+            <br />
+            {% if item.group is not null %}
+                <span class="group">{{ 'sylius.ui.group_membership'|trans }}: {{ item.group }}</span>
+                <br />
+            {% endif %}
+            <a href="mailto:{{ item.email }}">
+                <i class="envelope icon"></i> {{ item.email }}
             </a>
-            <div class="date">
-                {{ item.email }}
+            {% if item.phoneNumber is not null %}
+                <br />
+                <div id="phone-number">
+                    <i class="phone icon"></i> {{ item.phoneNumber }}
+                </div>
+            {% endif %}
+        </div>
+
+        <div class="extra">
+            <div class="ui right floated buttons">
+                <a class="ui labeled icon button" href="{{ path('sylius_admin_customer_order_index', {id: item.id}) }}">
+                    <i class="icon search"></i>
+                    {{ 'sylius.ui.show_orders'|trans }}
+                </a>
+                <a class="ui labeled icon button" href="{{ path('sylius_admin_customer_show', {id: item.id}) }}">
+                    <i class="icon search"></i>
+                    {{ 'sylius.ui.show'|trans }}
+                </a>
+                <a class="ui labeled icon button" href="{{ path('sylius_admin_customer_update', {id: item.id}) }}">
+                    <i class="icon pencil"></i>
+                    {{ 'sylius.ui.edit'|trans }}
+                </a>
             </div>
         </div>
     </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_product.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_product.html.twig
@@ -1,0 +1,15 @@
+<div class="event">
+    <div class="label">
+        {% include '@SyliusAdmin/Product/_mainImage.html.twig' with {'product': item} %}
+    </div>
+    <div class="content">
+        <div class="summary">
+            <a href="{{ path('sylius_admin_product_update', {id: item.id}) }}" class="user">
+                {{ item.name }}
+            </a>
+        </div>
+        <div class="extra text">
+            {{ item.description }}
+        </div>
+    </div>
+</div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_product.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_product.html.twig
@@ -1,15 +1,49 @@
-<div class="event">
-    <div class="label">
-        {% include '@SyliusAdmin/Product/_mainImage.html.twig' with {'product': item} %}
+<div class="item">
+    <div class="ui tiny image">
+        {% if item.imagesByType('thumbnail') is not empty %}
+            {% set path = item.imagesByType('thumbnail').first.path|imagine_filter(filter|default('sylius_small')) %}
+        {% elseif item.images.first %}
+            {% set path = item.images.first.path|imagine_filter(filter|default('sylius_small')) %}
+        {% else %}
+            {% set path = '//placehold.it/120x90' %}
+        {% endif %}
+
+        <img src="{{ path }}" alt="" class="ui bordered image" />
+
     </div>
     <div class="content">
-        <div class="summary">
-            <a href="{{ path('sylius_admin_product_update', {id: item.id}) }}" class="user">
-                {{ item.name }}
-            </a>
+        <a href="{{ path('sylius_admin_product_show', {id: item.id}) }}" class="header">
+            {{ item.name }}
+        </a>
+        <div class="meta">
+            <span class="main-taxon">
+                <a href="{{ path('sylius_admin_taxon_update', {id: item.mainTaxon.id}) }}"><i class="folder icon"></i> {{ item.mainTaxon.name }}</a>
+            </span>
         </div>
-        <div class="extra text">
-            {{ item.description }}
+        <div class="description">
+            <p>{{ item.description }}</p>
+        </div>
+        <div class="extra">
+            <div class="ui right floated buttons">
+                <a class="ui labeled icon button" href="{{ path('sylius_admin_product_show', {id: item.id}) }}">
+                    <i class="icon search"></i>
+                    {{ 'sylius.ui.details'|trans }}
+                </a>
+                <a class="ui labeled icon button" href="{{ path('sylius_admin_product_update', {id: item.id}) }}">
+                    <i class="icon pencil"></i>
+                    {{ 'sylius.ui.edit'|trans }}
+                </a>
+            </div>
+            <div class="ui right floated buttons">
+                <div class="ui labeled icon floating dropdown link button" tabindex="0">
+                    <i class="cubes icon"></i> <span class="text">{{ 'sylius.ui.manage_variants'|trans }}</span>
+                    <div class="menu" tabindex="-1">
+                        <a class="item" href="{{ path('sylius_admin_product_variant_index', {productId: item.id}) }}"><i class="list icon"></i> {{ 'sylius.ui.list_variants'|trans }}</a>
+                        <a class="item" href="{{ path('sylius_admin_product_variant_create', {productId: item.id}) }}"><i class="plus icon"></i> {{ 'sylius.ui.create'|trans }}</a>
+                        <a class="item" href="{{ path('sylius_admin_product_variant_generate', {productId: item.id}) }}"><i class="random icon"></i> {{ 'sylius.ui.generate'|trans }}</a>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_product_attribute.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_product_attribute.html.twig
@@ -1,0 +1,9 @@
+<div class="event">
+    <div class="content">
+        <div class="summary">
+            <a  href="{{ path('sylius_admin_product_attribute_update', {id: item.id}) }}" class="user">
+                {{ item.name }}
+            </a>
+        </div>
+    </div>
+</div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_product_attribute.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_product_attribute.html.twig
@@ -1,9 +1,18 @@
-<div class="event">
+<div class="item">
     <div class="content">
-        <div class="summary">
-            <a  href="{{ path('sylius_admin_product_attribute_update', {id: item.id}) }}" class="user">
-                {{ item.name }}
-            </a>
+        <a href="{{ path('sylius_admin_product_attribute_update', {id: item.id}) }}" class="header">
+            {{ item.name }}
+        </a>
+        <div class="meta">
+            <div class="ui label">{{ item.type }}</div>
+        </div>
+        <div class="extra">
+            <div class="ui right floated buttons">
+                <a class="ui labeled icon button" href="{{ path('sylius_admin_product_attribute_update', {id: item.id}) }}">
+                    <i class="icon pencil"></i>
+                    {{ 'sylius.ui.edit'|trans }}
+                </a>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_product_option.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_product_option.html.twig
@@ -1,9 +1,15 @@
-<div class="event">
+<div class="item">
     <div class="content">
-        <div class="summary">
-            <a  href="{{ path('sylius_admin_product_option_update', {id: item.id}) }}" class="user">
-                {{ item.name }}
-            </a>
+        <a href="{{ path('sylius_admin_product_option_update', {id: item.id}) }}" class="header">
+            {{ item.name }}
+        </a>
+        <div class="extra">
+            <div class="ui right floated buttons">
+                <a class="ui labeled icon button" href="{{ path('sylius_admin_product_option_update', {id: item.id}) }}">
+                    <i class="icon pencil"></i>
+                    {{ 'sylius.ui.edit'|trans }}
+                </a>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_product_option.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_product_option.html.twig
@@ -1,0 +1,9 @@
+<div class="event">
+    <div class="content">
+        <div class="summary">
+            <a  href="{{ path('sylius_admin_product_option_update', {id: item.id}) }}" class="user">
+                {{ item.name }}
+            </a>
+        </div>
+    </div>
+</div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_taxon.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_taxon.html.twig
@@ -1,0 +1,30 @@
+{% macro tree(taxon, isLeef = false) %}
+    {% if taxon.parent is not null %}
+        {{ _self.tree(taxon.parent) }}
+        <i class="right angle icon divider"></i>
+    {% endif %}
+
+    {% if isLeef %}
+        <div class="active section">{{ taxon.name }}</div>
+    {% else %}
+        <a href="{{ path('sylius_admin_taxon_update', {id: taxon.id}) }}" class="section">{{ taxon.name }}</a>
+    {% endif %}
+{% endmacro %}
+
+<div class="event">
+    <div class="content">
+        <div class="summary">
+            <a href="{{ path('sylius_admin_taxon_update', {id: item.id}) }}" class="user">
+                {{ item.name }}
+            </a>
+            <div class="date">
+                <div class="ui breadcrumb">
+                    {{ _self.tree(item, true) }}
+                </div>
+            </div>
+        </div>
+        <div class="extra text">
+            {{ item.description }}
+        </div>
+    </div>
+</div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_taxon.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Row/_row_taxon.html.twig
@@ -1,30 +1,45 @@
-{% macro tree(taxon, isLeef = false) %}
+{% macro tree(taxon) %}
     {% if taxon.parent is not null %}
         {{ _self.tree(taxon.parent) }}
         <i class="right angle icon divider"></i>
     {% endif %}
 
-    {% if isLeef %}
-        <div class="active section">{{ taxon.name }}</div>
-    {% else %}
-        <a href="{{ path('sylius_admin_taxon_update', {id: taxon.id}) }}" class="section">{{ taxon.name }}</a>
-    {% endif %}
+    <a href="{{ path('sylius_admin_taxon_update', {id: taxon.id}) }}" class="section">{{ taxon.name }}</a>
 {% endmacro %}
 
-<div class="event">
+<div class="item">
+    <div class="ui tiny image">
+        {% if item.images.first %}
+            {% set path = item.images.first.path|imagine_filter(filter|default('sylius_small')) %}
+        {% else %}
+            {% set path = '//placehold.it/120x90' %}
+        {% endif %}
+
+        <img src="{{ path }}" alt="" class="ui bordered image" />
+    </div>
     <div class="content">
-        <div class="summary">
-            <a href="{{ path('sylius_admin_taxon_update', {id: item.id}) }}" class="user">
-                {{ item.name }}
-            </a>
-            <div class="date">
-                <div class="ui breadcrumb">
-                    {{ _self.tree(item, true) }}
-                </div>
-            </div>
+        <a href="{{ path('sylius_admin_taxon_update', {id: item.id}) }}" class="header">
+            {{ item.name }}
+        </a>
+        <div class="meta">
+            <span class="taxon-tree">
+                {{ _self.tree(item) }}
+            </span>
         </div>
-        <div class="extra text">
-            {{ item.description }}
+        <div class="description">
+            <p>{{ item.description }}</p>
+        </div>
+        <div class="extra">
+            <div class="ui right floated buttons">
+                <a class="ui labeled icon button" href="{{ path('sylius_admin_product_per_taxon_index', {taxonId: item.id}) }}">
+                    <i class="icon search"></i>
+                    {{ 'sylius.ui.details'|trans }}
+                </a>
+                <a class="ui labeled icon button" href="{{ path('sylius_admin_taxon_update', {id: item.id}) }}">
+                    <i class="icon pencil"></i>
+                    {{ 'sylius.ui.edit'|trans }}
+                </a>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Title/_title.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Title/_title.html.twig
@@ -1,0 +1,1 @@
+{{ ('sylius.ui.'~resultSet.type~'s')|trans }} ({{ resultSet.pager.nbResults }})

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Title/_title.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/Title/_title.html.twig
@@ -1,1 +1,7 @@
-{{ ('sylius.ui.'~resultSet.type~'s')|trans }} ({{ resultSet.pager.nbResults }})
+{{ ('sylius.ui.'~resultSet.type~'s')|trans }}
+
+{% if resultSet.pager.nbResults >= 99 %}
+    <div class="ui label">99 +</div>
+{% elseif resultSet.pager.nbResults > 0 %}
+    <div class="ui label">{{ resultSet.pager.nbResults }}</div>
+{% endif %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/search.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/search.html.twig
@@ -1,0 +1,54 @@
+{% extends '@SyliusAdmin/layout.html.twig' %}
+
+{% import '@SyliusUi/Macro/pagination.html.twig' as pagination %}
+{% import '@SyliusUi/Macro/messages.html.twig' as messages %}
+
+{% block title %}{{ 'sylius.ui.search'|trans }}: {{ terms}} {{ parent() }}{% endblock %}
+
+{% block content %}
+    <div class="ui segment">
+        <form method="get" action="{{ path('sylius_admin_search') }}">
+            <div class="ui fluid left icon action input">
+                <input type="text" name="terms" autocomplete="off" placeholder="{{ 'sylius.ui.search'|trans }}..." value="{{ terms }}">
+                <i class="search link icon"></i>
+                <button class="ui button">{{ 'sylius.ui.search'|trans }}</button>
+                <a href="{{ path('sylius_admin_search') }}" class="ui icon grey button"><i class="icon remove"></i></a>
+            </div>
+        </form>
+    </div>
+
+    {% set results = results|sort((a, b) => b.pager.nbResults <=> a.pager.nbResults) %}
+
+    <div class="tabular-historized-container">
+        <div class="ui top attached tabular tabular-historized menu">
+            {% for resultSet in results %}
+                <a class="{{ loop.first ? 'active' }} item" data-tab="search-tab-{{ resultSet.type }}">
+                    {{ include(['@SyliusAdmin/Search/Title/_title_'~resultSet.type~'.html.twig', '@SyliusAdmin/Search/Title/_title.html.twig'], {resultSet: resultSet})}}
+                </a>
+            {% endfor %}
+        </div>
+
+        {% for resultSet in results %}
+            <div class="ui bottom attached {{ loop.first ? 'active' }} tab segment" data-tab="search-tab-{{ resultSet.type }}">
+                {{ block('pagination') }}
+
+                {% if resultSet.pager.currentPageResults|length > 0 %}
+                        <div class="ui feed">
+                            {% for item in resultSet.pager.currentPageResults %}
+                                {{ include(['@SyliusAdmin/Search/Row/_row_'~resultSet.type~'.html.twig', '@SyliusAdmin/Search/Row/_row.html.twig'], { item: item }) }}
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                    {{ messages.info('sylius.ui.no_results_to_display') }}
+                {% endif %}
+
+                {% block pagination %}
+                    {{ pagination.simple(resultSet.pager, {
+                        'pageParameter': '[page_'~resultSet.type~']',
+                        'template': '@BabDevPagerfanta/semantic_ui.html.twig',
+                    }) }}
+                {% endblock %}
+            </div>
+        {% endfor %}
+    </div>
+{% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Search/search.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Search/search.html.twig
@@ -11,7 +11,13 @@
             <div class="ui fluid left icon action input">
                 <input type="text" name="terms" autocomplete="off" placeholder="{{ 'sylius.ui.search'|trans }}..." value="{{ terms }}">
                 <i class="search link icon"></i>
-                <button class="ui button">{{ 'sylius.ui.search'|trans }}</button>
+                <button class="ui animated primary button">
+                    <div class="visible content">{{ 'sylius.ui.search'|trans }}</div>
+                    <div class="hidden content">
+                        <i class="search icon"></i>
+                    </div>
+
+                </button>
                 <a href="{{ path('sylius_admin_search') }}" class="ui icon grey button"><i class="icon remove"></i></a>
             </div>
         </form>
@@ -33,7 +39,7 @@
                 {{ block('pagination') }}
 
                 {% if resultSet.pager.currentPageResults|length > 0 %}
-                        <div class="ui feed">
+                        <div class="ui divided items">
                             {% for item in resultSet.pager.currentPageResults %}
                                 {{ include(['@SyliusAdmin/Search/Row/_row_'~resultSet.type~'.html.twig', '@SyliusAdmin/Search/Row/_row.html.twig'], { item: item }) }}
                             {% endfor %}

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/DQL/MatchAgainst.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/DQL/MatchAgainst.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Doctrine\DQL;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\AST\InputParameter;
+use Doctrine\ORM\Query\AST\Literal;
+use Doctrine\ORM\Query\Lexer;
+
+final class MatchAgainst extends FunctionNode
+{
+    /** @var array */
+    public $columns = [];
+    /** @var InputParameter|string */
+    public $needle;
+    /** @var Literal|string */
+    public $mode;
+
+    public function parse(\Doctrine\ORM\Query\Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+
+        do {
+            $this->columns[] = $parser->StateFieldPathExpression();
+            $parser->match(Lexer::T_COMMA);
+        } while ($parser->getLexer()->isNextToken(Lexer::T_IDENTIFIER));
+
+        $this->needle = $parser->InParameter();
+
+        while ($parser->getLexer()->isNextToken(Lexer::T_STRING)) {
+            $this->mode = $parser->Literal();
+        }
+
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(\Doctrine\ORM\Query\SqlWalker $sqlWalker)
+    {
+        $haystack = null;
+        $first = true;
+
+        foreach ($this->columns as $column) {
+            $first ? $first = false : $haystack .= ', ';
+            $haystack .= $column->dispatch($sqlWalker);
+        }
+
+        $query = sprintf('MATCH(%s) AGAINST (%s', $haystack, $this->needle->dispatch($sqlWalker));
+        if ($this->mode) {
+            $query .= sprintf(' %s )', $this->mode->dispatch($sqlWalker));
+        } else {
+            $query .= ' )';
+        }
+
+        return $query;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -39,6 +39,7 @@ doctrine:
                         DATE_FORMAT: Sylius\Bundle\CoreBundle\Doctrine\DQL\DateFormat
                         DAY: Sylius\Bundle\CoreBundle\Doctrine\DQL\Day
                         HOUR: Sylius\Bundle\CoreBundle\Doctrine\DQL\Hour
+                        MATCH_AGAINST: Sylius\Bundle\CoreBundle\Doctrine\DQL\MatchAgainst
                         MONTH: Sylius\Bundle\CoreBundle\Doctrine\DQL\Month
                         WEEK: Sylius\Bundle\CoreBundle\Doctrine\DQL\Week
                         YEAR: Sylius\Bundle\CoreBundle\Doctrine\DQL\Year

--- a/src/Sylius/Bundle/CustomerBundle/Resources/config/doctrine/model/Customer.orm.xml
+++ b/src/Sylius/Bundle/CustomerBundle/Resources/config/doctrine/model/Customer.orm.xml
@@ -48,6 +48,9 @@
         <field name="phoneNumber" column="phone_number" type="string" nullable="true" />
         <field name="subscribedToNewsletter" column="subscribed_to_newsletter" type="boolean" />
 
+        <indexes>
+            <index columns="email,first_name,last_name" flags="fulltext"/>
+        </indexes>
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductAttributeRepository.php
+++ b/src/Sylius/Bundle/ProductBundle/Doctrine/ORM/ProductAttributeRepository.php
@@ -1,48 +1,16 @@
 <?php
 
-/*
- * This file is part of the Sylius package.
- *
- * (c) Paweł Jędrzejewski
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace Sylius\Bundle\ProductBundle\Doctrine\ORM;
 
-use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\Pagerfanta;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
-use Sylius\Component\Product\Repository\ProductOptionRepositoryInterface;
+use Sylius\Component\Product\Repository\ProductAttributeRepositoryInterface;
 use Sylius\Component\Search\Model\SearchQueryInterface;
 
-class ProductOptionRepository extends EntityRepository implements ProductOptionRepositoryInterface
+class ProductAttributeRepository extends EntityRepository implements ProductAttributeRepositoryInterface
 {
-    public function createListQueryBuilder(string $locale): QueryBuilder
-    {
-        return $this->createQueryBuilder('o')
-            ->innerJoin('o.translations', 'translation')
-            ->andWhere('translation.locale = :locale')
-            ->setParameter('locale', $locale)
-        ;
-    }
-
-    public function findByName(string $name, string $locale): array
-    {
-        return $this->createQueryBuilder('o')
-            ->innerJoin('o.translations', 'translation')
-            ->andWhere('translation.name = :name')
-            ->andWhere('translation.locale = :locale')
-            ->setParameter('name', $name)
-            ->setParameter('locale', $locale)
-            ->getQuery()
-            ->getResult()
-        ;
-    }
-
     public function searchWithoutTerms(): Pagerfanta
     {
         $queryBuilder = $this->createQueryBuilder('o');

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductAttributeTranslation.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductAttributeTranslation.orm.xml
@@ -13,6 +13,10 @@
 
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping">
 
-    <mapped-superclass name="Sylius\Component\Product\Model\ProductAttributeTranslation" table="sylius_product_attribute_translation" />
+    <mapped-superclass name="Sylius\Component\Product\Model\ProductAttributeTranslation" table="sylius_product_attribute_translation">
+        <indexes>
+            <index columns="name" flags="fulltext"/>
+        </indexes>
+    </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductOptionTranslation.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductOptionTranslation.orm.xml
@@ -19,6 +19,10 @@
         </id>
 
         <field name="name" column="name" type="string" />
+
+        <indexes>
+            <index columns="name" flags="fulltext"/>
+        </indexes>
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductTranslation.orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/doctrine/model/ProductTranslation.orm.xml
@@ -27,6 +27,10 @@
         <unique-constraints>
             <unique-constraint columns="locale,slug" />
         </unique-constraints>
+
+        <indexes>
+            <index columns="name,description" flags="fulltext"/>
+        </indexes>
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/services/integrations/doctrine/orm.xml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/services/integrations/doctrine/orm.xml
@@ -15,7 +15,7 @@
     <parameters>
         <parameter key="sylius.repository.product.class">Sylius\Bundle\ProductBundle\Doctrine\ORM\ProductRepository</parameter>
         <parameter key="sylius.repository.product_variant.class">Sylius\Bundle\ProductBundle\Doctrine\ORM\ProductVariantRepository</parameter>
-        <parameter key="sylius.repository.product_attribute.class">Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository</parameter>
+        <parameter key="sylius.repository.product_attribute.class">Sylius\Bundle\ProductBundle\Doctrine\ORM\ProductAttributeRepository</parameter>
         <parameter key="sylius.repository.product_option.class">Sylius\Bundle\ProductBundle\Doctrine\ORM\ProductOptionRepository</parameter>
     </parameters>
 </container>

--- a/src/Sylius/Bundle/TaxonomyBundle/Resources/config/doctrine/model/TaxonTranslation.orm.xml
+++ b/src/Sylius/Bundle/TaxonomyBundle/Resources/config/doctrine/model/TaxonTranslation.orm.xml
@@ -26,6 +26,10 @@
         <unique-constraints>
             <unique-constraint columns="locale,slug" name="slug_uidx" />
         </unique-constraints>
+
+        <indexes>
+            <index columns="name,description" flags="fulltext"/>
+        </indexes>
     </mapped-superclass>
 
 </doctrine-mapping>

--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/app.js
@@ -7,6 +7,7 @@
  * file that was distributed with this source code.
  */
 
+import 'jquery-address';
 import 'semantic-ui-css/components/accordion';
 import 'semantic-ui-css/components/checkbox';
 import 'semantic-ui-css/components/dimmer';
@@ -38,7 +39,15 @@ $(document).ready(() => {
   $('.link.ui.dropdown').dropdown({ action: 'hide' });
   $('.button.ui.dropdown').dropdown({ action: 'hide' });
   $('.ui.fluid.search.selection.ui.dropdown').dropdown();
-  $('.ui.tabular.menu .item, .sylius-tabular-form .menu .item').tab();
+  $('.ui.tabular.menu:not(.tabular-historized) .item, .sylius-tabular-form .menu .item').tab();
+  $('.ui.tabular.tabular-historized.menu .item').tab({
+    context: '.tabular-historized-container',
+    history: true,
+  });
+  $('.ui.tab .pagination a').on('click', (event) => {
+    // eslint-disable-next-line no-param-reassign,no-restricted-globals
+    event.target.href = `${event.target.href}${location.hash}`;
+  });
   $('.ui.card .dimmable.image, .ui.cards .card .dimmable.image').dimmer({ on: 'hover' });
   $('.ui.rating').rating('disable');
 

--- a/src/Sylius/Component/Core/Repository/CustomerRepositoryInterface.php
+++ b/src/Sylius/Component/Core/Repository/CustomerRepositoryInterface.php
@@ -15,8 +15,9 @@ namespace Sylius\Component\Core\Repository;
 
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\Component\Search\Repository\SearchableRepositoryInterface;
 
-interface CustomerRepositoryInterface extends RepositoryInterface
+interface CustomerRepositoryInterface extends RepositoryInterface, SearchableRepositoryInterface
 {
     public function countCustomers(): int;
 

--- a/src/Sylius/Component/Core/Repository/ProductRepositoryInterface.php
+++ b/src/Sylius/Component/Core/Repository/ProductRepositoryInterface.php
@@ -18,8 +18,9 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Product\Repository\ProductRepositoryInterface as BaseProductRepositoryInterface;
+use Sylius\Component\Search\Repository\SearchableRepositoryInterface;
 
-interface ProductRepositoryInterface extends BaseProductRepositoryInterface
+interface ProductRepositoryInterface extends BaseProductRepositoryInterface, SearchableRepositoryInterface
 {
     /** @param mixed|null $taxonId */
     public function createListQueryBuilder(string $locale, $taxonId = null): QueryBuilder;

--- a/src/Sylius/Component/Product/Repository/ProductAttributeRepositoryInterface.php
+++ b/src/Sylius/Component/Product/Repository/ProductAttributeRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Product\Repository;
+
+use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\Component\Search\Repository\SearchableRepositoryInterface;
+
+interface ProductAttributeRepositoryInterface extends RepositoryInterface, SearchableRepositoryInterface
+{
+}

--- a/src/Sylius/Component/Product/Repository/ProductOptionRepositoryInterface.php
+++ b/src/Sylius/Component/Product/Repository/ProductOptionRepositoryInterface.php
@@ -16,8 +16,9 @@ namespace Sylius\Component\Product\Repository;
 use Doctrine\ORM\QueryBuilder;
 use Sylius\Component\Product\Model\ProductOptionInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\Component\Search\Repository\SearchableRepositoryInterface;
 
-interface ProductOptionRepositoryInterface extends RepositoryInterface
+interface ProductOptionRepositoryInterface extends RepositoryInterface, SearchableRepositoryInterface
 {
     public function createListQueryBuilder(string $locale): QueryBuilder;
 

--- a/src/Sylius/Component/Search/Model/ResultSet.php
+++ b/src/Sylius/Component/Search/Model/ResultSet.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Search\Model;
+
+use Pagerfanta\Pagerfanta;
+
+class ResultSet implements ResultSetInterface
+{
+    /** @var string */
+    private $type;
+
+    /** @var Pagerfanta */
+    private $pagerfanta;
+
+    public function __construct(string $type, Pagerfanta $pagerfanta)
+    {
+        $this->pagerfanta = $pagerfanta;
+        $this->type = $type;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getPager(): Pagerfanta
+    {
+        return $this->pagerfanta;
+    }
+}

--- a/src/Sylius/Component/Search/Model/ResultSetInterface.php
+++ b/src/Sylius/Component/Search/Model/ResultSetInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Search\Model;
+
+use Pagerfanta\Pagerfanta;
+
+interface ResultSetInterface
+{
+    public function getType(): string;
+
+    public function getPager(): Pagerfanta;
+}

--- a/src/Sylius/Component/Search/Model/SearchQuery.php
+++ b/src/Sylius/Component/Search/Model/SearchQuery.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Search\Model;
+
+use Symfony\Component\HttpFoundation\ParameterBag;
+
+class SearchQuery implements SearchQueryInterface
+{
+    /** @var string */
+    private $locale;
+
+    /** @var string */
+    private $terms;
+
+    /** @var ParameterBag */
+    private $parameterBag;
+
+    public function __construct(string $terms, string $locale, ParameterBag $parameterBag)
+    {
+        $this->terms = $terms;
+        $this->locale = $locale;
+        $this->parameterBag = $parameterBag;
+    }
+
+    public function getTerms(): string
+    {
+        return $this->terms;
+    }
+
+    public function getLocaleCode(): string
+    {
+        return $this->locale;
+    }
+
+    public function getPageNumber(string $type): int
+    {
+        return (int) $this->parameterBag->get(sprintf('page_%s', $type), 1);
+    }
+}

--- a/src/Sylius/Component/Search/Model/SearchQueryInterface.php
+++ b/src/Sylius/Component/Search/Model/SearchQueryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Search\Model;
+
+interface SearchQueryInterface
+{
+    public function getTerms(): string;
+
+    public function getLocaleCode(): string;
+
+    public function getPageNumber(string $type): int;
+}

--- a/src/Sylius/Component/Search/Provider/ResultSetProvider.php
+++ b/src/Sylius/Component/Search/Provider/ResultSetProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Search\Provider;
+
+use Sylius\Component\Search\Model\ResultSet;
+use Sylius\Component\Search\Model\ResultSetInterface;
+use Sylius\Component\Search\Model\SearchQueryInterface;
+use Sylius\Component\Search\Repository\SearchableRepositoryInterface;
+
+final class ResultSetProvider implements ResultSetProviderInterface
+{
+    /** @var string */
+    private $type;
+
+    /** @var SearchableRepositoryInterface */
+    private $searchableRepository;
+
+    public function __construct(string $type, SearchableRepositoryInterface $searchableRepository)
+    {
+        $this->searchableRepository = $searchableRepository;
+        $this->type = $type;
+    }
+
+    public function getResultSet(SearchQueryInterface $query): ResultSetInterface
+    {
+        if (strlen($query->getTerms()) < 3) {
+            $pager = $this->searchableRepository->searchWithoutTerms();
+        } else {
+            $pager = $this->searchableRepository->searchByTerms($query);
+        }
+
+        $pager->setCurrentPage($query->getPageNumber($this->type));
+
+        return new ResultSet($this->type, $pager);
+    }
+}

--- a/src/Sylius/Component/Search/Provider/ResultSetProviderInterface.php
+++ b/src/Sylius/Component/Search/Provider/ResultSetProviderInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Search\Provider;
+
+use Sylius\Component\Search\Model\ResultSetInterface;
+use Sylius\Component\Search\Model\SearchQueryInterface;
+
+interface ResultSetProviderInterface
+{
+    public function getResultSet(SearchQueryInterface $query): ResultSetInterface;
+}

--- a/src/Sylius/Component/Search/Repository/SearchableRepositoryInterface.php
+++ b/src/Sylius/Component/Search/Repository/SearchableRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Search\Repository;
+
+use Pagerfanta\Pagerfanta;
+use Sylius\Component\Search\Model\SearchQueryInterface;
+
+interface SearchableRepositoryInterface
+{
+    public function searchWithoutTerms(): Pagerfanta;
+
+    public function searchByTerms(SearchQueryInterface $query): Pagerfanta;
+}

--- a/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
+++ b/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
@@ -15,9 +15,10 @@ namespace Sylius\Component\Taxonomy\Repository;
 
 use Doctrine\ORM\QueryBuilder;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
+use Sylius\Component\Search\Repository\SearchableRepositoryInterface;
 use Sylius\Component\Taxonomy\Model\TaxonInterface;
 
-interface TaxonRepositoryInterface extends RepositoryInterface
+interface TaxonRepositoryInterface extends RepositoryInterface, SearchableRepositoryInterface
 {
     /**
      * @return array|TaxonInterface[]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5513,6 +5513,11 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
+jquery-address@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/jquery-address/-/jquery-address-1.6.0.tgz#c8ca4bae2dea368e9822494bd2dd413faf4a62b8"
+  integrity sha1-yMpLri3qNo6YIklL0t1BP69KYrg=
+
 jquery.dirtyforms@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/jquery.dirtyforms/-/jquery.dirtyforms-2.0.0.tgz#0a53011595d3d19c2c81c0e91ba0078439ed0d2d"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8 <!-- see the comment below -->
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

Adds a search in the admin for the following resources:
* products
* taxons
* customers
* attributes
* options

[![Demo](https://img.youtube.com/vi/6HcU1aEtYNI/0.jpg)](https://youtu.be/6HcU1aEtYNI)

It should be easy to add new searchable resources thanks to the use of the use of the tag `sylius.search.result_set_provider`. Services with this tag are used to retrieve ressources for given search terms.

<!--
 - Bug fixes must be submitted against the 1.7 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
