### PR TITLE
Replace placehold.it with via.placeholder.com

### DIFF
--- a/src/Sylius/Behat/Element/Admin/TopBarElement.php
+++ b/src/Sylius/Behat/Element/Admin/TopBarElement.php
@@ -24,7 +24,7 @@ final class TopBarElement extends Element implements TopBarElementInterface
 
     public function hasDefaultAvatarInMainBar(): bool
     {
-        return strpos($this->getAvatarImagePath(), '//placehold.it/50x50') !== false;
+        return strpos($this->getAvatarImagePath(), '//via.placeholder.com/50') !== false;
     }
 
     private function getAvatarImagePath(): string

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/AdminUser/_avatarImage.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/AdminUser/_avatarImage.html.twig
@@ -1,7 +1,7 @@
 {% if app.user.avatar is not empty and app.user.avatar.path is not empty %}
     {% set path = app.user.avatar.path|imagine_filter('sylius_admin_admin_user_avatar_thumbnail') %}
 {% else %}
-    {% set path = '//placehold.it/50x50' %}
+    {% set path = '//via.placeholder.com/50' %}
 {% endif %}
 
 <img style="margin-right: 10px;" class="ui avatar image" src="{{ path }}">

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_mainImage.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_mainImage.html.twig
@@ -3,7 +3,7 @@
 {% elseif product.images.first %}
     {% set path = product.images.first.path|imagine_filter(filter|default('sylius_admin_product_thumbnail')) %}
 {% else %}
-    {% set path = '//placehold.it/200x200' %}
+    {% set path = '//via.placeholder.com/200' %}
 {% endif %}
 
 <img src="{{ path }}" alt="{{ product.name }}" class="ui bordered image" />

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_media.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/Show/_media.html.twig
@@ -7,7 +7,7 @@
         {% if product.images|length >= 1 %}
             <div class="ui small images">
                 {% for image in product.images %}
-                    {% set path = image.path is not null ? image.path|imagine_filter('sylius_admin_product_small_thumbnail') : '//placehold.it/200x200' %}
+                    {% set path = image.path is not null ? image.path|imagine_filter('sylius_admin_product_small_thumbnail') : '//via.placeholder.com/200' %}
                     <div class="ui image">
                         {% if product.isConfigurable() and product.variants|length > 0 %}
                             {% include '@SyliusAdmin/Product/Show/_imageVariants.html.twig' %}

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_mainImage.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Product/_mainImage.html.twig
@@ -3,7 +3,7 @@
 {% elseif product.images.first %}
     {% set path = product.images.first.path|imagine_filter(filter|default('sylius_admin_product_thumbnail')) %}
 {% else %}
-    {% set path = '//placehold.it/50x50' %}
+    {% set path = '//via.placeholder.com/50' %}
 {% endif %}
 
 <img src="{{ path }}" alt="" class="ui bordered image sylius-grid-image" />

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_images.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_images.html.twig
@@ -7,7 +7,7 @@
     {% set original_path = source_path|imagine_filter('sylius_shop_product_original') %}
     {% set path = source_path|imagine_filter(filter|default('sylius_shop_product_large_thumbnail')) %}
 {% else %}
-    {% set original_path = '//placehold.it/400x300' %}
+    {% set original_path = '//via.placeholder.com/400x300' %}
     {% set path = original_path %}
 {% endif %}
 
@@ -22,7 +22,7 @@
 
 <div class="ui small images">
     {% for image in product.images %}
-    {% set path = image.path is not null ? image.path|imagine_filter('sylius_shop_product_small_thumbnail') : '//placehold.it/200x200' %}
+    {% set path = image.path is not null ? image.path|imagine_filter('sylius_shop_product_small_thumbnail') : '//via.placeholder.com/200' %}
     <div class="ui image">
     {% if product.isConfigurable() and product.enabledVariants|length > 0 %}
         {% include '@SyliusShop/Product/Show/_imageVariants.html.twig' %}

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/_mainImage.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/_mainImage.html.twig
@@ -3,7 +3,7 @@
 {% elseif product.images.first %}
     {% set path = product.images.first.path|imagine_filter(filter|default('sylius_shop_product_thumbnail')) %}
 {% else %}
-    {% set path = '//placehold.it/200x200' %}
+    {% set path = '//via.placeholder.com/200' %}
 {% endif %}
 
 <img src="{{ path }}" {{ sylius_test_html_attribute('main-image') }} alt="{{ product.name }}" class="ui bordered image" />


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | fixes #12754 
| License         | MIT

Replace `placehold.it` with `via.placeholder.com`. Also, when a square image is requested the second dimension can be omitted. 
