### PR TITLE
Changed behavior of string inflector

### DIFF
--- a/src/Sylius/Component/Core/Formatter/StringInflector.php
+++ b/src/Sylius/Component/Core/Formatter/StringInflector.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Formatter;
 
+use Behat\Transliterator\Transliterator;
 use function Symfony\Component\String\u;
 
 final class StringInflector
@@ -24,7 +25,7 @@ final class StringInflector
 
     public static function nameToSlug(string $value): string
     {
-        return str_replace(['_'], '-', self::nameToLowercaseCode($value));
+        return str_replace(['_'], '-', self::nameToLowercaseCode(Transliterator::transliterate($value)));
     }
 
     public static function nameToLowercaseCode(string $value): string

--- a/src/Sylius/Component/Core/Test/Tests/StringInflectorTest.php
+++ b/src/Sylius/Component/Core/Test/Tests/StringInflectorTest.php
@@ -21,7 +21,7 @@ final class StringInflectorTest extends TestCase
     /**
      * @test
      */
-    public function nameToCode(): void
+    public function it_converts_name_to_code(): void
     {
         self::assertEquals('Test_value', StringInflector::nameToCode('Test value'));
     }
@@ -29,7 +29,15 @@ final class StringInflectorTest extends TestCase
     /**
      * @test
      */
-    public function nameToSlug(): void
+    public function it_converts_name_with_special_characters_to_code(): void
+    {
+        self::assertEquals('Test?_value!', StringInflector::nameToCode('Test? value!'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_name_to_slug(): void
     {
         self::assertEquals('test-value', StringInflector::nameToSlug('Test value'));
     }
@@ -37,7 +45,7 @@ final class StringInflectorTest extends TestCase
     /**
      * @test
      */
-    public function nameWithSpecialCharactersToSlug(): void
+    public function it_converts_name_with_special_characters_to_slug(): void
     {
         self::assertEquals('test-value', StringInflector::nameToSlug('Test!%-value!'));
     }
@@ -45,7 +53,7 @@ final class StringInflectorTest extends TestCase
     /**
      * @test
      */
-    public function nameToLowercaseCode(): void
+    public function it_converts_name_to_lowercase_code(): void
     {
         self::assertEquals('test_value', StringInflector::nameToLowercaseCode('Test value'));
     }
@@ -53,7 +61,15 @@ final class StringInflectorTest extends TestCase
     /**
      * @test
      */
-    public function nameToUppercaseCode(): void
+    public function it_converts_name_with_special_characters_to_lowercase_code(): void
+    {
+        self::assertEquals('test?_value!', StringInflector::nameToLowercaseCode('Test? value!'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_name_to_upper_case_code(): void
     {
         self::assertEquals('TEST_VALUE', StringInflector::nameToUppercaseCode('Test value'));
     }
@@ -61,8 +77,24 @@ final class StringInflectorTest extends TestCase
     /**
      * @test
      */
-    public function nameToCamelCase(): void
+    public function it_converts_name_with_special_characters_to_upper_case_code(): void
+    {
+        self::assertEquals('TEST?_VALUE!', StringInflector::nameToUppercaseCode('Test? value!'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_name_to_camel_case(): void
     {
         self::assertEquals('testValue', StringInflector::nameToCamelCase('Test value'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_converts_name_with_special_characters_to_camel_case(): void
+    {
+        self::assertEquals('testValue', StringInflector::nameToCamelCase('Test? value!'));
     }
 }

--- a/src/Sylius/Component/Core/Test/Tests/StringInflectorTest.php
+++ b/src/Sylius/Component/Core/Test/Tests/StringInflectorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Test\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Formatter\StringInflector;
+
+final class StringInflectorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function nameToCode(): void
+    {
+        self::assertEquals('Test_value', StringInflector::nameToCode('Test value'));
+    }
+
+    /**
+     * @test
+     */
+    public function nameToSlug(): void
+    {
+        self::assertEquals('test-value', StringInflector::nameToSlug('Test value'));
+    }
+
+    /**
+     * @test
+     */
+    public function nameWithSpecialCharactersToSlug(): void
+    {
+        self::assertEquals('test-value', StringInflector::nameToSlug('Test!%-value!'));
+    }
+
+    /**
+     * @test
+     */
+    public function nameToLowercaseCode(): void
+    {
+        self::assertEquals('test_value', StringInflector::nameToLowercaseCode('Test value'));
+    }
+
+    /**
+     * @test
+     */
+    public function nameToUppercaseCode(): void
+    {
+        self::assertEquals('TEST_VALUE', StringInflector::nameToUppercaseCode('Test value'));
+    }
+
+    /**
+     * @test
+     */
+    public function nameToCamelCase(): void
+    {
+        self::assertEquals('testValue', StringInflector::nameToCamelCase('Test value'));
+    }
+}

--- a/src/Sylius/Component/Core/Test/phpunit.xml.dist
+++ b/src/Sylius/Component/Core/Test/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.5/phpunit.xsd"
+         colors="true"
+>
+    <php>
+        <server name="KERNEL_CLASS" value="AppKernel" />
+    </php>
+
+    <testsuites>
+        <testsuite name="SyliusCoreComponent Test Suite">
+            <directory>./Test/</directory>
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8 
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | possible
| Deprecations?   | no
| License         | MIT

When we change strings with special characters ( f.e. '!' ) String inflector doesn't change it as should. Now it will delete those characters.
