### PR TITLE
[Bugfix][1.8] `Kernel::configureContainer()` should match it's parent signature

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -61,10 +61,10 @@ class Kernel extends BaseKernel
         }
     }
 
-    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
-        $c->addResource(new FileResource($this->getProjectDir() . '/config/bundles.php'));
-        $c->setParameter('container.dumper.inline_class_loader', true);
+        $container->addResource(new FileResource($this->getProjectDir() . '/config/bundles.php'));
+        $container->setParameter('container.dumper.inline_class_loader', true);
         $confDir = $this->getProjectDir() . '/config';
 
         $loader->load($confDir . '/{packages}/*' . self::CONFIG_EXTS, 'glob');


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Error:
```
Argument 1 of App\Kernel::configureContainer has wrong name $c, expecting $container as defined by Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait::configureContainer
```

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
