### PR TITLE
[Docs] Fix link to token generation for API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "knplabs/knp-menu": "^3.1",
         "knplabs/knp-menu-bundle": "^3.0",
         "laminas/laminas-stdlib": "^3.3.1",
-        "lexik/jwt-authentication-bundle": "^2.6",
+        "lexik/jwt-authentication-bundle": "^2.11",
         "liip/imagine-bundle": "^2.3",
         "payum/payum": "^1.6",
         "payum/payum-bundle": "^2.4",

--- a/docs/book/api/index.rst
+++ b/docs/book/api/index.rst
@@ -6,7 +6,7 @@ API
     The new, unified Sylius API is still under development, that's why the whole ``ApiBundle`` is tagged with ``@experimental``.
     This means that all code from ``ApiBundle`` is excluded from :doc:`Backward Compatibility Promise </book/organization/backward-compatibility-promise>`.
 
-To use this API remember to generate JWT token. For more information, please visit `jwt package documentation <https://github.com/lexik/LexikJWTAuthenticationBundle/blob/master/Resources/doc/index.md#generate-the-ssh-keys>`_.
+To use this API remember to generate JWT token. For more information, please visit `jwt package documentation <https://github.com/lexik/LexikJWTAuthenticationBundle/blob/v2.11.0/Resources/doc/index.md#generate-the-ssl-keys>`_.
 
 This part of the documentation is about the currently developed unified API for the Sylius platform.
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

There is a new command for key generation and it is worth pointing Sylius users directly to it. We could consider adding it as a part of the installation process.

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
