### PR TITLE
Remove shipments if no shipping method available to the order

### DIFF
--- a/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
@@ -70,7 +70,8 @@ final class OrderShipmentProcessor implements OrderProcessorInterface
             $shipment = $this->getExistingShipmentWithProperMethod($order);
 
             if (null === $shipment) {
-                return;
+                // No shipping method available to this order, remove all shipments.
+                $order->removeShipments();
             }
 
             $this->processShipmentUnits($order, $shipment);

--- a/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
+++ b/src/Sylius/Component/Core/OrderProcessing/OrderShipmentProcessor.php
@@ -72,6 +72,8 @@ final class OrderShipmentProcessor implements OrderProcessorInterface
             if (null === $shipment) {
                 // No shipping method available to this order, remove all shipments.
                 $order->removeShipments();
+
+                return;
             }
 
             $this->processShipmentUnits($order, $shipment);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | MIT

**Description**  
- If a shipment already contain shipment previously, and system no longer have any default shipping method available, Sylius will return error 500.

**Steps to reproduce**  
- Create a cart and assign it with a shipping method
- Disable all shipping methods in system
- OrderShipmentProcessor will do nothing to that order, and then ShippingChargesProcessor will try to calculate price with the invalid shipping method and could cause error.

**Possible Solution**  
- Remove all shipments if no shipping method is available to this order.
