### PR TITLE
Bring back conflict to symfony/polyfill-mbstring

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -32,6 +32,10 @@ references related issues.
 
    References: https://github.com/Sylius/Sylius/issues/11970, https://github.com/symfony/symfony/issues/38861
 
+ - `symfony/polyfill-mbstring:^1.22.0`:
+
+   `polyfill-mbstring` ^1.22.0 potentially causes a problem with random segmentation faults. 
+
  - `symfony/property-info:4.4.22|5.2.7`:
 
    These versions of Symfony PropertyInfo Component introduce a bug with resolving wrong namespace for some translation entities 

--- a/composer.json
+++ b/composer.json
@@ -162,6 +162,7 @@
         "jms/serializer-bundle": "3.9.0",
         "laminas/laminas-code": "^4.0",
         "symfony/doctrine-bridge": "4.4.16",
+        "symfony/polyfill-mbstring": "^1.22.0",
         "symfony/property-info": "4.4.22 || 5.2.7",
         "symfony/serializer": "4.4.19 || 5.2.2"
     },


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT
