### PR TITLE
Bugfix | Don't use "json" native column in `Adjustment` entity

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20201204071301.php
@@ -30,7 +30,7 @@ final class Version20201204071301 extends AbstractMigration
             return;
         }
 
-        $this->addSql('ALTER TABLE sylius_adjustment ADD details JSON NOT NULL');
+        $this->addSql('ALTER TABLE sylius_adjustment ADD details LONGTEXT NOT NULL COMMENT \'(DC2Type:json_array)\'');
     }
 
     public function down(Schema $schema): void

--- a/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Adjustment.orm.xml
+++ b/src/Sylius/Bundle/OrderBundle/Resources/config/doctrine/model/Adjustment.orm.xml
@@ -28,7 +28,7 @@
         <field name="neutral" column="is_neutral" type="boolean" />
         <field name="locked" column="is_locked" type="boolean" />
         <field name="originCode" column="origin_code" type="string" nullable="true" />
-        <field name="details" type="json" />
+        <field name="details" column="details" type="json_array" />
 
         <field name="createdAt" column="created_at" type="datetime">
             <gedmo:timestampable on="create"/>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no(?)
| Deprecations?   | no
| License         | MIT

Using: `MariabDB:10.4.12`

Error while running migration:
```
In DBALException.php line 282:

Unknown column type " json" requested. Any Doctrine type that you use has t
o be registered with \Doctrine\DBAL\Types\Type::addType(). You can get a li  
st of all the known types with \Doctrine\DBAL\Types\Type::getTypesMap(). If  
this error occurs during database introspection then you might have forgot  
ten to register all database types for a Doctrine Type. Use AbstractPlatfor  
m#registerDoctrineTypeMapping() or have your custom types implement Type#ge
tMappedDatabaseTypes(). If the type name is empty you might have a problem   
with the cache or forgot some mapping information.    
```

Setting this doesn't help ;)
```yaml
doctrine:
    dbal:
        types:
            json: Doctrine\DBAL\Types\JsonType
