### PR TITLE
[Docs] Webpack - Display logo on login page

### DIFF
--- a/docs/cookbook/frontend/webpack.rst
+++ b/docs/cookbook/frontend/webpack.rst
@@ -47,6 +47,13 @@ This is a simple guide on how to start using webpack in Sylius apps. Webpack fin
             <img src="{{ asset('build/admin/images/admin-logo.svg', 'admin') }}" class="ui fluid image">
         </div>
     </a>
+    // templates/bundles/SyliusAdminBundle/Security/_content.html.twig
+    {% include '@SyliusUi/Security/_login.html.twig'
+        with {
+            'action': path('sylius_admin_login_check'),
+            'paths': {'logo': asset('build/admin/images/logo.png', 'admin')}
+        }
+    %}
 
     // templates/bundles/SyliusShopBundle/_scripts.html.twig
     {{ encore_entry_script_tags('shop-entry', null, 'shop') }}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | N/A
| License         | MIT

Hello :wave:,

While following webpack tutorial, I noticed that there is no logo on Admin Login page. 
By overriding the template `Security/_content.html.twig`, we could change logo path to use one provided by webpack instead one build with gulp. 

I targetted 1.9 branch, tell me if I should change to master or 1.10. 

