### PR TITLE
Add an option to use icon-only buttons on grids

### DIFF
--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/applyTransition.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/applyTransition.html.twig
@@ -1,9 +1,12 @@
+{% set labeled = options.labeled is defined ? options.labeled : true %}
+
 {% if sm_can(data, options.transition, options.graph) %}
     <form action="{{ path(options.link.route, options.link.parameters) }}" method="post">
         <input type="hidden" name="_csrf_token" value="{{ csrf_token(data.id) }}">
         <input type="hidden" name="_method" value="PUT">
-        <button class="ui loadable {{ options.class|default }} labeled icon button" type="submit" data-js-disable=".sylius-grid-table-wrapper button, .sylius-grid-table-wrapper a">
-            <i class="{{ action.icon }} icon"></i> {{ action.label|trans }}
+        <button class="ui loadable {{ options.class|default }} {% if labeled %}labeled{% endif%} icon button" type="submit" data-js-disable=".sylius-grid-table-wrapper button, .sylius-grid-table-wrapper a">
+            <i class="{{ action.icon }} icon"></i>
+            {% if labeled %}{{ action.label|trans }}{% endif %}
         </button>
     </form>
 {% endif %}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/applyTransition.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/applyTransition.html.twig
@@ -4,7 +4,7 @@
     <form action="{{ path(options.link.route, options.link.parameters) }}" method="post">
         <input type="hidden" name="_csrf_token" value="{{ csrf_token(data.id) }}">
         <input type="hidden" name="_method" value="PUT">
-        <button class="ui loadable {{ options.class|default }} {% if labeled %}labeled{% endif%} icon button" type="submit" data-js-disable=".sylius-grid-table-wrapper button, .sylius-grid-table-wrapper a">
+        <button class="ui loadable {{ options.class|default }} {% if labeled %}labeled{% endif %} icon button" type="submit" data-js-disable=".sylius-grid-table-wrapper button, .sylius-grid-table-wrapper a">
             <i class="{{ action.icon }} icon"></i>
             {% if labeled %}{{ action.label|trans }}{% endif %}
         </button>

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/create.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/create.html.twig
@@ -2,4 +2,5 @@
 
 {% set path = options.link.url|default(path(options.link.route|default(grid.requestConfiguration.getRouteName('create')), options.link.parameters|default([]))) %}
 
-{{ buttons.create(path, action.label) }}
+{% set labeled = options.labeled is defined ? options.labeled : true %}
+{{ buttons.edit(path, action.label, null, labeled) }}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/create.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/create.html.twig
@@ -3,4 +3,4 @@
 {% set path = options.link.url|default(path(options.link.route|default(grid.requestConfiguration.getRouteName('create')), options.link.parameters|default([]))) %}
 
 {% set labeled = options.labeled is defined ? options.labeled : true %}
-{{ buttons.edit(path, action.label, null, labeled) }}
+{{ buttons.create(path, action.label, null, labeled) }}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/delete.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/delete.html.twig
@@ -2,4 +2,5 @@
 
 {% set path = options.link.url|default(path(options.link.route|default(grid.requestConfiguration.getRouteName('delete')), options.link.parameters|default({'id': data.id}))) %}
 
-{{ buttons.delete(path, action.label, true, data.id) }}
+{% set labeled = options.labeled is defined ? options.labeled : true %}
+{{ buttons.delete(path, action.label, labeled, data.id) }}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/show.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/show.html.twig
@@ -2,4 +2,5 @@
 
 {% set path = options.link.url|default(path(options.link.route|default(grid.requestConfiguration.getRouteName('show')), options.link.parameters|default({'id': data.id}))) %}
 
-{{ buttons.show(path, action.label) }}
+{% set labeled = options.labeled is defined ? options.labeled : true %}
+{{ buttons.show(path, action.label, null, null, labeled) }}

--- a/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/update.html.twig
+++ b/src/Sylius/Bundle/UiBundle/Resources/views/Grid/Action/update.html.twig
@@ -2,4 +2,5 @@
 
 {% set path = options.link.url|default(path(options.link.route|default(grid.requestConfiguration.getRouteName('update')), options.link.parameters|default({'id': data.id}))) %}
 
-{{ buttons.edit(path, action.label) }}
+{% set labeled = options.labeled is defined ? options.labeled : true %}
+{{ buttons.edit(path, action.label, null, labeled) }}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Before
<img width="1919" alt="Capture d’écran 2022-03-22 à 11 20 58" src="https://user-images.githubusercontent.com/8329789/159459426-74b85637-14b1-463f-aa6c-35224c9a6167.png">

After
<img width="1919" alt="Capture d’écran 2022-03-22 à 11 22 20" src="https://user-images.githubusercontent.com/8329789/159459453-4fefa3ec-69aa-4dde-a604-043bb747df70.png">

