### PR TITLE
change inner join to left join

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/OrderRepository.php
@@ -44,7 +44,7 @@ class OrderRepository extends BaseOrderRepository implements OrderRepositoryInte
         return $this->createQueryBuilder('o')
             ->addSelect('channel')
             ->addSelect('customer')
-            ->innerJoin('o.channel', 'channel')
+            ->leftJoin('o.channel', 'channel')
             ->leftJoin('o.customer', 'customer')
             ->andWhere('o.state != :state')
             ->setParameter('state', OrderInterface::STATE_CART)


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

First attempt on optimizing repositories (one of options was to change inner join from orderRepository to left join)

sylius_orders filled with 500 000 orders

Results:

- With innerJoin
![image](https://user-images.githubusercontent.com/22825722/115869715-93d3f000-a43e-11eb-80a3-6cc1d68bbac4.png)

- With leftJoin
![image](https://user-images.githubusercontent.com/22825722/115869746-9f271b80-a43e-11eb-9925-7774a7fa6336.png)


<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
