### PR TITLE
[API] Make Sylius compatible with api-platform v2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-exif": "*",
         "ext-fileinfo": "*",
         "ext-gd": "*",
-        "api-platform/core": "^2.5",
+        "api-platform/core": "^2.6",
         "babdev/pagerfanta-bundle": "^2.5",
         "behat/transliterator": "^1.3",
         "doctrine/collections": "^1.6",
@@ -158,7 +158,6 @@
         "sylius/user-bundle": "self.version"
     },
     "conflict": {
-        "api-platform/core": "^2.6",
         "laminas/laminas-code": "^4.0.0",
         "symfony/doctrine-bridge": "4.4.16",
         "symfony/polyfill-mbstring": "^1.22.0",

--- a/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CheckoutContext.php
@@ -310,8 +310,9 @@ final class CheckoutContext implements Context
     public function iConfirmMyOrder(): void
     {
         $response = $this->completeOrder();
+        $statusCode = $response->getStatusCode();
 
-        if ($response->getStatusCode() === 400) {
+        if ($statusCode=== 400 || $statusCode === 422) {
             return;
         }
 
@@ -447,7 +448,7 @@ final class CheckoutContext implements Context
 
         $response = $this->ordersClient->getLastResponse();
 
-        Assert::same($response->getStatusCode(), 400);
+        Assert::oneOf($response->getStatusCode(), [400,422]);
 
         Assert::true($this->isViolationWithMessageInResponse(
             $response,
@@ -754,7 +755,7 @@ final class CheckoutContext implements Context
     {
         $response = $this->ordersClient->getLastResponse();
 
-        Assert::true($response->getStatusCode() === 400);
+        Assert::oneOf($response->getStatusCode(), [400, 422]);
 
         /** @var array|null $violations */
         $violations = $this->responseChecker->getResponseContent($response)['violations'];
@@ -785,7 +786,7 @@ final class CheckoutContext implements Context
      */
     public function iShouldNotSeeTheThankYouPage(): void
     {
-        Assert::same($this->ordersClient->getLastResponse()->getStatusCode(), 400);
+        Assert::oneOf($this->ordersClient->getLastResponse()->getStatusCode(), [400, 422]);
     }
 
     /**
@@ -814,7 +815,7 @@ final class CheckoutContext implements Context
     {
         $response = $this->ordersClient->getLastResponse();
 
-        Assert::same($response->getStatusCode(), 400);
+        Assert::oneOf($response->getStatusCode(), [400, 422]);
 
         Assert::true($this->isViolationWithMessageInResponse(
             $response,
@@ -884,7 +885,7 @@ final class CheckoutContext implements Context
     {
         $response = $this->ordersClient->getLastResponse();
 
-        Assert::same($response->getStatusCode(), 400);
+        Assert::oneOf($response->getStatusCode(), [400, 422]);
         Assert::true($this->isViolationWithMessageInResponse(
             $response,
             'Please select proper province.',

--- a/src/Sylius/Behat/Context/Api/Shop/CustomerContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/CustomerContext.php
@@ -326,7 +326,7 @@ final class CustomerContext implements Context
      */
     public function iShouldBeNotifiedThatProvidedPasswordIsDifferentThanTheCurrentOne(): void
     {
-        Assert::same($this->customerClient->getLastResponse()->getStatusCode(), 400);
+        Assert::oneOf($this->customerClient->getLastResponse()->getStatusCode(), [400, 422]);
 
         Assert::contains(
             $this->responseChecker->getError($this->customerClient->getLastResponse()),
@@ -339,7 +339,7 @@ final class CustomerContext implements Context
      */
     public function iShouldBeNotifiedThatTheEnteredPasswordsDoNotMatch(): void
     {
-        Assert::same($this->customerClient->getLastResponse()->getStatusCode(), 400);
+        Assert::oneOf($this->customerClient->getLastResponse()->getStatusCode(), [400, 422]);
 
         Assert::contains(
             $this->responseChecker->getError($this->customerClient->getLastResponse()),

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PasswordReset.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PasswordReset.xml
@@ -42,5 +42,7 @@
 
         <itemOperations/>
 
+        <property name="email" identifier="true" />
+
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
@@ -40,6 +40,7 @@
             <collectionOperation name="shop_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/products</attribute>
+                <attribute name="identifiedBy">code</attribute>
                 <attribute name="filters">
                     <attribute>sylius.api.product_name_filter</attribute>
                     <attribute>sylius.api.product_order_filter</attribute>
@@ -74,7 +75,8 @@
 
             <itemOperation name="shop_get">
                 <attribute name="method">GET</attribute>
-                <attribute name="path">/shop/products/{id}</attribute>
+                <attribute name="path">/shop/products/{code}</attribute>
+                <attribute name="identifiedBy">code</attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Use code to retrieve a product resource.</attribute>
                 </attribute>
@@ -97,8 +99,8 @@
             </itemOperation>
         </itemOperations>
 
-        <property name="id" identifier="false" writable="false" />
-        <property name="code" identifier="true" required="true" />
+        <property name="id" writable="false" />
+        <property name="code" required="true" />
         <property name="createdAt" writable="false" />
         <property name="updatedAt" writable="false" />
         <property name="translations" readable="true" writable="true">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
@@ -46,11 +46,12 @@
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-variants</attribute>
+                <attribute name="identifiedBy">id</attribute>
             </collectionOperation>
         </collectionOperations>
 
-        <property name="id" identifier="false" writable="false" />
-        <property name="code" identifier="true" required="true" />
+        <property name="id" writable="false" />
+        <property name="code" required="true" />
         <property name="product" />
         <property name="translations">
             <attribute name="openapi_context">


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes, i think so 😄 
| License         | MIT

- [x] Add api-platform 2.6 in composer and remove conflict
- [x] Prepare behats that test Validation to use 400 and 422 http status code as correct
- [x] Fix file PasswordReset.xml ( from 2.6 it shows error when there is no property to identify by)
- [x] Find the solution to fix proper IRI resolution
- [ ] Adapt solution for `red` scenarios