### PR TITLE
[API][Order] Fixed wrong where condition when looking for order

### DIFF
--- a/features/cart/shopping_cart/maintaining_last_picked_up_cart.feature
+++ b/features/cart/shopping_cart/maintaining_last_picked_up_cart.feature
@@ -1,0 +1,15 @@
+@shopping_cart
+Feature: Maintaining a last picked up cart
+    In order to manage proper cart
+    As a Visitor
+    I want to be able to always maintain last picked up cart
+
+    Background:
+        Given the store operates on a single channel in "United States"
+
+    @api
+    Scenario: Having access to a last picked up cart
+        When I pick up my cart
+        And I pick up my cart again
+        And I check details of my cart
+        Then I should have empty cart

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -144,6 +144,22 @@ final class CartContext implements Context
     }
 
     /**
+     * @When I pick up my cart (again)
+     */
+    public function iPickUpMyCart(): void
+    {
+        $this->pickupCart();
+    }
+
+    /**
+     * @When /^I check details of my (cart)$/
+     */
+    public function iCheckDetailsOfMyCart(string $tokenValue): void
+    {
+        $this->cartsClient->show($tokenValue);
+    }
+
+    /**
      * @Then I don't have access to see the summary of my cart
      */
     public function iDoNotHaveAccessToSeeTheSummaryOfMyCart(): void
@@ -321,6 +337,26 @@ final class CartContext implements Context
         $response = $this->cartsClient->getLastResponse();
 
         Assert::true($this->hasItemWithNameAndQuantity($response, $product->getName(), $quantity));
+    }
+
+    /**
+     * @Then /^I should have empty (cart)$/
+     */
+    public function iShouldHaveEmptyCart(string $tokenValue): void
+    {
+        $items = $this->responseChecker->getValue($this->cartsClient->show($tokenValue), 'items');
+
+        Assert::same(count($items), 0, 'There should be an empty cart');
+    }
+
+    private function pickupCart(): string
+    {
+        $this->cartsClient->buildCreateRequest();
+        $tokenValue = $this->responseChecker->getValue($this->cartsClient->create(), 'tokenValue');
+
+        $this->sharedStorage->set('cart_token', $tokenValue);
+
+        return $tokenValue;
     }
 
     private function putProductToCart(ProductInterface $product, string $tokenValue, int $quantity = 1): void

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/QueryItemExtension/OrderGetMethodItemExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/QueryItemExtension/OrderGetMethodItemExtension.php
@@ -67,8 +67,7 @@ final class OrderGetMethodItemExtension implements QueryItemExtensionInterface
             $queryBuilder
                 ->leftJoin(sprintf('%s.customer', $rootAlias), 'customer')
                 ->leftJoin('customer.user', 'user')
-                ->andWhere('user IS NULL')
-                ->orWhere(sprintf('%s.customer IS NULL', $rootAlias))
+                ->andWhere($queryBuilder->expr()->orX('user IS NULL', sprintf('%s.customer IS NULL', $rootAlias)))
             ;
 
             return;

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/QueryItemExtension/OrderMethodsItemExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/QueryItemExtension/OrderMethodsItemExtension.php
@@ -70,8 +70,7 @@ final class OrderMethodsItemExtension implements QueryItemExtensionInterface
             $queryBuilder
                 ->leftJoin(sprintf('%s.customer', $rootAlias), 'customer')
                 ->leftJoin('customer.user', 'user')
-                ->andWhere('user IS NULL')
-                ->orWhere(sprintf('%s.customer IS NULL', $rootAlias))
+                ->andWhere($queryBuilder->expr()->orX('user IS NULL', sprintf('%s.customer IS NULL', $rootAlias)))
                 ->andWhere(sprintf('%s.state = :state', $rootAlias))
                 ->setParameter('state', OrderInterface::STATE_CART)
             ;

--- a/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryItemExtension/OrderGetMethodItemExtensionSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryItemExtension/OrderGetMethodItemExtensionSpec.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\ApiBundle\Doctrine\QueryItemExtension;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\ApiBundle\Context\UserContextInterface;
@@ -34,7 +35,8 @@ final class OrderGetMethodItemExtensionSpec extends ObjectBehavior
     function it_applies_conditions_to_get_order_with_state_cart_and_without_user_if_current_user_is_null(
         UserContextInterface $userContext,
         QueryBuilder $queryBuilder,
-        QueryNameGeneratorInterface $queryNameGenerator
+        QueryNameGeneratorInterface $queryNameGenerator,
+        Expr $expr
     ): void {
         $queryBuilder->getRootAliases()->willReturn(['o']);
 
@@ -53,13 +55,18 @@ final class OrderGetMethodItemExtensionSpec extends ObjectBehavior
         ;
 
         $queryBuilder
-            ->andWhere('user IS NULL')
+            ->expr()
             ->shouldBeCalled()
-            ->willReturn($queryBuilder)
+            ->willReturn($expr);
+
+        $expr
+            ->orX('user IS NULL', sprintf('%s.customer IS NULL', 'o'))
+            ->shouldBeCalled()
+            ->willReturn(sprintf('user IS NULL OR %s.customer IS NULL', 'o'))
         ;
 
         $queryBuilder
-            ->orWhere(sprintf('%s.customer IS NULL', 'o'))
+            ->andWhere(sprintf('user IS NULL OR %s.customer IS NULL', 'o'))
             ->shouldBeCalled()
             ->willReturn($queryBuilder)
         ;

--- a/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryItemExtension/OrderMethodsItemExtensionSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryItemExtension/OrderMethodsItemExtensionSpec.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\ApiBundle\Doctrine\QueryItemExtension;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\ApiBundle\Context\UserContextInterface;
@@ -35,7 +36,8 @@ final class OrderMethodsItemExtensionSpec extends ObjectBehavior
     function it_applies_conditions_to_delete_order_with_state_cart_and_with_null_user_and_customer_if_present_user_and_customer_are_null(
         UserContextInterface $userContext,
         QueryBuilder $queryBuilder,
-        QueryNameGeneratorInterface $queryNameGenerator
+        QueryNameGeneratorInterface $queryNameGenerator,
+        Expr $expr
     ): void {
         $queryBuilder->getRootAliases()->willReturn(['o']);
 
@@ -54,13 +56,18 @@ final class OrderMethodsItemExtensionSpec extends ObjectBehavior
         ;
 
         $queryBuilder
-            ->andWhere('user IS NULL')
+            ->expr()
             ->shouldBeCalled()
-            ->willReturn($queryBuilder)
+            ->willReturn($expr);
+
+        $expr
+            ->orX('user IS NULL', sprintf('%s.customer IS NULL', 'o'))
+            ->shouldBeCalled()
+            ->willReturn(sprintf('user IS NULL OR %s.customer IS NULL', 'o'))
         ;
 
         $queryBuilder
-            ->orWhere(sprintf('%s.customer IS NULL', 'o'))
+            ->andWhere(sprintf('user IS NULL OR %s.customer IS NULL', 'o'))
             ->shouldBeCalled()
             ->willReturn($queryBuilder)
         ;
@@ -90,7 +97,8 @@ final class OrderMethodsItemExtensionSpec extends ObjectBehavior
     function it_applies_conditions_to_patch_order_with_state_cart_and_with_null_user_and_customer_if_present_user_and_customer_are_null(
         UserContextInterface $userContext,
         QueryBuilder $queryBuilder,
-        QueryNameGeneratorInterface $queryNameGenerator
+        QueryNameGeneratorInterface $queryNameGenerator,
+        Expr $expr
     ): void {
         $queryBuilder->getRootAliases()->willReturn(['o']);
 
@@ -109,13 +117,18 @@ final class OrderMethodsItemExtensionSpec extends ObjectBehavior
         ;
 
         $queryBuilder
-            ->andWhere('user IS NULL')
+            ->expr()
             ->shouldBeCalled()
-            ->willReturn($queryBuilder)
+            ->willReturn($expr);
+
+        $expr
+            ->orX('user IS NULL', sprintf('%s.customer IS NULL', 'o'))
+            ->shouldBeCalled()
+            ->willReturn(sprintf('user IS NULL OR %s.customer IS NULL', 'o'))
         ;
 
         $queryBuilder
-            ->orWhere(sprintf('%s.customer IS NULL', 'o'))
+            ->andWhere(sprintf('user IS NULL OR %s.customer IS NULL', 'o'))
             ->shouldBeCalled()
             ->willReturn($queryBuilder)
         ;
@@ -145,7 +158,8 @@ final class OrderMethodsItemExtensionSpec extends ObjectBehavior
     function it_applies_conditions_to_put_order_with_state_cart_and_with_null_user_and_customer_if_present_user_and_customer_are_null(
         UserContextInterface $userContext,
         QueryBuilder $queryBuilder,
-        QueryNameGeneratorInterface $queryNameGenerator
+        QueryNameGeneratorInterface $queryNameGenerator,
+        Expr $expr
     ): void {
         $queryBuilder->getRootAliases()->willReturn(['o']);
 
@@ -164,13 +178,18 @@ final class OrderMethodsItemExtensionSpec extends ObjectBehavior
         ;
 
         $queryBuilder
-            ->andWhere('user IS NULL')
+            ->expr()
             ->shouldBeCalled()
-            ->willReturn($queryBuilder)
+            ->willReturn($expr);
+
+        $expr
+            ->orX('user IS NULL', sprintf('%s.customer IS NULL', 'o'))
+            ->shouldBeCalled()
+            ->willReturn(sprintf('user IS NULL OR %s.customer IS NULL', 'o'))
         ;
 
         $queryBuilder
-            ->orWhere(sprintf('%s.customer IS NULL', 'o'))
+            ->andWhere(sprintf('user IS NULL OR %s.customer IS NULL', 'o'))
             ->shouldBeCalled()
             ->willReturn($queryBuilder)
         ;
@@ -217,6 +236,7 @@ final class OrderMethodsItemExtensionSpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn($queryBuilder)
         ;
+
         $queryBuilder
             ->setParameter('customer', 1)
             ->shouldBeCalled()
@@ -313,6 +333,7 @@ final class OrderMethodsItemExtensionSpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn($queryBuilder)
         ;
+
         $queryBuilder
             ->setParameter('customer', 1)
             ->shouldBeCalled()
@@ -361,6 +382,7 @@ final class OrderMethodsItemExtensionSpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn($queryBuilder)
         ;
+
         $queryBuilder
             ->setParameter('customer', 1)
             ->shouldBeCalled()
@@ -409,6 +431,7 @@ final class OrderMethodsItemExtensionSpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn($queryBuilder)
         ;
+
         $queryBuilder
             ->setParameter('customer', 1)
             ->shouldBeCalled()
@@ -457,6 +480,7 @@ final class OrderMethodsItemExtensionSpec extends ObjectBehavior
             ->shouldBeCalled()
             ->willReturn($queryBuilder)
         ;
+
         $queryBuilder
             ->setParameter('customer', 1)
             ->shouldBeCalled()


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

Wrong query:
```sql
SELECT s0_.number AS number_0, s0_.notes AS notes_1, s0_.state AS state_2, s0_.checkout_completed_at AS checkout_completed_at_3, s0_.items_total AS items_total_4, s0_.adjustments_total AS adjustments_total_5, s0_.total AS total_6, s0_.created_at AS created_at_7, s0_.updated_at AS updated_at_8, s0_.id AS id_9, s0_.currency_code AS currency_code_10, s0_.locale_code AS locale_code_11, s0_.checkout_state AS checkout_state_12, s0_.payment_state AS payment_state_13, s0_.shipping_state AS shipping_state_14, s0_.token_value AS token_value_15, s0_.customer_ip AS customer_ip_16, s1_.quantity AS quantity_17, s1_.unit_price AS unit_price_18, s1_.units_total AS units_total_19, s1_.adjustments_total AS adjustments_total_20, s1_.total AS total_21, s1_.is_immutable AS is_immutable_22, s1_.id AS id_23, s1_.product_name AS product_name_24, s1_.variant_name AS variant_name_25, s0_.channel_id AS channel_id_26, s0_.promotion_coupon_id AS promotion_coupon_id_27, s0_.customer_id AS customer_id_28, s0_.shipping_address_id AS shipping_address_id_29, s0_.billing_address_id AS billing_address_id_30, s1_.order_id AS order_id_31, s1_.variant_id AS variant_id_32 FROM sylius_order s0_ LEFT JOIN sylius_customer s2_ ON s0_.customer_id = s2_.id LEFT JOIN patient p3_ ON s2_.id = p3_.customer_id LEFT JOIN sylius_order_item s1_ ON s0_.id = s1_.order_id WHERE (s0_.token_value = ? AND p3_.id IS NULL) OR s0_.customer_id IS NULL)) AND s0_.state = ?
```

Fixed query:
```sql
SELECT s0_.number AS number_0, s0_.notes AS notes_1, s0_.state AS state_2, s0_.checkout_completed_at AS checkout_completed_at_3, s0_.items_total AS items_total_4, s0_.adjustments_total AS adjustments_total_5, s0_.total AS total_6, s0_.created_at AS created_at_7, s0_.updated_at AS updated_at_8, s0_.id AS id_9, s0_.currency_code AS currency_code_10, s0_.locale_code AS locale_code_11, s0_.checkout_state AS checkout_state_12, s0_.payment_state AS payment_state_13, s0_.shipping_state AS shipping_state_14, s0_.token_value AS token_value_15, s0_.customer_ip AS customer_ip_16, s1_.quantity AS quantity_17, s1_.unit_price AS unit_price_18, s1_.units_total AS units_total_19, s1_.adjustments_total AS adjustments_total_20, s1_.total AS total_21, s1_.is_immutable AS is_immutable_22, s1_.id AS id_23, s1_.product_name AS product_name_24, s1_.variant_name AS variant_name_25, s0_.channel_id AS channel_id_26, s0_.promotion_coupon_id AS promotion_coupon_id_27, s0_.customer_id AS customer_id_28, s0_.shipping_address_id AS shipping_address_id_29, s0_.billing_address_id AS billing_address_id_30, s1_.order_id AS order_id_31, s1_.variant_id AS variant_id_32 FROM sylius_order s0_ LEFT JOIN sylius_customer s2_ ON s0_.customer_id = s2_.id LEFT JOIN patient p3_ ON s2_.id = p3_.customer_id LEFT JOIN sylius_order_item s1_ ON s0_.id = s1_.order_id WHERE s0_.token_value = ? AND (p3_.id IS NULL OR s0_.customer_id IS NULL) AND s0_.state = ?
```

With first it will find more than one result cause if you allow guess orders, nor user, nor customer is set.

<!--
 - Bug fixes must be submitted against the 1.7 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
