### PR TITLE
Recalculate order adjustments total after adjustment is added or remo…

### DIFF
--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -236,9 +236,8 @@ class Order implements OrderInterface
             $this->adjustments->add($adjustment);
             $this->addToAdjustmentsTotal($adjustment);
             $adjustment->setAdjustable($this);
+            $this->recalculateAdjustmentsTotal();
         }
-        
-        $this->recalculateAdjustmentsTotal();
     }
 
     public function removeAdjustment(AdjustmentInterface $adjustment): void
@@ -247,9 +246,8 @@ class Order implements OrderInterface
             $this->adjustments->removeElement($adjustment);
             $this->subtractFromAdjustmentsTotal($adjustment);
             $adjustment->setAdjustable(null);
+            $this->recalculateAdjustmentsTotal();
         }
-        
-        $this->recalculateAdjustmentsTotal();
     }
 
     public function hasAdjustment(AdjustmentInterface $adjustment): bool

--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -237,6 +237,8 @@ class Order implements OrderInterface
             $this->addToAdjustmentsTotal($adjustment);
             $adjustment->setAdjustable($this);
         }
+        
+        $this->recalculateAdjustmentsTotal();
     }
 
     public function removeAdjustment(AdjustmentInterface $adjustment): void
@@ -246,6 +248,8 @@ class Order implements OrderInterface
             $this->subtractFromAdjustmentsTotal($adjustment);
             $adjustment->setAdjustable(null);
         }
+        
+        $this->recalculateAdjustmentsTotal();
     }
 
     public function hasAdjustment(AdjustmentInterface $adjustment): bool

--- a/src/Sylius/Component/Order/Model/OrderItem.php
+++ b/src/Sylius/Component/Order/Model/OrderItem.php
@@ -234,6 +234,7 @@ class OrderItem implements OrderItemInterface
             $this->adjustments->add($adjustment);
             $this->addToAdjustmentsTotal($adjustment);
             $adjustment->setAdjustable($this);
+            $this->recalculateAdjustmentsTotal();
         }
     }
 
@@ -243,6 +244,7 @@ class OrderItem implements OrderItemInterface
             $this->adjustments->removeElement($adjustment);
             $this->subtractFromAdjustmentsTotal($adjustment);
             $adjustment->setAdjustable(null);
+            $this->recalculateAdjustmentsTotal();
         }
     }
 

--- a/src/Sylius/Component/Order/Model/OrderItemUnit.php
+++ b/src/Sylius/Component/Order/Model/OrderItemUnit.php
@@ -79,6 +79,7 @@ class OrderItemUnit implements OrderItemUnitInterface
         $this->addToAdjustmentsTotal($adjustment);
         $this->orderItem->recalculateUnitsTotal();
         $adjustment->setAdjustable($this);
+        $this->recalculateAdjustmentsTotal();
     }
 
     public function removeAdjustment(AdjustmentInterface $adjustment): void
@@ -91,6 +92,7 @@ class OrderItemUnit implements OrderItemUnitInterface
         $this->subtractFromAdjustmentsTotal($adjustment);
         $this->orderItem->recalculateUnitsTotal();
         $adjustment->setAdjustable(null);
+        $this->recalculateAdjustmentsTotal();
     }
 
     public function hasAdjustment(AdjustmentInterface $adjustment): bool

--- a/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderItemSpec.php
@@ -357,8 +357,6 @@ final class OrderItemSpec extends ObjectBehavior
         $this->addAdjustment($adjustment1);
         $this->addAdjustment($adjustment2);
 
-        $this->getTotal()->shouldReturn(600);
-        $this->recalculateAdjustmentsTotal();
         $this->getTotal()->shouldReturn(400);
     }
 

--- a/src/Sylius/Component/Order/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderSpec.php
@@ -160,6 +160,19 @@ final class OrderSpec extends ObjectBehavior
         $this->hasAdjustment($adjustment)->shouldReturn(true);
     }
 
+    function it_adds_adjustments_and_recalculates_them_properly(AdjustmentInterface $adjustment): void
+    {
+        $adjustment->setAdjustable($this)->shouldBeCalled();
+        $adjustment->isNeutral()->willReturn(false);
+
+        $adjustment->getAmount()->willReturn(100);
+
+        $this->hasAdjustment($adjustment)->shouldReturn(false);
+        $this->addAdjustment($adjustment);
+        $this->hasAdjustment($adjustment)->shouldReturn(true);
+        $this->getAdjustmentsTotal()->shouldReturn(100);
+    }
+
     function it_removes_adjustments_properly(AdjustmentInterface $adjustment): void
     {
         $this->hasAdjustment($adjustment)->shouldReturn(false);

--- a/tests/Model/OrderAdjustmentsRecalculationTest.php
+++ b/tests/Model/OrderAdjustmentsRecalculationTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Model;
+
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Model\AdjustmentInterface;
+use Sylius\Component\Order\Model\Order;
+use Sylius\Component\Order\Model\OrderItem;
+use Sylius\Component\Order\Model\OrderItemInterface;
+use Sylius\Component\Order\Model\OrderItemUnit;
+
+final class OrderAdjustmentsRecalculationTest extends TestCase
+{
+    private Order $order;
+    private OrderItemInterface $item;
+
+    protected function setUp(): void
+    {
+        $neutralAdjustment = $this->createAdjustment(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, -150, true);
+
+        $this->order = new Order();
+        $this->item = new OrderItem();
+        $this->item->setUnitPrice(1000);
+        $this->unitNumberOne = new OrderItemUnit($this->item);
+        $this->unitNumberTwo = new OrderItemUnit($this->item);
+        $this->order->addItem($this->item);
+        $this->order->addAdjustment($neutralAdjustment);
+    }
+
+    /** @test */
+    public function it_recalculates_order_total_properly_with_order_item_adjustments(): void
+    {
+        $adjustmentNumberOne = $this->createAdjustment(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT, -300, false);
+        $this->item->addAdjustment($adjustmentNumberOne);
+
+        $this->assertEquals(1700, $this->order->getTotal());
+        $this->assertEquals(-300, $this->item->getAdjustmentsTotal());
+
+        $adjustmentNumberTwo = $this->createAdjustment(AdjustmentInterface::ORDER_ITEM_PROMOTION_ADJUSTMENT, -155, false);
+        $this->item->addAdjustment($adjustmentNumberTwo);
+
+        $this->assertEquals(1545, $this->order->getTotal());
+        $this->assertEquals(-455, $this->item->getAdjustmentsTotal());
+
+        $this->item->removeAdjustment($adjustmentNumberOne);
+
+        $this->assertEquals(1845, $this->order->getTotal());
+        $this->assertEquals(-155, $this->item->getAdjustmentsTotal());
+    }
+
+    /** @test */
+    public function it_recalculates_order_total_properly_with_order_adjustments(): void
+    {
+        $adjustmentNumberOne = $this->createAdjustment(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, -100, false);
+        $this->order->addAdjustment($adjustmentNumberOne);
+
+        $this->assertEquals(1900, $this->order->getTotal());
+        $this->assertEquals(-100, $this->order->getAdjustmentsTotal());
+
+        $adjustmentNumberTwo = $this->createAdjustment(AdjustmentInterface::ORDER_PROMOTION_ADJUSTMENT, -155, false);
+        $this->order->addAdjustment($adjustmentNumberTwo);
+
+        $this->assertEquals(1745, $this->order->getTotal());
+        $this->assertEquals(-255, $this->order->getAdjustmentsTotal());
+
+        $this->order->removeAdjustment($adjustmentNumberOne);
+
+        $this->assertEquals(1845, $this->order->getTotal());
+        $this->assertEquals(-155, $this->order->getAdjustmentsTotal());
+    }
+
+    /** @test */
+    public function it_recalculates_order_total_properly_with_order_unit_adjustments(): void
+    {
+        $adjustmentNumberOne = $this->createAdjustment(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT, -200, false);
+        $this->unitNumberOne->addAdjustment($adjustmentNumberOne);
+        $this->unitNumberTwo->addAdjustment($adjustmentNumberOne);
+
+        $this->assertEquals(1600, $this->order->getTotal());
+        $this->assertEquals(-200, $this->unitNumberOne->getAdjustmentsTotal());
+        $this->assertEquals(-200, $this->unitNumberTwo->getAdjustmentsTotal());
+
+        $adjustmentNumberTwo = $this->createAdjustment(AdjustmentInterface::ORDER_UNIT_PROMOTION_ADJUSTMENT, -125, false);
+        $this->unitNumberOne->addAdjustment($adjustmentNumberTwo);
+        $this->unitNumberTwo->addAdjustment($adjustmentNumberTwo);
+
+        $this->assertEquals(1350, $this->order->getTotal());
+        $this->assertEquals(-325, $this->unitNumberOne->getAdjustmentsTotal());
+        $this->assertEquals(-325, $this->unitNumberTwo->getAdjustmentsTotal());
+
+        $this->unitNumberOne->removeAdjustment($adjustmentNumberOne);
+
+        $this->assertEquals(1550, $this->order->getTotal());
+        $this->assertEquals(-125, $this->unitNumberOne->getAdjustmentsTotal());
+        $this->assertEquals(-325, $this->unitNumberTwo->getAdjustmentsTotal());
+    }
+
+    private function createAdjustment(string $type, int $amount, bool $isNeutral): AdjustmentInterface
+    {
+        $adjustment = $this->createMock(AdjustmentInterface::class);
+        $adjustment->method('isNeutral')->willReturn($isNeutral);
+        $adjustment->method('getAmount')->willReturn($amount);
+        $adjustment->method('getType')->willReturn($type);
+
+        return $adjustment;
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

In the current code (1.8 at least) adjustment total is not being updated after shipping fee is added to order. For example in the code below:

https://github.com/Sylius/Sylius/blob/f486b804e3e460847c90e29698698a8c88357d55/src/Sylius/Component/Core/OrderProcessing/ShippingChargesProcessor.php#L51-L59

Recalculation is designed to happen when `$adjustment->setAmount()` is called, however the Order object is only added after. (in the last line) 

Proposed fixed is to trigger `recalculateAdjustmentsTotal()` whenever adjustment is added (or removed) to order. 