### PR TITLE
Filter product variants by product & option values

### DIFF
--- a/features/cart/shopping_cart/adding_product_with_options_to_cart.feature
+++ b/features/cart/shopping_cart/adding_product_with_options_to_cart.feature
@@ -7,7 +7,7 @@ Feature: Adding a product with selected option to the cart
     Background:
         Given the store operates on a single channel in "United States"
 
-    @ui
+    @ui @api
     Scenario: Adding a product with single option to the cart
         Given the store has a product "T-shirt banana"
         And this product has option "Size" with values "S" and "M"

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -188,34 +188,6 @@ final class CartContext implements Context
     }
 
     /**
-     * @Given /^(this product) should have ([^"]+) "([^"]+)"$/
-     */
-    public function thisItemShouldHaveOptionValue(ProductInterface $product, string $optionName, string $optionValue): void
-    {
-        $item = $this->sharedStorage->get('item');
-
-        $variantData = json_decode($this->cartsClient->showByIri(urldecode($item['variant']))->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-
-        foreach ($variantData['optionValues'] as $valueIri) {
-            $optionValueData = json_decode($this->cartsClient->showByIri($valueIri)->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-
-            if ($optionValueData['value'] !== $optionValue) {
-                continue;
-            }
-
-            $optionData = json_decode($this->cartsClient->showByIri($optionValueData['option'])->getContent(), true, 512, \JSON_THROW_ON_ERROR);
-
-            if ($optionData['name'] !== $optionName) {
-                continue;
-            }
-
-            return;
-        }
-
-        throw new \DomainException(sprintf('Could not find item with option "%s" set to "%s"', $optionName, $optionValue));
-    }
-
-    /**
      * @When /^I change (product "[^"]+") quantity to (\d+) in my (cart)$/
      * @When /^the (?:visitor|customer) change (product "[^"]+") quantity to (\d+) in his (cart)$/
      * @When /^the visitor try to change (product "[^"]+") quantity to (\d+) in the customer (cart)$/
@@ -530,6 +502,34 @@ final class CartContext implements Context
         $items = $this->responseChecker->getValue($this->cartsClient->show($tokenValue), 'items');
 
         Assert::same(count($items), 0, 'There should be an empty cart');
+    }
+
+    /**
+     * @Then /^(this product) should have ([^"]+) "([^"]+)"$/
+     */
+    public function thisItemShouldHaveOptionValue(ProductInterface $product, string $optionName, string $optionValue): void
+    {
+        $item = $this->sharedStorage->get('item');
+
+        $variantData = json_decode($this->cartsClient->showByIri(urldecode($item['variant']))->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        foreach ($variantData['optionValues'] as $valueIri) {
+            $optionValueData = json_decode($this->cartsClient->showByIri($valueIri)->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+            if ($optionValueData['value'] !== $optionValue) {
+                continue;
+            }
+
+            $optionData = json_decode($this->cartsClient->showByIri($optionValueData['option'])->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+            if ($optionData['name'] !== $optionName) {
+                continue;
+            }
+
+            return;
+        }
+
+        throw new \DomainException(sprintf('Could not find item with option "%s" set to "%s"', $optionName, $optionValue));
     }
 
     private function pickupCart(?string $localeCode = null): string

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -37,6 +37,12 @@ final class CartContext implements Context
     /** @var ApiClientInterface */
     private $ordersAdminClient;
 
+    /** @var ApiClientInterface */
+    private $productsClient;
+
+    /** @var ApiClientInterface */
+    private $productVariantsClient;
+
     /** @var ResponseCheckerInterface */
     private $responseChecker;
 
@@ -49,12 +55,16 @@ final class CartContext implements Context
     public function __construct(
         ApiClientInterface $cartsClient,
         ApiClientInterface $ordersAdminClient,
+        ApiClientInterface $productsClient,
+        ApiClientInterface $productVariantsClient,
         ResponseCheckerInterface $responseChecker,
         SharedStorageInterface $sharedStorage,
         ProductVariantResolverInterface $productVariantResolver
     ) {
         $this->cartsClient = $cartsClient;
         $this->ordersAdminClient = $ordersAdminClient;
+        $this->productsClient = $productsClient;
+        $this->productVariantsClient = $productVariantsClient;
         $this->responseChecker = $responseChecker;
         $this->sharedStorage = $sharedStorage;
         $this->productVariantResolver = $productVariantResolver;
@@ -121,6 +131,88 @@ final class CartContext implements Context
     public function iAddVariantOfThisProductToTheCart(ProductVariantInterface $productVariant, ?string $tokenValue): void
     {
         $this->putProductVariantToCart($productVariant, $tokenValue, 1);
+    }
+
+    /**
+     * @When I add :product with :productOption :productOptionValue to the cart
+     */
+    public function iAddThisProductWithToTheCart(
+        ProductInterface $product,
+        string $productOption,
+        string $productOptionValue
+    ): void {
+        $productData = json_decode($this->productsClient->show($product->getCode())->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        $variantCode = null;
+        foreach ($productData['options'] as $optionIri) {
+            $optionData = json_decode($this->productsClient->showByIri($optionIri)->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+            if ($optionData['name'] !== $productOption) {
+                continue;
+            }
+
+            foreach ($optionData['values'] as $valueIri) {
+                $optionValueData = json_decode($this->productsClient->showByIri($valueIri)->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+                if ($optionValueData['value'] !== $productOptionValue) {
+                    continue;
+                }
+
+                $this->productVariantsClient->index();
+                $this->productVariantsClient->addFilter('product', $productData['@id']);
+                $this->productVariantsClient->addFilter('optionValues', $valueIri);
+
+                $variantsData = json_decode($this->productVariantsClient->filter()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+                Assert::same($variantsData['hydra:totalItems'], 1);
+
+                $variantCode = $variantsData['hydra:member'][0]['code'];
+            }
+        }
+
+        if (null === $variantCode) {
+            throw new \DomainException(sprintf('Could not find variant with option "%s" set to "%s"', $productOption, $productOptionValue));
+        }
+
+        $tokenValue = $this->pickupCart();
+
+        $request = Request::customItemAction('shop', 'orders', $tokenValue, HttpRequest::METHOD_PATCH, 'items');
+
+        $request->updateContent([
+            'productCode' => $productData['code'],
+            'productVariantCode' => $variantCode,
+            'quantity' => 1,
+        ]);
+
+        $this->cartsClient->executeCustomRequest($request);
+    }
+
+    /**
+     * @Given /^(this product) should have ([^"]+) "([^"]+)"$/
+     */
+    public function thisItemShouldHaveOptionValue(ProductInterface $product, string $optionName, string $optionValue): void
+    {
+        $item = $this->sharedStorage->get('item');
+
+        $variantData = json_decode($this->cartsClient->showByIri(urldecode($item['variant']))->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+        foreach ($variantData['optionValues'] as $valueIri) {
+            $optionValueData = json_decode($this->cartsClient->showByIri($valueIri)->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+            if ($optionValueData['value'] !== $optionValue) {
+                continue;
+            }
+
+            $optionData = json_decode($this->cartsClient->showByIri($optionValueData['option'])->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+
+            if ($optionData['name'] !== $optionName) {
+                continue;
+            }
+
+            return;
+        }
+
+        throw new \DomainException(sprintf('Could not find item with option "%s" set to "%s"', $optionName, $optionValue));
     }
 
     /**

--- a/src/Sylius/Behat/Context/Api/Shop/CartContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CartContext.php
@@ -23,6 +23,7 @@ use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Locale\Model\LocaleInterface;
+use Sylius\Component\Product\Model\ProductOptionInterface;
 use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Sylius/Behat/Resources/config/services/api.xml
+++ b/src/Sylius/Behat/Resources/config/services/api.xml
@@ -104,6 +104,11 @@
             <argument>shop</argument>
         </service>
 
+        <service id="sylius.behat.api_platform_client.shop.product_variant" class="Sylius\Behat\Client\ApiPlatformClient" parent="sylius.behat.api_platform_client">
+            <argument>product-variants</argument>
+            <argument>shop</argument>
+        </service>
+
         <service id="sylius.behat.api_platform_client.admin.province" class="Sylius\Behat\Client\ApiPlatformClient" parent="sylius.behat.api_platform_client">
             <argument>provinces</argument>
             <argument>admin</argument>

--- a/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api/shop.xml
@@ -34,6 +34,8 @@
         <service id="sylius.behat.context.api.shop.cart" class="Sylius\Behat\Context\Api\Shop\CartContext">
             <argument type="service" id="sylius.behat.api_platform_client.shop.cart" />
             <argument type="service" id="sylius.behat.api_platform_client.admin.order" />
+            <argument type="service" id="sylius.behat.api_platform_client.shop.product" />
+            <argument type="service" id="sylius.behat.api_platform_client.shop.product_variant" />
             <argument type="service" id="Sylius\Behat\Client\ResponseCheckerInterface" />
             <argument type="service" id="sylius.behat.shared_storage" />
             <argument type="service" id="sylius.product_variant_resolver.default" />

--- a/src/Sylius/Bundle/ApiBundle/DataProvider/ChannelAwareItemDataProvider.php
+++ b/src/Sylius/Bundle/ApiBundle/DataProvider/ChannelAwareItemDataProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\DataProvider;
+
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
+use Sylius\Bundle\ApiBundle\Serializer\ContextKeys;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
+
+/** @experimental */
+final class ChannelAwareItemDataProvider implements ItemDataProviderInterface
+{
+    /**
+     * @var ItemDataProviderInterface
+     */
+    private $itemDataProvider;
+
+    /**
+     * @var ChannelContextInterface
+     */
+    private $channelContext;
+
+    public function __construct(ItemDataProviderInterface $itemDataProvider, ChannelContextInterface $channelContext)
+    {
+        $this->itemDataProvider = $itemDataProvider;
+        $this->channelContext = $channelContext;
+    }
+
+    public function getItem(string $resourceClass, $id, string $operationName = null, array $context = []): ?object
+    {
+        return $this->itemDataProvider->getItem($resourceClass, $id, $operationName, $this->processContext($context));
+    }
+
+    private function processContext(array $context): array
+    {
+        if (array_key_exists(ContextKeys::CHANNEL, $context)) {
+            return $context;
+        }
+
+        try {
+            $context[ContextKeys::CHANNEL] = $this->channelContext->getChannel();
+        } catch (ChannelNotFoundException $exception) {
+        }
+
+        return $context;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/DataProvider/ChannelAwareItemDataProvider.php
+++ b/src/Sylius/Bundle/ApiBundle/DataProvider/ChannelAwareItemDataProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\DataProvider;
@@ -12,14 +21,10 @@ use Sylius\Component\Channel\Context\ChannelNotFoundException;
 /** @experimental */
 final class ChannelAwareItemDataProvider implements ItemDataProviderInterface
 {
-    /**
-     * @var ItemDataProviderInterface
-     */
+    /** @var ItemDataProviderInterface */
     private $itemDataProvider;
 
-    /**
-     * @var ChannelContextInterface
-     */
+    /** @var ChannelContextInterface */
     private $channelContext;
 
     public function __construct(ItemDataProviderInterface $itemDataProvider, ChannelContextInterface $channelContext)

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/Filter/ProductVariantOptionValueFilter.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/Filter/ProductVariantOptionValueFilter.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Doctrine\Filter;
@@ -15,15 +24,20 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Webmozart\Assert\Assert;
 
+/** @experimental */
 final class ProductVariantOptionValueFilter extends AbstractContextAwareFilter
 {
-    /**
-     * @var IriConverterInterface
-     */
+    /** @var IriConverterInterface */
     private IriConverterInterface $iriConverter;
 
-    public function __construct(IriConverterInterface $iriConverter, ManagerRegistry $managerRegistry, ?RequestStack $requestStack = null, LoggerInterface $logger = null, array $properties = null, NameConverterInterface $nameConverter = null)
-    {
+    public function __construct(
+        IriConverterInterface $iriConverter,
+        ManagerRegistry $managerRegistry,
+        ?RequestStack $requestStack = null,
+        LoggerInterface $logger = null,
+        array $properties = null,
+        NameConverterInterface $nameConverter = null
+    ) {
         parent::__construct($managerRegistry, $requestStack, $logger, $properties, $nameConverter);
 
         $this->iriConverter = $iriConverter;
@@ -49,7 +63,8 @@ final class ProductVariantOptionValueFilter extends AbstractContextAwareFilter
             $parameterName = $queryNameGenerator->generateParameterName($property);
             $queryBuilder
                 ->andWhere(sprintf(':%s MEMBER OF o.optionValues', $parameterName))
-                ->setParameter($parameterName, $optionValue);
+                ->setParameter($parameterName, $optionValue)
+            ;
         }
     }
 

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/Filter/ProductVariantOptionValueFilter.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/Filter/ProductVariantOptionValueFilter.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Doctrine\Filter;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use ApiPlatform\Core\Bridge\Doctrine\Common\Filter\OrderFilterInterface;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractContextAwareFilter;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Webmozart\Assert\Assert;
+
+final class ProductVariantOptionValueFilter extends AbstractContextAwareFilter
+{
+    /**
+     * @var IriConverterInterface
+     */
+    private IriConverterInterface $iriConverter;
+
+    public function __construct(IriConverterInterface $iriConverter, ManagerRegistry $managerRegistry, ?RequestStack $requestStack = null, LoggerInterface $logger = null, array $properties = null, NameConverterInterface $nameConverter = null)
+    {
+        parent::__construct($managerRegistry, $requestStack, $logger, $properties, $nameConverter);
+
+        $this->iriConverter = $iriConverter;
+    }
+
+    protected function filterProperty(
+        string $property,
+        $value,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        string $operationName = null
+    ): void {
+        if ($property !== 'optionValues') {
+            return;
+        }
+
+        $value = (array) $value;
+
+        foreach ($value as $optionValueIri) {
+            $optionValue = $this->iriConverter->getItemFromIri($optionValueIri);
+
+            $parameterName = $queryNameGenerator->generateParameterName($property);
+            $queryBuilder
+                ->andWhere(sprintf(':%s MEMBER OF o.optionValues', $parameterName))
+                ->setParameter($parameterName, $optionValue);
+        }
+    }
+
+    public function getDescription(string $resourceClass): array
+    {
+        return [
+            'optionValues' => [
+                'type' => 'string',
+                'required' => false,
+                'property' => 'optionValues',
+                'schema' => [
+                    'type' => 'string',
+                ],
+            ],
+            'optionValues[]' => [
+                'type' => 'array[string]',
+                'required' => false,
+                'property' => 'optionValues',
+                'schema' => [
+                    'type' => 'array[string]',
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/Filter/ProductVariantOptionValueFilter.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/Filter/ProductVariantOptionValueFilter.php
@@ -65,12 +65,10 @@ final class ProductVariantOptionValueFilter extends AbstractContextAwareFilter
                 ],
             ],
             'optionValues[]' => [
-                'type' => 'array[string]',
+                'type' => 'string',
                 'required' => false,
                 'property' => 'optionValues',
-                'schema' => [
-                    'type' => 'array[string]',
-                ],
+                'is_collection' => true,
             ],
         ];
     }

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductOptionValue.xml
@@ -16,8 +16,6 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.product_option_value.class%" shortName="ProductOptionValue">
-        <attribute name="route_prefix">admin</attribute>
-
         <attribute name="normalization_context">
             <attribute name="groups">
                 <attribute>product_option_value:read</attribute>
@@ -37,6 +35,12 @@
         <itemOperations>
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
+                <attribute name="path">/admin/product-option-values/{id}</attribute>
+            </itemOperation>
+
+            <itemOperation name="shop_get">
+                <attribute name="method">GET</attribute>
+                <attribute name="path">/shop/product-option-values/{id}</attribute>
             </itemOperation>
         </itemOperations>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
@@ -53,7 +53,7 @@
                 <attribute name="path">/shop/product-variants</attribute>
                 <attribute name="filters">
                     <attribute>sylius.api.product_variant_product_filter</attribute>
-<!--                    <attribute>sylius.api.product_variant_option_value_filter</attribute>-->
+                    <attribute>sylius.api.product_variant_option_value_filter</attribute>
                 </attribute>
             </collectionOperation>
         </collectionOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
@@ -47,6 +47,15 @@
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-variants</attribute>
             </collectionOperation>
+
+            <collectionOperation name="shop_get">
+                <attribute name="method">GET</attribute>
+                <attribute name="path">/shop/product-variants</attribute>
+                <attribute name="filters">
+                    <attribute>sylius.api.product_variant_product_filter</attribute>
+<!--                    <attribute>sylius.api.product_variant_option_value_filter</attribute>-->
+                </attribute>
+            </collectionOperation>
         </collectionOperations>
 
         <property name="id" identifier="false" writable="false" />
@@ -65,5 +74,6 @@
             </attribute>
         </property>
         <property name="channelPricings" writable="true" readable="true" />
+        <property name="optionValues" readable="true" />
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionValue.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductOptionValue.xml
@@ -19,6 +19,12 @@
         <attribute name="id">
             <group>product_option_value:read</group>
         </attribute>
+        <attribute name="value">
+            <group>product_option_value:read</group>
+        </attribute>
+        <attribute name="option">
+            <group>product_option_value:read</group>
+        </attribute>
         <attribute name="code">
             <group>product_option:create</group>
             <group>product_option:update</group>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
@@ -30,5 +30,8 @@
             <group>product_variant:read</group>
             <group>shop:cart:read</group>
         </attribute>
+        <attribute name="optionValues">
+            <group>product_variant:read</group>
+        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -154,5 +154,10 @@
         <service id="Sylius\Bundle\ApiBundle\Controller\DeleteOrderItemAction" public="true">
             <argument type="service" id="sylius_default.bus" />
         </service>
+
+        <service id="Sylius\Bundle\ApiBundle\DataProvider\ChannelAwareItemDataProvider" decorates="api_platform.item_data_provider">
+            <argument type="service" id="Sylius\Bundle\ApiBundle\DataProvider\ChannelAwareItemDataProvider.inner" />
+            <argument type="service" id="sylius.context.channel" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/filters.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/filters.xml
@@ -86,5 +86,11 @@
             <argument type="service" id="doctrine" />
             <tag name="api_platform.filter" />
         </service>
+
+        <service id="sylius.api.product_variant_option_value_filter" class="Sylius\Bundle\ApiBundle\Doctrine\Filter\ProductVariantOptionValueFilter">
+            <argument type="service" id="api_platform.iri_converter" />
+            <argument type="service" id="doctrine" />
+            <tag name="api_platform.filter" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/filters.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/filters.xml
@@ -47,6 +47,13 @@
             <tag name="api_platform.filter" />
         </service>
 
+        <service id="sylius.api.product_variant_product_filter" parent="api_platform.doctrine.orm.search_filter">
+            <argument type="collection">
+                <argument key="product">exact</argument>
+            </argument>
+            <tag name="api_platform.filter" />
+        </service>
+
         <service id="sylius.api.product_order_filter" parent="api_platform.doctrine.orm.order_filter">
             <argument type="collection">
                 <argument key="code" />

--- a/src/Sylius/Bundle/ApiBundle/spec/DataProvider/ChannelAwareItemDataProviderSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/DataProvider/ChannelAwareItemDataProviderSpec.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ApiBundle\DataProvider;
+
+use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ApiBundle\DataProvider\ChannelAwareItemDataProvider;
+use Sylius\Bundle\ApiBundle\Serializer\ContextKeys;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
+use Sylius\Component\Core\Model\ChannelInterface;
+
+final class ChannelAwareItemDataProviderSpec extends ObjectBehavior
+{
+    function let(ItemDataProviderInterface $itemDataProvider, ChannelContextInterface $channelContext): void
+    {
+        $this->beConstructedWith($itemDataProvider, $channelContext);
+    }
+
+    function it_is_an_item_data_provider(): void
+    {
+        $this->shouldImplement(ItemDataProviderInterface::class);
+    }
+
+    function it_adds_channel_to_the_context_if_not_there_yet(
+        ItemDataProviderInterface $itemDataProvider,
+        ChannelContextInterface $channelContext,
+        ChannelInterface $channel
+    ): void {
+        $channelContext->getChannel()->willReturn($channel);
+
+        $itemDataProvider->getItem('Class', 'ID', 'get', [ContextKeys::CHANNEL => $channel])->willReturn(null);
+
+        $this->getItem('Class', 'ID', 'get', [])->shouldReturn(null);
+    }
+
+    function it_does_not_add_channel_to_the_context_silently_if_it_could_not_be_found(
+        ItemDataProviderInterface $itemDataProvider,
+        ChannelContextInterface $channelContext
+    ): void {
+        $channelContext->getChannel()->willThrow(ChannelNotFoundException::class);
+
+        $itemDataProvider->getItem('Class', 'ID', 'get', [])->willReturn(null);
+
+        $this->getItem('Class', 'ID', 'get', [])->shouldReturn(null);
+    }
+
+    function it_does_not_add_channel_to_the_context_if_it_is_already_added(
+        ItemDataProviderInterface $itemDataProvider,
+        ChannelContextInterface $channelContext,
+        ChannelInterface $channel
+    ): void {
+        $channelContext->getChannel()->shouldNotBeCalled();
+
+        $itemDataProvider->getItem('Class', 'ID', 'get', [ContextKeys::CHANNEL => $channel])->willReturn(null);
+
+        $this->getItem('Class', 'ID', 'get', [ContextKeys::CHANNEL => $channel])->shouldReturn(null);
+    }
+}


### PR DESCRIPTION
TODO:
 - [x] Find out (and fix) why ProductItemDataProvider does not have channel in the context when filtering by product (`/api/v2/shop/product-variants?product=%2Fapi%2Fv2%2Fshop%2Fproducts%2FLoose_white_designer_T_Shirt`) - my idea is that `ChannelContextBuilder` is only run for the "main" API request, normalizing product's IRI and going through this data provider does not trigger context builder beforehand
 - [x] Implement filter for option values - `?optionValues=/option/value/iri`
 - [x] Implement Behat scenario