### PR TITLE
[Admin,Ui] Added collapse menu

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
@@ -26,7 +26,6 @@ import './sylius-notification';
 import './sylius-product-images-preview';
 import './sylius-product-slug';
 import './sylius-taxon-slug';
-import './sylius-chart';
 import customCollapse from './sylius-custom-collapse';
 
 import StatisticsComponent from './sylius-statistics';

--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
@@ -26,6 +26,8 @@ import './sylius-notification';
 import './sylius-product-images-preview';
 import './sylius-product-slug';
 import './sylius-taxon-slug';
+import './sylius-chart';
+import customCollapse from './sylius-custom-collapse';
 
 import StatisticsComponent from './sylius-statistics';
 import SyliusTaxonomyTree from './sylius-taxon-tree';
@@ -119,6 +121,8 @@ $(document).ready(() => {
   const dashboardStatistics = new StatisticsComponent(document.querySelector('.stats'));
 
   $('.sylius-admin-menu').searchable('.sylius-admin-menu-search-input');
+
+  customCollapse('#sidebar .item .header', '#sidebar .item', 'open', false);
 });
 
 window.$ = $;

--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-custom-collapse.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/sylius-custom-collapse.js
@@ -1,0 +1,30 @@
+//  ------------------------------------------------------=> CUSTOM COLLAPSE
+/**
+ * @description Show and hide blocks on click
+ *
+ * @param {HTMLElement} $blockClick - Element that will be clickable to show or hide
+ * @param {HTMLElement} $blockTarget - Target element that will be hidden or displayed
+ * @param {HTMLElement} $class - Class that we will put for to hide or display
+ * @param {boolean} [collapseAll=true] - Allows to leave open or close by default when clicking on an element.
+ * - true = close everything by clicking on an element
+ * - false = always leave the elements open
+ */
+function customCollapse($blockClick, $blockTarget, $class, collapseAll = true) {
+  const blockClick = document.querySelectorAll($blockClick);
+  blockClick.forEach((item) => {
+    item.addEventListener('click', function () {
+      // Closing other collapses
+      if (collapseAll === true) {
+        if (!this.closest($blockTarget).classList.contains($class)) {
+          blockClick.forEach((itemClean) => {
+            itemClean.closest($blockTarget).classList.remove($class);
+          });
+        }
+      }
+      // Opening / Closing of the targeted collapse
+      this.closest($blockTarget).classList.toggle($class);
+    });
+  });
+}
+
+export default customCollapse;

--- a/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_ui.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_ui.scss
@@ -137,7 +137,7 @@ a {
         }
         &.open,
         &.current_ancestor {
-            > .menu{
+            > .menu {
                 max-height: 120vh;
                 overflow: visible;
                 visibility: visible;

--- a/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_ui.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_ui.scss
@@ -79,7 +79,6 @@ a {
     .item > .header {
         text-transform: uppercase;
         font-size: 11px;
-        margin-bottom: 16px;
     }
 
     .item > i.icon {
@@ -96,6 +95,61 @@ a {
         font-weight: inherit !important;
         background: $sylius-brand-color !important;
         border-radius: 0 99px 99px 0 !important;
+    }
+    .item {
+        padding-bottom: 5px;
+        .menu {
+            visibility: hidden;
+            overflow: hidden;
+            max-height: 0;
+            -webkit-transform: translate(0, 0);
+            -webkit-transition: -webkit-transform .5s ease-in-out;
+            -moz-transform: translate(0, 0);
+            -moz-transition: -moz-transform .5s ease-in-out;
+            -ms-transform: translate(0, 0);
+            -ms-transition: -ms-transform .5s ease-in-out;
+        }
+        .header {
+            margin-bottom: 0;
+            -webkit-transform: translateY(0);
+            -webkit-transition: -webkit-transform .7s ease-in-out;
+            -moz-transform: translateY(0);
+            -moz-transition: -moz-transform .7s ease-in-out;
+            -ms-transform: translateY(0);
+            -ms-transition: -ms-transform .7s ease-in-out;
+            cursor: pointer;
+            position: relative;
+            &:before, &:after {
+                content: "";
+                display: block;
+                position: absolute;
+                top: 50%;
+                right: 0;
+                width: 10px;
+                height: 2px;
+                margin-top: -1px;
+                background: white;
+            }
+            &:after {
+                transform: rotate(90deg);
+                transition: .3s;
+            }
+        }
+        &.open,
+        &.current_ancestor {
+            .menu{
+                max-height: 120vh;
+                overflow: visible;
+                visibility: visible;
+                border-bottom-color: #f0f0f0;
+            }
+            .header {
+                margin-bottom: 15px;
+                &:after {
+                    transform: rotate(0deg);
+                }
+            }
+        }
     }
 }
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_ui.scss
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/sass/_ui.scss
@@ -98,7 +98,7 @@ a {
     }
     .item {
         padding-bottom: 5px;
-        .menu {
+        > .menu {
             visibility: hidden;
             overflow: hidden;
             max-height: 0;
@@ -109,7 +109,7 @@ a {
             -ms-transform: translate(0, 0);
             -ms-transition: -ms-transform .5s ease-in-out;
         }
-        .header {
+        > .header {
             margin-bottom: 0;
             -webkit-transform: translateY(0);
             -webkit-transition: -webkit-transform .7s ease-in-out;
@@ -137,13 +137,13 @@ a {
         }
         &.open,
         &.current_ancestor {
-            .menu{
+            > .menu{
                 max-height: 120vh;
                 overflow: visible;
                 visibility: visible;
                 border-bottom-color: #f0f0f0;
             }
-            .header {
+            > .header {
                 margin-bottom: 15px;
                 &:after {
                     transform: rotate(0deg);

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Menu/sidebar.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Menu/sidebar.html.twig
@@ -34,8 +34,8 @@
 {%- if classes is not empty %}
     {%- set attributes = attributes|merge({'class': classes|join(' ')}) %}
 {%- endif %}
-{% if item.level is same as(1) %}
-<div class="item open {% if attributes.class is defined %}{{ attributes.class }}{% endif %}">
+{% if item.hasChildren %}
+<div class="item {% if item.level is same as(1) %}open {%endif%}{% if attributes.class is defined %}{{ attributes.class }}{% endif %}">
     <div class="header">{{ item.label|trans }}</div>
     <div class="menu">
         {{ block('list') }}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Menu/sidebar.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Menu/sidebar.html.twig
@@ -35,7 +35,7 @@
     {%- set attributes = attributes|merge({'class': classes|join(' ')}) %}
 {%- endif %}
 {% if item.hasChildren %}
-<div class="item {% if item.level is same as(1) %}open {%endif%}{% if attributes.class is defined %}{{ attributes.class }}{% endif %}">
+<div class="item {% if item.level is same as(1) %}open {% endif %}{% if attributes.class is defined %}{{ attributes.class }}{% endif %}">
     <div class="header">{{ item.label|trans }}</div>
     <div class="menu">
         {{ block('list') }}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Menu/sidebar.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Menu/sidebar.html.twig
@@ -35,7 +35,7 @@
     {%- set attributes = attributes|merge({'class': classes|join(' ')}) %}
 {%- endif %}
 {% if item.level is same as(1) %}
-<div class="item {% if attributes.class is defined %}{{ attributes.class }}{% endif %}">
+<div class="item open {% if attributes.class is defined %}{{ attributes.class }}{% endif %}">
     <div class="header">{{ item.label|trans }}</div>
     <div class="menu">
         {{ block('list') }}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master (can change to 1.7)
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

This PR goal is to update #11668 and take rework why it was reverted in #11674
- [x] Fix transition performance (but testing it on your local would be appreciated !)
- [x] Don't collapse all menu

### Discussions

#### Collapse strategy

##### Remember uncollapsed menu
Should we keep information about the open menus between page navigation?

##### Sub-menu second level support
I would like to discuss which level of sub-menu should be collapsed. In my opinion, starting from the second level of the sub-menu, they should be collapsed.

Note: this isn't relevant as Sylius does not allow more than a level of sub-menu. Why? I would like to fix it.

#### Performance

I've fixed performance using this: https://github.com/Sylius/Sylius/pull/11668#discussion_r520640746
Performance is now way better, I couldn't reproduce the laggy menu on local but using Firefox Performance tool, I saw that it requires 4-5x less CPU computing. **My procedure was that one: uncollapsing all menus, from the lower one to the highest.** 
I'm not good at CSS but it seems like the "all" directive requires the browser to redraw elements, pixels per pixel in all directions. Translate let you use Hardware acceleration and somehow manage to perform way better.

Before :
![before](https://user-images.githubusercontent.com/17164385/103276635-5ea31e00-49c7-11eb-93a9-4d9daf2465ce.PNG)

After :
![after](https://user-images.githubusercontent.com/17164385/103276641-619e0e80-49c7-11eb-850c-95e3bc858632.PNG)

We can clearly see here that opening the menu has a negative impact on performance. With translate usage, it doesn't.
My average FPS is still low as I'm running IDE + the browser in WSL2, it will work better on the user machine.