### PR TITLE
Change default Liip loader and resolver names

### DIFF
--- a/UPGRADE-1.8.md
+++ b/UPGRADE-1.8.md
@@ -1,8 +1,3 @@
-# UPGRADE FROM `v1.8.11` TO `v1.8.12`
-
-1. Names of the default `LiipImagineBundle` resolver and loader were changed from **default** to **sylius_image** (check out [this PR](https://github.com/Sylius/Sylius/pull/12543)).
-To change the default resolver and/or loader for `LiipImagineBundle`, configure `cache` and/or `data_loader` parameters under the `liip_imagine` key.
-
 # UPGRADE FROM `v1.8.4` TO `v1.8.6`
 
 1. API is disabled by default, to enable it you need to set flag to ``true`` in ``config/packages/_sylius.yaml``:

--- a/UPGRADE-1.8.md
+++ b/UPGRADE-1.8.md
@@ -1,3 +1,8 @@
+# UPGRADE FROM `v1.8.11` TO `v1.8.12`
+
+1. Names of the default `LiipImagineBundle` resolver and loader were changed from **default** to **sylius_image** (check out [this PR](https://github.com/Sylius/Sylius/pull/12543)).
+To change the default resolver and/or loader for `LiipImagineBundle`, configure `cache` and/or `data_loader` parameters under the `liip_imagine` key.
+
 # UPGRADE FROM `v1.8.4` TO `v1.8.6`
 
 1. API is disabled by default, to enable it you need to set flag to ``true`` in ``config/packages/_sylius.yaml``:

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -42,6 +42,9 @@
 
 * Added the `Sylius\Component\Order\Context\ResettableCartContextInterface` that extends `Sylius\Component\Order\Context\CartContextInterface` and `Symfony\Contracts\Service\ResetInterface`.
 
+*  The name of the default `LiipImagineBundle`'s resolver and loader were changed from **default** to **sylius_image** ([reference](https://github.com/Sylius/Sylius/pull/12543)). 
+   To change the default resolver and/or loader for `LiipImagineBundle`, configure `cache` and/or `data_loader` parameters under the `liip_imagine` key.
+
 ## Frontend
 
 * `use_webpack` option was removed from the `sylius_ui` configuration, and the Webpack has become the only module bundler provided by Sylius.

--- a/config/packages/liip_imagine.yaml
+++ b/config/packages/liip_imagine.yaml
@@ -1,6 +1,0 @@
-liip_imagine:
-    resolvers:
-        sylius_image:
-            web_path:
-                web_root: "%kernel.project_dir%/public"
-                cache_prefix: "media/cache"

--- a/config/packages/liip_imagine.yaml
+++ b/config/packages/liip_imagine.yaml
@@ -1,6 +1,6 @@
 liip_imagine:
     resolvers:
-        default:
+        sylius_image:
             web_path:
                 web_root: "%kernel.project_dir%/public"
                 cache_prefix: "media/cache"

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/config.yml
@@ -64,12 +64,14 @@ knp_gaufrette:
             adapter: "%sylius.uploader.filesystem%"
 
 liip_imagine:
+    cache: sylius_image
+    data_loader: sylius_image
     loaders:
-        default:
+        sylius_image:
             filesystem:
                 data_root: "%sylius_core.images_dir%"
     resolvers:
-        default:
+        sylius_image:
             web_path:
                 web_root: "%sylius_core.public_dir%"
                 cache_prefix: "media/cache"


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 2.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #8143
| License         | MIT

As mentioned in [this comment](https://github.com/Sylius/Sylius/issues/8143#issuecomment-392771696), we should avoid using a `default` name for the Liip resolver and loader. Such a change would resolve in the easier bundle configuration overriding (although there is still work to be done on the Liip side).

I believe this change does not introduce any BC break (as we still use the new names of resolver/loader as the defaults one). I wonder, should it be specified in the core or in the Sylius-Standard 🤔 It would also probably deserve a mention in the `UPGRADE` file 🚀 