### PR TITLE
[FIXTURES] Use shopbillDataFactory in ChannelExampleFactory

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -20,6 +20,7 @@ use Sylius\Component\Channel\Factory\ChannelFactoryInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\Scope;
+use Sylius\Component\Core\Model\ShopBillingData;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
@@ -64,7 +65,11 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
         ?FactoryInterface $shopBillingDataFactory = null
     ) {
         if (null === $taxonRepository) {
-            @trigger_error('Passing RouterInterface as the fourth argument is deprecated since 1.8 and will be prohibited in 2.0', \E_USER_DEPRECATED);
+            @trigger_error('Passing RouterInterface as the fifth argument is deprecated since 1.8 and will be prohibited in 2.0', \E_USER_DEPRECATED);
+        }
+
+        if (null === $shopBillingDataFactory) {
+            @trigger_error('Passing RouterInterface as the sixth argument is deprecated since 1.8 and will be prohibited in 2.0', \E_USER_DEPRECATED);
         }
 
         $this->channelFactory = $channelFactory;
@@ -113,8 +118,8 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
             $channel->addCurrency($currency);
         }
 
-        if (isset($options['shop_billing_data']) && null !== $options['shop_billing_data'] && null !== $this->shopBillingDataFactory) {
-            $shopBillingData = $this->shopBillingDataFactory->createNew();
+        if (isset($options['shop_billing_data']) && null !== $options['shop_billing_data']) {
+            $shopBillingData = $this->shopBillingDataFactory ? $this->shopBillingDataFactory->createNew() : new ShopBillingData();
             $shopBillingData->setCompany($options['shop_billing_data']['company'] ?? null);
             $shopBillingData->setTaxId($options['shop_billing_data']['tax_id'] ?? null);
             $shopBillingData->setCountryCode($options['shop_billing_data']['country_code'] ?? null);

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/ChannelExampleFactory.php
@@ -20,10 +20,10 @@ use Sylius\Component\Channel\Factory\ChannelFactoryInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\Scope;
-use Sylius\Component\Core\Model\ShopBillingData;
 use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
 use Symfony\Component\OptionsResolver\Options;
@@ -52,12 +52,16 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
     /** @var TaxonRepositoryInterface|null */
     private $taxonRepository;
 
+    /** @var FactoryInterface|null */
+    private $shopBillingDataFactory;
+
     public function __construct(
         ChannelFactoryInterface $channelFactory,
         RepositoryInterface $localeRepository,
         RepositoryInterface $currencyRepository,
         RepositoryInterface $zoneRepository,
-        ?TaxonRepositoryInterface $taxonRepository = null
+        ?TaxonRepositoryInterface $taxonRepository = null,
+        ?FactoryInterface $shopBillingDataFactory = null
     ) {
         if (null === $taxonRepository) {
             @trigger_error('Passing RouterInterface as the fourth argument is deprecated since 1.8 and will be prohibited in 2.0', \E_USER_DEPRECATED);
@@ -68,6 +72,7 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
         $this->currencyRepository = $currencyRepository;
         $this->zoneRepository = $zoneRepository;
         $this->taxonRepository = $taxonRepository;
+        $this->shopBillingDataFactory = $shopBillingDataFactory;
 
         $this->faker = \Faker\Factory::create();
         $this->optionsResolver = new OptionsResolver();
@@ -108,8 +113,8 @@ class ChannelExampleFactory extends AbstractExampleFactory implements ExampleFac
             $channel->addCurrency($currency);
         }
 
-        if (isset($options['shop_billing_data']) && null !== $options['shop_billing_data']) {
-            $shopBillingData = new ShopBillingData();
+        if (isset($options['shop_billing_data']) && null !== $options['shop_billing_data'] && null !== $this->shopBillingDataFactory) {
+            $shopBillingData = $this->shopBillingDataFactory->createNew();
             $shopBillingData->setCompany($options['shop_billing_data']['company'] ?? null);
             $shopBillingData->setTaxId($options['shop_billing_data']['tax_id'] ?? null);
             $shopBillingData->setCountryCode($options['shop_billing_data']['country_code'] ?? null);

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/fixtures_factories.xml
@@ -40,6 +40,7 @@
             <argument type="service" id="sylius.repository.currency" />
             <argument type="service" id="sylius.repository.zone" />
             <argument type="service" id="sylius.repository.taxon" />
+            <argument type="service" id="sylius.factory.shop_billing_data" />
         </service>
 
         <service id="sylius.fixture.example_factory.customer_group" class="Sylius\Bundle\CoreBundle\Fixture\Factory\CustomerGroupExampleFactory">


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8 or master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


ShopBillingData model override (in configuration) breaks fixtures. ShopBillingData should be created from factory instead of `Sylius\Component\Core\Model\ShopBillingData` class.