### PR TITLE
Add missing PL translation for different_shipping_address

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.pl.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/translations/messages.pl.yml
@@ -12,6 +12,7 @@ sylius:
         checkout:
             addressing:
                 different_billing_address: Użyć innego adresu do rozliczeń?
+                different_shipping_address: Użyć innego adresu do wysyłki?
             payment_method: Metoda płatności
             shipping_method: Metoda wysyłki
         promotion:

--- a/src/Sylius/Bundle/CustomerBundle/Resources/translations/messages.pl.yml
+++ b/src/Sylius/Bundle/CustomerBundle/Resources/translations/messages.pl.yml
@@ -12,6 +12,7 @@ sylius:
             gender: Płeć
             birthday: Data urodzenia
             billing_address: Adres do rachunku
+            different_shipping_address: Użyć innego adresu do wysyłki?
             only_customer_registration: Utworzyć konto?
             subscribed_to_newsletter: Zapisz się do newslettera
         customer_group:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Polish translation for different_shipping_address
