### PR TITLE
Customize a controller fix typo in services config

### DIFF
--- a/docs/customization/controller.rst
+++ b/docs/customization/controller.rst
@@ -190,7 +190,7 @@ If you still need the methods of the original ``HomepageController``, then copy 
 
     # config/services.yaml
     services:
-        app.controller.shop.homepage:
+        sylius.controller.shop.homepage:
             class: App\Controller\Shop\HomepageController
             arguments: ['@templating']
             tags: ['controller.service_arguments']


### PR DESCRIPTION
in the services.yaml you need to override sylius.controller.shop.homepage not app.controller.shop.homepage

| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT