### PR TITLE
Make CheckoutResolver fail safe

### DIFF
--- a/UPGRADE-1.12.md
+++ b/UPGRADE-1.12.md
@@ -4,6 +4,9 @@
     constructor argument has been made optional and is `null` by default, subsequently the first argument of
     `sylius.form.type.attribute_type.select.choices_collection` has been removed.
 
+1. The default checkout resolving route pattern has been changed from `/checkout/.+` to
+   `%sylius.security.shop_regex%/checkout/.+` to reduce the probability of conflicts with other routes.
+
 # UPGRADE FROM `v1.12.9` TO `v1.12.10`
 
 1. The `Sylius\Component\Core\OrderProcessing\OrderPaymentProcessor` constructor has been changed:

--- a/src/Sylius/Bundle/CoreBundle/Checkout/CheckoutResolver.php
+++ b/src/Sylius/Bundle/CoreBundle/Checkout/CheckoutResolver.php
@@ -33,6 +33,13 @@ final class CheckoutResolver implements EventSubscriberInterface
     ) {
     }
 
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => 'onKernelRequest',
+        ];
+    }
+
     public function onKernelRequest(RequestEvent $event): void
     {
         if (\method_exists($event, 'isMainRequest')) {
@@ -55,31 +62,33 @@ final class CheckoutResolver implements EventSubscriberInterface
         $order = $this->cartContext->getCart();
         if ($order->isEmpty()) {
             $event->setResponse(new RedirectResponse($this->urlGenerator->generateForCart()));
+
+            return;
         }
 
-        $stateMachine = $this->stateMachineFactory->get($order, $this->getRequestedGraph($request));
+        $graph = $this->getRequestedGraph($request);
+        $transition = $this->getRequestedTransition($request);
 
-        if ($stateMachine->can($this->getRequestedTransition($request))) {
+        if (null === $graph || null === $transition) {
+            return;
+        }
+
+        $stateMachine = $this->stateMachineFactory->get($order, $graph);
+
+        if ($stateMachine->can($transition)) {
             return;
         }
 
         $event->setResponse(new RedirectResponse($this->urlGenerator->generateForOrderCheckoutState($order)));
     }
 
-    public static function getSubscribedEvents(): array
+    private function getRequestedGraph(Request $request): ?string
     {
-        return [
-            KernelEvents::REQUEST => 'onKernelRequest',
-        ];
+        return $request->attributes->get('_sylius', [])['state_machine']['graph'] ?? null;
     }
 
-    private function getRequestedGraph(Request $request): string
+    private function getRequestedTransition(Request $request): ?string
     {
-        return $request->attributes->get('_sylius')['state_machine']['graph'];
-    }
-
-    private function getRequestedTransition(Request $request): string
-    {
-        return $request->attributes->get('_sylius')['state_machine']['transition'];
+        return $request->attributes->get('_sylius', [])['state_machine']['transition'] ?? null;
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/Checkout/CheckoutResolverSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Checkout/CheckoutResolverSpec.php
@@ -1,0 +1,202 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\CoreBundle\Checkout;
+
+use Prophecy\Argument;
+use SM\Factory\FactoryInterface;
+use PhpSpec\ObjectBehavior;
+use SM\StateMachine\StateMachineInterface;
+use Sylius\Bundle\CoreBundle\Checkout\CheckoutStateUrlGeneratorInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Order\Context\CartContextInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+final class CheckoutResolverSpec extends ObjectBehavior
+{
+    function let(
+        CartContextInterface $cartContext,
+        CheckoutStateUrlGeneratorInterface $urlGenerator,
+        RequestMatcherInterface $requestMatcher,
+        FactoryInterface $stateMachineFactory
+    ): void {
+        $this->beConstructedWith(
+            $cartContext,
+            $urlGenerator,
+            $requestMatcher,
+            $stateMachineFactory
+        );
+    }
+
+    function it_only_applies_to_the_main_request(RequestEvent $event): void
+    {
+        $event->isMasterRequest()->willReturn(false);
+        $event->getRequest()->shouldNotBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+
+    function it_only_applies_to_a_mathched_request(
+        RequestEvent $event,
+        Request $request,
+        RequestMatcherInterface $requestMatcher,
+        CartContextInterface $cartContext
+    ): void {
+        $event->isMasterRequest()->willReturn(true);
+        $event->getRequest()->willReturn($request);
+        $requestMatcher->matches($request)->willReturn(false);
+        $cartContext->getCart()->shouldNotBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+
+    function it_redirects_when_order_has_no_items(
+        RequestEvent $event,
+        Request $request,
+        RequestMatcherInterface $requestMatcher,
+        CartContextInterface $cartContext,
+        OrderInterface $order,
+        CheckoutStateUrlGeneratorInterface $urlGenerator
+    ): void {
+        $event->isMasterRequest()->willReturn(true);
+        $event->getRequest()->willReturn($request);
+        $requestMatcher->matches($request)->willReturn(true);
+        $cartContext->getCart()->willReturn($order);
+        $order->isEmpty()->willReturn(true);
+        $urlGenerator->generateForCart()->willReturn('/target-url');
+        $event->setResponse(Argument::type(RedirectResponse::class))->shouldBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+
+    function it_does_nothing_when_there_is_no_sylius_request_attribute(
+        RequestEvent $event,
+        RequestMatcherInterface $requestMatcher,
+        CartContextInterface $cartContext,
+        OrderInterface $order,
+        FactoryInterface $stateMachineFactory
+    ): void {
+        $request = new Request();
+        $event->isMasterRequest()->willReturn(true);
+        $event->getRequest()->willReturn($request);
+        $requestMatcher->matches($request)->willReturn(true);
+        $cartContext->getCart()->willReturn($order);
+        $order->isEmpty()->willReturn(false);
+        $stateMachineFactory->get($order, Argument::any())->shouldNotBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+
+    function it_does_nothing_when_there_is_no_state_machine_request_attribute(
+        RequestEvent $event,
+        RequestMatcherInterface $requestMatcher,
+        CartContextInterface $cartContext,
+        OrderInterface $order,
+        FactoryInterface $stateMachineFactory
+    ): void {
+        $request = new Request([], [], ['_sylius' => []]);
+        $event->isMasterRequest()->willReturn(true);
+        $event->getRequest()->willReturn($request);
+        $requestMatcher->matches($request)->willReturn(true);
+        $cartContext->getCart()->willReturn($order);
+        $order->isEmpty()->willReturn(false);
+        $stateMachineFactory->get($order, Argument::any())->shouldNotBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+
+    function it_does_nothing_when_there_is_no_state_machine_graph_request_attribute(
+        RequestEvent $event,
+        RequestMatcherInterface $requestMatcher,
+        CartContextInterface $cartContext,
+        OrderInterface $order,
+        FactoryInterface $stateMachineFactory
+    ): void {
+        $request = new Request([], [], ['_sylius' => ['state_machine' => ['transition' => 'test_transition']]]);
+        $event->isMasterRequest()->willReturn(true);
+        $event->getRequest()->willReturn($request);
+        $requestMatcher->matches($request)->willReturn(true);
+        $cartContext->getCart()->willReturn($order);
+        $order->isEmpty()->willReturn(false);
+        $stateMachineFactory->get($order, Argument::any())->shouldNotBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+
+    function it_does_nothing_when_there_is_no_state_machine_transition_request_attribute(
+        RequestEvent $event,
+        RequestMatcherInterface $requestMatcher,
+        CartContextInterface $cartContext,
+        OrderInterface $order,
+        FactoryInterface $stateMachineFactory
+    ): void {
+        $request = new Request([], [], ['_sylius' => ['state_machine' => ['graph' => 'test_graph']]]);
+        $event->isMasterRequest()->willReturn(true);
+        $event->getRequest()->willReturn($request);
+        $requestMatcher->matches($request)->willReturn(true);
+        $cartContext->getCart()->willReturn($order);
+        $order->isEmpty()->willReturn(false);
+        $stateMachineFactory->get($order, Argument::any())->shouldNotBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+
+    function it_does_nothing_when_the_requested_transition_can_be_applied(
+        RequestEvent $event,
+        RequestMatcherInterface $requestMatcher,
+        CartContextInterface $cartContext,
+        OrderInterface $order,
+        FactoryInterface $stateMachineFactory,
+        StateMachineInterface $stateMachine
+    ): void {
+        $request = new Request([], [],
+            ['_sylius' => ['state_machine' => ['graph' => 'test_graph', 'transition' => 'test_transition']]]);
+        $event->isMasterRequest()->willReturn(true);
+        $event->getRequest()->willReturn($request);
+        $requestMatcher->matches($request)->willReturn(true);
+        $cartContext->getCart()->willReturn($order);
+        $order->isEmpty()->willReturn(false);
+        $stateMachineFactory->get($order, 'test_graph')->willReturn($stateMachine);
+        $stateMachine->can('test_transition')->willReturn(true);
+        $event->setResponse(Argument::any())->shouldNotBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+
+    function it_redirects_when_the_requested_transition_cannot_be_applied(
+        RequestEvent $event,
+        RequestMatcherInterface $requestMatcher,
+        CartContextInterface $cartContext,
+        OrderInterface $order,
+        FactoryInterface $stateMachineFactory,
+        StateMachineInterface $stateMachine,
+        CheckoutStateUrlGeneratorInterface $urlGenerator
+    ): void {
+        $request = new Request([], [],
+            ['_sylius' => ['state_machine' => ['graph' => 'test_graph', 'transition' => 'test_transition']]]);
+        $event->isMasterRequest()->willReturn(true);
+        $event->getRequest()->willReturn($request);
+        $requestMatcher->matches($request)->willReturn(true);
+        $cartContext->getCart()->willReturn($order);
+        $order->isEmpty()->willReturn(false);
+        $stateMachineFactory->get($order, 'test_graph')->willReturn($stateMachine);
+        $stateMachine->can('test_transition')->willReturn(false);
+        $urlGenerator->generateForOrderCheckoutState($order)->willReturn('/target-url');
+        $event->setResponse(Argument::type(RedirectResponse::class))->shouldBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/spec/Checkout/CheckoutResolverSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Checkout/CheckoutResolverSpec.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Sylius package.
  *
- * (c) Paweł Jędrzejewski
+ * (c) Sylius Sp. z o.o.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\CoreBundle\Checkout;
 
+use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use SM\Factory\FactoryInterface;
-use PhpSpec\ObjectBehavior;
 use SM\StateMachine\StateMachineInterface;
 use Sylius\Bundle\CoreBundle\Checkout\CheckoutStateUrlGeneratorInterface;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -31,31 +31,31 @@ final class CheckoutResolverSpec extends ObjectBehavior
         CartContextInterface $cartContext,
         CheckoutStateUrlGeneratorInterface $urlGenerator,
         RequestMatcherInterface $requestMatcher,
-        FactoryInterface $stateMachineFactory
+        FactoryInterface $stateMachineFactory,
     ): void {
         $this->beConstructedWith(
             $cartContext,
             $urlGenerator,
             $requestMatcher,
-            $stateMachineFactory
+            $stateMachineFactory,
         );
     }
 
     function it_only_applies_to_the_main_request(RequestEvent $event): void
     {
-        $event->isMasterRequest()->willReturn(false);
+        $event->isMainRequest()->willReturn(false);
         $event->getRequest()->shouldNotBeCalled();
 
         $this->onKernelRequest($event);
     }
 
-    function it_only_applies_to_a_mathched_request(
+    function it_only_applies_to_a_matched_request(
         RequestEvent $event,
         Request $request,
         RequestMatcherInterface $requestMatcher,
-        CartContextInterface $cartContext
+        CartContextInterface $cartContext,
     ): void {
-        $event->isMasterRequest()->willReturn(true);
+        $event->isMainRequest()->willReturn(true);
         $event->getRequest()->willReturn($request);
         $requestMatcher->matches($request)->willReturn(false);
         $cartContext->getCart()->shouldNotBeCalled();
@@ -69,9 +69,9 @@ final class CheckoutResolverSpec extends ObjectBehavior
         RequestMatcherInterface $requestMatcher,
         CartContextInterface $cartContext,
         OrderInterface $order,
-        CheckoutStateUrlGeneratorInterface $urlGenerator
+        CheckoutStateUrlGeneratorInterface $urlGenerator,
     ): void {
-        $event->isMasterRequest()->willReturn(true);
+        $event->isMainRequest()->willReturn(true);
         $event->getRequest()->willReturn($request);
         $requestMatcher->matches($request)->willReturn(true);
         $cartContext->getCart()->willReturn($order);
@@ -87,10 +87,10 @@ final class CheckoutResolverSpec extends ObjectBehavior
         RequestMatcherInterface $requestMatcher,
         CartContextInterface $cartContext,
         OrderInterface $order,
-        FactoryInterface $stateMachineFactory
+        FactoryInterface $stateMachineFactory,
     ): void {
         $request = new Request();
-        $event->isMasterRequest()->willReturn(true);
+        $event->isMainRequest()->willReturn(true);
         $event->getRequest()->willReturn($request);
         $requestMatcher->matches($request)->willReturn(true);
         $cartContext->getCart()->willReturn($order);
@@ -105,10 +105,10 @@ final class CheckoutResolverSpec extends ObjectBehavior
         RequestMatcherInterface $requestMatcher,
         CartContextInterface $cartContext,
         OrderInterface $order,
-        FactoryInterface $stateMachineFactory
+        FactoryInterface $stateMachineFactory,
     ): void {
         $request = new Request([], [], ['_sylius' => []]);
-        $event->isMasterRequest()->willReturn(true);
+        $event->isMainRequest()->willReturn(true);
         $event->getRequest()->willReturn($request);
         $requestMatcher->matches($request)->willReturn(true);
         $cartContext->getCart()->willReturn($order);
@@ -123,10 +123,10 @@ final class CheckoutResolverSpec extends ObjectBehavior
         RequestMatcherInterface $requestMatcher,
         CartContextInterface $cartContext,
         OrderInterface $order,
-        FactoryInterface $stateMachineFactory
+        FactoryInterface $stateMachineFactory,
     ): void {
         $request = new Request([], [], ['_sylius' => ['state_machine' => ['transition' => 'test_transition']]]);
-        $event->isMasterRequest()->willReturn(true);
+        $event->isMainRequest()->willReturn(true);
         $event->getRequest()->willReturn($request);
         $requestMatcher->matches($request)->willReturn(true);
         $cartContext->getCart()->willReturn($order);
@@ -141,10 +141,10 @@ final class CheckoutResolverSpec extends ObjectBehavior
         RequestMatcherInterface $requestMatcher,
         CartContextInterface $cartContext,
         OrderInterface $order,
-        FactoryInterface $stateMachineFactory
+        FactoryInterface $stateMachineFactory,
     ): void {
         $request = new Request([], [], ['_sylius' => ['state_machine' => ['graph' => 'test_graph']]]);
-        $event->isMasterRequest()->willReturn(true);
+        $event->isMainRequest()->willReturn(true);
         $event->getRequest()->willReturn($request);
         $requestMatcher->matches($request)->willReturn(true);
         $cartContext->getCart()->willReturn($order);
@@ -160,11 +160,12 @@ final class CheckoutResolverSpec extends ObjectBehavior
         CartContextInterface $cartContext,
         OrderInterface $order,
         FactoryInterface $stateMachineFactory,
-        StateMachineInterface $stateMachine
+        StateMachineInterface $stateMachine,
     ): void {
-        $request = new Request([], [],
-            ['_sylius' => ['state_machine' => ['graph' => 'test_graph', 'transition' => 'test_transition']]]);
-        $event->isMasterRequest()->willReturn(true);
+        $request = new Request([], [], [
+            '_sylius' => ['state_machine' => ['graph' => 'test_graph', 'transition' => 'test_transition']],
+        ]);
+        $event->isMainRequest()->willReturn(true);
         $event->getRequest()->willReturn($request);
         $requestMatcher->matches($request)->willReturn(true);
         $cartContext->getCart()->willReturn($order);
@@ -183,11 +184,12 @@ final class CheckoutResolverSpec extends ObjectBehavior
         OrderInterface $order,
         FactoryInterface $stateMachineFactory,
         StateMachineInterface $stateMachine,
-        CheckoutStateUrlGeneratorInterface $urlGenerator
+        CheckoutStateUrlGeneratorInterface $urlGenerator,
     ): void {
-        $request = new Request([], [],
-            ['_sylius' => ['state_machine' => ['graph' => 'test_graph', 'transition' => 'test_transition']]]);
-        $event->isMasterRequest()->willReturn(true);
+        $request = new Request([], [], [
+            '_sylius' => ['state_machine' => ['graph' => 'test_graph', 'transition' => 'test_transition']],
+        ]);
+        $event->isMainRequest()->willReturn(true);
         $event->getRequest()->willReturn($request);
         $requestMatcher->matches($request)->willReturn(true);
         $cartContext->getCart()->willReturn($order);

--- a/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
+++ b/src/Sylius/Bundle/ShopBundle/Resources/config/app/config.yml
@@ -26,7 +26,7 @@ sylius_grid:
 
 sylius_shop:
     checkout_resolver:
-        pattern: /checkout/.+
+        pattern: "%sylius.security.shop_regex%/checkout/.+"
         route_map:
             empty_order:
                 route: sylius_shop_cart_summary


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Some time ago I encountered several issues with the CheckoutResolver failing because of some assumptions that were not met by my customizations. Unfortunately, I can't remember the context.
This PR makes it fail safe in case those assumptions are not met and covers it with PHPSpec tests.
