### PR TITLE
Remove and replace depreceated GetResponseForExceptionEvent and ExceptionListener

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/EventListener/CircularDependencyBreakingExceptionListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/CircularDependencyBreakingExceptionListener.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
-use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 
 /**
  * For Symfony 4.
@@ -46,22 +46,22 @@ use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
  * @psalm-suppress UndefinedClass
  * @psalm-suppress MissingDependency
  */
-final class CircularDependencyBreakingExceptionListener extends ExceptionListener
+final class CircularDependencyBreakingExceptionListener extends ErrorListener
 {
-    /** @var ExceptionListener */
+    /** @var ErrorListener */
     private $decoratedListener;
 
-    public function __construct(ExceptionListener $decoratedListener)
+    public function __construct(ErrorListener $decoratedListener)
     {
         $this->decoratedListener = $decoratedListener;
     }
 
-    public function logKernelException(GetResponseForExceptionEvent $event): void
+    public function logKernelException(ExceptionEvent $event): void
     {
         $this->decoratedListener->logKernelException($event);
     }
 
-    public function onKernelException(GetResponseForExceptionEvent $event): void
+    public function onKernelException(ExceptionEvent $event): void
     {
         try {
             $this->decoratedListener->onKernelException($event);

--- a/src/Sylius/Bundle/CoreBundle/Tests/Listener/CircularDependencyBreakingExceptionListenerTest.php
+++ b/src/Sylius/Bundle/CoreBundle/Tests/Listener/CircularDependencyBreakingExceptionListenerTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Sylius\Bundle\CoreBundle\EventListener\CircularDependencyBreakingExceptionListener;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
-use Symfony\Component\HttpKernel\EventListener\ExceptionListener;
+use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 final class CircularDependencyBreakingExceptionListenerTest extends TestCase
@@ -27,7 +27,7 @@ final class CircularDependencyBreakingExceptionListenerTest extends TestCase
     public function it_breaks_circular_dependencies_in_exceptions(): void
     {
         // Arrange
-        $decoratedListener = $this->createMock(ExceptionListener::class);
+        $decoratedListener = $this->createMock(ErrorListener::class);
         $listener = new CircularDependencyBreakingExceptionListener($decoratedListener);
 
         $event = $this->createExceptionEvent();
@@ -61,7 +61,7 @@ final class CircularDependencyBreakingExceptionListenerTest extends TestCase
     public function it_breaks_more_complex_circular_dependencies_in_exceptions(): void
     {
         // Arrange
-        $decoratedListener = $this->createMock(ExceptionListener::class);
+        $decoratedListener = $this->createMock(ErrorListener::class);
         $listener = new CircularDependencyBreakingExceptionListener($decoratedListener);
 
         $event = $this->createExceptionEvent();
@@ -101,7 +101,7 @@ final class CircularDependencyBreakingExceptionListenerTest extends TestCase
     public function it_does_nothing_when_circular_dependencies_are_not_found(): void
     {
         // Arrange
-        $decoratedListener = $this->createMock(ExceptionListener::class);
+        $decoratedListener = $this->createMock(ErrorListener::class);
         $listener = new CircularDependencyBreakingExceptionListener($decoratedListener);
 
         $event = $this->createExceptionEvent();


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
