### PR TITLE
Removing hard timeout on edit while load selected values

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-auto-complete.js
+++ b/src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-auto-complete.js
@@ -65,13 +65,12 @@ $.fn.extend({
                 $(`<div class="item" data-value="${item[choiceValue]}">${item[choiceName]}</div>`)
               ));
             });
+
+            element.dropdown('refresh');
+            element.dropdown('set selected', element.find('input.autocomplete').val().split(',').filter(String));
           },
         });
       }
-
-      window.setTimeout(() => {
-        element.dropdown('set selected', element.find('input.autocomplete').val().split(',').filter(String));
-      }, 5000);
     });
   },
 });


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

In the js file, `src/Sylius/Bundle/UiBundle/Resources/private/js/sylius-auto-complete.js` is set timeout = 5 sec to wait for an async response from ajax autocomplete action.

possibly this was added because someone calculated that this time would be enough to load mutation observers. However, when we add more than one field of type `ResourceAutocompleteChoiceType` it loads with a long delay.
In this PR I removed timeout and add the `refresh` action on the dropdown with 'set selected' action after the response receiving.
