### PR TITLE
[CatalogPromotions] Move variant-related CatalogPromotionRule constant to Core

### DIFF
--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -19,11 +19,11 @@ use Sylius\Behat\Client\ApiClientInterface;
 use Sylius\Behat\Client\ResponseCheckerInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Core\Model\CatalogPromotionRuleInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Promotion\Event\CatalogPromotionUpdated;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
-use Sylius\Component\Promotion\Model\CatalogPromotionRuleInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Webmozart\Assert\Assert;
 

--- a/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
@@ -18,11 +18,10 @@ use Doctrine\ORM\EntityManagerInterface;
 use Sylius\Behat\Service\SharedStorageInterface;
 use Sylius\Bundle\CoreBundle\Fixture\Factory\ExampleFactoryInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Core\Model\CatalogPromotionRuleInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
-use Sylius\Component\Promotion\Model\CatalogPromotionRule;
-use Sylius\Component\Promotion\Model\CatalogPromotionRuleInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 
 final class CatalogPromotionContext implements Context
@@ -92,7 +91,7 @@ final class CatalogPromotionContext implements Context
     {
         /** @var CatalogPromotionRuleInterface $catalogPromotionRule */
         $catalogPromotionRule = $this->catalogPromotionRuleFactory->createNew();
-        $catalogPromotionRule->setType(CatalogPromotionRule::TYPE_FOR_VARIANTS);
+        $catalogPromotionRule->setType(CatalogPromotionRuleInterface::TYPE_FOR_VARIANTS);
         $catalogPromotionRule->setConfiguration([$variant->getCode()]);
 
         $catalogPromotion->addRule($catalogPromotionRule);

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius/sylius_promotion.yml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/app/sylius/sylius_promotion.yml
@@ -6,6 +6,9 @@ sylius_promotion:
         catalog_promotion:
             classes:
                 model: Sylius\Component\Core\Model\CatalogPromotion
+        catalog_promotion_rule:
+            classes:
+                model: Sylius\Component\Core\Model\CatalogPromotionRule
         promotion_subject:
             classes:
                 model: "%sylius.model.order.class%"

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/CatalogPromotionRule.orm.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/doctrine/model/CatalogPromotionRule.orm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+
+ This file is part of the Sylius package.
+
+ (c) Paweł Jędrzejewski
+
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+
+-->
+
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping">
+
+    <mapped-superclass name="Sylius\Component\Core\Model\CatalogPromotionRule" table="sylius_catalog_promotion_rule" />
+
+</doctrine-mapping>

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CatalogPromotionRulesValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CatalogPromotionRulesValidator.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Validator\Constraints;
 
+use Sylius\Component\Core\Model\CatalogPromotionRuleInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
-use Sylius\Component\Promotion\Model\CatalogPromotionRuleInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Webmozart\Assert\Assert;

--- a/src/Sylius/Bundle/CoreBundle/spec/Validator/Constraints/CatalogPromotionRulesValidatorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Validator/Constraints/CatalogPromotionRulesValidatorSpec.php
@@ -15,13 +15,11 @@ namespace spec\Sylius\Bundle\CoreBundle\Validator\Constraints;
 
 use PhpSpec\ObjectBehavior;
 use Sylius\Bundle\CoreBundle\Validator\Constraints\CatalogPromotionRules;
+use Sylius\Component\Core\Model\CatalogPromotionRuleInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
-use Sylius\Component\Promotion\Model\CatalogPromotionRuleInterface;
-use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
-use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 final class CatalogPromotionRulesValidatorSpec extends ObjectBehavior
 {

--- a/src/Sylius/Component/Core/Model/CatalogPromotionRule.php
+++ b/src/Sylius/Component/Core/Model/CatalogPromotionRule.php
@@ -13,9 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Component\Core\Model;
 
-use Sylius\Component\Channel\Model\ChannelsAwareInterface;
-use Sylius\Component\Promotion\Model\CatalogPromotionInterface as BaseCatalogPromotionInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionRule as BaseCatalogPromotionRule;
 
-interface CatalogPromotionInterface extends BaseCatalogPromotionInterface, ChannelsAwareInterface
+class CatalogPromotionRule extends BaseCatalogPromotionRule implements CatalogPromotionRuleInterface
 {
 }

--- a/src/Sylius/Component/Core/Model/CatalogPromotionRuleInterface.php
+++ b/src/Sylius/Component/Core/Model/CatalogPromotionRuleInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Component\Core\Model;
+
+use Sylius\Component\Promotion\Model\CatalogPromotionRuleInterface as BaseCatalogPromotionRuleInterface;
+
+interface CatalogPromotionRuleInterface extends BaseCatalogPromotionRuleInterface
+{
+    public const TYPE_FOR_VARIANTS = 'for_variants';
+}

--- a/src/Sylius/Component/Core/spec/Model/CatalogPromotionRuleSpec.php
+++ b/src/Sylius/Component/Core/spec/Model/CatalogPromotionRuleSpec.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Component\Core\Model;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Model\CatalogPromotionRuleInterface;
+use Sylius\Component\Promotion\Model\CatalogPromotionRule;
+
+final class CatalogPromotionRuleSpec extends ObjectBehavior
+{
+    function it_implements_catalog_promotion_rule_interface(): void
+    {
+        $this->shouldImplement(CatalogPromotionRuleInterface::class);
+    }
+
+    function it_extends_base_catalog_promotion_rule(): void
+    {
+        $this->shouldHaveType(CatalogPromotionRule::class);
+    }
+}

--- a/src/Sylius/Component/Promotion/Model/CatalogPromotionRuleInterface.php
+++ b/src/Sylius/Component/Promotion/Model/CatalogPromotionRuleInterface.php
@@ -17,8 +17,6 @@ use Sylius\Component\Resource\Model\ResourceInterface;
 
 interface CatalogPromotionRuleInterface extends ResourceInterface
 {
-    public const TYPE_FOR_VARIANTS = 'for_variants';
-
     public function setType(?string $type): void;
 
     public function getType(): ?string;

--- a/tests/Api/Admin/CatalogPromotionsTest.php
+++ b/tests/Api/Admin/CatalogPromotionsTest.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sylius\Tests\Api\Admin;
 
-use Sylius\Component\Promotion\Model\CatalogPromotionRuleInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Core\Model\CatalogPromotionRuleInterface;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 use Sylius\Tests\Api\JsonApiTestCase;
 use Sylius\Tests\Api\Utils\AdminUserLoginTrait;


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

Variants do not exist (even conceptually) within the `PromotionBundle` 🖖 