### PR TITLE
[API] AddressOrderHandler refactored to use customer provider

### DIFF
--- a/UPGRADE-API-1.11.md
+++ b/UPGRADE-API-1.11.md
@@ -42,6 +42,21 @@
         }
     ``` 
 
+1. The constructor of `Sylius\Bundle\ApiBundle\CommandHandler\Checkout\AddressOrderHandler` has been changed:
+
+    ```diff
+        public function __construct(
+            OrderRepositoryInterface $orderRepository,
+    -       CustomerRepositoryInterface $customerRepository,
+    -       FactoryInterface $customerFactory,
+            ObjectManager $manager,
+            StateMachineFactoryInterface $stateMachineFactory,
+            AddressMapperInterface $addressMapper
+            AddressMapperInterface $addressMapper,
+    +       CustomerProviderInterface $customerProvider
+        ) {
+    ``` 
+
 1. The response schema for endpoint `GET /api/v2/shop/orders/{tokenValue}/shipments/{shipments}/methods` has been changed from: 
 
     ```
@@ -117,38 +132,38 @@
     ```
 
 1. The service `Sylius\Bundle\ApiBundle\Converter\ItemIriToIdentifierConverter` has changed its name to `Sylius\Bundle\ApiBundle\Converter\IriToIdentifierConverter`
-    and its service definition from `Sylius\Bundle\ApiBundle\Converter\ItemIriToIdentifierConverter` to `Sylius\Bundle\ApiBundle\Converter\IriToIdentifierConverterInterface`
+     and its service definition from `Sylius\Bundle\ApiBundle\Converter\ItemIriToIdentifierConverter` to `Sylius\Bundle\ApiBundle\Converter\IriToIdentifierConverterInterface`
 
 1. The service `Sylius\Bundle\ApiBundle\Serializer\CommandFieldItemIriToIdentifierDenormalizer` has changed its name to `Sylius\Bundle\ApiBundle\Serializer\CommandArgumentsDenormalizer`
-    and also its service definition.
+     and also its service definition.
 
 1. Following namespaces has been changed:
-	* '\Sylius\Bundle\ApiBundle\CommandHandler\AddProductReviewHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Catalog\AddProductReviewHandler'
-	* '\Sylius\Bundle\ApiBundle\CommandHandler\BlameCartHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Cart\BlameCartHandler'
-	* '\Sylius\Bundle\ApiBundle\CommandHandler\RequestResetPasswordTokenHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Account\RequestResetPasswordTokenHandler'
-	* '\Sylius\Bundle\ApiBundle\CommandHandler\ResendVerificationEmailHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Account\ResendVerificationEmailHandler'
-	* '\Sylius\Bundle\ApiBundle\CommandHandler\ResetPasswordHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Account\ResetPasswordHandler'
-	* '\Sylius\Bundle\ApiBundle\CommandHandler\SendAccountRegistrationEmailHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Account\SendAccountRegistrationEmailHandler'
-	* '\Sylius\Bundle\ApiBundle\CommandHandler\SendAccountVerificationEmailHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Account\SendAccountVerificationEmailHandler'
-	* '\Sylius\Bundle\ApiBundle\CommandHandler\SendOrderConfirmationHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Checkout\SendOrderConfirmationHandler'
-	* '\Sylius\Bundle\ApiBundle\CommandHandler\SendResetPasswordEmailHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Account\SendResetPasswordEmailHandler'
-	* '\Sylius\Bundle\ApiBundle\CommandHandler\SendShipmentConfirmationEmailHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Checkout\SendShipmentConfirmationEmailHandler'
-	* '\Sylius\Bundle\ApiBundle\CommandHandler\VerifyCustomerAccountHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Account\VerifyCustomerAccountHandler'
-	* '\Sylius\Bundle\ApiBundle\Command\AddProductReview' => '\Sylius\Bundle\ApiBundle\Command\Catalog\AddProductReview'
-	* '\Sylius\Bundle\ApiBundle\Command\BlameCart' => '\Sylius\Bundle\ApiBundle\Command\Cart\BlameCart'
-	* '\Sylius\Bundle\ApiBundle\Command\RequestResetPasswordToken' => '\Sylius\Bundle\ApiBundle\Command\Account\RequestResetPasswordToken'
-	* '\Sylius\Bundle\ApiBundle\Command\ResendVerificationEmail' => '\Sylius\Bundle\ApiBundle\Command\Account\ResendVerificationEmail'
-	* '\Sylius\Bundle\ApiBundle\Command\ResetPassword' => '\Sylius\Bundle\ApiBundle\Command\Account\ResetPassword'
-	* '\Sylius\Bundle\ApiBundle\Command\SendAccountRegistrationEmail' => '\Sylius\Bundle\ApiBundle\Command\Account\SendAccountRegistrationEmail'
-	* '\Sylius\Bundle\ApiBundle\Command\SendAccountVerificationEmail' => '\Sylius\Bundle\ApiBundle\Command\Account\SendAccountVerificationEmail'
-	* '\Sylius\Bundle\ApiBundle\Command\SendOrderConfirmation' => '\Sylius\Bundle\ApiBundle\Command\Checkout\SendOrderConfirmation'
-	* '\Sylius\Bundle\ApiBundle\Command\SendResetPasswordEmail' => '\Sylius\Bundle\ApiBundle\Command\Account\SendResetPasswordEmail'
-	* '\Sylius\Bundle\ApiBundle\Command\SendShipmentConfirmationEmail' => '\Sylius\Bundle\ApiBundle\Command\Checkout\SendShipmentConfirmationEmail'
-	* '\Sylius\Bundle\ApiBundle\Command\VerifyCustomerAccount' => '\Sylius\Bundle\ApiBundle\Command\Account\VerifyCustomerAccount'
-    * `\Sylius\Bundle\ApiBundle\CommandHandler\ChangeShopUserPasswordHandler` => `\Sylius\Bundle\ApiBundle\CommandHandler\Account\ChangeShopUserPasswordHandler`
-    * `\Sylius\Bundle\ApiBundle\CommandHandler\PickupCartHandler` => `\Sylius\Bundle\ApiBundle\CommandHandler\Cart\PickupCartHandler`
-    * `\Sylius\Bundle\ApiBundle\CommandHandler\RegisterShopUserHandler` => `\Sylius\Bundle\ApiBundle\CommandHandler\Account\RegisterShopUserHandler`
-    * `\Sylius\Bundle\ApiBundle\Command\ChangeShopUserPassword` => `\Sylius\Bundle\ApiBundle\Command\Account\ChangeShopUserPassword`
-    * `\Sylius\Bundle\ApiBundle\Command\RegisterShopUser` => `\Sylius\Bundle\ApiBundle\Command\Account\RegisterShopUser`
-    * `\Sylius\Bundle\ApiBundle\Doctrine\Filters\ExchangeRateFilter` => `\Sylius\Bundle\ApiBundle\Doctrine\Filter\ExchangeRateFilter`
-    * `\Sylius\Bundle\ApiBundle\Doctrine\Filters\TranslationOrderNameAndLocaleFilter` => `Sylius\Bundle\ApiBundle\Doctrine\Filter\TranslationOrderNameAndLocaleFilter`
+     * '\Sylius\Bundle\ApiBundle\CommandHandler\AddProductReviewHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Catalog\AddProductReviewHandler'
+     * '\Sylius\Bundle\ApiBundle\CommandHandler\BlameCartHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Cart\BlameCartHandler'
+     * '\Sylius\Bundle\ApiBundle\CommandHandler\RequestResetPasswordTokenHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Account\RequestResetPasswordTokenHandler'
+     * '\Sylius\Bundle\ApiBundle\CommandHandler\ResendVerificationEmailHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Account\ResendVerificationEmailHandler'
+     * '\Sylius\Bundle\ApiBundle\CommandHandler\ResetPasswordHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Account\ResetPasswordHandler'
+     * '\Sylius\Bundle\ApiBundle\CommandHandler\SendAccountRegistrationEmailHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Account\SendAccountRegistrationEmailHandler'
+     * '\Sylius\Bundle\ApiBundle\CommandHandler\SendAccountVerificationEmailHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Account\SendAccountVerificationEmailHandler'
+     * '\Sylius\Bundle\ApiBundle\CommandHandler\SendOrderConfirmationHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Checkout\SendOrderConfirmationHandler'
+     * '\Sylius\Bundle\ApiBundle\CommandHandler\SendResetPasswordEmailHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Account\SendResetPasswordEmailHandler'
+     * '\Sylius\Bundle\ApiBundle\CommandHandler\SendShipmentConfirmationEmailHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Checkout\SendShipmentConfirmationEmailHandler'
+     * '\Sylius\Bundle\ApiBundle\CommandHandler\VerifyCustomerAccountHandler' => '\Sylius\Bundle\ApiBundle\CommandHandler\Account\VerifyCustomerAccountHandler'
+     * '\Sylius\Bundle\ApiBundle\Command\AddProductReview' => '\Sylius\Bundle\ApiBundle\Command\Catalog\AddProductReview'
+     * '\Sylius\Bundle\ApiBundle\Command\BlameCart' => '\Sylius\Bundle\ApiBundle\Command\Cart\BlameCart'
+     * '\Sylius\Bundle\ApiBundle\Command\RequestResetPasswordToken' => '\Sylius\Bundle\ApiBundle\Command\Account\RequestResetPasswordToken'
+     * '\Sylius\Bundle\ApiBundle\Command\ResendVerificationEmail' => '\Sylius\Bundle\ApiBundle\Command\Account\ResendVerificationEmail'
+     * '\Sylius\Bundle\ApiBundle\Command\ResetPassword' => '\Sylius\Bundle\ApiBundle\Command\Account\ResetPassword'
+     * '\Sylius\Bundle\ApiBundle\Command\SendAccountRegistrationEmail' => '\Sylius\Bundle\ApiBundle\Command\Account\SendAccountRegistrationEmail'
+     * '\Sylius\Bundle\ApiBundle\Command\SendAccountVerificationEmail' => '\Sylius\Bundle\ApiBundle\Command\Account\SendAccountVerificationEmail'
+     * '\Sylius\Bundle\ApiBundle\Command\SendOrderConfirmation' => '\Sylius\Bundle\ApiBundle\Command\Checkout\SendOrderConfirmation'
+     * '\Sylius\Bundle\ApiBundle\Command\SendResetPasswordEmail' => '\Sylius\Bundle\ApiBundle\Command\Account\SendResetPasswordEmail'
+     * '\Sylius\Bundle\ApiBundle\Command\SendShipmentConfirmationEmail' => '\Sylius\Bundle\ApiBundle\Command\Checkout\SendShipmentConfirmationEmail'
+     * '\Sylius\Bundle\ApiBundle\Command\VerifyCustomerAccount' => '\Sylius\Bundle\ApiBundle\Command\Account\VerifyCustomerAccount'
+     * `\Sylius\Bundle\ApiBundle\CommandHandler\ChangeShopUserPasswordHandler` => `\Sylius\Bundle\ApiBundle\CommandHandler\Account\ChangeShopUserPasswordHandler`
+     * `\Sylius\Bundle\ApiBundle\CommandHandler\PickupCartHandler` => `\Sylius\Bundle\ApiBundle\CommandHandler\Cart\PickupCartHandler`
+     * `\Sylius\Bundle\ApiBundle\CommandHandler\RegisterShopUserHandler` => `\Sylius\Bundle\ApiBundle\CommandHandler\Account\RegisterShopUserHandler`
+     * `\Sylius\Bundle\ApiBundle\Command\ChangeShopUserPassword` => `\Sylius\Bundle\ApiBundle\Command\Account\ChangeShopUserPassword`
+     * `\Sylius\Bundle\ApiBundle\Command\RegisterShopUser` => `\Sylius\Bundle\ApiBundle\Command\Account\RegisterShopUser`
+     * `\Sylius\Bundle\ApiBundle\Doctrine\Filters\ExchangeRateFilter` => `\Sylius\Bundle\ApiBundle\Doctrine\Filter\ExchangeRateFilter`
+     * `\Sylius\Bundle\ApiBundle\Doctrine\Filters\TranslationOrderNameAndLocaleFilter` => `Sylius\Bundle\ApiBundle\Doctrine\Filter\TranslationOrderNameAndLocaleFilter`

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/command_handlers.xml
@@ -57,11 +57,10 @@
 
         <service id="Sylius\Bundle\ApiBundle\CommandHandler\Checkout\AddressOrderHandler">
             <argument type="service" id="sylius.repository.order" />
-            <argument type="service" id="sylius.repository.customer" />
-            <argument type="service" id="sylius.factory.customer" />
-            <argument type="service" id="sylius.manager.customer" />
+            <argument type="service" id="sylius.manager.order" />
             <argument type="service" id="sm.factory" />
             <argument type="service" id="Sylius\Bundle\ApiBundle\Mapper\AddressMapperInterface" />
+            <argument type="service" id="Sylius\Bundle\ApiBundle\Provider\CustomerProviderInterface" />
             <tag name="messenger.message_handler" bus="sylius.command_bus" />
             <tag name="messenger.message_handler" bus="sylius_default.bus" />
         </service>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/providers.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/providers.xml
@@ -16,6 +16,8 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd"
 >
     <services>
+        <defaults public="true" />
+
         <service id="Sylius\Bundle\ApiBundle\Provider\CustomerProviderInterface" class="Sylius\Bundle\ApiBundle\Provider\CustomerProvider">
             <argument type="service" id="sylius.canonicalizer" />
             <argument type="service" id="sylius.factory.customer" />

--- a/src/Sylius/Bundle/ApiBundle/Tests/CommandHandler/ChangeAddressOrderHandlerTest.php
+++ b/src/Sylius/Bundle/ApiBundle/Tests/CommandHandler/ChangeAddressOrderHandlerTest.php
@@ -21,10 +21,9 @@ use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
 use Sylius\Bundle\ApiBundle\Command\Checkout\AddressOrder;
 use Sylius\Bundle\ApiBundle\CommandHandler\Checkout\AddressOrderHandler;
 use Sylius\Bundle\ApiBundle\Mapper\AddressMapperInterface;
+use Sylius\Bundle\ApiBundle\Provider\CustomerProviderInterface;
 use Sylius\Component\Core\Model\Address;
-use Sylius\Component\Core\Repository\CustomerRepositoryInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
-use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -40,14 +39,11 @@ final class ChangeAddressOrderHandlerTest extends KernelTestCase
         /** @var RepositoryInterface $addressRepository */
         $addressRepository = $container->get('sylius.repository.address');
 
-        /** @var CustomerRepositoryInterface $customerRepository */
-        $customerRepository = $container->get('sylius.repository.customer');
+        /** @var CustomerProviderInterface $customerProvider */
+        $customerProvider = $container->get('Sylius\Bundle\ApiBundle\Provider\CustomerProviderInterface');
 
         /** @var OrderRepositoryInterface $orderRepository */
         $orderRepository = $container->get('sylius.repository.order');
-
-        /** @var FactoryInterface $customerFactory */
-        $customerFactory =  $container->get('sylius.factory.customer');
 
         /** @var ObjectManager $manager */
         $manager = $container->get('doctrine.orm.default_entity_manager');
@@ -79,11 +75,10 @@ final class ChangeAddressOrderHandlerTest extends KernelTestCase
 
         $addressOrderHandler = new AddressOrderHandler(
             $orderRepository,
-            $customerRepository,
-            $customerFactory,
             $manager,
             $stateMachineFactory,
-            $addressMapper
+            $addressMapper,
+            $customerProvider
         );
 
         $newBillingAddress = $address = new Address();


### PR DESCRIPTION
instead of logic duplication

| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | partially 
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
