### PR TITLE
[Behat] Remove conflict with "lcobucci/jwt" and error reporting for E_USER_DEPRECATED

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -9,15 +9,6 @@ refereneces related issues.
    
    References: https://github.com/doctrine/inflector/issues/147
    
- - `lcobucci/jwt:^3.4`:
- 
-   Crashes Behat test suite while executing step `And I am logged in as "francis@underwood.com"`
-   in the new API context:
-    
-   ```
-   Warning: array_key_exists() expects parameter 2 to be array, null given in vendor/webmozart/assert/src/Assert.php line 1662
-   ```
-   
  - `symfony/doctrine-bridge:4.4.16`:
 
    This version of Doctrine Bridge introduces a bug that causes an issue related to `ChannelPricing` mapping.

--- a/composer.json
+++ b/composer.json
@@ -193,7 +193,6 @@
     },
     "conflict": {
         "doctrine/inflector": "^1.4",
-        "lcobucci/jwt": "^3.4",
         "phpspec/prophecy": "1.11.0",
         "sylius/grid-bundle": "1.7.4",
         "symfony/doctrine-bridge": "4.4.16",

--- a/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
+++ b/src/Sylius/Behat/Client/ApiPlatformSecurityClient.php
@@ -56,6 +56,8 @@ final class ApiPlatformSecurityClient implements ApiSecurityClientInterface
 
     public function call(): void
     {
+        error_reporting(error_reporting() & ~E_USER_DEPRECATED);
+
         $this->client->request(
             $this->request['method'],
             $this->request['url'],

--- a/src/Sylius/Behat/Service/ApiSecurityService.php
+++ b/src/Sylius/Behat/Service/ApiSecurityService.php
@@ -39,6 +39,8 @@ final class ApiSecurityService implements SecurityServiceInterface
 
     public function logIn(UserInterface $user): void
     {
+        error_reporting(error_reporting() & ~E_USER_DEPRECATED);
+
         $this->client->request(
             'POST',
             sprintf('/new-api/%s/authentication-token', $this->loginEndpoint),


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

After conflict with `lcobucci/jwt`

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
