### PR TITLE
Change on from string to array, consistent with other definitions

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_shipment.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_shipment.yml
@@ -22,7 +22,7 @@ winzou_state_machine:
         callbacks:
             before:
                 sylius_assign_date:
-                    on: "ship"
+                    on: ["ship"]
                     do: ["@sylius.shipping_date_assigner", "assign"]
                     args: ["object"]
                     priority: -200


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Nothing major, but the command `bin/console debug:winzou:state-machine sylius_shipment` errors due to a parsing bug in the underlying bundle. But next to that, this way is inconsistent with Sylius docs & the declaration below, so I think it's still good to adjust this in Sylius also.
