### PR TITLE
[Api]Remove redundant ReflectionExtractor

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,10 +25,6 @@ parameters:
         # Deprecated classes
         - 'src/Sylius/Bundle/CoreBundle/Application/Kernel.php'
 
-        # Symfony 5.1+ hotfixes
-        - 'src/Sylius/Bundle/ApiBundle/DependencyInjection/Compiler/ReflectionExtractorHotfixPass.php'
-        - 'src/Sylius/Bundle/ApiBundle/PropertyInfo/Extractor/ReflectionExtractor.php'
-
         # Symfony 4.4-specific issues
         - 'src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/CircularDependencyBreakingExceptionListenerPass.php'
         - 'src/Sylius/Bundle/CoreBundle/EventListener/CircularDependencyBreakingExceptionListener.php'

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,7 +10,6 @@
         <ignoreFiles>
             <file name="src/Sylius/Bundle/CoreBundle/Application/Kernel.php" />
             <file name="src/Sylius/Bundle/ApiBundle/ApiPlatform/Bridge/Symfony/Bundle/Action/SwaggerUiAction.php" />
-            <file name="src/Sylius/Bundle/ApiBundle/PropertyInfo/Extractor/ReflectionExtractor.php" />
 
             <directory name="src/Sylius/Behat" />
 

--- a/src/Sylius/Bundle/ApiBundle/SyliusApiBundle.php
+++ b/src/Sylius/Bundle/ApiBundle/SyliusApiBundle.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle;
 
 use Sylius\Bundle\ApiBundle\DependencyInjection\Compiler\CommandDataTransformerPass;
-use Sylius\Bundle\ApiBundle\DependencyInjection\Compiler\ReflectionExtractorHotfixPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -24,6 +23,5 @@ final class SyliusApiBundle extends Bundle
     public function build(ContainerBuilder $builder): void
     {
         $builder->addCompilerPass(new CommandDataTransformerPass());
-        $builder->addCompilerPass(new ReflectionExtractorHotfixPass());
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Redundant after merged https://github.com/symfony/symfony/pull/39896

<!--
 - Bug fixes must be submitted against the 1.7 or 1.8 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
