### PR TITLE
Bugfix | Filter out not enabled products in API collection

### DIFF
--- a/features/product/viewing_products/viewing_enabled_products_only.feature
+++ b/features/product/viewing_products/viewing_enabled_products_only.feature
@@ -1,0 +1,18 @@
+@viewing_products
+Feature: Viewing enabled products only
+    In order to see only available products
+    As a Customer
+    I want to see only enabled product variants
+
+    Background:
+        Given the store operates on a channel named "Web-US" in "USD" currency
+        And the store has a "Super Cool T-Shirt" product
+        And the store has a "PHP T-Shirt" product
+        And the store has a "Shiny T-Shirt" product
+        And the "PHP T-shirt" product is disabled
+
+    @api
+    Scenario: Seeing only enabled products
+        When I browse products
+        Then I should see only 2 products
+        And I should not see the product with name "PHP T-shirt"

--- a/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductContext.php
@@ -53,6 +53,41 @@ final class ProductContext implements Context
     }
 
     /**
+     * @When I browse products
+     */
+    public function iViewProducts(): void
+    {
+        $this->client->index();
+    }
+
+    /**
+     * @When /^I should see only (\d+) product(s)$/
+     */
+    public function iShouldSeeOnlyProducts(int $count): void
+    {
+        Assert::same(
+            count($this->responseChecker->getCollection($this->client->getLastResponse())),
+            $count,
+            'Number of products from response is different then expected'
+        );
+    }
+
+    /**
+     * @Then I should not see the product with name :name
+     */
+    public function iShouldNotSeeProductWithName(string $name): void
+    {
+        Assert::false(
+            $this->responseChecker->hasItemWithTranslation(
+                $this->client->getLastResponse(),
+                'en_US',
+                'name',
+                $name
+            )
+        );
+    }
+
+    /**
      * @Then I should see the product name :name
      */
     public function iShouldSeeProductName(string $name): void

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/QueryCollectionExtension/ProductsWithEnableFlagExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/QueryCollectionExtension/ProductsWithEnableFlagExtension.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Doctrine\QueryCollectionExtension;

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/QueryCollectionExtension/ProductsWithEnableFlagExtension.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/QueryCollectionExtension/ProductsWithEnableFlagExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Doctrine\QueryCollectionExtension;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\ContextAwareQueryCollectionExtensionInterface;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+use Sylius\Bundle\ApiBundle\Context\UserContextInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+
+/** @experimental */
+final class ProductsWithEnableFlagExtension implements ContextAwareQueryCollectionExtensionInterface
+{
+    /** @var UserContextInterface */
+    private $userContext;
+
+    public function __construct(UserContextInterface $userContext)
+    {
+        $this->userContext = $userContext;
+    }
+
+    public function applyToCollection(
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        ?string $operationName = null,
+        array $context = []
+    ): void {
+        if (!is_a($resourceClass, ProductInterface::class, true)) {
+            return;
+        }
+
+        $user = $this->userContext->getUser();
+        if ($user !== null && in_array('ROLE_API_ACCESS', $user->getRoles(), true)) {
+            return;
+        }
+
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+        $queryBuilder->andWhere($rootAlias.'.enabled = 1');
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/extensions.xml
@@ -35,6 +35,15 @@
         </service>
 
         <service
+            id="sylius.api.doctrine.query_collection_extension.products_with_enable_flag"
+            class="Sylius\Bundle\ApiBundle\Doctrine\QueryCollectionExtension\ProductsWithEnableFlagExtension"
+            public="true"
+        >
+            <argument type="service" id="sylius.api.context.user" />
+            <tag name="api_platform.doctrine.orm.query_extension.collection" />
+        </service>
+
+        <service
             id="sylius.api.doctrine.query_item_extension.get_order"
             class="Sylius\Bundle\ApiBundle\Doctrine\QueryItemExtension\OrderGetMethodItemExtension"
             public="true"

--- a/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryCollectionExtension/ProductsWithEnableFlagExtensionSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Doctrine/QueryCollectionExtension/ProductsWithEnableFlagExtensionSpec.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ApiBundle\Doctrine\QueryCollectionExtension;
+
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use Doctrine\ORM\QueryBuilder;
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ApiBundle\Context\UserContextInterface;
+use Sylius\Bundle\ApiBundle\Serializer\ContextKeys;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class ProductsWithEnableFlagExtensionSpec extends ObjectBehavior
+{
+    function let(UserContextInterface $userContext)
+    {
+        $this->beConstructedWith($userContext);
+    }
+
+    function it_does_nothing_if_current_resource_is_not_a_product(
+        UserContextInterface $userContext,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator
+    ): void {
+        $userContext->getUser()->shouldNotBeCalled();
+        $queryBuilder->getRootAliases()->shouldNotBeCalled();
+
+        $this->applyToCollection($queryBuilder, $queryNameGenerator, TaxonInterface::class, 'get', []);
+    }
+
+    function it_does_nothing_if_current_user_is_an_admin_user(
+        UserContextInterface $userContext,
+        UserInterface $user,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator
+    ): void {
+        $userContext->getUser()->willReturn($user);
+        $user->getRoles()->willReturn(['ROLE_API_ACCESS']);
+
+        $queryBuilder->getRootAliases()->shouldNotBeCalled();
+
+        $this->applyToCollection($queryBuilder, $queryNameGenerator, ProductInterface::class, 'get', []);
+    }
+
+    function it_filters_products_by_enabled_flag_for_shop_user(
+        UserContextInterface $userContext,
+        UserInterface $user,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        ChannelInterface $channel
+    ): void {
+        $userContext->getUser()->willReturn($user);
+        $user->getRoles()->willReturn([]);
+
+        $queryBuilder->getRootAliases()->willReturn(['o']);
+        $queryBuilder->andWhere('o.enabled = 1')->shouldBeCalled()->willReturn($queryBuilder);
+
+        $this->applyToCollection($queryBuilder, $queryNameGenerator, ProductInterface::class, 'get', [ContextKeys::CHANNEL => $channel, ContextKeys::LOCALE_CODE => 'en_US']);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Right now API `/shop/products` returns all products in database, even those that are explicitly disabled.
