### PR TITLE
Menu taxon can be null, even by default

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -184,7 +184,7 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
 
         if (null !== $this->taxonRepository) {
             $resolver
-                ->setDefault('menu_taxon', LazyOption::randomOne($this->taxonRepository))
+                ->setDefault('menu_taxon', LazyOption::randomOneOrNull($this->taxonRepository))
                 ->setAllowedTypes('menu_taxon', ['null', 'string', TaxonInterface::class])
                 ->setNormalizer('menu_taxon', LazyOption::findOneBy($this->taxonRepository, 'code'))
             ;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | kind of
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

I don't get exactly why I had that. But basically if you have no taxon then the fixture fails. And since a Channel can have a null value for the menu taxon…
