### PR TITLE
[API] add payment method code to methods endpoint

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethod.xml
@@ -23,5 +23,8 @@
             <group>payment_method:read</group>
             <group>checkout:read</group>
         </attribute>
+        <attribute name="code">
+            <group>payment_method:read</group>
+        </attribute>
     </class>
 </serializer>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

I have added to serialization code of payment method, as it is needed to complete 'select payment method' step in checkout.
![Zrzut ekranu 2020-09-25 o 08 46 03](https://user-images.githubusercontent.com/35863747/94235311-a1a6ae80-ff0b-11ea-920d-de539c237f69.png)
