### PR TITLE
[CatalogPromotion] Improve names and namespaces of catalog promotion rule form types

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Form/Extension/CatalogPromotionRuleTypeExtension.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Extension/CatalogPromotionRuleTypeExtension.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Form\Extension;
 
 use Sylius\Bundle\PromotionBundle\Form\Type\CatalogPromotionRuleType;
-use Sylius\Bundle\CoreBundle\Form\Type\CatalogRule\VariantRuleConfigurationType;
+use Sylius\Bundle\CoreBundle\Form\Type\CatalogPromotionRule\ForVariantsRuleConfigurationType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -22,7 +22,7 @@ final class CatalogPromotionRuleTypeExtension extends AbstractTypeExtension
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('configuration', VariantRuleConfigurationType::class, [
+        $builder->add('configuration', ForVariantsRuleConfigurationType::class, [
             'label' => false,
         ]);
     }

--- a/src/Sylius/Bundle/CoreBundle/Form/Type/CatalogPromotionRule/ForVariantsRuleConfigurationType.php
+++ b/src/Sylius/Bundle/CoreBundle/Form/Type/CatalogPromotionRule/ForVariantsRuleConfigurationType.php
@@ -11,14 +11,14 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Bundle\CoreBundle\Form\Type\CatalogRule;
+namespace Sylius\Bundle\CoreBundle\Form\Type\CatalogPromotionRule;
 
 use Sylius\Bundle\ResourceBundle\Form\Type\ResourceAutocompleteChoiceType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 
-final class VariantRuleConfigurationType extends AbstractType
+final class ForVariantsRuleConfigurationType extends AbstractType
 {
     private DataTransformerInterface $productVariantsToCodesTransformer;
 

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/form.xml
@@ -159,7 +159,7 @@
             <argument>%sylius.model.avatar_image.class%</argument>
             <tag name="form.type" />
         </service>
-        <service id="sylius.form.type.variant_rule" class="Sylius\Bundle\CoreBundle\Form\Type\CatalogRule\VariantRuleConfigurationType">
+        <service id="sylius.form.type.for_variants_rule" class="Sylius\Bundle\CoreBundle\Form\Type\CatalogPromotionRule\ForVariantsRuleConfigurationType">
             <argument type="service" id="sylius.form.type.data_transformer.product_variants_to_codes" />
             <tag name="form.type" />
         </service>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | after https://github.com/Sylius/Sylius/pull/13066#pullrequestreview-748814118
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
