### PR TITLE
Patch for Unable to extends ShopBillingData [#11625]

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Channel.orm.xml
@@ -67,7 +67,7 @@
             </join-table>
         </many-to-many>
 
-        <one-to-one field="shopBillingData" target-entity="Sylius\Component\Core\Model\ShopBillingData">
+        <one-to-one field="shopBillingData" target-entity="Sylius\Component\Core\Model\ShopBillingDataInterface">
             <join-column name="shop_billing_data_id" on-delete="CASCADE"/>
             <cascade>
                 <cascade-all />


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #11625 
| License         | MIT

Fix the relation between Channel and ShopBillingData to allow override the ShopBillingData entity.