### PR TITLE
[Admin][Product List] fix missing products

### DIFF
--- a/features/product/managing_products/sorting_products.feature
+++ b/features/product/managing_products/sorting_products.feature
@@ -67,5 +67,5 @@ Feature: Sorting listed products
     @ui @api
     Scenario: Products are visible independent from the user locale
         Given this administrator is using "Zulu (South Africa)" locale
-        Given I am browsing products
+        When I am browsing products
         Then I should see 3 products in the list

--- a/features/product/managing_products/sorting_products.feature
+++ b/features/product/managing_products/sorting_products.feature
@@ -63,3 +63,9 @@ Feature: Sorting listed products
         And I sort the products descending by name
         Then I should see 3 products in the list
         And the first product on the list should have name "Szałowy Mops"
+
+    @ui @api
+    Scenario: Products are visible independent from the user locale
+        Given this administrator is using "Zulu (South Africa)" locale
+        Given I am browsing products
+        Then I should see 3 products in the list

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -39,7 +39,7 @@ class ProductRepository extends BaseProductRepository implements ProductReposito
     {
         $queryBuilder = $this->createQueryBuilder('o')
             ->addSelect('translation')
-            ->innerJoin('o.translations', 'translation', 'WITH', 'translation.locale = :locale')
+            ->leftJoin('o.translations', 'translation', 'WITH', 'translation.locale = :locale')
             ->setParameter('locale', $locale)
         ;
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8 (will do 1.7 if this gets approved)
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related #10398
| License         | MIT

If the admin user has a locale set that is different from the ones your sales channels are using you will end up with 0 products. If products are not yet translated to the locale of the user they would also not show up.

How to reproduce:
- Visit the admin product grid (/admin/products/) and make sure you see some products.
- Change your user language to something your products do not have any translation for (for the Demo data simple "en" will 
work).  
- Go back to the grid, products should be gone.

Fix:
I changed `Sylius\Bundle\CoreBundle\Doctrine\ORM\ProductRepository::createListQueryBuilder` and exchanged the **innerJoin** to the translations with a **leftJoin**. Not perfect as for example the **Name** column shows now empty but better than not showing up at all. 

Possible Improvements
We could inject the default locale into the **ProductRepository** and also join this locale. 
Another way would be to modify `sylius.context.locale` to return all locale codes instead of one and then leftJoin all of these locale codes


