### PR TITLE
Maintain | Exclude tests, specs & behat from zip archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+/adr export-ignore
+/docs export-ignore
+/features export-ignore
+/phpspec.yml.dist export-ignore
+/phpstan.neon.dist export-ignore
+/phpunit.xml.dist export-ignore
+/psalm.xml export-ignore
+/src/Sylius/Behat export-ignore
+/tests export-ignore
+/.env export-ignore
+/.env.test export-ignore
+/.env.test_cached export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/AddressingBundle/.gitattributes
+++ b/src/Sylius/Bundle/AddressingBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/AdminBundle/.gitattributes
+++ b/src/Sylius/Bundle/AdminBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/ApiBundle/.gitattributes
+++ b/src/Sylius/Bundle/ApiBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/AttributeBundle/.gitattributes
+++ b/src/Sylius/Bundle/AttributeBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/ChannelBundle/.gitattributes
+++ b/src/Sylius/Bundle/ChannelBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/CoreBundle/.gitattributes
+++ b/src/Sylius/Bundle/CoreBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/CurrencyBundle/.gitattributes
+++ b/src/Sylius/Bundle/CurrencyBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/CustomerBundle/.gitattributes
+++ b/src/Sylius/Bundle/CustomerBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/InventoryBundle/.gitattributes
+++ b/src/Sylius/Bundle/InventoryBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/LocaleBundle/.gitattributes
+++ b/src/Sylius/Bundle/LocaleBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/MoneyBundle/.gitattributes
+++ b/src/Sylius/Bundle/MoneyBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/OrderBundle/.gitattributes
+++ b/src/Sylius/Bundle/OrderBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/PaymentBundle/.gitattributes
+++ b/src/Sylius/Bundle/PaymentBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/PayumBundle/.gitattributes
+++ b/src/Sylius/Bundle/PayumBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/ProductBundle/.gitattributes
+++ b/src/Sylius/Bundle/ProductBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/PromotionBundle/.gitattributes
+++ b/src/Sylius/Bundle/PromotionBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/ReviewBundle/.gitattributes
+++ b/src/Sylius/Bundle/ReviewBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/ShippingBundle/.gitattributes
+++ b/src/Sylius/Bundle/ShippingBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/ShopBundle/.gitattributes
+++ b/src/Sylius/Bundle/ShopBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/TaxationBundle/.gitattributes
+++ b/src/Sylius/Bundle/TaxationBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/TaxonomyBundle/.gitattributes
+++ b/src/Sylius/Bundle/TaxonomyBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/UiBundle/.gitattributes
+++ b/src/Sylius/Bundle/UiBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Bundle/UserBundle/.gitattributes
+++ b/src/Sylius/Bundle/UserBundle/.gitattributes
@@ -1,0 +1,9 @@
+/Behat export-ignore
+/fixtures export-ignore
+/spec export-ignore
+/test export-ignore
+/Tests export-ignore
+/phpspec.yml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Addressing/.gitattributes
+++ b/src/Sylius/Component/Addressing/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Attribute/.gitattributes
+++ b/src/Sylius/Component/Attribute/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Channel/.gitattributes
+++ b/src/Sylius/Component/Channel/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Core/.gitattributes
+++ b/src/Sylius/Component/Core/.gitattributes
@@ -1,0 +1,5 @@
+/spec export-ignore
+/Test export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Currency/.gitattributes
+++ b/src/Sylius/Component/Currency/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Customer/.gitattributes
+++ b/src/Sylius/Component/Customer/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Inventory/.gitattributes
+++ b/src/Sylius/Component/Inventory/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Locale/.gitattributes
+++ b/src/Sylius/Component/Locale/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Order/.gitattributes
+++ b/src/Sylius/Component/Order/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Payment/.gitattributes
+++ b/src/Sylius/Component/Payment/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Product/.gitattributes
+++ b/src/Sylius/Component/Product/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Promotion/.gitattributes
+++ b/src/Sylius/Component/Promotion/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Review/.gitattributes
+++ b/src/Sylius/Component/Review/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Shipping/.gitattributes
+++ b/src/Sylius/Component/Shipping/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Taxation/.gitattributes
+++ b/src/Sylius/Component/Taxation/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/Taxonomy/.gitattributes
+++ b/src/Sylius/Component/Taxonomy/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Sylius/Component/User/.gitattributes
+++ b/src/Sylius/Component/User/.gitattributes
@@ -1,0 +1,4 @@
+/spec export-ignore
+/phpspec.yml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no*
| Deprecations?   | no
| License         | MIT

Please read for Symfony decision why this is good idea: https://github.com/symfony/symfony/pull/33579

This also improves our 🌍 impact as developers cause smaller zips, mean less traffic, which reduces can a little reduce amount of pollution 🏭  !

Current `master` | My PR
------------ | -------------
Zip ~32M | Zip ~18M