### PR TITLE
[CatalogPromotion] refactor cp rule to be consistent with cp action

### DIFF
--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -201,8 +201,10 @@ final class ManagingCatalogPromotionsContext implements Context
         $rules = [[
             'type' => CatalogPromotionRuleInterface::TYPE_FOR_VARIANTS,
             'configuration' => [
-                $firstVariant->getCode(),
-                $secondVariant->getCode(),
+                'variants' => [
+                    $firstVariant->getCode(),
+                    $secondVariant->getCode(),
+                ]
             ],
         ]];
 
@@ -218,7 +220,9 @@ final class ManagingCatalogPromotionsContext implements Context
         $rules = [[
             'type' => CatalogPromotionRuleInterface::TYPE_FOR_VARIANTS,
             'configuration' => [
-                $productVariant->getCode(),
+                'variants' => [
+                    $productVariant->getCode(),
+                ]
             ],
         ]];
 
@@ -342,7 +346,7 @@ final class ManagingCatalogPromotionsContext implements Context
     public function itShouldHaveRule(ProductVariantInterface $firstVariant, ProductVariantInterface $secondVariant): void
     {
         Assert::same(
-            [$firstVariant->getCode(), $secondVariant->getCode()],
+            ['variants' => [$firstVariant->getCode(), $secondVariant->getCode()]],
             $this->responseChecker->getCollection($this->client->getLastResponse())[0]['rules'][0]['configuration']
         );
     }
@@ -531,7 +535,7 @@ final class ManagingCatalogPromotionsContext implements Context
         $response = $this->responseChecker->getResponseContent($this->client->getLastResponse());
 
         foreach ($productVariants as $productVariant) {
-            if ($this->hasVariantInConfiguration($response['rules'][0]['configuration'], $productVariant) === false) {
+            if ($this->hasVariantInConfiguration($response['rules'][0]['configuration']['variants'], $productVariant) === false) {
                 return false;
             }
         }

--- a/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
+++ b/src/Sylius/Behat/Context/Setup/CatalogPromotionContext.php
@@ -92,7 +92,7 @@ final class CatalogPromotionContext implements Context
         /** @var CatalogPromotionRuleInterface $catalogPromotionRule */
         $catalogPromotionRule = $this->catalogPromotionRuleFactory->createNew();
         $catalogPromotionRule->setType(CatalogPromotionRuleInterface::TYPE_FOR_VARIANTS);
-        $catalogPromotionRule->setConfiguration([$variant->getCode()]);
+        $catalogPromotionRule->setConfiguration(['variants' => [$variant->getCode()]]);
 
         $catalogPromotion->addRule($catalogPromotionRule);
 

--- a/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/theme.html.twig
+++ b/src/Sylius/Bundle/AdminBundle/Resources/views/CatalogPromotion/theme.html.twig
@@ -2,5 +2,5 @@
 
 {% block sylius_catalog_promotion_rule_widget %}
     {{ form_row(form.type) }}
-    {{ form_row(form.configuration, {'remote_url': path('sylius_admin_ajax_all_product_variants_by_phrase'), 'remote_criteria_type': 'contains', 'remote_criteria_name': 'phrase', 'load_edit_url': path('sylius_admin_ajax_all_product_variants_by_codes')}) }}
+    {{ form_row(form.configuration.variants, {'remote_url': path('sylius_admin_ajax_all_product_variants_by_phrase'), 'remote_criteria_type': 'contains', 'remote_criteria_name': 'phrase', 'load_edit_url': path('sylius_admin_ajax_all_product_variants_by_codes')}) }}
 {% endblock %}

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CatalogPromotionRuleTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CatalogPromotionRuleTypeExtension.php
@@ -1,11 +1,20 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Form\Extension;
 
 use Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionRuleType;
-use Sylius\Bundle\PromotionBundle\Form\Type\CatalogRule\VariantRuleConfigurationType;
+use Sylius\Bundle\CoreBundle\Form\Type\CatalogRule\VariantRuleConfigurationType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 

--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CatalogPromotionRuleTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CatalogPromotionRuleTypeExtension.php
@@ -5,32 +5,17 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Form\Extension;
 
 use Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionRuleType;
-use Sylius\Bundle\ResourceBundle\Form\Type\ResourceAutocompleteChoiceType;
+use Sylius\Bundle\PromotionBundle\Form\Type\CatalogRule\VariantRuleConfigurationType;
 use Symfony\Component\Form\AbstractTypeExtension;
-use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 
 final class CatalogPromotionRuleTypeExtension extends AbstractTypeExtension
 {
-    private DataTransformerInterface $productVariantsToCodesTransformer;
-
-    public function __construct(DataTransformerInterface $productVariantsToCodesTransformer)
-    {
-        $this->productVariantsToCodesTransformer = $productVariantsToCodesTransformer;
-    }
-
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('configuration', ResourceAutocompleteChoiceType::class, [
-            'label' => 'sylius.ui.variants',
-            'multiple' => true,
-            'required' => false,
-            'choice_name' => 'descriptor',
-            'choice_value' => 'code',
-            'resource' => 'sylius.product_variant',
+        $builder->add('configuration', VariantRuleConfigurationType::class, [
+            'label' => false,
         ]);
-
-        $builder->get('configuration')->addModelTransformer($this->productVariantsToCodesTransformer);
     }
 
     public static function getExtendedTypes(): iterable

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/CatalogRule/VariantRuleConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/CatalogRule/VariantRuleConfigurationType.php
@@ -1,8 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
-namespace Sylius\Bundle\PromotionBundle\Form\Type\CatalogRule;
+namespace Sylius\Bundle\CoreBundle\Form\Type\CatalogRule;
 
 use Sylius\Bundle\ResourceBundle\Form\Type\ResourceAutocompleteChoiceType;
 use Symfony\Component\Form\AbstractType;

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
@@ -79,7 +79,6 @@
             <tag name="form.type_extension" extended-type="Sylius\Bundle\OrderBundle\Form\Type\CartType" />
         </service>
         <service id="Sylius\Bundle\CoreBundle\Form\Extension\CatalogPromotionRuleTypeExtension">
-            <argument type="service" id="sylius.form.type.data_transformer.product_variants_to_codes" />
             <tag name="form.type_extension" extended-type="Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionRuleType" />
         </service>
         <service id="sylius.form.extension.type.cart_item" class="Sylius\Bundle\CoreBundle\Form\Extension\CartItemTypeExtension">
@@ -158,6 +157,10 @@
         </service>
         <service id="sylius.form.type.avatar_image" class="Sylius\Bundle\CoreBundle\Form\Type\User\AvatarImageType">
             <argument>%sylius.model.avatar_image.class%</argument>
+            <tag name="form.type" />
+        </service>
+        <service id="sylius.form.type.variant_rule" class="Sylius\Bundle\PromotionBundle\Form\Type\CatalogRule\VariantRuleConfigurationType">
+            <argument type="service" id="sylius.form.type.data_transformer.product_variants_to_codes" />
             <tag name="form.type" />
         </service>
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
@@ -159,7 +159,7 @@
             <argument>%sylius.model.avatar_image.class%</argument>
             <tag name="form.type" />
         </service>
-        <service id="sylius.form.type.variant_rule" class="Sylius\Bundle\PromotionBundle\Form\Type\CatalogRule\VariantRuleConfigurationType">
+        <service id="sylius.form.type.variant_rule" class="Sylius\Bundle\CoreBundle\Form\Type\CatalogRule\VariantRuleConfigurationType">
             <argument type="service" id="sylius.form.type.data_transformer.product_variants_to_codes" />
             <tag name="form.type" />
         </service>

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CatalogPromotionRulesValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CatalogPromotionRulesValidator.php
@@ -46,7 +46,6 @@ final class CatalogPromotionRulesValidator extends ConstraintValidator
 
     private function validateRuleConfiguration(array $configuration, CatalogPromotionRules $constraint): void
     {
-
         if (array_key_exists('variants', $configuration) === false) {
             $this->context->addViolation($constraint->invalidConfiguration);
 

--- a/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CatalogPromotionRulesValidator.php
+++ b/src/Sylius/Bundle/CoreBundle/Validator/Constraints/CatalogPromotionRulesValidator.php
@@ -40,13 +40,20 @@ final class CatalogPromotionRulesValidator extends ConstraintValidator
                 continue;
             }
 
-                $this->validateRuleConfiguration($rule->getConfiguration(), $constraint);
+            $this->validateRuleConfiguration($rule->getConfiguration(), $constraint);
         }
     }
 
     private function validateRuleConfiguration(array $configuration, CatalogPromotionRules $constraint): void
     {
-        foreach ($configuration as $variantCode) {
+
+        if (array_key_exists('variants', $configuration) === false) {
+            $this->context->addViolation($constraint->invalidConfiguration);
+
+            return;
+        }
+
+        foreach ($configuration['variants'] as $variantCode) {
             if (null === $this->variantRepository->findOneBy(['code' => $variantCode])) {
                 $this->context->addViolation($constraint->invalidConfiguration);
 

--- a/src/Sylius/Bundle/CoreBundle/spec/Validator/Constraints/CatalogPromotionRulesValidatorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Validator/Constraints/CatalogPromotionRulesValidatorSpec.php
@@ -18,6 +18,7 @@ use Sylius\Bundle\CoreBundle\Validator\Constraints\CatalogPromotionRules;
 use Sylius\Component\Core\Model\CatalogPromotionRuleInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Repository\ProductVariantRepositoryInterface;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
@@ -58,6 +59,18 @@ final class CatalogPromotionRulesValidatorSpec extends ObjectBehavior
         $this->validate([$rule], new CatalogPromotionRules());
     }
 
+    function it_adds_violation_if_catalog_promotion_rule_is_without_variants_key(
+        ExecutionContextInterface $executionContext,
+        CatalogPromotionRuleInterface $rule
+    ): void {
+        $rule->getType()->willReturn(CatalogPromotionRuleInterface::TYPE_FOR_VARIANTS);
+        $rule->getConfiguration()->willReturn(['first_variant', 'second_variant']);
+
+        $executionContext->addViolation('sylius.catalog_promotion.rules.invalid_configuration')->shouldBeCalled();
+
+        $this->validate([$rule], new CatalogPromotionRules());
+    }
+
     function it_does_nothing_if_catalog_promotion_rule_is_valid(
         ExecutionContextInterface $executionContext,
         CatalogPromotionRuleInterface $rule,
@@ -66,7 +79,7 @@ final class CatalogPromotionRulesValidatorSpec extends ObjectBehavior
         ProductVariantInterface $secondVariant
     ): void {
         $rule->getType()->willReturn(CatalogPromotionRuleInterface::TYPE_FOR_VARIANTS);
-        $rule->getConfiguration()->willReturn(['first_variant', 'second_variant']);
+        $rule->getConfiguration()->willReturn(['variants' => ['first_variant', 'second_variant']]);
 
         $executionContext->addViolation('sylius.catalog_promotion.rules.invalid_type')->shouldNotBeCalled();
 

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionRuleType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogPromotionRuleType.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Sylius\Bundle\PromotionBundle\Form\Type;

--- a/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogRule/VariantRuleConfigurationType.php
+++ b/src/Sylius/Bundle/PromotionBundle/Form/Type/CatalogRule/VariantRuleConfigurationType.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\PromotionBundle\Form\Type\CatalogRule;
+
+use Sylius\Bundle\ResourceBundle\Form\Type\ResourceAutocompleteChoiceType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class VariantRuleConfigurationType extends AbstractType
+{
+    private DataTransformerInterface $productVariantsToCodesTransformer;
+
+    public function __construct(DataTransformerInterface $productVariantsToCodesTransformer)
+    {
+        $this->productVariantsToCodesTransformer = $productVariantsToCodesTransformer;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('variants', ResourceAutocompleteChoiceType::class, [
+            'label' => 'sylius.ui.variants',
+            'multiple' => true,
+            'required' => false,
+            'choice_name' => 'descriptor',
+            'choice_value' => 'code',
+            'resource' => 'sylius.product_variant',
+        ]);
+
+        $builder->get('variants')->addModelTransformer($this->productVariantsToCodesTransformer);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'sylius_catalog_promotion_rule_variant_configuration';
+    }
+}

--- a/tests/Api/Admin/CatalogPromotionsTest.php
+++ b/tests/Api/Admin/CatalogPromotionsTest.php
@@ -92,7 +92,9 @@ final class CatalogPromotionsTest extends JsonApiTestCase
                     [
                         'type' => CatalogPromotionRuleInterface::TYPE_FOR_VARIANTS,
                         'configuration' => [
-                            'MUG'
+                            'variants' => [
+                                'MUG'
+                            ]
                         ],
                     ]
                 ],
@@ -187,7 +189,9 @@ final class CatalogPromotionsTest extends JsonApiTestCase
                     [
                         'type' => CatalogPromotionRuleInterface::TYPE_FOR_VARIANTS,
                         'configuration' => [
-                            'MUG'
+                            'variants' => [
+                                'MUG'
+                            ]
                         ],
                     ]
                 ],

--- a/tests/Api/Responses/Expected/admin/catalog_promotion/post_catalog_promotion_response.json
+++ b/tests/Api/Responses/Expected/admin/catalog_promotion/post_catalog_promotion_response.json
@@ -14,9 +14,11 @@
             "@id": @string@,
             "id": @integer@,
             "type": "for_variants",
-            "configuration": [
-                "MUG"
-            ]
+            "configuration": {
+                "variants": [
+                    "MUG"
+                ]
+            }
         }
     ],
     "actions": [

--- a/tests/Api/Responses/Expected/admin/catalog_promotion/put_catalog_promotion_response.json
+++ b/tests/Api/Responses/Expected/admin/catalog_promotion/put_catalog_promotion_response.json
@@ -14,9 +14,11 @@
             "@id": @string@,
             "id": @integer@,
             "type": "for_variants",
-            "configuration": [
-                "MUG"
-            ]
+            "configuration": {
+                "variants": [
+                    "MUG"
+                ]
+            }
         }
     ],
     "actions": [


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         |master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
