### PR TITLE
[Minor] Update service definition to not using depracated service

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/validator.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/validator.xml
@@ -29,7 +29,7 @@
 
         <service id="sylius.api.validator.shipping_method_eligibility" class="Sylius\Bundle\ApiBundle\Validator\Constraints\OrderShippingMethodEligibilityValidator">
             <argument type="service" id="sylius.repository.order" />
-            <argument type="service" id="sylius.shipping_eligibility_checker" />
+            <argument type="service" id="sylius.shipping_method_eligibility_checker" />
             <tag name="validator.constraint_validator" alias="sylius_api_validator_order_shipping_method_eligibility" />
         </service>
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Same as #11982, but this service does not exist in 1.8

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
