### PR TITLE
[API] Unification of filtration namespaces

### DIFF
--- a/UPGRADE-API-1.11.md
+++ b/UPGRADE-API-1.11.md
@@ -1,5 +1,7 @@
 # UPGRADE FROM `v1.10.X` TO `v1.11.0`
 
+1. `Sylius\Bundle\ApiBundle\Doctrine\Filters\ExchangeRateFilter` and `Sylius\Bundle\ApiBundle\Doctrine\Filters\TranslationOrderNameAndLocaleFilter` has been moved to `Sylius\Bundle\ApiBundle\Doctrine\Filter\ExchangeRateFilter` and `Sylius\Bundle\ApiBundle\Doctrine\Filter\TranslationOrderNameAndLocaleFilter` respectively.
+
 1. `Sylius\Bundle\ApiBundle\View\CartShippingMethodInterface` and `Sylius\Bundle\ApiBundle\View\CartShippingMethod` have been removed.
 
 1. `Sylius\Bundle\ApiBundle\View\Factory\CartShippingMethodFactoryInterface` and `Sylius\Bundle\ApiBundle\View\Factory\CartShippingMethodFactory` have been removed.

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/Filter/ExchangeRateFilter.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/Filter/ExchangeRateFilter.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ApiBundle\Doctrine\Filters;
+namespace Sylius\Bundle\ApiBundle\Doctrine\Filter;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractContextAwareFilter;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;

--- a/src/Sylius/Bundle/ApiBundle/Doctrine/Filter/TranslationOrderNameAndLocaleFilter.php
+++ b/src/Sylius/Bundle/ApiBundle/Doctrine/Filter/TranslationOrderNameAndLocaleFilter.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\ApiBundle\Doctrine\Filters;
+namespace Sylius\Bundle\ApiBundle\Doctrine\Filter;
 
 use ApiPlatform\Core\Bridge\Doctrine\Common\Filter\OrderFilterInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Filter\AbstractContextAwareFilter;

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/filters.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/filters.xml
@@ -97,12 +97,12 @@
             <tag name="api_platform.filter" />
         </service>
 
-        <service id="sylius.api.exchange_rate_filter" class="Sylius\Bundle\ApiBundle\Doctrine\Filters\ExchangeRateFilter">
+        <service id="sylius.api.exchange_rate_filter" class="Sylius\Bundle\ApiBundle\Doctrine\Filter\ExchangeRateFilter">
             <argument type="service" id="doctrine" />
             <tag name="api_platform.filter" />
         </service>
 
-        <service id="sylius.api.translation_order_name_and_locale_filter" class="Sylius\Bundle\ApiBundle\Doctrine\Filters\TranslationOrderNameAndLocaleFilter">
+        <service id="sylius.api.translation_order_name_and_locale_filter" class="Sylius\Bundle\ApiBundle\Doctrine\Filter\TranslationOrderNameAndLocaleFilter">
             <argument type="service" id="doctrine" />
             <tag name="api_platform.filter" />
         </service>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | 
| License         | MIT

All class folders are kept in the singular form. What is more, we already have one filter in the `Sylius\Bundle\ApiBundle\Doctrine\Filter` namespace

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
