### PR TITLE
[API] Conflict with symfony/property-info due to problem with wrong namespaces of some translation entities

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -53,3 +53,12 @@ references related issues.
    `ParseError - vendor/symfony/polyfill-mbstring/bootstrap80.php:125:86 - Syntax error, unexpected '=' on line 125 (see https://psalm.dev/173) function mb_scrub(string $string, string $encoding = null): string { $encoding ??= mb_internal_encoding(); return mb_convert_encoding($string, $encoding, $encoding); }`
 
    References: https://github.com/vimeo/psalm/issues/4961
+
+ - `symfony/property-info:4.4.22|5.2.7`:
+
+   These versions of Symfony PropertyInfo Component introduce a bug with resolving wrong namespace for some translation entities 
+   in Swagger UI docs for API.
+   
+   The potential solution would be to explicitly define these translation entities as API resources with proper serialization.
+
+   Probably introduced in: https://github.com/symfony/symfony/pull/40811

--- a/composer.json
+++ b/composer.json
@@ -166,6 +166,7 @@
         "laminas/laminas-code": "^4.0.0",
         "symfony/doctrine-bridge": "4.4.16",
         "symfony/polyfill-mbstring": "^1.22.0",
+        "symfony/property-info": "4.4.22 || 5.2.7",
         "symfony/serializer": "4.4.19 || 5.2.2"
     },
     "require-dev": {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no/
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | probably introduced in https://github.com/symfony/symfony/pull/40811
| License         | MIT

The problem occurs in Swagger UI docs and there is a problem with resolving proper namespaces during serializing translation entities, e.g.:
![image](https://user-images.githubusercontent.com/6140884/117978269-fb8ca500-b331-11eb-8dcc-08b1e346954a.png)
