### PR TITLE
Association hydrator private in product repo should be protected

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ProductRepository.php
@@ -25,7 +25,7 @@ use SyliusLabs\AssociationHydrator\AssociationHydrator;
 
 class ProductRepository extends BaseProductRepository implements ProductRepositoryInterface
 {
-    private AssociationHydrator $associationHydrator;
+    protected AssociationHydrator $associationHydrator;
 
     public function __construct(EntityManager $entityManager, ClassMetadata $class)
     {


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.13
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

This class is designed to be extended. Therefore having a private field not overridable seems to be a bad idea.

Another idea could be to take it as a constructor parameter but it just makes no sense since it would just suggest to the user add its own private property to make the whole thing work. This commit is to me the best approach to the problem.

