### PR TITLE
[CatalogPromotions] Inform about promotions applied on variants

### DIFF
--- a/features/promotion/applying_catalog_promotions/seeing_applied_catalog_promotions_on_variants_list.feature
+++ b/features/promotion/applying_catalog_promotions/seeing_applied_catalog_promotions_on_variants_list.feature
@@ -1,0 +1,21 @@
+@applying_catalog_promotions
+Feature: Seeing applied catalog promotions on variants list
+    In order to be attracted to products
+    As a Customer
+    I want to see discounted products in the catalog
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a "T-Shirt" configurable product
+        And this product has "PHP T-Shirt" variant priced at "$20.00"
+        And this product has "Kotlin T-Shirt" variant priced at "$40.00"
+        And this product has "Python T-Shirt" variant priced at "$40.00"
+        And there is a catalog promotion with "winter_sale" code and "Winter sale" name
+        And it will be applied on "PHP T-Shirt" variant
+        And it will reduce price by 50%
+
+    @api
+    Scenario: Seeing applied catalog promotion on variant
+        When I view variants
+        Then I should see "PHP T-Shirt" variant is discounted from "$20.00" to "$10.00" with "Winter sale" promotion
+        And I should see "Kotlin T-Shirt" variant and "Python T-Shirt" variant are not discounted

--- a/features/promotion/applying_catalog_promotions/seeing_applied_catalog_promotions_on_variants_list.feature
+++ b/features/promotion/applying_catalog_promotions/seeing_applied_catalog_promotions_on_variants_list.feature
@@ -12,7 +12,7 @@ Feature: Seeing applied catalog promotions on variants list
         And this product has "Python T-Shirt" variant priced at "$40.00"
         And there is a catalog promotion with "winter_sale" code and "Winter sale" name
         And it will be applied on "PHP T-Shirt" variant
-        And it will reduce price by 50%
+        And it will reduce price by "50%"
 
     @api
     Scenario: Seeing applied catalog promotion on variant

--- a/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
@@ -16,6 +16,7 @@ namespace Sylius\Behat\Context\Api\Shop;
 use Behat\Behat\Context\Context;
 use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
+use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Webmozart\Assert\Assert;
 
@@ -42,6 +43,14 @@ final class ProductVariantContext implements Context
     }
 
     /**
+     * @When I view variants
+     */
+    public function iViewVariants(): void
+    {
+        $this->client->index();
+    }
+
+    /**
      * @Then /^the product variant price should be ("[^"]+")$/
      */
     public function theProductVariantPriceShouldBe(int $price): void
@@ -59,5 +68,41 @@ final class ProductVariantContext implements Context
         $response = $this->responseChecker->getResponseContent($this->client->getLastResponse());
 
         Assert::same($response['originalPrice'], $originalPrice);
+    }
+
+    /**
+     * @Then /^I should see ("[^"]+" variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
+     */
+    public function iShouldSeeVariantIsDiscountedFromToWithPromotion(
+        ProductVariantInterface $targetVariant,
+        int $originalPrice,
+        int $price,
+        string $promotionName
+    ): void {
+        $response = $this->responseChecker->getResponseContent($this->client->getLastResponse());
+
+        foreach ($response['hydra:member'] as $variant) {
+            if ($variant['code'] !== $targetVariant->getCode()) {
+                continue;
+            }
+
+            Assert::same($variant['price'], $price);
+            Assert::same($variant['originalPrice'], $originalPrice);
+            Assert::inArray(['name' => $promotionName], $variant['appliedPromotions']);
+        }
+    }
+
+    /**
+     * @Then I should see :firstVariant variant and :secondVariant variant are not discounted
+     */
+    public function iShouldSeeVariantsAreNotDiscounted(string ...$variantsNames): void
+    {
+        $response = $this->responseChecker->getResponseContent($this->client->getLastResponse());
+
+        foreach ($response['hydra:member'] as $variant) {
+            if (in_array($variant['translations']['en_US']['name'], $variantsNames)) {
+                Assert::keyNotExists($variant, 'appliedPromotions');
+            }
+        }
     }
 }

--- a/src/Sylius/Behat/Resources/config/suites/api/promotion/applying_catalog_promotions.yml
+++ b/src/Sylius/Behat/Resources/config/suites/api/promotion/applying_catalog_promotions.yml
@@ -20,6 +20,7 @@ default:
                 - sylius.behat.context.transform.taxon
 
                 - sylius.behat.context.api.shop.product
+                - sylius.behat.context.api.shop.product_variant
 
             filters:
                 tags: "@applying_catalog_promotions && @api"

--- a/src/Sylius/Bundle/ApiBundle/Serializer/ProductVariantNormalizer.php
+++ b/src/Sylius/Bundle/ApiBundle/Serializer/ProductVariantNormalizer.php
@@ -64,14 +64,19 @@ final class ProductVariantNormalizer implements ContextAwareNormalizerInterface,
         $context[self::ALREADY_CALLED] = true;
 
         $data = $this->normalizer->normalize($object, $format, $context);
+        $channel = $this->channelContext->getChannel();
 
         try {
-            $data['price'] = $this->priceCalculator->calculate($object, ['channel' => $this->channelContext->getChannel()]);
-            $data['originalPrice'] = $this->priceCalculator->calculateOriginal($object, ['channel' => $this->channelContext->getChannel()]);
-
+            $data['price'] = $this->priceCalculator->calculate($object, ['channel' => $channel]);
+            $data['originalPrice'] = $this->priceCalculator->calculateOriginal($object, ['channel' => $channel]);
         } catch (ChannelNotFoundException $exception) {
             unset($data['price']);
             unset($data['originalPrice']);
+        }
+
+        $appliedPromotions = $object->getAppliedPromotionsForChannel($channel);
+        if (!empty($appliedPromotions)) {
+            $data['appliedPromotions'] = $appliedPromotions;
         }
 
         $data['inStock'] = $this->availabilityChecker->isStockAvailable($object);

--- a/src/Sylius/Bundle/CoreBundle/Applicator/CatalogPromotionApplicator.php
+++ b/src/Sylius/Bundle/CoreBundle/Applicator/CatalogPromotionApplicator.php
@@ -17,6 +17,7 @@ use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionTranslationInterface;
 
 final class CatalogPromotionApplicator implements CatalogPromotionApplicatorInterface
 {
@@ -44,12 +45,20 @@ final class CatalogPromotionApplicator implements CatalogPromotionApplicatorInte
 
             $channelPricing->setPrice((int) ($channelPricing->getPrice() - ($channelPricing->getPrice() * $discount)));
 
-            /** @var string $label */
-            $label = $catalogPromotion->getLabel();
-            /** @var string $code */
-            $code = $catalogPromotion->getCode();
-
-            $channelPricing->addAppliedPromotion([$code => ['name' => $label]]);
+            $channelPricing->addAppliedPromotion($this->formatAppliedPromotion($catalogPromotion));
         }
+    }
+
+    private function formatAppliedPromotion(CatalogPromotionInterface $catalogPromotion): array
+    {
+        /** @var CatalogPromotionTranslationInterface $translation */
+        $translation = $catalogPromotion->getTranslations()->first();
+
+        /** @var string $label */
+        $label = $translation->getLabel();
+        /** @var string $code */
+        $code = $catalogPromotion->getCode();
+
+        return [$code => ['name' => $label]];
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Applicator/CatalogPromotionApplicator.php
+++ b/src/Sylius/Bundle/CoreBundle/Applicator/CatalogPromotionApplicator.php
@@ -13,19 +13,43 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Applicator;
 
+use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 
 final class CatalogPromotionApplicator implements CatalogPromotionApplicatorInterface
 {
-    public function applyPercentageDiscount(ProductVariantInterface $variant, float $discount): void
-    {
+    public function applyCatalogPromotion(
+        ProductVariantInterface $variant,
+        CatalogPromotionInterface $catalogPromotion
+    ): void {
+        foreach ($catalogPromotion->getActions() as $action) {
+            $this->applyDiscountFromAction($catalogPromotion, $action, $variant);
+        }
+    }
+
+    private function applyDiscountFromAction(
+        CatalogPromotionInterface $catalogPromotion,
+        CatalogPromotionActionInterface $action,
+        ProductVariantInterface $variant
+    ) {
+        $discount = $action->getConfiguration()['amount'];
+
         /** @var ChannelPricingInterface $channelPricing */
         foreach ($variant->getChannelPricings() as $channelPricing) {
             if ($channelPricing->getOriginalPrice() === null) {
                 $channelPricing->setOriginalPrice($channelPricing->getPrice());
             }
+
             $channelPricing->setPrice((int) ($channelPricing->getPrice() - ($channelPricing->getPrice() * $discount)));
+
+            /** @var string $label */
+            $label = $catalogPromotion->getLabel();
+            /** @var string $code */
+            $code = $catalogPromotion->getCode();
+
+            $channelPricing->addAppliedPromotion([$code => ['name' => $label]]);
         }
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Applicator/CatalogPromotionApplicator.php
+++ b/src/Sylius/Bundle/CoreBundle/Applicator/CatalogPromotionApplicator.php
@@ -13,14 +13,21 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Applicator;
 
+use Sylius\Bundle\CoreBundle\Formatter\AppliedPromotionInformationFormatterInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
-use Sylius\Component\Promotion\Model\CatalogPromotionTranslationInterface;
 
 final class CatalogPromotionApplicator implements CatalogPromotionApplicatorInterface
 {
+    private AppliedPromotionInformationFormatterInterface $appliedPromotionInformationFormatter;
+
+    public function __construct(AppliedPromotionInformationFormatterInterface $appliedPromotionInformationFormatter)
+    {
+        $this->appliedPromotionInformationFormatter = $appliedPromotionInformationFormatter;
+    }
+
     public function applyCatalogPromotion(
         ProductVariantInterface $variant,
         CatalogPromotionInterface $catalogPromotion
@@ -45,20 +52,9 @@ final class CatalogPromotionApplicator implements CatalogPromotionApplicatorInte
 
             $channelPricing->setPrice((int) ($channelPricing->getPrice() - ($channelPricing->getPrice() * $discount)));
 
-            $channelPricing->addAppliedPromotion($this->formatAppliedPromotion($catalogPromotion));
+            $channelPricing->addAppliedPromotion(
+                $this->appliedPromotionInformationFormatter->format($catalogPromotion)
+            );
         }
-    }
-
-    private function formatAppliedPromotion(CatalogPromotionInterface $catalogPromotion): array
-    {
-        /** @var CatalogPromotionTranslationInterface $translation */
-        $translation = $catalogPromotion->getTranslations()->first();
-
-        /** @var string $label */
-        $label = $translation->getLabel();
-        /** @var string $code */
-        $code = $catalogPromotion->getCode();
-
-        return [$code => ['name' => $label]];
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Applicator/CatalogPromotionApplicatorInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Applicator/CatalogPromotionApplicatorInterface.php
@@ -13,9 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Applicator;
 
+use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 
 interface CatalogPromotionApplicatorInterface
 {
-    public function applyPercentageDiscount(ProductVariantInterface $variant, float $discount): void;
+    public function applyCatalogPromotion(ProductVariantInterface $variant, CatalogPromotionInterface $catalogPromotion): void;
 }

--- a/src/Sylius/Bundle/CoreBundle/Formatter/AppliedPromotionInformationFormatter.php
+++ b/src/Sylius/Bundle/CoreBundle/Formatter/AppliedPromotionInformationFormatter.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Formatter;
+
+use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionTranslationInterface;
+
+final class AppliedPromotionInformationFormatter implements AppliedPromotionInformationFormatterInterface
+{
+    public function format(CatalogPromotionInterface $catalogPromotion): array
+    {
+        /** @var CatalogPromotionTranslationInterface $translation */
+        $translation = $catalogPromotion->getTranslations()->first();
+        /** @var string $code */
+        $code = $catalogPromotion->getCode();
+        /** @var string $name */
+        $name = $translation->getLabel();
+
+        return [$code => ['name' => $name]];
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Formatter/AppliedPromotionInformationFormatterInterface.php
+++ b/src/Sylius/Bundle/CoreBundle/Formatter/AppliedPromotionInformationFormatterInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Formatter;
+
+use Sylius\Component\Core\Model\CatalogPromotionInterface;
+
+interface
+AppliedPromotionInformationFormatterInterface
+{
+    public function format(CatalogPromotionInterface $catalogPromotion): array;
+}

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210830193340.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210830193340.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210830193340 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_channel_pricing ADD applied_promotions JSON DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_channel_pricing DROP applied_promotions');
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Migrations/Version20210830193340.php
+++ b/src/Sylius/Bundle/CoreBundle/Migrations/Version20210830193340.php
@@ -14,7 +14,7 @@ final class Version20210830193340 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return '';
+        return 'Add information about applied catalog promotions on channel pricing';
     }
 
     public function up(Schema $schema): void

--- a/src/Sylius/Bundle/CoreBundle/Processor/CatalogPromotionProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/Processor/CatalogPromotionProcessor.php
@@ -45,12 +45,9 @@ final class CatalogPromotionProcessor implements CatalogPromotionProcessorInterf
             return;
         }
 
-        /** @var CatalogPromotionActionInterface $action */
-        foreach ($catalogPromotion->getActions() as $action) {
-            /** @var ProductVariantInterface $variant */
-            foreach ($variants as $variant) {
-                $this->catalogPromotionApplicator->applyPercentageDiscount($variant, $action->getConfiguration()['amount']);
-            }
+        /** @var ProductVariantInterface $variant */
+        foreach ($variants as $variant) {
+            $this->catalogPromotionApplicator->applyCatalogPromotion($variant, $catalogPromotion);
         }
 
         $this->entityManager->flush();

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ChannelPricing.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/ChannelPricing.orm.xml
@@ -28,6 +28,7 @@
         <field name="price" column="price" type="integer" nullable="true" />
         <field name="originalPrice" column="original_price" type="integer" nullable="true" />
         <field name="channelCode" column="channel_code" type="string" />
+        <field name="appliedPromotions" column="applied_promotions" type="json" nullable="true" />
 
         <many-to-one field="productVariant" target-entity="Sylius\Component\Product\Model\ProductVariantInterface" inversed-by="channelPricings">
             <join-column name="product_variant_id" referenced-column-name="id" nullable="false" on-delete="CASCADE" />

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -249,9 +249,16 @@
         </service>
 
         <service
+            id="Sylius\Bundle\CoreBundle\Formatter\AppliedPromotionInformationFormatterInterface"
+            class="Sylius\Bundle\CoreBundle\Formatter\AppliedPromotionInformationFormatter"
+        />
+
+        <service
             id="Sylius\Bundle\CoreBundle\Applicator\CatalogPromotionApplicatorInterface"
             class="Sylius\Bundle\CoreBundle\Applicator\CatalogPromotionApplicator"
-        />
+        >
+            <argument type="service" id="Sylius\Bundle\CoreBundle\Formatter\AppliedPromotionInformationFormatterInterface" />
+        </service>
 
         <service
             id="Sylius\Component\Core\Provider\CatalogPromotionVariantsProviderInterface"

--- a/src/Sylius/Bundle/CoreBundle/spec/Applicator/CatalogPromotionApplicatorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Applicator/CatalogPromotionApplicatorSpec.php
@@ -17,8 +17,10 @@ use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\CoreBundle\Applicator\CatalogPromotionApplicatorInterface;
+use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 
 final class CatalogPromotionApplicatorSpec extends ObjectBehavior
 {
@@ -29,40 +31,65 @@ final class CatalogPromotionApplicatorSpec extends ObjectBehavior
 
     function it_applies_percentage_discount_on_all_products_variants(
         ProductVariantInterface $variant,
+        CatalogPromotionInterface $catalogPromotion,
+        CatalogPromotionActionInterface $catalogPromotionAction,
         ChannelPricingInterface $firstChannelPricing,
         ChannelPricingInterface $secondChannelPricing
     ): void {
+        $catalogPromotion->getActions()->willReturn(new ArrayCollection([
+            $catalogPromotionAction->getWrappedObject(),
+        ]));
+
         $variant->getChannelPricings()->willReturn(new ArrayCollection([
             $firstChannelPricing->getWrappedObject(),
             $secondChannelPricing->getWrappedObject(),
         ]));
 
+        $catalogPromotionAction->getConfiguration()->willReturn(['amount' => 0.3]);
+
+        $catalogPromotion->getLabel()->willReturn('Winter sale');
+        $catalogPromotion->getCode()->willReturn('winter_sale');
+
         $firstChannelPricing->getPrice()->willReturn(1000);
         $firstChannelPricing->getOriginalPrice()->willReturn(null);
         $firstChannelPricing->setOriginalPrice(1000)->shouldBeCalled();
-        $firstChannelPricing->setPrice(600)->shouldBeCalled();
+        $firstChannelPricing->setPrice(700)->shouldBeCalled();
+        $firstChannelPricing->addAppliedPromotion(['winter_sale' => ['name' => 'Winter sale']])->shouldBeCalled();
 
         $secondChannelPricing->getPrice()->willReturn(1400);
         $secondChannelPricing->getOriginalPrice()->willReturn(null);
         $secondChannelPricing->setOriginalPrice(1400)->shouldBeCalled();
-        $secondChannelPricing->setPrice(840)->shouldBeCalled();
+        $secondChannelPricing->setPrice(980)->shouldBeCalled();
+        $secondChannelPricing->addAppliedPromotion(['winter_sale' => ['name' => 'Winter sale']])->shouldBeCalled();
 
-        $this->applyPercentageDiscount($variant, 0.4);
+        $this->applyCatalogPromotion($variant, $catalogPromotion);
     }
 
     function it_does_not_set_original_price_during_application_if_its_already_there(
         ProductVariantInterface $variant,
+        CatalogPromotionInterface $catalogPromotion,
+        CatalogPromotionActionInterface $catalogPromotionAction,
         ChannelPricingInterface $firstChannelPricing
     ): void {
         $variant->getChannelPricings()->willReturn(new ArrayCollection([
             $firstChannelPricing->getWrappedObject(),
         ]));
 
+        $catalogPromotion->getActions()->willReturn(new ArrayCollection([
+            $catalogPromotionAction->getWrappedObject(),
+        ]));
+
+        $catalogPromotionAction->getConfiguration()->willReturn(['amount' => 0.5]);
+
+        $catalogPromotion->getLabel()->willReturn('Winter sale');
+        $catalogPromotion->getCode()->willReturn('winter_sale');
+
         $firstChannelPricing->getPrice()->willReturn(1000);
         $firstChannelPricing->getOriginalPrice()->willReturn(2000);
         $firstChannelPricing->setOriginalPrice(Argument::any())->shouldNotBeCalled();
         $firstChannelPricing->setPrice(500)->shouldBeCalled();
+        $firstChannelPricing->addAppliedPromotion(['winter_sale' => ['name' => 'Winter sale']])->shouldBeCalled();
 
-        $this->applyPercentageDiscount($variant, 0.5);
+        $this->applyCatalogPromotion($variant, $catalogPromotion);
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/Applicator/CatalogPromotionApplicatorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Applicator/CatalogPromotionApplicatorSpec.php
@@ -21,6 +21,7 @@ use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionTranslationInterface;
 
 final class CatalogPromotionApplicatorSpec extends ObjectBehavior
 {
@@ -33,6 +34,7 @@ final class CatalogPromotionApplicatorSpec extends ObjectBehavior
         ProductVariantInterface $variant,
         CatalogPromotionInterface $catalogPromotion,
         CatalogPromotionActionInterface $catalogPromotionAction,
+        CatalogPromotionTranslationInterface $translation,
         ChannelPricingInterface $firstChannelPricing,
         ChannelPricingInterface $secondChannelPricing
     ): void {
@@ -46,8 +48,9 @@ final class CatalogPromotionApplicatorSpec extends ObjectBehavior
         ]));
 
         $catalogPromotionAction->getConfiguration()->willReturn(['amount' => 0.3]);
-
         $catalogPromotion->getLabel()->willReturn('Winter sale');
+        $catalogPromotion->getTranslations()->willReturn(new ArrayCollection([$translation->getWrappedObject()]));
+        $translation->getLabel()->willReturn('Winter sale');
         $catalogPromotion->getCode()->willReturn('winter_sale');
 
         $firstChannelPricing->getPrice()->willReturn(1000);
@@ -69,6 +72,7 @@ final class CatalogPromotionApplicatorSpec extends ObjectBehavior
         ProductVariantInterface $variant,
         CatalogPromotionInterface $catalogPromotion,
         CatalogPromotionActionInterface $catalogPromotionAction,
+        CatalogPromotionTranslationInterface $translation,
         ChannelPricingInterface $firstChannelPricing
     ): void {
         $variant->getChannelPricings()->willReturn(new ArrayCollection([
@@ -82,6 +86,8 @@ final class CatalogPromotionApplicatorSpec extends ObjectBehavior
         $catalogPromotionAction->getConfiguration()->willReturn(['amount' => 0.5]);
 
         $catalogPromotion->getLabel()->willReturn('Winter sale');
+        $catalogPromotion->getTranslations()->willReturn(new ArrayCollection([$translation->getWrappedObject()]));
+        $translation->getLabel()->willReturn('Winter sale');
         $catalogPromotion->getCode()->willReturn('winter_sale');
 
         $firstChannelPricing->getPrice()->willReturn(1000);

--- a/src/Sylius/Bundle/CoreBundle/spec/Applicator/CatalogPromotionApplicatorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Applicator/CatalogPromotionApplicatorSpec.php
@@ -17,6 +17,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\CoreBundle\Applicator\CatalogPromotionApplicatorInterface;
+use Sylius\Bundle\CoreBundle\Formatter\AppliedPromotionInformationFormatterInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
 use Sylius\Component\Core\Model\ChannelPricingInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
@@ -25,16 +26,21 @@ use Sylius\Component\Promotion\Model\CatalogPromotionTranslationInterface;
 
 final class CatalogPromotionApplicatorSpec extends ObjectBehavior
 {
+    function let(AppliedPromotionInformationFormatterInterface $appliedPromotionInformationFormatter): void
+    {
+        $this->beConstructedWith($appliedPromotionInformationFormatter);
+    }
+
     function it_implements_catalog_promotion_applicator_interface(): void
     {
         $this->shouldImplement(CatalogPromotionApplicatorInterface::class);
     }
 
     function it_applies_percentage_discount_on_all_products_variants(
+        AppliedPromotionInformationFormatterInterface $appliedPromotionInformationFormatter,
         ProductVariantInterface $variant,
         CatalogPromotionInterface $catalogPromotion,
         CatalogPromotionActionInterface $catalogPromotionAction,
-        CatalogPromotionTranslationInterface $translation,
         ChannelPricingInterface $firstChannelPricing,
         ChannelPricingInterface $secondChannelPricing
     ): void {
@@ -47,11 +53,8 @@ final class CatalogPromotionApplicatorSpec extends ObjectBehavior
             $secondChannelPricing->getWrappedObject(),
         ]));
 
+        $appliedPromotionInformationFormatter->format($catalogPromotion)->willReturn(['winter_sale' => ['name' => 'Winter sale']]);
         $catalogPromotionAction->getConfiguration()->willReturn(['amount' => 0.3]);
-        $catalogPromotion->getLabel()->willReturn('Winter sale');
-        $catalogPromotion->getTranslations()->willReturn(new ArrayCollection([$translation->getWrappedObject()]));
-        $translation->getLabel()->willReturn('Winter sale');
-        $catalogPromotion->getCode()->willReturn('winter_sale');
 
         $firstChannelPricing->getPrice()->willReturn(1000);
         $firstChannelPricing->getOriginalPrice()->willReturn(null);
@@ -69,6 +72,7 @@ final class CatalogPromotionApplicatorSpec extends ObjectBehavior
     }
 
     function it_does_not_set_original_price_during_application_if_its_already_there(
+        AppliedPromotionInformationFormatterInterface $appliedPromotionInformationFormatter,
         ProductVariantInterface $variant,
         CatalogPromotionInterface $catalogPromotion,
         CatalogPromotionActionInterface $catalogPromotionAction,
@@ -83,12 +87,8 @@ final class CatalogPromotionApplicatorSpec extends ObjectBehavior
             $catalogPromotionAction->getWrappedObject(),
         ]));
 
+        $appliedPromotionInformationFormatter->format($catalogPromotion)->willReturn(['winter_sale' => ['name' => 'Winter sale']]);
         $catalogPromotionAction->getConfiguration()->willReturn(['amount' => 0.5]);
-
-        $catalogPromotion->getLabel()->willReturn('Winter sale');
-        $catalogPromotion->getTranslations()->willReturn(new ArrayCollection([$translation->getWrappedObject()]));
-        $translation->getLabel()->willReturn('Winter sale');
-        $catalogPromotion->getCode()->willReturn('winter_sale');
 
         $firstChannelPricing->getPrice()->willReturn(1000);
         $firstChannelPricing->getOriginalPrice()->willReturn(2000);

--- a/src/Sylius/Bundle/CoreBundle/spec/Formatter/AppliedPromotionInformationFormatterSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Formatter/AppliedPromotionInformationFormatterSpec.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\CoreBundle\Formatter;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\CoreBundle\Formatter\AppliedPromotionInformationFormatterInterface;
+use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionTranslationInterface;
+
+final class AppliedPromotionInformationFormatterSpec extends ObjectBehavior
+{
+    function it_implements_applied_promotion_information_formatter_interface(): void
+    {
+        $this->shouldImplement(AppliedPromotionInformationFormatterInterface::class);
+    }
+
+    function it_formats_applied_promotion_information(
+        CatalogPromotionInterface $catalogPromotion,
+        CatalogPromotionTranslationInterface $translation
+    ): void {
+        $catalogPromotion->getTranslations()->willReturn(new ArrayCollection([$translation->getWrappedObject()]));
+
+        $catalogPromotion->getCode()->willReturn('winter_sale');
+        $translation->getLabel()->willReturn('Winter sale');
+
+        $this->format($catalogPromotion)->shouldReturn(['winter_sale' => ['name' => 'Winter sale']]);
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/spec/Processor/CatalogPromotionProcessorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Processor/CatalogPromotionProcessorSpec.php
@@ -19,7 +19,6 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\CoreBundle\Applicator\CatalogPromotionApplicatorInterface;
 use Sylius\Bundle\CoreBundle\Processor\CatalogPromotionProcessorInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
-use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Provider\CatalogPromotionVariantsProviderInterface;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
@@ -48,7 +47,6 @@ final class CatalogPromotionProcessorSpec extends ObjectBehavior
         CatalogPromotionApplicatorInterface $productCatalogPromotionApplicator,
         EntityManagerInterface $entityManager,
         CatalogPromotionInterface $catalogPromotion,
-        CatalogPromotionActionInterface $action,
         ProductVariantInterface $firstVariant,
         ProductVariantInterface $secondVariant
     ): void {
@@ -57,14 +55,8 @@ final class CatalogPromotionProcessorSpec extends ObjectBehavior
             ->willReturn([$firstVariant, $secondVariant])
         ;
 
-        $catalogPromotion->getActions()->willReturn(new ArrayCollection([
-            $action->getWrappedObject(),
-        ]));
-
-        $action->getConfiguration()->willReturn(['amount' => 0.3]);
-
-        $productCatalogPromotionApplicator->applyPercentageDiscount($firstVariant, 0.3)->shouldBeCalled();
-        $productCatalogPromotionApplicator->applyPercentageDiscount($secondVariant, 0.3)->shouldBeCalled();
+        $productCatalogPromotionApplicator->applyCatalogPromotion($firstVariant, $catalogPromotion)->shouldBeCalled();
+        $productCatalogPromotionApplicator->applyCatalogPromotion($secondVariant, $catalogPromotion)->shouldBeCalled();
 
         $entityManager->flush()->shouldBeCalled();
 

--- a/src/Sylius/Component/Core/Model/ChannelPricing.php
+++ b/src/Sylius/Component/Core/Model/ChannelPricing.php
@@ -30,6 +30,9 @@ class ChannelPricing implements ChannelPricingInterface
     /** @var int|null */
     protected $originalPrice;
 
+    /** @var array */
+    protected $appliedPromotions = [];
+
     public function __toString(): string
     {
         return (string) $this->getPrice();
@@ -83,5 +86,20 @@ class ChannelPricing implements ChannelPricingInterface
     public function isPriceReduced(): bool
     {
         return $this->originalPrice > $this->price;
+    }
+
+    public function addAppliedPromotion(array $promotion): void
+    {
+        $this->appliedPromotions = array_merge_recursive($this->appliedPromotions, $promotion);
+    }
+
+    public function removeAppliedPromotion(string $promotionCode): void
+    {
+        unset($this->appliedPromotions[$promotionCode]);
+    }
+
+    public function getAppliedPromotions(): array
+    {
+        return $this->appliedPromotions;
     }
 }

--- a/src/Sylius/Component/Core/Model/ChannelPricingInterface.php
+++ b/src/Sylius/Component/Core/Model/ChannelPricingInterface.php
@@ -37,4 +37,10 @@ interface ChannelPricingInterface extends ResourceInterface
     public function setOriginalPrice(?int $originalPrice): void;
 
     public function isPriceReduced(): bool;
+
+    public function addAppliedPromotion(array $promotion): void;
+
+    public function removeAppliedPromotion(string $promotionCode): void;
+
+    public function getAppliedPromotions(): array;
 }

--- a/src/Sylius/Component/Core/Model/ProductVariant.php
+++ b/src/Sylius/Component/Core/Model/ProductVariant.php
@@ -278,6 +278,13 @@ class ProductVariant extends BaseVariant implements ProductVariantInterface, Com
         $this->shippingRequired = $shippingRequired;
     }
 
+    public function getAppliedPromotionsForChannel(ChannelInterface $channel): array
+    {
+        $channelPricing = $this->getChannelPricingForChannel($channel);
+
+        return ($channelPricing !== null) ? $channelPricing->getAppliedPromotions() : [];
+    }
+
     /**
      * @psalm-suppress InvalidReturnType https://github.com/doctrine/collections/pull/220
      * @psalm-suppress InvalidReturnStatement https://github.com/doctrine/collections/pull/220

--- a/src/Sylius/Component/Core/Model/ProductVariantInterface.php
+++ b/src/Sylius/Component/Core/Model/ProductVariantInterface.php
@@ -70,4 +70,6 @@ interface ProductVariantInterface extends
     public function isShippingRequired(): bool;
 
     public function setShippingRequired(bool $shippingRequired): void;
+
+    public function getAppliedPromotionsForChannel(ChannelInterface $channel): array;
 }

--- a/src/Sylius/Component/Core/spec/Model/ChannelPricingSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ChannelPricingSpec.php
@@ -79,4 +79,19 @@ final class ChannelPricingSpec extends ObjectBehavior
         $this->setOriginalPrice(1500);
         $this->isPriceReduced()->shouldReturn(false);
     }
+
+    function it_can_have_promotions_applied(): void
+    {
+        $this->addAppliedPromotion(['winter_sale' => ['name' => 'Winter sale']]);
+        $this->addAppliedPromotion(['extra_sale' => ['name' => 'Extra sale']]);
+        $this->getAppliedPromotions()->shouldReturn([
+            'winter_sale' => ['name' => 'Winter sale'],
+            'extra_sale' => ['name' => 'Extra sale'],
+        ]);
+
+        $this->removeAppliedPromotion('winter_sale');
+        $this->getAppliedPromotions()->shouldReturn([
+            'extra_sale' => ['name' => 'Extra sale'],
+        ]);
+    }
 }

--- a/src/Sylius/Component/Core/spec/Model/ProductVariantSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/ProductVariantSpec.php
@@ -281,6 +281,20 @@ final class ProductVariantSpec extends ObjectBehavior
         $this->getImagesByType('thumbnail')->shouldBeLike(new ArrayCollection([$image->getWrappedObject()]));
     }
 
+    function it_returns_channel_pricing_applied_promotions(
+        ChannelPricingInterface $channelPricing,
+        ChannelInterface $channel
+    ): void {
+        $channel->getCode()->willReturn('CHANNEL_WEB');
+        $channelPricing->setProductVariant($this)->shouldBeCalled();
+        $channelPricing->getChannelCode()->willReturn('CHANNEL_WEB');
+        $channelPricing->getAppliedPromotions()->willReturn(['winter_sale' => ['name' => 'Winter sale']]);
+
+        $this->addChannelPricing($channelPricing);
+
+        $this->getAppliedPromotionsForChannel($channel)->shouldReturn(['winter_sale' => ['name' => 'Winter sale']]);
+    }
+
     function it_is_comparable(): void
     {
         $this->setCode('test');


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

We need to keep the information about applied catalog promotions on each `ChannelPricing`. I propose to start simple, with an array of arrays 💃 to make it happen sooner than later. If we decide in the future we need some more sophisticated structure - we can always change it 🚀 