### PR TITLE
Allow Symfony messenger 5

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -26,7 +26,7 @@
         "php": "^7.3",
         "api-platform/core": "^2.5",
         "sylius/core-bundle": "^1.7",
-        "symfony/messenger": "^4.4"
+        "symfony/messenger": "^4.4|^5"
     },
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^4.2",

--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -26,7 +26,7 @@
         "php": "^7.3",
         "api-platform/core": "^2.5",
         "sylius/core-bundle": "^1.7",
-        "symfony/messenger": "^4.4|^5"
+        "symfony/messenger": "^4.4|^5.0"
     },
     "require-dev": {
         "matthiasnoback/symfony-config-test": "^4.2",


### PR DESCRIPTION
There is no functionality that requires 4

| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| License         | MIT

