### PR TITLE
build: update ramsey/uuid version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "payum/payum-bundle": "^2.4",
         "php-http/guzzle6-adapter": "^2.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
-        "ramsey/uuid": "^3.9",
+        "ramsey/uuid": "^3.9 || ^4.0",
         "sonata-project/block-bundle": "^4.2",
         "stof/doctrine-extensions-bundle": "^1.4",
         "swiftmailer/swiftmailer": "^6.2",


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

ramsey/uuid 4.0 was released months ago. It may be time to have it as an allowed dependency.