### PR TITLE
Don't render _token field if it's already rendered in update template

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Crud/Update/_content.html.twig
@@ -10,7 +10,9 @@
     {% include '@SyliusAdmin/Crud/form_validation_errors_checker.html.twig' %}
     {% if configuration.vars.templates.form is defined %}
         {% include configuration.vars.templates.form %}
-        {{ form_row(form._token) }}
+        {% if not form._token.isRendered %}
+            {{ form_row(form._token) }}
+        {% endif %}
     {% else %}
         {{ form_widget(form) }}
     {% endif %}


### PR DESCRIPTION
See https://github.com/Sylius/Sylius/pull/12439#pullrequestreview-616113495.