### PR TITLE
Avoid excessive update in UserLastLoginSubscriber

### DIFF
--- a/src/Sylius/Bundle/UserBundle/EventListener/UserLastLoginSubscriber.php
+++ b/src/Sylius/Bundle/UserBundle/EventListener/UserLastLoginSubscriber.php
@@ -62,6 +62,11 @@ final class UserLastLoginSubscriber implements EventSubscriberInterface
         if (!$user instanceof UserInterface) {
             throw new \UnexpectedValueException('In order to use this subscriber, your class has to implement UserInterface');
         }
+        
+        // Update login time once per day to avoid excessive update query
+        if ($user->getLastLogin() && $user->getLastLogin()->diff(new DateTime('now'))->days === 0) {
+            return;
+        }
 
         $user->setLastLogin(new \DateTime());
         $this->userManager->persist($user);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

My site is more API heavy and the UserLastLoginSubscriber attempt to update last login time on every API request, it even caused a database lock on user table.

This patch will limit it to update the timestamp once per day.