### PR TITLE
[Admin] Fix shipping totals in order summary

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_totals.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/Summary/_totals.html.twig
@@ -23,34 +23,32 @@
             <div class="ui relaxed divided list">
                 <div class="item"><strong>{{ 'sylius.ui.shipping'|trans }}:</strong></div>
                 {% for shipment in order.shipments %}
-                    <div>
-                        {% for adjustment in shipment.adjustments(shippingAdjustment) %}
-                            <div class="item">
-                                <div id="shipping-base-value" class="right floated">{{ money.format(adjustment.amount, order.currencyCode) }}</div>
-                                <div class="content">
-                                    <div id="shipping-adjustment-label" class="description">
-                                        <strong>{{ adjustment.label }}</strong>:
-                                    </div>
+                    {% for adjustment in shipment.adjustments(shippingAdjustment) %}
+                        <div class="item">
+                            <div id="shipping-base-value" class="right floated">{{ money.format(adjustment.amount, order.currencyCode) }}</div>
+                            <div class="content">
+                                <div id="shipping-adjustment-label" class="description">
+                                    <strong>{{ adjustment.label }}</strong>:
                                 </div>
                             </div>
-                        {% endfor %}
+                        </div>
+                    {% endfor %}
 
-                        {% for adjustment in shipment.adjustments(taxAdjustment) %}
-                            <div class="item{% if adjustment.isNeutral %} tax-disabled{% endif %}">
-                                <div id="shipping-tax-value" class="right floated">
-                                    {{ money.format(adjustment.amount, order.currencyCode) }}
-                                    {% if adjustment.isNeutral %}
-                                        <small>({{ 'sylius.ui.included_in_price'|trans }})</small>
-                                    {% endif %}
-                                </div>
-                                <div class="content">
-                                    <div id="shipping-adjustment-label" class="description">
-                                        <strong{% if adjustment.isNeutral %} class="tax-disabled"{% endif %}>{{ adjustment.label }}</strong>:
-                                    </div>
+                    {% for adjustment in shipment.adjustments(taxAdjustment) %}
+                        <div class="item{% if adjustment.isNeutral %} tax-disabled{% endif %}">
+                            <div id="shipping-tax-value" class="right floated">
+                                {{ money.format(adjustment.amount, order.currencyCode) }}
+                                {% if adjustment.isNeutral %}
+                                    <small>({{ 'sylius.ui.included_in_price'|trans }})</small>
+                                {% endif %}
+                            </div>
+                            <div class="content">
+                                <div id="shipping-adjustment-label" class="description">
+                                    <strong{% if adjustment.isNeutral %} class="tax-disabled"{% endif %}>{{ adjustment.label }}</strong>:
                                 </div>
                             </div>
-                        {% endfor %}
-                    </div>
+                        </div>
+                    {% endfor %}
                 {% endfor %}
             </div>
         {% else %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

The extra wrapping div breaks Semantic UI's list here.

![before](https://user-images.githubusercontent.com/138721/128837332-df71cdf3-5f44-49fe-8d42-e7c65edf9be0.png)


I'm guessing the intended layout was this?
![after](https://user-images.githubusercontent.com/138721/128837638-25507a44-e94a-48f2-bbb6-ec79f339388b.png)
