### PR TITLE
[DX] Add sylius prefixes to normalizers ALREADY_CALLED consts values to avoid name collision

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Serializer/CommandNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/CommandNormalizer.php
@@ -22,7 +22,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 final class CommandNormalizer implements ContextAwareNormalizerInterface
 {
-    private const ALREADY_CALLED = 'command_normalizer_already_called';
+    private const ALREADY_CALLED = 'sylius_command_normalizer_already_called';
 
     /** @var NormalizerInterface */
     private $objectNormalizer;

--- a/src/Sylius/Bundle/ApiBundle/Serializer/ProductImageNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ProductImageNormalizer.php
@@ -26,7 +26,7 @@ class ProductImageNormalizer implements ContextAwareNormalizerInterface, Normali
 {
     use NormalizerAwareTrait;
 
-    private const ALREADY_CALLED = 'product_image_normalizer_already_called';
+    private const ALREADY_CALLED = 'sylius_product_image_normalizer_already_called';
 
     private CacheManager $cacheManager;
     private RequestStack $requestStack;

--- a/src/Sylius/Bundle/ApiBundle/Serializer/ProductNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ProductNormalizer.php
@@ -26,7 +26,7 @@ final class ProductNormalizer implements ContextAwareNormalizerInterface, Normal
 {
     use NormalizerAwareTrait;
 
-    private const ALREADY_CALLED = 'product_normalizer_already_called';
+    private const ALREADY_CALLED = 'sylius_product_normalizer_already_called';
 
     /** @var ProductVariantResolverInterface */
     private $defaultProductVariantResolver;

--- a/src/Sylius/Bundle/ApiBundle/Serializer/ProductVariantNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ProductVariantNormalizer.php
@@ -30,7 +30,7 @@ final class ProductVariantNormalizer implements ContextAwareNormalizerInterface,
 {
     use NormalizerAwareTrait;
 
-    private const ALREADY_CALLED = 'product_variant_normalizer_already_called';
+    private const ALREADY_CALLED = 'sylius_product_variant_normalizer_already_called';
 
     /** @var ProductVariantPricesCalculatorInterface */
     private $priceCalculator;

--- a/src/Sylius/Bundle/ApiBundle/Serializer/ShippingMethodNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ShippingMethodNormalizer.php
@@ -29,7 +29,7 @@ final class ShippingMethodNormalizer implements ContextAwareNormalizerInterface,
 {
     use NormalizerAwareTrait;
 
-    private const ALREADY_CALLED = 'shipping_method_normalizer_already_called';
+    private const ALREADY_CALLED = 'sylius_shipping_method_normalizer_already_called';
 
     /** @var OrderRepositoryInterface */
     private $orderRepository;

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/CommandNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/CommandNormalizerSpec.php
@@ -56,7 +56,7 @@ final class CommandNormalizerSpec extends ObjectBehavior
             ->supportsNormalization(
                 new class() { public function getClass(): string { return MissingConstructorArgumentsException::class; }},
                 null,
-                ['command_normalizer_already_called' => true]
+                ['sylius_command_normalizer_already_called' => true]
             )
             ->shouldReturn(false)
         ;
@@ -72,7 +72,7 @@ final class CommandNormalizerSpec extends ObjectBehavior
         \stdClass $object
     ): void {
         $baseNormalizer
-            ->normalize($object, null, ['command_normalizer_already_called' => true])
+            ->normalize($object, null, ['sylius_command_normalizer_already_called' => true])
             ->willReturn(['message' => 'Message'])
         ;
 

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductImageNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductImageNormalizerSpec.php
@@ -52,7 +52,7 @@ final class ProductImageNormalizerSpec extends ObjectBehavior
     ): void {
         $this->setNormalizer($normalizer);
 
-        $normalizer->normalize($productImage, null, ['product_image_normalizer_already_called' => true])->willReturn(['path' => 'some_path']);
+        $normalizer->normalize($productImage, null, ['sylius_product_image_normalizer_already_called' => true])->willReturn(['path' => 'some_path']);
 
         $requestStack->getCurrentRequest()->willReturn($request);
         $request->query = new ParameterBag([]);
@@ -69,7 +69,7 @@ final class ProductImageNormalizerSpec extends ObjectBehavior
     ): void {
         $this->setNormalizer($normalizer);
 
-        $normalizer->normalize($productImage, null, ['product_image_normalizer_already_called' => true])->willReturn(['path' => 'some_path']);
+        $normalizer->normalize($productImage, null, ['sylius_product_image_normalizer_already_called' => true])->willReturn(['path' => 'some_path']);
 
         $requestStack->getCurrentRequest()->willReturn($request);
         $request->query = new ParameterBag(['filter' => 'sylius_large']);

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductNormalizerSpec.php
@@ -40,7 +40,7 @@ final class ProductNormalizerSpec extends ObjectBehavior
     function it_does_not_support_if_the_normalizer_has_been_already_called(ProductVariantInterface $variant): void
     {
         $this
-            ->supportsNormalization($variant, null, ['product_normalizer_already_called' => true])
+            ->supportsNormalization($variant, null, ['sylius_product_normalizer_already_called' => true])
             ->shouldReturn(false)
         ;
     }
@@ -54,7 +54,7 @@ final class ProductNormalizerSpec extends ObjectBehavior
     ): void {
         $this->setNormalizer($normalizer);
 
-        $normalizer->normalize($product, null, ['product_normalizer_already_called' => true])->willReturn([]);
+        $normalizer->normalize($product, null, ['sylius_product_normalizer_already_called' => true])->willReturn([]);
         $defaultProductVariantResolver->getVariant($product)->willReturn($variant);
         $iriConverter->getIriFromItem($variant)->willReturn('/api/v2/shop/product-variants/CODE');
 
@@ -69,7 +69,7 @@ final class ProductNormalizerSpec extends ObjectBehavior
     ): void {
         $this->setNormalizer($normalizer);
 
-        $normalizer->normalize($product, null, ['product_normalizer_already_called' => true])->willReturn([]);
+        $normalizer->normalize($product, null, ['sylius_product_normalizer_already_called' => true])->willReturn([]);
         $defaultProductVariantResolver->getVariant($product)->willReturn(null);
         $iriConverter->getIriFromItem(Argument::any())->shouldNotBeCalled();
 
@@ -82,11 +82,11 @@ final class ProductNormalizerSpec extends ObjectBehavior
     ): void {
         $this->setNormalizer($normalizer);
 
-        $normalizer->normalize($product, null, ['product_normalizer_already_called' => true])->shouldNotBeCalled();
+        $normalizer->normalize($product, null, ['sylius_product_normalizer_already_called' => true])->shouldNotBeCalled();
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)
-            ->during('normalize', [$product, null, ['product_normalizer_already_called' => true]])
+            ->during('normalize', [$product, null, ['sylius_product_normalizer_already_called' => true]])
         ;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductVariantNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/ProductVariantNormalizerSpec.php
@@ -64,7 +64,7 @@ final class ProductVariantNormalizerSpec extends ObjectBehavior
     function it_does_not_support_if_the_normalizer_has_been_already_called(ProductVariantInterface $variant): void
     {
         $this
-            ->supportsNormalization($variant, null, ['product_variant_normalizer_already_called' => true])
+            ->supportsNormalization($variant, null, ['sylius_product_variant_normalizer_already_called' => true])
             ->shouldReturn(false)
         ;
     }
@@ -79,7 +79,7 @@ final class ProductVariantNormalizerSpec extends ObjectBehavior
     ): void {
         $this->setNormalizer($normalizer);
 
-        $normalizer->normalize($variant, null, ['product_variant_normalizer_already_called' => true])->willReturn([]);
+        $normalizer->normalize($variant, null, ['sylius_product_variant_normalizer_already_called' => true])->willReturn([]);
 
         $channelContext->getChannel()->willReturn($channel);
         $pricesCalculator->calculate($variant, ['channel' => $channel])->willReturn(1000);
@@ -100,7 +100,7 @@ final class ProductVariantNormalizerSpec extends ObjectBehavior
     ): void {
         $this->setNormalizer($normalizer);
 
-        $normalizer->normalize($variant, null, ['product_variant_normalizer_already_called' => true])->willReturn([]);
+        $normalizer->normalize($variant, null, ['sylius_product_variant_normalizer_already_called' => true])->willReturn([]);
 
         $channelContext->getChannel()->willReturn($channel);
         $pricesCalculator->calculate($variant, ['channel' => $channel])->willReturn(500);
@@ -121,7 +121,7 @@ final class ProductVariantNormalizerSpec extends ObjectBehavior
     ): void {
         $this->setNormalizer($normalizer);
 
-        $normalizer->normalize($variant, null, ['product_variant_normalizer_already_called' => true])->willReturn([]);
+        $normalizer->normalize($variant, null, ['sylius_product_variant_normalizer_already_called' => true])->willReturn([]);
 
         $channelContext->getChannel()->willReturn($channel);
         $pricesCalculator->calculate($variant, ['channel' => $channel])->willThrow(ChannelNotFoundException::class);
@@ -138,11 +138,11 @@ final class ProductVariantNormalizerSpec extends ObjectBehavior
     ): void {
         $this->setNormalizer($normalizer);
 
-        $normalizer->normalize($variant, null, ['product_variant_normalizer_already_called' => true])->shouldNotBeCalled();
+        $normalizer->normalize($variant, null, ['sylius_product_variant_normalizer_already_called' => true])->shouldNotBeCalled();
 
         $this
             ->shouldThrow(\InvalidArgumentException::class)
-            ->during('normalize', [$variant, null, ['product_variant_normalizer_already_called' => true]])
+            ->during('normalize', [$variant, null, ['sylius_product_variant_normalizer_already_called' => true]])
         ;
     }
 }

--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/ShippingMethodNormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/ShippingMethodNormalizerSpec.php
@@ -60,7 +60,7 @@ final class ShippingMethodNormalizerSpec extends ObjectBehavior
     {
         $this
             ->supportsNormalization($shippingMethod, null, [
-                'shipping_method_normalizer_already_called' => true,
+                'sylius_shipping_method_normalizer_already_called' => true,
                 'subresource_identifiers' => ['tokenValue' => '666', 'shipments' => '999'],
             ])
             ->shouldReturn(false)
@@ -90,7 +90,7 @@ final class ShippingMethodNormalizerSpec extends ObjectBehavior
 
         $normalizer
             ->normalize($shippingMethod, null, [
-                'shipping_method_normalizer_already_called' => true,
+                'sylius_shipping_method_normalizer_already_called' => true,
                 'subresource_identifiers' => ['tokenValue' => '666', 'shipments' => '999'],
             ])
             ->willReturn([])
@@ -118,7 +118,7 @@ final class ShippingMethodNormalizerSpec extends ObjectBehavior
 
         $normalizer
             ->normalize($shippingMethod, null, [
-                'shipping_method_normalizer_already_called' => true,
+                'sylius_shipping_method_normalizer_already_called' => true,
                 'subresource_identifiers' => ['tokenValue' => '666', 'shipments' => '999'],
             ])
             ->shouldNotBeCalled()


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | kind of
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

While adding custom normalizer, it may be tempting to use the same name for the flag. This may lead to skipping part of normalization. It would be better to prefix our config keys with `sylius` and make official recommendation, that such keys in end projects should be prefixed with `app`

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
