### PR TITLE
Fix doctrine migrations config in UPGRADE-1.8.md

### DIFF
--- a/UPGRADE-1.8.md
+++ b/UPGRADE-1.8.md
@@ -242,7 +242,7 @@ As we switched to the `3.0` version of Doctrine Migrations, there are some thing
    +        table_storage:
    +            table_name: sylius_migrations
    +    migrations_paths:
-   +        'DoctrineMigrations': 'src/Migrations'
+   +        'DoctrineMigrations': '%kernel.project_dir%/src/Migrations'
    ``` 
 
 1. Remove all the legacy Sylius-Standard migrations (they're not needed anymore)


### PR DESCRIPTION
The `doctrine:migrations:migrate` command will fail if not executed from the project root. This is the case when using Deployer. The `%kernel.project_dir%` parameter will fix that.

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT