### PR TITLE
Create resource belongs to collectionOperation

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
@@ -45,7 +45,6 @@
             <collectionOperation name="admin_post">
                 <attribute name="method">POST</attribute>
                 <attribute name="path">/admin/product-variants</attribute>
-                <attribute name="controller">api_platform.doctrine.orm.data_persister</attribute>
             </collectionOperation>
 
             <collectionOperation name="shop_get">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
@@ -30,12 +30,6 @@
                 <attribute name="path">/admin/product-variants/{id}</attribute>
             </itemOperation>
 
-            <itemOperation name="admin_post">
-                <attribute name="method">POST</attribute>
-                <attribute name="path">/admin/product-variants</attribute>
-                <attribute name="controller">api_platform.doctrine.orm.data_persister</attribute>
-            </itemOperation>
-
             <itemOperation name="shop_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-variants/{id}</attribute>
@@ -46,6 +40,12 @@
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-variants</attribute>
+            </collectionOperation>
+
+            <collectionOperation name="admin_post">
+                <attribute name="method">POST</attribute>
+                <attribute name="path">/admin/product-variants</attribute>
+                <attribute name="controller">api_platform.doctrine.orm.data_persister</attribute>
             </collectionOperation>
 
             <collectionOperation name="shop_get">


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Create resource operation in Api Platform always belongs to `collectionOperation`.

The same operation is also being defined in Sylius Plus so please remember to fix it as well