### PR TITLE
Fix RemoveExpiredCartsCommand description

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Command/RemoveExpiredCartsCommand.php
+++ b/src/Sylius/Bundle/OrderBundle/Command/RemoveExpiredCartsCommand.php
@@ -27,7 +27,7 @@ class RemoveExpiredCartsCommand extends ContainerAwareCommand
     protected function configure(): void
     {
         $this
-            ->setDescription('Removes carts that have been idle for a period set in `sylius_order.expiration.cart` configuration key.')
+            ->setDescription('Removes carts that have been idle for a period set in `sylius_order.cart_expiration_period` configuration key.')
         ;
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes (UI/documentation bug)
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| License         | MIT

The command description says it uses `sylius_order.expiration.cart` parameter but the `sylius_order.cart_expiration_period` parameter is used instead.