### PR TITLE
[FOSOAuthServerBundle] Remove incompatible version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "egulias/email-validator": "^2.1",
         "fakerphp/faker": "^1.9",
         "friendsofphp/proxy-manager-lts": "^1.0",
-        "friendsofsymfony/oauth-server-bundle": "^1.6 || >2.0.0-alpha.0 ^2.0@dev",
+        "friendsofsymfony/oauth-server-bundle": ">2.0.0-alpha.0 ^2.0@dev",
         "friendsofsymfony/rest-bundle": "^3.0",
         "gedmo/doctrine-extensions": "^2.4.12 || ^3.0",
         "jms/serializer-bundle": "^3.5",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9 only
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

If you try to install `Sylius ~1.9.0` with `Symfony ^4.4` you will get this type of error :

```
[TypeError]                                                                                                                                                                                                                          
  Argument 1 passed to FOS\OAuthServerBundle\Entity\ClientManager::__construct() must be an instance of Doctrine\Common\Persistence\ObjectManager, instance of EntityManager_9a5be93 given, called in var/cache/test/ContainerXDiFD64/getSylius_OauthServer_ClientManagerService.php on line 14
```

This error occurred because all deprecated Doctrine Persistence API have been replaced in Sylius 1.9 making `FOSOAuthServerBundle ^1.6` incompatible with `Sylius ~1.9.0`