### PR TITLE
Optimizing the attribute loading in product edit

### DIFF
--- a/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeChoiceType.php
+++ b/src/Sylius/Bundle/AttributeBundle/Form/Type/AttributeChoiceType.php
@@ -42,9 +42,7 @@ abstract class AttributeChoiceType extends AbstractType
     {
         $resolver
             ->setDefaults([
-                'choices' => function (Options $options) {
-                    return $this->attributeRepository->findAll();
-                },
+                'choices' => $this->attributeRepository->findAll(),
                 'choice_value' => 'code',
                 'choice_label' => 'name',
                 'choice_translation_domain' => false,


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | no (but performance improvement)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

## Before
We currently have about 110 attributes in our shop and opening up the product edit page takes quite a long time. (In dev without any caches, about 8 seconds). This is also due to a ton of queries running the in the background: 
![image](https://user-images.githubusercontent.com/14860264/125856748-e8a13533-db7d-494d-b103-4445ed0dfdd0.png)
![image](https://user-images.githubusercontent.com/14860264/125856533-d54325d8-0b5f-4fa1-9301-5a1ba4d9a846.png)
1719 queries to show a product edit page.

## After
After applying the fix this only causes the count to drop to about half of it:
![image](https://user-images.githubusercontent.com/14860264/125856917-7dd9a737-ad38-4f9e-ad6e-638e66199d6c.png)
![image](https://user-images.githubusercontent.com/14860264/125856957-62aa8cd0-1a54-46e0-9206-d42cf4bc2d48.png)
The reduction of computing time is mostly thanks to the fact that there are fewer entities to hydrate.

## Why
I don't see that this is causing any issues. The file was[ created when migrating to the newer version of Symfony forms](https://github.com/mamazu/Sylius/commit/c139f5a9cb507bb3a01538a4991f648d52f30b6b) and maybe the 'choices' and 'choice-loader' options were swapped and it happened by accident. So this would probably speed up the attribute loading for everyone.
