### PR TITLE
Fixed email template in API - SendOrderConfirmationHandler

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/SendOrderConfirmationHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/SendOrderConfirmationHandler.php
@@ -41,7 +41,7 @@ final class SendOrderConfirmationHandler implements MessageHandlerInterface
         $order = $this->orderRepository->findOneByTokenValue($sendOrderConfirmation->orderToken());
 
         $this->emailSender->send(
-            Emails::ORDER_CONFIRMATION_RESENT,
+            Emails::ORDER_CONFIRMATION,
             [$order->getCustomer()->getEmail()],
             [
                 'order' => $order,

--- a/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/SendOrderConfirmationHandlerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/CommandHandler/SendOrderConfirmationHandlerSpec.php
@@ -54,7 +54,7 @@ final class SendOrderConfirmationHandlerSpec extends ObjectBehavior
         $customer->getEmail()->willReturn('johnny.bravo@email.com');
 
         $sender->send(
-            Emails::ORDER_CONFIRMATION_RESENT,
+            Emails::ORDER_CONFIRMATION,
             ['johnny.bravo@email.com'],
             [
                 'order' => $order->getWrappedObject(),


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7, 1.8 or master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| License         | MIT

Wrong settings and template are used in API email on order confiramtion
