### PR TITLE
[Api] Renaming CommandAwareDataTransformerInterface to better express…

### DIFF
--- a/UPGRADE-1.9.md
+++ b/UPGRADE-1.9.md
@@ -147,7 +147,7 @@
 
 1. Unified API registration path in shop has been changed from `/new-api/shop/register` to `/new-api/shop/customers/`. 
  
-1. Identifier needed to retrieve a product in shop API endpoint (`/new-api/shop/products/{id}`) has been changed from `slug` to `code`. 
+1. Identifier needed to retrieve a product in shop API endpoint (`/new-api/shop/products/{id}`) has been changed from `slug` to `code`.
 
 1. Replace and add new keys in `config/packages/dev/jms_serializer.yaml`:
 
@@ -229,3 +229,11 @@ on `Sylius\Component\Core\Model\Adjustment` instead of `Sylius\Component\Order\M
     -       use Sylius\Component\Order\Model\Adjustment as BaseAdjustment;
     +       use Sylius\Component\Core\Model\Adjustment as BaseAdjustment;
     ```
+
+1. Following interfaces has been renamed:
+    * `Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface` to `Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface`
+    * `Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareInterface` to `Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareCommandInterface`
+    * `Sylius\Bundle\ApiBundle\Command\CommandAwareDataTransformerInterface` to `Sylius\Bundle\ApiBundle\Command\EnrichableCommandInterface`
+
+1. Following classes has been renamed:
+    * `\Sylius\Bundle\ApiBundle\DataTransformer\CommandAwareInputDataTransformer` to `\Sylius\Bundle\ApiBundle\DataTransformer\CompositeEnrichableCommandDataTransformer`

--- a/src/Sylius/Behat/Context/Setup/UserContext.php
+++ b/src/Sylius/Behat/Context/Setup/UserContext.php
@@ -16,7 +16,7 @@ namespace Sylius\Behat\Context\Setup;
 use Behat\Behat\Context\Context;
 use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
-use Sylius\Bundle\ApiBundle\Command\ChangeShopUserPassword;
+use Sylius\Bundle\ApiBundle\Command\ChangeShopUserPasswordCommand;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Model\UserInterface;
@@ -179,7 +179,7 @@ final class UserContext implements Context
      */
     public function iveChangedMyPasswordFromTo(UserInterface $user, string $currentPassword, string $newPassword): void
     {
-        $changeShopUserPassword = new ChangeShopUserPassword($newPassword, $newPassword, $currentPassword);
+        $changeShopUserPassword = new ChangeShopUserPasswordCommand($newPassword, $newPassword, $currentPassword);
 
         $changeShopUserPassword->setShopUserId($user->getId());
 

--- a/src/Sylius/Bundle/ApiBundle/Command/Cart/AddItemToCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Cart/AddItemToCart.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Command\Cart;
 
-use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface;
 
 /** @experimental */
-class AddItemToCart implements OrderTokenValueAwareInterface
+class AddItemToCart implements OrderTokenValueAwareCommandInterface
 {
     /** @var string|null */
     public $orderTokenValue;

--- a/src/Sylius/Bundle/ApiBundle/Command/Cart/ApplyCouponToCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Cart/ApplyCouponToCart.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Command\Cart;
 
-use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface;
 
 /** @experimental */
-class ApplyCouponToCart implements OrderTokenValueAwareInterface
+class ApplyCouponToCart implements OrderTokenValueAwareCommandInterface
 {
     /** @var string|null */
     public $orderTokenValue;

--- a/src/Sylius/Bundle/ApiBundle/Command/Cart/ChangeItemQuantityInCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Cart/ChangeItemQuantityInCart.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Command\Cart;
 
-use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface;
 
 /** @experimental */
-class ChangeItemQuantityInCart implements OrderTokenValueAwareInterface
+class ChangeItemQuantityInCart implements OrderTokenValueAwareCommandInterface
 {
     /** @var string|null */
     public $orderTokenValue;

--- a/src/Sylius/Bundle/ApiBundle/Command/Cart/RemoveItemFromCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Cart/RemoveItemFromCart.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Command\Cart;
 
-use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface;
 
 /** @experimental */
-class RemoveItemFromCart implements OrderTokenValueAwareInterface
+class RemoveItemFromCart implements OrderTokenValueAwareCommandInterface
 {
     /** @var string|null */
     public $orderTokenValue;

--- a/src/Sylius/Bundle/ApiBundle/Command/ChangeShopUserPasswordCommand.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/ChangeShopUserPasswordCommand.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\Command;
 
 /** @experimental */
-class ChangeShopUserPassword implements ShopUserIdAwareInterface
+class ChangeShopUserPasswordCommand implements ShopUserIdAwareCommandInterface
 {
     /** @var mixed|null */
     public $shopUserId;

--- a/src/Sylius/Bundle/ApiBundle/Command/Checkout/AddressOrder.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Checkout/AddressOrder.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Command\Checkout;
 
-use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface;
 use Sylius\Component\Addressing\Model\AddressInterface;
 
 /** @experimental */
-class AddressOrder implements OrderTokenValueAwareInterface
+class AddressOrder implements OrderTokenValueAwareCommandInterface
 {
     /** @var string */
     public $orderTokenValue;

--- a/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChoosePaymentMethod.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChoosePaymentMethod.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Command\Checkout;
 
-use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
-use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface;
+use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareCommandInterface;
 
 /** @experimental */
-class ChoosePaymentMethod implements OrderTokenValueAwareInterface, SubresourceIdAwareInterface
+class ChoosePaymentMethod implements OrderTokenValueAwareCommandInterface, SubresourceIdAwareCommandInterface
 {
     /** @var string|null */
     public $orderTokenValue;

--- a/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChooseShippingMethod.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChooseShippingMethod.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Command\Checkout;
 
-use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
-use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface;
+use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareCommandInterface;
 
 /** @experimental */
-class ChooseShippingMethod implements OrderTokenValueAwareInterface, SubresourceIdAwareInterface
+class ChooseShippingMethod implements OrderTokenValueAwareCommandInterface, SubresourceIdAwareCommandInterface
 {
     /** @var string|null */
     public $orderTokenValue;

--- a/src/Sylius/Bundle/ApiBundle/Command/Checkout/CompleteOrder.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Checkout/CompleteOrder.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Command\Checkout;
 
-use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface;
 
 /** @experimental */
-class CompleteOrder implements OrderTokenValueAwareInterface
+class CompleteOrder implements OrderTokenValueAwareCommandInterface
 {
     /** @var string|null */
     public $orderTokenValue;

--- a/src/Sylius/Bundle/ApiBundle/Command/EnrichableCommandInterface.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/EnrichableCommandInterface.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Command;
 
-/** @experimental */
-interface OrderTokenValueAwareInterface extends CommandAwareDataTransformerInterface
+/**
+ * Marker interface, used to inform \Sylius\Bundle\ApiBundle\DataTransformer\CompositeEnrichableCommandDataTransformer,
+ * that this command should be passed through Sylius transformers
+ *
+ * @experimental
+ */
+interface EnrichableCommandInterface
 {
-    public function getOrderTokenValue(): ?string;
-
-    public function setOrderTokenValue(?string $orderTokenValue): void;
 }

--- a/src/Sylius/Bundle/ApiBundle/Command/OrderTokenValueAwareCommandInterface.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/OrderTokenValueAwareCommandInterface.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\Command;
 
 /** @experimental */
-interface ShopUserIdAwareInterface extends CommandAwareDataTransformerInterface
+interface OrderTokenValueAwareCommandInterface extends EnrichableCommandInterface
 {
-    public function getShopUserId();
+    public function getOrderTokenValue(): ?string;
 
-    public function setShopUserId($shopUserId): void;
+    public function setOrderTokenValue(?string $orderTokenValue): void;
 }

--- a/src/Sylius/Bundle/ApiBundle/Command/ShopUserIdAwareCommandInterface.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/ShopUserIdAwareCommandInterface.php
@@ -14,11 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\Command;
 
 /** @experimental */
-interface SubresourceIdAwareInterface extends CommandAwareDataTransformerInterface
+interface ShopUserIdAwareCommandInterface extends EnrichableCommandInterface
 {
-    public function getSubresourceId(): ?string;
+    public function getShopUserId();
 
-    public function setSubresourceId(?string $subresourceId): void;
-
-    public function getSubresourceIdAttributeKey(): string;
+    public function setShopUserId($shopUserId): void;
 }

--- a/src/Sylius/Bundle/ApiBundle/Command/SubresourceIdAwareCommandInterface.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/SubresourceIdAwareCommandInterface.php
@@ -14,6 +14,11 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\Command;
 
 /** @experimental */
-interface CommandAwareDataTransformerInterface
+interface SubresourceIdAwareCommandInterface extends EnrichableCommandInterface
 {
+    public function getSubresourceId(): ?string;
+
+    public function setSubresourceId(?string $subresourceId): void;
+
+    public function getSubresourceIdAttributeKey(): string;
 }

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/ChangeShopUserPasswordHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/ChangeShopUserPasswordHandler.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\CommandHandler;
 
-use Sylius\Bundle\ApiBundle\Command\ChangeShopUserPassword;
+use Sylius\Bundle\ApiBundle\Command\ChangeShopUserPasswordCommand;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Sylius\Component\User\Security\PasswordUpdaterInterface;
@@ -35,7 +35,7 @@ final class ChangeShopUserPasswordHandler implements MessageHandlerInterface
         $this->userRepository = $userRepository;
     }
 
-    public function __invoke(ChangeShopUserPassword $changeShopUserPassword)
+    public function __invoke(ChangeShopUserPasswordCommand $changeShopUserPassword)
     {
         if ($changeShopUserPassword->confirmNewPassword !== $changeShopUserPassword->newPassword) {
             throw new \InvalidArgumentException('Passwords do not match.');

--- a/src/Sylius/Bundle/ApiBundle/DataTransformer/CompositeEnrichableCommandDataTransformer.php
+++ b/src/Sylius/Bundle/ApiBundle/DataTransformer/CompositeEnrichableCommandDataTransformer.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\DataTransformer;
 
 use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
-use Sylius\Bundle\ApiBundle\Command\CommandAwareDataTransformerInterface;
+use Sylius\Bundle\ApiBundle\Command\EnrichableCommandInterface;
 
 /** @experimental */
-final class CommandAwareInputDataTransformer implements DataTransformerInterface
+final class CompositeEnrichableCommandDataTransformer implements DataTransformerInterface
 {
     /** @var CommandDataTransformerInterface[] */
     private $commandDataTransformers;
@@ -42,7 +42,7 @@ final class CommandAwareInputDataTransformer implements DataTransformerInterface
     {
         return
             isset($context['input']['class']) &&
-            is_a($context['input']['class'], CommandAwareDataTransformerInterface::class, true)
+            is_a($context['input']['class'], EnrichableCommandInterface::class, true)
         ;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/DataTransformer/LoggedInShopUserIdAwareCommandDataTransformer.php
+++ b/src/Sylius/Bundle/ApiBundle/DataTransformer/LoggedInShopUserIdAwareCommandDataTransformer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\DataTransformer;
 
-use Sylius\Bundle\ApiBundle\Command\ShopUserIdAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\ShopUserIdAwareCommandInterface;
 use Sylius\Bundle\ApiBundle\Context\UserContextInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Model\UserInterface;
@@ -30,9 +30,9 @@ final class LoggedInShopUserIdAwareCommandDataTransformer implements CommandData
     }
 
     /**
-     * @param ShopUserIdAwareInterface $object
+     * @param ShopUserIdAwareCommandInterface $object
      */
-    public function transform($object, string $to, array $context = []): ShopUserIdAwareInterface
+    public function transform($object, string $to, array $context = []): ShopUserIdAwareCommandInterface
     {
         /** @var ShopUserInterface|UserInterface $user */
         $user = $this->userContext->getUser();
@@ -48,6 +48,6 @@ final class LoggedInShopUserIdAwareCommandDataTransformer implements CommandData
 
     public function supportsTransformation($object): bool
     {
-        return $object instanceof ShopUserIdAwareInterface;
+        return $object instanceof ShopUserIdAwareCommandInterface;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/DataTransformer/OrderTokenValueAwareInputCommandDataTransformer.php
+++ b/src/Sylius/Bundle/ApiBundle/DataTransformer/OrderTokenValueAwareInputCommandDataTransformer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\DataTransformer;
 
-use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 
 /** @experimental */
@@ -31,6 +31,6 @@ final class OrderTokenValueAwareInputCommandDataTransformer implements CommandDa
 
     public function supportsTransformation($object): bool
     {
-        return $object instanceof OrderTokenValueAwareInterface;
+        return $object instanceof OrderTokenValueAwareCommandInterface;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/DataTransformer/SubresourceIdAwareCommandDataTransformer.php
+++ b/src/Sylius/Bundle/ApiBundle/DataTransformer/SubresourceIdAwareCommandDataTransformer.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\DataTransformer;
 
-use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareCommandInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Webmozart\Assert\Assert;
 
@@ -45,6 +45,6 @@ final class SubresourceIdAwareCommandDataTransformer implements CommandDataTrans
 
     public function supportsTransformation($object): bool
     {
-        return $object instanceof SubresourceIdAwareInterface;
+        return $object instanceof SubresourceIdAwareCommandInterface;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/DependencyInjection/Compiler/CommandDataTransformerPass.php
+++ b/src/Sylius/Bundle/ApiBundle/DependencyInjection/Compiler/CommandDataTransformerPass.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\DependencyInjection\Compiler;
 
-use Sylius\Bundle\ApiBundle\DataTransformer\CommandAwareInputDataTransformer;
+use Sylius\Bundle\ApiBundle\DataTransformer\CompositeEnrichableCommandDataTransformer;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -24,7 +24,7 @@ final class CommandDataTransformerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        $commandDataTransformersChainDefinition = new Definition(CommandAwareInputDataTransformer::class);
+        $commandDataTransformersChainDefinition = new Definition(CompositeEnrichableCommandDataTransformer::class);
 
         $taggedServices = $container->findTaggedServiceIds('sylius.api.command_data_transformer');
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Customer.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Customer.xml
@@ -58,7 +58,7 @@
                 <attribute name="method">PUT</attribute>
                 <attribute name="path">/shop/customers/{id}/password</attribute>
                 <attribute name="messenger">input</attribute>
-                <attribute name="input">Sylius\Bundle\ApiBundle\Command\ChangeShopUserPassword</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Command\ChangeShopUserPasswordCommand</attribute>
                 <attribute name="output">false</attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">shop:customer:password:update</attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/ChangePasswordShopUser.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Account/ChangePasswordShopUser.xml
@@ -15,7 +15,7 @@
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
 >
-    <class name="Sylius\Bundle\ApiBundle\Command\ChangeShopUserPassword">
+    <class name="Sylius\Bundle\ApiBundle\Command\ChangeShopUserPasswordCommand">
         <attribute name="currentPassword">
             <group>shop:customer:password:update</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/validation/ChangePasswordShopUser.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/validation/ChangePasswordShopUser.xml
@@ -15,7 +15,7 @@
                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                     xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/services/constraint-mapping-1.0.xsd"
 >
-    <class name="Sylius\Bundle\ApiBundle\Command\ChangeShopUserPassword">
+    <class name="Sylius\Bundle\ApiBundle\Command\ChangeShopUserPasswordCommand">
         <constraint name="Sylius\Bundle\ApiBundle\Validator\Constraints\CorrectChangeShopUserConfirmPassword">
             <option name="groups">
                 <value>sylius</value>

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectChangeShopUserConfirmPasswordValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/CorrectChangeShopUserConfirmPasswordValidator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
-use Sylius\Bundle\ApiBundle\Command\ChangeShopUserPassword;
+use Sylius\Bundle\ApiBundle\Command\ChangeShopUserPasswordCommand;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Webmozart\Assert\Assert;
@@ -21,10 +21,10 @@ use Webmozart\Assert\Assert;
 /** @experimental */
 final class CorrectChangeShopUserConfirmPasswordValidator extends ConstraintValidator
 {
-    /** @param ChangeShopUserPassword|mixed $value */
+    /** @param ChangeShopUserPasswordCommand|mixed $value */
     public function validate($value, Constraint $constraint): void
     {
-        Assert::isInstanceOf($value, ChangeShopUserPassword::class);
+        Assert::isInstanceOf($value, ChangeShopUserPasswordCommand::class);
 
         if ($value->confirmNewPassword !== $value->newPassword) {
             $this->context->buildViolation('sylius.user.plainPassword.mismatch')

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderNotEmptyValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderNotEmptyValidator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
-use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
@@ -36,7 +36,7 @@ final class OrderNotEmptyValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint): void
     {
-        Assert::isInstanceOf($value, OrderTokenValueAwareInterface::class);
+        Assert::isInstanceOf($value, OrderTokenValueAwareCommandInterface::class);
 
         /** @var OrderNotEmpty $constraint */
         Assert::isInstanceOf($constraint, OrderNotEmpty::class);

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentMethodEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderPaymentMethodEligibilityValidator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
-use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
@@ -34,7 +34,7 @@ final class OrderPaymentMethodEligibilityValidator extends ConstraintValidator
 
     public function validate($value, Constraint $constraint): void
     {
-        Assert::isInstanceOf($value, OrderTokenValueAwareInterface::class);
+        Assert::isInstanceOf($value, OrderTokenValueAwareCommandInterface::class);
 
         /** @var OrderPaymentMethodEligibility $constraint */
         Assert::isInstanceOf($constraint, OrderPaymentMethodEligibility::class);

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderProductEligibilityValidator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
-use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
@@ -37,7 +37,7 @@ final class OrderProductEligibilityValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint): void
     {
-        Assert::isInstanceOf($value, OrderTokenValueAwareInterface::class);
+        Assert::isInstanceOf($value, OrderTokenValueAwareCommandInterface::class);
 
         /** @var OrderProductEligibility $constraint */
         Assert::isInstanceOf($constraint, OrderProductEligibility::class);

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/OrderShippingMethodEligibilityValidator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Validator\Constraints;
 
-use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Core\Model\ShippingMethodInterface;
@@ -42,7 +42,7 @@ final class OrderShippingMethodEligibilityValidator extends ConstraintValidator
 
     public function validate($value, Constraint $constraint)
     {
-        Assert::isInstanceOf($value, OrderTokenValueAwareInterface::class);
+        Assert::isInstanceOf($value, OrderTokenValueAwareCommandInterface::class);
 
         /** @var OrderShippingMethodEligibility $constraint */
         Assert::isInstanceOf($constraint, OrderShippingMethodEligibility::class);

--- a/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/ChangeShopUserPasswordHandlerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/ChangeShopUserPasswordHandlerSpec.php
@@ -15,7 +15,7 @@ namespace spec\Sylius\Bundle\ApiBundle\CommandHandler;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Sylius\Bundle\ApiBundle\Command\ChangeShopUserPassword;
+use Sylius\Bundle\ApiBundle\Command\ChangeShopUserPasswordCommand;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Sylius\Component\User\Security\PasswordUpdaterInterface;
@@ -43,7 +43,7 @@ final class ChangeShopUserPasswordHandlerSpec extends ObjectBehavior
         $shopUser->setPlainPassword('PLAIN_PASSWORD')->shouldBeCalled();
         $passwordUpdater->updatePassword($shopUser)->shouldBeCalled();
 
-        $changePasswordShopUser = new ChangeShopUserPassword(
+        $changePasswordShopUser = new ChangeShopUserPasswordCommand(
             'PLAIN_PASSWORD',
             'PLAIN_PASSWORD',
             'OLD_PASSWORD'
@@ -64,7 +64,7 @@ final class ChangeShopUserPasswordHandlerSpec extends ObjectBehavior
         $shopUser->setPlainPassword(Argument::any())->shouldNotBeCalled();
         $passwordUpdater->updatePassword(Argument::any())->shouldNotBeCalled();
 
-        $changePasswordShopUser = new ChangeShopUserPassword(
+        $changePasswordShopUser = new ChangeShopUserPasswordCommand(
             'PLAIN_PASSWORD',
             'WRONG_PASSWORD',
             'OLD_PASSWORD'
@@ -88,7 +88,7 @@ final class ChangeShopUserPasswordHandlerSpec extends ObjectBehavior
         $shopUser->setPlainPassword(Argument::any())->shouldNotBeCalled();
         $passwordUpdater->updatePassword(Argument::any())->shouldNotBeCalled();
 
-        $changePasswordShopUser = new ChangeShopUserPassword(
+        $changePasswordShopUser = new ChangeShopUserPasswordCommand(
             'PLAIN_PASSWORD',
             'PLAIN_PASSWORD',
             'OLD_PASSWORD'

--- a/src/Sylius/Bundle/ApiBundle/spec/DataTransformer/LoggedInShopUserIdAwareCommandDataTransformerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/DataTransformer/LoggedInShopUserIdAwareCommandDataTransformerSpec.php
@@ -15,8 +15,8 @@ namespace spec\Sylius\Bundle\ApiBundle\DataTransformer;
 
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Sylius\Bundle\ApiBundle\Command\CommandAwareDataTransformerInterface;
-use Sylius\Bundle\ApiBundle\Command\ShopUserIdAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\EnrichableCommandInterface;
+use Sylius\Bundle\ApiBundle\Command\ShopUserIdAwareCommandInterface;
 use Sylius\Bundle\ApiBundle\Context\UserContextInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Model\UserInterface;
@@ -29,8 +29,8 @@ final class LoggedInShopUserIdAwareCommandDataTransformerSpec extends ObjectBeha
     }
 
     function it_supports_only_shop_user_id_commands(
-        ShopUserIdAwareInterface $shopUserIdAware,
-        CommandAwareDataTransformerInterface $commandAwareDataTransformer
+        ShopUserIdAwareCommandInterface $shopUserIdAware,
+        EnrichableCommandInterface $commandAwareDataTransformer
     ): void {
         $this->supportsTransformation($shopUserIdAware)->shouldReturn(true);
         $this->supportsTransformation($commandAwareDataTransformer)->shouldReturn(false);
@@ -39,7 +39,7 @@ final class LoggedInShopUserIdAwareCommandDataTransformerSpec extends ObjectBeha
     function it_sets_current_shop_user_id(
         UserContextInterface $userContext,
         ShopUserInterface $shopUser,
-        ShopUserIdAwareInterface $shopUserIdAwareCommand
+        ShopUserIdAwareCommandInterface $shopUserIdAwareCommand
     ): void {
         $userContext->getUser()->willReturn($shopUser);
 
@@ -53,7 +53,7 @@ final class LoggedInShopUserIdAwareCommandDataTransformerSpec extends ObjectBeha
     function it_does_nothing_if_logged_in_user_is_not_shop_user(
         UserContextInterface $userContext,
         UserInterface $user,
-        ShopUserIdAwareInterface $shopUserIdAwareCommand
+        ShopUserIdAwareCommandInterface $shopUserIdAwareCommand
     ): void {
         $userContext->getUser()->willReturn($user);
 

--- a/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/OrderPaymentMethodEligibilityValidatorSpecCommand.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/OrderPaymentMethodEligibilityValidatorSpecCommand.php
@@ -16,7 +16,7 @@ namespace spec\Sylius\Bundle\ApiBundle\Validator\Constraints;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\ApiBundle\Command\Checkout\CompleteOrder;
-use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface;
 use Sylius\Bundle\ApiBundle\Validator\Constraints\OrderPaymentMethodEligibility;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PaymentInterface;
@@ -49,7 +49,7 @@ final class OrderPaymentMethodEligibilityValidatorSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_constraint_does_not_type_of_order_shipping_method_eligibility(): void
     {
-        $constraint = new class() extends Constraint implements OrderTokenValueAwareInterface {
+        $constraint = new class() extends Constraint implements OrderTokenValueAwareCommandInterface {
             private $orderTokenValue;
 
             function getOrderTokenValue(): ?string

--- a/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/OrderShippingMethodEligibilityValidatorSpecCommand.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/OrderShippingMethodEligibilityValidatorSpecCommand.php
@@ -16,7 +16,7 @@ namespace spec\Sylius\Bundle\ApiBundle\Validator\Constraints;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\ApiBundle\Command\Checkout\CompleteOrder;
-use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareCommandInterface;
 use Sylius\Bundle\ApiBundle\Validator\Constraints\OrderShippingMethodEligibility;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
@@ -52,7 +52,7 @@ final class OrderShippingMethodEligibilityValidatorSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_constraint_does_not_type_of_order_shipping_method_eligibility(): void
     {
-        $constraint = new class() extends Constraint implements OrderTokenValueAwareInterface {
+        $constraint = new class() extends Constraint implements OrderTokenValueAwareCommandInterface {
             private $orderTokenValue;
 
             public function getOrderTokenValue(): ?string


### PR DESCRIPTION
… its purpose

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Proposal of renaming, to better express intention behind the interface. `CommandAwareDataTransformerInterface` is placed on commands, that will be passed to our data transformers, so we can put additional data into them, like order token, or subresource id. There is nothing to be aware of because this interface is placed on command in the first place. 

In addition, I've added Command suffix to command interfaces.

If we would like to merge it, I should probably with UPGRADE note for this change. 

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
