### PR TITLE
Fix misleading signing in the admin panel feature description

### DIFF
--- a/features/admin/signing_in_to_administration_panel.feature
+++ b/features/admin/signing_in_to_administration_panel.feature
@@ -1,8 +1,8 @@
 @administrator_login
-Feature: Sign in to the store
-    In order to view my orders
-    As a Visitor
-    I want to be able to log in to the store
+Feature: Signing in to the administration panel
+    In order to manage the store
+    As an Administrator
+    I want to be able to log in to the administration panel
 
     Background:
         Given the store operates on a single channel in "United States"
@@ -29,7 +29,7 @@ Feature: Sign in to the store
     @ui @api
     Scenario: Sign in using customer account
         When I want to log in
-        And I specify the username as "bear@example.com"
+        And I specify the username as "ted@example.com"
         And I specify the password as "bear"
         And I log in
         Then I should be notified about bad credentials


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.7
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

The test didn't check the described scenario, because it contained incorrect customer login data, and the scenario assumes logging in with correct customer data, but to administration panel instead of customer panel in shop.
