### PR TITLE
[UI] Fix broken checkboxes that dont change state

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Form/theme.html.twig
@@ -60,8 +60,8 @@
             {%- for child in form %}
                 <div class="field">
                     <div class="ui toggle checkbox">
-                        {{- form_label(child, null, {translation_domain: choice_translation_domain}) -}}
                         {{- form_widget(child, sylius_test_form_attribute('option')) -}}
+                        {{- form_label(child, null, {translation_domain: choice_translation_domain}) -}}
                     </div>
                 </div>
             {% endfor -%}


### PR DESCRIPTION
Order (label <=> input) in Semantic UI

| Q               | A
| --------------- | -----
| Branch         | 1.7, 1.8 and master
| Bug fix        | yes
| New feature    | no
| BC breaks      | no
| Deprecations   | no
| License         | MIT

