### PR TITLE
Fix borders in order - show - addresses

### DIFF
--- a/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_addresses.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/Order/Show/_addresses.html.twig
@@ -1,5 +1,5 @@
 {% if order.billingAddress is not null %}
-    <h4 class="ui attached styled header{% if order.shippingAddress is null %} top{% endif %}">
+    <h4 class="ui attached styled header top">
         {{ 'sylius.ui.billing_address'|trans }}
     </h4>
     <div class="ui attached segment" id="billing-address">
@@ -7,7 +7,7 @@
     </div>
 {% endif %}
 {% if order.shippingAddress is not null %}
-    <h4 class="ui top attached styled header">
+    <h4 class="ui attached styled header{% if order.billingAddress is null %} top{% endif %}">
         {{ 'sylius.ui.shipping_address'|trans }}
     </h4>
     <div class="ui attached segment" id="shipping-address">


### PR DESCRIPTION
I think it was OK until shipping address was first. Now the logic is inverted, so this change is needed to fix ugly address borders.

| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT
