### PR TITLE
[Bug-fix] Fix default form problem with _token field

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_content.html.twig
@@ -9,6 +9,7 @@
     {% include '@SyliusAdmin/Crud/form_validation_errors_checker.html.twig' %}
     {% if configuration.vars.templates.form is defined %}
         {% include configuration.vars.templates.form %}
+        {{ form_row(form._token) }}
     {% else %}
         {{ form_widget(form) }}
     {% endif %}
@@ -17,6 +18,5 @@
 
     {% include '@SyliusUi/Form/Buttons/_create.html.twig' with {'paths': {'cancel': index_url}} %}
 
-    {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}
 </div>

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
@@ -10,6 +10,7 @@
     {% include '@SyliusAdmin/Crud/form_validation_errors_checker.html.twig' %}
     {% if configuration.vars.templates.form is defined %}
         {% include configuration.vars.templates.form %}
+        {{ form_row(form._token) }}
     {% else %}
         {{ form_widget(form) }}
     {% endif %}
@@ -18,6 +19,5 @@
 
     {% include '@SyliusUi/Form/Buttons/_update.html.twig' with {'paths': {'cancel': index_url}} %}
 
-    {{ form_row(form._token) }}
     {{ form_end(form, {'render_rest': false}) }}
 </div>


### PR DESCRIPTION
Discussion
----------

| Q               | A
| --------------- | -----
| Branch?         | 1.9 
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

After upgrade to Symfony 5, there is a problem with the default form for custom resources. Already rendered `_token` with `form_widget(form)` throws an exception when rendered again (previously it was just not rendered again).

<img width="1050" alt="Zrzut ekranu 2021-02-23 o 12 55 30" src="https://user-images.githubusercontent.com/6212718/108840942-50dcd400-75d7-11eb-8260-ba2cdf598dbb.png">

Probably it would be nice to have some test for a custom resource with default templates 💃 Write now it can be easily reproduced by removing `vars->all->templates->form` from one of the resources (e.g. `AdminUser`).