### PR TITLE
Make link buttons with confirmation modal work again

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-bulk-action-require-confirmation.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-bulk-action-require-confirmation.js
@@ -19,7 +19,11 @@ $.fn.extend({
         const actionButton = $(evt.currentTarget);
 
         if (actionButton.is('a')) {
-          $('#confirmation-button').attr('href', actionButton.attr('href'));
+          $('#confirmation-button').on('click', (event) => {
+            event.preventDefault();
+
+            window.location.href = actionButton.attr('href');
+          });
         }
 
         if (actionButton.is('button')) {

--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-require-confirmation.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-require-confirmation.js
@@ -19,7 +19,11 @@ $.fn.extend({
         const actionButton = $(evt.currentTarget);
 
         if (actionButton.is('a')) {
-          $('#confirmation-button').attr('href', actionButton.attr('href'));
+          $('#confirmation-button').on('click', (event) => {
+            event.preventDefault();
+
+            window.location.href = actionButton.attr('href');
+          });
         }
 
         if (actionButton.is('button')) {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

When trying to add a confirmation modal to a link button (`<a href..`) it didn't do anything when clicking the confirmation button inside the modal. It seems that the confirmation button (which is actually a div) gets a href set, but I don't discover (also not in the Semantic UI docs) that that is actually a functionality. 