### PR TITLE
[Api]Fix isAllowedProperty return type in ReflectionExtractor

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Sylius/Bundle/ApiBundle/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -595,7 +595,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         try {
             $reflectionProperty = new \ReflectionProperty($class, $property);
 
-            return $reflectionProperty->getModifiers() & $this->propertyReflectionFlags;
+            return boolval($reflectionProperty->getModifiers() & $this->propertyReflectionFlags);
         } catch (\ReflectionException $e) {
             // Return false if the property doesn't exist
         }

--- a/src/Sylius/Bundle/ApiBundle/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Sylius/Bundle/ApiBundle/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -595,7 +595,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         try {
             $reflectionProperty = new \ReflectionProperty($class, $property);
 
-            return boolval($reflectionProperty->getModifiers() & $this->propertyReflectionFlags);
+            return (bool) ($reflectionProperty->getModifiers() & $this->propertyReflectionFlags);
         } catch (\ReflectionException $e) {
             // Return false if the property doesn't exist
         }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Problem: 
<img width="1440" alt="Screenshot 2021-05-04 at 10 01 24" src="https://user-images.githubusercontent.com/39232096/116977337-9b0ebf80-acc2-11eb-8333-4edd52e1069d.png">
Adding boolval fix this problem:
<img width="630" alt="Screenshot 2021-05-04 at 10 19 40" src="https://user-images.githubusercontent.com/39232096/116977382-aa8e0880-acc2-11eb-8aba-52ced14bc717.png">

