### PR TITLE
Don't render _token field if it's already rendered

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Create/_content.html.twig
@@ -9,7 +9,9 @@
     {% include '@SyliusAdmin/Crud/form_validation_errors_checker.html.twig' %}
     {% if configuration.vars.templates.form is defined %}
         {% include configuration.vars.templates.form %}
-        {{ form_row(form._token) }}
+        {% if not form._token.isRendered %}
+            {{ form_row(form._token) }}
+        {% endif %}
     {% else %}
         {{ form_widget(form) }}
     {% endif %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #12438
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
