### PR TITLE
Use route name instead of a hardcoded '/' to redirect user on logout

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/services.xml
@@ -24,7 +24,7 @@
 
         <service id="sylius.handler.shop_user_logout" class="Sylius\Bundle\ShopBundle\EventListener\ShopUserLogoutHandler">
             <argument type="service" id="security.http_utils" />
-            <argument>/</argument>
+            <argument>sylius_shop_homepage</argument>
             <argument type="service" id="sylius.context.channel.composite" />
             <argument type="service" id="sylius.storage.cart_session" />
         </service>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

On logout, shop users are currently being redirected to a hardcoded `/` path. However, this isn't always desired. For example, if localized routes are involved, this effectively switches the shop to its default locale on logout.

This change passes `sylius_shop_homepage` route name instead of a `/` path to the LogoutHandler, meaning the actual path will be generated when the event occurs.