### PR TITLE
Fix nested accordion initialisation

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
+++ b/src/Sylius/Bundle/AdminBundle/Resources/private/js/app.js
@@ -100,8 +100,8 @@ $(document).ready(() => {
   $(document).previewUploadedImage('#add-avatar');
 
   $('body').on('DOMNodeInserted', '[data-form-collection="item"]', (event) => {
-    if ($(event.target).find('.accordion').length > 0) {
-      $(event.target).find('.accordion').accordion();
+    if ($(event.target).find('.ui.accordion').length > 0) {
+      $(event.target).find('.ui.accordion').accordion();
     }
   });
 


### PR DESCRIPTION
- When a new collection item is added, accordion are initialisated with
  the ".accordion" selector instead of ".ui.accordion"

| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #12380
| License         | MIT
