### PR TITLE
[API] Denying usage of coupon for invalid promotion

### DIFF
--- a/features/promotion/applying_promotion_coupon/applying_promotion_coupon_with_expiration_date.feature
+++ b/features/promotion/applying_promotion_coupon/applying_promotion_coupon_with_expiration_date.feature
@@ -27,7 +27,7 @@ Feature: Applying promotion coupon with an expiration date
         And my cart total should be "$100.00"
         And there should be no discount
 
-    @ui @api
+    @ui
     Scenario: Receiving no discount from valid coupon from expired promotion
         Given this promotion has already expired
         When I add product "PHP T-Shirt" to the cart

--- a/features/promotion/applying_promotion_coupon/applying_promotion_coupon_with_expiration_date.feature
+++ b/features/promotion/applying_promotion_coupon/applying_promotion_coupon_with_expiration_date.feature
@@ -26,12 +26,3 @@ Feature: Applying promotion coupon with an expiration date
         Then I should be notified that the coupon is invalid
         And my cart total should be "$100.00"
         And there should be no discount
-
-    @ui
-    Scenario: Receiving no discount from valid coupon from expired promotion
-        Given this promotion has already expired
-        When I add product "PHP T-Shirt" to the cart
-        And I use coupon with code "SANTA2016"
-        Then I should be notified that the coupon is invalid
-        And my cart total should be "$100.00"
-        And there should be no discount

--- a/features/promotion/applying_promotion_coupon/applying_promotion_coupon_with_per_customer_usage_limit.feature
+++ b/features/promotion/applying_promotion_coupon/applying_promotion_coupon_with_per_customer_usage_limit.feature
@@ -33,7 +33,7 @@ Feature: Applying promotion coupon with per customer usage limit
         Then my cart total should be "$90.00"
         And my discount should be "-$10.00"
 
-    @ui
+    @ui @api
     Scenario: Receiving no discount from valid coupon that has reached its per customer usage limit
         Given this coupon can be used once per customer
         And I placed an order "#00000022"

--- a/features/promotion/applying_promotion_coupon/receiving_no_discount_if_coupon_promotion_is_not_eligible.feature
+++ b/features/promotion/applying_promotion_coupon/receiving_no_discount_if_coupon_promotion_is_not_eligible.feature
@@ -20,3 +20,19 @@ Feature: Receiving no discount if coupon promotion is not eligible
         And I use coupon with code "SANTA2016"
         Then I should be notified that the promotion is invalid
         And my cart total should be "$100.00"
+
+    @api
+    Scenario: Receiving no discount if promotion for the applied coupon has not started yet
+        Given this promotion starts tomorrow
+        When I add product "PHP T-Shirt" to the cart
+        And I use coupon with code "SANTA2016"
+        Then I should be notified that the promotion is invalid
+        And my cart total should be "$100.00"
+
+    @api
+    Scenario: Receiving no discount if promotion for the applied coupon has already expired
+        Given this promotion has already expired
+        When I add product "PHP T-Shirt" to the cart
+        And I use coupon with code "SANTA2016"
+        Then I should be notified that the promotion is invalid
+        And my cart total should be "$100.00"

--- a/features/promotion/applying_promotion_coupon/receiving_no_discount_if_coupon_promotion_is_not_eligible.feature
+++ b/features/promotion/applying_promotion_coupon/receiving_no_discount_if_coupon_promotion_is_not_eligible.feature
@@ -36,3 +36,12 @@ Feature: Receiving no discount if coupon promotion is not eligible
         And I use coupon with code "SANTA2016"
         Then I should be notified that the promotion is invalid
         And my cart total should be "$100.00"
+
+    @api
+    Scenario: Receiving no discount if promotion's usage for the applied coupon is already exceeded
+        Given this promotion has usage limit equal to 100
+        And this promotion usage limit is already reached
+        When I add product "PHP T-Shirt" to the cart
+        And I use coupon with code "SANTA2016"
+        Then I should be notified that the promotion is invalid
+        And my cart total should be "$100.00"

--- a/features/promotion/applying_promotion_coupon/receiving_no_discount_if_coupon_promotion_is_not_eligible.feature
+++ b/features/promotion/applying_promotion_coupon/receiving_no_discount_if_coupon_promotion_is_not_eligible.feature
@@ -1,0 +1,22 @@
+@applying_promotion_coupon
+Feature: Receiving no discount if coupon promotion is not eligible
+    In order to be aware of not applied promotion on my cart
+    As a Customer
+    I want to be informed that coupon I want to apply is invalid
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "PHP T-Shirt" priced at "$100.00"
+        And the store has promotion "Christmas sale" with coupon "SANTA2016"
+        And this promotion gives "$10.00" discount to every order
+        And the store ships everywhere for free
+        And the store allows paying "Cash on Delivery"
+        And I am a logged in customer
+
+    @api
+    Scenario: Receiving no discount if promotion for the applied coupon is not enabled in the current channel
+        Given this promotion is not available in any channel
+        When I add product "PHP T-Shirt" to the cart
+        And I use coupon with code "SANTA2016"
+        Then I should be notified that the promotion is invalid
+        And my cart total should be "$100.00"

--- a/features/promotion/applying_promotion_coupon/receiving_no_discount_if_coupon_promotion_is_not_eligible.feature
+++ b/features/promotion/applying_promotion_coupon/receiving_no_discount_if_coupon_promotion_is_not_eligible.feature
@@ -8,7 +8,7 @@ Feature: Receiving no discount if coupon promotion is not eligible
         Given the store operates on a single channel in "United States"
         And the store has a product "PHP T-Shirt" priced at "$100.00"
         And the store has promotion "Christmas sale" with coupon "SANTA2016"
-        And this promotion gives "$10.00" discount to every order
+        And this promotion gives "$10.00" discount to every order with quantity at least 2
         And the store ships everywhere for free
         And the store allows paying "Cash on Delivery"
         And I am a logged in customer
@@ -16,32 +16,44 @@ Feature: Receiving no discount if coupon promotion is not eligible
     @api
     Scenario: Receiving no discount if promotion for the applied coupon is not enabled in the current channel
         Given this promotion is not available in any channel
-        When I add product "PHP T-Shirt" to the cart
+        When I add 2 products "PHP T-Shirt" to the cart
         And I use coupon with code "SANTA2016"
         Then I should be notified that the promotion is invalid
-        And my cart total should be "$100.00"
+        And my cart total should be "$200.00"
+        And there should be no discount
 
     @api
     Scenario: Receiving no discount if promotion for the applied coupon has not started yet
         Given this promotion starts tomorrow
-        When I add product "PHP T-Shirt" to the cart
+        When I add 2 products "PHP T-Shirt" to the cart
         And I use coupon with code "SANTA2016"
         Then I should be notified that the promotion is invalid
-        And my cart total should be "$100.00"
+        And my cart total should be "$200.00"
+        And there should be no discount
 
     @api
     Scenario: Receiving no discount if promotion for the applied coupon has already expired
         Given this promotion has already expired
-        When I add product "PHP T-Shirt" to the cart
+        When I add 2 products "PHP T-Shirt" to the cart
         And I use coupon with code "SANTA2016"
         Then I should be notified that the promotion is invalid
-        And my cart total should be "$100.00"
+        And my cart total should be "$200.00"
+        And there should be no discount
 
     @api
     Scenario: Receiving no discount if promotion's usage for the applied coupon is already exceeded
         Given this promotion has usage limit equal to 100
         And this promotion usage limit is already reached
+        When I add 2 products "PHP T-Shirt" to the cart
+        And I use coupon with code "SANTA2016"
+        Then I should be notified that the promotion is invalid
+        And my cart total should be "$200.00"
+        And there should be no discount
+
+    @api
+    Scenario: Receiving no discount if promotion's rules for the applied coupon are not fulfilled
         When I add product "PHP T-Shirt" to the cart
         And I use coupon with code "SANTA2016"
         Then I should be notified that the promotion is invalid
         And my cart total should be "$100.00"
+        And there should be no discount

--- a/features/promotion/applying_promotion_coupon/receiving_no_discount_if_coupon_promotion_is_not_eligible.feature
+++ b/features/promotion/applying_promotion_coupon/receiving_no_discount_if_coupon_promotion_is_not_eligible.feature
@@ -18,42 +18,42 @@ Feature: Receiving no discount if coupon promotion is not eligible
         Given this promotion is not available in any channel
         When I add 2 products "PHP T-Shirt" to the cart
         And I use coupon with code "SANTA2016"
-        Then I should be notified that the promotion is invalid
+        Then I should be notified that the coupon is invalid
         And my cart total should be "$200.00"
         And there should be no discount
 
-    @api
+    @ui @api
     Scenario: Receiving no discount if promotion for the applied coupon has not started yet
         Given this promotion starts tomorrow
         When I add 2 products "PHP T-Shirt" to the cart
         And I use coupon with code "SANTA2016"
-        Then I should be notified that the promotion is invalid
+        Then I should be notified that the coupon is invalid
         And my cart total should be "$200.00"
         And there should be no discount
 
-    @api
+    @ui @api
     Scenario: Receiving no discount if promotion for the applied coupon has already expired
         Given this promotion has already expired
         When I add 2 products "PHP T-Shirt" to the cart
         And I use coupon with code "SANTA2016"
-        Then I should be notified that the promotion is invalid
+        Then I should be notified that the coupon is invalid
         And my cart total should be "$200.00"
         And there should be no discount
 
-    @api
+    @ui @api
     Scenario: Receiving no discount if promotion's usage for the applied coupon is already exceeded
         Given this promotion has usage limit equal to 100
         And this promotion usage limit is already reached
         When I add 2 products "PHP T-Shirt" to the cart
         And I use coupon with code "SANTA2016"
-        Then I should be notified that the promotion is invalid
+        Then I should be notified that the coupon is invalid
         And my cart total should be "$200.00"
         And there should be no discount
 
-    @api
+    @ui @api
     Scenario: Receiving no discount if promotion's rules for the applied coupon are not fulfilled
         When I add product "PHP T-Shirt" to the cart
         And I use coupon with code "SANTA2016"
-        Then I should be notified that the promotion is invalid
+        Then I should be notified that the coupon is invalid
         And my cart total should be "$100.00"
         And there should be no discount

--- a/src/Sylius/Behat/Context/Api/Shop/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/PromotionContext.php
@@ -62,17 +62,6 @@ final class PromotionContext implements Context
         Assert::same($this->responseChecker->getError($response), 'couponCode: Coupon code is invalid.');
     }
 
-    /**
-     * @Then I should be notified that the promotion is invalid
-     */
-    public function iShouldBeNotifiedThatPromotionIsInvalid(): void
-    {
-        $response = $this->cartsClient->getLastResponse();
-
-        Assert::same($response->getStatusCode(), 422);
-        Assert::same($this->responseChecker->getError($response), 'couponCode: Promotion is invalid.');
-    }
-
     private function getCartTokenValue(): ?string
     {
         if ($this->sharedStorage->has('cart_token')) {

--- a/src/Sylius/Behat/Context/Api/Shop/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/PromotionContext.php
@@ -59,7 +59,18 @@ final class PromotionContext implements Context
         $response = $this->cartsClient->getLastResponse();
 
         Assert::same($response->getStatusCode(), 422);
-        Assert::notNull($this->responseChecker->getError($response));
+        Assert::same($this->responseChecker->getError($response), 'couponCode: Coupon code is invalid.');
+    }
+
+    /**
+     * @Then I should be notified that the promotion is invalid
+     */
+    public function iShouldBeNotifiedThatPromotionIsInvalid(): void
+    {
+        $response = $this->cartsClient->getLastResponse();
+
+        Assert::same($response->getStatusCode(), 422);
+        Assert::same($this->responseChecker->getError($response), 'couponCode: Promotion is invalid.');
     }
 
     private function getCartTokenValue(): ?string

--- a/src/Sylius/Behat/Context/Setup/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/PromotionContext.php
@@ -775,6 +775,19 @@ final class PromotionContext implements Context
         $this->generateCoupons($amount, $promotion, $codeLength, null, $suffix);
     }
 
+    /**
+     * @Given /^(this promotion) is not available in any channel$/
+     */
+    public function thisPromotionIsNotAvailableInAnyChannel(PromotionInterface $promotion): void
+    {
+        /** @var ChannelInterface $channel */
+        foreach ($promotion->getChannels() as $channel) {
+            $promotion->removeChannel($channel);
+        }
+
+        $this->objectManager->flush();
+    }
+
     private function getTaxonFilterConfiguration(array $taxonCodes): array
     {
         return ['filters' => ['taxons_filter' => ['taxons' => $taxonCodes]]];

--- a/src/Sylius/Behat/Context/Setup/PromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/PromotionContext.php
@@ -788,6 +788,26 @@ final class PromotionContext implements Context
         $this->objectManager->flush();
     }
 
+    /**
+     * @Given /^(this promotion) has usage limit equal to (\d+)$/
+     */
+    public function thisPromotionHasUsageLimitEqualTo(PromotionInterface $promotion, int $usageLimit): void
+    {
+        $promotion->setUsageLimit($usageLimit);
+
+        $this->objectManager->flush();
+    }
+
+    /**
+     * @Given /^(this promotion) usage limit is already reached$/
+     */
+    public function thisPromotionUsageLimitIsAlreadyReached(PromotionInterface $promotion): void
+    {
+        $promotion->setUsed($promotion->getUsageLimit());
+
+        $this->objectManager->flush();
+    }
+
     private function getTaxonFilterConfiguration(array $taxonCodes): array
     {
         return ['filters' => ['taxons_filter' => ['taxons' => $taxonCodes]]];

--- a/src/Sylius/Behat/Resources/config/suites/api/promotion/applying_promotion_coupon.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/promotion/applying_promotion_coupon.yml
@@ -24,7 +24,7 @@ default:
                 - sylius.behat.context.setup.payment
                 - sylius.behat.context.setup.product
                 - sylius.behat.context.setup.promotion
-                - sylius.behat.context.setup.shop_security
+                - sylius.behat.context.setup.shop_api_security
                 - sylius.behat.context.setup.shipping
                 - sylius.behat.context.setup.taxonomy
 

--- a/src/Sylius/Bundle/ApiBundle/Checker/AppliedCouponEligibilityChecker.php
+++ b/src/Sylius/Bundle/ApiBundle/Checker/AppliedCouponEligibilityChecker.php
@@ -35,8 +35,12 @@ final class AppliedCouponEligibilityChecker implements AppliedCouponEligibilityC
         $this->promotionCouponChecker = $promotionCouponChecker;
     }
 
-    public function isEligible(PromotionCouponInterface $promotionCoupon, OrderInterface $cart): bool
+    public function isEligible(?PromotionCouponInterface $promotionCoupon, OrderInterface $cart): bool
     {
+        if (null === $promotionCoupon) {
+            return false;
+        }
+
         /** @var PromotionInterface $promotion */
         $promotion = $promotionCoupon->getPromotion();
 

--- a/src/Sylius/Bundle/ApiBundle/Checker/AppliedCouponEligibilityChecker.php
+++ b/src/Sylius/Bundle/ApiBundle/Checker/AppliedCouponEligibilityChecker.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Checker;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PromotionCouponInterface;
+use Sylius\Component\Core\Model\PromotionInterface;
+use Sylius\Component\Promotion\Checker\Eligibility\PromotionCouponEligibilityCheckerInterface;
+use Sylius\Component\Promotion\Checker\Eligibility\PromotionEligibilityCheckerInterface;
+
+final class AppliedCouponEligibilityChecker implements AppliedCouponEligibilityCheckerInterface
+{
+    /** @var PromotionEligibilityCheckerInterface */
+    private $promotionChecker;
+
+    /** @var PromotionCouponEligibilityCheckerInterface */
+    private $promotionCouponChecker;
+
+    public function __construct(
+        PromotionEligibilityCheckerInterface $promotionChecker,
+        PromotionCouponEligibilityCheckerInterface $promotionCouponChecker
+    ) {
+        $this->promotionChecker = $promotionChecker;
+        $this->promotionCouponChecker = $promotionCouponChecker;
+    }
+
+    public function isEligible(PromotionCouponInterface $promotionCoupon, OrderInterface $cart): bool
+    {
+        /** @var PromotionInterface $promotion */
+        $promotion = $promotionCoupon->getPromotion();
+
+        if (!$promotion->getChannels()->contains($cart->getChannel())) {
+            return false;
+        }
+
+        if (!$this->promotionCouponChecker->isEligible($cart, $promotionCoupon)) {
+            return false;
+        }
+
+        if (!$this->promotionChecker->isEligible($cart, $promotionCoupon->getPromotion())) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Checker/AppliedCouponEligibilityCheckerInterface.php
+++ b/src/Sylius/Bundle/ApiBundle/Checker/AppliedCouponEligibilityCheckerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Checker;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PromotionCouponInterface;
+
+interface AppliedCouponEligibilityCheckerInterface
+{
+    public function isEligible(PromotionCouponInterface $promotionCoupon, OrderInterface $cart): bool;
+}

--- a/src/Sylius/Bundle/ApiBundle/Checker/AppliedCouponEligibilityCheckerInterface.php
+++ b/src/Sylius/Bundle/ApiBundle/Checker/AppliedCouponEligibilityCheckerInterface.php
@@ -9,5 +9,5 @@ use Sylius\Component\Core\Model\PromotionCouponInterface;
 
 interface AppliedCouponEligibilityCheckerInterface
 {
-    public function isEligible(PromotionCouponInterface $promotionCoupon, OrderInterface $cart): bool;
+    public function isEligible(?PromotionCouponInterface $promotionCoupon, OrderInterface $cart): bool;
 }

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/validator.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/validator.xml
@@ -93,9 +93,13 @@
         <service id="sylius.api.validator.promotion_coupon_eligibility" class="Sylius\Bundle\ApiBundle\Validator\Constraints\PromotionCouponEligibilityValidator">
             <argument type="service" id="sylius.repository.promotion_coupon" />
             <argument type="service" id="sylius.repository.order" />
+            <argument type="service" id="sylius.api.checker.applied_coupon_eligibility_checker" />
+            <tag name="validator.constraint_validator" alias="sylius_api_promotion_coupon_eligibility" />
+        </service>
+
+        <service id="sylius.api.checker.applied_coupon_eligibility_checker" class="Sylius\Bundle\ApiBundle\Checker\AppliedCouponEligibilityChecker">
             <argument type="service" id="sylius.promotion_eligibility_checker" />
             <argument type="service" id="sylius.promotion_coupon_eligibility_checker" />
-            <tag name="validator.constraint_validator" alias="sylius_api_promotion_coupon_eligibility" />
         </service>
 
         <service id="sylius.api.validator.shipment_already_shipped" class="Sylius\Bundle\ApiBundle\Validator\Constraints\ShipmentAlreadyShippedValidator">

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibilityValidator.php
@@ -60,10 +60,7 @@ final class PromotionCouponEligibilityValidator extends ConstraintValidator
 
         $cart->setPromotionCoupon($promotionCoupon);
 
-        if (
-            $promotionCoupon === null ||
-            !$this->appliedCouponEligibilityChecker->isEligible($promotionCoupon, $cart)
-        ) {
+        if (!$this->appliedCouponEligibilityChecker->isEligible($promotionCoupon, $cart)) {
             $this->context
                 ->buildViolation('sylius.promotion_coupon.is_invalid')
                 ->atPath('couponCode')

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibilityValidator.php
@@ -74,22 +74,19 @@ final class PromotionCouponEligibilityValidator extends ConstraintValidator
             $promotionCoupon === null ||
             !$this->promotionCouponChecker->isEligible($cart, $promotionCoupon)
         ) {
-            $this->context->buildViolation('sylius.promotion_coupon.is_invalid')
-                ->atPath('couponCode')
-                ->addViolation()
-            ;
-
-            return;
+            $this->addViolation('sylius.promotion_coupon.is_invalid', 'couponCode');
         }
 
         if (
             !$this->promotionChecker->isEligible($cart, $promotionCoupon->getPromotion()) ||
             !$promotion->getChannels()->contains($cart->getChannel())
         ) {
-            $this->context->buildViolation('sylius.promotion.is_invalid')
-                ->atPath('couponCode')
-                ->addViolation()
-            ;
+            $this->addViolation('sylius.promotion.is_invalid', 'couponCode');
         }
+    }
+
+    private function addViolation(string $message, string $path): void
+    {
+        $this->context->buildViolation($message)->atPath($path)->addViolation();
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibilityValidator.php
+++ b/src/Sylius/Bundle/ApiBundle/Validator/Constraints/PromotionCouponEligibilityValidator.php
@@ -72,16 +72,11 @@ final class PromotionCouponEligibilityValidator extends ConstraintValidator
 
         if (
             $promotionCoupon === null ||
-            !$this->promotionCouponChecker->isEligible($cart, $promotionCoupon)
-        ) {
-            $this->addViolation('sylius.promotion_coupon.is_invalid', 'couponCode');
-        }
-
-        if (
+            !$this->promotionCouponChecker->isEligible($cart, $promotionCoupon) ||
             !$this->promotionChecker->isEligible($cart, $promotionCoupon->getPromotion()) ||
             !$promotion->getChannels()->contains($cart->getChannel())
         ) {
-            $this->addViolation('sylius.promotion.is_invalid', 'couponCode');
+            $this->addViolation('sylius.promotion_coupon.is_invalid', 'couponCode');
         }
     }
 

--- a/src/Sylius/Bundle/ApiBundle/spec/Checker/AppliedCouponEligibilityCheckerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Checker/AppliedCouponEligibilityCheckerSpec.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ApiBundle\Checker;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Sylius\Bundle\ApiBundle\Checker\AppliedCouponEligibilityCheckerInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\PromotionCouponInterface;
+use Sylius\Component\Core\Model\PromotionInterface;
+use Sylius\Component\Promotion\Checker\Eligibility\PromotionCouponEligibilityCheckerInterface;
+use Sylius\Component\Promotion\Checker\Eligibility\PromotionEligibilityCheckerInterface;
+
+final class AppliedCouponEligibilityCheckerSpec extends ObjectBehavior
+{
+    function let(
+        PromotionEligibilityCheckerInterface $promotionChecker,
+        PromotionCouponEligibilityCheckerInterface $promotionCouponChecker
+    ): void {
+        $this->beConstructedWith($promotionChecker, $promotionCouponChecker);
+    }
+
+    function it_implements_promotion_coupon_eligibility_checker_interface(): void
+    {
+        $this->shouldImplement(AppliedCouponEligibilityCheckerInterface::class);
+    }
+
+    function it_returns_false_if_cart_channel_is_not_one_of_promotion_channels(
+        PromotionEligibilityCheckerInterface $promotionChecker,
+        PromotionCouponEligibilityCheckerInterface $promotionCouponChecker,
+        PromotionCouponInterface $promotionCoupon,
+        PromotionInterface $promotion,
+        OrderInterface $cart,
+        ChannelInterface $firstChannel,
+        ChannelInterface $secondChannel,
+        ChannelInterface $thirdChannel
+    ): void {
+        $promotionCoupon->getPromotion()->willReturn($promotion);
+
+        $promotion->getChannels()->willReturn(new ArrayCollection([
+            $secondChannel->getWrappedObject(),
+            $thirdChannel->getWrappedObject()
+        ]));
+        $cart->getChannel()->willReturn($firstChannel);
+
+        $promotionChecker->isEligible(Argument::any())->shouldNotBeCalled();
+        $promotionCouponChecker->isEligible(Argument::any())->shouldNotBeCalled();
+
+        $this->isEligible($promotionCoupon, $cart)->shouldReturn(false);
+    }
+
+    function it_returns_false_if_coupon_is_not_eligible(
+        PromotionEligibilityCheckerInterface $promotionChecker,
+        PromotionCouponEligibilityCheckerInterface $promotionCouponChecker,
+        PromotionCouponInterface $promotionCoupon,
+        PromotionInterface $promotion,
+        OrderInterface $cart,
+        ChannelInterface $firstChannel,
+        ChannelInterface $secondChannel
+    ): void {
+        $promotionCoupon->getPromotion()->willReturn($promotion);
+
+        $promotion->getChannels()->willReturn(new ArrayCollection([
+            $firstChannel->getWrappedObject(),
+            $secondChannel->getWrappedObject()
+        ]));
+        $cart->getChannel()->willReturn($firstChannel);
+
+        $promotionCouponChecker->isEligible($cart, $promotionCoupon)->willReturn(false);
+        $promotionChecker->isEligible(Argument::any())->shouldNotBeCalled();
+
+        $this->isEligible($promotionCoupon, $cart)->shouldReturn(false);
+    }
+
+    function it_returns_false_if_promotion_is_not_eligible(
+        PromotionEligibilityCheckerInterface $promotionChecker,
+        PromotionCouponEligibilityCheckerInterface $promotionCouponChecker,
+        PromotionCouponInterface $promotionCoupon,
+        PromotionInterface $promotion,
+        OrderInterface $cart,
+        ChannelInterface $firstChannel,
+        ChannelInterface $secondChannel
+    ): void {
+        $promotionCoupon->getPromotion()->willReturn($promotion);
+
+        $promotion->getChannels()->willReturn(new ArrayCollection([
+            $firstChannel->getWrappedObject(),
+            $secondChannel->getWrappedObject()
+        ]));
+        $cart->getChannel()->willReturn($firstChannel);
+
+        $promotionCouponChecker->isEligible($cart, $promotionCoupon)->willReturn(true);
+        $promotionChecker->isEligible($cart, $promotion)->willReturn(false);
+
+        $this->isEligible($promotionCoupon, $cart)->shouldReturn(false);
+    }
+
+    function it_returns_true_if_promotion_and_coupon_are_eligible(
+        PromotionEligibilityCheckerInterface $promotionChecker,
+        PromotionCouponEligibilityCheckerInterface $promotionCouponChecker,
+        PromotionCouponInterface $promotionCoupon,
+        PromotionInterface $promotion,
+        OrderInterface $cart,
+        ChannelInterface $firstChannel,
+        ChannelInterface $secondChannel
+    ): void {
+        $promotionCoupon->getPromotion()->willReturn($promotion);
+
+        $promotion->getChannels()->willReturn(new ArrayCollection([
+            $firstChannel->getWrappedObject(),
+            $secondChannel->getWrappedObject()
+        ]));
+        $cart->getChannel()->willReturn($firstChannel);
+
+        $promotionCouponChecker->isEligible($cart, $promotionCoupon)->willReturn(true);
+        $promotionChecker->isEligible($cart, $promotion)->willReturn(true);
+
+        $this->isEligible($promotionCoupon, $cart)->shouldReturn(true);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/spec/Checker/AppliedCouponEligibilityCheckerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Checker/AppliedCouponEligibilityCheckerSpec.php
@@ -38,6 +38,21 @@ final class AppliedCouponEligibilityCheckerSpec extends ObjectBehavior
         $this->shouldImplement(AppliedCouponEligibilityCheckerInterface::class);
     }
 
+    function it_returns_false_if_promotion_coupon_is_null(
+        PromotionEligibilityCheckerInterface $promotionChecker,
+        PromotionCouponEligibilityCheckerInterface $promotionCouponChecker,
+        PromotionCouponInterface $promotionCoupon,
+        PromotionInterface $promotion,
+        OrderInterface $cart
+    ): void {
+        $promotionCoupon->getPromotion()->shouldNotBeCalled();
+        $promotion->getChannels()->shouldNotBeCalled();
+        $promotionChecker->isEligible(Argument::any())->shouldNotBeCalled();
+        $promotionCouponChecker->isEligible(Argument::any())->shouldNotBeCalled();
+
+        $this->isEligible(null, $cart)->shouldReturn(false);
+    }
+
     function it_returns_false_if_cart_channel_is_not_one_of_promotion_channels(
         PromotionEligibilityCheckerInterface $promotionChecker,
         PromotionCouponEligibilityCheckerInterface $promotionCouponChecker,

--- a/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/PromotionCouponEligibilityValidatorSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/PromotionCouponEligibilityValidatorSpec.php
@@ -13,17 +13,13 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\ApiBundle\Validator\Constraints;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ApiBundle\Checker\AppliedCouponEligibilityCheckerInterface;
 use Sylius\Bundle\ApiBundle\Command\Cart\ApplyCouponToCart;
 use Sylius\Bundle\ApiBundle\Validator\Constraints\PromotionCouponEligibility;
-use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\PromotionCouponInterface;
-use Sylius\Component\Core\Model\PromotionInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Sylius\Component\Promotion\Checker\Eligibility\PromotionCouponEligibilityCheckerInterface;
-use Sylius\Component\Promotion\Checker\Eligibility\PromotionEligibilityCheckerInterface;
 use Sylius\Component\Promotion\Repository\PromotionCouponRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
@@ -35,14 +31,12 @@ final class PromotionCouponEligibilityValidatorSpec extends ObjectBehavior
     function let(
         PromotionCouponRepositoryInterface $promotionCouponRepository,
         OrderRepositoryInterface $orderRepository,
-        PromotionEligibilityCheckerInterface $promotionChecker,
-        PromotionCouponEligibilityCheckerInterface $promotionCouponChecker
+        AppliedCouponEligibilityCheckerInterface $appliedCouponEligibilityChecker
     ): void {
         $this->beConstructedWith(
             $promotionCouponRepository,
             $orderRepository,
-            $promotionChecker,
-            $promotionCouponChecker
+            $appliedCouponEligibilityChecker
         );
     }
 
@@ -61,15 +55,11 @@ final class PromotionCouponEligibilityValidatorSpec extends ObjectBehavior
 
     function it_does_not_add_violation_if_promotion_coupon_is_eligible(
         PromotionCouponRepositoryInterface $promotionCouponRepository,
-        PromotionCouponEligibilityCheckerInterface $promotionCouponChecker,
-        PromotionEligibilityCheckerInterface $promotionChecker,
+        AppliedCouponEligibilityCheckerInterface $appliedCouponEligibilityChecker,
         PromotionCouponInterface $promotionCoupon,
-        PromotionInterface $promotion,
         OrderRepositoryInterface $orderRepository,
         OrderInterface $cart,
-        ExecutionContextInterface $executionContext,
-        ChannelInterface $firstChannel,
-        ChannelInterface $secondChannel
+        ExecutionContextInterface $executionContext
     ): void {
         $this->initialize($executionContext);
         $constraint = new PromotionCouponEligibility();
@@ -78,18 +68,11 @@ final class PromotionCouponEligibilityValidatorSpec extends ObjectBehavior
         $value->setOrderTokenValue('token');
 
         $promotionCouponRepository->findOneBy(['code' => 'couponCode'])->willReturn($promotionCoupon);
-
         $orderRepository->findCartByTokenValue('token')->willReturn($cart);
-        $cart->getChannel()->willReturn($firstChannel);
 
         $cart->setPromotionCoupon($promotionCoupon)->shouldBeCalled();
 
-        $promotionCouponChecker->isEligible($cart, $promotionCoupon)->willReturn(true);
-
-        $promotionCoupon->getPromotion()->willReturn($promotion);
-        $promotion->getChannels()->willReturn(new ArrayCollection([$firstChannel->getWrappedObject(), $secondChannel->getWrappedObject()]));
-
-        $promotionChecker->isEligible($cart, $promotion)->willReturn(true);
+        $appliedCouponEligibilityChecker->isEligible($promotionCoupon, $cart)->willReturn(true);
 
         $executionContext->buildViolation('sylius.promotion_coupon.is_invalid')->shouldNotBeCalled();
 
@@ -98,7 +81,7 @@ final class PromotionCouponEligibilityValidatorSpec extends ObjectBehavior
 
     function it_adds_violation_if_promotion_coupon_is_not_eligible(
         PromotionCouponRepositoryInterface $promotionCouponRepository,
-        PromotionCouponEligibilityCheckerInterface $promotionCouponChecker,
+        AppliedCouponEligibilityCheckerInterface $appliedCouponEligibilityChecker,
         PromotionCouponInterface $promotionCoupon,
         OrderRepositoryInterface $orderRepository,
         OrderInterface $cart,
@@ -112,87 +95,11 @@ final class PromotionCouponEligibilityValidatorSpec extends ObjectBehavior
         $value->setOrderTokenValue('token');
 
         $promotionCouponRepository->findOneBy(['code' => 'couponCode'])->willReturn($promotionCoupon);
-
         $orderRepository->findCartByTokenValue('token')->willReturn($cart);
 
         $cart->setPromotionCoupon($promotionCoupon)->shouldBeCalled();
 
-        $promotionCouponChecker->isEligible($cart, $promotionCoupon)->willReturn(false);
-
-        $executionContext->buildViolation('sylius.promotion_coupon.is_invalid')->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->atPath('couponCode')->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->addViolation()->shouldBeCalled();
-
-        $this->validate($value, $constraint);
-    }
-
-    function it_adds_violation_if_promotion_is_not_available_in_cart_channel(
-        PromotionCouponRepositoryInterface $promotionCouponRepository,
-        PromotionCouponEligibilityCheckerInterface $promotionCouponChecker,
-        PromotionEligibilityCheckerInterface $promotionChecker,
-        PromotionCouponInterface $promotionCoupon,
-        PromotionInterface $promotion,
-        OrderRepositoryInterface $orderRepository,
-        OrderInterface $cart,
-        ExecutionContextInterface $executionContext,
-        ConstraintViolationBuilderInterface $constraintViolationBuilder,
-        ChannelInterface $firstChannel,
-        ChannelInterface $secondChannel,
-        ChannelInterface $thirdChannel
-    ): void {
-        $this->initialize($executionContext);
-        $constraint = new PromotionCouponEligibility();
-
-        $value = new ApplyCouponToCart('couponCode');
-        $value->setOrderTokenValue('token');
-
-        $promotionCouponRepository->findOneBy(['code' => 'couponCode'])->willReturn($promotionCoupon);
-        $promotionCoupon->getPromotion()->willReturn($promotion);
-        $promotion->getChannels()->willReturn(new ArrayCollection([$firstChannel->getWrappedObject(), $secondChannel->getWrappedObject()]));
-
-        $orderRepository->findCartByTokenValue('token')->willReturn($cart);
-        $cart->getChannel()->willReturn($thirdChannel);
-
-        $cart->setPromotionCoupon($promotionCoupon)->shouldBeCalled();
-
-        $promotionCouponChecker->isEligible($cart, $promotionCoupon)->willReturn(true);
-
-        $promotionChecker->isEligible($cart, $promotion)->willReturn(false);
-
-        $executionContext->buildViolation('sylius.promotion_coupon.is_invalid')->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->atPath('couponCode')->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->addViolation()->shouldBeCalled();
-
-        $this->validate($value, $constraint);
-    }
-
-    function it_adds_violation_if_promotion_is_not_eligible(
-        PromotionCouponRepositoryInterface $promotionCouponRepository,
-        PromotionCouponEligibilityCheckerInterface $promotionCouponChecker,
-        PromotionEligibilityCheckerInterface $promotionChecker,
-        PromotionCouponInterface $promotionCoupon,
-        PromotionInterface $promotion,
-        OrderRepositoryInterface $orderRepository,
-        OrderInterface $cart,
-        ExecutionContextInterface $executionContext,
-        ConstraintViolationBuilderInterface $constraintViolationBuilder
-    ): void {
-        $this->initialize($executionContext);
-        $constraint = new PromotionCouponEligibility();
-
-        $value = new ApplyCouponToCart('couponCode');
-        $value->setOrderTokenValue('token');
-
-        $promotionCouponRepository->findOneBy(['code' => 'couponCode'])->willReturn($promotionCoupon);
-
-        $orderRepository->findCartByTokenValue('token')->willReturn($cart);
-
-        $cart->setPromotionCoupon($promotionCoupon)->shouldBeCalled();
-
-        $promotionCouponChecker->isEligible($cart, $promotionCoupon)->willReturn(true);
-
-        $promotionCoupon->getPromotion()->willReturn($promotion);
-        $promotionChecker->isEligible($cart, $promotion)->willReturn(false);
+        $appliedCouponEligibilityChecker->isEligible($promotionCoupon, $cart)->willReturn(false);
 
         $executionContext->buildViolation('sylius.promotion_coupon.is_invalid')->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder->atPath('couponCode')->willReturn($constraintViolationBuilder);

--- a/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/PromotionCouponEligibilityValidatorSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/PromotionCouponEligibilityValidatorSpec.php
@@ -86,14 +86,12 @@ final class PromotionCouponEligibilityValidatorSpec extends ObjectBehavior
 
         $promotionCouponChecker->isEligible($cart, $promotionCoupon)->willReturn(true);
 
-        $executionContext->buildViolation('sylius.promotion_coupon.is_invalid')->shouldNotBeCalled();
-
         $promotionCoupon->getPromotion()->willReturn($promotion);
         $promotion->getChannels()->willReturn(new ArrayCollection([$firstChannel->getWrappedObject(), $secondChannel->getWrappedObject()]));
 
         $promotionChecker->isEligible($cart, $promotion)->willReturn(true);
 
-        $executionContext->buildViolation('sylius.promotion.is_invalid')->shouldNotBeCalled();
+        $executionContext->buildViolation('sylius.promotion_coupon.is_invalid')->shouldNotBeCalled();
 
         $this->validate($value, $constraint);
     }
@@ -161,7 +159,7 @@ final class PromotionCouponEligibilityValidatorSpec extends ObjectBehavior
 
         $promotionChecker->isEligible($cart, $promotion)->willReturn(false);
 
-        $executionContext->buildViolation('sylius.promotion.is_invalid')->willReturn($constraintViolationBuilder);
+        $executionContext->buildViolation('sylius.promotion_coupon.is_invalid')->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder->atPath('couponCode')->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder->addViolation()->shouldBeCalled();
 
@@ -193,14 +191,10 @@ final class PromotionCouponEligibilityValidatorSpec extends ObjectBehavior
 
         $promotionCouponChecker->isEligible($cart, $promotionCoupon)->willReturn(true);
 
-        $executionContext->buildViolation('sylius.promotion_coupon.is_invalid')->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->atPath('couponCode')->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->addViolation()->shouldNotBeCalled();
-
         $promotionCoupon->getPromotion()->willReturn($promotion);
         $promotionChecker->isEligible($cart, $promotion)->willReturn(false);
 
-        $executionContext->buildViolation('sylius.promotion.is_invalid')->willReturn($constraintViolationBuilder);
+        $executionContext->buildViolation('sylius.promotion_coupon.is_invalid')->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder->atPath('couponCode')->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder->addViolation()->shouldBeCalled();
 

--- a/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/PromotionCouponEligibilityValidatorSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Validator/Constraints/PromotionCouponEligibilityValidatorSpec.php
@@ -107,30 +107,4 @@ final class PromotionCouponEligibilityValidatorSpec extends ObjectBehavior
 
         $this->validate($value, $constraint);
     }
-
-    function it_does_add_violation_if_promotion_code_does_not_exist(
-        PromotionCouponRepositoryInterface $promotionCouponRepository,
-        OrderRepositoryInterface $orderRepository,
-        OrderInterface $cart,
-        ExecutionContextInterface $executionContext,
-        ConstraintViolationBuilderInterface $constraintViolationBuilder
-    ): void {
-        $this->initialize($executionContext);
-        $constraint = new PromotionCouponEligibility();
-
-        $value = new ApplyCouponToCart('couponCode');
-        $value->setOrderTokenValue('token');
-
-        $promotionCouponRepository->findOneBy(['code' => 'couponCode'])->willReturn(null);
-
-        $orderRepository->findCartByTokenValue('token')->willReturn($cart);
-
-        $cart->setPromotionCoupon(null)->shouldBeCalled();
-
-        $executionContext->buildViolation('sylius.promotion_coupon.is_invalid')->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->atPath('couponCode')->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->addViolation()->shouldBeCalled();
-
-        $this->validate($value, $constraint);
-    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

I've also unified the validation message to always show that coupon code is invalid (from the perspective of a Customer, much more natural information than `Promotion is invalid` 💃)