### PR TITLE
Use Symfony 5.2.* instead of ^5.2 for GitHub Actions

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -32,7 +32,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: [7.3, 7.4]
-                symfony: [^4.4, ^5.2]
+                symfony: [^4.4, 5.2.*]
 
         steps:
             -
@@ -120,7 +120,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: [7.3, 7.4]
-                symfony: [^4.4, ^5.2]
+                symfony: [^4.4, 5.2.*]
                 mysql: [5.7, 8.0]
 
                 exclude:
@@ -253,7 +253,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: [7.3, 7.4]
-                symfony: [^4.4, ^5.2]
+                symfony: [^4.4, 5.2.*]
                 node: [10.x]
                 mysql: [5.7, 8.0]
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -49,7 +49,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: [7.3, 7.4]
-                symfony: [^4.4, ^5.2]
+                symfony: [^4.4, 5.2.*]
                 package: "${{ fromJson(needs.list.outputs.packages) }}"
                 
         steps:


### PR DESCRIPTION
Symfony 5.3 breaks the build now.

References:
- https://github.com/symfony/symfony/issues/41470
- https://github.com/symfony/symfony/issues/41492