### PR TITLE
[Translations] Fix wrong select field in German

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.de.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/translations/messages.de.yml
@@ -23,7 +23,7 @@ sylius:
         province:
             name: Name
             abbreviation: Abkürzung
-            select: Bundesland auswählen
+            select: Provinz auswählen
         zone:
             add_member: Mitglied hinzufügen
             members: Mitglieder
@@ -36,7 +36,7 @@ sylius:
             scope: Umfang
             scopes:
                 all: Alle
-            select: Bundesland auswählen
+            select: Mitglied auswählen
             select_scope: Bereich wählen
         zone_member:
-            select: Bundesland auswählen
+            select: Mitglied auswählen

--- a/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.de.yml
+++ b/src/Sylius/Bundle/AttributeBundle/Resources/translations/messages.de.yml
@@ -18,7 +18,7 @@ sylius:
             datetime: Datum / Zeit
             integer: Integer
             percent: Prozent
-            select: Bundesland auswählen
+            select: Auswahl
             text: Text
             textarea: Textfeld
             title: Attributtyp

--- a/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de.yml
+++ b/src/Sylius/Bundle/UiBundle/Resources/translations/messages.de.yml
@@ -727,7 +727,7 @@ sylius:
         search_products: 'Artikel suchen'
         security_settings: 'Sicherheitseinstellungen'
         see_issue: 'Fehler gefunden'
-        select: 'Bundesland auswählen'
+        select: 'Auswahl'
         select_address_from_book: 'Adresse aus Adressbuch auswählen'
         select_products: 'Produkt auswählen'
         select_taxon: 'Klassifizierung wählen'


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


Just a few updates to select fields.
Two basic issues: The naming of the `select` type should not be "Bundesland auswählen" and not every selection should be titled as such.