### PR TITLE
Getting back to customer details in admin panel.

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Order/Index/_breadcrumb.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Customer/Order/Index/_breadcrumb.html.twig
@@ -3,7 +3,7 @@
 {% set breadcrumbs = [
         { label: 'sylius.ui.administration'|trans, url: path('sylius_admin_dashboard') },
         { label: 'sylius.ui.customers'|trans, url: path('sylius_admin_customer_index') },
-        { label: app.request.attributes.get('id') },
+        { label: app.request.attributes.get('id'), url: path('sylius_admin_customer_show', {id: app.request.attributes.get('id') })},
         { label: 'sylius.ui.orders'|trans },
     ]
 %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -none-
| License         | MIT

If you are looking at the orders of a customer you want to click on the id of the customer in the breadcrum to get back to the customer details page.

This is now clickable:
![image](https://user-images.githubusercontent.com/14860264/105995808-cd989300-60a9-11eb-876c-39374e01a0d9.png)
