### PR TITLE
[Order] Order cancelation fix

### DIFF
--- a/src/Sylius/Component/Core/Updater/UnpaidOrdersStateUpdater.php
+++ b/src/Sylius/Component/Core/Updater/UnpaidOrdersStateUpdater.php
@@ -15,6 +15,7 @@ namespace Sylius\Component\Core\Updater;
 
 use Psr\Log\LoggerInterface;
 use SM\Factory\Factory;
+use SM\SMException;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Order\OrderTransitions;
@@ -61,7 +62,7 @@ final class UnpaidOrdersStateUpdater implements UnpaidOrdersStateUpdaterInterfac
         foreach ($expiredUnpaidOrders as $expiredUnpaidOrder) {
             try {
                 $this->cancelOrder($expiredUnpaidOrder);
-            } catch (\Exception $e) {
+            } catch (SMException $e) {
                 if (null !== $this->logger) {
                     $this->logger->error(
                         sprintf('An error occurred while cancelling unpaid order #%s', $expiredUnpaidOrder->getId()),

--- a/src/Sylius/Component/Core/spec/Updater/UnpaidOrdersStateUpdaterSpec.php
+++ b/src/Sylius/Component/Core/spec/Updater/UnpaidOrdersStateUpdaterSpec.php
@@ -17,6 +17,7 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 use SM\Factory\Factory;
+use SM\SMException;
 use SM\StateMachine\StateMachineInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Core\Updater\UnpaidOrdersStateUpdaterInterface;
@@ -77,7 +78,7 @@ final class UnpaidOrdersStateUpdaterSpec extends ObjectBehavior
         $stateMachineFactory->get($secondOrder, 'sylius_order')->willReturn($secondOrderStateMachine);
 
         $firstOrderStateMachine->apply(OrderTransitions::TRANSITION_CANCEL)->shouldBeCalled()
-            ->willThrow(new \Exception());
+            ->willThrow(new SMException());
         $secondOrderStateMachine->apply(OrderTransitions::TRANSITION_CANCEL)->shouldBeCalled();
 
         $logger->error(
@@ -109,7 +110,7 @@ final class UnpaidOrdersStateUpdaterSpec extends ObjectBehavior
         $stateMachineFactory->get($secondOrder, 'sylius_order')->willReturn($secondOrderStateMachine);
 
         $firstOrderStateMachine->apply(OrderTransitions::TRANSITION_CANCEL)->shouldBeCalled()
-            ->willThrow(new \Exception());
+            ->willThrow(new SMException());
         $secondOrderStateMachine->apply(OrderTransitions::TRANSITION_CANCEL)->shouldBeCalled();
 
         $this->cancel();


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | kind of(as I reduced the scope of exceptions, that are caught)
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Catching all exceptions may lead to flushing partially changed data. If after transition some service will change some part of data and after that, an exception will occur, we would silence this exception and proceed further without compensating partially changed data.

However, the release with these changes was published on Thursday, so the impact of it is negligible  (comparing to the problems it can create).

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
