### PR TITLE
Removing typehint for Symfony 4.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         "symfony/polyfill-php80": "^1.17",
         "symfony/process": "^4.4",
         "symfony/property-access": "^4.4",
-        "symfony/property-info": "4.4.*",
+        "symfony/property-info": "^4.4",
         "symfony/proxy-manager-bridge": "^4.4",
         "symfony/routing": "^4.4",
         "symfony/security-bundle": "^4.4",

--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,7 @@
         "symfony/polyfill-php80": "^1.17",
         "symfony/process": "^4.4",
         "symfony/property-access": "^4.4",
+        "symfony/property-info": "4.4.*",
         "symfony/proxy-manager-bridge": "^4.4",
         "symfony/routing": "^4.4",
         "symfony/security-bundle": "^4.4",

--- a/src/Sylius/Bundle/ApiBundle/PropertyInfo/Extractor/EmptyPropertyListExtractor.php
+++ b/src/Sylius/Bundle/ApiBundle/PropertyInfo/Extractor/EmptyPropertyListExtractor.php
@@ -18,7 +18,7 @@ use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
 /** @experimental */
 final class EmptyPropertyListExtractor implements PropertyListExtractorInterface
 {
-    public function getProperties(string $class, array $context = []): ?array
+    public function getProperties($class, array $context = []): ?array
     {
         if (class_exists($class)) {
             return [];


### PR DESCRIPTION
In the [symfony/property-info 4.4](https://github.com/symfony/property-info/blob/v4.4.15/PropertyListExtractorInterface.php) the interface does not have a string typehint so Sylius does nolonger work with 4.4

| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no (fixing one)
| Deprecations?   | no
| Related tickets | -
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
