### PR TITLE
Fix promote and demote user command for Symfony 5

### DIFF
--- a/src/Sylius/Bundle/UserBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/services.xml
@@ -29,9 +29,13 @@
 
         <service id="Sylius\Bundle\UserBundle\Command\DemoteUserCommand">
             <tag name="console.command" />
+            <argument type="service" id="doctrine" />
+            <argument>%sylius.user.users%</argument>
         </service>
         <service id="Sylius\Bundle\UserBundle\Command\PromoteUserCommand">
             <tag name="console.command" />
+            <argument type="service" id="doctrine" />
+            <argument>%sylius.user.users%</argument>
         </service>
 
         <service id="sylius.authentication.success_handler" class="Sylius\Bundle\UserBundle\Authentication\AuthenticationSuccessHandler" parent="security.authentication.success_handler" public="false" />


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | partially #10928 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

There is a bc-break cause these two commands are not container aware anymore.
@pamil maybe can we make something like you did on controllers ?
