### PR TITLE
Refactor UpdatePaymentStateExtension 

### DIFF
--- a/src/Sylius/Bundle/PayumBundle/DependencyInjection/Compiler/PayumStoragePaymentAliasPass.php
+++ b/src/Sylius/Bundle/PayumBundle/DependencyInjection/Compiler/PayumStoragePaymentAliasPass.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\PayumBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class PayumStoragePaymentAliasPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $paymentClass = $container->getParameter('sylius.model.payment.class');
+        $serviceIds = $container->findTaggedServiceIds('payum.storage');
+        /** @var string $serviceId */
+        foreach (array_keys($serviceIds) as $serviceId) {
+            $serviceDefinition = $container->findDefinition($serviceId);
+            $modelClass = $this->findModelClassAttribute($serviceDefinition);
+            if ($paymentClass === $modelClass) {
+                $container->setAlias('sylius.payum.storage.payment', $serviceId);
+
+                return;
+            }
+        }
+    }
+
+    private function findModelClassAttribute(Definition $serviceDefinition): ?string
+    {
+        /** @var string[] $attributes */
+        foreach ($serviceDefinition->getTag('payum.storage') as $attributes) {
+            return $attributes['model_class'] ?? null;
+        }
+
+        return null;
+    }
+}

--- a/src/Sylius/Bundle/PayumBundle/Extension/UpdatePaymentStateExtension.php
+++ b/src/Sylius/Bundle/PayumBundle/Extension/UpdatePaymentStateExtension.php
@@ -27,7 +27,8 @@ use Sylius\Component\Resource\StateMachine\StateMachineInterface;
 use Webmozart\Assert\Assert;
 
 /**
- * Reproduction of the Payum Core StorageExtension behaviour for Sylius payments
+ * Reproduction of the Payum Core StorageExtension behaviour to apply Sylius payment state machine
+ * at the very end of a Payum request
  *
  * @see \Payum\Core\Extension\StorageExtension
  */
@@ -119,7 +120,6 @@ final class UpdatePaymentStateExtension implements ExtensionInterface
     private function updatePaymentState(PaymentInterface $payment, string $nextState): void
     {
         $stateMachine = $this->factory->get($payment, PaymentTransitions::GRAPH);
-
         Assert::isInstanceOf($stateMachine, StateMachineInterface::class);
 
         $transition = $stateMachine->getTransitionToState($nextState);
@@ -132,12 +132,9 @@ final class UpdatePaymentStateExtension implements ExtensionInterface
 
     private function scheduleForProcessingIfSupported(PaymentInterface $payment): void
     {
+        /** @var int|null $id */
         $id = $payment->getId();
         if (null === $id) {
-            return;
-        }
-
-        if (false === is_int($id)) {
             return;
         }
 

--- a/src/Sylius/Bundle/PayumBundle/Resources/config/services/extension.xml
+++ b/src/Sylius/Bundle/PayumBundle/Resources/config/services/extension.xml
@@ -9,6 +9,8 @@
 
         <service id="sylius.payum_extension.update_payment_state" class="Sylius\Bundle\PayumBundle\Extension\UpdatePaymentStateExtension">
             <argument type="service" id="sm.factory" />
+            <argument type="service" id="sylius.payum.storage.payment" />
+            <argument type="service" id="sylius.factory.payum_get_status_action" />
             <tag name="payum.extension" all="true" prepend="true" />
         </service>
     </services>

--- a/src/Sylius/Bundle/PayumBundle/SyliusPayumBundle.php
+++ b/src/Sylius/Bundle/PayumBundle/SyliusPayumBundle.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\PayumBundle;
 
 use Sylius\Bundle\PayumBundle\DependencyInjection\Compiler\InjectContainerIntoControllersPass;
+use Sylius\Bundle\PayumBundle\DependencyInjection\Compiler\PayumStoragePaymentAliasPass;
 use Sylius\Bundle\PayumBundle\DependencyInjection\Compiler\RegisterGatewayConfigTypePass;
 use Sylius\Bundle\PayumBundle\DependencyInjection\Compiler\UseTweakedDoctrineStoragePass;
 use Sylius\Bundle\ResourceBundle\AbstractResourceBundle;
@@ -36,5 +37,6 @@ final class SyliusPayumBundle extends AbstractResourceBundle
         $container->addCompilerPass(new InjectContainerIntoControllersPass());
         $container->addCompilerPass(new RegisterGatewayConfigTypePass());
         $container->addCompilerPass(new UseTweakedDoctrineStoragePass());
+        $container->addCompilerPass(new PayumStoragePaymentAliasPass());
     }
 }

--- a/src/Sylius/Bundle/PayumBundle/spec/Extension/UpdatePaymentStateExtensionSpec.php
+++ b/src/Sylius/Bundle/PayumBundle/spec/Extension/UpdatePaymentStateExtensionSpec.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\PayumBundle\Extension;
+
+use Payum\Core\Extension\Context;
+use Payum\Core\Extension\ExtensionInterface;
+use Payum\Core\GatewayInterface;
+use Payum\Core\Model\ModelAggregateInterface;
+use Payum\Core\Model\PaymentInterface as PayumPaymentInterface;
+use Payum\Core\Request\GetStatusInterface;
+use Payum\Core\Security\TokenAggregateInterface;
+use Payum\Core\Storage\IdentityInterface;
+use Payum\Core\Storage\StorageInterface;
+use PhpSpec\ObjectBehavior;
+use SM\Factory\FactoryInterface;
+use Sylius\Bundle\PayumBundle\Factory\GetStatusFactoryInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+use Sylius\Component\Payment\PaymentTransitions;
+use Sylius\Component\Resource\StateMachine\StateMachineInterface;
+
+final class UpdatePaymentStateExtensionSpec extends ObjectBehavior
+{
+    public function let(
+        FactoryInterface $factory,
+        StorageInterface $storage,
+        GetStatusFactoryInterface $getStatusRequestFactory
+    ): void {
+        $this->beConstructedWith($factory, $storage, $getStatusRequestFactory);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldBeAnInstanceOf(ExtensionInterface::class);
+    }
+
+    public function it_onPreExecute_with_Identity_finds_the_related_payment_and_stores_it(
+        Context $context,
+        ModelAggregateInterface $request,
+        IdentityInterface $model,
+        StorageInterface $storage,
+        PaymentInterface $payment
+    ): void {
+        $context->getRequest()->willReturn($request);
+        $request->getModel()->willReturn($model);
+
+        $storage->find($model)->willReturn($payment);
+        $model->getId()->willReturn(1);
+
+        $this->onPreExecute($context);
+    }
+
+    public function it_onPreExecute_with_Payment_stores_it(
+        Context $context,
+        ModelAggregateInterface $request,
+        PaymentInterface $model
+    ): void {
+        $context->getRequest()->willReturn($request);
+        $request->getModel()->willReturn($model);
+        $model->getId()->willReturn(1);
+
+        $this->onPreExecute($context);
+    }
+
+    public function it_onPreExecute_without_Payment_or_Identify_does_nothing(
+        Context $context,
+        ModelAggregateInterface $request,
+        PayumPaymentInterface $model
+    ): void {
+        $context->getRequest()->willReturn($request);
+        $request->getModel()->willReturn($model);
+
+        $this->onPreExecute($context);
+    }
+
+    public function it_onPreExecute_without_ModelAggregateInterface_does_nothing(
+        Context $context,
+        TokenAggregateInterface $request
+    ): void {
+        $context->getRequest()->willReturn($request);
+
+        $this->onPreExecute($context);
+    }
+
+    public function it_onExecute_does_nothing(Context $context): void
+    {
+        $this->onExecute($context);
+    }
+
+    public function it_OnPostExecute_apply_a_transition(
+        Context $context,
+        ModelAggregateInterface $request,
+        PaymentInterface $payment,
+        GetStatusInterface $status,
+        GetStatusFactoryInterface $getStatusRequestFactory,
+        GatewayInterface $gateway,
+        FactoryInterface $factory,
+        StateMachineInterface $stateMachine
+    ): void {
+        $context->getRequest()->willReturn($request);
+        $request->getModel()->willReturn($payment);
+        $payment->getId()->willReturn(1);
+
+        $context->getPrevious()->willReturn([]);
+
+        $context->getGateway()->willReturn($gateway);
+        $status->beConstructedWith([$payment]);
+        $getStatusRequestFactory->createNewWithModel($payment)->willReturn($status);
+
+        $gateway->execute($status)->shouldBeCalled();
+        $payment->getState()->willReturn(PaymentInterface::STATE_NEW);
+        $status->getValue()->willReturn(PaymentInterface::STATE_COMPLETED);
+
+        $factory->get($payment, PaymentTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->getTransitionToState(PaymentInterface::STATE_COMPLETED)->willReturn('complete');
+        $stateMachine->apply('complete')->shouldBeCalled();
+
+        $this->onPostExecute($context);
+    }
+
+    public function it_OnPostExecute_apply_a_transition_without_a_Sylius_PaymentInterface_when_there_was_previously_stored_payment(
+        Context $previousContext,
+        ModelAggregateInterface $previousRequest,
+        PaymentInterface $previousPayment,
+        Context $context,
+        ModelAggregateInterface $request,
+        PayumPaymentInterface $payment,
+        GetStatusInterface $status,
+        GetStatusFactoryInterface $getStatusRequestFactory,
+        GatewayInterface $gateway,
+        FactoryInterface $factory,
+        StateMachineInterface $stateMachine
+    ): void {
+        $previousContext->getRequest()->willReturn($previousRequest);
+        $previousRequest->getModel()->willReturn($previousPayment);
+        $previousPayment->getId()->willReturn(1);
+
+        $context->getRequest()->willReturn($request);
+        $request->getModel()->willReturn($payment);
+
+        $context->getPrevious()->willReturn([]);
+
+        $context->getGateway()->willReturn($gateway);
+        $status->beConstructedWith([$previousPayment]);
+        $getStatusRequestFactory->createNewWithModel($previousPayment)->willReturn($status);
+
+        $gateway->execute($status)->shouldBeCalled();
+        $previousPayment->getState()->willReturn(PaymentInterface::STATE_NEW);
+        $status->getValue()->willReturn(PaymentInterface::STATE_COMPLETED);
+
+        $factory->get($previousPayment, PaymentTransitions::GRAPH)->willReturn($stateMachine);
+        $stateMachine->getTransitionToState(PaymentInterface::STATE_COMPLETED)->willReturn('complete');
+        $stateMachine->apply('complete')->shouldBeCalled();
+
+        $this->onPreExecute($previousContext);
+
+        $this->onPostExecute($context);
+    }
+
+    public function it_OnPostExecute_without_ModelAggregateInterface_does_nothing_if_there_is_previous_context(
+        Context $context,
+        TokenAggregateInterface $request
+    ): void {
+        $context->getRequest()->willReturn($request);
+
+        $context->getPrevious()->willReturn([1]);
+
+        $this->onPostExecute($context);
+    }
+
+    public function it_OnPostExecute_without_ModelAggregateInterface_does_nothing_if_there_is_no_previous_context(
+        Context $context,
+        TokenAggregateInterface $request
+    ): void {
+        $context->getRequest()->willReturn($request);
+
+        $context->getPrevious()->willReturn([]);
+
+        $this->onPostExecute($context);
+    }
+
+    public function it_OnPostExecute_with_ModelAggregateInterface_does_nothing_if_it_is_not_a_sylius_PaymentInterface(
+        Context $context,
+        ModelAggregateInterface $request,
+        PayumPaymentInterface $model
+    ): void {
+        $context->getRequest()->willReturn($request);
+        $request->getModel()->willReturn($model);
+
+        $context->getPrevious()->willReturn([]);
+
+        $this->onPostExecute($context);
+    }
+}

--- a/src/Sylius/Bundle/PayumBundle/spec/Extension/UpdatePaymentStateExtensionSpec.php
+++ b/src/Sylius/Bundle/PayumBundle/spec/Extension/UpdatePaymentStateExtensionSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\PayumBundle\Extension;
 
+use Exception;
 use Payum\Core\Extension\Context;
 use Payum\Core\Extension\ExtensionInterface;
 use Payum\Core\GatewayInterface;
@@ -98,6 +99,7 @@ final class UpdatePaymentStateExtensionSpec extends ObjectBehavior
         FactoryInterface $factory,
         StateMachineInterface $stateMachine
     ): void {
+        $context->getException()->willReturn(null);
         $context->getRequest()->willReturn($request);
         $request->getModel()->willReturn($payment);
         $payment->getId()->willReturn(1);
@@ -132,6 +134,7 @@ final class UpdatePaymentStateExtensionSpec extends ObjectBehavior
         FactoryInterface $factory,
         StateMachineInterface $stateMachine
     ): void {
+        $context->getException()->willReturn(null);
         $previousContext->getRequest()->willReturn($previousRequest);
         $previousRequest->getModel()->willReturn($previousPayment);
         $previousPayment->getId()->willReturn(1);
@@ -162,6 +165,7 @@ final class UpdatePaymentStateExtensionSpec extends ObjectBehavior
         Context $context,
         TokenAggregateInterface $request
     ): void {
+        $context->getException()->willReturn(null);
         $context->getRequest()->willReturn($request);
 
         $context->getPrevious()->willReturn([1]);
@@ -173,6 +177,7 @@ final class UpdatePaymentStateExtensionSpec extends ObjectBehavior
         Context $context,
         TokenAggregateInterface $request
     ): void {
+        $context->getException()->willReturn(null);
         $context->getRequest()->willReturn($request);
 
         $context->getPrevious()->willReturn([]);
@@ -185,10 +190,21 @@ final class UpdatePaymentStateExtensionSpec extends ObjectBehavior
         ModelAggregateInterface $request,
         PayumPaymentInterface $model
     ): void {
+        $context->getException()->willReturn(null);
         $context->getRequest()->willReturn($request);
         $request->getModel()->willReturn($model);
 
         $context->getPrevious()->willReturn([]);
+
+        $this->onPostExecute($context);
+    }
+
+    public function it_onPostExecute_with_exception_does_nothing(
+        Context $context,
+        TokenAggregateInterface $request
+    ): void {
+        $exception = new Exception();
+        $context->getException()->willReturn($exception);
 
         $this->onPostExecute($context);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

The actual `UpdatePaymentStateExtension` is trying to please some different use cases for specific gateways, but it doesn't comply with all gateways.
If you get back to Payum library and read how a `Payment` entity is managed, then you will found that this extension : [`Payum\Core\Extension\StorageExtension`](https://github.com/Payum/Payum/blob/master/src/Payum/Core/Extension/StorageExtension.php)  is simply building a list of entities to update  `onPreExecute` and then `onPostExecute` of the first Payum `Request` (meaning after all `Request` have been done) the `Payment` entities will be updated.

This PR allow to save all `Payment` entities `onPreExecute` and then `onPostExecute` will decide to trigger the state machine if it's required. This way all previous gateways which needed to trigger the state machine will be working as expected, but now all gateways with specific cases won't need to make extra code to handle it.

It also allows Notify safe and unsafe one to be able to save the updated `Payment` to the database.