### PR TITLE
[Adjustment] Update down methods of new migrations not to execute if the changes already exist in db

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201130071338.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201130071338.php
@@ -38,6 +38,11 @@ final class Version20201130071338 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        $adjustmentTable = $schema->getTable('sylius_adjustment');
+        if (!$adjustmentTable->hasColumn('shipment_id')) {
+            return;
+        }
+
         $this->addSql('ALTER TABLE sylius_adjustment DROP FOREIGN KEY FK_ACA6E0F27BE036FC');
         $this->addSql('DROP INDEX IDX_ACA6E0F27BE036FC ON sylius_adjustment');
         $this->addSql('ALTER TABLE sylius_adjustment DROP shipment_id');

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
@@ -35,6 +35,11 @@ final class Version20201204071301 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        $adjustmentTable = $schema->getTable('sylius_adjustment');
+        if (!$adjustmentTable->hasColumn('details')) {
+            return;
+        }
+
         $this->addSql('ALTER TABLE sylius_adjustment DROP details');
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/pull/12364#issuecomment-780582088
| License         | MIT
