### PR TITLE
[Behat] Allow to use some useful methods on Order show page

### DIFF
--- a/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
+++ b/src/Sylius/Behat/Page/Admin/Order/ShowPage.php
@@ -436,7 +436,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         return $this->tableAccessor;
     }
 
-    private function hasAddress(string $elementText, string $customerName, string $street, string $postcode, string $city, string $countryName): bool
+    protected function hasAddress(string $elementText, string $customerName, string $street, string $postcode, string $city, string $countryName): bool
     {
         return
             (stripos($elementText, $customerName) !== false) &&
@@ -446,7 +446,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         ;
     }
 
-    private function getItemProperty(string $itemName, string $property): string
+    protected function getItemProperty(string $itemName, string $property): string
     {
         $rows = $this->tableAccessor->getRowsWithFields(
             $this->getElement('table'),
@@ -456,12 +456,12 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         return $rows[0]->find('css', '.' . $property)->getText();
     }
 
-    private function getRowWithItem(string $itemName): ?NodeElement
+    protected function getRowWithItem(string $itemName): ?NodeElement
     {
         return $this->tableAccessor->getRowWithFields($this->getElement('table'), ['item' => $itemName]);
     }
 
-    private function getLastOrderPaymentElement(OrderInterface $order): ?NodeElement
+    protected function getLastOrderPaymentElement(OrderInterface $order): ?NodeElement
     {
         $payment = $order->getPayments()->last();
 
@@ -471,7 +471,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         return $paymentStateElement->getParent()->getParent();
     }
 
-    private function getLastOrderShipmentElement(OrderInterface $order): ?NodeElement
+    protected function getLastOrderShipmentElement(OrderInterface $order): ?NodeElement
     {
         $shipment = $order->getShipments()->last();
 
@@ -481,7 +481,7 @@ class ShowPage extends SymfonyPage implements ShowPageInterface
         return $shipmentStateElement->getParent()->getParent();
     }
 
-    private function getFormattedMoney(int $orderPromotionTotal): string
+    protected function getFormattedMoney(int $orderPromotionTotal): string
     {
         return $this->moneyFormatter->format($orderPromotionTotal, $this->getDocument()->find('css', '#sylius-order-currency')->getText());
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | no but useful for Behat tests
| New feature?    | no
| BC breaks?      | still no bc-promise on Behat?
| Deprecations?   | no
| Related tickets |
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->

All these methods are useful when you customize the order show page.