### PR TITLE
Cleanup resend verification email handler

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/ResendVerificationEmailHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/ResendVerificationEmailHandler.php
@@ -17,8 +17,6 @@ use Sylius\Component\User\Repository\UserRepositoryInterface;
 use Webmozart\Assert\Assert;
 use Sylius\Bundle\ApiBundle\Command\ResendVerificationEmail;
 use Sylius\Bundle\ApiBundle\Command\SendAccountVerificationEmail;
-use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
-use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\User\Model\UserInterface;
 use Sylius\Component\User\Security\Generator\GeneratorInterface;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
@@ -34,21 +32,16 @@ final class ResendVerificationEmailHandler implements MessageHandlerInterface
     /** @var GeneratorInterface */
     private $tokenGenerator;
 
-    /** @var ChannelRepositoryInterface */
-    private $channelRepository;
-
     /** @var MessageBusInterface */
     private $commandBus;
 
     public function __construct(
         UserRepositoryInterface $shopUserRepository,
         GeneratorInterface $tokenGenerator,
-        ChannelRepositoryInterface $channelRepository,
         MessageBusInterface $commandBus
     ) {
         $this->shopUserRepository = $shopUserRepository;
         $this->tokenGenerator = $tokenGenerator;
-        $this->channelRepository = $channelRepository;
         $this->commandBus = $commandBus;
     }
 
@@ -56,9 +49,6 @@ final class ResendVerificationEmailHandler implements MessageHandlerInterface
     {
         /** @var UserInterface|null $user */
         Assert::notNull($user = $this->shopUserRepository->findOneByEmail($command->email));
-
-        /** @var ChannelInterface $channel */
-        $channel = $this->channelRepository->findOneByCode($command->channelCode);
 
         $token = $this->tokenGenerator->generate();
         $user->setEmailVerificationToken($token);

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
@@ -129,7 +129,6 @@
         <service id="Sylius\Bundle\ApiBundle\CommandHandler\ResendVerificationEmailHandler">
             <argument type="service" id="sylius.repository.shop_user" />
             <argument type="service" id="sylius.shop_user.token_generator.email_verification" />
-            <argument type="service" id="sylius.repository.channel" />
             <argument type="service" id="sylius_default.bus" />
             <tag name="messenger.message_handler" bus="sylius_default.bus" />
         </service>

--- a/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/ResendVerificationEmailHandlerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/ResendVerificationEmailHandlerSpec.php
@@ -7,7 +7,6 @@ namespace spec\Sylius\Bundle\ApiBundle\CommandHandler;
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\ApiBundle\Command\ResendVerificationEmail;
 use Sylius\Bundle\ApiBundle\Command\SendAccountVerificationEmail;
-use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ShopUserInterface;
 use Sylius\Component\User\Repository\UserRepositoryInterface;
@@ -22,10 +21,9 @@ final class ResendVerificationEmailHandlerSpec extends ObjectBehavior
     function let(
         UserRepositoryInterface $userRepository,
         GeneratorInterface $generator,
-        ChannelRepositoryInterface $channelRepository,
         MessageBusInterface $messageBus
     ): void {
-        $this->beConstructedWith($userRepository, $generator, $channelRepository, $messageBus);
+        $this->beConstructedWith($userRepository, $generator, $messageBus);
     }
 
     function it_is_a_message_handler(): void
@@ -49,14 +47,12 @@ final class ResendVerificationEmailHandlerSpec extends ObjectBehavior
 
     function it_handles_request_for_resend_verification_email(
         UserRepositoryInterface $userRepository,
-        ChannelRepositoryInterface $channelRepository,
         ShopUserInterface $shopUser,
         GeneratorInterface $generator,
         MessageBusInterface $messageBus,
         ChannelInterface $channel
     ): void {
         $userRepository->findOneByEmail('test@email.com')->willReturn($shopUser);
-        $channelRepository->findOneByCode('WEB')->willReturn($channel);
 
         $channel->isAccountVerificationRequired()->willReturn(true);
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


`ChannelRepository` was not used in this handler, hence I removed it 