### PR TITLE
[Bug] Fix default sylius config file path in Sylius 1.10

### DIFF
--- a/UPGRADE-1.10.md
+++ b/UPGRADE-1.10.md
@@ -1,6 +1,6 @@
 # UPGRADE FROM `v1.10.0` TO `v1.10.1`
 
-1. API is disabled by default, to enable it you need to set flag to ``true`` in ``app/config/packages/_sylius.yaml``:
+1. API is disabled by default, to enable it you need to set flag to ``true`` in ``config/packages/_sylius.yaml``:
 
     ```yaml
     sylius_api:

--- a/UPGRADE-API-1.10.md
+++ b/UPGRADE-API-1.10.md
@@ -1,6 +1,6 @@
 # UPGRADE FROM `v1.10.0` TO `v1.10.1`
 
-1. API is disabled by default, to enable it you need to set flag to ``true`` in ``app/config/packages/_sylius.yaml``:
+1. API is disabled by default, to enable it you need to set flag to ``true`` in ``config/packages/_sylius.yaml``:
 
     ```yaml
     sylius_api:


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

There is no such file as `app/config/packages/_sylius.yaml`. App prefix is not needed, because related configuration should be placed in: https://github.com/Sylius/Sylius-Standard/blob/1.10/config/packages/_sylius.yaml

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
