### PR TITLE
Include just one MySQL 5.7 build

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -122,7 +122,14 @@ jobs:
                 php: ["7.4", "8.0"]
                 symfony: ["^4.4", "^5.2"]
                 node: ["10.x"]
-                mysql: ["5.7", "8.0"]
+                mysql: ["8.0"]
+
+                include:
+                    -   
+                        php: "8.0"
+                        symfony: "^5.2"
+                        node: "10.x"
+                        mysql: "5.7"
 
         env:
             APP_ENV: test_cached
@@ -251,7 +258,14 @@ jobs:
                 php: ["7.4", "8.0"]
                 symfony: ["^4.4", "^5.2"]
                 node: ["10.x"]
-                mysql: ["5.7", "8.0"]
+                mysql: ["8.0"]
+                
+                include:
+                    -
+                        php: "8.0"
+                        symfony: "^5.2"
+                        node: "10.x"
+                        mysql: "5.7"
 
         env:
             APP_ENV: test_cached


### PR DESCRIPTION
Make our builds fast again - there's almost no chance this behaviour would differ much between MySQL 5.7 and multiple versions of PHP and Symfony. We should switch to supporting MySQL 8.0 as the main database engine, replacing MySQL 5.7.