### PR TITLE
[Bug] Fix default sylius config file path in Sylius master branch

### DIFF
--- a/UPGRADE-API-1.11.md
+++ b/UPGRADE-API-1.11.md
@@ -15,7 +15,7 @@
         } 
    ```
    
-   To change the prefix you need to set parameter in ``app/config/packages/_sylius.yaml``:
+   To change the prefix you need to set parameter in ``config/packages/_sylius.yaml``:
 
     ```yaml
     sylius_api:

--- a/docs/cookbook/taxation/customize-tax-by-address.rst
+++ b/docs/cookbook/taxation/customize-tax-by-address.rst
@@ -13,7 +13,7 @@ To change the way how the taxes are calculated: by billing or by shipping addres
 
 .. code-block:: yaml
 
-    # app/config/packages/_sylius.yaml
+    # config/packages/_sylius.yaml
     sylius_core:
         # resources definitions
         shipping_address_based_taxation: true


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

There is no such file as `app/config/packages/_sylius.yaml`. App prefix is not needed, because related configuration should be placed in: https://github.com/Sylius/Sylius-Standard/blob/1.10/config/packages/_sylius.yaml

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
