### PR TITLE
Bugfix | Don't declare `default_bus` for Messenger & always use Sylius Bus

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -86,17 +86,17 @@ jobs:
 
             -
                 name: Validate Doctrine mapping
-                run: bin/console doctrine:schema:validate --skip-sync -vvv
+                run: bin/console doctrine:schema:validate --skip-sync -vvv --env=test
                 if: always() && steps.end-of-setup.outcome == 'success'
 
             -
                 name: Validate Twig templates
-                run: bin/console lint:twig src
+                run: bin/console lint:twig src --env=test
                 if: always() && steps.end-of-setup.outcome == 'success'
 
             -
                 name: Validate Yaml files
-                run: bin/console lint:yaml src
+                run: bin/console lint:yaml src --env=test
                 if: always() && steps.end-of-setup.outcome == 'success'
 
             -
@@ -186,7 +186,7 @@ jobs:
 
             -
                 name: Warmup cache
-                run: bin/console cache:warmup
+                run: bin/console cache:warmup --env=test
 
             -
                 name: Make filesystem readonly
@@ -195,23 +195,23 @@ jobs:
             -
                 name: Prepare application database
                 run: |
-                    APP_DEBUG=1 bin/console doctrine:database:create -vvv
-                    bin/console doctrine:migrations:migrate -n -vvv
+                    APP_DEBUG=1 bin/console doctrine:database:create -vvv --env=test
+                    bin/console doctrine:migrations:migrate -n -vvv --env=test
 
             -
                 name: Test provided migrations
                 run: |
-                    bin/console doctrine:migrations:migrate first --no-interaction
-                    bin/console doctrine:migrations:migrate latest --no-interaction
-                    bin/console doctrine:schema:validate --skip-mapping -vvv
+                    bin/console doctrine:migrations:migrate first --no-interaction --env=test
+                    bin/console doctrine:migrations:migrate latest --no-interaction --env=test
+                    bin/console doctrine:schema:validate --skip-mapping -vvv --env=test
 
             -
                 name: Test installer
-                run: bin/console sylius:install --no-interaction -vvv
+                run: bin/console sylius:install --no-interaction -vvv --env=test
 
             -
                 name: Load fixtures
-                run: bin/console sylius:fixtures:load default --no-interaction
+                run: bin/console sylius:fixtures:load default --no-interaction --env=test
 
             -
                 name: Run PHPSpec
@@ -351,7 +351,7 @@ jobs:
 
             -
                 name: Warmup cache
-                run: bin/console cache:warmup
+                run: bin/console cache:warmup --env=test
 
             -
                 name: Run webserver
@@ -360,13 +360,13 @@ jobs:
             -
                 name: Prepare application database
                 run: |
-                    APP_DEBUG=1 bin/console doctrine:database:create -vvv
-                    bin/console doctrine:migrations:migrate -n -vvv
+                    APP_DEBUG=1 bin/console doctrine:database:create -vvv --env=test
+                    bin/console doctrine:migrations:migrate -n -vvv --env=test
 
             -
                 name: Build assets
                 run: |
-                    bin/console assets:install public -vvv
+                    bin/console assets:install public -vvv --env=test
                     yarn build
 
             -

--- a/config/packages/staging/messenger.yaml
+++ b/config/packages/staging/messenger.yaml
@@ -1,0 +1,3 @@
+framework:
+    messenger:
+        default_bus: sylius_default.bus

--- a/config/packages/test/messenger.yaml
+++ b/config/packages/test/messenger.yaml
@@ -1,0 +1,3 @@
+framework:
+    messenger:
+        default_bus: sylius_default.bus

--- a/config/packages/test_cached/messenger.yaml
+++ b/config/packages/test_cached/messenger.yaml
@@ -1,0 +1,3 @@
+framework:
+    messenger:
+        default_bus: sylius_default.bus

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
@@ -128,7 +128,7 @@
 
         <service id="Sylius\Bundle\ApiBundle\CommandHandler\RequestResetPasswordTokenHandler">
             <argument type="service" id="sylius.repository.shop_user" />
-            <argument type="service" id="messenger.default_bus" />
+            <argument type="service" id="sylius_default.bus" />
             <argument type="service" id="sylius.shop_user.token_generator.password_reset" />
             <tag name="messenger.message_handler" bus="sylius_default.bus" />
         </service>

--- a/src/Sylius/Bundle/ApiBundle/test/config/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/test/config/config.yaml
@@ -26,6 +26,8 @@ framework:
     serializer:
         mapping:
             paths: ['%kernel.project_dir%/config/serialization']
+    messenger:
+        default_bus: sylius_default.bus
 
 doctrine_migrations:
     storage:

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/messenger.yaml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/messenger.yaml
@@ -13,6 +13,5 @@ framework:
         # Route your messages to the transports
         # 'App\Message\YourMessage': async
 
-        default_bus: sylius_default.bus
         buses:
             sylius_default.bus: ~


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10-dev, but possibly lower as well
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Having that `framework.messenger.default_bus` being set, makes impossible to declared own one & forces to use `sylius_default.bus` as bus in our project.
