### PR TITLE
[Adjustment] Update new migrations not to execute if the changes already exist in db

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201130071338.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201130071338.php
@@ -25,6 +25,11 @@ final class Version20201130071338 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $adjustmentTable = $schema->getTable('sylius_adjustment');
+        if ($adjustmentTable->hasColumn('shipment_id')) {
+            return;
+        }
+
         $this->addSql('ALTER TABLE sylius_adjustment ADD shipment_id INT DEFAULT NULL');
         $this->addSql('ALTER TABLE sylius_adjustment ADD CONSTRAINT FK_ACA6E0F27BE036FC FOREIGN KEY (shipment_id) REFERENCES sylius_shipment (id) ON DELETE CASCADE');
         $this->addSql('CREATE INDEX IDX_ACA6E0F27BE036FC ON sylius_adjustment (shipment_id)');

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
@@ -25,6 +25,11 @@ final class Version20201204071301 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $adjustmentTable = $schema->getTable('sylius_adjustment');
+        if ($adjustmentTable->hasColumn('details')) {
+            return;
+        }
+
         $this->addSql('ALTER TABLE sylius_adjustment ADD details JSON NOT NULL');
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I'm adding these `if` statements not to execute migrations if the changes already exist in the database. It could resolve potential problems for upgrading Sylius from 1.8 to 1.9 with installed the newest RefundPlugin.