### PR TITLE
Add "enabled" property to API serialization

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Product.xml
@@ -88,5 +88,10 @@
         <attribute name="associations">
             <group>shop:product:read</group>
         </attribute>
+        <attribute name="enabled">
+            <group>admin:product:create</group>
+            <group>admin:product:read</group>
+            <group>admin:product:update</group>
+        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductImage.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" ?>
 
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
 <serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTaxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTaxon.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" ?>
 
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
 <serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductTranslation.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" ?>
 
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
 <serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
@@ -41,5 +41,10 @@
         <attribute name="name">
             <group>shop:product_variant:read</group>
         </attribute>
+        <attribute name="enabled">
+            <group>admin:product_variant:read</group>
+            <group>admin:product_variant:create</group>
+            <group>admin:product_variant:update</group>
+        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariantTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariantTranslation.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" ?>
 
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
 <serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Promotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Promotion.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" ?>
 
 <!--
+
  This file is part of the Sylius package.
+
  (c) Paweł Jędrzejewski
+
  For the full copyright and license information, please view the LICENSE
  file that was distributed with this source code.
+
 -->
 
 <serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Taxon.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" ?>
 
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
 <serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Taxon.xml
@@ -31,5 +31,10 @@
             <group>admin:taxon:read</group>
             <group>shop:taxon:read</group>
         </attribute>
+        <attribute name="enabled">
+            <group>admin:taxon:read</group>
+            <group>admin:taxon:create</group>
+            <group>admin:taxon:update</group>
+        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/TaxonTranslation.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" ?>
 
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
 <serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"

--- a/tests/Api/Admin/ProductVariantsTest.php
+++ b/tests/Api/Admin/ProductVariantsTest.php
@@ -102,7 +102,7 @@ final class ProductVariantsTest extends JsonApiTestCase
     }
 
     /** @test */
-    public function it_creates_product_variant(): void
+    public function it_creates_product_variant_enabled_by_default(): void
     {
         $fixtures = $this->loadFixturesFromFiles(['channel.yaml', 'product/product_variant.yaml', 'authentication/api_administrator.yaml']);
         $header = array_merge($this->logInAdminUser('api@example.com'), self::CONTENT_TYPE_HEADER);
@@ -123,13 +123,47 @@ final class ProductVariantsTest extends JsonApiTestCase
                     'price' => 4000,
                     'originalPrice' => 5000,
                     'minimumPrice' => 2000,
-                ]]
+                ]],
             ], JSON_THROW_ON_ERROR),
         );
 
         $this->assertResponse(
             $this->client->getResponse(),
             'admin/product_variant/post_product_variant_response',
+            Response::HTTP_CREATED,
+        );
+    }
+
+    /** @test */
+    public function it_creates_disabled_product_variant(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['channel.yaml', 'product/product_variant.yaml', 'authentication/api_administrator.yaml']);
+        $header = array_merge($this->logInAdminUser('api@example.com'), self::CONTENT_TYPE_HEADER);
+
+        /** @var ProductInterface $product */
+        $product = $fixtures['product'];
+
+        $this->client->request(
+            method: 'POST',
+            uri: '/api/v2/admin/product-variants',
+            server: $header,
+            content: json_encode([
+                'code' => 'MUG_2',
+                'position' => 1,
+                'product' => sprintf('/api/v2/admin/products/%s', $product->getCode()),
+                'channelPricings' => ['WEB' => [
+                    'channelCode' => 'WEB',
+                    'price' => 4000,
+                    'originalPrice' => 5000,
+                    'minimumPrice' => 2000,
+                ]],
+                'enabled' => false,
+            ], JSON_THROW_ON_ERROR),
+        );
+
+        $this->assertResponse(
+            $this->client->getResponse(),
+            'admin/product_variant/post_product_variant_disabled_response',
             Response::HTTP_CREATED,
         );
     }

--- a/tests/Api/Responses/Expected/admin/get_product_response.json
+++ b/tests/Api/Responses/Expected/admin/get_product_response.json
@@ -17,6 +17,7 @@
     ],
     "createdAt": @date@,
     "updatedAt": @date@,
+    "enabled": true,
     "translations": {
         "en_US": {
             "@id": "\/api\/v2\/admin\/product-translations\/@integer@",

--- a/tests/Api/Responses/Expected/admin/get_products_collection_response.json
+++ b/tests/Api/Responses/Expected/admin/get_products_collection_response.json
@@ -21,6 +21,7 @@
             ],
             "createdAt": @date@,
             "updatedAt": @date@,
+            "enabled": true,
             "translations": {
                 "en_US": {
                     "@id": "\/api\/v2\/admin\/product-translations\/@integer@",

--- a/tests/Api/Responses/Expected/admin/product_variant/get_product_variant_response.json
+++ b/tests/Api/Responses/Expected/admin/product_variant/get_product_variant_response.json
@@ -24,5 +24,6 @@
             "name":"Mug",
             "locale":"en_US"
         }
-    }
+    },
+    "enabled": true
 }

--- a/tests/Api/Responses/Expected/admin/product_variant/get_product_variants_response.json
+++ b/tests/Api/Responses/Expected/admin/product_variant/get_product_variants_response.json
@@ -20,6 +20,7 @@
                 }
             },
             "optionValues": [],
+            "enabled": true,
             "translations": {
                 "en_US": {
                     "@id": "\/api\/v2\/admin\/product-variant-translation\/@integer@",

--- a/tests/Api/Responses/Expected/admin/product_variant/post_product_variant_disabled_response.json
+++ b/tests/Api/Responses/Expected/admin/product_variant/post_product_variant_disabled_response.json
@@ -14,5 +14,5 @@
             "minimumPrice": 2000
         }
     },
-    "enabled": true
+    "enabled": false
 }

--- a/tests/Api/Responses/Expected/admin/product_variant/put_product_variant_response.json
+++ b/tests/Api/Responses/Expected/admin/product_variant/put_product_variant_response.json
@@ -16,6 +16,7 @@
         }
     },
     "optionValues":[],
+    "enabled": true,
     "translations": {
         "en_US": {
             "@id":"\/api\/v2\/admin\/product-variant-translation\/@integer@",

--- a/tests/Api/Responses/Expected/admin/taxon/get_taxon_response.json
+++ b/tests/Api/Responses/Expected/admin/taxon/get_taxon_response.json
@@ -19,5 +19,6 @@
         "\/api\/v2\/admin\/taxons\/MUG",
         "\/api\/v2\/admin\/taxons\/HAT",
         "\/api\/v2\/admin\/taxons\/T_SHIRTS"
-    ]
+    ],
+    "enabled": true
 }

--- a/tests/Api/Responses/Expected/admin/taxon/get_taxons_response.json
+++ b/tests/Api/Responses/Expected/admin/taxon/get_taxons_response.json
@@ -23,7 +23,8 @@
                 "\/api\/v2\/admin\/taxons\/MUG",
                 "\/api\/v2\/admin\/taxons\/HAT",
                 "\/api\/v2\/admin\/taxons\/T_SHIRTS"
-            ]
+            ],
+            "enabled": true
         },
         {
             "@id": "\/api\/v2\/admin\/taxons\/MUG",
@@ -50,7 +51,8 @@
                     "locale": "de_DE"
                 }
             },
-            "children": []
+            "children": [],
+            "enabled": true
         },
         {
             "@id": "\/api\/v2\/admin\/taxons\/HAT",
@@ -77,7 +79,8 @@
                     "locale": "de_DE"
                 }
             },
-            "children": []
+            "children": [],
+            "enabled": true
         },
         {
             "@id": "\/api\/v2\/admin\/taxons\/T_SHIRTS",
@@ -107,7 +110,8 @@
             "children": [
                 "\/api\/v2\/admin\/taxons\/MEN_T_SHIRTS",
                 "\/api\/v2\/admin\/taxons\/WOMEN_T_SHIRTS"
-            ]
+            ],
+            "enabled": true
         },
         {
             "@id": "\/api\/v2\/admin\/taxons\/MEN_T_SHIRTS",
@@ -134,7 +138,8 @@
                     "locale": "de_DE"
                 }
             },
-            "children": []
+            "children": [],
+            "enabled": true
         },
         {
             "@id": "\/api\/v2\/admin\/taxons\/WOMEN_T_SHIRTS",
@@ -161,7 +166,8 @@
                     "locale": "de_DE"
                 }
             },
-            "children": []
+            "children": [],
+            "enabled": true
         },
         {
             "@id": "\/api\/v2\/admin\/taxons\/BRAND",
@@ -188,7 +194,8 @@
                     "locale": "de_DE"
                 }
             },
-            "children": []
+            "children": [],
+            "enabled": true
         },
         {
             "@id": "\/api\/v2\/admin\/taxons\/de%3Flol=xd%23boom",
@@ -206,7 +213,8 @@
                     "locale": "en_US"
                 }
             },
-            "children": []
+            "children": [],
+            "enabled": true
         }
     ],
     "hydra:totalItems": 8

--- a/tests/Api/Responses/Expected/admin/taxon/post_taxon_response.json
+++ b/tests/Api/Responses/Expected/admin/taxon/post_taxon_response.json
@@ -15,5 +15,6 @@
             "description": null,
             "locale": "en_US"
         }
-    }
+    },
+    "enabled": true
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

This is a suggestion/feature. But it really makes sense to expose if an item is enabled or not in admin serialization, it's actually a piece of super-critical information for admin data results.

Sorry for the noise of fixing also copyright but my brain was not happy it was not heterogeneous. x) It's split into 2 proper commits if you want to review with ease.

Happy coding guys.
