### PR TITLE
Add friendsofphp/proxy-manager-lts for ocramius/proxy-manager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "knplabs/knp-menu-bundle": "^3.0",
         "lexik/jwt-authentication-bundle": "^2.6",
         "liip/imagine-bundle": "^2.3",
-        "ocramius/proxy-manager": "^2.2",
+        "friendsofphp/proxy-manager-lts": "^1.0",
         "payum/payum": "^1.6",
         "payum/payum-bundle": "^2.4",
         "php-http/guzzle6-adapter": "^2.0",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

`friendsofphp/proxy-manager-lts` is fork with LTS for `ocramius/proxy-manager`

After this update you can get error with return type on `getProxyInitializer()` method in `src/ProxyManager/Proxy/LazyLoadingInterface.php` - tip: `clear:cache` is not enough but `rm -fr var/cache` fix problem
