### PR TITLE
[Documentation] One more fix for warning about version of Sylius in Plus installation guide

### DIFF
--- a/docs/book/installation/sylius_plus_installation.rst
+++ b/docs/book/installation/sylius_plus_installation.rst
@@ -70,11 +70,11 @@ Installing Sylius Plus as a plugin to a Sylius application
     Recommended Sylius version to use with Sylius Plus is 1.10. If, for any reason, you need to use Sylius 1.9, it's required
     to customise some API configurations. Run the following commands, to do it:
 
-.. code-block:: bash
+    .. code-block:: bash
 
-    rm vendor/sylius/plus/src/Resources/config/api_resources/Shipment.xml
-    mkdir config/api_platform/
-    cp -R vendor/sylius/plus/etc/sylius-1.9/Resources/config/api_resources/* config/api_platform/
+        rm vendor/sylius/plus/src/Resources/config/api_resources/Shipment.xml
+        mkdir config/api_platform/
+        cp -R vendor/sylius/plus/etc/sylius-1.9/Resources/config/api_resources/* config/api_platform/
 
 **5.** Configure Shop, Admin and Admin API routing:
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | after #12767 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
