### PR TITLE
Remove sylius.model.shop_billing_data.class

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
@@ -51,7 +51,6 @@
         <parameter key="sylius.form.type.product_image.validation_groups" type="collection">
             <parameter>sylius</parameter>
         </parameter>
-        <parameter key="sylius.model.shop_billing_data.class">Sylius\Component\Core\Model\ShopBillingData</parameter>
         <parameter key="sylius.catalog_promotion.action.fixed_discount" type="constant">Sylius\Bundle\CoreBundle\CatalogPromotion\Calculator\FixedDiscountPriceCalculator::TYPE</parameter>
         <parameter key="sylius.catalog_promotion.action.percentage_discount" type="constant">Sylius\Bundle\CoreBundle\CatalogPromotion\Calculator\PercentageDiscountPriceCalculator::TYPE</parameter>
         <parameter key="sylius.catalog_promotion.scope.for_products" type="constant">Sylius\Bundle\CoreBundle\CatalogPromotion\Checker\InForProductScopeVariantChecker::TYPE</parameter>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

## Description

Defining a custom model class for the shop billing data resource will break the new API:
```yaml
sylius_core:
    resources:
        shop_billing_data:
            classes:
                model: App\Entity\Channel\ShopBillingData
```
![image](https://user-images.githubusercontent.com/7114562/130443045-f7e4a9ab-8b86-4d21-a01a-cdf398bcc338.png)

## Reproduction


1. Clone https://github.com/vvasiloi/Sylius and checkout branch [custom-shop-billing-data-api-bug](https://github.com/vvasiloi/Sylius/tree/custom-shop-billing-data-api-bug)

2. Bootstrap the application
```bash
(cd src/Sylius/Bundle/ApiBundle && composer install)
(cd src/Sylius/Bundle/ApiBundle/test && bin/console doctrine:database:create -e test)
(cd src/Sylius/Bundle/ApiBundle/test && bin/console doctrine:schema:update --force -e test)
(cd src/Sylius/Bundle/ApiBundle/test && bin/console assets:install public)
(cd src/Sylius/Bundle/ApiBundle/test && APP_ENV=test symfony serve)
```

3. Access https://demo.sylius.com/api/v2. It should display the error like in the attached screenshot.

## Solution

Remove explicitly defined `sylius.model.shop_billing_data.class` parameter.
It's no longer necessary since https://github.com/Sylius/Sylius/pull/11108 .
