### PR TITLE
[WIP][PoC][API] Liip imagine image handling

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Applicator/ProductImageFilterController.php
+++ b/src/Sylius/Bundle/ApiBundle/Applicator/ProductImageFilterController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Applicator;
+
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Sylius\Component\Core\Model\ProductImage;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+
+/** @experimental */
+final class ProductImageFilterController
+{
+    private CacheManager $cache;
+    private RequestStack $requestStack;
+
+    public function __construct(CacheManager $cache, RequestStack $requestStack)
+    {
+        $this->cache = $cache;
+        $this->requestStack = $requestStack;
+    }
+
+    public function __invoke(ProductImage $data): Response
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        $path = $this->cache->getBrowserPath(parse_url($data->getPath(), PHP_URL_PATH), $request->query->get('filter'));
+
+        return new RedirectResponse($path);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Filter/ImageFilters.php
+++ b/src/Sylius/Bundle/ApiBundle/Filter/ImageFilters.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace Sylius\Bundle\ApiBundle\Filter;
+
+
+class ImageFilters
+{
+    /** @var array */
+    private $filters;
+
+    public function __construct($filters)
+    {
+        $this->filters = $filters;
+    }
+
+    public function getFilters(): array
+    {
+        return $this->filters;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Provider/LiipProductImageFilterProvider.php
+++ b/src/Sylius/Bundle/ApiBundle/Provider/LiipProductImageFilterProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Provider;
+
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+/** @experimental */
+class LiipProductImageFilterProvider implements ProductImageFilterProviderInterface
+{
+    use ContainerAwareTrait;
+
+    public function provide(): array
+    {
+        return $this->container->getParameter('liip_imagine.filter_sets');
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Provider/ProductImageFilterProviderInterface.php
+++ b/src/Sylius/Bundle/ApiBundle/Provider/ProductImageFilterProviderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Provider;
+
+/** @experimental */
+interface ProductImageFilterProviderInterface
+{
+    public function provide(): array;
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductImage.xml
@@ -33,20 +33,17 @@
                 </attribute>
                 <attribute name="controller">sylius.api.product_image</attribute>
                 <attribute name="openapi_context">
-                    <attribute name="parameters">
-                        <attribute>
-                            <attribute name="name">filter</attribute>
-                            <attribute name="in">query</attribute>
-                            <attribute name="description">Provide one of supported image liip imagine filters. </attribute>
-                            <attribute name="schema">
-                                <attribute name="type">string</attribute>
-                                <attribute name="enum">
-                                    <attribute>sylius_shop_product_thumbnail</attribute>
-                                    <attribute>sylius_shop_product_large_thumbnail</attribute>
-                                </attribute>
-                            </attribute>
+                <attribute name="parameters">
+                    <attribute>
+                        <attribute name="name">filter</attribute>
+                        <attribute name="in">query</attribute>
+                        <attribute name="description">Provide one of supported image liip imagine filters. </attribute>
+                        <attribute name="schema">
+                            <attribute name="type">string</attribute>
+                            <attribute name="enum" />
                         </attribute>
                     </attribute>
+                </attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductImage.xml
@@ -31,6 +31,23 @@
                 <attribute name="normalization_context">
                     <attribute name="groups">shop:product_image:read</attribute>
                 </attribute>
+                <attribute name="controller">sylius.api.product_image</attribute>
+                <attribute name="openapi_context">
+                    <attribute name="parameters">
+                        <attribute>
+                            <attribute name="name">filter</attribute>
+                            <attribute name="in">query</attribute>
+                            <attribute name="description">Provide one of supported image liip imagine filters. </attribute>
+                            <attribute name="schema">
+                                <attribute name="type">string</attribute>
+                                <attribute name="enum">
+                                    <attribute>sylius_shop_product_thumbnail</attribute>
+                                    <attribute>sylius_shop_product_large_thumbnail</attribute>
+                                </attribute>
+                            </attribute>
+                        </attribute>
+                    </attribute>
+                </attribute>
             </itemOperation>
         </itemOperations>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
@@ -40,3 +40,9 @@ lexik_jwt_authentication:
             prefix: Bearer
             name: "%sylius.api.authorization_header%"
 
+liip_imagine:
+    filter_sets:
+        sylius_api_product_original: ~
+        sylius_api_product_thumbnail:
+            filters:
+                thumbnail: { size: [260, 260], mode: outbound }

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/applicators.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/applicators.xml
@@ -20,6 +20,11 @@
             <argument type="service" id="sylius.calendar" />
         </service>
 
+        <service id="sylius.api.product_image" class="Sylius\Bundle\ApiBundle\Applicator\ProductImageFilterController" public="true">
+            <argument type="service" id="liip_imagine.cache.manager" />
+            <argument type="service" id="request_stack" />
+        </service>
+
         <service id="sylius.api.order_state_machine_transition_applicator" class="Sylius\Bundle\ApiBundle\Applicator\OrderStateMachineTransitionApplicator" public="true">
             <argument id="sm.factory" type="service" />
         </service>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/providers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/providers.xml
@@ -26,5 +26,11 @@
             <argument type="service" id="sylius.api.context.user" />
             <argument>%sylius.security.new_api_route%</argument>
         </service>
+
+        <service id="Sylius\Bundle\ApiBundle\Provider\ProductImageFilterProviderInterface" class="Sylius\Bundle\ApiBundle\Provider\LiipProductImageFilterProvider">
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/swagger.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/swagger.xml
@@ -52,6 +52,18 @@
         </service>
 
         <service
+            id="sylius.api.swagger_product_image_documentation_normalizer"
+            class="Sylius\Bundle\ApiBundle\Swagger\ProductImageDocumentationNormalizer"
+            decorates="api_platform.swagger.normalizer.documentation"
+            public="true"
+            autoconfigure="false"
+            decoration-priority="20"
+        >
+            <argument type="service" id="sylius.api.swagger_product_image_documentation_normalizer.inner" />
+            <argument type="service" id="Sylius\Bundle\ApiBundle\Provider\ProductImageFilterProviderInterface" />
+        </service>
+
+        <service
             id="sylius.api.swagger_product_variant_documentation_normalizer"
             class="Sylius\Bundle\ApiBundle\Swagger\ProductVariantDocumentationNormalizer"
             decorates="api_platform.swagger.normalizer.documentation"

--- a/src/Sylius/Bundle/ApiBundle/Swagger/ProductImageDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/ProductImageDocumentationNormalizer.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Swagger;
+
+use Sylius\Bundle\ApiBundle\Provider\ProductImageFilterProviderInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/** @experimental */
+class ProductImageDocumentationNormalizer implements NormalizerInterface
+{
+    /** @var NormalizerInterface */
+    private $decoratedNormalizer;
+
+    /** @var ProductImageFilterProviderInterface */
+    private $filterProvider;
+
+    public function __construct(NormalizerInterface $decoratedNormalizer, ProductImageFilterProviderInterface $filterProvider)
+    {
+        $this->decoratedNormalizer = $decoratedNormalizer;
+        $this->filterProvider = $filterProvider;
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        return $this->decoratedNormalizer->supportsNormalization($data, $format);
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $docs = $this->decoratedNormalizer->normalize($object, $format, $context);
+
+        $enums = $this->filterProvider->provide();
+        $enums = array_keys($enums);
+
+        $params = $docs['paths']['/api/v2/shop/product-images/{id}']['get']['parameters'];
+
+        foreach ($params as $index => $param) {
+            if ($param['in'] === 'query') {
+                if (is_string($param['schema']['enum']) || $param['schema']['enum'] === null) {
+                    $docs['paths']['/api/v2/shop/product-images/{id}']['get']['parameters'][$index]['schema']['enum'] = $enums;
+                    break;
+                }
+
+                $docs['paths']['/api/v2/shop/product-images/{id}']['get']['parameters'][$index]['schema']['enum'] = array_merge($param['schema']['enum'], $enums);
+            }
+        }
+
+        return $docs;
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

A sample implementation of liip imagines handling. Each product image may be requested with additional filter query parameters and in return, a 302 redirect to the image on the server will be returned. It will leave up to the frontend developer to crop it on their own in the frontend or use one of backend prepared cached images: 
![image](https://user-images.githubusercontent.com/6213903/125636145-b6014191-4698-451a-ae9a-2433e5d00499.png)

Enum value should be propagated automatically from the liip config.


<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
