### PR TITLE
[Minor] Use explicit bus instead of the default one

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/event_handlers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/event_handlers.xml
@@ -17,7 +17,7 @@
 >
     <services>
         <service id="Sylius\Bundle\ApiBundle\EventHandler\OrderCompletedHandler">
-            <argument type="service" id="messenger.default_bus" />
+            <argument type="service" id="sylius_default.bus" />
             <argument type="service" id="sylius.repository.order" />
             <tag name="messenger.message_handler" bus="sylius_event.bus"/>
         </service>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
