### PR TITLE
[Catalog Promotion] Create data transformer instead CP persister

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services.xml
@@ -95,6 +95,11 @@
             <tag name="sylius.api.command_data_transformer" />
         </service>
 
+        <service id="Sylius\Bundle\ApiBundle\DataTransformer\CatalogPromotionDataTransformer">
+            <argument type="service" id="api_platform.iri_converter" />
+            <tag name="api_platform.data_transformer" />
+        </service>
+
         <service id="Sylius\Bundle\ApiBundle\Changer\PaymentMethodChangerInterface" class="Sylius\Bundle\ApiBundle\Changer\PaymentMethodChanger">
             <argument type="service" id="sylius.repository.payment" />
             <argument type="service" id="sylius.repository.payment_method" />

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/services/data_persisters.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/services/data_persisters.xml
@@ -35,11 +35,5 @@
             <argument type="service" id="api_platform.doctrine.orm.data_persister" />
             <tag name="api_platform.data_persister" />
         </service>
-
-        <service id="Sylius\Bundle\ApiBundle\DataPersister\CatalogPromotionDataPersister">
-            <argument type="service" id="api_platform.doctrine.orm.data_persister" />
-            <argument type="service" id="api_platform.iri_converter" />
-            <tag name="api_platform.data_persister" />
-        </service>
     </services>
 </container>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         |  master

We want to validate data before persisting to the database, so this data should be already prepared to persist.

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
