### PR TITLE
[API][FIX] Remove code attribute of OrderItem in API serialization

### DIFF
--- a/UPGRADE-1.11.md
+++ b/UPGRADE-1.11.md
@@ -5,6 +5,9 @@
 `Sylius\Component\Channel\Context\RequestBased\HostnameBasedRequestResolver::findChannel` will start selecting only a channel from a range
 of enabled channels.
 
+2. The `code` field was removed from OrderItem serialization (in `src/Sylius/Bundle/ApiBundle/Resources/config/serialization/OrderItem.xml`)
+as such field does not exist. Please, add it in your code base if you need it.
+
 # UPGRADE FROM `v1.11.2` TO `v1.11.3`
 
 1. Order Processors' priorities have changed and `sylius.order_processing.order_prices_recalculator` has now a higher priority than `sylius.order_processing.order_shipment_processor`.

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/OrderItem.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/OrderItem.xml
@@ -23,11 +23,6 @@
             <group>shop:order:account:read</group>
             <group>shop:order_item:read</group>
         </attribute>
-        <attribute name="code">
-            <group>admin:order:read</group>
-            <group>admin:order_item:read</group>
-            <group>shop:order_item:read</group>
-        </attribute>
         <attribute name="order">
             <group>admin:order_item:read</group>
             <group>shop:order_item:read</group>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | 
| License         | MIT

OrderItem has no attribut `code` but this attribute is in Serialisation configuration.
This throw an error when we Normalize Object.