### PR TITLE
[Product Variant] Price Calculator fixed to return always int

### DIFF
--- a/src/Sylius/Component/Core/Calculator/ProductVariantPriceCalculator.php
+++ b/src/Sylius/Component/Core/Calculator/ProductVariantPriceCalculator.php
@@ -25,7 +25,7 @@ final class ProductVariantPriceCalculator implements ProductVariantPricesCalcula
 
         $channelPricing = $productVariant->getChannelPricingForChannel($context['channel']);
 
-        if (null === $channelPricing) {
+        if (null === $channelPricing || $channelPricing->getPrice() === null) {
             $message = sprintf('Channel %s has no price defined for product variant', $context['channel']->getName());
 
             if ($productVariant->getName() !== null) {
@@ -58,6 +58,18 @@ final class ProductVariantPriceCalculator implements ProductVariantPricesCalcula
         }
 
         if (null === $channelPricing->getOriginalPrice()) {
+            if ($channelPricing->getPrice() === null) {
+                $message = sprintf('Channel %s has no price defined for product variant', $context['channel']->getName());
+
+                if ($productVariant->getName() !== null) {
+                    $message .= sprintf(' %s (%s)', $productVariant->getName(), $productVariant->getCode());
+                } else {
+                    $message .= sprintf(' with code %s', $productVariant->getCode());
+                }
+
+                throw new MissingChannelConfigurationException($message);
+            }
+
             return $channelPricing->getPrice();
         }
 

--- a/src/Sylius/Component/Core/Calculator/ProductVariantPriceCalculator.php
+++ b/src/Sylius/Component/Core/Calculator/ProductVariantPriceCalculator.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sylius\Component\Core\Calculator;
 
 use Sylius\Component\Core\Exception\MissingChannelConfigurationException;
-use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Webmozart\Assert\Assert;
 
@@ -27,7 +26,7 @@ final class ProductVariantPriceCalculator implements ProductVariantPricesCalcula
         $channelPricing = $productVariant->getChannelPricingForChannel($context['channel']);
 
         if (null === $channelPricing || $channelPricing->getPrice() === null) {
-            throw new MissingChannelConfigurationException(MissingChannelConfigurationException::getMissingChannelProductVariantPriceMessage($context['channel'], $productVariant));
+            throw MissingChannelConfigurationException::createForProductVariantChannelPricing($productVariant, $context['channel']);
         }
 
         return $channelPricing->getPrice();
@@ -43,7 +42,7 @@ final class ProductVariantPriceCalculator implements ProductVariantPricesCalcula
         $channelPricing = $productVariant->getChannelPricingForChannel($context['channel']);
 
         if (null === $channelPricing) {
-            throw new MissingChannelConfigurationException(MissingChannelConfigurationException::getMissingChannelProductVariantPriceMessage($context['channel'], $productVariant));
+            throw MissingChannelConfigurationException::createForProductVariantChannelPricing($productVariant, $context['channel']);
         }
 
         if (null !== $channelPricing->getOriginalPrice()) {
@@ -54,6 +53,6 @@ final class ProductVariantPriceCalculator implements ProductVariantPricesCalcula
             return $channelPricing->getPrice();
         }
 
-        throw new MissingChannelConfigurationException(MissingChannelConfigurationException::getMissingChannelProductVariantPriceMessage($context['channel'], $productVariant));
+        throw MissingChannelConfigurationException::createForProductVariantChannelPricing($productVariant, $context['channel']);
     }
 }

--- a/src/Sylius/Component/Core/Exception/MissingChannelConfigurationException.php
+++ b/src/Sylius/Component/Core/Exception/MissingChannelConfigurationException.php
@@ -13,10 +13,23 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Exception;
 
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
 final class MissingChannelConfigurationException extends \RuntimeException
 {
     public function __construct(string $message, ?\Exception $previousException = null)
     {
         parent::__construct($message, 0, $previousException);
+    }
+
+    public static function getMissingChannelProductVariantPriceMessage(ChannelInterface $channel, ProductVariantInterface $productVariant): string
+    {
+        $message = sprintf('Channel %s has no price defined for product variant', $channel->getName());
+        if ($productVariant->getName() !== null) {
+            return $message . sprintf(' %s (%s)', $productVariant->getName(), $productVariant->getCode());
+        }
+
+        return $message . sprintf(' with code %s', $productVariant->getCode());
     }
 }

--- a/src/Sylius/Component/Core/Exception/MissingChannelConfigurationException.php
+++ b/src/Sylius/Component/Core/Exception/MissingChannelConfigurationException.php
@@ -23,13 +23,8 @@ final class MissingChannelConfigurationException extends \RuntimeException
         parent::__construct($message, 0, $previousException);
     }
 
-    public static function getMissingChannelProductVariantPriceMessage(ChannelInterface $channel, ProductVariantInterface $productVariant): string
+    public static function createForProductVariantChannelPricing(ProductVariantInterface $productVariant, ChannelInterface $channel): self
     {
-        $message = sprintf('Channel %s has no price defined for product variant', $channel->getName());
-        if ($productVariant->getName() !== null) {
-            return $message . sprintf(' %s (%s)', $productVariant->getName(), $productVariant->getCode());
-        }
-
-        return $message . sprintf(' with code %s', $productVariant->getCode());
+        return new self(sprintf('Product variant %s has no price defined for channel %s', $productVariant->getDescriptor(), $channel->getName()));
     }
 }

--- a/src/Sylius/Component/Core/spec/Calculator/ProductVariantPriceCalculatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Calculator/ProductVariantPriceCalculatorSpec.php
@@ -38,13 +38,31 @@ final class ProductVariantPriceCalculatorSpec extends ObjectBehavior
         $this->calculate($productVariant, ['channel' => $channel])->shouldReturn(1000);
     }
 
-    function it_throws_a_channel_not_defined_exception_if_there_is_no_variant_price_for_given_channel(
+    function it_throws_a_channel_not_defined_exception_if_there_is_no_channel_pricing(
         ChannelInterface $channel,
         ProductVariantInterface $productVariant
     ): void {
         $channel->getName()->willReturn('WEB');
 
         $productVariant->getChannelPricingForChannel($channel)->willReturn(null);
+        $productVariant->getName()->willReturn('Red variant');
+        $productVariant->getCode()->willReturn('RED_VARIANT');
+
+        $this
+            ->shouldThrow(MissingChannelConfigurationException::class)
+            ->during('calculate', [$productVariant, ['channel' => $channel]])
+        ;
+    }
+
+    function it_throws_a_channel_not_defined_exception_if_there_is_no_variant_price_for_given_channel(
+        ChannelInterface $channel,
+        ProductVariantInterface $productVariant,
+        ChannelPricingInterface $channelPricing
+    ): void {
+        $channel->getName()->willReturn('WEB');
+
+        $productVariant->getChannelPricingForChannel($channel)->willReturn($channelPricing);
+        $channelPricing->getPrice()->willReturn(null);
         $productVariant->getName()->willReturn('Red variant');
         $productVariant->getCode()->willReturn('RED_VARIANT');
 
@@ -85,13 +103,32 @@ final class ProductVariantPriceCalculatorSpec extends ObjectBehavior
         $this->calculateOriginal($productVariant, ['channel' => $channel])->shouldReturn(1000);
     }
 
-    function it_throws_a_channel_not_defined_exception_if_there_is_no_variant_price_for_given_channel_when_calculating_original_price(
+    function it_throws_a_channel_not_defined_exception_if_there_is_no_channel_pricing_when_calculating_original_price(
         ChannelInterface $channel,
         ProductVariantInterface $productVariant
     ): void {
         $channel->getName()->willReturn('WEB');
 
         $productVariant->getChannelPricingForChannel($channel)->willReturn(null);
+        $productVariant->getName()->willReturn('Red variant');
+        $productVariant->getCode()->willReturn('RED_VARIANT');
+
+        $this
+            ->shouldThrow(MissingChannelConfigurationException::class)
+            ->during('calculateOriginal', [$productVariant, ['channel' => $channel]])
+        ;
+    }
+
+    function it_throws_a_channel_not_defined_exception_if_there_is_no_variant_price_for_given_channel_when_calculating_original_price(
+        ChannelInterface $channel,
+        ProductVariantInterface $productVariant,
+        ChannelPricingInterface $channelPricing
+    ): void {
+        $channel->getName()->willReturn('WEB');
+
+        $productVariant->getChannelPricingForChannel($channel)->willReturn($channelPricing);
+        $channelPricing->getOriginalPrice()->willReturn(null);
+        $channelPricing->getPrice()->willReturn(null);
         $productVariant->getName()->willReturn('Red variant');
         $productVariant->getCode()->willReturn('RED_VARIANT');
 

--- a/src/Sylius/Component/Core/spec/Calculator/ProductVariantPriceCalculatorSpec.php
+++ b/src/Sylius/Component/Core/spec/Calculator/ProductVariantPriceCalculatorSpec.php
@@ -45,8 +45,7 @@ final class ProductVariantPriceCalculatorSpec extends ObjectBehavior
         $channel->getName()->willReturn('WEB');
 
         $productVariant->getChannelPricingForChannel($channel)->willReturn(null);
-        $productVariant->getName()->willReturn('Red variant');
-        $productVariant->getCode()->willReturn('RED_VARIANT');
+        $productVariant->getDescriptor()->willReturn('Red variant (RED_VARIANT)');
 
         $this
             ->shouldThrow(MissingChannelConfigurationException::class)
@@ -63,8 +62,7 @@ final class ProductVariantPriceCalculatorSpec extends ObjectBehavior
 
         $productVariant->getChannelPricingForChannel($channel)->willReturn($channelPricing);
         $channelPricing->getPrice()->willReturn(null);
-        $productVariant->getName()->willReturn('Red variant');
-        $productVariant->getCode()->willReturn('RED_VARIANT');
+        $productVariant->getDescriptor()->willReturn('Red variant (RED_VARIANT)');
 
         $this
             ->shouldThrow(MissingChannelConfigurationException::class)
@@ -110,8 +108,7 @@ final class ProductVariantPriceCalculatorSpec extends ObjectBehavior
         $channel->getName()->willReturn('WEB');
 
         $productVariant->getChannelPricingForChannel($channel)->willReturn(null);
-        $productVariant->getName()->willReturn('Red variant');
-        $productVariant->getCode()->willReturn('RED_VARIANT');
+        $productVariant->getDescriptor()->willReturn('Red variant (RED_VARIANT)');
 
         $this
             ->shouldThrow(MissingChannelConfigurationException::class)
@@ -129,8 +126,7 @@ final class ProductVariantPriceCalculatorSpec extends ObjectBehavior
         $productVariant->getChannelPricingForChannel($channel)->willReturn($channelPricing);
         $channelPricing->getOriginalPrice()->willReturn(null);
         $channelPricing->getPrice()->willReturn(null);
-        $productVariant->getName()->willReturn('Red variant');
-        $productVariant->getCode()->willReturn('RED_VARIANT');
+        $productVariant->getDescriptor()->willReturn('Red variant (RED_VARIANT)');
 
         $this
             ->shouldThrow(MissingChannelConfigurationException::class)


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | no
| License         | MIT

This Pull Request will avoid returning null on int only return type allowed function. If getPrice is null for the channel the same exception is thrown.
