### PR TITLE
Fix build for CoreBundle and ApiBundle packages

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/composer.json
+++ b/src/Sylius/Bundle/ApiBundle/composer.json
@@ -43,7 +43,7 @@
     },
     "conflict": {
         "api-platform/core": "^2.6",
-        "symfony/doctrine-bridge": "4.4.20 || 5.2.4"
+        "symfony/doctrine-bridge": "4.4.20 || 5.2.4 || 5.2.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Sylius/Bundle/CoreBundle/composer.json
+++ b/src/Sylius/Bundle/CoreBundle/composer.json
@@ -80,7 +80,7 @@
         "symfony/dependency-injection": "^4.4 || ^5.2"
     },
     "conflict": {
-        "symfony/doctrine-bridge": "4.4.20 || 5.2.4"
+        "symfony/doctrine-bridge": "4.4.20 || 5.2.4 || 5.2.5"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
See https://github.com/symfony/symfony/issues/40365, the fix for ^5.2 hasn't been released yet.