### PR TITLE
Suggest PayPalPlugin as the default PayPal integration

### DIFF
--- a/docs/book/orders/payments.rst
+++ b/docs/book/orders/payments.rst
@@ -117,8 +117,10 @@ Payment Gateways that already have a Sylius bridge
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First you need to create the configuration form type for your gateway. Have a look at the configuration form types of
-`Paypal <https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/PayumBundle/Form/Type/PaypalGatewayConfigurationType.php>`_
-and `Stripe <https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/PayumBundle/Form/Type/StripeGatewayConfigurationType.php>`_.
+
+* `Paypal Commerce Platform <https://github.com/Sylius/PayPalPlugin/blob/master/src/Form/Type/PayPalConfigurationType.php>`_
+* `Paypal Express Checkout <https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/PayumBundle/Form/Type/PaypalGatewayConfigurationType.php>`_
+* `Stripe <https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/PayumBundle/Form/Type/StripeGatewayConfigurationType.php>`_
 
 Then you should register its configuration form type with ``sylius.gateway_configuration_type`` tag.
 After that it will be available in the Admin panel in the gateway choice dropdown.

--- a/docs/cookbook/payments/paypal.rst
+++ b/docs/cookbook/payments/paypal.rst
@@ -1,9 +1,15 @@
 How to configure PayPal Express Checkout?
 =========================================
 
+.. warning::
+
+    PayPal Express Checkout integration is deprecated. Take a look at the
+    `PayPal Commerce Platform <https://github.com/Sylius/PayPalPlugin>`_ integration, which is now the default
+    PayPal-related gateway for Sylius.
+
 One of the most frequently used payment methods in e-commerce is PayPal. Its configuration in Sylius is really simple.
 
-Add a payment method with the Paypal Expresss gateway in the Admin Panel
+Add a payment method with the Paypal Express gateway in the Admin Panel
 ------------------------------------------------------------------------
 
 .. note::

--- a/docs/getting-started-with-sylius/shipping-and-payment.rst
+++ b/docs/getting-started-with-sylius/shipping-and-payment.rst
@@ -17,8 +17,8 @@ Payment method
 --------------
 
 Customer should also be able to choose, how they are willing to pay. At least one payment method is required - let's make it "Cash on delivery".
-Before creation, we need to specify the payment method gateway, which is a way for processing the payment (*Offline*, *PayPal Express Checkout*,
-and *Stripe* are supported by default).
+Before creation, we need to specify the payment method gateway, which is a way for processing the payment
+(*Offline*, *PayPal Commerce Platform*, *PayPal Express Checkout* and *Stripe* are supported by default).
 
 Gateway selection:
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/translations/messages.en.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/translations/messages.en.yml
@@ -46,4 +46,7 @@ sylius:
     ui:
         gateway:
             no_sca_support_notice: The chosen payment gateway does not support SCA.
+            pay_pal_express_checkout_deprecation_notice: >
+                PayPal Express Checkout is deprecated. Please, use new
+                <a href="https://github.com/Sylius/PayPalPlugin" target="_blank">PayPal Commerce Platform</a> integration.
         sales_summary: Sales summary

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/PaymentMethod/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/PaymentMethod/_form.html.twig
@@ -28,6 +28,17 @@
             </div>
         </div>
     {% endif %}
+    {% if resource.gatewayConfig.factoryName == 'paypal_express_checkout' %}
+        <div class="ui icon negative orange message sylius-flash-message">
+            <i class="close icon"></i>
+            <i class="warning icon"></i>
+            <div class="content">
+                <div class="header">
+                    {% autoescape false %}{{ 'sylius.ui.gateway.pay_pal_express_checkout_deprecation_notice'|trans }}{% endautoescape %}
+                </div>
+            </div>
+        </div>
+    {% endif %}
 
     {{ form_row(form.gatewayConfig.factoryName) }}
     {% if form.gatewayConfig.config is defined %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

The next step is installing PayPalPlugin on Sylius-Standard by default 💃 

<img width="1102" alt="Zrzut ekranu 2020-11-9 o 11 55 47" src="https://user-images.githubusercontent.com/6212718/98536784-a68bab80-2288-11eb-992b-6be9328ff93c.png">
