### PR TITLE
Do not fail when mb_detect_encoding returns false

### DIFF
--- a/src/Sylius/Component/User/Canonicalizer/Canonicalizer.php
+++ b/src/Sylius/Component/User/Canonicalizer/Canonicalizer.php
@@ -17,6 +17,6 @@ final class Canonicalizer implements CanonicalizerInterface
 {
     public function canonicalize(?string $string): ?string
     {
-        return null === $string ? null : mb_convert_case($string, \MB_CASE_LOWER, mb_detect_encoding($string));
+        return null === $string ? null : mb_convert_case($string, \MB_CASE_LOWER, mb_detect_encoding($string) ?: null);
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

In case `mb_detect_encoding` returns false, the call to `mb_convert_case` results in a `TypeError` as it has to be a nullable string as input.
