### PR TITLE
[Adjustment] Add more details to adjustment and make shipment adjustable

### DIFF
--- a/UPGRADE-1.9.md
+++ b/UPGRADE-1.9.md
@@ -20,4 +20,6 @@
 1. Identifier needed to retrieve a product in shop API endpoint (`/new-api/shop/products/{id}`) has been changed 
 from `slug` to `code`. 
 
-1. Migration added `CoreBundle/Migrations/Version20201208105207.php` which connects existing shipping adjustment to shipping and fills adjustment details.
+# warning
+Migration added `CoreBundle/Migrations/Version20201208105207.php` which connects existing shipping adjustment to shipping and fills adjustment details.
+If TaxRate Name was customized it may cause issues, as it's name should contain actual tax rate! (it is use to connect tax rate and adjustment details)

--- a/UPGRADE-1.9.md
+++ b/UPGRADE-1.9.md
@@ -20,6 +20,16 @@
 1. Identifier needed to retrieve a product in shop API endpoint (`/new-api/shop/products/{id}`) has been changed 
 from `slug` to `code`. 
 
-# warning
-Migration added `CoreBundle/Migrations/Version20201208105207.php` which connects existing shipping adjustment to shipping and fills adjustment details.
-If TaxRate Name was customized it may cause issues, as it's name should contain actual tax rate! (it is use to connect tax rate and adjustment details)
+1. The `CoreBundle/Migrations/Version20201208105207.php` migration was added which adds:
+ * Taxation details(percentage and relation to tax rate)
+ * Shipping details(shipping relation)
+ * Taxation for shipping(combined details of percentage and shipping relation)
+ 
+ This data is fetched based on two assumptions:
+ * Order level taxes relates to shipping only (default Sylius behaviour)
+ * Tax rate name has not change since the time, the first order has been placed
+ 
+ It these are not true, please adjust migration accordingly to your need. To exclude following migration from execution run following code: 
+    ```
+    bin/console doctrine:migrations:version 'CoreBundle/Migrations/Version20201208105207' --add
+    ```

--- a/UPGRADE-1.9.md
+++ b/UPGRADE-1.9.md
@@ -20,16 +20,16 @@
 1. Identifier needed to retrieve a product in shop API endpoint (`/new-api/shop/products/{id}`) has been changed 
 from `slug` to `code`. 
 
-1. The `CoreBundle/Migrations/Version20201208105207.php` migration was added which adds:
- * Taxation details(percentage and relation to tax rate)
- * Shipping details(shipping relation)
- * Taxation for shipping(combined details of percentage and shipping relation)
+1. The `CoreBundle/Migrations/Version20201208105207.php` migration was added which extends existing adjustments with additional details(context). Depending on the type of adjustment, additionally defined information are:
+ * Taxation details (percentage and relation to tax rate)
+ * Shipping details (shipping relation)
+ * Taxation for shipping (combined details of percentage and shipping relation)
  
  This data is fetched based on two assumptions:
  * Order level taxes relates to shipping only (default Sylius behaviour)
  * Tax rate name has not change since the time, the first order has been placed
  
- It these are not true, please adjust migration accordingly to your need. To exclude following migration from execution run following code: 
+ If these are not true, please adjust migration accordingly to your need. To exclude following migration from execution run following code: 
     ```
     bin/console doctrine:migrations:version 'CoreBundle/Migrations/Version20201208105207' --add
     ```

--- a/UPGRADE-1.9.md
+++ b/UPGRADE-1.9.md
@@ -19,3 +19,5 @@
  
 1. Identifier needed to retrieve a product in shop API endpoint (`/new-api/shop/products/{id}`) has been changed 
 from `slug` to `code`. 
+
+1. Migration added `CoreBundle/Migrations/Version20201208105207.php` which connects existing shipping adjustment to shipping and fills adjustment details.

--- a/features/order/managing_orders/order_details/seeing_order_aggregated_taxes.feature
+++ b/features/order/managing_orders/order_details/seeing_order_aggregated_taxes.feature
@@ -26,6 +26,7 @@ Feature: Seeing aggregated taxes of an order
         And the customer chose "DHL" shipping method to "United States" with "Offline" payment
         When I view the summary of the order "#00000001"
         Then there should be a shipping charge "DHL $10.00"
+        And there should be a shipping tax "$2.30"
         And the order's shipping total should be "$12.30"
         And the order's tax total should be "$25.30"
         And the order's total should be "$135.30"
@@ -37,6 +38,7 @@ Feature: Seeing aggregated taxes of an order
         And the customer chose "DHL" shipping method to "United States" with "Offline" payment
         When I view the summary of the order "#00000001"
         Then there should be a shipping charge "DHL $10.00"
+        And there should be a shipping tax "$2.30"
         And the order's shipping total should be "$12.30"
         And the order's tax total should be "$45.30"
         And the order's total should be "$355.30"

--- a/features/order/managing_orders/order_details/seeing_order_shipping_taxes.feature
+++ b/features/order/managing_orders/order_details/seeing_order_shipping_taxes.feature
@@ -23,6 +23,7 @@ Feature: Seeing taxes of an order
         When I view the summary of the order "#00000666"
         Then the order's items total should be "$172.20"
         And there should be a shipping charge "DHL $10.00"
+        And there should be a shipping tax "$2.30"
         And the order's shipping total should be "$12.30"
         And the order's tax total should be "$34.50"
         And the order's total should be "$184.50"

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingOrdersContext.php
@@ -345,6 +345,14 @@ final class ManagingOrdersContext implements Context
     }
 
     /**
+     * @Then there should be a shipping tax :shippingTax
+     */
+    public function thereShouldBeAShippingTax(string $shippingTax): void
+    {
+        Assert::true($this->showPage->hasShippingTax($shippingTax));
+    }
+
+    /**
      * @Then the order's shipping total should be :shippingTotal
      */
     public function theOrdersShippingTotalShouldBe($shippingTotal)

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
@@ -186,6 +186,11 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         return stripos($shippingChargesText, $shippingCharge) !== false;
     }
 
+    public function hasShippingTax(string $shippingTax): bool
+    {
+        return stripos($this->getElement('shipping_tax')->getText(), $shippingTax) !== false;
+    }
+
     public function getOrderPromotionTotal(): string
     {
         $promotionTotalElement = $this->getElement('promotion_total');
@@ -405,6 +410,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
             'shipping_address' => '#shipping-address',
             'shipping_adjustment_name' => '#shipping-adjustment-label',
             'shipping_charges' => '#shipping-base-value',
+            'shipping_tax' => '#shipping-tax-value',
             'shipping_total' => '#shipping-total',
             'table' => '.table',
             'tax_total' => '#tax-total',

--- a/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPageInterface.php
@@ -54,6 +54,8 @@ interface ShowPageInterface extends SymfonyPageInterface
 
     public function hasShippingCharge(string $shippingCharge): bool;
 
+    public function hasShippingTax(string $shippingTax): bool;
+
     public function getTaxTotal(): string;
 
     public function getOrderPromotionTotal(): string;

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_totals.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_totals.html.twig
@@ -22,15 +22,33 @@
         {% if not order.adjustments(shippingAdjustment).isEmpty() %}
             <div class="ui relaxed divided list">
                 <div class="item"><strong>{{ 'sylius.ui.shipping'|trans }}:</strong></div>
-                {% for adjustment in order.adjustments(shippingAdjustment) %}
-                    <div class="item">
-                        <div id="shipping-base-value" class="right floated">{{ money.format(adjustment.amount, order.currencyCode) }}</div>
-                        <div class="content">
-                            <div id="shipping-adjustment-label" class="description">
-                                <strong>{{ adjustment.label }}</strong>:
+                {% for shipment in order.shipments %}
+                    {% for adjustment in shipment.adjustments(shippingAdjustment) %}
+                        <div class="item">
+                            <div id="shipping-base-value" class="right floated">{{ money.format(adjustment.amount, order.currencyCode) }}</div>
+                            <div class="content">
+                                <div id="shipping-adjustment-label" class="description">
+                                    <strong>{{ adjustment.label }}</strong>:
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    {% endfor %}
+
+                    {% for adjustment in shipment.adjustments(taxAdjustment) %}
+                        <div class="item{% if adjustment.isNeutral %} tax-disabled{% endif %}">
+                            <div id="shipping-tax-value" class="right floated">
+                                {{ money.format(adjustment.amount, order.currencyCode) }}
+                                {% if adjustment.isNeutral %}
+                                    <small>({{ 'sylius.ui.included_in_price'|trans }})</small>
+                                {% endif %}
+                            </div>
+                            <div class="content">
+                                <div id="shipping-adjustment-label" class="description">
+                                    <strong{% if adjustment.isNeutral %} class="tax-disabled"{% endif %}>{{ adjustment.label }}</strong>:
+                                </div>
+                            </div>
+                        </div>
+                    {% endfor %}
                 {% endfor %}
             </div>
         {% else %}

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201126103037.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201126103037.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20201126103037 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add details to adjustment';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_adjustment ADD details LONGTEXT NOT NULL COMMENT \'(DC2Type:array)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_adjustment DROP details');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201130071338.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201130071338.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20201130071338 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make shipment adjustable';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_adjustment ADD shipment_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE sylius_adjustment ADD CONSTRAINT FK_ACA6E0F27BE036FC FOREIGN KEY (shipment_id) REFERENCES sylius_shipment (id) ON DELETE CASCADE');
+        $this->addSql('CREATE INDEX IDX_ACA6E0F27BE036FC ON sylius_adjustment (shipment_id)');
+        $this->addSql('ALTER TABLE sylius_shipment ADD adjustments_total INT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_adjustment DROP FOREIGN KEY FK_ACA6E0F27BE036FC');
+        $this->addSql('DROP INDEX IDX_ACA6E0F27BE036FC ON sylius_adjustment');
+        $this->addSql('ALTER TABLE sylius_adjustment DROP shipment_id');
+        $this->addSql('ALTER TABLE sylius_shipment DROP adjustments_total');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
@@ -25,7 +25,7 @@ final class Version20201204071301 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql("ALTER TABLE sylius_adjustment ADD details JSON NOT NULL DEFAULT ( JSON_ARRAY() )");
+        $this->addSql("ALTER TABLE sylius_adjustment ADD details JSON NOT NULL");
     }
 
     public function down(Schema $schema): void

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
@@ -16,7 +16,7 @@ namespace Sylius\Bundle\CoreBundle\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-final class Version20201126103037 extends AbstractMigration
+final class Version20201204071301 extends AbstractMigration
 {
     public function getDescription(): string
     {
@@ -25,7 +25,7 @@ final class Version20201126103037 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE sylius_adjustment ADD details LONGTEXT NOT NULL COMMENT \'(DC2Type:array)\'');
+        $this->addSql('ALTER TABLE sylius_adjustment ADD details JSON NOT NULL');
     }
 
     public function down(Schema $schema): void

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
@@ -25,7 +25,7 @@ final class Version20201204071301 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('ALTER TABLE sylius_adjustment ADD details JSON NOT NULL');
+        $this->addSql("ALTER TABLE sylius_adjustment ADD details JSON NOT NULL DEFAULT ( JSON_ARRAY() )");
     }
 
     public function down(Schema $schema): void

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201208105207.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201208105207.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Migrations;
@@ -9,22 +18,17 @@ use Doctrine\Migrations\AbstractMigration;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-final class Version20201208105207 extends AbstractMigration implements ContainerAwareInterface
+final class Version20201208105207 extends AbstractMigration
 {
     /** @var ContainerInterface */
     private $container;
 
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
-    }
-
-    public function getDescription() : string
+    public function getDescription(): string
     {
         return 'Set details and shipment_id on shipping adjustments.';
     }
 
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         $this->setDefaultAdjustmentData();
 
@@ -39,7 +43,7 @@ final class Version20201208105207 extends AbstractMigration implements Container
         }
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         $this->setDefaultAdjustmentData();
     }
@@ -58,11 +62,11 @@ final class Version20201208105207 extends AbstractMigration implements Container
     {
        return $this->connection->fetchAllAssociative(
             '
-                SELECT sa.id, sa.label, sa.order_id, s.id as shipping_id, s.method_id, ssm.code AS shipment_code
-                FROM sylius_adjustment sa
-                JOIN sylius_shipment s ON s.order_id = sa.order_id
-                JOIN sylius_shipping_method ssm on s.method_id = ssm.id
-                WHERE sa.type = "shipping"
+                SELECT adjustment.id, adjustment.label, adjustment.order_id, shipment.id as shipping_id, shipment.method_id, shipping_method.code AS shipment_code
+                FROM sylius_adjustment adjustment
+                JOIN sylius_shipment shipment ON shipment.order_id = adjustment.order_id
+                JOIN sylius_shipping_method shipping_method on shipment.method_id = shipping_method.id
+                WHERE adjustment.type = "shipping"
             '
         );
     }

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201208105207.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201208105207.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\ORM\EntityManagerInterface;
+use Sylius\Component\Attribute\AttributeType\SelectAttributeType;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20201208105207 extends AbstractMigration implements ContainerAwareInterface
+{
+    /** @var ContainerInterface */
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $adjustments = $this->getAdjustments();
+
+        // this up() migration is auto-generated, please modify it to your needs
+
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+
+    private function getAdjustments(): array
+    {
+        $adjustmentClass = $this->container->getParameter('sylius.model.adjustment.class');
+
+        $entityManager = $this->getEntityManager($adjustmentClass);
+
+        return $entityManager->createQueryBuilder()
+            ->select('o')
+            ->from($adjustmentClass, 'o')
+            ->getQuery()
+            ->getArrayResult()
+            ;
+    }
+
+    private function getEntityManager(string $class): EntityManagerInterface
+    {
+        /** @var ManagerRegistry $managerRegistry */
+        $managerRegistry = $this->container->get('doctrine');
+
+        /** @var EntityManagerInterface $manager */
+        $manager = $managerRegistry->getManagerForClass($class);
+
+        return $manager;
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201208105207.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201208105207.php
@@ -46,17 +46,17 @@ final class Version20201208105207 extends AbstractMigration implements Container
 
     private function setDefaultAdjustmentData(): void
     {
-        $this->connection->exec("UPDATE sylius_adjustment SET shipment_id = null, details = '[]'");
+        $this->connection->executeQuery("UPDATE sylius_adjustment SET shipment_id = null, details = '[]'");
     }
 
     private function updateAdjustment(int $adjustmentId, int $shipmentId, string $details): void
     {
-        $this->connection->exec("UPDATE sylius_adjustment SET shipment_id = $shipmentId, details = '" . $details . "' WHERE id = $adjustmentId");
+        $this->connection->executeQuery("UPDATE sylius_adjustment SET shipment_id = $shipmentId, details = '" . $details . "' WHERE id = $adjustmentId");
     }
 
     private function getShipmentAdjustmentsWithData(): array
     {
-       return $this->connection->fetchAll(
+       return $this->connection->fetchAllAssociative(
             '
                 SELECT sa.id, sa.label, sa.order_id, s.id as shipping_id, s.method_id, ssm.code AS shipment_code
                 FROM sylius_adjustment sa

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius/sylius_order.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius/sylius_order.yml
@@ -3,6 +3,9 @@
 
 sylius_order:
     resources:
+        adjustment:
+            classes:
+                model: Sylius\Component\Core\Model\Adjustment
         order:
             classes:
                 model: Sylius\Component\Core\Model\Order

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Adjustment.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Adjustment.orm.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping">
+
+    <mapped-superclass name="Sylius\Component\Core\Model\Adjustment" table="sylius_adjustment">
+        <many-to-one field="shipment" target-entity="Sylius\Component\Core\Model\ShipmentInterface" inversed-by="adjustments">
+            <join-column name="shipment_id" on-delete="CASCADE"/>
+        </many-to-one>
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Shipment.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/Shipment.orm.xml
@@ -17,6 +17,14 @@
                                       http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
     <mapped-superclass name="Sylius\Component\Core\Model\Shipment" table="sylius_shipment">
+        <field name="adjustmentsTotal" column="adjustments_total" type="integer" />
+
+        <one-to-many field="adjustments" target-entity="Sylius\Component\Core\Model\AdjustmentInterface" mapped-by="shipment" orphan-removal="true">
+            <cascade>
+                <cascade-all/>
+            </cascade>
+        </one-to-many>
+
         <many-to-one field="order" target-entity="Sylius\Component\Order\Model\OrderInterface" inversed-by="shipments">
             <join-column name="order_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />
         </many-to-one>

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Adjustment.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Adjustment.orm.xml
@@ -28,7 +28,7 @@
         <field name="neutral" column="is_neutral" type="boolean" />
         <field name="locked" column="is_locked" type="boolean" />
         <field name="originCode" column="origin_code" type="string" nullable="true" />
-        <field name="details" type="array" />
+        <field name="details" type="json" />
 
         <field name="createdAt" column="created_at" type="datetime">
             <gedmo:timestampable on="create"/>

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Adjustment.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Adjustment.orm.xml
@@ -27,8 +27,8 @@
         <field name="amount" column="amount" type="integer" />
         <field name="neutral" column="is_neutral" type="boolean" />
         <field name="locked" column="is_locked" type="boolean" />
-
         <field name="originCode" column="origin_code" type="string" nullable="true" />
+        <field name="details" type="array" />
 
         <field name="createdAt" column="created_at" type="datetime">
             <gedmo:timestampable on="create"/>

--- a/src/Sylius/Component/Core/Model/Adjustment.php
+++ b/src/Sylius/Component/Core/Model/Adjustment.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Model;
+
+use Sylius\Component\Order\Model\Adjustment as BaseAdjustment;
+
+class Adjustment extends BaseAdjustment implements AdjustmentInterface
+{
+    /** @var ShipmentInterface|null */
+    protected $shipment;
+
+    public function getShipment(): ?ShipmentInterface
+    {
+        return $this->shipment;
+    }
+
+    public function setShipment(?ShipmentInterface $shipment): void
+    {
+        $this->shipment = $shipment;
+    }
+}

--- a/src/Sylius/Component/Core/Model/Adjustment.php
+++ b/src/Sylius/Component/Core/Model/Adjustment.php
@@ -27,6 +27,18 @@ class Adjustment extends BaseAdjustment implements AdjustmentInterface
 
     public function setShipment(?ShipmentInterface $shipment): void
     {
+        if ($this->shipment === $shipment) {
+            return;
+        }
+
+        if ($this->shipment !== null) {
+            $this->shipment->removeAdjustment($this);
+        }
+
         $this->shipment = $shipment;
+
+        if ($shipment !== null) {
+            $this->setAdjustable($this->shipment->getOrder());
+        }
     }
 }

--- a/src/Sylius/Component/Core/Model/AdjustmentInterface.php
+++ b/src/Sylius/Component/Core/Model/AdjustmentInterface.php
@@ -28,4 +28,8 @@ interface AdjustmentInterface extends BaseAdjustmentInterface
     public const SHIPPING_ADJUSTMENT = 'shipping';
 
     public const TAX_ADJUSTMENT = 'tax';
+
+    public const DETAILS_ASSOCIATED_WITH_ORDER_ITEM_UNIT = 'order_item_unit';
+
+    public const DETAILS_ASSOCIATED_WITH_SHIPMENT = 'shipment';
 }

--- a/src/Sylius/Component/Core/Model/AdjustmentInterface.php
+++ b/src/Sylius/Component/Core/Model/AdjustmentInterface.php
@@ -28,4 +28,8 @@ interface AdjustmentInterface extends BaseAdjustmentInterface
     public const SHIPPING_ADJUSTMENT = 'shipping';
 
     public const TAX_ADJUSTMENT = 'tax';
+
+    public function getShipment(): ?ShipmentInterface;
+
+    public function setShipment(?ShipmentInterface $shipment): void;
 }

--- a/src/Sylius/Component/Core/Model/AdjustmentInterface.php
+++ b/src/Sylius/Component/Core/Model/AdjustmentInterface.php
@@ -28,8 +28,4 @@ interface AdjustmentInterface extends BaseAdjustmentInterface
     public const SHIPPING_ADJUSTMENT = 'shipping';
 
     public const TAX_ADJUSTMENT = 'tax';
-
-    public const DETAILS_ASSOCIATED_WITH_ORDER_ITEM_UNIT = 'order_item_unit';
-
-    public const DETAILS_ASSOCIATED_WITH_SHIPMENT = 'shipment';
 }

--- a/src/Sylius/Component/Core/Model/Shipment.php
+++ b/src/Sylius/Component/Core/Model/Shipment.php
@@ -25,9 +25,9 @@ class Shipment extends BaseShipment implements ShipmentInterface
     protected $order;
 
     /**
-     * @var Collection|AdjustmentInterface[]
+     * @var Collection|BaseAdjustmentInterface[]
      *
-     * @psalm-var Collection<array-key, AdjustmentInterface>
+     * @psalm-var Collection<array-key, BaseAdjustmentInterface>
      */
     protected $adjustments;
 
@@ -38,7 +38,7 @@ class Shipment extends BaseShipment implements ShipmentInterface
     {
         parent::__construct();
 
-        /** @var ArrayCollection<array-key, AdjustmentInterface> $this->adjustments */
+        /** @var ArrayCollection<array-key, BaseAdjustmentInterface> $this->adjustments */
         $this->adjustments = new ArrayCollection();
     }
 

--- a/src/Sylius/Component/Core/Model/Shipment.php
+++ b/src/Sylius/Component/Core/Model/Shipment.php
@@ -15,7 +15,7 @@ namespace Sylius\Component\Core\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Sylius\Component\Order\Model\AdjustmentInterface;
+use Sylius\Component\Order\Model\AdjustmentInterface as BaseAdjustmentInterface;
 use Sylius\Component\Order\Model\OrderInterface as BaseOrderInterface;
 use Sylius\Component\Shipping\Model\Shipment as BaseShipment;
 
@@ -63,29 +63,33 @@ class Shipment extends BaseShipment implements ShipmentInterface
         });
     }
 
-    public function addAdjustment(AdjustmentInterface $adjustment): void
+    public function addAdjustment(BaseAdjustmentInterface $adjustment): void
     {
+        /** @var AdjustmentInterface $adjustment */
         if ($this->hasAdjustment($adjustment)) {
             return;
         }
 
         $this->adjustments->add($adjustment);
-        $this->order->addAdjustment($adjustment);
-        $adjustment->setAdjustable($this);
+        $adjustment->setShipment($this);
+        $this->recalculateAdjustmentsTotal();
+        $this->order->recalculateAdjustmentsTotal();
     }
 
-    public function removeAdjustment(AdjustmentInterface $adjustment): void
+    public function removeAdjustment(BaseAdjustmentInterface $adjustment): void
     {
+        /** @var AdjustmentInterface $adjustment */
         if ($adjustment->isLocked() || !$this->hasAdjustment($adjustment)) {
             return;
         }
 
         $this->adjustments->removeElement($adjustment);
-        $this->order->removeAdjustment($adjustment);
-        $adjustment->setAdjustable(null);
+        $adjustment->setShipment(null);
+        $this->recalculateAdjustmentsTotal();
+        $this->order->recalculateAdjustmentsTotal();
     }
 
-    public function hasAdjustment(AdjustmentInterface $adjustment): bool
+    public function hasAdjustment(BaseAdjustmentInterface $adjustment): bool
     {
         return $this->adjustments->contains($adjustment);
     }

--- a/src/Sylius/Component/Core/Model/Shipment.php
+++ b/src/Sylius/Component/Core/Model/Shipment.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Order\Model\AdjustmentInterface;
 use Sylius\Component\Order\Model\OrderInterface as BaseOrderInterface;
 use Sylius\Component\Shipping\Model\Shipment as BaseShipment;
 
@@ -20,6 +23,24 @@ class Shipment extends BaseShipment implements ShipmentInterface
 {
     /** @var BaseOrderInterface|null */
     protected $order;
+
+    /**
+     * @var Collection|AdjustmentInterface[]
+     *
+     * @psalm-var Collection<array-key, AdjustmentInterface>
+     */
+    protected $adjustments;
+
+    /** @var int */
+    protected $adjustmentsTotal = 0;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        /** @var ArrayCollection<array-key, AdjustmentInterface> $this->adjustments */
+        $this->adjustments = new ArrayCollection();
+    }
 
     public function getOrder(): ?BaseOrderInterface
     {
@@ -29,5 +50,67 @@ class Shipment extends BaseShipment implements ShipmentInterface
     public function setOrder(?BaseOrderInterface $order): void
     {
         $this->order = $order;
+    }
+
+    public function getAdjustments(?string $type = null): Collection
+    {
+        if (null === $type) {
+            return $this->adjustments;
+        }
+
+        return $this->adjustments->filter(function (AdjustmentInterface $adjustment) use ($type): bool {
+            return $type === $adjustment->getType();
+        });
+    }
+
+    public function addAdjustment(AdjustmentInterface $adjustment): void
+    {
+        if ($this->hasAdjustment($adjustment)) {
+            return;
+        }
+
+        $this->adjustments->add($adjustment);
+        $this->order->addAdjustment($adjustment);
+        $adjustment->setAdjustable($this);
+    }
+
+    public function removeAdjustment(AdjustmentInterface $adjustment): void
+    {
+        if ($adjustment->isLocked() || !$this->hasAdjustment($adjustment)) {
+            return;
+        }
+
+        $this->adjustments->removeElement($adjustment);
+        $this->order->removeAdjustment($adjustment);
+        $adjustment->setAdjustable(null);
+    }
+
+    public function hasAdjustment(AdjustmentInterface $adjustment): bool
+    {
+        return $this->adjustments->contains($adjustment);
+    }
+
+    public function getAdjustmentsTotal(?string $type = null): int
+    {
+        $total = 0;
+        foreach ($this->getAdjustments($type) as $adjustment) {
+            if (!$adjustment->isNeutral()) {
+                $total += $adjustment->getAmount();
+            }
+        }
+
+        return $total;
+    }
+
+    public function removeAdjustments(?string $type = null): void
+    {
+        foreach ($this->getAdjustments($type) as $adjustment) {
+            $this->removeAdjustment($adjustment);
+        }
+    }
+
+    public function recalculateAdjustmentsTotal(): void
+    {
+        $this->adjustmentsTotal = $this->getAdjustmentsTotal();
     }
 }

--- a/src/Sylius/Component/Core/Model/ShipmentInterface.php
+++ b/src/Sylius/Component/Core/Model/ShipmentInterface.php
@@ -13,11 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Model;
 
+use Sylius\Component\Order\Model\AdjustableInterface;
 use Sylius\Component\Order\Model\OrderAwareInterface;
 use Sylius\Component\Order\Model\OrderInterface as BaseOrderInterface;
 use Sylius\Component\Shipping\Model\ShipmentInterface as BaseShipmentInterface;
 
-interface ShipmentInterface extends BaseShipmentInterface, OrderAwareInterface
+interface ShipmentInterface extends BaseShipmentInterface, OrderAwareInterface, AdjustableInterface
 {
     /**
      * @return OrderInterface|null

--- a/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php
@@ -47,6 +47,8 @@ final class ShippingChargesProcessor implements OrderProcessorInterface
         $order->removeAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT);
 
         foreach ($order->getShipments() as $shipment) {
+            $shipment->removeAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT);
+
             try {
                 $shippingCharge = $this->shippingChargesCalculator->calculate($shipment);
                 $shippingMethod = $shipment->getMethod();
@@ -62,7 +64,7 @@ final class ShippingChargesProcessor implements OrderProcessorInterface
                 ]);
 
 
-                $order->addAdjustment($adjustment);
+                $shipment->addAdjustment($adjustment);
             } catch (UndefinedShippingMethodException $exception) {
             }
         }

--- a/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php
@@ -49,12 +49,18 @@ final class ShippingChargesProcessor implements OrderProcessorInterface
         foreach ($order->getShipments() as $shipment) {
             try {
                 $shippingCharge = $this->shippingChargesCalculator->calculate($shipment);
+                $shippingMethod = $shipment->getMethod();
 
                 /** @var AdjustmentInterface $adjustment */
                 $adjustment = $this->adjustmentFactory->createNew();
                 $adjustment->setType(AdjustmentInterface::SHIPPING_ADJUSTMENT);
                 $adjustment->setAmount($shippingCharge);
-                $adjustment->setLabel($shipment->getMethod()->getName());
+                $adjustment->setLabel($shippingMethod->getName());
+                $adjustment->setDetails([
+                    'shippingMethodCode' => $shippingMethod->getCode(),
+                    'shippingMethodName' => $shippingMethod->getName(),
+                ]);
+
 
                 $order->addAdjustment($adjustment);
             } catch (UndefinedShippingMethodException $exception) {

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderItemUnitsTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderItemUnitsTaxesApplicator.php
@@ -17,6 +17,7 @@ use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
+use Sylius\Component\Core\Model\TaxRateInterface;
 use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
 use Sylius\Component\Taxation\Calculator\CalculatorInterface;
 use Sylius\Component\Taxation\Resolver\TaxRateResolverInterface;
@@ -45,6 +46,7 @@ class OrderItemUnitsTaxesApplicator implements OrderTaxesApplicatorInterface
     public function apply(OrderInterface $order, ZoneInterface $zone): void
     {
         foreach ($order->getItems() as $item) {
+            /** @var TaxRateInterface|null $taxRate */
             $taxRate = $this->taxRateResolver->resolve($item->getVariant(), ['zone' => $zone]);
             if (null === $taxRate) {
                 continue;
@@ -56,16 +58,25 @@ class OrderItemUnitsTaxesApplicator implements OrderTaxesApplicatorInterface
                     continue;
                 }
 
-                $this->addTaxAdjustment($unit, (int) $taxAmount, $taxRate->getLabel(), $taxRate->isIncludedInPrice());
+                $this->addAdjustment($unit, (int) $taxAmount, $taxRate);
             }
         }
     }
 
-    private function addTaxAdjustment(OrderItemUnitInterface $unit, int $taxAmount, string $label, bool $included): void
+    private function addAdjustment(OrderItemUnitInterface $unit, int $taxAmount, TaxRateInterface $taxRate): void
     {
-        $unitTaxAdjustment = $this->adjustmentFactory
-            ->createWithData(AdjustmentInterface::TAX_ADJUSTMENT, $label, $taxAmount, $included)
-        ;
+        $unitTaxAdjustment = $this->adjustmentFactory->createWithData(
+            AdjustmentInterface::TAX_ADJUSTMENT,
+            $taxRate->getLabel(),
+            $taxAmount,
+            $taxRate->isIncludedInPrice(),
+            [
+                'associatedWith' => AdjustmentInterface::DETAILS_ASSOCIATED_WITH_ORDER_ITEM_UNIT,
+                'taxRateCode' => $taxRate->getCode(),
+                'taxRateName' => $taxRate->getName(),
+                'taxRateAmount' => $taxRate->getAmount(),
+            ]
+        );
         $unit->addAdjustment($unitTaxAdjustment);
     }
 }

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderItemUnitsTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderItemUnitsTaxesApplicator.php
@@ -71,7 +71,6 @@ class OrderItemUnitsTaxesApplicator implements OrderTaxesApplicatorInterface
             $taxAmount,
             $taxRate->isIncludedInPrice(),
             [
-                'associatedWith' => AdjustmentInterface::DETAILS_ASSOCIATED_WITH_ORDER_ITEM_UNIT,
                 'taxRateCode' => $taxRate->getCode(),
                 'taxRateName' => $taxRate->getName(),
                 'taxRateAmount' => $taxRate->getAmount(),

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderItemsTaxesApplicator.php
@@ -88,7 +88,6 @@ class OrderItemsTaxesApplicator implements OrderTaxesApplicatorInterface
             $taxAmount,
             $taxRate->isIncludedInPrice(),
             [
-                'associatedWith' => AdjustmentInterface::DETAILS_ASSOCIATED_WITH_ORDER_ITEM_UNIT,
                 'taxRateCode' => $taxRate->getCode(),
                 'taxRateName' => $taxRate->getName(),
                 'taxRateAmount' => $taxRate->getAmount(),

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderShipmentTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderShipmentTaxesApplicator.php
@@ -95,7 +95,7 @@ class OrderShipmentTaxesApplicator implements OrderTaxesApplicatorInterface
      */
     private function getShipment(OrderInterface $order): ShipmentInterface
     {
-        /** @var ShipmentInterface|bool $shipment */
+        /** @var ShipmentInterface|false $shipment */
         $shipment = $order->getShipments()->first();
         if (false === $shipment) {
             throw new \LogicException('Order should have at least one shipment.');

--- a/src/Sylius/Component/Core/Taxation/Applicator/OrderShipmentTaxesApplicator.php
+++ b/src/Sylius/Component/Core/Taxation/Applicator/OrderShipmentTaxesApplicator.php
@@ -69,8 +69,8 @@ class OrderShipmentTaxesApplicator implements OrderTaxesApplicatorInterface
     }
 
     private function addAdjustment(
-        OrderInterface $order, 
-        int $taxAmount, 
+        OrderInterface $order,
+        int $taxAmount,
         TaxRateInterface $taxRate,
         ShippingMethodInterface $shippingMethod
     ): void {
@@ -81,7 +81,6 @@ class OrderShipmentTaxesApplicator implements OrderTaxesApplicatorInterface
             $taxAmount,
             $taxRate->isIncludedInPrice(),
             [
-                'associatedWith' => AdjustmentInterface::DETAILS_ASSOCIATED_WITH_SHIPMENT,
                 'shippingMethodCode' => $shippingMethod->getCode(),
                 'shippingMethodName' => $shippingMethod->getName(),
                 'taxRateCode' => $taxRate->getCode(),

--- a/src/Sylius/Component/Core/spec/Model/AdjustmentSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/AdjustmentSpec.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Core\Model;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+
+class AdjustmentSpec extends ObjectBehavior
+{
+    function it_implements_an_adjustment_interface(): void
+    {
+        $this->shouldImplement(AdjustmentInterface::class);
+    }
+
+    function it_allows_assigning_itself_to_a_shipment(ShipmentInterface $shipment, OrderInterface $order): void
+    {
+        $shipment->getOrder()->willReturn($order);
+
+        $this->setShipment($shipment);
+
+        $this->getShipment()->shouldReturn($shipment);
+    }
+}

--- a/src/Sylius/Component/Core/spec/Model/ShipmentSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ShipmentSpec.php
@@ -56,18 +56,18 @@ final class ShipmentSpec extends ObjectBehavior
         $this->setOrder($order);
 
         $adjustment->isNeutral()->willReturn(true);
-        $adjustment->setAdjustable($this)->shouldBeCalled();
+        $adjustment->setShipment($this)->shouldBeCalled();
 
         $this->addAdjustment($adjustment);
-        $order->addAdjustment($adjustment)->shouldBeCalled();
         $this->hasAdjustment($adjustment)->shouldReturn(true);
 
-        $adjustment->setAdjustable(null)->shouldBeCalled();
+        $adjustment->setShipment(null)->shouldBeCalled();
         $adjustment->isLocked()->willReturn(false);
 
         $this->removeAdjustment($adjustment);
-        $order->removeAdjustment($adjustment)->shouldBeCalled();
         $this->hasAdjustment($adjustment)->shouldReturn(false);
+
+        $order->recalculateAdjustmentsTotal()->shouldBeCalledTimes(2);
     }
 
     function it_does_not_remove_adjustment_when_it_is_locked(
@@ -77,17 +77,17 @@ final class ShipmentSpec extends ObjectBehavior
         $this->setOrder($order);
 
         $adjustment->isNeutral()->willReturn(true);
-        $adjustment->setAdjustable($this)->shouldBeCalled();
+        $adjustment->setShipment($this)->shouldBeCalled();
 
         $this->addAdjustment($adjustment);
-        $order->addAdjustment($adjustment)->shouldBeCalled();
 
-        $adjustment->setAdjustable(null)->shouldNotBeCalled();
+        $adjustment->setShipment(null)->shouldNotBeCalled();
         $adjustment->isLocked()->willReturn(true);
 
         $this->removeAdjustment($adjustment);
-        $order->removeAdjustment($adjustment)->shouldNotBeCalled();
         $this->hasAdjustment($adjustment)->shouldReturn(true);
+
+        $order->recalculateAdjustmentsTotal()->shouldBeCalledOnce();
     }
 
     function it_has_correct_adjustments_total_after_adjustment_add_and_remove(
@@ -100,34 +100,31 @@ final class ShipmentSpec extends ObjectBehavior
         $this->setOrder($order);
 
         $adjustment1->isNeutral()->willReturn(false);
-        $adjustment1->setAdjustable($this)->shouldBeCalled();
+        $adjustment1->setShipment($this)->shouldBeCalled();
         $adjustment1->isLocked()->willReturn(false);
-        $adjustment1->setAdjustable(null)->shouldBeCalled();
+        $adjustment1->setShipment(null)->shouldBeCalled();
         $adjustment1->getAmount()->willReturn(100);
 
         $adjustment2->isNeutral()->willReturn(false);
-        $adjustment2->setAdjustable($this)->shouldBeCalled();
+        $adjustment2->setShipment($this)->shouldBeCalled();
         $adjustment2->getAmount()->willReturn(50);
 
         $adjustment3->isNeutral()->willReturn(false);
-        $adjustment3->setAdjustable($this)->shouldBeCalled();
+        $adjustment3->setShipment($this)->shouldBeCalled();
         $adjustment3->getAmount()->willReturn(250);
 
         $adjustment4->isNeutral()->willReturn(true);
-        $adjustment4->setAdjustable($this)->shouldBeCalled();
+        $adjustment4->setShipment($this)->shouldBeCalled();
         $adjustment4->getAmount()->willReturn(150);
 
         $this->addAdjustment($adjustment1);
-        $order->addAdjustment($adjustment1)->shouldBeCalled();
         $this->addAdjustment($adjustment2);
-        $order->addAdjustment($adjustment2)->shouldBeCalled();
         $this->addAdjustment($adjustment3);
-        $order->addAdjustment($adjustment3)->shouldBeCalled();
         $this->addAdjustment($adjustment4);
-        $order->addAdjustment($adjustment4)->shouldBeCalled();
 
         $this->removeAdjustment($adjustment1);
-        $order->removeAdjustment($adjustment1)->shouldBeCalled();
+
+        $order->recalculateAdjustmentsTotal()->shouldBeCalledTimes(5);
 
         $this->getAdjustmentsTotal()->shouldReturn(300);
     }

--- a/src/Sylius/Component/Core/spec/Model/ShipmentSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ShipmentSpec.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace spec\Sylius\Component\Core\Model;
 
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Shipping\Model\Shipment as BaseShipment;
@@ -48,5 +49,86 @@ final class ShipmentSpec extends ObjectBehavior
 
         $this->setOrder(null);
         $this->getOrder()->shouldReturn(null);
+    }
+
+    function it_adds_and_removes_adjustments(AdjustmentInterface $adjustment, OrderInterface $order): void
+    {
+        $this->setOrder($order);
+
+        $adjustment->isNeutral()->willReturn(true);
+        $adjustment->setAdjustable($this)->shouldBeCalled();
+
+        $this->addAdjustment($adjustment);
+        $order->addAdjustment($adjustment)->shouldBeCalled();
+        $this->hasAdjustment($adjustment)->shouldReturn(true);
+
+        $adjustment->setAdjustable(null)->shouldBeCalled();
+        $adjustment->isLocked()->willReturn(false);
+
+        $this->removeAdjustment($adjustment);
+        $order->removeAdjustment($adjustment)->shouldBeCalled();
+        $this->hasAdjustment($adjustment)->shouldReturn(false);
+    }
+
+    function it_does_not_remove_adjustment_when_it_is_locked(
+        AdjustmentInterface $adjustment,
+        OrderInterface $order
+    ): void {
+        $this->setOrder($order);
+
+        $adjustment->isNeutral()->willReturn(true);
+        $adjustment->setAdjustable($this)->shouldBeCalled();
+
+        $this->addAdjustment($adjustment);
+        $order->addAdjustment($adjustment)->shouldBeCalled();
+
+        $adjustment->setAdjustable(null)->shouldNotBeCalled();
+        $adjustment->isLocked()->willReturn(true);
+
+        $this->removeAdjustment($adjustment);
+        $order->removeAdjustment($adjustment)->shouldNotBeCalled();
+        $this->hasAdjustment($adjustment)->shouldReturn(true);
+    }
+
+    function it_has_correct_adjustments_total_after_adjustment_add_and_remove(
+        AdjustmentInterface $adjustment1,
+        AdjustmentInterface $adjustment2,
+        AdjustmentInterface $adjustment3,
+        AdjustmentInterface $adjustment4,
+        OrderInterface $order
+    ): void {
+        $this->setOrder($order);
+
+        $adjustment1->isNeutral()->willReturn(false);
+        $adjustment1->setAdjustable($this)->shouldBeCalled();
+        $adjustment1->isLocked()->willReturn(false);
+        $adjustment1->setAdjustable(null)->shouldBeCalled();
+        $adjustment1->getAmount()->willReturn(100);
+
+        $adjustment2->isNeutral()->willReturn(false);
+        $adjustment2->setAdjustable($this)->shouldBeCalled();
+        $adjustment2->getAmount()->willReturn(50);
+
+        $adjustment3->isNeutral()->willReturn(false);
+        $adjustment3->setAdjustable($this)->shouldBeCalled();
+        $adjustment3->getAmount()->willReturn(250);
+
+        $adjustment4->isNeutral()->willReturn(true);
+        $adjustment4->setAdjustable($this)->shouldBeCalled();
+        $adjustment4->getAmount()->willReturn(150);
+
+        $this->addAdjustment($adjustment1);
+        $order->addAdjustment($adjustment1)->shouldBeCalled();
+        $this->addAdjustment($adjustment2);
+        $order->addAdjustment($adjustment2)->shouldBeCalled();
+        $this->addAdjustment($adjustment3);
+        $order->addAdjustment($adjustment3)->shouldBeCalled();
+        $this->addAdjustment($adjustment4);
+        $order->addAdjustment($adjustment4)->shouldBeCalled();
+
+        $this->removeAdjustment($adjustment1);
+        $order->removeAdjustment($adjustment1)->shouldBeCalled();
+
+        $this->getAdjustmentsTotal()->shouldReturn(300);
     }
 }

--- a/src/Sylius/Component/Core/spec/OrderProcessing/ShippingChargesProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/ShippingChargesProcessorSpec.php
@@ -18,10 +18,10 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Shipping\Calculator\DelegatingCalculatorInterface;
-use Sylius\Component\Shipping\Model\ShipmentInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 
 final class ShippingChargesProcessorSpec extends ObjectBehavior
@@ -82,7 +82,8 @@ final class ShippingChargesProcessorSpec extends ObjectBehavior
         ;
 
         $order->removeAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->shouldBeCalled();
-        $order->addAdjustment($adjustment)->shouldBeCalled();
+        $shipment->removeAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->shouldBeCalled();
+        $shipment->addAdjustment($adjustment)->shouldBeCalled();
 
         $this->process($order);
     }

--- a/src/Sylius/Component/Core/spec/OrderProcessing/ShippingChargesProcessorSpec.php
+++ b/src/Sylius/Component/Core/spec/OrderProcessing/ShippingChargesProcessorSpec.php
@@ -67,11 +67,19 @@ final class ShippingChargesProcessorSpec extends ObjectBehavior
         $calculator->calculate($shipment)->willReturn(450);
 
         $shipment->getMethod()->willReturn($shippingMethod);
+        $shippingMethod->getCode()->willReturn('fedex');
         $shippingMethod->getName()->willReturn('FedEx');
 
         $adjustment->setAmount(450)->shouldBeCalled();
         $adjustment->setType(AdjustmentInterface::SHIPPING_ADJUSTMENT)->shouldBeCalled();
         $adjustment->setLabel('FedEx')->shouldBeCalled();
+        $adjustment
+            ->setDetails([
+                'shippingMethodCode' => 'fedex',
+                'shippingMethodName' => 'FedEx',
+            ])
+            ->shouldBeCalled()
+        ;
 
         $order->removeAdjustments(AdjustmentInterface::SHIPPING_ADJUSTMENT)->shouldBeCalled();
         $order->addAdjustment($adjustment)->shouldBeCalled();

--- a/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemUnitsTaxesApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemUnitsTaxesApplicatorSpec.php
@@ -23,10 +23,10 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Model\TaxRateInterface;
 use Sylius\Component\Core\Taxation\Applicator\OrderTaxesApplicatorInterface;
 use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
 use Sylius\Component\Taxation\Calculator\CalculatorInterface;
-use Sylius\Component\Taxation\Model\TaxRateInterface;
 use Sylius\Component\Taxation\Resolver\TaxRateResolverInterface;
 
 final class OrderItemUnitsTaxesApplicatorSpec extends ObjectBehavior
@@ -69,6 +69,9 @@ final class OrderItemUnitsTaxesApplicatorSpec extends ObjectBehavior
         $taxRateResolver->resolve($productVariant, ['zone' => $zone])->willReturn($taxRate);
 
         $taxRate->getLabel()->willReturn('Simple tax (10%)');
+        $taxRate->getCode()->willReturn('simple_tax');
+        $taxRate->getName()->willReturn('Simple tax');
+        $taxRate->getAmount()->willReturn(0.1);
         $taxRate->isIncludedInPrice()->willReturn(false);
 
         $orderItem->getUnits()->willReturn($units);
@@ -81,11 +84,33 @@ final class OrderItemUnitsTaxesApplicatorSpec extends ObjectBehavior
         $calculator->calculate(900, $taxRate)->willReturn(90);
 
         $adjustmentsFactory
-            ->createWithData(AdjustmentInterface::TAX_ADJUSTMENT, 'Simple tax (10%)', 100, false)
+            ->createWithData(
+                AdjustmentInterface::TAX_ADJUSTMENT,
+                'Simple tax (10%)',
+                100,
+                false,
+                [
+                    'associatedWith' => AdjustmentInterface::DETAILS_ASSOCIATED_WITH_ORDER_ITEM_UNIT,
+                    'taxRateCode' => 'simple_tax',
+                    'taxRateName' => 'Simple tax',
+                    'taxRateAmount' => 0.1,
+                ]
+            )
             ->willReturn($taxAdjustment1)
         ;
         $adjustmentsFactory
-            ->createWithData(AdjustmentInterface::TAX_ADJUSTMENT, 'Simple tax (10%)', 90, false)
+            ->createWithData(
+                AdjustmentInterface::TAX_ADJUSTMENT,
+                'Simple tax (10%)',
+                90,
+                false,
+                [
+                    'associatedWith' => AdjustmentInterface::DETAILS_ASSOCIATED_WITH_ORDER_ITEM_UNIT,
+                    'taxRateCode' => 'simple_tax',
+                    'taxRateName' => 'Simple tax',
+                    'taxRateAmount' => 0.1,
+                ]
+            )
             ->willReturn($taxAdjustment2)
         ;
 

--- a/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemUnitsTaxesApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemUnitsTaxesApplicatorSpec.php
@@ -90,7 +90,6 @@ final class OrderItemUnitsTaxesApplicatorSpec extends ObjectBehavior
                 100,
                 false,
                 [
-                    'associatedWith' => AdjustmentInterface::DETAILS_ASSOCIATED_WITH_ORDER_ITEM_UNIT,
                     'taxRateCode' => 'simple_tax',
                     'taxRateName' => 'Simple tax',
                     'taxRateAmount' => 0.1,
@@ -105,7 +104,6 @@ final class OrderItemUnitsTaxesApplicatorSpec extends ObjectBehavior
                 90,
                 false,
                 [
-                    'associatedWith' => AdjustmentInterface::DETAILS_ASSOCIATED_WITH_ORDER_ITEM_UNIT,
                     'taxRateCode' => 'simple_tax',
                     'taxRateName' => 'Simple tax',
                     'taxRateAmount' => 0.1,

--- a/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemsTaxesApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemsTaxesApplicatorSpec.php
@@ -23,10 +23,10 @@ use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Model\TaxRateInterface;
 use Sylius\Component\Core\Taxation\Applicator\OrderTaxesApplicatorInterface;
 use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
 use Sylius\Component\Taxation\Calculator\CalculatorInterface;
-use Sylius\Component\Taxation\Model\TaxRateInterface;
 use Sylius\Component\Taxation\Resolver\TaxRateResolverInterface;
 
 final class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
@@ -76,6 +76,9 @@ final class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         $calculator->calculate(1000, $taxRate)->willReturn(100);
 
         $taxRate->getLabel()->willReturn('Simple tax (10%)');
+        $taxRate->getCode()->willReturn('simple_tax');
+        $taxRate->getName()->willReturn('Simple tax');
+        $taxRate->getAmount()->willReturn(0.1);
         $taxRate->isIncludedInPrice()->willReturn(false);
 
         $orderItem->getUnits()->willReturn($units);
@@ -84,7 +87,18 @@ final class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
         $distributor->distribute(100, 2)->willReturn([50, 50]);
 
         $adjustmentsFactory
-            ->createWithData(AdjustmentInterface::TAX_ADJUSTMENT, 'Simple tax (10%)', 50, false)
+            ->createWithData(
+                AdjustmentInterface::TAX_ADJUSTMENT,
+                'Simple tax (10%)',
+                50,
+                false,
+                [
+                    'associatedWith' => AdjustmentInterface::DETAILS_ASSOCIATED_WITH_ORDER_ITEM_UNIT,
+                    'taxRateCode' => 'simple_tax',
+                    'taxRateName' => 'Simple tax',
+                    'taxRateAmount' => 0.1,
+                ]
+            )
             ->willReturn($taxAdjustment1, $taxAdjustment2)
         ;
 

--- a/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemsTaxesApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderItemsTaxesApplicatorSpec.php
@@ -93,7 +93,6 @@ final class OrderItemsTaxesApplicatorSpec extends ObjectBehavior
                 50,
                 false,
                 [
-                    'associatedWith' => AdjustmentInterface::DETAILS_ASSOCIATED_WITH_ORDER_ITEM_UNIT,
                     'taxRateCode' => 'simple_tax',
                     'taxRateName' => 'Simple tax',
                     'taxRateAmount' => 0.1,

--- a/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderShipmentTaxesApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderShipmentTaxesApplicatorSpec.php
@@ -85,7 +85,7 @@ final class OrderShipmentTaxesApplicatorSpec extends ObjectBehavior
                 ])
             ->willReturn($shippingTaxAdjustment)
         ;
-        $order->addAdjustment($shippingTaxAdjustment)->shouldBeCalled();
+        $shipment->addAdjustment($shippingTaxAdjustment)->shouldBeCalled();
 
         $this->apply($order, $zone);
     }

--- a/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderShipmentTaxesApplicatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Taxation/Applicator/OrderShipmentTaxesApplicatorSpec.php
@@ -77,7 +77,6 @@ final class OrderShipmentTaxesApplicatorSpec extends ObjectBehavior
                 100,
                 false,
                 [
-                    'associatedWith' => AdjustmentInterface::DETAILS_ASSOCIATED_WITH_SHIPMENT,
                     'shippingMethodCode' => 'fedex',
                     'shippingMethodName' => 'FedEx',
                     'taxRateCode' => 'simple_tax',

--- a/src/Sylius/Component/Order/Factory/AdjustmentFactory.php
+++ b/src/Sylius/Component/Order/Factory/AdjustmentFactory.php
@@ -31,13 +31,19 @@ class AdjustmentFactory implements AdjustmentFactoryInterface
         return $this->adjustmentFactory->createNew();
     }
 
-    public function createWithData(string $type, string $label, int $amount, bool $neutral = false): AdjustmentInterface
-    {
+    public function createWithData(
+        string $type,
+        string $label,
+        int $amount,
+        bool $neutral = false,
+        array $details = []
+    ): AdjustmentInterface {
         $adjustment = $this->createNew();
         $adjustment->setType($type);
         $adjustment->setLabel($label);
         $adjustment->setAmount($amount);
         $adjustment->setNeutral($neutral);
+        $adjustment->setDetails($details);
 
         return $adjustment;
     }

--- a/src/Sylius/Component/Order/Factory/AdjustmentFactoryInterface.php
+++ b/src/Sylius/Component/Order/Factory/AdjustmentFactoryInterface.php
@@ -18,5 +18,11 @@ use Sylius\Component\Resource\Factory\FactoryInterface;
 
 interface AdjustmentFactoryInterface extends FactoryInterface
 {
-    public function createWithData(string $type, string $label, int $amount, bool $neutral = false): AdjustmentInterface;
+    public function createWithData(
+        string $type,
+        string $label,
+        int $amount,
+        bool $neutral = false,
+        array $details = []
+    ): AdjustmentInterface;
 }

--- a/src/Sylius/Component/Order/Model/Adjustment.php
+++ b/src/Sylius/Component/Order/Model/Adjustment.php
@@ -49,6 +49,9 @@ class Adjustment implements AdjustmentInterface
     /** @var string|null */
     protected $originCode;
 
+    /** @var array */
+    protected $details = [];
+
     public function __construct()
     {
         $this->createdAt = new \DateTime();
@@ -180,6 +183,16 @@ class Adjustment implements AdjustmentInterface
     public function getOrderItemUnit(): ?OrderItemUnitInterface
     {
         return $this->orderItemUnit;
+    }
+
+    public function getDetails(): array
+    {
+        return $this->details;
+    }
+
+    public function setDetails(array $details): void
+    {
+        $this->details = $details;
     }
 
     private function recalculateAdjustable(): void

--- a/src/Sylius/Component/Order/Model/AdjustmentInterface.php
+++ b/src/Sylius/Component/Order/Model/AdjustmentInterface.php
@@ -63,4 +63,8 @@ interface AdjustmentInterface extends ResourceInterface, TimestampableInterface
     public function getOrderItem(): ?OrderItemInterface;
 
     public function getOrderItemUnit(): ?OrderItemUnitInterface;
+
+    public function getDetails(): array;
+
+    public function setDetails(array $details): void;
 }

--- a/src/Sylius/Component/Order/spec/Factory/AdjustmentFactorySpec.php
+++ b/src/Sylius/Component/Order/spec/Factory/AdjustmentFactorySpec.php
@@ -48,7 +48,11 @@ final class AdjustmentFactorySpec extends ObjectBehavior
         $adjustment->setLabel('Tax description')->shouldBeCalled();
         $adjustment->setAmount(1000)->shouldBeCalled();
         $adjustment->setNeutral(false)->shouldBeCalled();
+        $adjustment->setDetails(['taxRateAmount' => 0.1])->shouldBeCalled();
 
-        $this->createWithData('tax', 'Tax description', 1000, false)->shouldReturn($adjustment);
+        $this
+            ->createWithData('tax', 'Tax description', 1000, false, ['taxRateAmount' => 0.1])
+            ->shouldReturn($adjustment)
+        ;
     }
 }

--- a/src/Sylius/Component/Order/spec/Model/AdjustmentSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/AdjustmentSpec.php
@@ -234,4 +234,10 @@ final class AdjustmentSpec extends ObjectBehavior
     {
         $this->getUpdatedAt()->shouldReturn(null);
     }
+
+    function its_details_are_mutable(): void
+    {
+        $this->setDetails(['taxRateAmount' => 0.1]);
+        $this->getDetails()->shouldReturn(['taxRateAmount' => 0.1]);
+    }
 }

--- a/tests/Responses/order/cart_show_response.json
+++ b/tests/Responses/order/cart_show_response.json
@@ -78,7 +78,35 @@
             "id": @integer@,
             "type": "shipping",
             "label": "UPS",
-            "amount": 1000
+            "amount": 1000,
+            "shipment": {
+                "id": @integer@,
+                "state": "cart",
+                "method": {
+                    "id": @integer@,
+                    "code": "UPS",
+                    "enabled": true,
+                    "_links": {
+                        "self": {
+                            "href": "\/api\/v1\/shipping-methods\/UPS"
+                        },
+                        "zone": {
+                            "href": "\/api\/v1\/zones\/EU"
+                        }
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "@string@"
+                    },
+                    "shipping-method": {
+                        "href": "\/api\/v1\/shipping-methods\/UPS"
+                    },
+                    "order": {
+                        "href": "@string@"
+                    }
+                }
+            }
         }
     ],
     "adjustmentsTotal": 1000,

--- a/tests/Responses/order/order_canceled_show_response.json
+++ b/tests/Responses/order/order_canceled_show_response.json
@@ -87,7 +87,35 @@
             "id": @integer@,
             "type": "shipping",
             "label": "UPS",
-            "amount": 1000
+            "amount": 1000,
+            "shipment": {
+                "id": @integer@,
+                "state": "cancelled",
+                "method": {
+                    "id": @integer@,
+                    "code": "UPS",
+                    "enabled": true,
+                    "_links": {
+                        "self": {
+                            "href": "\/api\/v1\/shipping-methods\/UPS"
+                        },
+                        "zone": {
+                            "href": "\/api\/v1\/zones\/EU"
+                        }
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "@string@"
+                    },
+                    "shipping-method": {
+                        "href": "\/api\/v1\/shipping-methods\/UPS"
+                    },
+                    "order": {
+                        "href": "@string@"
+                    }
+                }
+            }
         }
     ],
     "adjustmentsTotal": 1000,

--- a/tests/Responses/order/order_fulfilled_show_response.json
+++ b/tests/Responses/order/order_fulfilled_show_response.json
@@ -87,7 +87,35 @@
             "id": @integer@,
             "type": "shipping",
             "label": "UPS",
-            "amount": 1000
+            "amount": 1000,
+            "shipment": {
+                "id": @integer@,
+                "state": "shipped",
+                "method": {
+                    "id": @integer@,
+                    "code": "UPS",
+                    "enabled": true,
+                    "_links": {
+                        "self": {
+                            "href": "\/api\/v1\/shipping-methods\/UPS"
+                        },
+                        "zone": {
+                            "href": "\/api\/v1\/zones\/EU"
+                        }
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "@string@"
+                    },
+                    "shipping-method": {
+                        "href": "\/api\/v1\/shipping-methods\/UPS"
+                    },
+                    "order": {
+                        "href": "@string@"
+                    }
+                }
+            }
         }
     ],
     "adjustmentsTotal": 1000,

--- a/tests/Responses/order/order_payed_show_response.json
+++ b/tests/Responses/order/order_payed_show_response.json
@@ -87,7 +87,35 @@
             "id": @integer@,
             "type": "shipping",
             "label": "UPS",
-            "amount": 1000
+            "amount": 1000,
+            "shipment": {
+                "id": @integer@,
+                "state": "ready",
+                "method": {
+                    "id": @integer@,
+                    "code": "UPS",
+                    "enabled": true,
+                    "_links": {
+                        "self": {
+                            "href": "\/api\/v1\/shipping-methods\/UPS"
+                        },
+                        "zone": {
+                            "href": "\/api\/v1\/zones\/EU"
+                        }
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "@string@"
+                    },
+                    "shipping-method": {
+                        "href": "\/api\/v1\/shipping-methods\/UPS"
+                    },
+                    "order": {
+                        "href": "@string@"
+                    }
+                }
+            }
         }
     ],
     "adjustmentsTotal": 1000,

--- a/tests/Responses/order/order_shipped_show_response.json
+++ b/tests/Responses/order/order_shipped_show_response.json
@@ -87,7 +87,35 @@
             "id": @integer@,
             "type": "shipping",
             "label": "UPS",
-            "amount": 1000
+            "amount": 1000,
+            "shipment": {
+                "id": @integer@,
+                "state": "shipped",
+                "method": {
+                    "id": @integer@,
+                    "code": "UPS",
+                    "enabled": true,
+                    "_links": {
+                        "self": {
+                            "href": "\/api\/v1\/shipping-methods\/UPS"
+                        },
+                        "zone": {
+                            "href": "\/api\/v1\/zones\/EU"
+                        }
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "@string@"
+                    },
+                    "shipping-method": {
+                        "href": "\/api\/v1\/shipping-methods\/UPS"
+                    },
+                    "order": {
+                        "href": "@string@"
+                    }
+                }
+            }
         }
     ],
     "adjustmentsTotal": 1000,

--- a/tests/Responses/order/order_shipped_with_tracking_show_response.json
+++ b/tests/Responses/order/order_shipped_with_tracking_show_response.json
@@ -87,7 +87,36 @@
             "id": @integer@,
             "type": "shipping",
             "label": "UPS",
-            "amount": 1000
+            "amount": 1000,
+            "shipment": {
+                "id": @integer@,
+                "state": "shipped",
+                "method": {
+                    "id": @integer@,
+                    "code": "UPS",
+                    "enabled": true,
+                    "_links": {
+                        "self": {
+                            "href": "\/api\/v1\/shipping-methods\/UPS"
+                        },
+                        "zone": {
+                            "href": "\/api\/v1\/zones\/EU"
+                        }
+                    }
+                },
+                "tracking": "BANANAS",
+                "_links": {
+                    "self": {
+                        "href": "@string@"
+                    },
+                    "shipping-method": {
+                        "href": "\/api\/v1\/shipping-methods\/UPS"
+                    },
+                    "order": {
+                        "href": "@string@"
+                    }
+                }
+            }
         }
     ],
     "adjustmentsTotal": 1000,

--- a/tests/Responses/order/order_show_response.json
+++ b/tests/Responses/order/order_show_response.json
@@ -87,7 +87,35 @@
             "id": @integer@,
             "type": "shipping",
             "label": "UPS",
-            "amount": 1000
+            "amount": 1000,
+            "shipment": {
+                "id": @integer@,
+                "state": "ready",
+                "method": {
+                    "id": @integer@,
+                    "code": "UPS",
+                    "enabled": true,
+                    "_links": {
+                        "self": {
+                            "href": "\/api\/v1\/shipping-methods\/UPS"
+                        },
+                        "zone": {
+                            "href": "\/api\/v1\/zones\/EU"
+                        }
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "@string@"
+                    },
+                    "shipping-method": {
+                        "href": "\/api\/v1\/shipping-methods\/UPS"
+                    },
+                    "order": {
+                        "href": "@string@"
+                    }
+                }
+            }
         }
     ],
     "adjustmentsTotal": 1000,

--- a/tests/Responses/order/order_with_coupon_based_promotion_show_response.json
+++ b/tests/Responses/order/order_with_coupon_based_promotion_show_response.json
@@ -93,7 +93,35 @@
             "id": @integer@,
             "type": "shipping",
             "label": "UPS",
-            "amount": 1000
+            "amount": 1000,
+            "shipment": {
+                "id": @integer@,
+                "state": "ready",
+                "method": {
+                    "id": @integer@,
+                    "code": "UPS",
+                    "enabled": true,
+                    "_links": {
+                        "self": {
+                            "href": "\/api\/v1\/shipping-methods\/UPS"
+                        },
+                        "zone": {
+                            "href": "\/api\/v1\/zones\/EU"
+                        }
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "@string@"
+                    },
+                    "shipping-method": {
+                        "href": "\/api\/v1\/shipping-methods\/UPS"
+                    },
+                    "order": {
+                        "href": "@string@"
+                    }
+                }
+            }
         }
     ],
     "adjustmentsTotal": 1000,

--- a/tests/Responses/order/order_with_promotion_show_response.json
+++ b/tests/Responses/order/order_with_promotion_show_response.json
@@ -93,7 +93,35 @@
             "id": @integer@,
             "type": "shipping",
             "label": "UPS",
-            "amount": 1000
+            "amount": 1000,
+            "shipment": {
+                "id": @integer@,
+                "state": "ready",
+                "method": {
+                    "id": @integer@,
+                    "code": "UPS",
+                    "enabled": true,
+                    "_links": {
+                        "self": {
+                            "href": "\/api\/v1\/shipping-methods\/UPS"
+                        },
+                        "zone": {
+                            "href": "\/api\/v1\/zones\/EU"
+                        }
+                    }
+                },
+                "_links": {
+                    "self": {
+                        "href": "@string@"
+                    },
+                    "shipping-method": {
+                        "href": "\/api\/v1\/shipping-methods\/UPS"
+                    },
+                    "order": {
+                        "href": "@string@"
+                    }
+                }
+            }
         }
     ],
     "adjustmentsTotal": 1000,


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no?
| Deprecations?   | no
| Related tickets | 
| License         | MIT

This PR is the first step to solve the problem with too little information while generating documents on InvoicingPlugin and RefundPlugin.

I've added also information about shipment tax on order show page in admin panel:

- example with tax excluded:

![image](https://user-images.githubusercontent.com/6140884/100893989-43261f80-34bc-11eb-87fb-ffd753fe6d43.png)

- example with tax included:

![image](https://user-images.githubusercontent.com/6140884/100894017-4caf8780-34bc-11eb-84f4-2f3fd2a1f6bc.png)

TODO:

- [x] Add array of details on `Adjustment` entity

- [x] Make `Shipment` entity adjustable

- [x] Prepare a proper migration to fill details on existing adjustments

- [x] Prepare a proper migration to add related adjustments to existing shipments

- [x] Consider adding a note about above migrations in UPGRADE file