### PR TITLE
[WIP] Adding GraphQL endpoints with tests 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,6 +111,7 @@
         "twig/intl-extra": "^2.12",
         "twig/twig": "^2.12",
         "webmozart/assert": "^1.9",
+        "webonyx/graphql-php": "^14.9",
         "willdurand/hateoas": "^3.0",
         "willdurand/hateoas-bundle": "^2.0",
         "winzou/state-machine-bundle": "^0.5"

--- a/src/Sylius/Behat/Context/Api/GraphQLApiPlatformContext.php
+++ b/src/Sylius/Behat/Context/Api/GraphQLApiPlatformContext.php
@@ -1,0 +1,310 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Api;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\Environment\InitializedContextEnvironment;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Element\DocumentElement;
+use Behatch\Context\RestContext;
+use GraphQL\Type\Introspection;
+use PHPUnit\Framework\ExpectationFailedException;
+
+/**
+ * Context for GraphQL.
+ */
+final class GraphQLApiPlatformContext implements Context
+{
+    private const METHOD_POST = 'POST';
+
+    private const METHOD_GET = 'GET';
+
+    private const METHOD_PATCH = 'PATCH';
+
+    private const METHOD_DELETE = 'DELETE';
+
+    private $lastResponse;
+
+    private $savedValues = [];
+
+    /** @var RestContext */
+    private $restContext;
+
+    /** @var array */
+    private $graphqlRequest;
+
+    /**
+     * Gives access to the Behatch context.
+     *
+     * @BeforeScenario
+     */
+    public function gatherContexts(BeforeScenarioScope $scope)
+    {
+        /**
+         * @var InitializedContextEnvironment $environment
+         */
+        $environment = $scope->getEnvironment();
+        /**
+         * @var RestContext $restContext
+         */
+        $restContext = $environment->getContext(RestContext::class);
+        $this->restContext = $restContext;
+    }
+
+    /**
+     * @When I have the following GraphQL request:
+     */
+    public function IHaveTheFollowingGraphqlRequest(PyStringNode $request)
+    {
+        $this->graphqlRequest = ['query' => $request->getRaw()];
+        $this->graphqlLine = $request->getLine();
+    }
+
+    /**
+     * @When I send the following GraphQL request:
+     */
+    public function ISendTheFollowingGraphqlRequest(PyStringNode $request)
+    {
+        $this->IHaveTheFollowingGraphqlRequest($request);
+        $this->sendGraphqlRequest();
+    }
+
+    private function saveLastResponse(DocumentElement $response)
+    {
+        $content = $response->getContent();
+        $json = $this->getJsonFromResponse($content);
+        if ($json === null) {
+            throw new \Exception('Return data is not Json format');
+        }
+        $this->lastResponse = $json;
+    }
+
+    /**
+     * @When I should see following response:
+     */
+    public function IShouldSeeFollowingResponse(PyStringNode $json): bool
+    {
+        $expected = json_decode($json->getRaw(), true);
+        $result_array = self::diff($expected, $this->lastResponse);
+        if (empty($result_array)) {
+            return true;
+        }
+        var_dump($result_array);
+        var_dump($this->lastResponse);
+
+        throw new \Exception('Expected response doest match last one');
+    }
+
+    /**
+     * @Then I save value at key :arg1 from last response as :arg2.
+     */
+    public function iSaveValueAs($key, $valueName)
+    {
+        $flatResponse = $this->flattenArray($this->lastResponse);
+        if (!array_key_exists($key, $flatResponse)) {
+            var_dump($flatResponse);
+
+            throw new \Exception(sprintf('Last response did not have any key named %s', $key));
+        }
+        $this->savedValues[$valueName] = $flatResponse[$key];
+    }
+
+    /**
+     * @When I send the GraphQL request with variables:
+     */
+    public function ISendTheGraphqlRequestWithVariables(PyStringNode $variables)
+    {
+        $this->graphqlRequest['variables'] = $variables->getRaw();
+        $this->sendGraphqlRequest();
+    }
+
+    /**
+     * @When I prepare the variables for GraphQL request with saved data:
+     */
+    public function IPrepareTheVariablesForGraphqlRequest(PyStringNode $variables)
+    {
+        $raw = $variables->getRaw();
+        preg_match_all('/{(\w+)}/', $raw, $matches);
+        $parsed = $raw;
+        foreach ($matches[0] as $index => $var_name) {
+            $key = $matches[1][$index];
+            if (array_key_exists($key, $this->savedValues)) {
+                $parsed = str_replace($var_name, $this->savedValues[$key], $parsed);
+            }
+        }
+        $this->graphqlRequest['variables'] = $parsed;
+        $this->sendGraphqlRequest();
+    }
+
+    /**
+     * @When I send the GraphQL request with operationName :operationName
+     */
+    public function ISendTheGraphqlRequestWithOperation(string $operationName)
+    {
+        $this->graphqlRequest['operationName'] = $operationName;
+        $this->sendGraphqlRequest();
+    }
+
+    /**
+     * @Given I have the following file(s) for a GraphQL request:
+     */
+    public function iHaveTheFollowingFilesForAGraphqlRequest(TableNode $table)
+    {
+        $files = [];
+
+        foreach ($table->getHash() as $row) {
+            if (!isset($row['name'], $row['file'])) {
+                throw new \InvalidArgumentException('You must provide a "name" and "file" column in your table node.');
+            }
+
+            $files[$row['name']] = $this->restContext->getMinkParameter('files_path') . \DIRECTORY_SEPARATOR . $row['file'];
+        }
+
+        $this->graphqlRequest['files'] = $files;
+    }
+
+    /**
+     * @Given I have the following GraphQL multipart request map:
+     */
+    public function iHaveTheFollowingGraphqlMultipartRequestMap(PyStringNode $string)
+    {
+        $this->graphqlRequest['map'] = $string->getRaw();
+    }
+
+    /**
+     * @When I send the following GraphQL multipart request operations:
+     */
+    public function iSendTheFollowingGraphqlMultipartRequestOperations(PyStringNode $string)
+    {
+        $params = [];
+        $params['operations'] = $string->getRaw();
+        $params['map'] = $this->graphqlRequest['map'];
+
+        $this->request->setHttpHeader('Content-type', 'multipart/form-data'); // @phpstan-ignore-line
+        $this->request->send('POST', '/graphql', $params, $this->graphqlRequest['files']); // @phpstan-ignore-line
+    }
+
+    /**
+     * @When I send the query to introspect the schema
+     */
+    public function ISendTheQueryToIntrospectTheSchema()
+    {
+        $this->graphqlRequest = ['query' => Introspection::getIntrospectionQuery()];
+        $this->sendGraphqlRequest();
+    }
+
+    /**
+     * @Then the GraphQL field :fieldName is deprecated for the reason :reason
+     */
+    public function theGraphQLFieldIsDeprecatedForTheReason(string $fieldName, string $reason)
+    {
+        foreach (json_decode($this->request->getContent(), true)['data']['__type']['fields'] as $field) { // @phpstan-ignore-line
+            if ($fieldName === $field['name'] && $field['isDeprecated'] && $reason === $field['deprecationReason']) {
+                return;
+            }
+        }
+
+        throw new ExpectationFailedException(sprintf('The field "%s" is not deprecated.', $fieldName));
+    }
+
+    /**
+     * @Then I should see following error message :message
+     */
+    public function iShouldSeeFollowingErrorMessage(string $message): bool
+    {
+        $flatLastResponse = $this->flattenArray($this->lastResponse);
+        if(!key_exists("errors.0.message",$flatLastResponse)){
+            var_dump($flatLastResponse);
+            throw new \Exception("No errors were produced.");
+        }
+        if($flatLastResponse["errors.0.message"] !== $message){
+            var_dump($flatLastResponse);
+            throw new \Exception("The error message is different then expected.");
+        }
+        return true;
+    }
+
+
+    private function sendGraphqlRequest(string $method = self::METHOD_POST): DocumentElement
+    {
+        $response = $this->restContext->iSendARequestTo($method, '/api/v2/graphql?' . http_build_query($this->graphqlRequest));
+        $this->saveLastResponse($response);
+
+        return  $response;
+    }
+
+    /**
+     * @return mixed|null
+     */
+    private function getJsonFromResponse(string $response)
+    {
+        $jsonData = json_decode($response, true);
+        if (json_last_error() === \JSON_ERROR_NONE) {
+            return $jsonData;
+        }
+
+        return null;
+    }
+
+    public static function diff($arr1, $arr2)
+    {
+        $diff = [];
+
+        // Check the similarities
+        foreach ($arr1 as $k1 => $v1) {
+            if (isset($arr2[$k1])) {
+                $v2 = $arr2[$k1];
+                if (is_array($v1) && is_array($v2)) {
+                    // 2 arrays: just go further...
+                    // .. and explain it's an update!
+                    $changes = self::diff($v1, $v2);
+                    if (count($changes) > 0) {
+                        // If we have no change, simply ignore
+                        $diff[$k1] = ['upd' => $changes];
+                    }
+                    unset($arr2[$k1]); // don't forget
+                } elseif ($v2 === $v1) {
+                    // unset the value on the second array
+                    // for the "surplus"
+                    unset($arr2[$k1]);
+                } else {
+                    // Don't mind if arrays or not.
+                    $diff[$k1] = ['old' => $v1, 'new' => $v2];
+                    unset($arr2[$k1]);
+                }
+            } else {
+                // remove information
+                $diff[$k1] = ['old' => $v1];
+            }
+        }
+
+        // Now, check for new stuff in $arr2
+        reset($arr2); // Don't argue it's unnecessary (even I believe you)
+        foreach ($arr2 as $k => $v) {
+            // OK, it is quite stupid my friend
+            $diff[$k] = ['new' => $v];
+        }
+
+        return $diff;
+    }
+
+    private function flattenArray(array $array)
+    {
+        $array = reset($array['data']);
+        $ritit = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($array));
+        $result = [];
+        foreach ($ritit as $leafValue) {
+            $keys = [];
+            foreach (range(0, $ritit->getDepth()) as $depth) {
+                $keys[] = $ritit->getSubIterator($depth)->key();
+            }
+            $result[implode('.', $keys)] = $leafValue;
+        }
+
+        return $result;
+    }
+}

--- a/src/Sylius/Behat/Context/Api/GraphQLApiPlatformContext.php
+++ b/src/Sylius/Behat/Context/Api/GraphQLApiPlatformContext.php
@@ -37,6 +37,9 @@ final class GraphQLApiPlatformContext implements Context
     /** @var array */
     private $graphqlRequest;
 
+    /** @var array */
+    private $lastRequest;
+
     /**
      * Gives access to the Behatch context.
      *
@@ -150,6 +153,18 @@ final class GraphQLApiPlatformContext implements Context
     }
 
     /**
+     * @Then I send the same request again
+     * @Then I resend the request
+     */
+    public function IResendGraphqlRequest(string $method = self::METHOD_POST): DocumentElement
+    {
+        $response = $this->restContext->iSendARequestTo($method, '/api/v2/graphql?' . http_build_query($this->graphqlRequest));
+        $this->saveLastResponse($response);
+
+        return  $response;
+    }
+
+    /**
      * @Given I have the following file(s) for a GraphQL request:
      */
     public function iHaveTheFollowingFilesForAGraphqlRequest(TableNode $table)
@@ -231,6 +246,7 @@ final class GraphQLApiPlatformContext implements Context
 
     private function sendGraphqlRequest(string $method = self::METHOD_POST): DocumentElement
     {
+        $this->lastRequest = $this->graphqlRequest;
         $response = $this->restContext->iSendARequestTo($method, '/api/v2/graphql?' . http_build_query($this->graphqlRequest));
         $this->saveLastResponse($response);
 

--- a/src/Sylius/Behat/Resources/config/services/contexts/api.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/api.xml
@@ -18,4 +18,9 @@
     <imports>
         <import resource="api/**/*.xml" />
     </imports>
+
+    <services>
+        <service id="sylius.behat.context.api_platform.graphql" class="Sylius\Behat\Context\Api\GraphQLApiPlatformContext" />
+    </services>
+
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Command/Account/Login.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Account/Login.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\Command\Account;
+
+/** @experimental */
+class Login
+{
+
+    /**
+     * @var string
+     */
+    public $email;
+
+    /**
+     * @var string
+     */
+    public $password;
+
+    public function __construct(string $email, string $password)
+    {
+        $this->email = $email;
+        $this->password = $password;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param string $email
+     */
+    public function setEmail(string $email): void
+    {
+        $this->email = $email;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPassword(): string
+    {
+        return $this->password;
+    }
+
+    /**
+     * @param string $password
+     */
+    public function setPassword(string $password): void
+    {
+        $this->password = $password;
+    }
+
+}

--- a/src/Sylius/Bundle/ApiBundle/Command/Cart/ChangeItemQuantityInCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Cart/ChangeItemQuantityInCart.php
@@ -31,9 +31,10 @@ class ChangeItemQuantityInCart implements OrderTokenValueAwareInterface, Subreso
      */
     public $quantity;
 
-    public function __construct(int $quantity)
+    public function __construct(int $quantity, ?string $orderItemId = null)
     {
         $this->quantity = $quantity;
+        $this->orderItemId = $orderItemId;
     }
 
     public static function createFromData(string $tokenValue, string $orderItemId, int $quantity): self

--- a/src/Sylius/Bundle/ApiBundle/Command/Cart/RemoveCouponFromCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Cart/RemoveCouponFromCart.php
@@ -16,27 +16,25 @@ namespace Sylius\Bundle\ApiBundle\Command\Cart;
 use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
 
 /** @experimental */
-class ApplyCouponToCart implements OrderTokenValueAwareInterface
+class RemoveCouponFromCart implements OrderTokenValueAwareInterface
 {
     /** @var string|null */
     public $orderTokenValue;
 
-    /** @var string|null */
+    /**
+     * @var string
+     */
     public $couponCode;
 
-    public function __construct(?string $couponCode,?string $orderTokenValue)
+    public function __construct(?string $orderTokenValue, string $couponCode)
     {
-        $this->couponCode = $couponCode;
         $this->orderTokenValue = $orderTokenValue;
+        $this->couponCode = $couponCode;
     }
 
-    public static function createFromData(string $orderTokenValue, ?string $couponCode): self
+    public static function removeFromData(string $tokenValue, string $couponCode): self
     {
-        $command = new self($couponCode,$orderTokenValue);
-
-        $command->setOrderTokenValue($orderTokenValue);
-
-        return $command;
+        return new self($tokenValue, $couponCode);
     }
 
     public function getOrderTokenValue(): ?string

--- a/src/Sylius/Bundle/ApiBundle/Command/Cart/RemoveItemFromCart.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Cart/RemoveItemFromCart.php
@@ -27,10 +27,10 @@ class RemoveItemFromCart implements OrderTokenValueAwareInterface
      */
     public $itemId;
 
-    public function __construct(?string $orderTokenValue, string $itemId)
+    public function __construct(?string $orderTokenValue, string $orderItemId)
     {
         $this->orderTokenValue = $orderTokenValue;
-        $this->itemId = $itemId;
+        $this->itemId = $orderItemId;
     }
 
     public static function removeFromData(string $tokenValue, string $orderItemId): self

--- a/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChoosePaymentMethod.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChoosePaymentMethod.php
@@ -13,13 +13,12 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Command\Checkout;
 
-use Sylius\Bundle\ApiBundle\Command\IriToIdentifierConversionAwareInterface;
 use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
 use Sylius\Bundle\ApiBundle\Command\PaymentMethodCodeAwareInterface;
 use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareInterface;
 
 /** @experimental */
-class ChoosePaymentMethod implements OrderTokenValueAwareInterface, SubresourceIdAwareInterface, PaymentMethodCodeAwareInterface, IriToIdentifierConversionAwareInterface
+class ChoosePaymentMethod implements OrderTokenValueAwareInterface, SubresourceIdAwareInterface, PaymentMethodCodeAwareInterface
 {
     /** @var string|null */
     public $orderTokenValue;
@@ -38,8 +37,9 @@ class ChoosePaymentMethod implements OrderTokenValueAwareInterface, SubresourceI
      */
     public $paymentMethodCode;
 
-    public function __construct(string $paymentMethodCode)
+    public function __construct(string $orderTokenValue, string $paymentMethodCode)
     {
+        $this->orderTokenValue = $orderTokenValue;
         $this->paymentMethodCode = $paymentMethodCode;
     }
 

--- a/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChooseShippingMethod.php
+++ b/src/Sylius/Bundle/ApiBundle/Command/Checkout/ChooseShippingMethod.php
@@ -13,12 +13,11 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\Command\Checkout;
 
-use Sylius\Bundle\ApiBundle\Command\IriToIdentifierConversionAwareInterface;
 use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
 use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareInterface;
 
 /** @experimental */
-class ChooseShippingMethod implements OrderTokenValueAwareInterface, SubresourceIdAwareInterface, IriToIdentifierConversionAwareInterface
+class ChooseShippingMethod implements OrderTokenValueAwareInterface, SubresourceIdAwareInterface
 {
     /** @var string|null */
     public $orderTokenValue;
@@ -33,9 +32,11 @@ class ChooseShippingMethod implements OrderTokenValueAwareInterface, Subresource
      */
     public $shippingMethodCode;
 
-    public function __construct(string $shippingMethodCode)
+    public function __construct(string $orderTokenValue, string $shippingMethodCode, string $shipmentId)
     {
+        $this->orderTokenValue = $orderTokenValue;
         $this->shippingMethodCode = $shippingMethodCode;
+        $this->shipmentId = $shipmentId;
     }
 
     public function getOrderTokenValue(): ?string

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Cart/RemoveCouponFromCartHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Cart/RemoveCouponFromCartHandler.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\CommandHandler\Cart;
 
-use Sylius\Bundle\ApiBundle\Command\Cart\ApplyCouponToCart;
+use Sylius\Bundle\ApiBundle\Command\Cart\RemoveCouponFromCart;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
@@ -23,7 +23,7 @@ use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Webmozart\Assert\Assert;
 
 /** @experimental */
-final class ApplyCouponToCartHandler implements MessageHandlerInterface
+final class RemoveCouponFromCartHandler implements MessageHandlerInterface
 {
     /** @var OrderRepositoryInterface */
     private $orderRepository;
@@ -44,15 +44,17 @@ final class ApplyCouponToCartHandler implements MessageHandlerInterface
         $this->orderProcessor = $orderProcessor;
     }
 
-    public function __invoke(ApplyCouponToCart $command): OrderInterface
+    public function __invoke(RemoveCouponFromCart $command): OrderInterface
     {
         /** @var OrderInterface $cart */
         $cart = $this->orderRepository->findCartByTokenValue($command->getOrderTokenValue());
 
         Assert::notNull($cart, 'Cart doesn\'t exist');
-        $promotionCoupon = $this->getPromotionCoupon($command->couponCode);
 
-        $cart->setPromotionCoupon($promotionCoupon);
+        $promotionCoupon = $this->getPromotionCoupon($command->couponCode);
+        $promotion = $promotionCoupon->getPromotion();
+
+        $cart->removePromotion($promotion);
 
         $this->orderProcessor->process($cart);
 

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Checkout/AddressOrderHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Checkout/AddressOrderHandler.php
@@ -16,8 +16,6 @@ namespace Sylius\Bundle\ApiBundle\CommandHandler\Checkout;
 use Doctrine\Persistence\ObjectManager;
 use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
 use Sylius\Bundle\ApiBundle\Command\Checkout\AddressOrder;
-use Sylius\Bundle\ApiBundle\Mapper\AddressMapperInterface;
-use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\OrderCheckoutTransitions;
@@ -45,23 +43,18 @@ final class AddressOrderHandler implements MessageHandlerInterface
     /** @var StateMachineFactoryInterface */
     private $stateMachineFactory;
 
-    /** @var AddressMapperInterface */
-    private $addressMapper;
-
     public function __construct(
         OrderRepositoryInterface $orderRepository,
         CustomerRepositoryInterface $customerRepository,
         FactoryInterface $customerFactory,
         ObjectManager $manager,
-        StateMachineFactoryInterface $stateMachineFactory,
-        AddressMapperInterface $addressMapper
+        StateMachineFactoryInterface $stateMachineFactory
     ) {
         $this->orderRepository = $orderRepository;
         $this->customerRepository = $customerRepository;
         $this->customerFactory = $customerFactory;
         $this->manager = $manager;
         $this->stateMachineFactory = $stateMachineFactory;
-        $this->addressMapper = $addressMapper;
     }
 
     public function __invoke(AddressOrder $addressOrder): OrderInterface
@@ -83,24 +76,8 @@ final class AddressOrderHandler implements MessageHandlerInterface
             $order->setCustomer($this->provideCustomerByEmail($addressOrder->email));
         }
 
-        /** @var AddressInterface|null $billingAddress */
-        $billingAddress = $order->getBillingAddress();
-        /** @var AddressInterface|null $shippingAddress */
-        $shippingAddress = $order->getShippingAddress();
-
-        if ($billingAddress !== null) {
-            $order->setBillingAddress($this->addressMapper->mapExisting($billingAddress, $addressOrder->billingAddress));
-        } else {
-            $order->setBillingAddress($addressOrder->billingAddress);
-        }
-
-        $newShippingAddress = $addressOrder->shippingAddress ?? clone $addressOrder->billingAddress;
-
-        if ($shippingAddress !== null) {
-            $order->setShippingAddress($this->addressMapper->mapExisting($shippingAddress, $newShippingAddress));
-        } else {
-            $order->setShippingAddress($newShippingAddress);
-        }
+        $order->setBillingAddress($addressOrder->billingAddress);
+        $order->setShippingAddress($addressOrder->shippingAddress ?? clone $addressOrder->billingAddress);
 
         $stateMachine->apply(OrderCheckoutTransitions::TRANSITION_ADDRESS);
 

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Checkout/ChoosePaymentMethodHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Checkout/ChoosePaymentMethodHandler.php
@@ -86,7 +86,9 @@ final class ChoosePaymentMethodHandler implements MessageHandlerInterface
             $stateMachine = $this->stateMachineFactory->get($cart, OrderCheckoutTransitions::GRAPH);
 
             Assert::true(
-                $stateMachine->can(OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT),
+                $stateMachine->can(
+                OrderCheckoutTransitions::TRANSITION_SELECT_PAYMENT
+            ),
                 'Order cannot have payment method assigned.'
             );
 

--- a/src/Sylius/Bundle/ApiBundle/CommandHandler/Checkout/ChooseShippingMethodHandler.php
+++ b/src/Sylius/Bundle/ApiBundle/CommandHandler/Checkout/ChooseShippingMethodHandler.php
@@ -15,6 +15,7 @@ namespace Sylius\Bundle\ApiBundle\CommandHandler\Checkout;
 
 use SM\Factory\FactoryInterface;
 use Sylius\Bundle\ApiBundle\Command\Checkout\ChooseShippingMethod;
+use Sylius\Component\Addressing\Model\Address;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ShippingMethodInterface;
 use Sylius\Component\Core\OrderCheckoutTransitions;

--- a/src/Sylius/Bundle/ApiBundle/Controller/DeleteOrderItemAction.php
+++ b/src/Sylius/Bundle/ApiBundle/Controller/DeleteOrderItemAction.php
@@ -32,7 +32,7 @@ final class DeleteOrderItemAction
     public function __invoke(Request $request): Response
     {
         $command = new RemoveItemFromCart(
-            $request->attributes->get('tokenValue'),
+            $request->attributes->get('id'),
             $request->attributes->get('itemId')
         );
 

--- a/src/Sylius/Bundle/ApiBundle/DataProvider/TaxonCollectionDataProvider.php
+++ b/src/Sylius/Bundle/ApiBundle/DataProvider/TaxonCollectionDataProvider.php
@@ -13,6 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\ApiBundle\DataProvider;
 
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\PaginationExtension;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryResultCollectionExtensionInterface;
+use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
 use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
 use Sylius\Bundle\ApiBundle\Context\UserContextInterface;
@@ -27,13 +31,34 @@ final class TaxonCollectionDataProvider implements CollectionDataProviderInterfa
     /** @var TaxonRepositoryInterface */
     private $taxonRepository;
 
+    /** @var PaginationExtension */
+    private $paginationExtension;
+
     /** @var UserContextInterface */
     private $userContext;
 
-    public function __construct(TaxonRepositoryInterface $taxonRepository, UserContextInterface $userContext)
-    {
+    /**
+     * @var iterable
+     *
+     * @see QueryCollectionExtensionInterface
+     */
+    private $collectionExtensions;
+
+    /** @var QueryNameGeneratorInterface */
+    private $queryNameGenerator;
+
+    public function __construct(
+        TaxonRepositoryInterface $taxonRepository,
+        PaginationExtension $paginationExtension,
+        UserContextInterface $userContext,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        iterable $collectionExtensions
+    ) {
         $this->taxonRepository = $taxonRepository;
+        $this->paginationExtension = $paginationExtension;
         $this->userContext = $userContext;
+        $this->queryNameGenerator = $queryNameGenerator;
+        $this->collectionExtensions = $collectionExtensions;
     }
 
     public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
@@ -51,6 +76,22 @@ final class TaxonCollectionDataProvider implements CollectionDataProviderInterfa
             return $this->taxonRepository->findAll();
         }
 
-        return $this->taxonRepository->findChildrenByChannelMenuTaxon($channelMenuTaxon);
+        $queryBuilder = $this->taxonRepository->createChildrenByChannelMenuTaxonQueryBuilder(
+            $channelMenuTaxon
+        );
+        foreach ($this->collectionExtensions as $extension) {
+            $extension->applyToCollection($queryBuilder, $this->queryNameGenerator, $resourceClass, $operationName, $context);
+
+            if ($extension instanceof QueryResultCollectionExtensionInterface && $extension->supportsResult($resourceClass, $operationName, $context)) {
+                return $extension->getResult($queryBuilder, $resourceClass, $operationName, $context);
+            }
+        }
+
+        return $this->paginationExtension->getResult(
+            $queryBuilder,
+            $resourceClass,
+            $operationName,
+            $context
+        );
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/DataTransformer/OrderTokenValueAwareInputCommandDataTransformer.php
+++ b/src/Sylius/Bundle/ApiBundle/DataTransformer/OrderTokenValueAwareInputCommandDataTransformer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\DataTransformer;
 
 use Sylius\Bundle\ApiBundle\Command\OrderTokenValueAwareInterface;
+use Sylius\Bundle\ApiBundle\DataTransformer\CommandDataTransformerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 
 /** @experimental */
@@ -22,9 +23,17 @@ final class OrderTokenValueAwareInputCommandDataTransformer implements CommandDa
     public function transform($object, string $to, array $context = [])
     {
         /** @var OrderInterface $cart */
-        $cart = $context['object_to_populate'];
 
-        $object->setOrderTokenValue($cart->getTokenValue());
+        if(key_exists('object_to_populate',$context)){
+            $cart = $context['object_to_populate'];
+            $tokenValue = $cart->getTokenValue();
+        }else if(property_exists($object,'orderTokenValue')){
+            $tokenValue = $object->orderTokenValue;
+        }else{
+            throw new \Exception('Token value could not be found');
+        }
+
+        $object->setOrderTokenValue($tokenValue);
 
         return $object;
     }

--- a/src/Sylius/Bundle/ApiBundle/DataTransformer/SubresourceIdAwareCommandDataTransformer.php
+++ b/src/Sylius/Bundle/ApiBundle/DataTransformer/SubresourceIdAwareCommandDataTransformer.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\ApiBundle\DataTransformer;
 
 use Sylius\Bundle\ApiBundle\Command\SubresourceIdAwareInterface;
+use Sylius\Bundle\ApiBundle\DataTransformer\CommandDataTransformerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Webmozart\Assert\Assert;
 
@@ -37,6 +38,10 @@ final class SubresourceIdAwareCommandDataTransformer implements CommandDataTrans
         $attributes = $this->requestStack->getCurrentRequest()->attributes;
 
         $attributeKey = $object->getSubresourceIdAttributeKey();
+
+        //Todo : To discuss - support getting attributes from url ?
+        // How does it exactly work for changing item quantity
+
         Assert::true($attributes->has($attributeKey), 'Path does not have subresource id');
 
         /** @var string $subresourceId */

--- a/src/Sylius/Bundle/ApiBundle/DataTransformer/SubresourceIdAwareCommandDataTransformer.php
+++ b/src/Sylius/Bundle/ApiBundle/DataTransformer/SubresourceIdAwareCommandDataTransformer.php
@@ -30,6 +30,10 @@ final class SubresourceIdAwareCommandDataTransformer implements CommandDataTrans
 
     public function transform($object, string $to, array $context = [])
     {
+        if (null !== $object->getSubresourceId()) {
+            return $object;
+        }
+
         $attributes = $this->requestStack->getCurrentRequest()->attributes;
 
         $attributeKey = $object->getSubresourceIdAttributeKey();

--- a/src/Sylius/Bundle/ApiBundle/GraphQl/Resolver/LoginMutationResolver.php
+++ b/src/Sylius/Bundle/ApiBundle/GraphQl/Resolver/LoginMutationResolver.php
@@ -1,0 +1,64 @@
+<?php
+
+
+namespace Sylius\Bundle\ApiBundle\GraphQl\Resolver;
+
+
+use ApiPlatform\Core\GraphQl\Resolver\MutationResolverInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Sylius\Component\Core\Model\ShopUser;
+use Sylius\Component\Core\Model\ShopUserInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+
+class LoginMutationResolver implements MutationResolverInterface
+{
+
+    /** @var EncoderFactoryInterface */
+    private $encoderFactory;
+
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    /** @var JWTTokenManagerInterface */
+    private $jwtManager;
+
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        JWTTokenManagerInterface $jwtManager,
+        EncoderFactoryInterface $encoderFactory
+    )
+    {
+        $this->entityManager = $entityManager;
+        $this->jwtManager = $jwtManager;
+        $this->encoderFactory = $encoderFactory;
+    }
+
+    public function __invoke( $item, $context)
+    {
+        if(!is_array($context) || !isset($context['args']['input'])){
+            return null;
+        }
+
+        $username = $context['args']['input']['username'];
+        $password = $context['args']['input']['password'];
+
+        $shopUserRepository = $this->entityManager->getRepository(ShopUser::class);
+
+        /** @var ShopUserInterface $user */
+        $user = $shopUserRepository->findOneBy(['username' => $username]);
+
+        $encoder = $this->encoderFactory->getEncoder($user);
+
+        if ($encoder->isPasswordValid($user->getPassword(),$password,$user->getSalt())) {
+            $token = $this->jwtManager->create($user);
+            $user->setToken($token);
+            return $user;
+
+        }
+        return null;
+    }
+
+
+}

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Address.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Address.xml
@@ -12,6 +12,17 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.address.class%" shortName="Address">
+        <graphql>
+            <operation name="item_query" />
+
+            <operation name="collection_query">
+                <attribute name="pagination_type">page</attribute>
+                <attribute name="filters">
+                    <attribute>sylius.api.payment_method_enabled_filter</attribute>
+                </attribute>
+            </operation>
+        </graphql>
+
         <attribute name="validation_groups">sylius</attribute>
 
         <collectionOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Channel.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Channel.xml
@@ -16,6 +16,14 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.channel.class%" shortName="Channel">
+        <graphql>
+            <operation name="collection_query">
+                <attribute name="pagination_type">page</attribute>
+            </operation>
+
+            <operation name="item_query" />
+        </graphql>
+
         <collectionOperations>
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ChannelPricing.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ChannelPricing.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" ?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<resources xmlns="https://api-platform.com/schema/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
+>
+    <resource class="%sylius.model.channel_pricing.class%" shortName="ChannelPricing">
+        <graphql>
+            <operation name="collection_query">
+                <attribute name="pagination_type">page</attribute>
+            </operation>
+        </graphql>
+
+        <attribute name="validation_groups">sylius</attribute>
+
+        <attribute name="normalization_context">
+            <attribute name="groups">
+                <attribute>shop:channel_pricing:read</attribute>
+            </attribute>
+        </attribute>
+
+        <itemOperations>
+            <itemOperation name="shop_get">
+                <attribute name="method">GET</attribute>
+                <attribute name="path">/shop/channel-pricings/{id}</attribute>
+            </itemOperation>
+        </itemOperations>
+
+        <collectionOperations>
+        </collectionOperations>
+
+        <property name="id" writable="false" readable="true" identifier="true" />
+        <property name="price" writable="false" readable="true" />
+        <property name="originalPrice" writable="false" readable="true" />
+    </resource>
+</resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Customer.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Customer.xml
@@ -16,7 +16,75 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.customer.class%" shortName="Customer">
+        <graphql>
+            <operation name="shop_get">
+                <attribute name="method">GET</attribute>
+                <attribute name="path">/shop/customers/{id}</attribute>
+                <attribute name="normalization_context">
+                    <attribute name="groups">
+                        <attribute>shop:customer:read</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
 
+            <operation name="shop_post">
+                <attribute name="method">POST</attribute>
+                <attribute name="path">/shop/customers</attribute>
+                <attribute name="openapi_context">
+                    <attribute name="summary">Registers a new customer</attribute>
+                </attribute>
+                <attribute name="denormalization_context">
+                    <attribute name="groups">shop:customer:create</attribute>
+                </attribute>
+                <attribute name="messenger">input</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Command\RegisterShopUser</attribute>
+                <attribute name="output">false</attribute>
+                <attribute name="args">
+                    <attribute name="firstName">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="lastName">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="email">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="password">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="phoneNumber">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="subscribedToNewsletter">
+                        <attribute name="type">Boolean</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
+
+            <operation name="shop_password_update">
+                <attribute name="method">PUT</attribute>
+                <attribute name="messenger">input</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Command\ChangeShopUserPassword</attribute>
+                <attribute name="output">false</attribute>
+                <attribute name="denormalization_context">
+                    <attribute name="groups">shop:customer:password:update</attribute>
+                </attribute>
+                <attribute name="args">
+                    <attribute name="shopUserId">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="currentPassword">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="newPassword">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="confirmNewPassword">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
+        </graphql>
         <attribute name="validation_groups">sylius</attribute>
 
         <collectionOperations>
@@ -73,9 +141,6 @@
                 <attribute name="path">/shop/customers/{id}</attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">shop:customer:update</attribute>
-                </attribute>
-                <attribute name="normalization_context">
-                    <attribute name="groups">shop:customer:read</attribute>
                 </attribute>
             </itemOperation>
         </itemOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
@@ -65,7 +65,7 @@
                 <attribute name="method">DELETE</attribute>
                 <attribute name="path">/shop/orders/{id}/items/{itemId}</attribute>
                 <attribute name="messenger">input</attribute>
-                <attribute name="input">Sylius\Bundle\ApiBundle\Controller\DeleteOrderItemAction</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\RemoveItemFromCart</attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">shop:cart:remove_item</attribute>
                 </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
@@ -19,15 +19,8 @@
         <graphql>
             <operation name="shop_post">
                 <attribute name="method">POST</attribute>
-                <attribute name="path">/shop/orders</attribute>
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\PickupCart</attribute>
-                <attribute name="denormalization_context">
-                    <attribute name="groups">shop:order:create</attribute>
-                </attribute>
-                <attribute name="openapi_context">
-                    <attribute name="summary">Pickups a new cart. Provided locale code has to be one of available for a particular channel.</attribute>
-                </attribute>
                 <attribute name="args">
                     <attribute name="tokenValue">
                         <attribute name="type">String</attribute>
@@ -40,7 +33,6 @@
 
             <operation name="item_query">
                 <attribute name="method">GET</attribute>
-                <attribute name="path">/shop/orders/{id}</attribute>
                 <attribute name="args">
                     <attribute name="tokenValue">
                         <attribute name="type">String</attribute>
@@ -50,45 +42,14 @@
 
             <operation name="shop_add_item">
                 <attribute name="method">PATCH</attribute>
-                <attribute name="path">/shop/orders/{id}/items</attribute>
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\AddItemToCart</attribute>
-                <attribute name="denormalization_context">
-                    <attribute name="groups">shop:cart:add_item</attribute>
-                </attribute>
-                <attribute name="openapi_context">
-                    <attribute name="summary">Adds Item to cart</attribute>
-                </attribute>
             </operation>
 
             <operation name="shop_remove_item">
                 <attribute name="method">DELETE</attribute>
-                <attribute name="path">/shop/orders/{id}/items/{itemId}</attribute>
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\RemoveItemFromCart</attribute>
-                <attribute name="denormalization_context">
-                    <attribute name="groups">shop:cart:remove_item</attribute>
-                </attribute>
-                <attribute name="openapi_context">
-                    <attribute name="parameters">
-                        <attribute>
-                            <attribute name="name">id</attribute>
-                            <attribute name="in">path</attribute>
-                            <attribute name="required">true</attribute>
-                            <attribute name="schema">
-                                <attribute name="type">string</attribute>
-                            </attribute>
-                        </attribute>
-                        <attribute>
-                            <attribute name="name">itemId</attribute>
-                            <attribute name="in">path</attribute>
-                            <attribute name="required">true</attribute>
-                            <attribute name="schema">
-                                <attribute name="type">string</attribute>
-                            </attribute>
-                        </attribute>
-                    </attribute>
-                </attribute>
                 <attribute name="args">
                     <attribute name="id">
                         <attribute name="type">String</attribute>
@@ -101,33 +62,8 @@
 
             <operation name="shop_change_quantity">
                 <attribute name="method">PATCH</attribute>
-                <attribute name="path">/shop/orders/{tokenValue}/items/{orderItemId}</attribute>
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\ChangeItemQuantityInCart</attribute>
-                <attribute name="denormalization_context">
-                    <attribute name="groups">shop:cart:change_quantity</attribute>
-                </attribute>
-                <attribute name="openapi_context">
-                    <attribute name="summary">Changes quantity of order item</attribute>
-                    <attribute name="parameters">
-                        <attribute>
-                            <attribute name="name">tokenValue</attribute>
-                            <attribute name="in">path</attribute>
-                            <attribute name="required">true</attribute>
-                            <attribute name="schema">
-                                <attribute name="type">string</attribute>
-                            </attribute>
-                        </attribute>
-                        <attribute>
-                            <attribute name="name">orderItemId</attribute>
-                            <attribute name="in">path</attribute>
-                            <attribute name="required">true</attribute>
-                            <attribute name="schema">
-                                <attribute name="type">string</attribute>
-                            </attribute>
-                        </attribute>
-                    </attribute>
-                </attribute>
                 <attribute name="args">
                     <attribute name="id">
                         <attribute name="type">String</attribute>
@@ -143,12 +79,114 @@
 
             <operation name="delete">
                 <attribute name="method">DELETE</attribute>
-                <attribute name="path">/shop/orders/{id}</attribute>
-                <attribute name="openapi_context">
-                    <attribute name="summary">Deletes cart</attribute>
-                </attribute>
                 <attribute name="args">
                     <attribute name="id">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
+
+            <operation name="shop_address">
+                <attribute name="method">PATCH</attribute>
+                <attribute name="messenger">input</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Command\Checkout\AddressOrder</attribute>
+                <attribute name="args">
+                    <attribute name="id">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="email">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="orderTokenValue">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="billingAddress">
+                        <attribute name="type">BillingAddress</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
+
+            <operation name="shop_select_shipping_method">
+                <attribute name="method">PATCH</attribute>
+                <attribute name="messenger">input</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Command\Checkout\ChooseShippingMethod</attribute>
+                <attribute name="args">
+                    <attribute name="shipmentId">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="orderTokenValue">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="shippingMethodCode">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
+
+            <operation name="shop_select_payment_method">
+                <attribute name="method">PATCH</attribute>
+                <attribute name="messenger">input</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Command\Checkout\ChoosePaymentMethod</attribute>
+                <attribute name="args">
+                    <attribute name="paymentId">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="orderTokenValue">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="paymentMethodCode">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
+
+            <operation name="shop_apply_coupon">
+                <attribute name="method">PATCH</attribute>
+                <attribute name="messenger">input</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\ApplyCouponToCart</attribute>
+                <attribute name="args">
+                    <attribute name="id">
+                        <attribute name="type">ID</attribute>
+                    </attribute>
+                    <attribute name="couponCode">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="orderTokenValue">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
+
+            <operation name="shop_remove_coupon">
+                <attribute name="method">PATCH</attribute>
+                <attribute name="messenger">input</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\RemoveCouponFromCart</attribute>
+                <attribute name="args">
+                    <attribute name="couponCode">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="orderTokenValue">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
+
+            <operation name="shop_complete">
+                <attribute name="method">PATCH</attribute>
+                <attribute name="validation_groups">
+                    <attribute>sylius</attribute>
+                    <attribute>sylius_checkout_complete</attribute>
+                </attribute>
+                <attribute name="messenger">input</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Command\Checkout\CompleteOrder</attribute>
+                <attribute name="args">
+                    <attribute name="id">
+                        <attribute name="type">String!</attribute>
+                    </attribute>
+                    <attribute name="orderTokenValue">
+                        <attribute name="type">String!</attribute>
+                    </attribute>
+                    <attribute name="notes">
                         <attribute name="type">String</attribute>
                     </attribute>
                 </attribute>
@@ -178,7 +216,10 @@
                     <attribute name="groups">shop:order:create</attribute>
                 </attribute>
                 <attribute name="openapi_context">
-                    <attribute name="summary">Pickups a new cart. Provided locale code has to be one of available for a particular channel.</attribute>                </attribute>
+                    <attribute name="summary">Pickups a new cart. Provided locale code has to be one of available for a
+                        particular channel.
+                    </attribute>
+                </attribute>
             </collectionOperation>
 
             <collectionOperation name="shop_get">
@@ -201,9 +242,6 @@
             <itemOperation name="shop_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/orders/{tokenValue}</attribute>
-                <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:read</attribute>
-                </attribute>
             </itemOperation>
 
             <itemOperation name="shop_delete">
@@ -211,9 +249,6 @@
                 <attribute name="path">/shop/orders/{tokenValue}</attribute>
                 <attribute name="openapi_context">
                     <attribute name="summary">Deletes cart</attribute>
-                </attribute>
-                <attribute name="normalization_context">
-                    <attribute name="groups">shop:order:read</attribute>
                 </attribute>
             </itemOperation>
 
@@ -235,9 +270,6 @@
                 <attribute name="path">/shop/orders/{tokenValue}/items</attribute>
                 <attribute name="messenger">input</attribute>
                 <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\AddItemToCart</attribute>
-                <attribute name="normalization_context">
-                    <attribute name="groups">shop:cart:read</attribute>
-                </attribute>
                 <attribute name="denormalization_context">
                     <attribute name="groups">shop:cart:add_item</attribute>
                 </attribute>
@@ -258,7 +290,9 @@
                     <attribute name="groups">shop:cart:read</attribute>
                 </attribute>
                 <attribute name="openapi_context">
-                    <attribute name="summary">Addresses cart to given location, logged in Customer does not have to provide an email</attribute>
+                    <attribute name="summary">Addresses cart to given location, logged in Customer does not have to
+                        provide an email
+                    </attribute>
                 </attribute>
             </itemOperation>
 
@@ -266,6 +300,7 @@
                 <attribute name="method">PATCH</attribute>
                 <attribute name="validation_groups">
                     <attribute>sylius</attribute>
+                    <attribute>sylius_checkout_complete</attribute>
                 </attribute>
                 <attribute name="path">/shop/orders/{tokenValue}/shipments/{shipmentId}</attribute>
                 <attribute name="messenger">input</attribute>
@@ -535,33 +570,32 @@
             </subresourceOperation>
         </subresourceOperations>
 
-        <property name="id" identifier="false" writable="false" />
-        <property name="number" identifier="false" writable="false" />
-        <property name="tokenValue" identifier="true" writable="false" />
-        <property name="channel" writable="false" />
-        <property name="customer" writable="false" />
+        <property name="id" identifier="false" writable="false"/>
+        <property name="number" identifier="false" writable="false"/>
+        <property name="tokenValue" identifier="true" writable="false"/>
+        <property name="channel" writable="false"/>
+        <property name="customer" writable="false"/>
         <property name="shipments" writable="false">
-            <subresource resourceClass="%sylius.model.shipment.class%" />
+            <subresource resourceClass="%sylius.model.shipment.class%"/>
         </property>
         <property name="payments" writable="false">
-            <subresource resourceClass="%sylius.model.payment.class%" />
+            <subresource resourceClass="%sylius.model.payment.class%"/>
         </property>
-        <property name="state" writable="false" />
-        <property name="paymentState" writable="false" />
-        <property name="shippingState" writable="false" />
-        <property name="total" writable="false" />
-        <property name="orderPromotionTotal" writable="false" />
+        <property name="state" writable="false"/>
+        <property name="paymentState" writable="false"/>
+        <property name="shippingState" writable="false"/>
+        <property name="total" writable="false"/>
+        <property name="orderPromotionTotal" writable="false"/>
         <property name="items" readable="true" writable="true">
-            <subresource resourceClass="%sylius.model.order_item.class%" />
+            <subresource resourceClass="%sylius.model.order_item.class%"/>
         </property>
-        <property name="notes" writable="true" />
-        <property name="itemsTotal" readable="true" />
+        <property name="notes" writable="true"/>
         <property name="taxTotal" readable="true"/>
         <property name="adjustments" writable="false">
-            <subresource resourceClass="%sylius.model.adjustment.class%" />
+            <subresource resourceClass="%sylius.model.adjustment.class%"/>
         </property>
-        <property name="billingAddress" writable="false" />
-        <property name="shippingAddress" writable="false" />
-        <property name="localeCode" writable="true" />
+        <property name="billingAddress" writable="true"/>
+        <property name="shippingAddress" writable="false"/>
+        <property name="localeCode" writable="true"/>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Order.xml
@@ -16,6 +16,145 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.order.class%" shortName="Order">
+        <graphql>
+            <operation name="shop_post">
+                <attribute name="method">POST</attribute>
+                <attribute name="path">/shop/orders</attribute>
+                <attribute name="messenger">input</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\PickupCart</attribute>
+                <attribute name="denormalization_context">
+                    <attribute name="groups">shop:order:create</attribute>
+                </attribute>
+                <attribute name="openapi_context">
+                    <attribute name="summary">Pickups a new cart. Provided locale code has to be one of available for a particular channel.</attribute>
+                </attribute>
+                <attribute name="args">
+                    <attribute name="tokenValue">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="localeCode">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
+
+            <operation name="item_query">
+                <attribute name="method">GET</attribute>
+                <attribute name="path">/shop/orders/{id}</attribute>
+                <attribute name="args">
+                    <attribute name="tokenValue">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
+
+            <operation name="shop_add_item">
+                <attribute name="method">PATCH</attribute>
+                <attribute name="path">/shop/orders/{id}/items</attribute>
+                <attribute name="messenger">input</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\AddItemToCart</attribute>
+                <attribute name="denormalization_context">
+                    <attribute name="groups">shop:cart:add_item</attribute>
+                </attribute>
+                <attribute name="openapi_context">
+                    <attribute name="summary">Adds Item to cart</attribute>
+                </attribute>
+            </operation>
+
+            <operation name="shop_remove_item">
+                <attribute name="method">DELETE</attribute>
+                <attribute name="path">/shop/orders/{id}/items/{itemId}</attribute>
+                <attribute name="messenger">input</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Controller\DeleteOrderItemAction</attribute>
+                <attribute name="denormalization_context">
+                    <attribute name="groups">shop:cart:remove_item</attribute>
+                </attribute>
+                <attribute name="openapi_context">
+                    <attribute name="parameters">
+                        <attribute>
+                            <attribute name="name">id</attribute>
+                            <attribute name="in">path</attribute>
+                            <attribute name="required">true</attribute>
+                            <attribute name="schema">
+                                <attribute name="type">string</attribute>
+                            </attribute>
+                        </attribute>
+                        <attribute>
+                            <attribute name="name">itemId</attribute>
+                            <attribute name="in">path</attribute>
+                            <attribute name="required">true</attribute>
+                            <attribute name="schema">
+                                <attribute name="type">string</attribute>
+                            </attribute>
+                        </attribute>
+                    </attribute>
+                </attribute>
+                <attribute name="args">
+                    <attribute name="id">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="orderItemId">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
+
+            <operation name="shop_change_quantity">
+                <attribute name="method">PATCH</attribute>
+                <attribute name="path">/shop/orders/{tokenValue}/items/{orderItemId}</attribute>
+                <attribute name="messenger">input</attribute>
+                <attribute name="input">Sylius\Bundle\ApiBundle\Command\Cart\ChangeItemQuantityInCart</attribute>
+                <attribute name="denormalization_context">
+                    <attribute name="groups">shop:cart:change_quantity</attribute>
+                </attribute>
+                <attribute name="openapi_context">
+                    <attribute name="summary">Changes quantity of order item</attribute>
+                    <attribute name="parameters">
+                        <attribute>
+                            <attribute name="name">tokenValue</attribute>
+                            <attribute name="in">path</attribute>
+                            <attribute name="required">true</attribute>
+                            <attribute name="schema">
+                                <attribute name="type">string</attribute>
+                            </attribute>
+                        </attribute>
+                        <attribute>
+                            <attribute name="name">orderItemId</attribute>
+                            <attribute name="in">path</attribute>
+                            <attribute name="required">true</attribute>
+                            <attribute name="schema">
+                                <attribute name="type">string</attribute>
+                            </attribute>
+                        </attribute>
+                    </attribute>
+                </attribute>
+                <attribute name="args">
+                    <attribute name="id">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="orderItemId">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="quantity">
+                        <attribute name="type">Int</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
+
+            <operation name="delete">
+                <attribute name="method">DELETE</attribute>
+                <attribute name="path">/shop/orders/{id}</attribute>
+                <attribute name="openapi_context">
+                    <attribute name="summary">Deletes cart</attribute>
+                </attribute>
+                <attribute name="args">
+                    <attribute name="id">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
+        </graphql>
+
         <attribute name="normalization_context">
             <attribute name="groups">
                 <attribute>admin:order:read</attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PaymentMethod.xml
@@ -16,6 +16,21 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.payment_method.class%" shortName="PaymentMethod">
+        <graphql>
+            <operation name="collection_query">
+                <attribute name="pagination_type">page</attribute>
+                <attribute name="filters">
+                    <attribute>sylius.api.payment_method_enabled_filter</attribute>
+                </attribute>
+            </operation>
+
+            <operation name="item_query" />
+        </graphql>
+
+        <attribute name="filters">
+            <attribute>sylius.api.payment_method_enabled_filter</attribute>
+        </attribute>
+
         <collectionOperations />
 
         <itemOperations>
@@ -36,19 +51,20 @@
             </itemOperation>
         </itemOperations>
 
-        <subresourceOperations>
-            <subresourceOperation name="api_orders_payments_methods_get_subresource">
-                <attribute name="method">GET</attribute>
-                <attribute name="normalization_context">
-                    <attribute name="groups">
-                        <attribute>shop:payment_method:read</attribute>
-                    </attribute>
-                </attribute>
-            </subresourceOperation>
-        </subresourceOperations>
-
         <property name="id" identifier="false" writable="false" />
         <property name="code" identifier="true" writable="false" />
         <property name="name" writable="true" />
+        <property name="translations" readable="true" writable="true">
+            <attribute name="openapi_context">
+                <attribute name="type">object</attribute>
+                <attribute name="example">
+                    <attribute name="en_US">
+                        <attribute name="name">string</attribute>
+                        <attribute name="slug">string</attribute>
+                        <attribute name="locale">string</attribute>
+                    </attribute>
+                </attribute>
+            </attribute>
+        </property>
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PaymentMethodTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/PaymentMethodTranslation.xml
@@ -15,7 +15,7 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
-    <resource class="%sylius.model.shipping_method_translation.class%" shortName="ShippingMethodTranslation">
+    <resource class="%sylius.model.payment_method_translation.class%" shortName="PaymentMethodTranslation">
         <graphql>
             <operation name="collection_query">
                 <attribute name="pagination_type">page</attribute>
@@ -31,18 +31,19 @@
         <itemOperations>
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
-                <attribute name="path">/admin/shipping-method-translations/{id}</attribute>
+                <attribute name="path">/admin/payment-method-translations/{id}</attribute>
             </itemOperation>
 
             <itemOperation name="shop_get">
                 <attribute name="method">GET</attribute>
-                <attribute name="path">/shop/shipping-method-translations/{id}</attribute>
+                <attribute name="path">/shop/payment-method-translations/{id}</attribute>
             </itemOperation>
         </itemOperations>
 
         <property name="id" identifier="true" writable="false" />
         <property name="name" identifier="false" required="true" />
         <property name="description" identifier="false" />
+        <property name="instructions" identifier="false" />
         <property name="locale" identifier="false" required="true" />
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
@@ -16,6 +16,29 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.product.class%" shortName="Product">
+        <graphql>
+            <operation name="collection_query">
+                <attribute name="pagination_type">page</attribute>
+                <attribute name="filters">
+                    <attribute>sylius.api.product_name_filter</attribute>
+                    <attribute>sylius.api.product_slug_filter</attribute>
+                    <attribute>sylius.api.product_order_filter</attribute>
+                    <attribute>sylius.api.product_taxon_code_filter</attribute>
+                    <attribute>sylius.api.product_taxon_slug_filter</attribute>
+                </attribute>
+            </operation>
+
+            <operation name="item_query" />
+        </graphql>
+
+        <attribute name="filters">
+            <attribute>sylius.api.product_name_filter</attribute>
+            <attribute>sylius.api.product_slug_filter</attribute>
+            <attribute>sylius.api.product_order_filter</attribute>
+            <attribute>sylius.api.product_taxon_code_filter</attribute>
+            <attribute>sylius.api.product_taxon_slug_filter</attribute>
+        </attribute>
+
         <attribute name="validation_groups">sylius</attribute>
 
         <attribute name="order">

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Product.xml
@@ -25,6 +25,7 @@
                     <attribute>sylius.api.product_order_filter</attribute>
                     <attribute>sylius.api.product_taxon_code_filter</attribute>
                     <attribute>sylius.api.product_taxon_slug_filter</attribute>
+                    <attribute>sylius.api.product_price_filter</attribute>
                 </attribute>
             </operation>
 
@@ -37,6 +38,7 @@
             <attribute>sylius.api.product_order_filter</attribute>
             <attribute>sylius.api.product_taxon_code_filter</attribute>
             <attribute>sylius.api.product_taxon_slug_filter</attribute>
+            <attribute>sylius.api.product_price_filter</attribute>
         </attribute>
 
         <attribute name="validation_groups">sylius</attribute>
@@ -143,7 +145,7 @@
         <property name="channels" required="false" />
         <property name="images" required="false" />
         <property name="mainTaxon" required="false" />
-        <property name="variants" readable="true"/>
+        <property name="variants" readable="true" />
         <property name="averageRating" readable="true" />
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductImage.xml
@@ -13,13 +13,16 @@
 
         <attribute name="validation_groups">sylius</attribute>
 
+        <attribute name="normalization_context">
+            <attribute name="groups">
+                <attribute>product_image:read</attribute>
+            </attribute>
+        </attribute>
+
         <collectionOperations>
             <collectionOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-images</attribute>
-                <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_image:read</attribute>
-                </attribute>
             </collectionOperation>
         </collectionOperations>
 
@@ -27,34 +30,14 @@
             <itemOperation name="admin_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/admin/product-images/{id}</attribute>
-                <attribute name="normalization_context">
-                    <attribute name="groups">admin:product_image:read</attribute>
-                </attribute>
             </itemOperation>
             <itemOperation name="shop_get">
                 <attribute name="method">GET</attribute>
                 <attribute name="path">/shop/product-images/{id}</attribute>
-                <attribute name="normalization_context">
-                    <attribute name="groups">shop:product_image:read</attribute>
-                </attribute>
-                <attribute name="openapi_context">
-                    <attribute name="parameters">
-                        <attribute>
-                            <attribute name="name">filter</attribute>
-                            <attribute name="in">query</attribute>
-                            <attribute name="description">Provide one of supported image liip imagine filters.</attribute>
-                            <attribute name="schema">
-                                <attribute name="type">string</attribute>
-                                <attribute name="enum" />
-                            </attribute>
-                        </attribute>
-                    </attribute>
-                </attribute>
             </itemOperation>
         </itemOperations>
 
         <property name="id" identifier="true" writable="false" />
         <property name="path" required="true" />
-        <property name="type" />
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductImage.xml
@@ -5,6 +5,12 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.product_image.class%" shortName="ProductImage">
+        <graphql>
+            <operation name="collection_query">
+                <attribute name="pagination_type">page</attribute>
+            </operation>
+        </graphql>
+
         <attribute name="validation_groups">sylius</attribute>
 
         <collectionOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductTranslation.xml
@@ -5,6 +5,12 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.product_translation.class%" shortName="ProductTranslation">
+        <graphql>
+            <operation name="collection_query">
+                <attribute name="pagination_type">page</attribute>
+            </operation>
+        </graphql>
+
         <attribute name="validation_groups">sylius</attribute>
 
         <collectionOperations />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
@@ -69,6 +69,7 @@
         <property name="id" identifier="false" writable="false" />
         <property name="code" identifier="true" required="true" />
         <property name="product" />
+        <property name="onHand" />
         <property name="translations">
             <attribute name="openapi_context">
                 <attribute name="type">array</attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariant.xml
@@ -16,6 +16,14 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.product_variant.class%" shortName="ProductVariant">
+        <graphql>
+            <operation name="collection_query">
+                <attribute name="pagination_type">page</attribute>
+            </operation>
+
+            <operation name="item_query" />
+        </graphql>
+
         <attribute name="validation_groups">sylius</attribute>
 
         <itemOperations>
@@ -73,6 +81,7 @@
                 </attribute>
             </attribute>
         </property>
+        <property name="channelPricings" writable="true" readable="true" />
         <property name="optionValues" readable="true" />
     </resource>
 </resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariantTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ProductVariantTranslation.xml
@@ -5,6 +5,12 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.product_variant_translation.class%" shortName="ProductVariantTranslation">
+        <graphql>
+            <operation name="collection_query">
+                <attribute name="pagination_type">page</attribute>
+            </operation>
+        </graphql>
+
         <attribute name="validation_groups">sylius</attribute>
 
         <collectionOperations />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Promotion.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Promotion.xml
@@ -16,6 +16,14 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.promotion.class%" shortName="Promotion">
+        <graphql>
+            <operation name="collection_query">
+                <attribute name="pagination_type">page</attribute>
+            </operation>
+
+            <operation name="item_query" />
+        </graphql>
+
         <attribute name="route_prefix">admin</attribute>
 
         <attribute name="validation_groups">sylius</attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingCategory.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingCategory.xml
@@ -16,6 +16,14 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.shipping_category.class%" shortName="ShippingCategory">
+        <graphql>
+            <operation name="collection_query">
+                <attribute name="pagination_type">page</attribute>
+            </operation>
+
+            <operation name="item_query" />
+        </graphql>
+
         <attribute name="route_prefix">admin</attribute>
 
         <attribute name="validation_groups">sylius</attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShippingMethod.xml
@@ -16,7 +16,21 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.shipping_method.class%" shortName="ShippingMethod">
+        <graphql>
+            <operation name="collection_query">
+                <attribute name="pagination_type">page</attribute>
+                <attribute name="filters">
+                    <attribute>sylius.api.shipping_method_enabled_filter</attribute>
+                </attribute>
+            </operation>
+
+            <operation name="item_query" />
+        </graphql>
         <attribute name="validation_groups">sylius</attribute>
+
+        <attribute name="filters">
+            <attribute>sylius.api.shipping_method_enabled_filter</attribute>
+        </attribute>
 
         <attribute name="order">
             <attribute name="position">ASC</attribute>
@@ -99,17 +113,6 @@
                 </attribute>
             </collectionOperation>
         </collectionOperations>
-
-        <subresourceOperations>
-            <subresourceOperation name="api_orders_shipments_methods_get_subresource">
-                <attribute name="method">GET</attribute>
-                <attribute name="normalization_context">
-                    <attribute name="groups">
-                        <attribute>shop:shipping_method:read</attribute>
-                    </attribute>
-                </attribute>
-            </subresourceOperation>
-        </subresourceOperations>
 
         <property name="id" identifier="false" writable="false" />
         <property name="code" identifier="true" required="true" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShopUser.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/ShopUser.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" ?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<resources xmlns="https://api-platform.com/schema/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
+>
+    <resource class="%sylius.model.shop_user.class%" shortName="User">
+        <graphql>
+            <operation name="shop_login">
+                <attribute name="mutation">api_platform.login_mutation_resolver</attribute>
+                <attribute name="write">false</attribute>
+                <attribute name="args">
+                    <attribute name="username">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                    <attribute name="password">
+                        <attribute name="type">String</attribute>
+                    </attribute>
+                </attribute>
+            </operation>
+        </graphql>
+
+        <property name="id" identifier="true" writable="false"/>
+    </resource>
+</resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Taxon.xml
@@ -5,6 +5,14 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.taxon.class%" shortName="Taxon">
+        <graphql>
+            <operation name="collection_query">
+                <attribute name="pagination_type">page</attribute>
+            </operation>
+
+            <operation name="item_query" />
+        </graphql>
+
         <attribute name="validation_groups">sylius</attribute>
 
         <collectionOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Taxon.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/Taxon.xml
@@ -8,10 +8,19 @@
         <graphql>
             <operation name="collection_query">
                 <attribute name="pagination_type">page</attribute>
+                <attribute name="filters">
+                    <attribute>sylius.api.taxa_translation_slug_filter</attribute>
+                    <attribute>sylius.api.taxa_date_filter</attribute>
+                </attribute>
             </operation>
 
             <operation name="item_query" />
         </graphql>
+
+        <attribute name="filters">
+            <attribute>sylius.api.taxa_translation_slug_filter</attribute>
+            <attribute>sylius.api.taxa_date_filter</attribute>
+        </attribute>
 
         <attribute name="validation_groups">sylius</attribute>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxonTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxonTranslation.xml
@@ -5,6 +5,12 @@
            xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
 >
     <resource class="%sylius.model.taxon_translation.class%" shortName="TaxonTranslation">
+        <graphql>
+            <operation name="collection_query">
+                <attribute name="pagination_type">page</attribute>
+            </operation>
+        </graphql>
+        
         <attribute name="validation_groups">sylius</attribute>
 
         <collectionOperations>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxonTranslation.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/TaxonTranslation.xml
@@ -10,7 +10,7 @@
                 <attribute name="pagination_type">page</attribute>
             </operation>
         </graphql>
-        
+
         <attribute name="validation_groups">sylius</attribute>
 
         <collectionOperations>
@@ -51,7 +51,7 @@
         </itemOperations>
 
         <property name="id" identifier="true" writable="false" />
-        <property name="name" required="true" />
+        <property name="name" required="true" readable="true" />
         <property name="slug" required="true" />
         <property name="description" required="false" />
     </resource>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
@@ -31,8 +31,8 @@ api_platform:
     collection:
         pagination:
             client_items_per_page: true
-    mapping:
-        paths: ['%kernel.project_dir%/config/api_platform']
+#    mapping:
+#        paths: ['%kernel.project_dir%/config/api_platform']
 
 lexik_jwt_authentication:
     token_extractors:

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ChannelPricing.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ChannelPricing.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<serializer xmlns="http://symfony.com/schema/dic/serializer-mapping"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
+>
+    <class name="Sylius\Component\Core\Model\ChannelPricing">
+        <attribute name="price">
+            <group>shop:channel_pricing:read</group>
+        </attribute>
+        <attribute name="originalPrice">
+            <group>shop:channel_pricing:read</group>
+        </attribute>
+        <attribute name="channelCode">
+            <group>shop:channel_pricing:read</group>
+        </attribute>
+    </class>
+</serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Cart/ChangeItemQuantityInCart.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Cart/ChangeItemQuantityInCart.xml
@@ -19,5 +19,8 @@
         <attribute name="quantity">
             <group>shop:cart:change_quantity</group>
         </attribute>
+        <attribute name="orderItemId">
+            <group>shop:cart:change_quantity</group>
+        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Cart/RemoveItemFromCart.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Cart/RemoveItemFromCart.xml
@@ -16,6 +16,9 @@
             xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
 >
     <class name="Sylius\Bundle\ApiBundle\Command\Cart\RemoveItemFromCart">
+        <attribute name="orderTokenValue">
+            <group>shop:cart:remove_item</group>
+        </attribute>
         <attribute name="orderItemId">
             <group>shop:cart:remove_item</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Checkout/ChoosePaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Checkout/ChoosePaymentMethod.xml
@@ -16,7 +16,13 @@
             xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
 >
     <class name="Sylius\Bundle\ApiBundle\Command\Checkout\ChoosePaymentMethod">
-        <attribute name="paymentMethodCode" serialized-name="paymentMethod">
+        <attribute name="paymentId">
+            <group>shop:cart:select_payment_method</group>
+        </attribute>
+        <attribute name="orderTokenValue">
+            <group>shop:cart:select_payment_method</group>
+        </attribute>
+        <attribute name="paymentMethodCode">
             <group>shop:cart:select_payment_method</group>
         </attribute>
     </class>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Checkout/ChooseShippingMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Commands/Checkout/ChooseShippingMethod.xml
@@ -16,7 +16,13 @@
             xsi:schemaLocation="http://symfony.com/schema/dic/serializer-mapping https://symfony.com/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd"
 >
     <class name="Sylius\Bundle\ApiBundle\Command\Checkout\ChooseShippingMethod">
-        <attribute name="shippingMethodCode" serialized-name="shippingMethod">
+        <attribute name="shipmentId">
+            <group>shop:cart:select_shipping_method</group>
+        </attribute>
+        <attribute name="orderTokenValue">
+            <group>shop:cart:select_shipping_method</group>
+        </attribute>
+        <attribute name="shippingMethodCode">
             <group>shop:cart:select_shipping_method</group>
         </attribute>
     </class>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Order.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/Order.xml
@@ -105,7 +105,6 @@
         </attribute>
 
         <attribute name="itemsTotal">
-            <group>admin:order:read</group>
             <group>shop:cart:read</group>
             <group>shop:order:read</group>
             <group>shop:order:account:read</group>
@@ -139,6 +138,7 @@
         <attribute name="billingAddress">
             <group>admin:order:read</group>
             <group>shop:cart:read</group>
+            <group>shop:cart:address</group>
             <group>shop:order:account:read</group>
         </attribute>
     </class>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethod.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/PaymentMethod.xml
@@ -23,6 +23,7 @@
         <attribute name="name">
             <group>admin:payment:read</group>
             <group>admin:payment_method:read</group>
+            <group>shop:cart:read</group>
             <group>shop:order:account:read</group>
             <group>shop:payment:read</group>
             <group>shop:payment_method:read</group>
@@ -31,13 +32,8 @@
             <group>admin:payment_method:read</group>
             <group>shop:payment_method:read</group>
         </attribute>
-        <attribute name="description">
-            <group>shop:payment_method:read</group>
-        </attribute>
-        <attribute name="instructions">
-            <group>shop:payment_method:read</group>
-        </attribute>
-        <attribute name="position">
+        <attribute name="translations">
+            <group>admin:payment_method:read</group>
             <group>shop:payment_method:read</group>
         </attribute>
     </class>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductImage.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductImage.xml
@@ -6,20 +6,12 @@
 >
     <class name="Sylius\Component\Core\Model\ProductImage">
         <attribute name="id">
-            <group>admin:product_image:read</group>
-            <group>shop:product_image:read</group>
+            <group>product_image:read</group>
             <group>admin:product:read</group>
             <group>shop:product:read</group>
         </attribute>
         <attribute name="path">
-            <group>admin:product_image:read</group>
-            <group>shop:product_image:read</group>
-            <group>admin:product:read</group>
-            <group>shop:product:read</group>
-        </attribute>
-        <attribute name="type">
-            <group>admin:product_image:read</group>
-            <group>shop:product_image:read</group>
+            <group>product_image:read</group>
             <group>admin:product:read</group>
             <group>shop:product:read</group>
         </attribute>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ProductVariant.xml
@@ -17,25 +17,22 @@
 >
     <class name="Sylius\Component\Core\Model\ProductVariant">
         <attribute name="id">
-            <group>admin:product_variant:read</group>
-            <group>shop:product_variant:read</group>
+            <group>product_variant:read</group>
         </attribute>
         <attribute name="code">
-            <group>admin:product_variant:read</group>
-            <group>shop:product_variant:read</group>
+            <group>product_variant:read</group>
         </attribute>
         <attribute name="product">
-            <group>admin:product_variant:read</group>
+            <group>product_variant:read</group>
             <group>shop:product_variant:read</group>
         </attribute>
         <attribute name="translations">
             <group>shop:order:account:read</group>
-            <group>admin:product_variant:read</group>
-            <group>shop:product_variant:read</group>
+            <group>product_variant:read</group>
+            <group>shop:cart:read</group>
         </attribute>
-        <attribute name="optionValues">
-            <group>admin:product_variant:read</group>
-            <group>shop:product_variant:read</group>
+        <attribute name="channelPricings">
+            <group>product_variant:read</group>
         </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShopUser.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/serialization/ShopUser.xml
@@ -19,5 +19,9 @@
         <attribute name="verified">
             <group>shop:customer:read</group>
         </attribute>
+
+        <attribute name="token">
+            <group>shop:customer:read</group>
+        </attribute>
     </class>
 </serializer>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
@@ -178,6 +178,16 @@
             <tag name="messenger.message_handler" bus="sylius_default.bus" />
         </service>
 
+        <service class="Sylius\Bundle\ApiBundle\CommandHandler\Cart\RemoveCouponFromCartHandler"
+                 id="Sylius\Bundle\ApiBundle\CommandHandler\Cart\RemoveCouponFromCartHandler"
+        >
+            <argument type="service" id="sylius.repository.order"/>
+            <argument type="service" id="sylius.repository.promotion_coupon"/>
+            <argument type="service" id="sylius.order_processing.order_processor"/>
+            <tag name="messenger.message_handler" bus="sylius.command_bus"/>
+            <tag name="messenger.message_handler" bus="sylius_default.bus"/>
+        </service>
+
         <service id="Sylius\Bundle\ApiBundle\CommandHandler\SendAccountRegistrationEmailHandler">
             <argument type="service" id="sylius.repository.shop_user" />
             <argument type="service" id="sylius.repository.channel" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/context_builders.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/context_builders.xml
@@ -47,37 +47,5 @@
             <argument type="service" id="sylius_api.serializer_context_builder.http_request_method_type.inner" />
         </service>
 
-        <service
-            id="sylius_api.serializer_context_builder.graphql.channel"
-            class="Sylius\Bundle\ApiBundle\SerializerContextBuilder\GraphQL\ChannelContextBuilder"
-            decorates="api_platform.graphql.serializer.context_builder"
-            decoration-priority="64"
-        >
-            <argument type="service" id="sylius_api.serializer_context_builder.graphql.channel.inner" />
-            <argument type="service" id="sylius.context.channel" />
-        </service>
-
-        <service
-            id="sylius_api.serializer_context_builder.graphql.locale"
-            class="Sylius\Bundle\ApiBundle\SerializerContextBuilder\GraphQL\LocaleContextBuilder"
-            decorates="api_platform.graphql.serializer.context_builder"
-            decoration-priority="64"
-        >
-            <argument type="service" id="sylius_api.serializer_context_builder.graphql.locale.inner" />
-            <argument type="service" id="sylius.context.locale" />
-        </service>
-
-        <service
-            id="sylius_api.serializer_context_builder.graphql.http_request_method_type"
-            class="Sylius\Bundle\ApiBundle\SerializerContextBuilder\GraphQL\HttpRequestMethodTypeContextBuilder"
-            decorates="api_platform.graphql.serializer.context_builder"
-            decoration-priority="64"
-        >
-            <argument
-                type="service"
-                id="sylius_api.serializer_context_builder.graphql.http_request_method_type.inner"
-            />
-            <argument type="service" id="api_platform.metadata.resource.metadata_factory.operation" />
-        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/context_builders.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/context_builders.xml
@@ -46,5 +46,38 @@
         >
             <argument type="service" id="sylius_api.serializer_context_builder.http_request_method_type.inner" />
         </service>
+
+        <service
+            id="sylius_api.serializer_context_builder.graphql.channel"
+            class="Sylius\Bundle\ApiBundle\SerializerContextBuilder\GraphQL\ChannelContextBuilder"
+            decorates="api_platform.graphql.serializer.context_builder"
+            decoration-priority="64"
+        >
+            <argument type="service" id="sylius_api.serializer_context_builder.graphql.channel.inner" />
+            <argument type="service" id="sylius.context.channel" />
+        </service>
+
+        <service
+            id="sylius_api.serializer_context_builder.graphql.locale"
+            class="Sylius\Bundle\ApiBundle\SerializerContextBuilder\GraphQL\LocaleContextBuilder"
+            decorates="api_platform.graphql.serializer.context_builder"
+            decoration-priority="64"
+        >
+            <argument type="service" id="sylius_api.serializer_context_builder.graphql.locale.inner" />
+            <argument type="service" id="sylius.context.locale" />
+        </service>
+
+        <service
+            id="sylius_api.serializer_context_builder.graphql.http_request_method_type"
+            class="Sylius\Bundle\ApiBundle\SerializerContextBuilder\GraphQL\HttpRequestMethodTypeContextBuilder"
+            decorates="api_platform.graphql.serializer.context_builder"
+            decoration-priority="64"
+        >
+            <argument
+                type="service"
+                id="sylius_api.serializer_context_builder.graphql.http_request_method_type.inner"
+            />
+            <argument type="service" id="api_platform.metadata.resource.metadata_factory.operation" />
+        </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/data_providers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/data_providers.xml
@@ -54,7 +54,10 @@
 
         <service id="sylius.api.collection_data_provider.taxon" class="Sylius\Bundle\ApiBundle\DataProvider\TaxonCollectionDataProvider">
             <argument type="service" id="sylius.repository.taxon" />
+            <argument type="service" id="api_platform.doctrine.orm.query_extension.pagination" />
             <argument type="service" id="sylius.api.context.user" />
+            <argument type="service" id="api_platform.core.bridge.doctrine.orm.util.query_name_generator" />
+            <argument type="tagged" tag="api_platform.doctrine.orm.query_extension.collection" />
             <tag name="api_platform.collection_data_provider" priority="10" />
         </service>
 

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/filters.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/filters.xml
@@ -40,6 +40,13 @@
             <tag name="api_platform.filter" />
         </service>
 
+        <service id="sylius.api.product_taxon_slug_filter" parent="api_platform.doctrine.orm.search_filter">
+            <argument type="collection">
+                <argument key="productTaxons.taxon.translations.slug">exact</argument>
+            </argument>
+            <tag name="api_platform.filter" />
+        </service>
+
         <service id="sylius.api.product_taxon_filter" class="Sylius\Bundle\ApiBundle\Filter\TaxonFilter">
             <argument type="service" id="doctrine" />
             <argument type="service" id="api_platform.iri_converter" />
@@ -49,6 +56,13 @@
         <service id="sylius.api.product_name_filter" parent="api_platform.doctrine.orm.search_filter">
             <argument type="collection">
                 <argument key="translations.name">partial</argument>
+            </argument>
+            <tag name="api_platform.filter" />
+        </service>
+
+        <service id="sylius.api.product_slug_filter" parent="api_platform.doctrine.orm.search_filter">
+            <argument type="collection">
+                <argument key="translations.slug">exact</argument>
             </argument>
             <tag name="api_platform.filter" />
         </service>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/filters.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/filters.xml
@@ -40,13 +40,6 @@
             <tag name="api_platform.filter" />
         </service>
 
-        <service id="sylius.api.product_taxon_slug_filter" parent="api_platform.doctrine.orm.search_filter">
-            <argument type="collection">
-                <argument key="productTaxons.taxon.translations.slug">exact</argument>
-            </argument>
-            <tag name="api_platform.filter" />
-        </service>
-
         <service id="sylius.api.product_taxon_filter" class="Sylius\Bundle\ApiBundle\Filter\TaxonFilter">
             <argument type="service" id="doctrine" />
             <argument type="service" id="api_platform.iri_converter" />
@@ -66,6 +59,21 @@
             </argument>
             <tag name="api_platform.filter" />
         </service>
+
+        <service id="sylius.api.product_price_filter" parent="api_platform.doctrine.orm.range_filter">
+            <argument type="collection">
+                <argument key="variants.channelPricings.price" />
+            </argument>
+            <tag name="api_platform.filter" />
+        </service>
+
+        <service id="sylius.api.product_taxon_slug_filter" parent="api_platform.doctrine.orm.search_filter">
+            <argument type="collection">
+                <argument key="productTaxons.taxon.translations.slug">exact</argument>
+            </argument>
+            <tag name="api_platform.filter" />
+        </service>
+
 
         <service id="sylius.api.product_variant_product_filter" parent="api_platform.doctrine.orm.search_filter">
             <argument type="collection">
@@ -124,6 +132,35 @@
         <service id="sylius.api.product_variant_option_value_filter" class="Sylius\Bundle\ApiBundle\Doctrine\Filter\ProductVariantOptionValueFilter">
             <argument type="service" id="api_platform.iri_converter" />
             <argument type="service" id="doctrine" />
+            <tag name="api_platform.filter" />
+        </service>
+
+        <service id="sylius.api.taxa_translation_slug_filter" parent="api_platform.doctrine.orm.search_filter">
+            <argument type="collection">
+                <argument key="translations.name">partial</argument>
+                <argument key="translations.slug">partial</argument>
+            </argument>
+            <tag name="api_platform.filter" />
+        </service>
+
+        <service id="sylius.api.taxa_date_filter" parent="api_platform.doctrine.orm.order_filter">
+            <argument type="collection">
+                <argument key="createdAt" />
+            </argument>
+            <tag name="api_platform.filter" />
+        </service>
+
+        <service id="sylius.api.shipping_method_enabled_filter" parent="api_platform.doctrine.orm.boolean_filter">
+            <argument type="collection">
+                <argument key="enabled" />
+            </argument>
+            <tag name="api_platform.filter" />
+        </service>
+
+        <service id="sylius.api.payment_method_enabled_filter" parent="api_platform.doctrine.orm.boolean_filter">
+            <argument type="collection">
+                <argument key="enabled" />
+            </argument>
             <tag name="api_platform.filter" />
         </service>
     </services>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/graphql_types.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/graphql_types.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
+    <services>
+        <defaults autowire="false" autoconfigure="false" public="false" />
+
+        <service id="sylius.api.product_slug_filter" class="Sylius\Bundle\ApiBundle\Types\BillingAddress">
+            <tag name="api_platform.graphql.type" />
+        </service>
+    </services>
+</container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/resolver.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/resolver.xml
@@ -26,5 +26,13 @@
             <argument type="service" id="api_platform.route_name_resolver.cached.inner" />
             <argument type="service" id="Sylius\Bundle\ApiBundle\Provider\PathPrefixProviderInterface" />
         </service>
+
+        <service id="api_platform.login_mutation_resolver" class="Sylius\Bundle\ApiBundle\GraphQl\Resolver\LoginMutationResolver">
+            <argument type="service" id="doctrine.orm.entity_manager" />
+            <argument type="service" id="lexik_jwt_authentication.jwt_manager" />
+            <argument type="service" id="security.encoder_factory" />
+            <tag name="api_platform.graphql.mutation_resolver" />
+        </service>
+
     </services>
 </container>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/services.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
+>
+    <services>
+        <defaults autowire="false" autoconfigure="false" public="false" />
+
+        <service
+            id="api_platform.core.bridge.doctrine.orm.util.query_name_generator"
+            class="ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGenerator"
+        />
+    </services>
+</container>

--- a/src/Sylius/Bundle/ApiBundle/SerializerContextBuilder/GraphQL/ChannelContextBuilder.php
+++ b/src/Sylius/Bundle/ApiBundle/SerializerContextBuilder/GraphQL/ChannelContextBuilder.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\SerializerContextBuilder\GraphQL;
+
+use ApiPlatform\Core\GraphQl\Serializer\SerializerContextBuilderInterface;
+use Sylius\Bundle\ApiBundle\Serializer\ContextKeys;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Channel\Context\ChannelNotFoundException;
+
+/** @experimental */
+final class ChannelContextBuilder implements SerializerContextBuilderInterface
+{
+    /** @var SerializerContextBuilderInterface */
+    private $decoratedContextBuilder;
+
+    /** @var ChannelContextInterface */
+    private $channelContext;
+
+    public function __construct(
+        SerializerContextBuilderInterface $decoratedContextBuilder,
+        ChannelContextInterface $channelContext
+    ) {
+        $this->decoratedContextBuilder = $decoratedContextBuilder;
+        $this->channelContext = $channelContext;
+    }
+
+    public function create(
+        string $resourceClass,
+        string $operationName,
+        array $resolverContext,
+        bool $normalization
+    ): array {
+        $context = $this->decoratedContextBuilder->create(
+            $resourceClass,
+            $operationName,
+            $resolverContext,
+            $normalization
+        );
+
+        try {
+            $context[ContextKeys::CHANNEL] = $this->channelContext->getChannel();
+        } catch (ChannelNotFoundException $exception) {
+        }
+
+        return $context;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/SerializerContextBuilder/GraphQL/HttpRequestMethodTypeContextBuilder.php
+++ b/src/Sylius/Bundle/ApiBundle/SerializerContextBuilder/GraphQL/HttpRequestMethodTypeContextBuilder.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\SerializerContextBuilder\GraphQL;
+
+use ApiPlatform\Core\Exception\ResourceClassNotFoundException;
+use ApiPlatform\Core\GraphQl\Serializer\SerializerContextBuilderInterface;
+use ApiPlatform\Core\Metadata\Resource\Factory\ResourceMetadataFactoryInterface;
+use Sylius\Bundle\ApiBundle\Serializer\ContextKeys;
+use Symfony\Component\HttpFoundation\Request;
+
+/** @experimental */
+final class HttpRequestMethodTypeContextBuilder implements SerializerContextBuilderInterface
+{
+    private const OPERATION_ITEM_QUERY = 'item_query';
+
+    private const OPERATION_COLLECTION_QUERY = 'collection_query';
+
+    private const OPERATION_CREATE = 'create';
+
+    private const OPERATION_UPDATE = 'update';
+
+    private const OPERATION_DELETE = 'delete';
+
+    private const DEFAULT_OPERATIONS_TO_METHODS_MAPPING = [
+        self::OPERATION_ITEM_QUERY => Request::METHOD_GET,
+        self::OPERATION_COLLECTION_QUERY => Request::METHOD_GET,
+        self::OPERATION_CREATE => Request::METHOD_POST,
+        self::OPERATION_UPDATE => Request::METHOD_PATCH,
+        self::OPERATION_DELETE => Request::METHOD_DELETE,
+    ];
+
+    /** @var SerializerContextBuilderInterface */
+    private $decoratedContextBuilder;
+
+    /** @var ResourceMetadataFactoryInterface */
+    private $resourceMetadataFactory;
+
+    public function __construct(
+        SerializerContextBuilderInterface $decoratedContextBuilder,
+        ResourceMetadataFactoryInterface $resourceMetadataFactory
+    ) {
+        $this->decoratedContextBuilder = $decoratedContextBuilder;
+        $this->resourceMetadataFactory = $resourceMetadataFactory;
+    }
+
+    public function create(
+        string $resourceClass,
+        string $operationName,
+        array $resolverContext,
+        bool $normalization
+    ): array {
+        $context = $this->decoratedContextBuilder->create(
+            $resourceClass,
+            $operationName,
+            $resolverContext,
+            $normalization
+        );
+
+        try {
+            if (true === $this->isDefaultOperation($operationName)) {
+                $context[ContextKeys::HTTP_REQUEST_METHOD_TYPE] = $this->getMethodTypeForDefaultOperation(
+                    $operationName
+                );
+
+                return $context;
+            }
+
+            if (false === isset($resolverContext['is_collection'])) {
+                return $context;
+            }
+
+            $resourceMetadata = $this->resourceMetadataFactory->create($resourceClass);
+
+            $availableCustomOperations = true === $resolverContext['is_collection'] ?
+                $resourceMetadata->getCollectionOperations() :
+                $resourceMetadata->getItemOperations()
+            ;
+
+            if (false === isset($availableCustomOperations[$operationName])) {
+                return $context;
+            }
+
+            if (false === isset($availableCustomOperations[$operationName]['method'])) {
+                return $context;
+            }
+
+            $context[ContextKeys::HTTP_REQUEST_METHOD_TYPE] = strtoupper(
+                $availableCustomOperations[$operationName]['method']
+            );
+        } catch (ResourceClassNotFoundException $exception) {
+        }
+
+        return $context;
+    }
+
+    private function isDefaultOperation(string $operationName): bool
+    {
+        return array_key_exists($operationName, self::DEFAULT_OPERATIONS_TO_METHODS_MAPPING);
+    }
+
+    private function getMethodTypeForDefaultOperation(string $operationName): string
+    {
+        return self::DEFAULT_OPERATIONS_TO_METHODS_MAPPING[$operationName];
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/SerializerContextBuilder/GraphQL/LocaleContextBuilder.php
+++ b/src/Sylius/Bundle/ApiBundle/SerializerContextBuilder/GraphQL/LocaleContextBuilder.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\ApiBundle\SerializerContextBuilder\GraphQL;
+
+use ApiPlatform\Core\GraphQl\Serializer\SerializerContextBuilderInterface;
+use Sylius\Bundle\ApiBundle\Serializer\ContextKeys;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Sylius\Component\Locale\Context\LocaleNotFoundException;
+
+/** @experimental */
+final class LocaleContextBuilder implements SerializerContextBuilderInterface
+{
+    /** @var SerializerContextBuilderInterface */
+    private $decoratedContextBuilder;
+
+    /** @var LocaleContextInterface */
+    private $localeContext;
+
+    public function __construct(
+        SerializerContextBuilderInterface $decoratedContextBuilder,
+        LocaleContextInterface $localeContext
+    ) {
+        $this->decoratedContextBuilder = $decoratedContextBuilder;
+        $this->localeContext = $localeContext;
+    }
+
+    public function create(
+        string $resourceClass,
+        string $operationName,
+        array $resolverContext,
+        bool $normalization
+    ): array {
+        $context = $this->decoratedContextBuilder->create(
+            $resourceClass,
+            $operationName,
+            $resolverContext,
+            $normalization
+        );
+
+        try {
+            $context[ContextKeys::LOCALE_CODE] = $this->localeContext->getLocaleCode();
+        } catch (LocaleNotFoundException $exception) {
+        }
+
+        return $context;
+    }
+}

--- a/src/Sylius/Bundle/ApiBundle/Types/BillingAddress.php
+++ b/src/Sylius/Bundle/ApiBundle/Types/BillingAddress.php
@@ -1,0 +1,38 @@
+<?php
+
+
+namespace Sylius\Bundle\ApiBundle\Types;
+
+
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\Type;
+
+class BillingAddress extends InputObjectType
+{
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function __construct()
+    {
+        $this->name = 'BillingAddress';
+        $this->description = 'The `BillingAddress` object type.';
+        $config = [
+            'fields' => [
+                'id' => Type::id(),
+                'firstName'=> Type::string(),
+                'lastName'=> Type::string(),
+                'countryCode'=> Type::string(),
+                'street'=> Type::string(),
+                'city'=> Type::string(),
+                'postcode'=> Type::string()
+            ]
+        ];
+        parent::__construct($config);
+    }
+}
+

--- a/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
@@ -122,4 +122,19 @@ class TaxonRepository extends EntityRepository implements TaxonRepositoryInterfa
 
         return $queryBuilder;
     }
+
+    public function createChildrenByChannelMenuTaxonQueryBuilder(
+        ?TaxonInterface $menuTaxon = null,
+        ?string $locale = null
+    ): QueryBuilder {
+        return $this->createTranslationBasedQueryBuilder($locale)
+            ->addSelect('child')
+            ->innerJoin('o.parent', 'parent')
+            ->leftJoin('o.children', 'child')
+            ->andWhere('o.enabled = true')
+            ->andWhere('parent.code = :parentCode')
+            ->addOrderBy('o.position')
+            ->setParameter('parentCode', ($menuTaxon !== null) ? $menuTaxon->getCode() : 'category')
+        ;
+    }
 }

--- a/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
+++ b/src/Sylius/Bundle/TaxonomyBundle/Doctrine/ORM/TaxonRepository.php
@@ -135,6 +135,6 @@ class TaxonRepository extends EntityRepository implements TaxonRepositoryInterfa
             ->andWhere('parent.code = :parentCode')
             ->addOrderBy('o.position')
             ->setParameter('parentCode', ($menuTaxon !== null) ? $menuTaxon->getCode() : 'category')
-        ;
+            ;
     }
 }

--- a/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
+++ b/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
@@ -44,4 +44,9 @@ interface TaxonRepositoryInterface extends RepositoryInterface
     public function findByNamePart(string $phrase, ?string $locale = null, ?int $limit = null): array;
 
     public function createListQueryBuilder(): QueryBuilder;
+
+    public function createChildrenByChannelMenuTaxonQueryBuilder(
+        ?TaxonInterface $menuTaxon = null,
+        ?string $locale = null
+    ): QueryBuilder;
 }

--- a/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
+++ b/src/Sylius/Component/Taxonomy/Repository/TaxonRepositoryInterface.php
@@ -44,9 +44,4 @@ interface TaxonRepositoryInterface extends RepositoryInterface
     public function findByNamePart(string $phrase, ?string $locale = null, ?int $limit = null): array;
 
     public function createListQueryBuilder(): QueryBuilder;
-
-    public function createChildrenByChannelMenuTaxonQueryBuilder(
-        ?TaxonInterface $menuTaxon = null,
-        ?string $locale = null
-    ): QueryBuilder;
 }

--- a/src/Sylius/Component/User/Model/CredentialsHolderInterface.php
+++ b/src/Sylius/Component/User/Model/CredentialsHolderInterface.php
@@ -47,4 +47,8 @@ interface CredentialsHolderInterface
      * the plain-text password is stored on this object.
      */
     public function eraseCredentials();
+
+    public function getToken(): ?string;
+
+    public function setToken(?string $token): void;
 }

--- a/src/Sylius/Component/User/Model/User.php
+++ b/src/Sylius/Component/User/Model/User.php
@@ -56,6 +56,13 @@ class User implements UserInterface
      */
     protected $plainPassword;
 
+    /**
+     * Used for GraphQL serialisation validation. Must not be persisted.
+     *
+     * @var string|null
+     */
+    protected $token;
+
     /** @var \DateTimeInterface|null */
     protected $lastLogin;
 
@@ -336,6 +343,7 @@ class User implements UserInterface
     public function eraseCredentials(): void
     {
         $this->plainPassword = null;
+        $this->token = null;
     }
 
     public function getOAuthAccounts(): Collection
@@ -376,6 +384,16 @@ class User implements UserInterface
     public function setEncoderName(?string $encoderName): void
     {
         $this->encoderName = $encoderName;
+    }
+
+    public function getToken(): ?string
+    {
+        return $this->token;
+    }
+
+    public function setToken(?string $token): void
+    {
+        $this->token = $token;
     }
 
     /**

--- a/symfony.lock
+++ b/symfony.lock
@@ -1042,6 +1042,9 @@
     "webmozart/path-util": {
         "version": "2.3.0"
     },
+    "webonyx/graphql-php": {
+        "version": "v14.9.0"
+    },
     "willdurand/hateoas": {
         "version": "2.12.0"
     },


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         |  master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Following PR is in progress for developing experimental GraphQL APIPlatform feature along with Behat tests covering newly added GraphQL mutations and queries.

The goal for first iteration of published work was to create working login mutation and complete simple order with ability to browse through taxons and products with basic filtering.

Ultimately this GraphQL endpoints shall be used with VueStoreFront 2, frontend shop implementation.


<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->


