### PR TITLE
Bugfix | Don't suggest old format for template locations

### DIFF
--- a/docs/cookbook/entities/custom-model.rst
+++ b/docs/cookbook/entities/custom-model.rst
@@ -159,7 +159,7 @@ Having a grid prepared we can configure routing for the entity administration:
             alias: app.supplier
             section: admin
             path: admin
-            templates: SyliusAdminBundle:Crud
+            templates: "@SyliusAdmin\\Crud"
             redirect: update
             grid: app_admin_supplier
             vars:

--- a/docs/cookbook/entities/custom-translatable-model.rst
+++ b/docs/cookbook/entities/custom-translatable-model.rst
@@ -450,7 +450,7 @@ Having a grid prepared we can configure routing for the entity administration:
         resource: |
             alias: app.supplier
             section: admin
-            templates: SyliusAdminBundle:Crud
+            templates: "@SyliusAdmin\\Crud"
             redirect: update
             grid: app_admin_supplier
             vars:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7 / 1.8 
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no(?)
| Deprecations?   | no
| License         | MIT

With old format in Symfony 5 there is fatal error that templates cannot be found, in code those locations are correct already:
- https://github.com/Sylius/Sylius/blob/1.8/src/Sylius/Bundle/AdminBundle/Resources/config/routing/product.yml#L5
