### PR TITLE
[UserBundle] Allow user password to be null for SSO

### DIFF
--- a/src/Sylius/Bundle/AdminApiBundle/Migrations/Version20210311142134.php
+++ b/src/Sylius/Bundle/AdminApiBundle/Migrations/Version20210311142134.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\AdminApiBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210311142134 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_admin_user CHANGE password password VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE sylius_shop_user CHANGE password password VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_admin_user CHANGE password password VARCHAR(255) CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`');
+        $this->addSql('ALTER TABLE sylius_shop_user CHANGE password password VARCHAR(255) CHARACTER SET utf8 NOT NULL COLLATE `utf8_unicode_ci`');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210311142134.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210311142134.php
@@ -1,8 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
-namespace Sylius\Bundle\AdminApiBundle\Migrations;
+namespace Sylius\Bundle\CoreBundle\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/src/Sylius/Bundle/UserBundle/Resources/config/doctrine/model/User.orm.xml
+++ b/src/Sylius/Bundle/UserBundle/Resources/config/doctrine/model/User.orm.xml
@@ -21,7 +21,7 @@
         <field name="usernameCanonical" column="username_canonical" type="string" nullable="true" />
         <field name="enabled" column="enabled" type="boolean" nullable="false" />
         <field name="salt" column="salt" type="string" nullable="false" />
-        <field name="password" column="password" type="string" nullable="false" />
+        <field name="password" column="password" type="string" nullable="true" />
         <field name="encoderName" column="encoder_name" type="string" nullable="true" />
 
         <field name="lastLogin" column="last_login" type="datetime" nullable="true" />


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7, 1.8 or master <!-- see the comment below -->
| Bug fix?        | no/yes
| New feature?    | no/yes
| BC breaks?      | no/yes
| Deprecations?   | no/yes <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

When using a SSO such as Keycloak, you don't need a password. It's better to allow null instead of setting plain password with a random value.

Moreover, password will be decoupled from user interface on Symfony security user.
https://github.com/symfony/symfony/pull/40267

