### PR TITLE
[API] Add liip image filters to API

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Provider/LiipProductImageFilterProvider.php
+++ b/src/Sylius/Bundle/ApiBundle/Provider/LiipProductImageFilterProvider.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Provider;
+
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+/** @experimental */
+class LiipProductImageFilterProvider implements ProductImageFilterProviderInterface
+{
+    use ContainerAwareTrait;
+
+    public function provideAllFilters(): array
+    {
+        return $this->container->getParameter('liip_imagine.filter_sets');
+    }
+
+    public function provideShopFilters(): array
+    {
+        $filters = $this->container->getParameter('liip_imagine.filter_sets');
+
+        return $this->removeAdminFilters($filters);
+    }
+
+    private function removeAdminFilters(array $filters): array {
+        /** @var string $filter */
+        foreach ($filters as $key => $filter) {
+            if (str_contains($key, 'admin')) {
+                unset($filters[$key]);
+            }
+        }
+
+        return $filters;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Provider/LiipProductImageFilterProvider.php
+++ b/src/Sylius/Bundle/ApiBundle/Provider/LiipProductImageFilterProvider.php
@@ -18,16 +18,21 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 /** @experimental */
 class LiipProductImageFilterProvider implements ProductImageFilterProviderInterface
 {
-    use ContainerAwareTrait;
+    private array $filters;
+
+    public function __construct(array $filters)
+    {
+        $this->filters = $filters;
+    }
 
     public function provideAllFilters(): array
     {
-        return $this->container->getParameter('liip_imagine.filter_sets');
+        return $this->filters;
     }
 
     public function provideShopFilters(): array
     {
-        $filters = $this->container->getParameter('liip_imagine.filter_sets');
+        $filters = $this->provideAllFilters();
 
         return $this->removeAdminFilters($filters);
     }

--- a/src/Sylius/Bundle/ApiBundle/Provider/ProductImageFilterProviderInterface.php
+++ b/src/Sylius/Bundle/ApiBundle/Provider/ProductImageFilterProviderInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Provider;
+
+/** @experimental */
+interface ProductImageFilterProviderInterface
+{
+    public function provideAllFilters(): array;
+
+    public function provideShopFilters(): array;
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductImage.xml
@@ -31,6 +31,19 @@
                 <attribute name="normalization_context">
                     <attribute name="groups">shop:product_image:read</attribute>
                 </attribute>
+                <attribute name="openapi_context">
+                    <attribute name="parameters">
+                        <attribute>
+                            <attribute name="name">filter</attribute>
+                            <attribute name="in">query</attribute>
+                            <attribute name="description">Provide one of supported image liip imagine filters.</attribute>
+                            <attribute name="schema">
+                                <attribute name="type">string</attribute>
+                                <attribute name="enum" />
+                            </attribute>
+                        </attribute>
+                    </attribute>
+                </attribute>
             </itemOperation>
         </itemOperations>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/providers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/providers.xml
@@ -28,9 +28,7 @@
         </service>
 
         <service id="Sylius\Bundle\ApiBundle\Provider\ProductImageFilterProviderInterface" class="Sylius\Bundle\ApiBundle\Provider\LiipProductImageFilterProvider">
-            <call method="setContainer">
-                <argument type="service" id="service_container" />
-            </call>
+            <argument>%liip_imagine.filter_sets%</argument>
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/providers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/providers.xml
@@ -26,5 +26,11 @@
             <argument type="service" id="sylius.api.context.user" />
             <argument>%sylius.security.new_api_route%</argument>
         </service>
+
+        <service id="Sylius\Bundle\ApiBundle\Provider\ProductImageFilterProviderInterface" class="Sylius\Bundle\ApiBundle\Provider\LiipProductImageFilterProvider">
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/serializers.xml
@@ -37,6 +37,8 @@
         </service>
 
         <service id="Sylius\Bundle\ApiBundle\Serializer\ProductImageNormalizer">
+            <argument type="service" id="liip_imagine.cache.manager" />
+            <argument type="service" id="request_stack" />
             <argument type="string">%sylius_api.product_image_prefix%</argument>
             <tag name="serializer.normalizer" priority="64" />
         </service>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/swagger.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/swagger.xml
@@ -52,6 +52,18 @@
         </service>
 
         <service
+            id="sylius.api.swagger_product_image_documentation_normalizer"
+            class="Sylius\Bundle\ApiBundle\Swagger\ProductImageDocumentationNormalizer"
+            decorates="api_platform.swagger.normalizer.documentation"
+            public="true"
+            autoconfigure="false"
+            decoration-priority="20"
+        >
+            <argument type="service" id="sylius.api.swagger_product_image_documentation_normalizer.inner" />
+            <argument type="service" id="Sylius\Bundle\ApiBundle\Provider\ProductImageFilterProviderInterface" />
+        </service>
+
+        <service
             id="sylius.api.swagger_product_variant_documentation_normalizer"
             class="Sylius\Bundle\ApiBundle\Swagger\ProductVariantDocumentationNormalizer"
             decorates="api_platform.swagger.normalizer.documentation"

--- a/src/Sylius/Bundle/ApiBundle/Serializer/ProductImageNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ProductImageNormalizer.php
@@ -77,8 +77,12 @@ class ProductImageNormalizer implements ContextAwareNormalizerInterface, Normali
     {
         $request = $this->requestStack->getCurrentRequest();
 
-        if (null !== $request->query->get('filter')) {
-            $data['filtered_path'] = $this->cacheManager->getBrowserPath(parse_url($data['path'], PHP_URL_PATH), $request->query->get('filter'));
+        if ($request->query->has('filter')) {
+            /** @var string $filter */
+            $filter = $request->query->get('filter');
+
+            $data['path'] = $this->cacheManager->getBrowserPath(parse_url($data['path'], PHP_URL_PATH), $filter);
+            return $data;
         }
 
         $data['path'] = $this->prefix . $data['path'];

--- a/src/Sylius/Bundle/ApiBundle/Serializer/ProductImageNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ProductImageNormalizer.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Serializer;
 
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use Sylius\Component\Core\Model\ProductImageInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
@@ -26,11 +28,14 @@ class ProductImageNormalizer implements ContextAwareNormalizerInterface, Normali
 
     private const ALREADY_CALLED = 'product_image_normalizer_already_called';
 
-    /** @var string */
-    private $prefix;
+    private CacheManager $cacheManager;
+    private RequestStack $requestStack;
+    private string $prefix;
 
-    public function __construct(string $prefix)
+    public function __construct(CacheManager $cacheManager, RequestStack $requestStack, string $prefix)
     {
+        $this->cacheManager = $cacheManager;
+        $this->requestStack = $requestStack;
         $this->prefix = $this->validatePrefix($prefix);
     }
 
@@ -43,9 +48,7 @@ class ProductImageNormalizer implements ContextAwareNormalizerInterface, Normali
 
         $data = $this->normalizer->normalize($object, $format, $context);
 
-        $data['path'] = $this->prefix . $data['path'];
-
-        return $data;
+        return $this->resolvePath($data);
     }
 
     public function supportsNormalization($data, $format = null, $context = []): bool
@@ -68,5 +71,18 @@ class ProductImageNormalizer implements ContextAwareNormalizerInterface, Normali
         }
 
         return $prefix . \DIRECTORY_SEPARATOR;
+    }
+
+    private function resolvePath($data): array
+    {
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (null !== $request->query->get('filter')) {
+            $data['filtered_path'] = $this->cacheManager->getBrowserPath(parse_url($data['path'], PHP_URL_PATH), $request->query->get('filter'));
+        }
+
+        $data['path'] = $this->prefix . $data['path'];
+
+        return $data;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/Swagger/ProductImageDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/ProductImageDocumentationNormalizer.php
@@ -19,6 +19,8 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 /** @experimental */
 class ProductImageDocumentationNormalizer implements NormalizerInterface
 {
+    private const SHOP_ITEM_PATH = '/api/v2/shop/product-images/{id}';
+
     /** @var NormalizerInterface */
     private $decoratedNormalizer;
 
@@ -43,16 +45,16 @@ class ProductImageDocumentationNormalizer implements NormalizerInterface
         $enums = $this->filterProvider->provideShopFilters();
         $enums = array_keys($enums);
 
-        $params = $docs['paths']['/api/v2/shop/product-images/{id}']['get']['parameters'];
+        $params = $docs['paths'][self::SHOP_ITEM_PATH]['get']['parameters'];
 
         foreach ($params as $index => $param) {
             if ($param['in'] === 'query') {
                 if (is_string($param['schema']['enum']) || $param['schema']['enum'] === null) {
-                    $docs['paths']['/api/v2/shop/product-images/{id}']['get']['parameters'][$index]['schema']['enum'] = $enums;
+                    $docs['paths'][self::SHOP_ITEM_PATH]['get']['parameters'][$index]['schema']['enum'] = $enums;
                     break;
                 }
 
-                $docs['paths']['/api/v2/shop/product-images/{id}']['get']['parameters'][$index]['schema']['enum'] = array_merge($param['schema']['enum'], $enums);
+                $docs['paths'][self::SHOP_ITEM_PATH]['get']['parameters'][$index]['schema']['enum'] = array_merge($param['schema']['enum'], $enums);
             }
         }
 

--- a/src/Sylius/Bundle/ApiBundle/Swagger/ProductImageDocumentationNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Swagger/ProductImageDocumentationNormalizer.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Swagger;
+
+use Sylius\Bundle\ApiBundle\Provider\ProductImageFilterProviderInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/** @experimental */
+class ProductImageDocumentationNormalizer implements NormalizerInterface
+{
+    /** @var NormalizerInterface */
+    private $decoratedNormalizer;
+
+    /** @var ProductImageFilterProviderInterface */
+    private $filterProvider;
+
+    public function __construct(NormalizerInterface $decoratedNormalizer, ProductImageFilterProviderInterface $filterProvider)
+    {
+        $this->decoratedNormalizer = $decoratedNormalizer;
+        $this->filterProvider = $filterProvider;
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        return $this->decoratedNormalizer->supportsNormalization($data, $format);
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $docs = $this->decoratedNormalizer->normalize($object, $format, $context);
+
+        $enums = $this->filterProvider->provideShopFilters();
+        $enums = array_keys($enums);
+
+        $params = $docs['paths']['/api/v2/shop/product-images/{id}']['get']['parameters'];
+
+        foreach ($params as $index => $param) {
+            if ($param['in'] === 'query') {
+                if (is_string($param['schema']['enum']) || $param['schema']['enum'] === null) {
+                    $docs['paths']['/api/v2/shop/product-images/{id}']['get']['parameters'][$index]['schema']['enum'] = $enums;
+                    break;
+                }
+
+                $docs['paths']['/api/v2/shop/product-images/{id}']['get']['parameters'][$index]['schema']['enum'] = array_merge($param['schema']['enum'], $enums);
+            }
+        }
+
+        return $docs;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/spec/Provider/LiipProductImageFilterProviderSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Provider/LiipProductImageFilterProviderSpec.php
@@ -19,6 +19,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class LiipProductImageFilterProviderSpec extends ObjectBehavior
 {
+    function let(): void
+    {
+        $this->beConstructedWith(['sylius_shop_product_original' => 'args', 'sylius_admin_product_original' => 'args']);
+    }
+
     function it_is_a_product_image_filter_provider(): void
     {
         $this->shouldImplement(ProductImageFilterProviderInterface::class);
@@ -26,23 +31,11 @@ class LiipProductImageFilterProviderSpec extends ObjectBehavior
 
     function it_returns_all_image_filters(ContainerInterface $container): void
     {
-        $filters = ['sylius_shop_product_original' => 'args', 'sylius_admin_product_original' => 'args'];
-        $container->setParameter('liip_imagine.filter_sets', $filters);
-        $this->setContainer($container);
-
-        $container->getParameter('liip_imagine.filter_sets')->willReturn($filters);
-
-        $this->provideAllFilters()->shouldReturn($filters);
+        $this->provideAllFilters()->shouldReturn(['sylius_shop_product_original' => 'args', 'sylius_admin_product_original' => 'args']);
     }
 
     function it_returns_shop_image_filters(ContainerInterface $container): void
     {
-        $filters = ['sylius_shop_product_original' => 'args', 'sylius_admin_product_original' => 'args'];
-        $container->setParameter('liip_imagine.filter_sets', $filters);
-        $this->setContainer($container);
-
-        $container->getParameter('liip_imagine.filter_sets')->willReturn($filters);
-
         $this->provideShopFilters()->shouldReturn(['sylius_shop_product_original' => 'args']);
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/spec/Provider/LiipProductImageFilterProviderSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Provider/LiipProductImageFilterProviderSpec.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\ApiBundle\Provider;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\ApiBundle\Provider\ProductImageFilterProviderInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class LiipProductImageFilterProviderSpec extends ObjectBehavior
+{
+    function it_is_a_product_image_filter_provider(): void
+    {
+        $this->shouldImplement(ProductImageFilterProviderInterface::class);
+    }
+
+    function it_returns_all_image_filters(ContainerInterface $container): void
+    {
+        $filters = ['sylius_shop_product_original' => 'args', 'sylius_admin_product_original' => 'args'];
+        $container->setParameter('liip_imagine.filter_sets', $filters);
+        $this->setContainer($container);
+
+        $container->getParameter('liip_imagine.filter_sets')->willReturn($filters);
+
+        $this->provideAllFilters()->shouldReturn($filters);
+    }
+
+    function it_returns_shop_image_filters(ContainerInterface $container): void
+    {
+        $filters = ['sylius_shop_product_original' => 'args', 'sylius_admin_product_original' => 'args'];
+        $container->setParameter('liip_imagine.filter_sets', $filters);
+        $this->setContainer($container);
+
+        $container->getParameter('liip_imagine.filter_sets')->willReturn($filters);
+
+        $this->provideShopFilters()->shouldReturn(['sylius_shop_product_original' => 'args']);
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductImageNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductImageNormalizerSpec.php
@@ -17,7 +17,6 @@ use Liip\ImagineBundle\Imagine\Cache\CacheManager;
 use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ProductImageInterface;
-use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -56,7 +55,7 @@ final class ProductImageNormalizerSpec extends ObjectBehavior
         $normalizer->normalize($productImage, null, ['product_image_normalizer_already_called' => true])->willReturn(['path' => 'some_path']);
 
         $requestStack->getCurrentRequest()->willReturn($request);
-        $request->query = new InputBag([]);
+        $request->query = new ParameterBag([]);
 
         $this->normalize($productImage, null, [])->shouldReturn(['path' => '/prefix/some_path']);
     }

--- a/tests/Api/Responses/Expected/shop/get_filtered_product_image_response.json
+++ b/tests/Api/Responses/Expected/shop/get_filtered_product_image_response.json
@@ -1,0 +1,8 @@
+{
+  "@context": "\/api\/v2\/contexts\/ProductImage",
+  "@id": "\/api\/v2\/shop\/product-images\/@integer@",
+  "@type": "ProductImage",
+  "id": "@integer@",
+  "type": "thumbnail",
+  "path": "@string@\/media\/cache\/resolve\/sylius_small\/uo\/product.jpg"
+}

--- a/tests/Api/Shop/ProductImageTest.php
+++ b/tests/Api/Shop/ProductImageTest.php
@@ -37,4 +37,23 @@ final class ProductImageTest extends JsonApiTestCase
 
         $this->assertResponse($response, 'shop/get_product_image_response', Response::HTTP_OK);
     }
+
+    /** @test */
+    public function it_gets_one_filtered_product_image(): void
+    {
+        $fixtures = $this->loadFixturesFromFiles(['product_image.yaml', 'authentication/api_administrator.yaml']);
+        /** @var ProductImageInterface $productImage */
+        $productImage = $fixtures["product_thumbnail"];
+
+        $this->client->request(
+            'GET',
+            sprintf('/api/v2/shop/product-images/%s', (string) $productImage->getId()),
+            ['filter' => 'sylius_small'],
+            [],
+            self::CONTENT_TYPE_HEADER
+        );
+        $response = $this->client->getResponse();
+
+        $this->assertResponse($response, 'shop/get_filtered_product_image_response', Response::HTTP_OK);
+    }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         |  master 
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | PR with PoC: https://github.com/Sylius/Sylius/pull/12798
| License         | MIT

At the moment it adds 'filtered_path' with normal 'path'.
![image](https://user-images.githubusercontent.com/35863747/128310010-d29f2a5b-8414-4b65-9147-26f5a5d38dbd.png)

You can choose filter from list 
![image](https://user-images.githubusercontent.com/35863747/128310130-3b6c05b2-1151-498e-9a24-3ecfdc2cd04c.png)

