### PR TITLE
[Maintenance] Conflict with JMSSerializer 3.9.0 due to issues with mapping of persistent collection

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -9,6 +9,13 @@ references related issues.
 
    References: https://github.com/doctrine/DoctrineBundle/issues/1305
 
+ - `jms/serializer-bundle:3.9`:
+
+   This version automatically registered DocBlockDriver, which is always turned on, while docblocks used in our code are not usable with it. Sample error:
+   `Can't use incorrect type object for collection in Doctrine\ORM\PersistentCollection:owner`
+
+   References: https://github.com/schmittjoh/JMSSerializerBundle/issues/844
+
  - `symfony/serializer:4.4.19|5.2.2`:
 
    These versions of Symfony Serializer introduces a bug with trying to access some private properties that don't have getters.

--- a/composer.json
+++ b/composer.json
@@ -160,6 +160,7 @@
     "conflict": {
         "api-platform/core": "^2.6",
         "doctrine/doctrine-bundle": "2.3.0",
+        "jms/serializer-bundle": "3.9",
         "laminas/laminas-code": "^4.0.0",
         "symfony/doctrine-bridge": "4.4.16",
         "symfony/polyfill-mbstring": "^1.22.0",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Highly probable that issues are related to this tag: https://github.com/schmittjoh/JMSSerializerBundle/releases/tag/3.9.0 or this PR in particular: https://github.com/schmittjoh/JMSSerializerBundle/pull/824

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
