### PR TITLE
[API] Refactor SubresourceIdAwareCommandDataTransformer into two more precise implementation

### DIFF
--- a/UPGRADE-1.9.md
+++ b/UPGRADE-1.9.md
@@ -1,0 +1,5 @@
+# UPGRADE FROM `v1.8.x` TO `v1.9.0`
+
+1. `Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareInterface` has been split into `Sylius\Bundle\ApiBundle\Command\PaymentIdSubresourceAwareInterface`
+ and `Sylius\Bundle\ApiBundle\Command\ShipmentIdSubresourceAwareInterface`. Classes which implement these interfaces don't 
+ need to specify request attribute. This logic was transferred to coresponding data transformer. Please adjust your code accordingly.

--- a/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChoosePaymentMethod.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChoosePaymentMethod.php
@@ -14,10 +14,11 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\Command\Checkout;
 
 use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\PaymentIdSubresourceAwareInterface;
 use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareInterface;
 
 /** @experimental */
-class ChoosePaymentMethod implements OrderTokenValueAwareInterface, SubresourceIdAwareInterface
+class ChoosePaymentMethod implements OrderTokenValueAwareInterface, PaymentIdSubresourceAwareInterface
 {
     /** @var string|null */
     public $orderTokenValue;
@@ -51,18 +52,13 @@ class ChoosePaymentMethod implements OrderTokenValueAwareInterface, SubresourceI
         $this->orderTokenValue = $orderTokenValue;
     }
 
-    public function getSubresourceId(): ?string
+    public function getPaymentId(): string
     {
         return $this->paymentId;
     }
 
-    public function setSubresourceId(?string $subresourceId): void
+    public function setPaymentId(string $paymentId): void
     {
-        $this->paymentId = $subresourceId;
-    }
-
-    public function getSubresourceIdAttributeKey(): string
-    {
-        return 'paymentId';
+        $this->paymentId = $paymentId;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChooseShippingMethod.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChooseShippingMethod.php
@@ -14,10 +14,11 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\Command\Checkout;
 
 use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\ShipmentIdSubresourceAwareInterface;
 use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareInterface;
 
 /** @experimental */
-class ChooseShippingMethod implements OrderTokenValueAwareInterface, SubresourceIdAwareInterface
+class ChooseShippingMethod implements OrderTokenValueAwareInterface, ShipmentIdSubresourceAwareInterface
 {
     /** @var string|null */
     public $orderTokenValue;
@@ -47,18 +48,13 @@ class ChooseShippingMethod implements OrderTokenValueAwareInterface, Subresource
         $this->orderTokenValue = $orderTokenValue;
     }
 
-    public function getSubresourceId(): ?string
+    public function getShipmentId(): string
     {
         return $this->shipmentId;
     }
 
-    public function setSubresourceId(?string $subresourceId): void
+    public function setShipmentId(string $shipmentId): void
     {
-        $this->shipmentId = $subresourceId;
-    }
-
-    public function getSubresourceIdAttributeKey(): string
-    {
-        return 'shipmentId';
+        $this->shipmentId = $shipmentId;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Command/PaymentIdSubresourceAwareInterface.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/PaymentIdSubresourceAwareInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Command;
+
+/** @experimental */
+interface PaymentIdSubresourceAwareInterface extends CommandAwareDataTransformerInterface
+{
+    public function getPaymentId(): string;
+
+    public function setPaymentId(string $subresourceId): void;
+}

--- a/src/Sylius/Bundle/ApiBundle/Command/ShipmentIdSubresourceAwareInterface.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/ShipmentIdSubresourceAwareInterface.php
@@ -13,11 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Command;
 
-interface SubresourceIdAwareInterface extends CommandAwareDataTransformerInterface
+/** @experimental */
+interface ShipmentIdSubresourceAwareInterface extends CommandAwareDataTransformerInterface
 {
-    public function getSubresourceId(): ?string;
+    public function getShipmentId(): string;
 
-    public function setSubresourceId(?string $subresourceId): void;
-
-    public function getSubresourceIdAttributeKey(): string;
+    public function setShipmentId(string $shipmentId): void;
 }

--- a/src/Sylius/Bundle/ApiBundle/DataTransformer/PaymentIdSubresourceAwareCommandDataTransformer.php
+++ b/src/Sylius/Bundle/ApiBundle/DataTransformer/PaymentIdSubresourceAwareCommandDataTransformer.php
@@ -13,12 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\DataTransformer;
 
-use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\PaymentIdSubresourceAwareInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Webmozart\Assert\Assert;
 
 /** @experimental */
-final class SubresourceIdAwareCommandDataTransformer implements CommandDataTransformerInterface
+final class PaymentIdSubresourceAwareCommandDataTransformer implements CommandDataTransformerInterface
 {
     /** @var RequestStack */
     private $requestStack;
@@ -30,21 +30,21 @@ final class SubresourceIdAwareCommandDataTransformer implements CommandDataTrans
 
     public function transform($object, string $to, array $context = [])
     {
+        /** @var PaymentIdSubresourceAwareInterface $object */
         $attributes = $this->requestStack->getCurrentRequest()->attributes;
 
-        $attributeKey = $object->getSubresourceIdAttributeKey();
-        Assert::true($attributes->has($attributeKey), 'Path does not have subresource id');
+        Assert::true($attributes->has('paymentId'), 'Path does not have payment id');
 
         /** @var string $subresourceId */
-        $subresourceId = $attributes->get($object->getSubresourceIdAttributeKey());
+        $paymentId = $attributes->get('paymentId');
 
-        $object->setSubresourceId($subresourceId);
+        $object->setPaymentId($paymentId);
 
         return $object;
     }
 
     public function supportsTransformation($object): bool
     {
-        return $object instanceof SubresourceIdAwareInterface;
+        return $object instanceof PaymentIdSubresourceAwareInterface;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/DataTransformer/ShipmentIdSubresourceAwareCommandDataTransformer.php
+++ b/src/Sylius/Bundle/ApiBundle/DataTransformer/ShipmentIdSubresourceAwareCommandDataTransformer.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\DataTransformer;
+
+use Sylius\Bundle\ApiBundle\Command\ShipmentIdSubresourceAwareInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Webmozart\Assert\Assert;
+
+/** @experimental */
+final class ShipmentIdSubresourceAwareCommandDataTransformer implements CommandDataTransformerInterface
+{
+    /** @var RequestStack */
+    private $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    public function transform($object, string $to, array $context = [])
+    {
+        /** @var ShipmentIdSubresourceAwareInterface $object */
+        $attributes = $this->requestStack->getCurrentRequest()->attributes;
+
+        Assert::true($attributes->has('shipmentId'), 'Path does not have shipment id');
+
+        /** @var string $subresourceId */
+        $shipmentId = $attributes->get('shipmentId');
+
+        $object->setShipmentId($shipmentId);
+
+        return $object;
+    }
+
+    public function supportsTransformation($object): bool
+    {
+        return $object instanceof ShipmentIdSubresourceAwareInterface;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -99,7 +99,12 @@
             <tag name="sylius.api.command_data_transformer" />
         </service>
 
-        <service id="sylius.api.data_transformer.subresource_id_aware_data_transformer" class="Sylius\Bundle\ApiBundle\DataTransformer\SubresourceIdAwareCommandDataTransformer">
+        <service id="sylius.api.data_transformer.shipment_id_subresource_aware_data_transformer" class="Sylius\Bundle\ApiBundle\DataTransformer\ShipmentIdSubresourceAwareCommandDataTransformer">
+            <argument type="service" id="request_stack" />
+            <tag name="sylius.api.command_data_transformer" />
+        </service>
+
+        <service id="sylius.api.data_transformer.payment_id_subresource_aware_data_transformer" class="Sylius\Bundle\ApiBundle\DataTransformer\PaymentIdSubresourceAwareCommandDataTransformer">
             <argument type="service" id="request_stack" />
             <tag name="sylius.api.command_data_transformer" />
         </service>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bugfix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This PR aims to define corresponding fields of request in service instead of command, as it seems to break the encapsulation of data. The command is aware of some external object, while service without proper command is incomplete in its business logic. 
<!--
 - Bug fixes must be submitted against the 1.7 branches (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
