### PR TITLE
[CI] Switch from ubuntu-latest to ubuntu-18.04

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
     static-checks:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         
         name: "Static checks (PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }})"
 
@@ -103,7 +103,7 @@ jobs:
                 if: always() && steps.end-of-setup.outcome == 'success'
 
     test-application-without-frontend:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
 
         name: "Test non-JS application (PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }})"
 
@@ -229,7 +229,7 @@ jobs:
                     if-no-files-found: ignore
             
     test-application-with-frontend:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
 
         name: "Test JS application (PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }})"
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
     tests:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         
         name: "Build"
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
     list:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         
         name: "Create a list of packages"
         
@@ -36,7 +36,7 @@ jobs:
     test:
         needs: list
         
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         
         name: "${{ matrix.package }}, PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}"
 


### PR DESCRIPTION
In the coming weeks, ubuntu-latest will start pointing to ubuntu-20.04 instead of ubuntu-18.04. Let's prevent potential failures by specifying directly ubuntu-18.04 for now and consiously upgrading to ubuntu-20.04 when we're ready - possibly after dropping PHP 7.3 compatibility, since setting it up on the newer version of Ubuntu takes a lot more time.

Ref: https://github.com/actions/virtual-environments/issues/1816