### PR TITLE
Enable API by default in dev environment

### DIFF
--- a/config/packages/dev/_sylius.yaml
+++ b/config/packages/dev/_sylius.yaml
@@ -1,0 +1,2 @@
+sylius_api:
+    enabled: true


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

I believe it would be useful for the development 🖖 Without it if I want to change something in the API I need to change the parameter and pray to not forget to remove it before committing 🙏 🎉 