### PR TITLE
Improve retrying Behat and reduce failure rate

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -356,12 +356,8 @@ jobs:
                 run: chmod -R 555 app bin config docs features src templates tests translations vendor
                 
             -
-                name: Run JS Behat (max 3 times)
-                uses: nick-invision/retry@v2
-                with:
-                    timeout_minutes: 15
-                    max_attempts: 3
-                    command: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript && ~@todo && ~@cli" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript && ~@todo && ~@cli" --rerun
+                name: Run JS Behat
+                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript && ~@todo && ~@cli" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript && ~@todo && ~@cli" --rerun || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript && ~@todo && ~@cli" --rerun
 
             -   
                 name: Upload Behat logs

--- a/src/Sylius/Behat/Service/Setter/CookieSetter.php
+++ b/src/Sylius/Behat/Service/Setter/CookieSetter.php
@@ -83,7 +83,7 @@ final class CookieSetter implements CookieSetterInterface
             return true;
         }
 
-        if ($driver instanceof ChromeDriver && $driver->isStarted() === false) {
+        if ($driver instanceof ChromeDriver) {
             return true;
         }
 


### PR DESCRIPTION
This change probably increases the execution time for JS Behat tests, but drastically reduces the failure rate.

I did a benchmark running `features/product/managing_products/changing_images_of_product.feature` 50 times and the results are:

Pre-change:

Passed: 34
Failed: 16

Post-change:

Passed: 49
Failed: 1