### PR TITLE
Fix packages builds: ResourceBundle v1.8 does not require StofDoctrineExtensionsBundle anymore

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/AddressingBundle/test/app/AppKernel.php
@@ -24,7 +24,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sylius\Bundle\AddressingBundle\SyliusAddressingBundle(),

--- a/src/Sylius/Bundle/AttributeBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/AttributeBundle/test/app/AppKernel.php
@@ -23,7 +23,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sylius\Bundle\AttributeBundle\SyliusAttributeBundle(),

--- a/src/Sylius/Bundle/ChannelBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/ChannelBundle/test/app/AppKernel.php
@@ -24,7 +24,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sylius\Bundle\ChannelBundle\SyliusChannelBundle(),

--- a/src/Sylius/Bundle/CurrencyBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/CurrencyBundle/test/app/AppKernel.php
@@ -24,7 +24,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sylius\Bundle\CurrencyBundle\SyliusCurrencyBundle(),

--- a/src/Sylius/Bundle/CustomerBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/CustomerBundle/test/app/AppKernel.php
@@ -24,7 +24,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sylius\Bundle\CustomerBundle\SyliusCustomerBundle(),

--- a/src/Sylius/Bundle/LocaleBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/LocaleBundle/test/app/AppKernel.php
@@ -24,7 +24,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sylius\Bundle\LocaleBundle\SyliusLocaleBundle(),

--- a/src/Sylius/Bundle/MoneyBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/MoneyBundle/test/app/AppKernel.php
@@ -24,7 +24,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sylius\Bundle\MoneyBundle\SyliusMoneyBundle(),

--- a/src/Sylius/Bundle/OrderBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/OrderBundle/test/app/AppKernel.php
@@ -23,7 +23,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sylius\Bundle\MoneyBundle\SyliusMoneyBundle(),

--- a/src/Sylius/Bundle/PaymentBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/PaymentBundle/test/app/AppKernel.php
@@ -24,7 +24,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sylius\Bundle\PaymentBundle\SyliusPaymentBundle(),

--- a/src/Sylius/Bundle/ProductBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/ProductBundle/test/app/AppKernel.php
@@ -23,7 +23,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sylius\Bundle\AttributeBundle\SyliusAttributeBundle(),

--- a/src/Sylius/Bundle/PromotionBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/PromotionBundle/test/app/AppKernel.php
@@ -24,7 +24,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sylius\Bundle\PromotionBundle\SyliusPromotionBundle(),

--- a/src/Sylius/Bundle/ReviewBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/ReviewBundle/test/app/AppKernel.php
@@ -25,7 +25,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),

--- a/src/Sylius/Bundle/ShippingBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/ShippingBundle/test/app/AppKernel.php
@@ -24,7 +24,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sylius\Bundle\ShippingBundle\SyliusShippingBundle(),

--- a/src/Sylius/Bundle/TaxationBundle/test/app/AppKernel.php
+++ b/src/Sylius/Bundle/TaxationBundle/test/app/AppKernel.php
@@ -24,7 +24,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sylius\Bundle\TaxationBundle\SyliusTaxationBundle(),

--- a/src/Sylius/Bundle/TaxonomyBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Tests/Functional/app/AppKernel.php
@@ -23,7 +23,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sylius\Bundle\TaxonomyBundle\SyliusTaxonomyBundle(),

--- a/src/Sylius/Bundle/UserBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Sylius/Bundle/UserBundle/Tests/Functional/app/AppKernel.php
@@ -24,7 +24,6 @@ class AppKernel extends Kernel
             new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
             new FOS\RestBundle\FOSRestBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
-            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
             new BabDev\PagerfantaBundle\BabDevPagerfantaBundle(),
             new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),


### PR DESCRIPTION
Those bundles don't even need those extensions to be enabled.