### PR TITLE
[API] Fix command denormalizer to not throw exception if command does not have constructor

### DIFF
--- a/src/Sylius/Bundle/ApiBundle/spec/Serializer/CommandDenormalizerSpec.php
+++ b/src/Sylius/Bundle/ApiBundle/spec/Serializer/CommandDenormalizerSpec.php
@@ -101,6 +101,30 @@ final class CommandDenormalizerSpec extends ObjectBehavior
         ;
     }
 
+    function it_does_not_check_parameters_if_there_is_no_constructor(
+        DenormalizerInterface $baseNormalizer
+    ): void {
+        $baseNormalizer
+            ->denormalize(
+                [],
+                Customer::class,
+                null,
+                ['input' => ['class' => \stdClass::class]]
+            )
+            ->willReturn(['key' => 'value'])
+        ;
+
+        $this
+            ->denormalize(
+                [],
+                Customer::class,
+                null,
+                ['input' => ['class' => \stdClass::class]]
+            )
+            ->shouldReturn(['key' => 'value'])
+        ;
+    }
+
     function it_implements_context_aware_denormalizer_interface(): void
     {
         $this->shouldImplement(ContextAwareDenormalizerInterface::class);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
