### PR TITLE
[BUG-FIX] display customer email if user is not logged in

### DIFF
--- a/features/checkout/seeing_proper_checkout_name.feature
+++ b/features/checkout/seeing_proper_checkout_name.feature
@@ -1,0 +1,30 @@
+@checkout
+Feature: Seeing proper checkout name when im checking out with existing account.
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Gaming chair" priced at "$399"
+        And the store ships everywhere for free
+        And the store allows paying offline
+        And there is a customer "John Doe" identified by an email "john@example.com" and a password "secret"
+
+    @ui
+    Scenario: Seeing email in checkout header as a guest
+        Given I have product "Gaming chair" in the cart
+        When I complete addressing step with email "john@example.com" and "United States" based billing address
+        Then I should see "john@example.com" in checkout header
+
+    @ui
+    Scenario: Seeing full name in checkout header as a logged user with full name
+        Given I am a logged in customer with name "John Doe"
+        And I have product "Gaming chair" in the cart
+        When I complete addressing step with "United States" based billing address
+        Then I should see "John Doe" in checkout header
+
+    @ui
+    Scenario: Seeing email in checkout header as a logged user without full name
+        Given there is a customer account "nameless@example.com"
+        And I am logged in as "nameless@example.com"
+        And I have product "Gaming chair" in the cart
+        When I complete addressing step with "United States" based billing address
+        Then I should see "nameless@example.com" in checkout header

--- a/features/checkout/seeing_purchaser_identifier_in_checkout_page.feature
+++ b/features/checkout/seeing_purchaser_identifier_in_checkout_page.feature
@@ -1,5 +1,8 @@
 @checkout
-Feature: Seeing proper checkout name when im checking out with existing account.
+Feature: Seeing purchaser identifier in checkout page
+    In order to improve checkout experience
+    As a customer
+    I want to see my name or email in checkout header
 
     Background:
         Given the store operates on a single channel in "United States"

--- a/src/Sylius/Behat/Context/Setup/ShopSecurityContext.php
+++ b/src/Sylius/Behat/Context/Setup/ShopSecurityContext.php
@@ -58,12 +58,22 @@ final class ShopSecurityContext implements Context
     }
 
     /**
+     * @Given I am a logged in customer with name :fullName
      * @Given I am a logged in customer
      * @Given the customer logged in
      */
-    public function iAmLoggedInCustomer()
+    public function iAmLoggedInCustomer(?string $fullName = null): void
     {
-        $user = $this->userFactory->create(['email' => 'sylius@example.com', 'password' => 'sylius', 'enabled' => true]);
+        $userData = ['email' => 'sylius@example.com', 'password' => 'sylius', 'enabled' => true];
+
+        if ($fullName !== null) {
+            $names = explode(' ', $fullName);
+
+            $userData['first_name'] = $names[0];
+            $userData['last_name'] = $names[1];
+        }
+
+        $user = $this->userFactory->create($userData);
         $this->userRepository->add($user);
 
         $this->securityService->logIn($user);

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
@@ -287,6 +287,14 @@ final class CheckoutAddressingContext implements Context
     }
 
     /**
+     * @Then I should see :displayName in checkout header
+     */
+    public function iShouldSeeInCheckoutHeader(string $displayName): void
+    {
+        Assert::contains($this->selectShippingPage->getPurchaserEmail(), $displayName);
+    }
+
+    /**
      * @When I sign in
      */
     public function iSignIn()

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutAddressingContext.php
@@ -287,11 +287,11 @@ final class CheckoutAddressingContext implements Context
     }
 
     /**
-     * @Then I should see :displayName in checkout header
+     * @Then I should see :purchaserIdentifier in checkout header
      */
-    public function iShouldSeeInCheckoutHeader(string $displayName): void
+    public function iShouldSeeInCheckoutHeader(string $purchaserIdentifier): void
     {
-        Assert::contains($this->selectShippingPage->getPurchaserEmail(), $displayName);
+        Assert::contains($this->selectShippingPage->getPurchaserIdentifier(), $purchaserIdentifier);
     }
 
     /**

--- a/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutShippingContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/Checkout/CheckoutShippingContext.php
@@ -202,6 +202,6 @@ final class CheckoutShippingContext implements Context
      */
     public function iShouldBeCheckingOutAs($email)
     {
-        Assert::same($this->selectShippingPage->getPurchaserEmail(), 'Checking out as ' . $email . '.');
+        Assert::same($this->selectShippingPage->getPurchaserIdentifier(), 'Checking out as ' . $email . '.');
     }
 }

--- a/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPage.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPage.php
@@ -106,7 +106,7 @@ class SelectShippingPage extends SymfonyPage implements SelectShippingPageInterf
         $this->getElement('address')->click();
     }
 
-    public function getPurchaserEmail(): string
+    public function getPurchaserIdentifier(): string
     {
         return $this->getElement('purchaser_email')->getText();
     }

--- a/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPageInterface.php
+++ b/src/Sylius/Behat/Page/Shop/Checkout/SelectShippingPageInterface.php
@@ -35,7 +35,7 @@ interface SelectShippingPageInterface extends SymfonyPageInterface
 
     public function changeAddressByStepLabel(): void;
 
-    public function getPurchaserEmail(): string;
+    public function getPurchaserIdentifier(): string;
 
     public function getValidationMessageForShipment(): string;
 

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_header.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Checkout/_header.html.twig
@@ -5,7 +5,7 @@
         </div>
         <div class="right menu">
             {% if order.customer.id|default(null) is not null %}
-                <div class="item" id="purchaser-email" {{ sylius_test_html_attribute('purchaser-name-or-email') }}>{{ 'sylius.ui.checking_out_as'|trans }} {{ order.customer.fullName|default(order.customer.email) }}.</div>
+                <div class="item" id="purchaser-email" {{ sylius_test_html_attribute('purchaser-name-or-email') }}>{{ 'sylius.ui.checking_out_as'|trans }} {{ app.user is null ? order.customer.email : order.customer.fullName|default(order.customer.email) }}.</div>
             {% else %}
                 <a href="{{ path('sylius_shop_login') }}" class="item">{{ 'sylius.ui.sign_in'|trans }}</a>
             {% endif %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8?
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

logged out (with same email as registered user):
![image](https://user-images.githubusercontent.com/22825722/103212478-2a6a2780-490b-11eb-9f0e-21499cd403d4.png)

logged in (with same email):
![image](https://user-images.githubusercontent.com/22825722/103212579-7917c180-490b-11eb-80aa-70aee409434a.png)


