### PR TITLE
Add conflict with polyfill-mbstring 1.22.0

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -14,3 +14,11 @@ refereneces related issues.
    This version of Doctrine Bridge introduces a bug that causes an issue related to `ChannelPricing` mapping.
 
    References: https://github.com/Sylius/Sylius/issues/11970, https://github.com/symfony/symfony/issues/38861
+   
+ - `symfony/polyfill-mbstring": "1.22.0`:
+ 
+   Polyfill-mbstring 1.22.0 has problem with code analyse on php7.3. After run `vendor/bin/psalm --show-info=false --php-version=7.3` throw exception: 
+   
+   `ParseError - vendor/symfony/polyfill-mbstring/bootstrap80.php:125:86 - Syntax error, unexpected '=' on line 125 (see https://psalm.dev/173) function mb_scrub(string $string, string $encoding = null): string { $encoding ??= mb_internal_encoding(); return mb_convert_encoding($string, $encoding, $encoding); }` 
+   
+   References: https://github.com/vimeo/psalm/issues/4961

--- a/composer.json
+++ b/composer.json
@@ -156,7 +156,8 @@
     },
     "conflict": {
         "doctrine/inflector": "^1.4",
-        "symfony/doctrine-bridge": "4.4.16"
+        "symfony/doctrine-bridge": "4.4.16",
+        "symfony/polyfill-mbstring": "1.22.0"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Fix build after conflict: 

<img width="1305" alt="Screenshot 2021-01-07 at 21 32 33" src="https://user-images.githubusercontent.com/39232096/103942006-00e1a500-5130-11eb-8758-2522a4af6464.png">


<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
