### PR TITLE
Remove security.yaml change when disabling localized URLs

### DIFF
--- a/docs/cookbook/shop/disabling-localised-urls.rst
+++ b/docs/cookbook/shop/disabling-localised-urls.rst
@@ -41,29 +41,7 @@ With:
     sylius_shop_payum:
         resource: "@SyliusShopBundle/Resources/config/routing/payum.yml"
 
-**2.** Customise the security settings in the ``config/packages/security.yaml``.
-
-Replace:
-
-.. code-block:: yaml
-
-    # config/packages/security.yaml
-
-    parameters:
-        # ...
-        sylius.security.shop_regex: "^/(?!admin|api/.*|api$|media/.*)[^/]++"
-
-With:
-
-.. code-block:: yaml
-
-    # config/packages/security.yaml
-
-    parameters:
-        # ...
-        sylius.security.shop_regex: "^"
-
-**3.** Customise SyliusShopBundle to use storage-based locale switching in the ``config/packages/_sylius.yaml``.
+**2.** Customise SyliusShopBundle to use storage-based locale switching in the ``config/packages/_sylius.yaml``.
 
 Replace :
 


### PR DESCRIPTION
I think we don't need to change the actual `sylius.security.shop_regex`.

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT