### PR TITLE
[Build] Force symfony flex in github actions

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -52,7 +52,7 @@ jobs:
                 name: Restrict Symfony version
                 if: matrix.symfony != ''
                 run: |
-                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:^1.10"
+                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:1.13.4"
                     composer config extra.symfony.require "${{ matrix.symfony }}"
 
             -
@@ -161,7 +161,7 @@ jobs:
                 name: Restrict Symfony version
                 if: matrix.symfony != ''
                 run: |
-                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:^1.10"
+                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:1.13.4"
                     composer config extra.symfony.require "${{ matrix.symfony }}"
 
             -
@@ -295,7 +295,7 @@ jobs:
                 name: Restrict Symfony version
                 if: matrix.symfony != ''
                 run: |
-                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:^1.10"
+                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:1.13.4"
                     composer config extra.symfony.require "${{ matrix.symfony }}"
 
             -

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -82,7 +82,7 @@ jobs:
                 name: Restrict Symfony version
                 if: matrix.symfony != ''
                 run: |
-                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:^1.10"
+                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:1.13.4"
                     composer config extra.symfony.require "${{ matrix.symfony }}"
                 working-directory: "src/Sylius/${{ matrix.package }}"
                     


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   |
| Related tickets |
| License         | MIT

symfony/flex 1.14 came out recently, which crashes sylius app (vendor files are not found)
force github actions to use symfony flex 1.13.4

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
