### PR TITLE
Filter on product's name as well

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/config/grids/inventory.yml
+++ b/src/Sylius/Bundle/AdminBundle/Resources/config/grids/inventory.yml
@@ -32,7 +32,7 @@ sylius_grid:
                     type: string
                     label: sylius.ui.name
                     options:
-                        fields: [translation.name]
+                        fields: [translation.name, product.translations.name]
             actions:
                 item:
                     update_product:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

The variant's name is optional.
Meaning that we won't find any product with an empty variant name if we filter on the name.

Now we filter on the product's name as well so we can find what we are searching for!
