### PR TITLE
Pass path delimiter up to parent taxon

### DIFF
--- a/src/Sylius/Component/Taxonomy/Model/Taxon.php
+++ b/src/Sylius/Component/Taxonomy/Model/Taxon.php
@@ -182,7 +182,7 @@ class Taxon implements TaxonInterface
 
         return sprintf(
             '%s%s%s',
-            $this->getParent()->getFullname(),
+            $this->getParent()->getFullname($pathDelimiter),
             $pathDelimiter,
             $this->getName()
         );

--- a/src/Sylius/Component/Taxonomy/spec/Model/TaxonSpec.php
+++ b/src/Sylius/Component/Taxonomy/spec/Model/TaxonSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Component\Taxonomy\Model;
 
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
+use Sylius\Component\Taxonomy\Model\Taxon;
 use Sylius\Component\Taxonomy\Model\TaxonInterface;
 
 final class TaxonSpec extends ObjectBehavior
@@ -128,17 +129,23 @@ final class TaxonSpec extends ObjectBehavior
         $this->getFullname()->shouldReturn('Category');
     }
 
-    function its_fullname_prepends_with_parents_fullname(TaxonInterface $root): void
+    function its_fullname_prepends_with_parents_fullname(): void
     {
-        $root->getFullname(' / ')->willReturn('Category');
-        $root->getFullname(' -- ')->willReturn('Category');
+        $rootTaxon = new Taxon();
+        $rootTaxon->setCurrentLocale('en_US');
+        $rootTaxon->setName('Category');
+
+        $clothesTaxon = new Taxon();
+        $clothesTaxon->setCurrentLocale('en_US');
+        $clothesTaxon->setName('Clothes');
+        $clothesTaxon->setParent($rootTaxon);
+
+        $this->setCurrentLocale('en_US');
         $this->setName('T-shirts');
+        $this->setParent($clothesTaxon);
 
-        $root->addChild($this)->shouldBeCalled();
-        $this->setParent($root);
-
-        $this->getFullname()->shouldReturn('Category / T-shirts');
-        $this->getFullname(' -- ')->shouldReturn('Category -- T-shirts');
+        $this->getFullname()->shouldReturn('Category / Clothes / T-shirts');
+        $this->getFullname(' -- ')->shouldReturn('Category -- Clothes -- T-shirts');
     }
 
     function it_has_no_description_by_default(): void

--- a/src/Sylius/Component/Taxonomy/spec/Model/TaxonSpec.php
+++ b/src/Sylius/Component/Taxonomy/spec/Model/TaxonSpec.php
@@ -130,7 +130,8 @@ final class TaxonSpec extends ObjectBehavior
 
     function its_fullname_prepends_with_parents_fullname(TaxonInterface $root): void
     {
-        $root->getFullname()->willReturn('Category');
+        $root->getFullname(' / ')->willReturn('Category');
+        $root->getFullname(' -- ')->willReturn('Category');
         $this->setName('T-shirts');
 
         $root->addChild($this)->shouldBeCalled();


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

This fixes a bug where this following taxon tree:

* A
    * B
        * C

would lead to a full name of `A  / B > C` instead of `A > B > C` if the call was `$taxonC->getFullname('>');`