### PR TITLE
Avoid error if no enabled variant

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_price.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_price.html.twig
@@ -1,14 +1,17 @@
 {% import "@SyliusShop/Common/Macro/money.html.twig" as money %}
 
 {% set variant = product|sylius_resolve_variant %}
-{% set hasDiscount = variant|sylius_has_discount({'channel': sylius.channel}) %}
 
-<span class="ui small header" id="product-original-price" {{ sylius_test_html_attribute('product-original-price', money.calculateOriginalPrice(variant)) }}>
-    {% if hasDiscount %}
-        <del>{{ money.calculateOriginalPrice(variant) }}</del>
-    {% endif %}
-</span>
+{% if variant is not null %}
+    {% set hasDiscount = variant|sylius_has_discount({'channel': sylius.channel}) %}
 
-<span class="ui huge header" id="product-price" {{ sylius_test_html_attribute('product-price', money.calculatePrice(variant)) }}>
-    {{ money.calculatePrice(variant) }}
-</span>
+    <span class="ui small header" id="product-original-price" {{ sylius_test_html_attribute('product-original-price', money.calculateOriginalPrice(variant)) }}>
+        {% if hasDiscount %}
+            <del>{{ money.calculateOriginalPrice(variant) }}</del>
+        {% endif %}
+    </span>
+
+    <span class="ui huge header" id="product-price" {{ sylius_test_html_attribute('product-price', money.calculatePrice(variant)) }}>
+        {{ money.calculatePrice(variant) }}
+    </span>
+{% endif %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

It seems we have an issue here if the product has no enabled variant.
This fixes the issue by just avoiding displaying the price (since no variant, no price!)