### PR TITLE
Avoid cancellation exception during sylius:cancel-unpaid-orders

### DIFF
--- a/src/Sylius/Component/Core/Inventory/Operator/OrderInventoryOperator.php
+++ b/src/Sylius/Component/Core/Inventory/Operator/OrderInventoryOperator.php
@@ -63,8 +63,10 @@ final class OrderInventoryOperator implements OrderInventoryOperatorInterface
                 ($variant->getOnHold() - $orderItem->getQuantity()),
                 0,
                 sprintf(
-                    'Not enough units to decrease on hold quantity from the inventory of a variant "%s".',
-                    $variant->getName()
+                    'Not enough units to decrease on hold quantity from the inventory of a variant "%s" (ID: "%d") on order item "%d".',
+                    $variant->getName(),
+                    $variant->getId(),
+                    $orderItem->getId() 
                 )
             );
 
@@ -72,8 +74,10 @@ final class OrderInventoryOperator implements OrderInventoryOperatorInterface
                 ($variant->getOnHand() - $orderItem->getQuantity()),
                 0,
                 sprintf(
-                    'Not enough units to decrease on hand quantity from the inventory of a variant "%s".',
-                    $variant->getName()
+                    'Not enough units to decrease on hand quantity from the inventory of a variant "%s" (ID: "%d") on order item "%d".',
+                    $variant->getName(),
+                    $variant->getId(),
+                    $orderItem->getId()
                 )
             );
 
@@ -99,8 +103,10 @@ final class OrderInventoryOperator implements OrderInventoryOperatorInterface
                 ($variant->getOnHold() - $orderItem->getQuantity()),
                 0,
                 sprintf(
-                    'Not enough units to decrease on hold quantity from the inventory of a variant "%s".',
-                    $variant->getName()
+                    'Not enough units to decrease on hold quantity from the inventory of a variant "%s" (ID: "%d") on order item "%d".',
+                    $variant->getName(),
+                    $variant->getId(),
+                    $orderItem->getId()
                 )
             );
 

--- a/src/Sylius/Component/Core/Updater/UnpaidOrdersStateUpdater.php
+++ b/src/Sylius/Component/Core/Updater/UnpaidOrdersStateUpdater.php
@@ -19,6 +19,7 @@ use SM\SMException;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Order\OrderTransitions;
+use Webmozart\Assert\InvalidArgumentException;
 
 final class UnpaidOrdersStateUpdater implements UnpaidOrdersStateUpdaterInterface
 {
@@ -63,6 +64,13 @@ final class UnpaidOrdersStateUpdater implements UnpaidOrdersStateUpdaterInterfac
             try {
                 $this->cancelOrder($expiredUnpaidOrder);
             } catch (SMException $e) {
+                if (null !== $this->logger) {
+                    $this->logger->error(
+                        sprintf('An error occurred while cancelling unpaid order #%s', $expiredUnpaidOrder->getId()),
+                        ['exception' => $e, 'message' => $e->getMessage()]
+                    );
+                }
+            } catch (InvalidArgumentException $e) {
                 if (null !== $this->logger) {
                     $this->logger->error(
                         sprintf('An error occurred while cancelling unpaid order #%s', $expiredUnpaidOrder->getId()),


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | ^1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

We have some issue sometimes on cancel unpaid order cron.

```
CRITICAL
Message: 	

Error thrown while running command "sylius:cancel-unpaid-orders -e prod". Message: "Not enough units to decrease on hold quantity from the inventory of a variant ""."

Time: 	

2021-07-19T15:02:30.317737+00:00

Channel: 	

console

Context: 	
exception: 	

{
    "class": "Webmozart\\Assert\\InvalidArgumentException",
    "message": "Not enough units to decrease on hold quantity from the inventory of a variant \"\".",
    "code": 0,
    "file": "/var/www/sylius/vendor/webmozart/assert/src/Assert.php:2060",
    "trace": [
        "/var/www/sylius/vendor/webmozart/assert/src/Assert.php:876",
        "/var/www/sylius/vendor/sylius/sylius/src/Sylius/Component/Core/Inventory/Operator/OrderInventoryOperator.php:103",
        "/var/www/sylius/vendor/sylius/sylius/src/Sylius/Component/Core/Inventory/Operator/OrderInventoryOperator.php:35",
        "/var/www/sylius/vendor/sylius/sylius/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/Inventory/Operator/OrderInventoryOperator.php:46",
        "/var/www/sylius/vendor/winzou/state-machine/src/SM/Callback/Callback.php:75",
        "/var/www/sylius/vendor/winzou/state-machine-bundle/Callback/ContainerAwareCallback.php:48",
        "/var/www/sylius/vendor/winzou/state-machine/src/SM/Callback/Callback.php:84",
        "/var/www/sylius/vendor/winzou/state-machine/src/SM/StateMachine/StateMachine.php:231",
        "/var/www/sylius/vendor/winzou/state-machine/src/SM/StateMachine/StateMachine.php:145",
        "/var/www/sylius/vendor/sylius/sylius/src/Sylius/Component/Core/Updater/UnpaidOrdersStateUpdater.php:79",
        "/var/www/sylius/vendor/sylius/sylius/src/Sylius/Component/Core/Updater/UnpaidOrdersStateUpdater.php:64",
        "/var/www/sylius/vendor/sylius/sylius/src/Sylius/Bundle/CoreBundle/Command/CancelUnpaidOrdersCommand.php:44",
        "/var/www/sylius/vendor/symfony/console/Command/Command.php:255",
        "/var/www/sylius/vendor/symfony/console/Application.php:1027",
        "/var/www/sylius/vendor/symfony/framework-bundle/Console/Application.php:97",
        "/var/www/sylius/vendor/symfony/console/Application.php:273",
        "/var/www/sylius/vendor/symfony/framework-bundle/Console/Application.php:83",
        "/var/www/sylius/vendor/symfony/console/Application.php:149",
        "/var/www/sylius/bin/console:39"
    ]
}

command: 	

sylius:cancel-unpaid-orders -e prod

message: 	

Not enough units to decrease on hold quantity from the inventory of a variant "".
```
