### PR TITLE
[API] Fix admin API filtering has no effect

### DIFF
--- a/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/customer.yml
+++ b/src/Sylius/Bundle/AdminApiBundle/Resources/config/routing/customer.yml
@@ -11,6 +11,7 @@ sylius_admin_api_customer_index:
             serialization_groups: [Default]
             paginate: $limit
             sortable: true
+            grid: sylius_admin_customer
             sorting:
                 id: desc
 
@@ -64,5 +65,6 @@ sylius_admin_api_customer_order_index:
             filterable: true
             criteria: { customer: $id }
             sortable: true
+            grid: sylius_admin_customer_order
             sorting: { updatedAt: desc }
             csrf_protection: false


### PR DESCRIPTION
Add grid config to customer API index routes. Otherwise if we want to filter the customers over criterias like: https://demo.sylius.com/api/v1/customers?criteria[search][type]=contains&criteria[search][value]=test it will have no effect on the expected result.

I think the grids must also be set on other _index routes in the AdminAPIBundle.

The filtering for the orders works because the grid is defined in order.yml:
sylius_admin_api_order:
    resource: |
        alias: sylius.order
        path: ''
        section: admin_api
        only: [show, index]
        grid: sylius_admin_order
        serialization_version: $version
    type: sylius.resource_api

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | none found
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
