### PR TITLE
Fix typo in the order state machine's callback

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order.yml
@@ -78,7 +78,7 @@ winzou_state_machine:
                     on: ["cancel"]
                     do: ["@sm.callback.cascade_transition", "apply"]
                     args: ["object", "event", "'cancel'", "'sylius_order_shipping'"]
-                sylis_cancel_order:
+                sylius_cancel_order:
                     on: ["cancel"]
                     do: ["@sylius.inventory.order_inventory_operator", "cancel"]
                     args: ["object"]


### PR DESCRIPTION
fix typo ~~sylis_cancel_order~~ => **sylius_cancel_order**
This does not seem to be referenced anywhere so this should not break anything.

| Q               | A
| --------------- | -----
| Branch?         | master 
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

