### PR TITLE
Remove lcobucci/jwt v3.4 conflict

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -8,16 +8,7 @@ refereneces related issues.
    Inflector 1.4 changes pluralization of `taxon` from `taxons` (used in Sylius) to `taxa`.
    
    References: https://github.com/doctrine/inflector/issues/147
-   
- - `lcobucci/jwt:^3.4`:
  
-   Crashes Behat test suite while executing step `And I am logged in as "francis@underwood.com"`
-   in the new API context:
-    
-   ```
-   Warning: array_key_exists() expects parameter 2 to be array, null given in vendor/webmozart/assert/src/Assert.php line 1662
-   ```
-   
  - `symfony/doctrine-bridge:4.4.16`:
 
    This version of Doctrine Bridge introduces a bug that causes an issue related to `ChannelPricing` mapping.

--- a/composer.json
+++ b/composer.json
@@ -193,11 +193,7 @@
     },
     "conflict": {
         "doctrine/inflector": "^1.4",
-        "lcobucci/jwt": "^3.4",
-        "phpspec/prophecy": "1.11.0",
-        "sylius/grid-bundle": "1.7.4",
-        "symfony/doctrine-bridge": "4.4.16",
-        "twig/twig": "2.6.1"
+        "symfony/doctrine-bridge": "4.4.16"
     },
     "suggest": {
         "ext-iconv": "For better performance than using Symfony Polyfill Component",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Fixed after this PR: https://github.com/lexik/LexikJWTAuthenticationBundle/pull/797
And new LexikJWTAuthenticationBundle tag v2.10.1

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
