### PR TITLE
Remove serialization moved to admin api bundle

### DIFF
--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/serializer/Model.Country.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/serializer/Model.Country.yml
@@ -19,9 +19,3 @@ Sylius\Component\Addressing\Model\Country:
             expose: true
             type: iterable
             groups: [Detailed]
-    relations:
-        -   rel: self
-            href:
-                route: sylius_admin_api_country_show
-                parameters:
-                    code: expr(object.getCode())

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/serializer/Model.Province.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/serializer/Model.Province.yml
@@ -27,19 +27,3 @@ Sylius\Component\Addressing\Model\Province:
             expose: true
             type: DateTime
             groups: [Detailed]
-    relations:
-        -   rel: self
-            href:
-                route: sylius_admin_api_province_show
-                parameters:
-                    countryCode: expr(object.getCountry().getCode())
-                    code: expr(object.getCode())
-            exclusion:
-                groups: [Default, Detailed]
-        -   rel: country
-            href:
-                route: sylius_admin_api_country_show
-                parameters:
-                    code: expr(object.getCountry().getCode())
-            exclusion:
-                groups: [Detailed]

--- a/src/Sylius/Bundle/AddressingBundle/Resources/config/serializer/Model.Zone.yml
+++ b/src/Sylius/Bundle/AddressingBundle/Resources/config/serializer/Model.Zone.yml
@@ -35,9 +35,3 @@ Sylius\Component\Addressing\Model\Zone:
             expose: true
             type: DateTime
             groups: [Detailed]
-    relations:
-        -   rel: self
-            href:
-                route: sylius_admin_api_zone_show
-                parameters:
-                    code: expr(object.getCode())

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/serializer/Model.Currency.yml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/serializer/Model.Currency.yml
@@ -19,9 +19,3 @@ Sylius\Component\Currency\Model\Currency:
             expose: true
             type: boolean
             groups: [Default, Detailed]
-    relations:
-        -   rel: self
-            href:
-                route: sylius_admin_api_currency_show
-                parameters:
-                    code: expr(object.getCode())

--- a/src/Sylius/Bundle/CurrencyBundle/Resources/config/serializer/Model.ExchangeRate.yml
+++ b/src/Sylius/Bundle/CurrencyBundle/Resources/config/serializer/Model.ExchangeRate.yml
@@ -19,12 +19,3 @@ Sylius\Component\Currency\Model\ExchangeRate:
         updatedAt:
             expose: true
             groups: [Default, Detailed]
-    relations:
-        -   rel: self
-            href:
-                route: sylius_admin_api_exchange_rate_show
-                parameters:
-                    sourceCurrencyCode: expr(object.getSourceCurrency().getCode())
-                    targetCurrencyCode: expr(object.getTargetCurrency().getCode())
-                exclusion:
-                    groups: [Default, Detailed]

--- a/src/Sylius/Bundle/LocaleBundle/Resources/config/serializer/Model.Locale.yml
+++ b/src/Sylius/Bundle/LocaleBundle/Resources/config/serializer/Model.Locale.yml
@@ -19,9 +19,3 @@ Sylius\Component\Locale\Model\Locale:
             expose: true
             type: DateTime
             groups: [Detailed]
-    relations:
-        -   rel: self
-            href:
-                route: sylius_admin_api_locale_show
-                parameters:
-                    code: expr(object.getCode())

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductAssociationType.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductAssociationType.yml
@@ -23,9 +23,3 @@ Sylius\Component\Product\Model\ProductAssociationType:
             expose: true
             type: DateTime
             groups: [Detailed]
-    relations:
-        -   rel: self
-            href:
-                route: sylius_admin_api_product_association_type_show
-                parameters:
-                    code: expr(object.getCode())

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductAttribute.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductAttribute.yml
@@ -7,9 +7,3 @@ Sylius\Component\Product\Model\ProductAttribute:
             type: integer
             xml_attribute: true
             groups: [Default, Detailed]
-    relations:
-        -   rel: self
-            href:
-                route: sylius_admin_api_product_attribute_show
-                parameters:
-                    code: expr(object.getCode())

--- a/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductOption.yml
+++ b/src/Sylius/Bundle/ProductBundle/Resources/config/serializer/Model.ProductOption.yml
@@ -23,9 +23,3 @@ Sylius\Component\Product\Model\ProductOption:
             expose: true
             type: iterable
             groups: [Default, Detailed]
-    relations:
-        -   rel: self
-            href:
-                route: sylius_admin_api_product_option_show
-                parameters:
-                    code: expr(object.getCode())

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/serializer/Model.ShipmentUnit.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/serializer/Model.ShipmentUnit.yml
@@ -15,15 +15,3 @@ Sylius\Component\Shipping\Model\ShipmentUnit:
         updatedAt:
             expose: true
             type: DateTime
-    relations:
-        -   rel: self
-            href:
-                route: sylius_admin_api_shipment_unit_show
-                parameters:
-                    shipmentId: expr(object.getShipment().getId())
-                    id: expr(object.getId())
-        -   rel: shipment
-            href:
-                route: sylius_admin_api_shipment_show
-                parameters:
-                    id: expr(object.getShipment().getId())

--- a/src/Sylius/Bundle/ShippingBundle/Resources/config/serializer/Model.ShippingCategory.yml
+++ b/src/Sylius/Bundle/ShippingBundle/Resources/config/serializer/Model.ShippingCategory.yml
@@ -27,9 +27,3 @@ Sylius\Component\Shipping\Model\ShippingCategory:
             expose: true
             type: DateTime
             groups: [Detailed]
-    relations:
-        -   rel: self
-            href:
-                route: sylius_admin_api_shipping_category_show
-                parameters:
-                    code: expr(object.getCode())

--- a/src/Sylius/Bundle/TaxationBundle/Resources/config/serializer/Model.TaxCategory.yml
+++ b/src/Sylius/Bundle/TaxationBundle/Resources/config/serializer/Model.TaxCategory.yml
@@ -27,9 +27,3 @@ Sylius\Component\Taxation\Model\TaxCategory:
             expose: true
             type: DateTime
             groups: [Detailed]
-    relations:
-        -   rel: self
-            href:
-                route: sylius_admin_api_tax_category_show
-                parameters:
-                    code: expr(object.getCode())


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Related tickets | https://github.com/Sylius/SyliusAdminApiBundle/pull/9
| License         | MIT

After moved AdminApiBundle to a separate repo, we accidentally left part of serialization which cause errors in the applications without AdminApiBundle, now we moved these configs to AdminApiBundle so it should be deleted from Sylius core.

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
