### PR TITLE
[API] Do not check command arguments if there is an object to populate

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Serializer/CommandDenormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/CommandDenormalizer.php
@@ -22,6 +22,8 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
  */
 final class CommandDenormalizer implements ContextAwareDenormalizerInterface
 {
+    private const OBJECT_TO_POPULATE = 'object_to_populate';
+
     /** @var DenormalizerInterface */
     private $itemNormalizer;
 
@@ -37,6 +39,10 @@ final class CommandDenormalizer implements ContextAwareDenormalizerInterface
 
     public function denormalize($data, $type, $format = null, array $context = [])
     {
+        if (isset($context[self::OBJECT_TO_POPULATE])) {
+            return $this->itemNormalizer->denormalize($data, $type, $format, $context);
+        }
+
         $parameters = (new \ReflectionClass($context['input']['class']))->getConstructor()->getParameters();
 
         $missingFields = [];

--- a/src/Sylius/Bundle/ApiBundle/Serializer/CommandNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/CommandNormalizer.php
@@ -38,7 +38,11 @@ final class CommandNormalizer implements ContextAwareNormalizerInterface
             return false;
         }
 
-        return method_exists($data, 'getClass') && $data->getClass() === MissingConstructorArgumentsException::class;
+        return
+            is_object($data) &&
+            method_exists($data, 'getClass') &&
+            $data->getClass() === MissingConstructorArgumentsException::class
+        ;
     }
 
     public function normalize($object, $format = null, array $context = [])

--- a/src/Sylius/Bundle/ApiBundle/Tests/ApiPlatform/Bridge/Symfony/Routing/CachedRouteNameResolverTest.php
+++ b/src/Sylius/Bundle/ApiBundle/Tests/ApiPlatform/Bridge/Symfony/Routing/CachedRouteNameResolverTest.php
@@ -18,11 +18,11 @@ use ApiPlatform\Core\Bridge\Symfony\Routing\RouteNameResolverInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Psr\Cache\CacheException;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Sylius\Bundle\ApiBundle\ApiPlatform\Bridge\Symfony\Routing\CachedRouteNameResolver;
 use Sylius\Bundle\ApiBundle\Provider\PathPrefixProviderInterface;
+use Symfony\Component\Cache\Exception\CacheException;
 
 final class CachedRouteNameResolverTest extends TestCase
 {
@@ -260,16 +260,11 @@ final class CachedRouteNameResolverTest extends TestCase
      */
     public function get_route_name_with_cache_item_throws_cache_exception(): void
     {
-        $cacheException = $this->prophesize(\Exception::class);
-        $cacheException->willImplement(CacheException::class);
-
         $cacheItemPool = $this->prophesize(CacheItemPoolInterface::class);
         $cacheItemPool
             ->getItem(Argument::type('string'))
             ->shouldBeCalledTimes(1)
-            ->willThrow(
-                $cacheException->reveal()
-            );
+            ->willThrow(new CacheException());
 
         $decorated = $this->prophesize(RouteNameResolverInterface::class);
         $decorated

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/CommandDenormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/CommandDenormalizerSpec.php
@@ -16,6 +16,7 @@ namespace spec\Sylius\Bundle\ApiBundle\Serializer;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\ApiBundle\Command\RegisterShopUser;
+use Sylius\Bundle\ApiBundle\Command\VerifyCustomerAccount;
 use Sylius\Component\Core\Model\Customer;
 use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
 use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
@@ -68,6 +69,36 @@ final class CommandDenormalizerSpec extends ObjectBehavior
             null,
             ['input' => ['class' => RegisterShopUser::class]]
         )->shouldReturn(['key' => 'value']);
+    }
+
+    function it_does_not_check_parameters_if_there_is_an_object_to_populate(
+        DenormalizerInterface $baseNormalizer
+    ): void {
+        $baseNormalizer
+            ->denormalize(
+                [],
+                Customer::class,
+                null,
+                [
+                    'input' => ['class' => VerifyCustomerAccount::class],
+                    'object_to_populate' => new VerifyCustomerAccount('TOKEN')
+                ]
+            )
+            ->willReturn(['key' => 'value'])
+        ;
+
+        $this
+            ->denormalize(
+                [],
+                Customer::class,
+                null,
+                [
+                    'input' => ['class' => VerifyCustomerAccount::class],
+                    'object_to_populate' => new VerifyCustomerAccount('TOKEN')
+                ]
+            )
+            ->shouldReturn(['key' => 'value'])
+        ;
     }
 
     function it_implements_context_aware_denormalizer_interface(): void

--- a/src/Sylius/Bundle/ApiBundle/test/config/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/test/config/config.yaml
@@ -79,4 +79,4 @@ sylius_resource:
 services:
     Sylius\Bundle\ApiBundle\Application\CommandHandler\FooHandler:
         tags:
-            - { name: messenger.message_handler, bus: sylius_default.bus }
+            - { name: messenger.message_handler, bus: sylius.command_bus }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #12811
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
