### PR TITLE
[Order] Fix race condition problem with multiple order recalculations

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210422105530.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210422105530.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20210422105530 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add version field to order item';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_order_item ADD version INT DEFAULT 1 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_order_item DROP version');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/OrderItem.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/OrderItem.orm.xml
@@ -19,6 +19,7 @@
     <mapped-superclass name="Sylius\Component\Core\Model\OrderItem" table="sylius_order_item">
         <field name="productName" column="product_name" type="string" nullable="true"/>
         <field name="variantName" column="variant_name" type="string" nullable="true"/>
+        <field name="version" type="integer" version="true" />
 
         <many-to-one field="variant" target-entity="Sylius\Component\Product\Model\ProductVariantInterface">
             <join-column name="variant_id" referenced-column-name="id" nullable="false" />

--- a/src/Sylius/Component/Core/Model/OrderItem.php
+++ b/src/Sylius/Component/Core/Model/OrderItem.php
@@ -19,6 +19,9 @@ use Webmozart\Assert\Assert;
 
 class OrderItem extends BaseOrderItem implements OrderItemInterface
 {
+    /** @var int */
+    protected $version = 1;
+
     /** @var ProductVariantInterface */
     protected $variant;
 
@@ -27,6 +30,16 @@ class OrderItem extends BaseOrderItem implements OrderItemInterface
 
     /** @var string */
     protected $variantName;
+
+    public function getVersion(): ?int
+    {
+        return $this->version;
+    }
+
+    public function setVersion(?int $version): void
+    {
+        $this->version = $version;
+    }
 
     public function getVariant(): ?ProductVariantInterface
     {

--- a/src/Sylius/Component/Core/Model/OrderItemInterface.php
+++ b/src/Sylius/Component/Core/Model/OrderItemInterface.php
@@ -14,8 +14,9 @@ declare(strict_types=1);
 namespace Sylius\Component\Core\Model;
 
 use Sylius\Component\Order\Model\OrderItemInterface as BaseOrderItemInterface;
+use Sylius\Component\Resource\Model\VersionedInterface;
 
-interface OrderItemInterface extends BaseOrderItemInterface
+interface OrderItemInterface extends BaseOrderItemInterface, VersionedInterface
 {
     public function getProduct(): ?ProductInterface;
 

--- a/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/OrderItemSpec.php
@@ -16,9 +16,15 @@ namespace spec\Sylius\Component\Core\Model;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\AdjustmentInterface;
 use Sylius\Component\Core\Model\OrderItemUnitInterface;
+use Sylius\Component\Resource\Model\VersionedInterface;
 
 final class OrderItemSpec extends ObjectBehavior
 {
+    function it_implements_versioned_interface(): void
+    {
+        $this->shouldImplement(VersionedInterface::class);
+    }
+
     function it_returns_0_tax_total_when_there_are_no_units(): void
     {
         $this->getTaxTotal()->shouldReturn(0);
@@ -114,5 +120,10 @@ final class OrderItemSpec extends ObjectBehavior
     function it_has_no_variant_by_default(): void
     {
         $this->getVariant()->shouldReturn(null);
+    }
+
+    function it_has_version_1_by_default(): void
+    {
+        $this->getVersion()->shouldReturn(1);
     }
 }

--- a/src/Sylius/Component/Order/Model/Order.php
+++ b/src/Sylius/Component/Order/Model/Order.php
@@ -293,6 +293,8 @@ class Order implements OrderInterface
 
             $this->removeAdjustment($adjustment);
         }
+
+        $this->recalculateAdjustmentsTotal();
     }
 
     public function removeAdjustmentsRecursively(?string $type = null): void

--- a/src/Sylius/Component/Order/Model/OrderItem.php
+++ b/src/Sylius/Component/Order/Model/OrderItem.php
@@ -276,6 +276,8 @@ class OrderItem implements OrderItemInterface
         foreach ($this->getAdjustments($type) as $adjustment) {
             $this->removeAdjustment($adjustment);
         }
+
+        $this->recalculateAdjustmentsTotal();
     }
 
     public function removeAdjustmentsRecursively(?string $type = null): void

--- a/src/Sylius/Component/Order/Model/OrderItemUnit.php
+++ b/src/Sylius/Component/Order/Model/OrderItemUnit.php
@@ -125,6 +125,8 @@ class OrderItemUnit implements OrderItemUnitInterface
         foreach ($this->getAdjustments($type) as $adjustment) {
             $this->removeAdjustment($adjustment);
         }
+
+        $this->recalculateAdjustmentsTotal();
     }
 
     public function recalculateAdjustmentsTotal(): void

--- a/src/Sylius/Component/Order/spec/Model/OrderSpec.php
+++ b/src/Sylius/Component/Order/spec/Model/OrderSpec.php
@@ -175,6 +175,7 @@ final class OrderSpec extends ObjectBehavior
         $this->removeAdjustment($adjustment);
 
         $this->hasAdjustment($adjustment)->shouldReturn(false);
+        $this->getAdjustmentsTotal()->shouldReturn(0);
     }
 
     function it_removes_adjustments_recursively_properly(
@@ -197,6 +198,7 @@ final class OrderSpec extends ObjectBehavior
         $this->removeAdjustmentsRecursively();
 
         $this->hasAdjustment($orderAdjustment)->shouldReturn(false);
+        $this->getAdjustmentsTotal()->shouldReturn(0);
     }
 
     function it_removes_adjustments_recursively_by_type_properly(
@@ -232,6 +234,7 @@ final class OrderSpec extends ObjectBehavior
 
         $this->hasAdjustment($orderPromotionAdjustment)->shouldReturn(true);
         $this->hasAdjustment($orderTaxAdjustment)->shouldReturn(false);
+        $this->getAdjustmentsTotal('tax')->shouldReturn(0);
     }
 
     function it_returns_adjustments_recursively(


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

While testing many requests in a short time to change the quantity of product in the cart, I detected 2 problems:

- an incorrect number of order item units in relation to the quantity on order item
- an incorrect adjustments total

This PR solves these two issues.