### PR TITLE
Introducing a unified template for configuration per channel

### DIFF
--- a/src/Sylius/Behat/Page/Admin/ProductVariant/GeneratePage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/GeneratePage.php
@@ -67,8 +67,8 @@ class GeneratePage extends SymfonyPage implements GeneratePageInterface
     {
         return array_merge(parent::getDefinedElements(), [
             'code' => '#sylius_product_generate_variants_variants_%position%_code',
-            'price' => '#sylius_product_generate_variants_variants_%position%_channelPricings input[id*="%channelCode%"]',
-            'prices_validation_message' => '#sylius_product_generate_variants_variants_%position%_channelPricings ~ .sylius-validation-error',
+            'price' => '#sylius_product_generate_variants_variants_%position%_channelPricings_%channelCode% input[id*="%channelCode%"]',
+            'prices_validation_message' => 'div[data-form-collection-index="%position%"] div.tabular.menu ~ .sylius-validation-error',
         ]);
     }
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Form/theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Form/theme.html.twig
@@ -26,3 +26,26 @@
 {% block sylius_product_autocomplete_choice_row %}
     {{ form_row(form, {'remote_url': path('sylius_admin_ajax_product_by_name_phrase'), 'load_edit_url': path('sylius_admin_ajax_product_by_code')}) }}
 {% endblock %}
+
+{% block sylius_channel_collection_widget %}
+    <div class="ui top attached tabular menu">
+        {% for channelCode, channelBasedForm in form %}
+            {% set channelName = channelBasedForm.vars.label %}
+            {% if loop.index0 == 0 %}
+                <a class="item active" data-tab="{{ channelCode }}">{{ channelName }}</a>
+            {% else %}
+                <a class="item" data-tab="{{ channelCode }}">{{ channelName }}</a>
+            {% endif %}
+        {% endfor %}
+    </div>
+    {% for channelCode, channelBasedForm in form %}
+        {% if loop.index0 == 0 %}
+            <div class="ui bottom attached active tab segment" data-tab="{{ channelCode }}">
+        {% else %}
+            <div class="ui bottom attached tab segment" data-tab="{{ channelCode }}">
+        {% endif %}
+
+        {{ form_row(channelBasedForm, {'label': false}) }}
+        </div>
+    {% endfor %}
+{% endblock %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/ShippingMethod/_form.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/ShippingMethod/_form.html.twig
@@ -28,9 +28,7 @@
             {% endfor %}
             <div class="ui segment configuration">
                 {% if form.configuration is defined %}
-                    {% for field in form.configuration %}
-                        {{ form_row(field) }}
-                    {% endfor %}
+                    {{ form_widget(form.configuration) }}
                 {% endif %}
             </div>
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | related to #11529
| License         | MIT

The same as in #11529 now all instances that inherit from the `ChannelCollectionType` look the same. 

Here an example how it looks on the shipping method edit box:
![image](https://user-images.githubusercontent.com/14860264/100883580-c477b500-34b0-11eb-8bc7-869934dac594.png)

## Known issues with this PR.
* This still however poses a question about empty configuration as mentioned in the issue #12111. Which is now becoming more relevant as you can't see the whole configuration at a glance.
* This maybe hinders a fast entry of data as you can't easily cycle through the fields with the tab key anymore. But it looks cool. I am open for suggestions on how to improve on this.

