### PR TITLE
fix: zone cannot contains itself validator #11881

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneCannotContainItselfValidator.php
+++ b/src/Sylius/Bundle/AddressingBundle/Validator/Constraints/ZoneCannotContainItselfValidator.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\AddressingBundle\Validator\Constraints;
 
+use Sylius\Component\Addressing\Model\ZoneInterface;
 use Sylius\Component\Addressing\Model\ZoneMemberInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -31,7 +32,13 @@ final class ZoneCannotContainItselfValidator extends ConstraintValidator
 
         /** @var ZoneMemberInterface $zoneMember */
         foreach ($value as $zoneMember) {
-            if ($zoneMember->getCode() === $zoneMember->getBelongsTo()->getCode()) {
+            $zone = $zoneMember->getBelongsTo();
+
+            if ($zone->getType() === ZoneInterface::TYPE_COUNTRY) {
+                continue;
+            }
+
+            if ($zoneMember->getCode() === $zone->getCode()) {
                 $this->context->addViolation($constraint->message);
             }
         }

--- a/src/Sylius/Bundle/AddressingBundle/spec/Validator/Constraints/ZoneCannotContainItselfValidatorSpec.php
+++ b/src/Sylius/Bundle/AddressingBundle/spec/Validator/Constraints/ZoneCannotContainItselfValidatorSpec.php
@@ -57,6 +57,7 @@ final class ZoneCannotContainItselfValidatorSpec extends ObjectBehavior
         ZoneMemberInterface $zoneMember
     ): void {
         $zone->getCode()->willReturn('WORLD');
+        $zone->getType()->willReturn(ZoneInterface::TYPE_ZONE);
         $zoneMember->getCode()->willReturn('EU');
         $zoneMember->getBelongsTo()->willReturn($zone);
 
@@ -71,10 +72,26 @@ final class ZoneCannotContainItselfValidatorSpec extends ObjectBehavior
         ZoneMemberInterface $zoneMember
     ): void {
         $zone->getCode()->willReturn('EU');
+        $zone->getType()->willReturn(ZoneInterface::TYPE_ZONE);
         $zoneMember->getCode()->willReturn('EU');
         $zoneMember->getBelongsTo()->willReturn($zone);
 
         $executionContext->addViolation(Argument::cetera())->shouldBeCalled();
+
+        $this->validate([$zoneMember], new ZoneCannotContainItself());
+    }
+
+    function it_does_not_add_violation_if_zone_containing_itself_is_country_type(
+        ExecutionContextInterface $executionContext,
+        ZoneInterface $zone,
+        ZoneMemberInterface $zoneMember
+    ): void {
+        $zone->getCode()->willReturn('FR');
+        $zone->getType()->willReturn(ZoneInterface::TYPE_COUNTRY);
+        $zoneMember->getCode()->willReturn('FR');
+        $zoneMember->getBelongsTo()->willReturn($zone);
+
+        $executionContext->addViolation(Argument::cetera())->shouldNotBeCalled();
 
         $this->validate([$zoneMember], new ZoneCannotContainItself());
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9, 1.10 and master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/Sylius/Sylius/issues/11881
| License         | MIT

You can experiment with the issue here, the form will not validate: https://demo.sylius.com/admin/zones/1443/edit
