### PR TITLE
Fix incorrect money format being used

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/views/Collector/cart.html.twig
+++ b/src/Sylius/Bundle/CoreBundle/Resources/views/Collector/cart.html.twig
@@ -17,11 +17,11 @@
                 </div>
                 <div class="sf-toolbar-info-piece">
                     <b>Subtotal</b>
-                    <span>{{ money.convertAndFormat(collector.subtotal, collector.currency) }}</span>
+                    <span>{{ money.format(collector.subtotal, collector.currency) }}</span>
                 </div>
                 <div class="sf-toolbar-info-piece">
                     <b>Total</b>
-                    <span>{{ money.convertAndFormat(collector.total, collector.currency) }}</span>
+                    <span>{{ money.format(collector.total, collector.currency) }}</span>
                 </div>
             </div>
             <div class="sf-toolbar-info-group">
@@ -64,8 +64,8 @@
                 <td>{{ collector.id }}</td>
                 <td>{{ collector.currency }}</td>
                 <td>{{ collector.locale }}</td>
-                <td>{{ money.convertAndFormat(collector.subtotal, collector.currency) }}</td>
-                <td>{{ money.convertAndFormat(collector.total, collector.currency) }}</td>
+                <td>{{ money.format(collector.subtotal, collector.currency) }}</td>
+                <td>{{ money.format(collector.total, collector.currency) }}</td>
             </tr>
         </table>
 


### PR DESCRIPTION
Only format accept currency as argument. 
Fix #11941.

| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #11941
| License         | MIT

A "Cart" menu/collector is added in Sylius 1.8, but this feature requires Channel to exist in the debugger/profiler's route, otherwise user will get the following error:

> An exception has been thrown during the rendering of a template ("Channel could not be found! Tip: You can use the Web Debug Toolbar to switch between channels in development.").

The error is triggered by `convertAndFormat()` in the Twig file. Change it to `format()` fix the problem. I think it was meant to use `format` since method signature was incorrect also.