### PR TITLE
[1.8] Fix migration generation

### DIFF
--- a/src/Sylius/Bundle/AdminApiBundle/DependencyInjection/SyliusAdminApiExtension.php
+++ b/src/Sylius/Bundle/AdminApiBundle/DependencyInjection/SyliusAdminApiExtension.php
@@ -65,10 +65,11 @@ final class SyliusAdminApiExtension extends AbstractResourceExtension implements
             return;
         }
 
+        $doctrineConfig = $container->getExtensionConfig('doctrine_migrations');
         $container->prependExtensionConfig('doctrine_migrations', [
-            'migrations_paths' => [
+            'migrations_paths' => \array_merge(\array_pop($doctrineConfig)['migrations_paths'] ?? [], [
                 'Sylius\Bundle\AdminApiBundle\Migrations' => '@SyliusAdminApiBundle/Migrations',
-            ],
+            ]),
         ]);
 
         $container->prependExtensionConfig('sylius_labs_doctrine_migrations_extra', [

--- a/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/DependencyInjection/SyliusCoreExtension.php
@@ -100,10 +100,11 @@ final class SyliusCoreExtension extends AbstractResourceExtension implements Pre
             return;
         }
 
+        $doctrineConfig = $container->getExtensionConfig('doctrine_migrations');
         $container->prependExtensionConfig('doctrine_migrations', [
-            'migrations_paths' => [
+            'migrations_paths' => \array_merge(\array_pop($doctrineConfig)['migrations_paths'] ?? [], [
                 'Sylius\Bundle\CoreBundle\Migrations' => '@SyliusCoreBundle/Migrations',
-            ],
+            ]),
         ]);
 
         $container->prependExtensionConfig('sylius_labs_doctrine_migrations_extra', [
@@ -111,11 +112,5 @@ final class SyliusCoreExtension extends AbstractResourceExtension implements Pre
                 'Sylius\Bundle\CoreBundle\Migrations' => [],
             ],
         ]);
-
-        // set application "migrations_path" configuration as default to not require `--namespace` option for `doctrine:migrations:diff`
-        $doctrineConfig = $container->getExtensionConfig('doctrine_migrations');
-        if (count($doctrineConfig) > 2 && isset($doctrineConfig[count($doctrineConfig)-1]['migrations_paths'])) {
-            $container->prependExtensionConfig('doctrine_migrations', \array_pop($doctrineConfig));
-        }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8 
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #11864, continuation of #11898
| License         | MIT

As I mentionned in [slack](https://sylius-devs.slack.com/archives/CBV3ZLA8P/p1601565976036000?thread_ts=1601372428.024800&cid=CBV3ZLA8P) after trying the fix provided by @Zales0123, there is still a problem when the AdminApiBundle is registered after CoreBundle in `config/bundles.php`.

This PR should fix that, by merging the new migration_path of CoreBundle AND AdminApiBundle with the latest migration_path provided in `doctrine_migrations` config. That's the project one.

