### PR TITLE
`JSON ` data type in `Version20201204071301` migration file causing compatibility issues with some MariaDB versions

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
@@ -30,7 +30,7 @@ final class Version20201204071301 extends AbstractMigration
             return;
         }
 
-        $this->addSql('ALTER TABLE sylius_adjustment ADD details JSON NOT NULL');
+        $this->addSql('ALTER TABLE sylius_adjustment ADD details LONGTEXT NOT NULL');
     }
 
     public function down(Schema $schema): void

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
@@ -30,7 +30,7 @@ final class Version20201204071301 extends AbstractMigration
             return;
         }
 
-        $this->addSql('ALTER TABLE sylius_adjustment ADD details LONGTEXT NOT NULL');
+        $this->addSql('ALTER TABLE sylius_adjustment ADD details LONGTEXT NOT NULL COMMENT \'(DC2Type:json)\'');
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7, 1.8 or master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

While creating a brand new Sylius project on 1.9, I encountered the following error during the step 2 of `bin/console sylius:install`:

```shell
  An exception occurred while executing 'ALTER TABLE sylius_adjustment ADD details JSON NOT NULL':

  SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the man
  ual that corresponds to your MariaDB server version for the right syntax to use near 'JSON NOT NULL' at lin
  e 1
```

For context, here's my MariaDB version:
```shell
mysq -V
mysql  Ver 15.1 Distrib 10.1.48-MariaDB, for debian-linux-gnu (x86_64) using readline 5.2
```

JSON itself as a data type is just an alias for LONGTEXT in MariaDB:

```
JSON is an alias for LONGTEXT introduced for compatibility reasons with MySQL's JSON data type. MariaDB implements this as a LONGTEXT rather, as the JSON data type contradicts the SQL standard, and MariaDB's benchmarks indicate that performance is at least equivalent.
```
source: https://mariadb.com/kb/en/json-data-type/

However the JSON_VALID function can only be used on this aliased data type:
```
The JSON_VALID function can be used as a CHECK constraint. This constraint is automatically included for types using the JSON alias from MariaDB 10.4.3.
```
source: https://mariadb.com/kb/en/json-data-type/

As I couldn't see any specific requirements for which min version of MariaDB to use, and the environment I'm in is also within the requirements listed here: https://docs.sylius.com/en/latest/book/installation/requirements.html, I decided to open this PR.


As I imagine this cannot be merged for several reasons, I've also created a patch which can be included in your composer.json if, like me, your version of MariaDB does not support the JSON alias yet, but you cannot update it.

```shell
composer require cweagans/composer-patches
```

and, in the "extra" part of your composer.json:
```json
        "patches": {
            "sylius/sylius": {
                "Changes JSON data type to LONGTEXT in a migration file to avoid breaking backwards compatilibity with MariaDB versions": "https://gist.githubusercontent.com/Gogopex/b82f68c91c916374ac8d2145e68da086/raw/ec97d11dcb4da6dd54765822d98ec3345bb197c0/.patch"
            }
        }
```