### PR TITLE
Fix #13123, Only use products total in OrderTotalRuleChecker to select shipping methods

### DIFF
--- a/features/checkout/consistent_shipping_method_selection.feature
+++ b/features/checkout/consistent_shipping_method_selection.feature
@@ -1,0 +1,30 @@
+@checkout
+Feature: Selected shipping method stays consistent throughout checkout
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a tax category "tax category"
+        And the store has "VAT" tax rate of 20% for "tax cageroy" within the "United States" zone
+        And the store has a product "Mantis blade" priced at "$91"
+        And the product "Mantis blade" belongs to "tax category" tax category
+        And the store has "A" shipping method with "$10" fee
+        And this shipping method is only available for orders under or equal to "$100"
+        And the store has "B" shipping method with "$0" fee
+        And this shipping method is only available for orders over or equal to "$100"
+        And the store allows paying offline
+        And there is a customer "John Doe" identified by an email "john@example.com" and a password "secret"
+
+    @ui
+    Scenario: Method A should be available and not method B
+        Given I have product "Mantis blade" in the cart
+        When I complete addressing step with email "john@example.com" and "United States" based billing address
+        Then I should see "A" shipping method
+        And I should not see "B" shipping method
+
+    @ui
+    Scenario: Selected shipping method stays consistent throughout checkout
+        Given I have product "Mantis blade" in the cart
+        When I complete addressing step with email "john@example.com" and "United States" based billing address
+        And I completed the shipping step with "A" shipping method
+        And I choose "Offline" payment method
+        Then my order's shipping method should be "A"

--- a/src/Sylius/Component/Core/Shipping/Checker/Rule/OrderTotalRuleChecker.php
+++ b/src/Sylius/Component/Core/Shipping/Checker/Rule/OrderTotalRuleChecker.php
@@ -40,7 +40,7 @@ abstract class OrderTotalRuleChecker implements RuleCheckerInterface
             return false;
         }
 
-        return $this->compare($order->getTotal(), $amount);
+        return $this->compare($order->getItemsTotal(), $amount);
     }
 
     abstract protected function compare(int $total, int $threshold): bool;

--- a/src/Sylius/Component/Core/spec/Shipping/Checker/Rule/OrderTotalGreaterThanOrEqualRuleCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Shipping/Checker/Rule/OrderTotalGreaterThanOrEqualRuleCheckerSpec.php
@@ -45,7 +45,7 @@ final class OrderTotalGreaterThanOrEqualRuleCheckerSpec extends ObjectBehavior
     ): void {
         $subject->getOrder()->willReturn($order);
         $order->getChannel()->willReturn($channel);
-        $order->getTotal()->willReturn(101);
+        $order->getItemsTotal()->willReturn(101);
         $channel->getCode()->willReturn('CHANNEL');
 
         $this->isEligible($subject, [
@@ -62,7 +62,7 @@ final class OrderTotalGreaterThanOrEqualRuleCheckerSpec extends ObjectBehavior
     ): void {
         $subject->getOrder()->willReturn($order);
         $order->getChannel()->willReturn($channel);
-        $order->getTotal()->willReturn(100);
+        $order->getItemsTotal()->willReturn(100);
         $channel->getCode()->willReturn('CHANNEL');
 
         $this->isEligible($subject, [
@@ -79,7 +79,7 @@ final class OrderTotalGreaterThanOrEqualRuleCheckerSpec extends ObjectBehavior
     ): void {
         $subject->getOrder()->willReturn($order);
         $order->getChannel()->willReturn($channel);
-        $order->getTotal()->willReturn(99);
+        $order->getItemsTotal()->willReturn(99);
         $channel->getCode()->willReturn('CHANNEL');
 
         $this->isEligible($subject, [

--- a/src/Sylius/Component/Core/spec/Shipping/Checker/Rule/OrderTotalLessThanOrEqualRuleCheckerSpec.php
+++ b/src/Sylius/Component/Core/spec/Shipping/Checker/Rule/OrderTotalLessThanOrEqualRuleCheckerSpec.php
@@ -45,7 +45,7 @@ final class OrderTotalLessThanOrEqualRuleCheckerSpec extends ObjectBehavior
     ): void {
         $subject->getOrder()->willReturn($order);
         $order->getChannel()->willReturn($channel);
-        $order->getTotal()->willReturn(99);
+        $order->getItemsTotal()->willReturn(99);
         $channel->getCode()->willReturn('CHANNEL');
 
         $this->isEligible($subject, [
@@ -62,7 +62,7 @@ final class OrderTotalLessThanOrEqualRuleCheckerSpec extends ObjectBehavior
     ): void {
         $subject->getOrder()->willReturn($order);
         $order->getChannel()->willReturn($channel);
-        $order->getTotal()->willReturn(100);
+        $order->getItemsTotal()->willReturn(100);
         $channel->getCode()->willReturn('CHANNEL');
 
         $this->isEligible($subject, [
@@ -79,7 +79,7 @@ final class OrderTotalLessThanOrEqualRuleCheckerSpec extends ObjectBehavior
     ): void {
         $subject->getOrder()->willReturn($order);
         $order->getChannel()->willReturn($channel);
-        $order->getTotal()->willReturn(101);
+        $order->getItemsTotal()->willReturn(101);
         $channel->getCode()->willReturn('CHANNEL');
 
         $this->isEligible($subject, [


### PR DESCRIPTION
Only use products total in OrderTotalRuleChecker to select shipping methods. Not sure if it should be a breaking change or not.

| Q               | A
| --------------- | -----
| Branch?         | 1.9
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no?
| Deprecations?   | no
| Related tickets | fixes #13123
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
