### PR TITLE
[API] Explicitly define bus to all handlers

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
@@ -20,7 +20,7 @@
             <argument type="service" id="sylius.factory.shop_user" />
             <argument type="service" id="sylius.manager.shop_user" />
             <argument type="service" id="Sylius\Bundle\ApiBundle\Provider\CustomerProviderInterface" />
-            <tag name="messenger.message_handler" />
+            <tag name="messenger.message_handler" bus="sylius_default.bus"/>
         </service>
 
         <service id="Sylius\Bundle\ApiBundle\CommandHandler\PickupCartHandler">
@@ -29,7 +29,7 @@
             <argument type="service" id="sylius.api.context.user" />
             <argument type="service" id="sylius.manager.order" />
             <argument type="service" id="sylius.random_generator" />
-            <tag name="messenger.message_handler" />
+            <tag name="messenger.message_handler" bus="sylius_default.bus"/>
         </service>
 
         <service id="Sylius\Bundle\ApiBundle\CommandHandler\Cart\AddItemToCartHandler">
@@ -39,14 +39,14 @@
             <argument type="service" id="sylius.factory.order_item" />
             <argument type="service" id="sylius.order_item_quantity_modifier" />
             <argument type="service" id="sylius.order_processing.order_processor" />
-            <tag name="messenger.message_handler" />
+            <tag name="messenger.message_handler" bus="sylius_default.bus"/>
         </service>
 
         <service id="Sylius\Bundle\ApiBundle\CommandHandler\Cart\RemoveItemFromCartHandler">
             <argument type="service" id="sylius.repository.order_item"/>
             <argument type="service" id="sylius.order_modifier" />
             <argument type="service" id="sylius.order_processing.order_processor" />
-            <tag name="messenger.message_handler" />
+            <tag name="messenger.message_handler" bus="sylius_default.bus"/>
         </service>
 
         <service id="Sylius\Bundle\ApiBundle\CommandHandler\Checkout\AddressOrderHandler">
@@ -55,7 +55,7 @@
             <argument type="service" id="sylius.factory.customer"/>
             <argument type="service" id="sylius.manager.customer"/>
             <argument type="service" id="sm.factory" />
-            <tag name="messenger.message_handler" />
+            <tag name="messenger.message_handler" bus="sylius_default.bus"/>
         </service>
 
         <service id="Sylius\Bundle\ApiBundle\CommandHandler\Checkout\ChooseShippingMethodHandler">
@@ -64,7 +64,7 @@
             <argument type="service" id="sylius.repository.shipment"/>
             <argument type="service" id="sylius.shipping_method_eligibility_checker"/>
             <argument type="service" id="sm.factory" />
-            <tag name="messenger.message_handler" />
+            <tag name="messenger.message_handler" bus="sylius_default.bus"/>
         </service>
 
         <service id="Sylius\Bundle\ApiBundle\CommandHandler\Checkout\ChoosePaymentMethodHandler">
@@ -72,20 +72,20 @@
             <argument type="service" id="sylius.repository.payment_method"/>
             <argument type="service" id="sylius.repository.payment"/>
             <argument type="service" id="sm.factory" />
-            <tag name="messenger.message_handler" />
+            <tag name="messenger.message_handler" bus="sylius_default.bus"/>
         </service>
 
         <service id="Sylius\Bundle\ApiBundle\CommandHandler\Checkout\CompleteOrderHandler">
             <argument type="service" id="sylius.repository.order"/>
             <argument type="service" id="sm.factory" />
-            <tag name="messenger.message_handler" />
+            <tag name="messenger.message_handler" bus="sylius_default.bus"/>
         </service>
 
         <service id="Sylius\Bundle\ApiBundle\CommandHandler\Cart\ChangeItemQuantityInCartHandler">
             <argument type="service" id="sylius.repository.order_item" />
             <argument type="service" id="sylius.order_item_quantity_modifier" />
             <argument type="service" id="sylius.order_processing.order_processor" />
-            <tag name="messenger.message_handler" />
+            <tag name="messenger.message_handler" bus="sylius_default.bus"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no (kind of)
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Symfony messenger component will register handlers into all busses if we won't specify it. I would say, that additional busses are common enough, that we should not register our handlers in different busses by default. 

Ref. https://symfony.com/doc/current/messenger/multiple_buses.html#restrict-handlers-per-bus

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
