### PR TITLE
[CatalogPromotions] Do not display applied promotion description in label if not set

### DIFF
--- a/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-variants-prices.js
+++ b/src/Sylius/Bundle/ShopBundle/Resources/private/js/sylius-variants-prices.js
@@ -15,7 +15,11 @@ function formatAppliedPromotions(appliedPromotions, locale = 'en_US') {
 
   if (appliedPromotions !== '[]') {
     $.each(appliedPromotions, (index, promotion) => {
-      appliedPromotionsElement += `<div class="ui blue label" id="promotion_label" style="margin: 1rem 0;">${promotion[locale].name} - ${promotion[locale].description}</div>`;
+      if (promotion[locale].description !== null) {
+        appliedPromotionsElement += `<div class="ui blue label" id="promotion_label" style="margin: 1rem 0;">${promotion[locale].name} - ${promotion[locale].description}</div>`;
+      } else {
+        appliedPromotionsElement += `<div class="ui blue label" id="promotion_label" style="margin: 1rem 0;">${promotion[locale].name}</div>`;
+      }
     });
     $('#appliedPromotions').html(appliedPromotionsElement);
   }

--- a/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_price.html.twig
+++ b/src/Sylius/Bundle/ShopBundle/Resources/views/Product/Show/_price.html.twig
@@ -13,10 +13,10 @@
 
 <div id="appliedPromotions" data-applied-promotions-locale="{{ sylius.localeCode }}">
     {% for appliedPromotion in channelPricing.appliedPromotions %}
-    <div class="ui blue label" id="promotion_label" style="display: {{ channelPricing.appliedPromotions ? 'block' : none }}; margin: 1rem 0;">
+    <div class="ui blue label" id="promotion_label" style="margin: 1rem 0;">
         {% set promotion = appliedPromotion[sylius.localeCode] %}
         <div class="row ui small" id="sylius_catalog_promotion">
-            {{ promotion.name }} - {{ promotion.description }}
+            {{ promotion.name }}{% if promotion.description %} - {{ promotion.description }}{% endif %}
         </div>
     </div>
     {% endfor %}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | introduced in https://github.com/Sylius/Sylius/pull/13101
| License         | MIT

Before:

<img width="588" alt="Zrzut ekranu 2021-09-16 o 08 59 13" src="https://user-images.githubusercontent.com/6212718/133565044-a6ff33f4-2236-4e50-b738-fc7c27e4f774.png">


After:

<img width="607" alt="Zrzut ekranu 2021-09-16 o 08 57 03" src="https://user-images.githubusercontent.com/6212718/133565003-6b0c7c39-eafb-4724-8894-7b9daed531e6.png">
