### PR TITLE
Replace Doctrine\Common\Persistence with Doctrine\Persistence

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -86,10 +86,6 @@
 
         <DeprecatedClass>
             <errorLevel type="info">
-                <referencedClass name="Doctrine\Common\Persistence\ManagerRegistry" />
-                <referencedClass name="Doctrine\Common\Persistence\Mapping\ClassMetadata" />
-                <referencedClass name="Doctrine\Common\Persistence\ObjectManager" />
-                <referencedClass name="Doctrine\Common\Persistence\ObjectRepository" />
                 <referencedClass name="Payum\Core\Action\GatewayAwareAction" />
                 <referencedClass name="Payum\Core\Security\GenericTokenFactoryInterface" />
                 <referencedClass name="Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface" />
@@ -107,8 +103,6 @@
         </DeprecatedClass>
         <DeprecatedInterface>
             <errorLevel type="info">
-                <referencedClass name="Doctrine\Common\Persistence\ObjectManager" />
-                <referencedClass name="Doctrine\Common\Persistence\ObjectRepository" />
                 <referencedClass name="Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface" />
                 <referencedClass name="Symfony\Component\Security\Core\User\AdvancedUserInterface" />
             </errorLevel>

--- a/src/Sylius/Behat/Context/Domain/CartContext.php
+++ b/src/Sylius/Behat/Context/Domain/CartContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Domain;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Order\Remover\ExpiredCartsRemoverInterface;
 use Webmozart\Assert\Assert;

--- a/src/Sylius/Behat/Context/Domain/ManagingOrdersContext.php
+++ b/src/Sylius/Behat/Context/Domain/ManagingOrdersContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Domain;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ProductInterface;

--- a/src/Sylius/Behat/Context/Domain/ManagingShippingMethodsContext.php
+++ b/src/Sylius/Behat/Context/Domain/ManagingShippingMethodsContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Domain;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;
 use Webmozart\Assert\Assert;

--- a/src/Sylius/Behat/Context/Setup/AddressContext.php
+++ b/src/Sylius/Behat/Context/Setup/AddressContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;

--- a/src/Sylius/Behat/Context/Setup/AdminUserContext.php
+++ b/src/Sylius/Behat/Context/Setup/AdminUserContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
 use Sylius\Component\Core\Model\AdminUserInterface;

--- a/src/Sylius/Behat/Context/Setup/ChannelContext.php
+++ b/src/Sylius/Behat/Context/Setup/ChannelContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;

--- a/src/Sylius/Behat/Context/Setup/CurrencyContext.php
+++ b/src/Sylius/Behat/Context/Setup/CurrencyContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;

--- a/src/Sylius/Behat/Context/Setup/CustomerContext.php
+++ b/src/Sylius/Behat/Context/Setup/CustomerContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;
 use Sylius\Component\Core\Model\AddressInterface;

--- a/src/Sylius/Behat/Context/Setup/GeographicalContext.php
+++ b/src/Sylius/Behat/Context/Setup/GeographicalContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Converter\CountryNameConverterInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;

--- a/src/Sylius/Behat/Context/Setup/LocaleContext.php
+++ b/src/Sylius/Behat/Context/Setup/LocaleContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Locale\Converter\LocaleConverterInterface;

--- a/src/Sylius/Behat/Context/Setup/OrderContext.php
+++ b/src/Sylius/Behat/Context/Setup/OrderContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\AddressInterface;

--- a/src/Sylius/Behat/Context/Setup/PaymentContext.php
+++ b/src/Sylius/Behat/Context/Setup/PaymentContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
 use Sylius\Component\Core\Formatter\StringInflector;

--- a/src/Sylius/Behat/Context/Setup/ProductAssociationContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductAssociationContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Product\Model\ProductAssociationInterface;

--- a/src/Sylius/Behat/Context/Setup/ProductAttributeContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductAttributeContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Attribute\AttributeType\SelectAttributeType;
 use Sylius\Component\Attribute\Factory\AttributeFactoryInterface;

--- a/src/Sylius/Behat/Context/Setup/ProductContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductContext.php
@@ -16,7 +16,7 @@ namespace Sylius\Behat\Context\Setup;
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Element\NodeElement;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\ChannelInterface;

--- a/src/Sylius/Behat/Context/Setup/ProductOptionContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductOptionContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Product\Model\ProductOptionInterface;

--- a/src/Sylius/Behat/Context/Setup/ProductTaxonContext.php
+++ b/src/Sylius/Behat/Context/Setup/ProductTaxonContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductTaxonInterface;
 use Sylius\Component\Core\Model\TaxonInterface;

--- a/src/Sylius/Behat/Context/Setup/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/PromotionContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Factory\PromotionActionFactoryInterface;
 use Sylius\Component\Core\Factory\PromotionRuleFactoryInterface;

--- a/src/Sylius/Behat/Context/Setup/ShippingContext.php
+++ b/src/Sylius/Behat/Context/Setup/ShippingContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ShippingMethodExampleFactory;
 use Sylius\Component\Addressing\Model\Scope;

--- a/src/Sylius/Behat/Context/Setup/TaxationContext.php
+++ b/src/Sylius/Behat/Context/Setup/TaxationContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Core\Formatter\StringInflector;

--- a/src/Sylius/Behat/Context/Setup/TaxonomyContext.php
+++ b/src/Sylius/Behat/Context/Setup/TaxonomyContext.php
@@ -15,7 +15,7 @@ namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
 use Behat\Mink\Element\NodeElement;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Core\Formatter\StringInflector;
 use Sylius\Component\Core\Model\ImageInterface;
 use Sylius\Component\Core\Model\TaxonInterface;

--- a/src/Sylius/Behat/Context/Setup/ThemeContext.php
+++ b/src/Sylius/Behat/Context/Setup/ThemeContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\ThemeBundle\Configuration\Test\TestThemeConfigurationManagerInterface;
 use Sylius\Bundle\ThemeBundle\Model\ThemeInterface;

--- a/src/Sylius/Behat/Context/Setup/UserContext.php
+++ b/src/Sylius/Behat/Context/Setup/UserContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;

--- a/src/Sylius/Behat/Context/Setup/ZoneContext.php
+++ b/src/Sylius/Behat/Context/Setup/ZoneContext.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Behat\Context\Setup;
 
 use Behat\Behat\Context\Context;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Addressing\Factory\ZoneFactoryInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;

--- a/src/Sylius/Bundle/AddressingBundle/Form/EventListener/BuildAddressFormSubscriber.php
+++ b/src/Sylius/Bundle/AddressingBundle/Form/EventListener/BuildAddressFormSubscriber.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AddressingBundle\Form\EventListener;
 
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectRepository;
 use Sylius\Bundle\AddressingBundle\Form\Type\ProvinceCodeChoiceType;
 use Sylius\Component\Addressing\Model\AddressInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;

--- a/src/Sylius/Bundle/AdminApiBundle/EventListener/CartChangeListener.php
+++ b/src/Sylius/Bundle/AdminApiBundle/EventListener/CartChangeListener.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminApiBundle\EventListener;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Core\Model\OrderItemInterface;
 use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;

--- a/src/Sylius/Bundle/AdminApiBundle/Tests/Fixture/ApiAccessTokenFixtureTest.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Tests/Fixture/ApiAccessTokenFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminApiBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\AdminApiBundle\Fixture\ApiAccessTokenFixture;

--- a/src/Sylius/Bundle/AdminApiBundle/Tests/Fixture/ApiClientFixtureTest.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Tests/Fixture/ApiClientFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AdminApiBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\AdminApiBundle\Fixture\ApiClientFixture;

--- a/src/Sylius/Bundle/AdminApiBundle/spec/EventListener/CartChangeListenerSpec.php
+++ b/src/Sylius/Bundle/AdminApiBundle/spec/EventListener/CartChangeListenerSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\AdminApiBundle\EventListener;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;

--- a/src/Sylius/Bundle/ApiBundle/ApiPlatform/Bridge/Doctrine/ORM/SubresourceDataProvider.php
+++ b/src/Sylius/Bundle/ApiBundle/ApiPlatform/Bridge/Doctrine/ORM/SubresourceDataProvider.php
@@ -26,7 +26,7 @@ use ApiPlatform\Core\Exception\RuntimeException;
 use ApiPlatform\Core\Identifier\IdentifierConverterInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyMetadataFactoryInterface;
 use ApiPlatform\Core\Metadata\Property\Factory\PropertyNameCollectionFactoryInterface;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\QueryBuilder;

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/Handler/ResourceUpdateHandler.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/Handler/ResourceUpdateHandler.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Doctrine\ORM\Handler;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Doctrine\ORM\OptimisticLockException;
 use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;
 use Sylius\Bundle\ResourceBundle\Controller\ResourceUpdateHandlerInterface;

--- a/src/Sylius/Bundle/CoreBundle/EventListener/CartBlamerListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/CartBlamerListener.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Bundle\UserBundle\Event\UserEvent;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/AbstractResourceFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/AbstractResourceFixture.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
 use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/CurrencyFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/CurrencyFixture.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
 use Sylius\Component\Currency\Model\CurrencyInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/Factory/OrderExampleFactory.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/Factory/OrderExampleFactory.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Fixture\Factory;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
 use Sylius\Bundle\CoreBundle\Fixture\OptionsResolver\LazyOption;
 use Sylius\Component\Addressing\Model\CountryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/GeographicalFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/GeographicalFixture.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
 use Sylius\Component\Addressing\Factory\ZoneFactoryInterface;
 use Sylius\Component\Addressing\Model\CountryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/LocaleFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/LocaleFixture.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;
 use Sylius\Component\Locale\Model\LocaleInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/OrderFixture.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\OrderExampleFactory;
 use Sylius\Bundle\FixturesBundle\Fixture\AbstractFixture;

--- a/src/Sylius/Bundle/CoreBundle/Fixture/ProductAttributeFixture.php
+++ b/src/Sylius/Bundle/CoreBundle/Fixture/ProductAttributeFixture.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 

--- a/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelSetup.php
+++ b/src/Sylius/Bundle/CoreBundle/Installer/Setup/ChannelSetup.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Installer\Setup;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Currency\Model\CurrencyInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;

--- a/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/OAuth/UserProvider.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\OAuth;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use HWI\Bundle\OAuthBundle\Connect\AccountConnectorInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;
 use HWI\Bundle\OAuthBundle\Security\Core\User\OAuthAwareUserProviderInterface;

--- a/src/Sylius/Bundle/CoreBundle/Remover/ReviewerReviewsRemover.php
+++ b/src/Sylius/Bundle/CoreBundle/Remover/ReviewerReviewsRemover.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Remover;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 use Sylius\Bundle\ReviewBundle\Updater\ReviewableRatingUpdaterInterface;
 use Sylius\Component\Review\Model\ReviewableInterface;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/AddressFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/AddressFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\AddressFixture;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/AdminUserFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/AdminUserFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\AdminUserFixture;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ChannelFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ChannelFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\ChannelFixture;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/CurrencyFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/CurrencyFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\CurrencyFixture;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/CustomerGroupFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/CustomerGroupFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\CustomerGroupFixture;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/GeographicalFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/GeographicalFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\GeographicalFixture;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/LocaleFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/LocaleFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\LocaleFixture;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/PaymentMethodFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/PaymentMethodFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductAssociationFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductAssociationFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductAssociationTypeFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductAssociationTypeFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductAttributeFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductAttributeFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductOptionFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductOptionFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductReviewFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ProductReviewFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/PromotionFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/PromotionFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ShippingCategoryFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ShippingCategoryFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ShippingMethodFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ShippingMethodFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ShopUserFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/ShopUserFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/TaxCategoryFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/TaxCategoryFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/TaxRateFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/TaxRateFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Tests/Fixture/TaxonFixtureTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Fixture/TaxonFixtureTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Tests\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Matthias\SymfonyConfigTest\PhpUnit\ConfigurationTestCaseTrait;
 use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntityValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/HasEnabledEntityValidator.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Persistence\Mapping\ClassMetadata;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Validator\Constraint;

--- a/src/Sylius/Bundle/CoreBundle/spec/Doctrine/ORM/Handler/ResourceUpdateHandlerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Doctrine/ORM/Handler/ResourceUpdateHandlerSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\CoreBundle\Doctrine\ORM\Handler;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Doctrine\ORM\OptimisticLockException;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\ResourceBundle\Controller\RequestConfiguration;

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/CartBlamerListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/CartBlamerListenerSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\CoreBundle\EventListener;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\UserBundle\Event\UserEvent;

--- a/src/Sylius/Bundle/CoreBundle/spec/Fixture/GeographicalFixtureSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Fixture/GeographicalFixtureSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\CoreBundle\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
 use Sylius\Component\Addressing\Factory\ZoneFactoryInterface;

--- a/src/Sylius/Bundle/CoreBundle/spec/Fixture/LocaleFixtureSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Fixture/LocaleFixtureSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\CoreBundle\Fixture;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\FixturesBundle\Fixture\FixtureInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;

--- a/src/Sylius/Bundle/CoreBundle/spec/OAuth/UserProviderSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/OAuth/UserProviderSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\CoreBundle\OAuth;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use HWI\Bundle\OAuthBundle\Connect\AccountConnectorInterface;
 use HWI\Bundle\OAuthBundle\OAuth\ResourceOwnerInterface;
 use HWI\Bundle\OAuthBundle\OAuth\Response\UserResponseInterface;

--- a/src/Sylius/Bundle/CoreBundle/spec/Remover/ReviewerReviewsRemoverSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Remover/ReviewerReviewsRemoverSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\CoreBundle\Remover;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\CoreBundle\Remover\ReviewerReviewsRemoverInterface;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;

--- a/src/Sylius/Bundle/CoreBundle/spec/Validator/Constraints/HasEnabledEntityValidatorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Validator/Constraints/HasEnabledEntityValidatorSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\CoreBundle\Validator\Constraints;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Validator\ConstraintValidator;
 

--- a/src/Sylius/Bundle/OrderBundle/Remover/ExpiredCartsRemover.php
+++ b/src/Sylius/Bundle/OrderBundle/Remover/ExpiredCartsRemover.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\OrderBundle\Remover;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Bundle\OrderBundle\SyliusExpiredCartsEvents;
 use Sylius\Component\Order\Remover\ExpiredCartsRemoverInterface;
 use Sylius\Component\Order\Repository\OrderRepositoryInterface;

--- a/src/Sylius/Bundle/OrderBundle/spec/Remover/ExpiredCartsRemoverSpec.php
+++ b/src/Sylius/Bundle/OrderBundle/spec/Remover/ExpiredCartsRemoverSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\OrderBundle\Remover;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\OrderBundle\SyliusExpiredCartsEvents;

--- a/src/Sylius/Bundle/ReviewBundle/Updater/AverageRatingUpdater.php
+++ b/src/Sylius/Bundle/ReviewBundle/Updater/AverageRatingUpdater.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ReviewBundle\Updater;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Review\Calculator\ReviewableRatingCalculatorInterface;
 use Sylius\Component\Review\Model\ReviewableInterface;
 use Sylius\Component\Review\Model\ReviewInterface;

--- a/src/Sylius/Bundle/ReviewBundle/spec/Updater/AverageRatingUpdaterSpec.php
+++ b/src/Sylius/Bundle/ReviewBundle/spec/Updater/AverageRatingUpdaterSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\ReviewBundle\Updater;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\ReviewBundle\Updater\ReviewableRatingUpdaterInterface;
 use Sylius\Component\Review\Calculator\ReviewableRatingCalculatorInterface;

--- a/src/Sylius/Bundle/ShopBundle/EventListener/OrderIntegrityChecker.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/OrderIntegrityChecker.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ShopBundle\EventListener;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PromotionInterface;

--- a/src/Sylius/Bundle/ShopBundle/EventListener/UserRegistrationListener.php
+++ b/src/Sylius/Bundle/ShopBundle/EventListener/UserRegistrationListener.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ShopBundle\EventListener;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Bundle\UserBundle\Security\UserLoginInterface;
 use Sylius\Bundle\UserBundle\UserEvents;
 use Sylius\Component\Channel\Context\ChannelContextInterface;

--- a/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderIntegrityCheckerSpec.php
+++ b/src/Sylius/Bundle/ShopBundle/spec/EventListener/OrderIntegrityCheckerSpec.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace spec\Sylius\Bundle\ShopBundle\EventListener;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;

--- a/src/Sylius/Bundle/ShopBundle/spec/EventListener/UserRegistrationListenerSpec.php
+++ b/src/Sylius/Bundle/ShopBundle/spec/EventListener/UserRegistrationListenerSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\ShopBundle\EventListener;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\UserBundle\Security\UserLoginInterface;

--- a/src/Sylius/Bundle/UserBundle/Command/AbstractRoleCommand.php
+++ b/src/Sylius/Bundle/UserBundle/Command/AbstractRoleCommand.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\UserBundle\Command;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\User\Model\UserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;

--- a/src/Sylius/Bundle/UserBundle/EventListener/UpdateUserEncoderListener.php
+++ b/src/Sylius/Bundle/UserBundle/EventListener/UpdateUserEncoderListener.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\UserBundle\EventListener;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\User\Model\UserInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 

--- a/src/Sylius/Bundle/UserBundle/EventListener/UserLastLoginSubscriber.php
+++ b/src/Sylius/Bundle/UserBundle/EventListener/UserLastLoginSubscriber.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\UserBundle\EventListener;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Bundle\UserBundle\Event\UserEvent;
 use Sylius\Bundle\UserBundle\UserEvents;
 use Sylius\Component\User\Model\UserInterface;

--- a/src/Sylius/Bundle/UserBundle/Reloader/UserReloader.php
+++ b/src/Sylius/Bundle/UserBundle/Reloader/UserReloader.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\UserBundle\Reloader;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\User\Model\UserInterface;
 
 final class UserReloader implements UserReloaderInterface

--- a/src/Sylius/Bundle/UserBundle/spec/EventListener/UpdateUserEncoderListenerSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/EventListener/UpdateUserEncoderListenerSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\UserBundle\EventListener;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\UserBundle\spec\Fixture\FixtureUser;

--- a/src/Sylius/Bundle/UserBundle/spec/EventListener/UserLastLoginSubscriberSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/EventListener/UserLastLoginSubscriberSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\UserBundle\EventListener;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\UserBundle\Event\UserEvent;

--- a/src/Sylius/Bundle/UserBundle/spec/Reloader/UserReloaderSpec.php
+++ b/src/Sylius/Bundle/UserBundle/spec/Reloader/UserReloaderSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\UserBundle\Reloader;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\UserBundle\Reloader\UserReloaderInterface;
 use Sylius\Component\User\Model\UserInterface;

--- a/src/Sylius/Component/Promotion/Generator/PromotionCouponGenerator.php
+++ b/src/Sylius/Component/Promotion/Generator/PromotionCouponGenerator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Promotion\Generator;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Sylius\Component\Promotion\Exception\FailedGenerationException;
 use Sylius\Component\Promotion\Model\PromotionCouponInterface;
 use Sylius\Component\Promotion\Model\PromotionInterface;

--- a/src/Sylius/Component/Promotion/spec/Generator/PromotionCouponGeneratorSpec.php
+++ b/src/Sylius/Component/Promotion/spec/Generator/PromotionCouponGeneratorSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Component\Promotion\Generator;
 
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Component\Promotion\Exception\FailedGenerationException;

--- a/src/Sylius/Component/Shipping/Resolver/ShippingMethodsResolver.php
+++ b/src/Sylius/Component/Shipping/Resolver/ShippingMethodsResolver.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Shipping\Resolver;
 
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectRepository;
 use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface;
 use Sylius\Component\Shipping\Model\ShippingSubjectInterface;
 

--- a/src/Sylius/Component/Shipping/spec/Resolver/ShippingMethodsResolverSpec.php
+++ b/src/Sylius/Component/Shipping/spec/Resolver/ShippingMethodsResolverSpec.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Component\Shipping\Resolver;
 
-use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\Persistence\ObjectRepository;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Shipping\Checker\Eligibility\ShippingMethodEligibilityCheckerInterface;
 use Sylius\Component\Shipping\Model\ShippingMethodInterface;


### PR DESCRIPTION
`Doctrine\Common\Persistence` is an alias for `Doctrine\Persistence`, so this change is 100% backwards-compatible, while
allows for `doctrine\persistence:^2.0` to be used. This will allow for reverting #12140.