### PR TITLE
[Cart] Change logic for maintaining cart after logging in

### DIFF
--- a/features/cart/shopping_cart/clearing_cart_after_logging_out.feature
+++ b/features/cart/shopping_cart/clearing_cart_after_logging_out.feature
@@ -19,4 +19,4 @@ Feature: Clearing cart after logging out
     @api
     Scenario: Clearing cart after logging out
         When I log out
-        Then I don't have access to see the summary of my cart
+        Then I don't have access to see the summary of my previous cart

--- a/features/cart/shopping_cart/maintaining_cart_after_authorization.feature
+++ b/features/cart/shopping_cart/maintaining_cart_after_authorization.feature
@@ -17,7 +17,7 @@ Feature: Maintaining cart after authorization
         Then there should be one item in my cart
         And this item should have name "Stark T-Shirt"
 
-    @ui
+    @ui @api
     Scenario: Having cart maintained after logging in when the user has been logged in earlier and has empty cart
         When I log in as "robb@stark.com" with "KingInTheNorth" password
         And I log out
@@ -27,7 +27,7 @@ Feature: Maintaining cart after authorization
         Then there should be one item in my cart
         And this item should have name "Stark T-Shirt"
 
-    @ui
+    @ui @api
     Scenario: Having cart maintained after logging in when the user has removed all items from the cart earlier
         When I log in as "robb@stark.com" with "KingInTheNorth" password
         And I add "Stark T-Shirt" product to the cart
@@ -39,7 +39,7 @@ Feature: Maintaining cart after authorization
         Then there should be one item in my cart
         And this item should have name "Stark T-Shirt"
 
-    @ui
+    @ui @api
     Scenario: Having cart maintained after logging in when the user has cleared the cart earlier
         When I log in as "robb@stark.com" with "KingInTheNorth" password
         And I add "Stark T-Shirt" product to the cart

--- a/features/cart/shopping_cart/maintaining_cart_after_authorization.feature
+++ b/features/cart/shopping_cart/maintaining_cart_after_authorization.feature
@@ -6,7 +6,7 @@ Feature: Maintaining cart after authorization
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store has a product "Stark T-shirt" priced at "$12.00"
+        And the store has a product "Stark T-Shirt" priced at "$12.00"
         And there is a user "robb@stark.com" identified by "KingInTheNorth"
 
     @ui @api
@@ -15,9 +15,9 @@ Feature: Maintaining cart after authorization
         And I log in as "robb@stark.com" with "KingInTheNorth" password
         And I see the summary of my cart
         Then there should be one item in my cart
-        And this item should have name "Stark T-shirt"
+        And this item should have name "Stark T-Shirt"
 
-    @ui @api @todo
+    @ui
     Scenario: Having cart maintained after logging in when the user has been logged in earlier and has empty cart
         When I log in as "robb@stark.com" with "KingInTheNorth" password
         And I log out
@@ -25,9 +25,9 @@ Feature: Maintaining cart after authorization
         And I log in as "robb@stark.com" with "KingInTheNorth" password
         And I see the summary of my cart
         Then there should be one item in my cart
-        And this item should have name "Stark T-shirt"
+        And this item should have name "Stark T-Shirt"
 
-    @ui @api @todo
+    @ui
     Scenario: Having cart maintained after logging in when the user has removed all items from the cart earlier
         When I log in as "robb@stark.com" with "KingInTheNorth" password
         And I add "Stark T-Shirt" product to the cart
@@ -37,9 +37,9 @@ Feature: Maintaining cart after authorization
         And I log in as "robb@stark.com" with "KingInTheNorth" password
         And I see the summary of my cart
         Then there should be one item in my cart
-        And this item should have name "Stark T-shirt"
+        And this item should have name "Stark T-Shirt"
 
-    @ui @api
+    @ui
     Scenario: Having cart maintained after logging in when the user has cleared the cart earlier
         When I log in as "robb@stark.com" with "KingInTheNorth" password
         And I add "Stark T-Shirt" product to the cart
@@ -49,7 +49,7 @@ Feature: Maintaining cart after authorization
         And I log in as "robb@stark.com" with "KingInTheNorth" password
         And I see the summary of my cart
         Then there should be one item in my cart
-        And this item should have name "Stark T-shirt"
+        And this item should have name "Stark T-Shirt"
 
     @ui
     Scenario: Having cart maintained after registration
@@ -57,4 +57,4 @@ Feature: Maintaining cart after authorization
         When I register with email "eddard@stak.com" and password "handOfTheKing"
         And I see the summary of my cart
         Then there should be one item in my cart
-        And this item should have name "Stark T-shirt"
+        And this item should have name "Stark T-Shirt"

--- a/features/cart/shopping_cart/maintaining_cart_after_authorization.feature
+++ b/features/cart/shopping_cart/maintaining_cart_after_authorization.feature
@@ -1,6 +1,6 @@
 @shopping_cart
 Feature: Maintaining cart after authorization
-    In order to not lose cart after authorization
+    In order not to lose cart after authorization
     As a Visitor
     I want to be able to have my cart maintained
 
@@ -12,6 +12,40 @@ Feature: Maintaining cart after authorization
     @ui @api
     Scenario: Having cart maintained after logging in
         When I add "Stark T-Shirt" product to the cart
+        And I log in as "robb@stark.com" with "KingInTheNorth" password
+        And I see the summary of my cart
+        Then there should be one item in my cart
+        And this item should have name "Stark T-shirt"
+
+    @ui @api @todo
+    Scenario: Having cart maintained after logging in when the user has been logged in earlier and has empty cart
+        When I log in as "robb@stark.com" with "KingInTheNorth" password
+        And I log out
+        And I add "Stark T-Shirt" product to the cart
+        And I log in as "robb@stark.com" with "KingInTheNorth" password
+        And I see the summary of my cart
+        Then there should be one item in my cart
+        And this item should have name "Stark T-shirt"
+
+    @ui @api @todo
+    Scenario: Having cart maintained after logging in when the user has removed all items from the cart earlier
+        When I log in as "robb@stark.com" with "KingInTheNorth" password
+        And I add "Stark T-Shirt" product to the cart
+        And I remove product "Stark T-Shirt" from the cart
+        And I log out
+        And I add "Stark T-Shirt" product to the cart
+        And I log in as "robb@stark.com" with "KingInTheNorth" password
+        And I see the summary of my cart
+        Then there should be one item in my cart
+        And this item should have name "Stark T-shirt"
+
+    @ui @api
+    Scenario: Having cart maintained after logging in when the user has cleared the cart earlier
+        When I log in as "robb@stark.com" with "KingInTheNorth" password
+        And I add "Stark T-Shirt" product to the cart
+        And I clear my cart
+        And I log out
+        And I add "Stark T-Shirt" product to the cart
         And I log in as "robb@stark.com" with "KingInTheNorth" password
         And I see the summary of my cart
         Then there should be one item in my cart

--- a/features/cart/shopping_cart/maintaining_previous_cart_after_authorization.feature
+++ b/features/cart/shopping_cart/maintaining_previous_cart_after_authorization.feature
@@ -16,6 +16,6 @@ Feature: Maintaining previous cart after authorization
         And I log out
         And I add "Targaryen T-Shirt" product to the cart
         And I log in as "robb@stark.com" with "KingInTheNorth" password
-        And I see the summary of my cart
+        And I see the summary of my previous cart
         Then there should be one item in my cart
         And this item should have name "Stark T-Shirt"

--- a/features/cart/shopping_cart/maintaining_previous_cart_after_authorization.feature
+++ b/features/cart/shopping_cart/maintaining_previous_cart_after_authorization.feature
@@ -6,7 +6,7 @@ Feature: Maintaining previous cart after authorization
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store has a product "Stark T-shirt" priced at "$12.00"
+        And the store has "Stark T-shirt" and "Targaryen T-shirt" products
         And there is a user "robb@stark.com" identified by "KingInTheNorth"
         And I log in as "robb@stark.com" with "KingInTheNorth" password
 
@@ -14,6 +14,7 @@ Feature: Maintaining previous cart after authorization
     Scenario: Having cart maintained after logging out and then logging in
         When I add "Stark T-Shirt" product to the cart
         And I log out
+        And I add "Targaryen T-Shirt" product to the cart
         And I log in as "robb@stark.com" with "KingInTheNorth" password
         And I see the summary of my cart
         Then there should be one item in my cart

--- a/features/cart/shopping_cart/maintaining_previous_cart_after_authorization.feature
+++ b/features/cart/shopping_cart/maintaining_previous_cart_after_authorization.feature
@@ -6,7 +6,7 @@ Feature: Maintaining previous cart after authorization
 
     Background:
         Given the store operates on a single channel in "United States"
-        And the store has "Stark T-shirt" and "Targaryen T-shirt" products
+        And the store has "Stark T-Shirt" and "Targaryen T-Shirt" products
         And there is a user "robb@stark.com" identified by "KingInTheNorth"
         And I log in as "robb@stark.com" with "KingInTheNorth" password
 
@@ -18,4 +18,4 @@ Feature: Maintaining previous cart after authorization
         And I log in as "robb@stark.com" with "KingInTheNorth" password
         And I see the summary of my cart
         Then there should be one item in my cart
-        And this item should have name "Stark T-shirt"
+        And this item should have name "Stark T-Shirt"

--- a/src/Sylius/Behat/Client/ApiPlatformClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformClient.php
@@ -221,8 +221,8 @@ final class ApiPlatformClient implements ApiClientInterface
         return $this->getLastResponse();
     }
 
-    private function getToken(): string
+    private function getToken(): ?string
     {
-        return $this->sharedStorage->has('token') ? $this->sharedStorage->get('token') : '';
+        return $this->sharedStorage->has('token') ? $this->sharedStorage->get('token') : null;
     }
 }

--- a/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
@@ -91,5 +91,10 @@ final class ApiPlatformSecurityClient implements ApiSecurityClientInterface
     public function logOut(): void
     {
         $this->sharedStorage->set('token', null);
+
+        if ($this->sharedStorage->has('cart_token')) {
+            $this->sharedStorage->set('previous_cart_token', $this->sharedStorage->get('cart_token'));
+            $this->sharedStorage->set('cart_token', null);
+        }
     }
 }

--- a/src/Sylius/Behat/Client/Request.php
+++ b/src/Sylius/Behat/Client/Request.php
@@ -57,19 +57,20 @@ final class Request implements RequestInterface
         );
     }
 
-    public static function show(?string $section, string $resource, string $id, string $token): RequestInterface
+    public static function show(?string $section, string $resource, string $id, ?string $token = null): RequestInterface
     {
+        $headers = $token ? ['HTTP_Authorization' => 'Bearer ' . $token] : [];
+
         return new self(
             sprintf('/new-api/%s%s/%s', self::prepareSection($section), $resource, $id),
             HttpRequest::METHOD_GET,
-            ['HTTP_Authorization' => 'Bearer ' . $token]
+            $headers
         );
     }
 
     public static function create(?string $section, string $resource, ?string $token = null): RequestInterface
     {
         $headers = ['CONTENT_TYPE' => 'application/ld+json'];
-
         if ($token !== null) {
             $headers['HTTP_Authorization'] = 'Bearer ' . $token;
         }
@@ -81,21 +82,28 @@ final class Request implements RequestInterface
         );
     }
 
-    public static function update(?string $section, string $resource, string $id, string $token): RequestInterface
+    public static function update(?string $section, string $resource, string $id, ?string $token = null): RequestInterface
     {
+        $headers = ['CONTENT_TYPE' => 'application/ld+json'];
+        if ($token !== null) {
+            $headers['HTTP_Authorization'] = 'Bearer ' . $token;
+        }
+
         return new self(
             sprintf('/new-api/%s%s/%s', self::prepareSection($section), $resource, $id),
             HttpRequest::METHOD_PUT,
-            ['CONTENT_TYPE' => 'application/ld+json', 'HTTP_Authorization' => 'Bearer ' . $token]
+            $headers
         );
     }
 
-    public static function delete(?string $section, string $resource, string $id, string $token): RequestInterface
+    public static function delete(?string $section, string $resource, string $id, ?string $token = null): RequestInterface
     {
+        $headers = $token ? ['HTTP_Authorization' => 'Bearer ' . $token] : [];
+
         return new self(
             sprintf('/new-api/%s%s/%s', self::prepareSection($section), $resource, $id),
             HttpRequest::METHOD_DELETE,
-            ['HTTP_Authorization' => 'Bearer ' . $token]
+            $headers
         );
     }
 
@@ -113,12 +121,17 @@ final class Request implements RequestInterface
         );
     }
 
-    public static function upload(?string $section, string $resource, string $token): RequestInterface
+    public static function upload(?string $section, string $resource, ?string $token = null): RequestInterface
     {
+        $headers = ['CONTENT_TYPE' => 'multipart/form-data'];
+        if ($token !== null) {
+            $headers['HTTP_Authorization'] = 'Bearer ' . $token;
+        }
+
         return new self(
             sprintf('/new-api/%s%s', self::prepareSection($section), $resource),
             HttpRequest::METHOD_POST,
-            ['CONTENT_TYPE' => 'multipart/form-data', 'HTTP_Authorization' => 'Bearer ' . $token]
+            $headers
         );
     }
 
@@ -195,9 +208,11 @@ final class Request implements RequestInterface
         }
     }
 
-    public function authorize(string $token): void
+    public function authorize(?string $token): void
     {
-        $this->headers['HTTP_Authorization'] = 'Bearer ' . $token;
+        if ($token !== null) {
+            $this->headers['HTTP_Authorization'] = 'Bearer ' . $token;
+        }
     }
 
     private function mergeArraysUniquely(array $firstArray, array $secondArray): array

--- a/src/Sylius/Behat/Client/RequestInterface.php
+++ b/src/Sylius/Behat/Client/RequestInterface.php
@@ -15,21 +15,21 @@ namespace Sylius\Behat\Client;
 
 interface RequestInterface
 {
-    public static function index(?string $section, string $resource, string $token): self;
+    public static function index(?string $section, string $resource, ?string $token = null): self;
 
     public static function subResourceIndex(?string $section, string $resource, string $id, string $subResource): self;
 
-    public static function show(?string $section, string $resource, string $id, string $token): self;
+    public static function show(?string $section, string $resource, string $id, ?string $token = null): self;
 
     public static function create(?string $section, string $resource, ?string $token = null): self;
 
-    public static function update(?string $section, string $resource, string $id, string $token): self;
+    public static function update(?string $section, string $resource, string $id, ?string $token = null): self;
 
-    public static function delete(?string $section, string $resource, string $id, string $token): self;
+    public static function delete(?string $section, string $resource, string $id, ?string $token = null): self;
 
     public static function transition(?string $section, string $resource, string $id, string $transition): self;
 
-    public static function upload(?string $section, string $resource, string $token): self;
+    public static function upload(?string $section, string $resource, ?string $token = null): self;
 
     public static function custom(string $url, string $method): self;
 
@@ -57,5 +57,5 @@ interface RequestInterface
 
     public function removeSubResource(string $subResource, string $id): void;
 
-    public function authorize(string $token): void;
+    public function authorize(?string $token): void;
 }

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -75,6 +75,8 @@ final class CartContext implements Context
     public function iClearMyCart(string $tokenValue): void
     {
         $this->cartsClient->delete($tokenValue);
+
+        $this->sharedStorage->set('cart_token', null);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -80,7 +80,7 @@ final class CartContext implements Context
     }
 
     /**
-     * @When /^I see the summary of my (cart)$/
+     * @When /^I see the summary of my ((?:|previous )cart)$/
      * @When /^the visitor try to see the summary of ((?:visitor|customer)'s cart)$/
      * @When /^the (?:visitor|customer) see the summary of ((?:|their )cart)$/
      */
@@ -151,11 +151,11 @@ final class CartContext implements Context
     }
 
     /**
-     * @Then I don't have access to see the summary of my cart
+     * @Then /^I don't have access to see the summary of my (previous cart)$/
      */
-    public function iDoNotHaveAccessToSeeTheSummaryOfMyCart(): void
+    public function iDoNotHaveAccessToSeeTheSummaryOfMyCart(string $tokenValue): void
     {
-        Assert::same($this->getCart()['code'], 404);
+        Assert::same($this->cartsClient->show($tokenValue)->getStatusCode(), Response::HTTP_NOT_FOUND);
     }
 
     /**
@@ -501,12 +501,5 @@ final class CartContext implements Context
                 );
             }
         }
-    }
-
-    private function getCart(): array
-    {
-        $response = $this->cartsClient->show($this->sharedStorage->get('cart_token'));
-
-        return $this->responseChecker->getResponseContent($response);
     }
 }

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -904,7 +904,7 @@ final class CheckoutContext implements Context
 
         $this->client->request(
             Request::METHOD_PATCH,
-            \sprintf('/new-api/shop/orders/%s/address', $this->sharedStorage->get('cart_token')),
+            \sprintf('/new-api/shop/orders/%s/address', $this->getCartTokenValue()),
             [],
             [],
             $this->getHeaders(),
@@ -914,9 +914,20 @@ final class CheckoutContext implements Context
 
     private function getCart(): array
     {
-        $response = $this->ordersClient->show($this->sharedStorage->get('cart_token'));
+        return $this->responseChecker->getResponseContent($this->ordersClient->show($this->getCartTokenValue()));
+    }
 
-        return $this->responseChecker->getResponseContent($response);
+    private function getCartTokenValue(): ?string
+    {
+        if ($this->sharedStorage->has('cart_token')) {
+            return $this->sharedStorage->get('cart_token');
+        }
+
+        if ($this->sharedStorage->has('previous_cart_token')) {
+            return $this->sharedStorage->get('previous_cart_token');
+        }
+
+        return null;
     }
 
     private function getCheckoutState(): string

--- a/src/Sylius/Behat/Context/Transform/CartTokenContext.php
+++ b/src/Sylius/Behat/Context/Transform/CartTokenContext.php
@@ -42,22 +42,14 @@ final class CartTokenContext implements Context
     }
 
     /**
-     * @Transform /^(customer cart)$/
-     * @Transform /^(customer's cart)$/
-     * @Transform /^(visitor's cart)$/
-     * @Transform /^(their cart)$/
+     * @Transform /^((?:previous|customer|customer's|visitor's|their) cart)$/
      */
     public function providePreviousCartToken(): ?string
     {
-        $tokenValue = $this->provideCartToken();
-        if ($tokenValue !== null) {
-            return $tokenValue;
-        }
-
         if ($this->sharedStorage->has('previous_cart_token')) {
             return $this->sharedStorage->get('previous_cart_token');
         }
 
-        return null;
+        return $this->provideCartToken();
     }
 }

--- a/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/CartContext.php
@@ -51,7 +51,7 @@ final class CartContext implements Context
     }
 
     /**
-     * @When I see the summary of my cart
+     * @When /^I see the summary of my (?:|previous )cart$/
      */
     public function iOpenCartSummaryPage()
     {

--- a/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/setup.xml
@@ -33,6 +33,7 @@
         <service id="sylius.behat.context.setup.cart" class="Sylius\Behat\Context\Setup\CartContext">
             <argument type="service" id="sylius_default.bus" />
             <argument type="service" id="sylius.product_variant_resolver.default" />
+            <argument type="service" id="sylius.random_generator" />
             <argument type="service" id="sylius.behat.shared_storage" />
         </service>
 

--- a/src/Sylius/Behat/Resources/config/services/contexts/transform.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/transform.xml
@@ -151,8 +151,6 @@
         </service>
 
         <service id="sylius.behat.context.transform.cart" class="Sylius\Behat\Context\Transform\CartTokenContext">
-            <argument type="service" id="sylius_default.bus" />
-            <argument type="service" id="sylius.random_generator" />
             <argument type="service" id="sylius.behat.shared_storage" />
         </service>
 

--- a/src/Sylius/Bundle/ApiBundle/Context/TokenValueBasedCartContext.php
+++ b/src/Sylius/Bundle/ApiBundle/Context/TokenValueBasedCartContext.php
@@ -64,7 +64,7 @@ final class TokenValueBasedCartContext implements CartContextInterface
     {
         $masterRequest = $this->requestStack->getMasterRequest();
         if (null === $masterRequest) {
-            throw new \UnexpectedValueException('There is no master request on request stack.');
+            throw new CartNotFoundException('There is no master request on request stack.');
         }
 
         return $masterRequest;

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
@@ -25,6 +25,7 @@
 
         <service id="Sylius\Bundle\ApiBundle\CommandHandler\PickupCartHandler">
             <argument type="service" id="sylius.factory.order" />
+            <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="sylius.context.channel" />
             <argument type="service" id="sylius.api.context.user" />
             <argument type="service" id="sylius.manager.order" />

--- a/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/PickupCartHandlerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/PickupCartHandlerSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Bundle\ApiBundle\CommandHandler;
 
 use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Sylius\Bundle\ApiBundle\Command\Cart\PickupCart;
 use Sylius\Bundle\ApiBundle\Context\UserContextInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
@@ -22,6 +23,7 @@ use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
@@ -32,6 +34,7 @@ final class PickupCartHandlerSpec extends ObjectBehavior
 {
     function let(
         FactoryInterface $cartFactory,
+        OrderRepositoryInterface $cartRepository,
         ChannelContextInterface $channelContext,
         UserContextInterface $userContext,
         ObjectManager $orderManager,
@@ -40,6 +43,7 @@ final class PickupCartHandlerSpec extends ObjectBehavior
     ): void {
         $this->beConstructedWith(
             $cartFactory,
+            $cartRepository,
             $channelContext,
             $userContext,
             $orderManager,
@@ -52,8 +56,9 @@ final class PickupCartHandlerSpec extends ObjectBehavior
         $this->shouldImplement(MessageHandlerInterface::class);
     }
 
-    function it_picks_up_a_cart_for_logged_shop_user(
+    function it_picks_up_a_new_cart_for_logged_in_shop_user(
         FactoryInterface $cartFactory,
+        OrderRepositoryInterface $cartRepository,
         ChannelContextInterface $channelContext,
         UserContextInterface $userContext,
         ShopUserInterface $user,
@@ -65,21 +70,21 @@ final class PickupCartHandlerSpec extends ObjectBehavior
         CurrencyInterface $currency,
         LocaleInterface $locale
     ): void {
-        $cartFactory->createNew()->willReturn($cart);
         $channelContext->getChannel()->willReturn($channel);
-        $generator->generateUriSafeString(10)->willReturn('urisafestr');
-
         $channel->getBaseCurrency()->willReturn($currency);
         $channel->getDefaultLocale()->willReturn($locale);
+
         $userContext->getUser()->willReturn($user);
         $user->getCustomer()->willReturn($customer);
 
-        $cart->setCustomer($customer)->shouldBeCalled();
+        $cartRepository->findLatestNotEmptyCartByChannelAndCustomer($channel, $customer)->willReturn(null);
 
+        $generator->generateUriSafeString(10)->willReturn('urisafestr');
         $currency->getCode()->willReturn('USD');
-
         $locale->getCode()->willReturn('en_US');
 
+        $cartFactory->createNew()->willReturn($cart);
+        $cart->setCustomer($customer)->shouldBeCalled();
         $cart->setChannel($channel)->shouldBeCalled();
         $cart->setCurrencyCode('USD')->shouldBeCalled();
         $cart->setLocaleCode('en_US')->shouldBeCalled();
@@ -90,8 +95,36 @@ final class PickupCartHandlerSpec extends ObjectBehavior
         $this(new PickupCart());
     }
 
+    function it_picks_up_an_existing_cart_for_logged_in_shop_user(
+        FactoryInterface $cartFactory,
+        OrderRepositoryInterface $cartRepository,
+        ChannelContextInterface $channelContext,
+        UserContextInterface $userContext,
+        ShopUserInterface $user,
+        CustomerInterface $customer,
+        ObjectManager $orderManager,
+        OrderInterface $cart,
+        ChannelInterface $channel
+    ): void {
+        $channelContext->getChannel()->willReturn($channel);
+
+        $userContext->getUser()->willReturn($user);
+        $user->getCustomer()->willReturn($customer);
+
+        $cartRepository->findLatestNotEmptyCartByChannelAndCustomer($channel, $customer)->willReturn($cart);
+
+        $cartFactory->createNew()->willReturn($cart);
+        $cart->setCustomer($customer)->shouldNotBeCalled();
+        $cart->setChannel($channel)->shouldNotBeCalled();
+
+        $orderManager->persist($cart)->shouldNotBeCalled();
+
+        $this(new PickupCart());
+    }
+
     function it_picks_up_a_cart_for_visitor(
         FactoryInterface $cartFactory,
+        OrderRepositoryInterface $cartRepository,
         ChannelContextInterface $channelContext,
         UserContextInterface $userContext,
         ObjectManager $orderManager,
@@ -101,18 +134,20 @@ final class PickupCartHandlerSpec extends ObjectBehavior
         CurrencyInterface $currency,
         LocaleInterface $locale
     ): void {
-        $cartFactory->createNew()->willReturn($cart);
         $channelContext->getChannel()->willReturn($channel);
-        $generator->generateUriSafeString(10)->willReturn('urisafestr');
-
         $channel->getBaseCurrency()->willReturn($currency);
         $channel->getDefaultLocale()->willReturn($locale);
+
         $userContext->getUser()->willReturn(null);
 
-        $currency->getCode()->willReturn('USD');
+        $cartRepository->findLatestNotEmptyCartByChannelAndCustomer($channel, Argument::any())->shouldNotBeCalled(null);
 
+        $generator->generateUriSafeString(10)->willReturn('urisafestr');
+        $currency->getCode()->willReturn('USD');
         $locale->getCode()->willReturn('en_US');
 
+        $cartFactory->createNew()->willReturn($cart);
+        $cart->setCustomer(Argument::any())->shouldNotBeCalled();
         $cart->setChannel($channel)->shouldBeCalled();
         $cart->setCurrencyCode('USD')->shouldBeCalled();
         $cart->setLocaleCode('en_US')->shouldBeCalled();

--- a/src/Sylius/Bundle/ApiBundle/spec/Context/TokenValueBasedCartContextSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Context/TokenValueBasedCartContextSpec.php
@@ -54,7 +54,7 @@ final class TokenValueBasedCartContextSpec extends ObjectBehavior
         $requestStack->getMasterRequest()->willReturn(null);
 
         $this
-            ->shouldThrow(new \UnexpectedValueException('There is no master request on request stack.'))
+            ->shouldThrow(new CartNotFoundException('There is no master request on request stack.'))
             ->during('getCart')
         ;
     }

--- a/src/Sylius/Bundle/CoreBundle/Context/CustomerAndChannelBasedCartContext.php
+++ b/src/Sylius/Bundle/CoreBundle/Context/CustomerAndChannelBasedCartContext.php
@@ -55,7 +55,7 @@ final class CustomerAndChannelBasedCartContext implements CartContextInterface
             throw new CartNotFoundException('Sylius was not able to find the cart, as there is no logged in user.');
         }
 
-        $cart = $this->orderRepository->findLatestCartByChannelAndCustomer($channel, $customer);
+        $cart = $this->orderRepository->findLatestNotEmptyCartByChannelAndCustomer($channel, $customer);
         if (null === $cart) {
             throw new CartNotFoundException('Sylius was not able to find the cart for currently logged in user.');
         }

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -182,6 +182,25 @@ class OrderRepository extends BaseOrderRepository implements OrderRepositoryInte
         ;
     }
 
+    public function findLatestNotEmptyCartByChannelAndCustomer(
+        ChannelInterface $channel,
+        CustomerInterface $customer
+    ): ?OrderInterface {
+        return $this->createQueryBuilder('o')
+            ->andWhere('o.state = :state')
+            ->andWhere('o.channel = :channel')
+            ->andWhere('o.customer = :customer')
+            ->andWhere('o.items IS NOT EMPTY')
+            ->setParameter('state', OrderInterface::STATE_CART)
+            ->setParameter('channel', $channel)
+            ->setParameter('customer', $customer)
+            ->addOrderBy('o.createdAt', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+
     public function getTotalSalesForChannel(ChannelInterface $channel): int
     {
         return (int) $this->createQueryBuilder('o')

--- a/src/Sylius/Bundle/CoreBundle/spec/Context/CustomerAndChannelBasedCartContextSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Context/CustomerAndChannelBasedCartContextSpec.php
@@ -50,7 +50,7 @@ final class CustomerAndChannelBasedCartContextSpec extends ObjectBehavior
         $channelContext->getChannel()->willReturn($channel);
         $customerContext->getCustomer()->willReturn($customer);
 
-        $orderRepository->findLatestCartByChannelAndCustomer($channel, $customer)->willReturn($order);
+        $orderRepository->findLatestNotEmptyCartByChannelAndCustomer($channel, $customer)->willReturn($order);
 
         $this->getCart()->shouldReturn($order);
     }
@@ -65,7 +65,7 @@ final class CustomerAndChannelBasedCartContextSpec extends ObjectBehavior
         $channelContext->getChannel()->willReturn($channel);
         $customerContext->getCustomer()->willReturn($customer);
 
-        $orderRepository->findLatestCartByChannelAndCustomer($channel, $customer)->willReturn(null);
+        $orderRepository->findLatestNotEmptyCartByChannelAndCustomer($channel, $customer)->willReturn(null);
 
         $this
             ->shouldThrow(new CartNotFoundException('Sylius was not able to find the cart for currently logged in user.'))

--- a/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
+++ b/src/Sylius/Component/Core/Repository/OrderRepositoryInterface.php
@@ -50,6 +50,8 @@ interface OrderRepositoryInterface extends BaseOrderRepositoryInterface
 
     public function findLatestCartByChannelAndCustomer(ChannelInterface $channel, CustomerInterface $customer): ?OrderInterface;
 
+    public function findLatestNotEmptyCartByChannelAndCustomer(ChannelInterface $channel, CustomerInterface $customer): ?OrderInterface;
+
     public function getTotalSalesForChannel(ChannelInterface $channel): int;
 
     public function getTotalPaidSalesForChannel(ChannelInterface $channel): int;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no?
| Deprecations?   | 
| Related tickets | 
| License         | MIT

Now, when the customer didn't have or had an empty cart and their had a cart in session, the one from session will be assigned to them.
