### PR TITLE
Check if the form is submitted before validation

### DIFF
--- a/src/Sylius/Bundle/OrderBundle/Controller/OrderController.php
+++ b/src/Sylius/Bundle/OrderBundle/Controller/OrderController.php
@@ -80,7 +80,7 @@ class OrderController extends ResourceController
 
         $form = $this->resourceFormFactory->create($configuration, $resource);
 
-        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && $form->handleRequest($request)->isValid()) {
+        if (in_array($request->getMethod(), ['POST', 'PUT', 'PATCH'], true) && $form->handleRequest($request)->isSubmitted() && $form->isValid()) {
             $resource = $form->getData();
 
             $event = $this->eventDispatcher->dispatchPreEvent(ResourceActions::UPDATE, $configuration, $resource);


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.10
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

I got this error during the development of a cart related feature:

```
Symfony\Component\Form\Exception\LogicException:
Cannot check if an unsubmitted form is valid. Call Form::isSubmitted() before Form::isValid().

  at vendor/symfony/form/Form.php:752
  at Symfony\Component\Form\Form->isValid()
     (vendor/sylius/sylius/src/Sylius/Bundle/OrderBundle/Controller/OrderController.php:83)
  at Sylius\Bundle\OrderBundle\Controller\OrderController->saveAction(object(Request))
     (vendor/symfony/http-kernel/HttpKernel.php:157)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:79)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:199)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:25)
```

This PR fixes that.

We _could_ update all controllers with the same fix but right now I prefer to change only this one since I know the behavior.