### PR TITLE
Use CustomerProvider in OAuth UserProvider

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/integrations/hwi_oauth.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/integrations/hwi_oauth.xml
@@ -24,7 +24,7 @@
             <argument type="service" id="sylius.repository.oauth_user" />
             <argument type="service" id="sylius.manager.shop_user" />
             <argument type="service" id="sylius.canonicalizer" />
-            <argument type="service" id="sylius.repository.customer" />
+            <argument type="service" id="Sylius\Bundle\ApiBundle\Provider\CustomerProviderInterface" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | -
| License         | MIT

---

The current OAuth UserProvider doesn't assign customer pool when create new customer. 
Using `CustomerProvider` will fix it.