### PR TITLE
[Bug] Fix default sylius config file path in Sylius 1.8

### DIFF
--- a/UPGRADE-1.8.md
+++ b/UPGRADE-1.8.md
@@ -1,6 +1,6 @@
 # UPGRADE FROM `v1.8.4` TO `v1.8.6`
 
-1. API is disabled by default, to enable it you need to set flag to ``true`` in ``app/config/packages/_sylius.yaml``:
+1. API is disabled by default, to enable it you need to set flag to ``true`` in ``config/packages/_sylius.yaml``:
 
     ```yaml
     sylius_api:

--- a/UPGRADE-API-1.8.md
+++ b/UPGRADE-API-1.8.md
@@ -1,6 +1,6 @@
 # UPGRADE FROM `v1.8.4` TO `v1.8.6`
 
-1. Api is disabled by default, to enable it you need to set flag ``sylius_api.enabled`` to ``true`` in ``app/config/packages/_sylius.yaml``.
+1. Api is disabled by default, to enable it you need to set flag ``sylius_api.enabled`` to ``true`` in ``config/packages/_sylius.yaml``.
 
 1. Change configuration of new ApiBundle in your `config/packages/security.yaml` file:
 

--- a/docs/api/unified_api/introduction.rst
+++ b/docs/api/unified_api/introduction.rst
@@ -5,7 +5,7 @@ Introduction
 
     The new, unified Sylius API is still under development, that's why the whole ``ApiBundle`` is tagged with ``@experimental``.
     This means that all code from ``ApiBundle`` is excluded from :doc:`Backward Compatibility Promise </book/organization/backward-compatibility-promise>`.
-    You can enable entire API by changing the flag ``sylius_api.enabled`` to ``true`` in ``app/config/packages/_sylius.yaml``.
+    You can enable entire API by changing the flag ``sylius_api.enabled`` to ``true`` in ``config/packages/_sylius.yaml``.
 
 We have decided that we should rebuild our API and use API Platform to build a truly mature, multi-purpose API
 which can define a new standard for headless e-commerce backends.


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.8
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

There is no such file as `app/config/packages/_sylius.yaml`. App prefix is not needed, because related configuration should be placed in: https://github.com/Sylius/Sylius-Standard/blob/1.10/config/packages/_sylius.yaml

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
