### PR TITLE
Country api resource shouldn't have created/updated at

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Country.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Country.xml
@@ -84,7 +84,5 @@
         <property name="provinces" readable="true" writable="true">
             <subresource resourceClass="%sylius.model.province.class%" collection="true" />
         </property>
-        <property name="createdAt" writable="false" />
-        <property name="updatedAt" writable="false" />
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Country.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Country.xml
@@ -19,12 +19,6 @@
         <attribute name="id">
             <group>admin:country:read</group>
         </attribute>
-        <attribute name="createdAt">
-           <group>admin:country:read</group>
-       </attribute>
-        <attribute name="updatedAt">
-           <group>admin:country:read</group>
-       </attribute>
        <attribute name="code">
            <group>admin:country:read</group>
            <group>admin:country:create</group>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Country object doesn't have created/updated at field. It shouldn't be defined in api resources. 