### PR TITLE
[Admin][Shop][Api] Extract route prefixes to bundles

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,14 +1,3 @@
-parameters:
-    sylius.security.admin_regex: "^/%sylius_admin.path_name%"
-    sylius.security.api_regex: "^/api"
-    sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|new-api|api/.*|api$|media/.*)[^/]++"
-    sylius.security.new_api_route: "/new-api"
-    sylius.security.new_api_regex: "^%sylius.security.new_api_route%"
-    sylius.security.new_api_admin_route: "%sylius.security.new_api_route%/admin"
-    sylius.security.new_api_admin_regex: "^%sylius.security.new_api_admin_route%"
-    sylius.security.new_api_shop_route: "%sylius.security.new_api_route%/shop"
-    sylius.security.new_api_shop_regex: "^%sylius.security.new_api_shop_route%"
-
 security:
     always_authenticate_before_granting: true
     providers:

--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/app/config.yml
@@ -13,6 +13,9 @@ imports:
     - { resource: "@SyliusAdminApiBundle/Resources/config/grids/shipment.yml" }
     - { resource: "@SyliusAdminApiBundle/Resources/config/grids/taxon.yml" }
 
+parameters:
+    sylius.security.api_regex: "^/api"
+
 sylius_admin_api:
     resources:
         api_user:

--- a/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/app/config.yml
@@ -36,6 +36,7 @@ imports:
 parameters:
     env(SYLIUS_ADMIN_ROUTING_PATH_NAME): admin
     sylius_admin.path_name: '%env(resolve:SYLIUS_ADMIN_ROUTING_PATH_NAME)%'
+    sylius.security.admin_regex: "^/%sylius_admin.path_name%"
 
 sylius_grid:
     templates:

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
@@ -1,6 +1,14 @@
 # This file is part of the Sylius package.
 # (c) Paweł Jędrzejewski
 
+parameters:
+    sylius.security.new_api_route: "/new-api"
+    sylius.security.new_api_regex: "^%sylius.security.new_api_route%"
+    sylius.security.new_api_admin_route: "%sylius.security.new_api_route%/admin"
+    sylius.security.new_api_admin_regex: "^%sylius.security.new_api_admin_route%"
+    sylius.security.new_api_shop_route: "%sylius.security.new_api_route%/shop"
+    sylius.security.new_api_shop_regex: "^%sylius.security.new_api_shop_route%"
+
 api_platform:
     patch_formats:
         json: ['application/merge-patch+json']

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
@@ -8,6 +8,9 @@ imports:
     - { resource: "@SyliusShopBundle/Resources/config/grids/account/order.yml" }
     - { resource: "@SyliusShopBundle/Resources/config/grids/product.yml" }
 
+parameters:
+    sylius.security.shop_regex: "^/(?!%sylius_admin.path_name%|new-api|api/.*|api$|media/.*)[^/]++"
+
 sylius_grid:
     templates:
         action:
@@ -19,7 +22,7 @@ sylius_grid:
 
 sylius_shop:
     checkout_resolver:
-        pattern: /checkout/.+
+        pattern: "%sylius.security.shop_regex%/checkout/.+"
         route_map:
             empty_order:
                 route: sylius_shop_cart_summary


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | kind of
| New feature?    | kind of
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I want to propose a small DX improvement with two bug fixes. I've extracted parameters from the security config file, so they can be used in other places as well. Why? First of all, they are used outside of this context anyway(like here: https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml#L55). Secondly, it would allow solving issues like https://github.com/Sylius/ShopApiPlugin/issues/241.

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
