### PR TITLE
[API] Allow creation of commands with no arguments with a default value

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Serializer/CommandDenormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/CommandDenormalizer.php
@@ -41,7 +41,7 @@ final class CommandDenormalizer implements ContextAwareDenormalizerInterface
 
         $missingFields = [];
         foreach ($parameters as $parameter) {
-            if (!isset($data[$parameter->getName()]) && !$parameter->allowsNull()) {
+            if (!isset($data[$parameter->getName()]) && !($parameter->allowsNull() || $parameter->isDefaultValueAvailable())) {
                 $missingFields[] = $parameter->getName();
             }
         }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #12811
| License         | MIT

Fixes tests on 1.10 and master branches, where we test [RegisterShopUser](https://github.com/Sylius/Sylius/blob/1.10/src/Sylius/Bundle/ApiBundle/Command/RegisterShopUser.php#L69) that has new not nullable argument with a default value.

Failing test: https://github.com/Sylius/Sylius/runs/3122767036?check_suite_focus=true#step:18:75