### PR TITLE
Doc: Fix Doctrine project url

### DIFF
--- a/docs/book/architecture/architecture.rst
+++ b/docs/book/architecture/architecture.rst
@@ -34,7 +34,7 @@ Doctrine
 The most important are the object-relational mapper (ORM) and the database abstraction layer (DBAL).
 One of Doctrine's key features is the possibility to write database queries in Doctrine Query Language (DQL) - an object-oriented dialect of SQL.
 
-To learn more about Doctrine - see `their documentation <http://www.doctrine-project.org/about.html>`_.
+To learn more about Doctrine - see `their documentation <https://www.doctrine-project.org/>`_.
 
 Twig
 ----


### PR DESCRIPTION
Into "architecture overview", replace Doctrine "About" URL pointed to a "Page Not Found"

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |  #12384
| License         | MIT

(PR based on master post 1.9 merge -- 188ea740e9 )

Hope this one will be better :)