### PR TITLE
[API][CatalogPromotion] Reapplying catalog promotions on rule update

### DIFF
--- a/features/promotion/applying_catalog_promotions/reapplying_catalog_promotion_after_changing_rule.feature
+++ b/features/promotion/applying_catalog_promotions/reapplying_catalog_promotion_after_changing_rule.feature
@@ -15,30 +15,25 @@ Feature: Reapplying catalog promotion after editing its rule
         And I am logged in as an administrator
 
     @api
-    Scenario: Reapplying catalog promotion after adding its rule
+    Scenario: Reapplying catalog promotion after adding a new rule to it
         Given there is a catalog promotion with "mug_sale" code and "Mug sale" name
         When I want to modify a catalog promotion "Mug sale"
-        And I add rule that applies on variants "Expensive Mug" variant and "PHP Mug" variant
+        And I add rule that applies on "Expensive Mug" variant and "PHP Mug" variant
         And I add action that gives "50%" percentage discount
         And I save my changes
-        Then the visitor view "Expensive Mug" variant
-        And He should see this variant is discounted from "$50.00" to "$25.00" with "Mug sale" promotion
-        And the visitor should see "$2.50" as the price of the "Mug" product in the "Web-US" channel
+        Then the visitor should see that the "Expensive Mug" variant is discounted from "$50.00" to "$25.00" with "Mug sale" promotion
+        And the visitor should see that the "PHP Mug" variant is discounted from "$5.00" to "$2.50" with "Mug sale" promotion
 
     @api
     Scenario: Reapplying catalog promotion after editing its rule
         When I edit "Summer sale" catalog promotion to be applied on "Expensive Mug" variant
         And I save my changes
-        Then the visitor view "Expensive Mug" variant
-        And He should see this variant is discounted from "$50.00" to "$25.00" with "Summer sale" promotion
+        And the visitor should see that the "Expensive Mug" variant is discounted from "$50.00" to "$25.00" with "Summer sale" promotion
 
     @api
-    Scenario: Reapplying catalog promotion after removing and adding new rule variant
+    Scenario: Reapplying catalog promotion after removing its rules
         When I want to modify a catalog promotion "Summer sale"
-        And I remove its every rule
-        When I edit "Summer sale" catalog promotion to be applied on "PHP Mug" variant
+        And I remove its every rules
         And I save my changes
-        Then the visitor view "Expensive Mug" variant
-        And He should see this variant is not discounted
-        And the visitor view "PHP Mug" variant
-        And He should see this variant is discounted from "$5.00" to "$2.50" with "Summer sale" promotion
+        And the visitor should see that the "Expensive Mug" variant is not discounted
+        And the visitor should see that the "PHP Mug" variant is not discounted

--- a/features/promotion/applying_catalog_promotions/reapplying_catalog_promotion_after_changing_rule.feature
+++ b/features/promotion/applying_catalog_promotions/reapplying_catalog_promotion_after_changing_rule.feature
@@ -25,15 +25,22 @@ Feature: Reapplying catalog promotion after editing its rule
         And the visitor should see that the "PHP Mug" variant is discounted from "$5.00" to "$2.50" with "Mug sale" promotion
 
     @api
+    Scenario: Reapplying catalog promotion after adding another action
+        When I modify a catalog promotion "Summer sale"
+        And I add another rule that applies on "PHP Mug" variant
+        And I save my changes
+        And the visitor should see that the "PHP Mug" variant is discounted from "$5.00" to "$2.50" with "Summer sale" promotion
+
+    @api
     Scenario: Reapplying catalog promotion after editing its rule
         When I edit "Summer sale" catalog promotion to be applied on "Expensive Mug" variant
         And I save my changes
         And the visitor should see that the "Expensive Mug" variant is discounted from "$50.00" to "$25.00" with "Summer sale" promotion
+        And the visitor should see that the "PHP T-Shirt" variant is not discounted
 
     @api
     Scenario: Reapplying catalog promotion after removing its rules
         When I want to modify a catalog promotion "Summer sale"
         And I remove its every rules
         And I save my changes
-        And the visitor should see that the "Expensive Mug" variant is not discounted
-        And the visitor should see that the "PHP Mug" variant is not discounted
+        And the visitor should see that the "PHP T-Shirt" variant is not discounted

--- a/features/promotion/applying_catalog_promotions/reapplying_catalog_promotion_after_changing_rule.feature
+++ b/features/promotion/applying_catalog_promotions/reapplying_catalog_promotion_after_changing_rule.feature
@@ -1,0 +1,44 @@
+@applying_catalog_promotions
+Feature: Reapplying catalog promotion after editing its rule
+    In order to have proper discounts per catalog promotion action
+    As a Store Owner
+    I want to have catalog promotion reapplied in product catalog once the rule of catalog promotion changes
+
+    Background:
+        Given the store operates on a channel identified by "Web-US" code
+        And the store has a "T-Shirt" configurable product
+        And this product has "PHP T-Shirt" variant priced at "$20.00"
+        And the store has a "Mug" configurable product
+        And this product has "PHP Mug" variant priced at "$5.00"
+        And this product has "Expensive Mug" variant priced at "$50.00"
+        And there is a catalog promotion "Summer sale" that reduces price by "50%" and applies on "PHP T-shirt" variant
+        And I am logged in as an administrator
+
+    @api
+    Scenario: Reapplying catalog promotion after adding its rule
+        Given there is a catalog promotion with "mug_sale" code and "Mug sale" name
+        When I want to modify a catalog promotion "Mug sale"
+        And I add rule that applies on variants "Expensive Mug" variant and "PHP Mug" variant
+        And I add action that gives "50%" percentage discount
+        And I save my changes
+        Then the visitor view "Expensive Mug" variant
+        And He should see this variant is discounted from "$50.00" to "$25.00" with "Mug sale" promotion
+        And the visitor should see "$2.50" as the price of the "Mug" product in the "Web-US" channel
+
+    @api
+    Scenario: Reapplying catalog promotion after editing its rule
+        When I edit "Summer sale" catalog promotion to be applied on "Expensive Mug" variant
+        And I save my changes
+        Then the visitor view "Expensive Mug" variant
+        And He should see this variant is discounted from "$50.00" to "$25.00" with "Summer sale" promotion
+
+    @api
+    Scenario: Reapplying catalog promotion after removing and adding new rule variant
+        When I want to modify a catalog promotion "Summer sale"
+        And I remove its every rule
+        When I edit "Summer sale" catalog promotion to be applied on "PHP Mug" variant
+        And I save my changes
+        Then the visitor view "Expensive Mug" variant
+        And He should see this variant is not discounted
+        And the visitor view "PHP Mug" variant
+        And He should see this variant is discounted from "$5.00" to "$2.50" with "Summer sale" promotion

--- a/features/promotion/applying_catalog_promotions/reapplying_catalog_promotions_after_editing_their_actions.feature
+++ b/features/promotion/applying_catalog_promotions/reapplying_catalog_promotions_after_editing_their_actions.feature
@@ -1,5 +1,5 @@
 @applying_catalog_promotions
-Feature: Reapplying catalog promotion after editing its action
+Feature: Reapplying catalog promotions after editing their actions
     In order to have proper discounts per catalog promotion action
     As a Store Owner
     I want to have discounts reapplied in product catalog once the action of catalog promotion changes

--- a/features/promotion/applying_catalog_promotions/reapplying_catalog_promotions_after_editing_their_rules.feature
+++ b/features/promotion/applying_catalog_promotions/reapplying_catalog_promotions_after_editing_their_rules.feature
@@ -1,5 +1,5 @@
 @applying_catalog_promotions
-Feature: Reapplying catalog promotion after editing its rule
+Feature: Reapplying catalog promotion after editing their rules
     In order to have proper discounts per catalog promotion action
     As a Store Owner
     I want to have catalog promotion reapplied in product catalog once the rule of catalog promotion changes
@@ -11,13 +11,13 @@ Feature: Reapplying catalog promotion after editing its rule
         And the store has a "Mug" configurable product
         And this product has "PHP Mug" variant priced at "$5.00"
         And this product has "Expensive Mug" variant priced at "$50.00"
-        And there is a catalog promotion "Summer sale" that reduces price by "50%" and applies on "PHP T-shirt" variant
+        And there is a catalog promotion "Summer sale" that reduces price by "50%" and applies on "PHP T-Shirt" variant
         And I am logged in as an administrator
 
     @api
     Scenario: Reapplying catalog promotion after adding a new rule to it
         Given there is a catalog promotion with "mug_sale" code and "Mug sale" name
-        When I want to modify a catalog promotion "Mug sale"
+        When I modify a catalog promotion "Mug sale"
         And I add rule that applies on "Expensive Mug" variant and "PHP Mug" variant
         And I add action that gives "50%" percentage discount
         And I save my changes
@@ -29,18 +29,18 @@ Feature: Reapplying catalog promotion after editing its rule
         When I modify a catalog promotion "Summer sale"
         And I add another rule that applies on "PHP Mug" variant
         And I save my changes
-        And the visitor should see that the "PHP Mug" variant is discounted from "$5.00" to "$2.50" with "Summer sale" promotion
+        Then the visitor should see that the "PHP Mug" variant is discounted from "$5.00" to "$2.50" with "Summer sale" promotion
+        And the visitor should still see that the "PHP T-Shirt" variant is discounted from "$20.00" to "$10.00" with "Summer sale" promotion
 
     @api
     Scenario: Reapplying catalog promotion after editing its rule
         When I edit "Summer sale" catalog promotion to be applied on "Expensive Mug" variant
-        And I save my changes
-        And the visitor should see that the "Expensive Mug" variant is discounted from "$50.00" to "$25.00" with "Summer sale" promotion
+        Then the visitor should see that the "Expensive Mug" variant is discounted from "$50.00" to "$25.00" with "Summer sale" promotion
         And the visitor should see that the "PHP T-Shirt" variant is not discounted
 
     @api
     Scenario: Reapplying catalog promotion after removing its rules
-        When I want to modify a catalog promotion "Summer sale"
-        And I remove its every rules
+        When I modify a catalog promotion "Summer sale"
+        And I remove its every rule
         And I save my changes
-        And the visitor should see that the "PHP T-Shirt" variant is not discounted
+        Then the visitor should see that the "PHP T-Shirt" variant is not discounted

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -214,6 +214,25 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
+     * @When /^I add another rule that applies on ("[^"]+" variant)$/
+     */
+    public function iAddAnotherRuleThatGivesPercentageDiscount(ProductVariantInterface $productVariant): void
+    {
+        $rules = $this->client->getContent()['rules'];
+
+        $additionalRule = [[
+            'type' => CatalogPromotionRuleInterface::TYPE_FOR_VARIANTS,
+            'configuration' => [
+                'variants' => [$productVariant->getCode()],
+            ],
+        ]];
+
+        $rules = array_merge_recursive($rules, $additionalRule);
+
+        $this->client->addRequestData('rules', $rules);
+    }
+
+    /**
      * @When /^I edit its action so that it reduces price by ("[^"]+")$/
      */
     public function iEditItsActionSoThatItReducesPriceBy(float $amount): void

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -283,6 +283,16 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
+     * @When I remove its every rule
+     */
+    public function iRemoveItsEveryRule(): void
+    {
+        $content = $this->client->getContent();
+        $content['rules'] = [];
+        $this->client->updateRequestData($content);
+    }
+
+    /**
      * @When /^I edit ("[^"]+" catalog promotion) to be applied on ("[^"]+" variant)$/
      */
     public function iEditCatalogPromotionToBeAppliedOn(CatalogPromotionInterface $catalogPromotion, ProductVariantInterface $productVariant): void

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -303,20 +303,22 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
-     * @When I remove its every rules
+     * @When I remove its every rule
      */
     public function iRemoveItsEveryRule(): void
     {
         $content = $this->client->getContent();
         $content['rules'] = [];
-        $this->client->updateRequestData($content);
+        $this->client->setRequestData($content);
     }
 
     /**
      * @When /^I edit ("[^"]+" catalog promotion) to be applied on ("[^"]+" variant)$/
      */
-    public function iEditCatalogPromotionToBeAppliedOn(CatalogPromotionInterface $catalogPromotion, ProductVariantInterface $productVariant): void
-    {
+    public function iEditCatalogPromotionToBeAppliedOn(
+        CatalogPromotionInterface $catalogPromotion,
+        ProductVariantInterface $productVariant
+    ): void {
         $this->client->buildUpdateRequest($catalogPromotion->getCode());
         $rules = [[
             'type' => CatalogPromotionRuleInterface::TYPE_FOR_VARIANTS,

--- a/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Api/Admin/ManagingCatalogPromotionsContext.php
@@ -265,6 +265,7 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
+     * @When /^I add rule that applies on ("[^"]+" variant) and ("[^"]+" variant)$/
      * @When /^I add rule that applies on variants ("[^"]+" variant) and ("[^"]+" variant)$/
      */
     public function iAddRuleThatAppliesOnVariants(ProductVariantInterface $firstVariant, ProductVariantInterface $secondVariant): void
@@ -283,7 +284,7 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
-     * @When I remove its every rule
+     * @When I remove its every rules
      */
     public function iRemoveItsEveryRule(): void
     {

--- a/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
@@ -87,7 +87,6 @@ final class ProductVariantContext implements Context
     }
 
     /**
-     * @Then /^He should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
      * @Then /^I should see ("[^"]+" variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
      * @Then /^I should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
      */
@@ -105,6 +104,21 @@ final class ProductVariantContext implements Context
     }
 
     /**
+     * @Then /^the visitor should see that the ("[^"]+" variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
+     */
+    public function theVisitorShouldSeeThatTheVariantIsDiscountedWithPromotion(
+        ProductVariantInterface $productVariant,
+        int $originalPrice,
+        int $price,
+        string $promotionName
+    ): void {
+        $this->sharedStorage->set('token', null);
+        $this->client->show($productVariant->getCode());
+
+        $this->iShouldSeeVariantIsDiscountedFromToWithPromotion($productVariant, $originalPrice, $price, $promotionName);
+    }
+
+    /**
      * @Then /^I should see ("[^"]+" variant) is not discounted$/
      */
     public function iShouldSeeVariantIsNotDiscounted(ProductVariantInterface $variant): void
@@ -115,8 +129,18 @@ final class ProductVariantContext implements Context
     }
 
     /**
-     * @Then /^I should see (this variant) is not discounted$/
      * @Then /^the visitor should see (this variant) is not discounted$/
+     * @Then /^the visitor should see that the ("[^"]+" variant) is not discounted$/
+     */
+    public function theVisitorShouldSeeThatTheVariantIsNotDiscounted(ProductVariantInterface $variant): void
+    {
+        $this->sharedStorage->set('token', null);
+
+        $this->iShouldSeeThisVariantIsNotDiscounted($variant);
+    }
+
+    /**
+     * @Then /^I should see (this variant) is not discounted$/
      */
     public function iShouldSeeThisVariantIsNotDiscounted(ProductVariantInterface $variant): void
     {

--- a/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
@@ -104,7 +104,7 @@ final class ProductVariantContext implements Context
     }
 
     /**
-     * @Then /^the visitor should see that the ("[^"]+" variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
+     * @Then /^the visitor should(?:| still) see that the ("[^"]+" variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
      */
     public function theVisitorShouldSeeThatTheVariantIsDiscountedWithPromotion(
         ProductVariantInterface $productVariant,

--- a/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
+++ b/src/Sylius/Behat/Context/Api/Shop/ProductVariantContext.php
@@ -87,6 +87,7 @@ final class ProductVariantContext implements Context
     }
 
     /**
+     * @Then /^He should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
      * @Then /^I should see ("[^"]+" variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
      * @Then /^I should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
      */

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingCatalogPromotionsContext.php
@@ -146,6 +146,7 @@ final class ManagingCatalogPromotionsContext implements Context
     }
 
     /**
+     * @When /^I add rule that applies on ("[^"]+" variant) and ("[^"]+" variant)$/
      * @When /^I add rule that applies on variants ("[^"]+" variant) and ("[^"]+" variant)$/
      */
     public function iAddRuleThatAppliesOnVariants(ProductVariantInterface ...$variants): void

--- a/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
@@ -408,7 +408,6 @@ final class ProductContext implements Context
     }
 
     /**
-     * @Then /^He should see (this variant) is not discounted$/
      * @Then /^I should see ("[^"]+" variant) is not discounted$/
      * @Then /^I should see (this variant) is not discounted$/
      */
@@ -493,7 +492,7 @@ final class ProductContext implements Context
     }
 
     /**
-     * @Then /^He should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
+     * @Then /^the visitor should see that the ("[^"]+" variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
      * @Then /^I should see ("[^"]+" variant) is discounted from "([^"]+)" to "([^"]+)" with "([^"]+)" promotion$/
      * @Then /^I should see (this variant) is discounted from "([^"]+)" to "([^"]+)" with "([^"]+)" promotion$/
      */

--- a/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
@@ -408,6 +408,7 @@ final class ProductContext implements Context
     }
 
     /**
+     * @Then /^He should see (this variant) is not discounted$/
      * @Then /^I should see ("[^"]+" variant) is not discounted$/
      * @Then /^I should see (this variant) is not discounted$/
      */
@@ -492,6 +493,7 @@ final class ProductContext implements Context
     }
 
     /**
+     * @Then /^He should see (this variant) is discounted from ("[^"]+") to ("[^"]+") with "([^"]+)" promotion$/
      * @Then /^I should see ("[^"]+" variant) is discounted from "([^"]+)" to "([^"]+)" with "([^"]+)" promotion$/
      * @Then /^I should see (this variant) is discounted from "([^"]+)" to "([^"]+)" with "([^"]+)" promotion$/
      */

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotionRule.xml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources/CatalogPromotionRule.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+
+<!--
+ This file is part of the Sylius package.
+ (c) Paweł Jędrzejewski
+ For the full copyright and license information, please view the LICENSE
+ file that was distributed with this source code.
+-->
+
+<resources xmlns="https://api-platform.com/schema/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://api-platform.com/schema/metadata https://api-platform.com/schema/metadata/metadata-2.0.xsd"
+>
+    <resource class="%sylius.model.catalog_promotion_rule.class%" shortName="CatalogPromotionRule">
+        <attribute name="route_prefix">admin</attribute>
+
+        <itemOperations>
+            <itemOperation name="admin_get">
+                <attribute name="method">GET</attribute>
+                <attribute name="enabled">false</attribute>
+                <attribute name="controller">ApiPlatform\Core\Action\NotFoundAction</attribute>
+                <attribute name="read">false</attribute>
+                <attribute name="output">false</attribute>
+            </itemOperation>
+        </itemOperations>
+
+        <collectionOperations/>
+
+        <property name="id" identifier="true" writable="false" />
+    </resource>
+</resources>

--- a/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
+++ b/src/Sylius/Bundle/ApiBundle/Resources/config/app/config.yaml
@@ -6,6 +6,7 @@ parameters:
     sylius.api.authorization_header: "%env(resolve:SYLIUS_API_AUTHORIZATION_HEADER)%"
     sylius.api.paths_to_hide: 
         - "/api/v2/admin/catalog-promotion-actions/{id}"
+        - "/api/v2/admin/catalog-promotion-rules/{id}"
         - "/api/v2/admin/channel-pricings/{id}"
     sylius.security.new_api_route: "/api/v2"
     sylius.security.new_api_regex: "^%sylius.security.new_api_route%"

--- a/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ChannelPricingRepository.php
+++ b/src/Sylius/Bundle/CoreBundle/Doctrine/ORM/ChannelPricingRepository.php
@@ -21,8 +21,7 @@ class ChannelPricingRepository extends EntityRepository implements ChannelPricin
     public function findWithDiscountedPrice(): array
     {
         return $this->createQueryBuilder('o')
-            ->andWhere('o.originalPrice IS NOT NULL')
-            ->andWhere('o.originalPrice > o.price')
+            ->andWhere('o.appliedPromotions != \'[]\'')
             ->getQuery()
             ->getResult()
         ;

--- a/src/Sylius/Bundle/CoreBundle/EventListener/CatalogPromotionEventListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/CatalogPromotionEventListener.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\EventListener;
 
 use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Sylius\Component\Core\Model\CatalogPromotionRuleInterface;
 use Sylius\Component\Promotion\Event\CatalogPromotionUpdated;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 use Sylius\Component\Promotion\Model\CatalogPromotionInterface;
@@ -32,7 +33,7 @@ final class CatalogPromotionEventListener
     {
         $entity = $args->getObject();
 
-        if ($entity instanceof CatalogPromotionActionInterface) {
+        if ($entity instanceof CatalogPromotionActionInterface || $entity instanceof CatalogPromotionRuleInterface) {
             $this->eventBus->dispatch(new CatalogPromotionUpdated($entity->getCatalogPromotion()->getCode()));
         }
     }
@@ -45,7 +46,7 @@ final class CatalogPromotionEventListener
             $this->eventBus->dispatch(new CatalogPromotionUpdated($entity->getCode()));
         }
 
-        if ($entity instanceof CatalogPromotionActionInterface) {
+        if ($entity instanceof CatalogPromotionActionInterface || $entity instanceof CatalogPromotionRuleInterface) {
             $this->eventBus->dispatch(new CatalogPromotionUpdated($entity->getCatalogPromotion()->getCode()));
         }
     }

--- a/src/Sylius/Bundle/CoreBundle/Provider/CatalogPromotionVariantsProvider.php
+++ b/src/Sylius/Bundle/CoreBundle/Provider/CatalogPromotionVariantsProvider.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sylius\Bundle\CoreBundle\Provider;
 
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Provider\CatalogPromotionVariantsProviderInterface;
 use Sylius\Component\Core\Model\CatalogPromotionRuleInterface;
 
@@ -35,11 +36,20 @@ final class CatalogPromotionVariantsProvider implements CatalogPromotionVariants
             /** @var VariantsProviderInterface $provider */
             foreach ($this->variantsProviders as $provider) {
                 if ($provider->supports($rule)) {
-                    return $provider->provideEligibleVariants($rule);
+                    $variants = array_merge($variants, $provider->provideEligibleVariants($rule));
                 }
             }
         }
 
-        return $variants;
+        return $this->prepareUniqueVariants($variants);
+    }
+
+    private function prepareUniqueVariants(array $variants): array
+    {
+        $codes = array_map(function(ProductVariantInterface $variant) {
+            return $variant->getCode();
+        }, $variants);
+
+        return array_values(array_intersect_key($variants, array_unique($codes)));
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/CatalogPromotionEventListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/CatalogPromotionEventListenerSpec.php
@@ -17,6 +17,7 @@ use Doctrine\Persistence\Event\LifecycleEventArgs;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\CoreBundle\EventListener\CatalogPromotionEventListener;
+use Sylius\Component\Core\Model\CatalogPromotionRuleInterface;
 use Sylius\Component\Promotion\Event\CatalogPromotionUpdated;
 use Sylius\Component\Promotion\Model\CatalogPromotionActionInterface;
 use Sylius\Component\Promotion\Model\CatalogPromotionInterface;
@@ -47,8 +48,6 @@ final class CatalogPromotionEventListenerSpec extends ObjectBehavior
 
         $message = new CatalogPromotionUpdated('winter_sale');
         $eventBus->dispatch($message)->willReturn(new Envelope($message))->shouldBeCalled();
-
-        $this->postPersist($args);
     }
 
     function it_does_not_send_catalog_promotion_updated_after_persisting_other_entity(
@@ -61,10 +60,42 @@ final class CatalogPromotionEventListenerSpec extends ObjectBehavior
         $this->postPersist($args);
     }
 
+    function it_sends_catalog_promotion_updated_after_persisting_catalog_promotion_rule(
+        MessageBusInterface $eventBus,
+        LifecycleEventArgs $args,
+        CatalogPromotionRuleInterface $entity,
+        CatalogPromotionInterface $catalogPromotion
+    ): void {
+        $args->getObject()->willReturn($entity);
+        $entity->getCatalogPromotion()->willReturn($catalogPromotion);
+        $catalogPromotion->getCode()->willReturn('winter_sale');
+
+        $message = new CatalogPromotionUpdated('winter_sale');
+        $eventBus->dispatch($message)->willReturn(new Envelope($message))->shouldBeCalled();
+
+        $this->postPersist($args);
+    }
+
     function it_sends_catalog_promotion_updated_after_updating_catalog_promotion(
         MessageBusInterface $eventBus,
         LifecycleEventArgs $args,
         CatalogPromotionActionInterface $entity,
+        CatalogPromotionInterface $catalogPromotion
+    ): void {
+        $args->getObject()->willReturn($entity);
+        $entity->getCatalogPromotion()->willReturn($catalogPromotion);
+        $catalogPromotion->getCode()->willReturn('winter_sale');
+
+        $message = new CatalogPromotionUpdated('winter_sale');
+        $eventBus->dispatch($message)->willReturn(new Envelope($message))->shouldBeCalled();
+
+        $this->postUpdate($args);
+    }
+
+    function it_sends_catalog_promotion_updated_after_updating_catalog_promotion_rule(
+        MessageBusInterface $eventBus,
+        LifecycleEventArgs $args,
+        CatalogPromotionRuleInterface $entity,
         CatalogPromotionInterface $catalogPromotion
     ): void {
         $args->getObject()->willReturn($entity);

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/CatalogPromotionEventListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/CatalogPromotionEventListenerSpec.php
@@ -48,6 +48,8 @@ final class CatalogPromotionEventListenerSpec extends ObjectBehavior
 
         $message = new CatalogPromotionUpdated('winter_sale');
         $eventBus->dispatch($message)->willReturn(new Envelope($message))->shouldBeCalled();
+
+        $this->postPersist($args);
     }
 
     function it_does_not_send_catalog_promotion_updated_after_persisting_other_entity(


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         |master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
