### PR TITLE
[API] Serialize only payment id and method as payment in order response

### DIFF
--- a/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/OrderContext.php
@@ -288,7 +288,7 @@ final class OrderContext implements Context
             ->getValue($this->client->show($this->sharedStorage->get('cart_token')), 'payments')[0]
         ;
 
-        Assert::same($this->iriConverter->getIriFromItem($paymentMethod), $payment['method']['@id']);
+        Assert::same($this->iriConverter->getIriFromItem($paymentMethod), $payment['method']);
     }
 
     /**

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethod.xml
@@ -23,7 +23,6 @@
         <attribute name="name">
             <group>admin:payment:read</group>
             <group>admin:payment_method:read</group>
-            <group>shop:cart:read</group>
             <group>shop:order:account:read</group>
             <group>shop:payment:read</group>
             <group>shop:payment_method:read</group>

--- a/tests/Api/DataFixtures/ORM/cart.yaml
+++ b/tests/Api/DataFixtures/ORM/cart.yaml
@@ -63,7 +63,7 @@ Sylius\Component\Product\Model\ProductVariantTranslation:
 Sylius\Component\Core\Model\ChannelPricing:
     channel_pricing_product_variant_mug_blue_web:
         channelCode: 'WEB'
-        price: 20
+        price: 2000
 
 Sylius\Component\Product\Model\ProductOption:
     product_option_color:

--- a/tests/Api/Responses/Expected/shop/get_order_response.json
+++ b/tests/Api/Responses/Expected/shop/get_order_response.json
@@ -1,0 +1,39 @@
+{
+    "@context": "\/api\/v2\/contexts\/Order",
+    "@id": "\/api\/v2\/shop\/orders\/nAWw2jewpA",
+    "@type": "Order",
+    "payments": [
+        {
+            "@id": "\/api\/v2\/shop\/payments\/@integer@",
+            "@type": "Payment",
+            "id": @integer@,
+            "method": "\/api\/v2\/shop\/payment-methods\/CASH_ON_DELIVERY"
+        }
+    ],
+    "shipments": [],
+    "currencyCode": "USD",
+    "localeCode": "en_US",
+    "checkoutState": "cart",
+    "paymentState": "cart",
+    "shippingState": "cart",
+    "tokenValue": "nAWw2jewpA",
+    "id": @integer@,
+    "items": [
+        {
+            "@id": "\/api\/v2\/shop\/order-items\/@integer@",
+            "@type": "OrderItem",
+            "variant": "\/api\/v2\/shop\/product-variants\/MUG_BLUE",
+            "productName": "Mug",
+            "id": @integer@,
+            "quantity": 3,
+            "unitPrice": 2000,
+            "total": 6000,
+            "subtotal": 6000
+        }
+    ],
+    "itemsTotal": 6000,
+    "total": 6000,
+    "taxTotal": 0,
+    "shippingTotal": 0,
+    "orderPromotionTotal": 0
+}

--- a/tests/Api/Shop/OrdersTest.php
+++ b/tests/Api/Shop/OrdersTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Tests\Api\Shop;
+
+use Sylius\Bundle\ApiBundle\Command\Cart\AddItemToCart;
+use Sylius\Bundle\ApiBundle\Command\Cart\PickupCart;
+use Sylius\Tests\Api\JsonApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class OrdersTest extends JsonApiTestCase
+{
+    /** @test */
+    public function it_gets_an_order(): void
+    {
+        $this->loadFixturesFromFiles(['cart.yaml', 'payment_method.yaml']);
+
+        $tokenValue = 'nAWw2jewpA';
+
+        /** @var MessageBusInterface $commandBus */
+        $commandBus = $this->get('sylius.command_bus');
+
+        $pickupCartCommand = new PickupCart($tokenValue, 'en_US');
+        $pickupCartCommand->setChannelCode('WEB');
+        $commandBus->dispatch($pickupCartCommand);
+
+        $addItemToCartCommand = new AddItemToCart('MUG_BLUE', 3);
+        $addItemToCartCommand->setOrderTokenValue($tokenValue);
+        $commandBus->dispatch($addItemToCartCommand);
+
+        $this->client->request('GET', '/api/v2/shop/orders/nAWw2jewpA', [], [], self::CONTENT_TYPE_HEADER);
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'shop/get_order_response', Response::HTTP_OK);
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | replaces https://github.com/Sylius/Sylius/pull/12723
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
