### PR TITLE
[Api] Be able to change authorization header 

### DIFF
--- a/src/Sylius/Behat/Client/ApiPlatformClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformClient.php
@@ -180,7 +180,13 @@ final class ApiPlatformClient implements ApiClientInterface
 
     public function buildCustomUpdateRequest(string $id, string $customSuffix): void
     {
-        $this->request = Request::update($this->section, $this->resource, sprintf('%s/%s', $id, $customSuffix), $this->getToken());
+        $this->request = Request::update(
+            $this->section, 
+            $this->resource,
+            sprintf('%s/%s', $id, $customSuffix),
+            $this->authorizationHeader,
+            $this->getToken()
+        );
     }
 
     public function buildUploadRequest(): void

--- a/src/Sylius/Behat/Client/ApiPlatformIriClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformIriClient.php
@@ -26,16 +26,23 @@ final class ApiPlatformIriClient implements ApiIriClientInterface
     /** @var SharedStorageInterface */
     private $sharedStorage;
 
-    public function __construct(AbstractBrowser $client, SharedStorageInterface $sharedStorage)
-    {
+    /** @var string */
+    private $authorizationHeader;
+
+    public function __construct(
+        AbstractBrowser $client,
+        SharedStorageInterface $sharedStorage,
+        string $authorizationHeader
+    ) {
         $this->client = $client;
         $this->sharedStorage = $sharedStorage;
+        $this->authorizationHeader = $authorizationHeader;
     }
 
     public function showByIri(string $iri): Response
     {
         $request = Request::custom($iri, HttpRequest::METHOD_GET);
-        $request->authorize($this->sharedStorage->get('token'));
+        $request->authorize($this->sharedStorage->get('token'), $this->authorizationHeader);
 
         return $this->request($request);
     }

--- a/src/Sylius/Behat/Client/Request.php
+++ b/src/Sylius/Behat/Client/Request.php
@@ -42,11 +42,19 @@ final class Request implements RequestInterface
         $this->headers = array_merge($this->headers, $headers);
     }
 
-    public static function index(?string $section, string $resource, ?string $token = null): RequestInterface
-    {
-        $headers = $token ? ['HTTP_Authorization' => 'Bearer ' . $token] : [];
+    public static function index(
+        ?string $section,
+        string $resource,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface {
+        $headers = $token ? ['HTTP_' . $authorizationHeader => 'Bearer ' . $token] : [];
 
-        return new self(sprintf('/new-api/%s%s', self::prepareSection($section), $resource), HttpRequest::METHOD_GET, $headers);
+        return new self(
+            sprintf('/new-api/%s%s', self::prepareSection($section), $resource),
+            HttpRequest::METHOD_GET,
+            $headers
+        );
     }
 
     public static function subResourceIndex(?string $section, string $resource, string $id, string $subResource): RequestInterface
@@ -57,9 +65,14 @@ final class Request implements RequestInterface
         );
     }
 
-    public static function show(?string $section, string $resource, string $id, ?string $token = null): RequestInterface
-    {
-        $headers = $token ? ['HTTP_Authorization' => 'Bearer ' . $token] : [];
+    public static function show(
+        ?string $section,
+        string $resource,
+        string $id,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface {
+        $headers = $token ? ['HTTP_' . $authorizationHeader => 'Bearer ' . $token] : [];
 
         return new self(
             sprintf('/new-api/%s%s/%s', self::prepareSection($section), $resource, $id),
@@ -68,11 +81,15 @@ final class Request implements RequestInterface
         );
     }
 
-    public static function create(?string $section, string $resource, ?string $token = null): RequestInterface
-    {
+    public static function create(
+        ?string $section,
+        string $resource,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface {
         $headers = ['CONTENT_TYPE' => 'application/ld+json'];
         if ($token !== null) {
-            $headers['HTTP_Authorization'] = 'Bearer ' . $token;
+            $headers['HTTP_' . $authorizationHeader] = 'Bearer ' . $token;
         }
 
         return new self(
@@ -82,11 +99,16 @@ final class Request implements RequestInterface
         );
     }
 
-    public static function update(?string $section, string $resource, string $id, ?string $token = null): RequestInterface
-    {
+    public static function update(
+        ?string $section,
+        string $resource,
+        string $id,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface {
         $headers = ['CONTENT_TYPE' => 'application/ld+json'];
         if ($token !== null) {
-            $headers['HTTP_Authorization'] = 'Bearer ' . $token;
+            $headers['HTTP_' . $authorizationHeader] = 'Bearer ' . $token;
         }
 
         return new self(
@@ -96,9 +118,14 @@ final class Request implements RequestInterface
         );
     }
 
-    public static function delete(?string $section, string $resource, string $id, ?string $token = null): RequestInterface
-    {
-        $headers = $token ? ['HTTP_Authorization' => 'Bearer ' . $token] : [];
+    public static function delete(
+        ?string $section,
+        string $resource,
+        string $id,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface {
+        $headers = $token ? ['HTTP_' . $authorizationHeader => 'Bearer ' . $token] : [];
 
         return new self(
             sprintf('/new-api/%s%s/%s', self::prepareSection($section), $resource, $id),
@@ -121,11 +148,15 @@ final class Request implements RequestInterface
         );
     }
 
-    public static function upload(?string $section, string $resource, ?string $token = null): RequestInterface
-    {
+    public static function upload(
+        ?string $section,
+        string $resource,
+        string $authorizationHeader,
+        ?string $token = null
+    ): RequestInterface {
         $headers = ['CONTENT_TYPE' => 'multipart/form-data'];
         if ($token !== null) {
-            $headers['HTTP_Authorization'] = 'Bearer ' . $token;
+            $headers['HTTP_' . $authorizationHeader] = 'Bearer ' . $token;
         }
 
         return new self(
@@ -209,10 +240,10 @@ final class Request implements RequestInterface
         }
     }
 
-    public function authorize(?string $token): void
+    public function authorize(?string $token, string $authorizationHeader): void
     {
         if ($token !== null) {
-            $this->headers['HTTP_Authorization'] = 'Bearer ' . $token;
+            $this->headers['HTTP_' . $authorizationHeader] = 'Bearer ' . $token;
         }
     }
 

--- a/src/Sylius/Behat/Client/RequestInterface.php
+++ b/src/Sylius/Behat/Client/RequestInterface.php
@@ -15,21 +15,56 @@ namespace Sylius\Behat\Client;
 
 interface RequestInterface
 {
-    public static function index(?string $section, string $resource, ?string $token = null): self;
+    public static function index(
+        ?string $section,
+        string $resource,
+        string $authorizationHeader,
+        ?string $token = null
+    ): self;
 
     public static function subResourceIndex(?string $section, string $resource, string $id, string $subResource): self;
 
-    public static function show(?string $section, string $resource, string $id, ?string $token = null): self;
+    public static function show(
+        ?string $section,
+        string $resource,
+        string $id,
+        string $authorizationHeader,
+        ?string $token = null
+    ): self;
 
-    public static function create(?string $section, string $resource, ?string $token = null): self;
+    public static function create(
+        ?string $section,
+        string $resource,
+        string $authorizationHeader,
+        ?string $token = null
+    ): self;
 
-    public static function update(?string $section, string $resource, string $id, ?string $token = null): self;
+    public static function update(
+        ?string $section,
+        string $resource,
+        string $id,
+        string $authorizationHeader,
+        ?string $token = null
+    ): self;
 
-    public static function delete(?string $section, string $resource, string $id, ?string $token = null): self;
+    public static function delete(
+        ?string $section,
+        string $resource,
+        string $id,
+        string $authorizationHeader,
+        ?string $token = null
+    ): self;
 
     public static function transition(?string $section, string $resource, string $id, string $transition): self;
 
-    public static function upload(?string $section, string $resource, ?string $token = null): self;
+    public static function customItemAction(?string $section, string $resource, string $id, string $type, string $action): self;
+
+    public static function upload(
+        ?string $section,
+        string $resource,
+        string $authorizationHeader,
+        ?string $token = null
+    ): self;
 
     public static function custom(string $url, string $method, ?string $token = null): self;
 
@@ -57,5 +92,5 @@ interface RequestInterface
 
     public function removeSubResource(string $subResource, string $id): void;
 
-    public function authorize(?string $token): void;
+    public function authorize(?string $token, string $authorizationHeader): void;
 }

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -73,6 +73,9 @@ final class CheckoutContext implements Context
     /** @var SharedStorageInterface */
     private $sharedStorage;
 
+    /** @var string */
+    private $authorizationHeader;
+
     /** @var string[] */
     private $content = [];
 
@@ -86,7 +89,8 @@ final class CheckoutContext implements Context
         OrderRepositoryInterface $orderRepository,
         RepositoryInterface $paymentMethodRepository,
         ProductVariantResolverInterface $productVariantResolver,
-        SharedStorageInterface $sharedStorage
+        SharedStorageInterface $sharedStorage,
+        string $authorizationHeader
     ) {
         $this->client = $client;
         $this->ordersClient = $ordersClient;
@@ -98,6 +102,7 @@ final class CheckoutContext implements Context
         $this->paymentMethodRepository = $paymentMethodRepository;
         $this->productVariantResolver = $productVariantResolver;
         $this->sharedStorage = $sharedStorage;
+        $this->authorizationHeader = $authorizationHeader;
     }
 
     /**
@@ -959,7 +964,7 @@ final class CheckoutContext implements Context
         }
 
         if ($this->sharedStorage->has('token')) {
-            $headers['HTTP_Authorization'] = 'Bearer ' . $this->sharedStorage->get('token');
+            $headers['HTTP_' . $this->authorizationHeader] = 'Bearer ' . $this->sharedStorage->get('token');
         }
 
         return $headers;

--- a/src/Sylius/Behat/Resources/config/services/api.xml
+++ b/src/Sylius/Behat/Resources/config/services/api.xml
@@ -16,7 +16,7 @@
         <service id="sylius.behat.api_platform_client" class="Sylius\Behat\Client\ApiPlatformClient" abstract="true">
             <argument type="service" id="test.client" />
             <argument type="service" id="sylius.behat.shared_storage" />
-            <argument>%sylius_api.authorization_header%</argument>
+            <argument>%sylius.api.authorization_header%</argument>
         </service>
 
         <service id="sylius.behat.api_platform_client.shop.address" class="Sylius\Behat\Client\ApiPlatformClient" parent="sylius.behat.api_platform_client">
@@ -193,7 +193,7 @@
         <service id="sylius.behat.api_platform_client.iri" class="Sylius\Behat\Client\ApiPlatformIriClient">
             <argument type="service" id="test.client" />
             <argument type="service" id="sylius.behat.shared_storage" />
-            <argument>%sylius_api.authorization_header%</argument>
+            <argument>%sylius.api.authorization_header%</argument>
         </service>
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/services/api.xml
+++ b/src/Sylius/Behat/Resources/config/services/api.xml
@@ -16,6 +16,7 @@
         <service id="sylius.behat.api_platform_client" class="Sylius\Behat\Client\ApiPlatformClient" abstract="true">
             <argument type="service" id="test.client" />
             <argument type="service" id="sylius.behat.shared_storage" />
+            <argument>%sylius_api.authorization_header%</argument>
         </service>
 
         <service id="sylius.behat.api_platform_client.shop.address" class="Sylius\Behat\Client\ApiPlatformClient" parent="sylius.behat.api_platform_client">
@@ -192,6 +193,7 @@
         <service id="sylius.behat.api_platform_client.iri" class="Sylius\Behat\Client\ApiPlatformIriClient">
             <argument type="service" id="test.client" />
             <argument type="service" id="sylius.behat.shared_storage" />
+            <argument>%sylius_api.authorization_header%</argument>
         </service>
     </services>
 </container>

--- a/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
@@ -65,6 +65,7 @@
             <argument type="service" id="sylius.repository.payment_method" />
             <argument type="service" id="sylius.product_variant_resolver.default" />
             <argument type="service" id="sylius.behat.shared_storage" />
+            <argument>%sylius_api.authorization_header%</argument>
         </service>
 
         <service id="sylius.behat.context.api.shop.homepage" class="Sylius\Behat\Context\Api\Shop\HomepageContext">

--- a/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
@@ -65,7 +65,7 @@
             <argument type="service" id="sylius.repository.payment_method" />
             <argument type="service" id="sylius.product_variant_resolver.default" />
             <argument type="service" id="sylius.behat.shared_storage" />
-            <argument>%sylius_api.authorization_header%</argument>
+            <argument>%sylius.api.authorization_header%</argument>
         </service>
 
         <service id="sylius.behat.context.api.shop.homepage" class="Sylius\Behat\Context\Api\Shop\HomepageContext">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
@@ -1,6 +1,9 @@
 # This file is part of the Sylius package.
 # (c) Paweł Jędrzejewski
 
+parameters:
+    sylius_api.authorization_header: AuthorizationTestHeader
+
 api_platform:
     patch_formats:
         json: ['application/merge-patch+json']
@@ -9,7 +12,7 @@ api_platform:
         versions: [3]
         api_keys:
             apiKey:
-                name: Authorization
+                name: "%sylius_api.authorization_header%"
                 type: header
     exception_to_status:
         SM\SMException: 422
@@ -29,3 +32,9 @@ framework:
                 middleware:
                     - 'validation'
                     - 'doctrine_transaction'
+lexik_jwt_authentication:
+    token_extractors:
+        authorization_header:
+            enabled: true
+            prefix: Bearer
+            name: "%sylius_api.authorization_header%"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
@@ -2,7 +2,8 @@
 # (c) Paweł Jędrzejewski
 
 parameters:
-    sylius_api.authorization_header: AuthorizationTestHeader
+    env(SYLIUS_API_AUTHORIZATION_HEADER): Authorization
+    sylius.api.authorization_header: "%env(resolve:SYLIUS_API_AUTHORIZATION_HEADER)%"
 
 api_platform:
     patch_formats:
@@ -12,7 +13,7 @@ api_platform:
         versions: [3]
         api_keys:
             apiKey:
-                name: "%sylius_api.authorization_header%"
+                name: "%sylius.api.authorization_header%"
                 type: header
     exception_to_status:
         SM\SMException: 422
@@ -37,4 +38,4 @@ lexik_jwt_authentication:
         authorization_header:
             enabled: true
             prefix: Bearer
-            name: "%sylius_api.authorization_header%"
+            name: "%sylius.api.authorization_header%"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Sometimes someone needs to add second security firewall like BasicAuth, Default authentication header allows to add only one type(Bearer in our case), This PR add ability to change default authentication header to other on our app, and automatically release default `Authorization` header to use with other security firewall  