### PR TITLE
Reorganize flushes in Catalog Promotions processing

### DIFF
--- a/src/Sylius/Bundle/CoreBundle/Listener/CatalogPromotionUpdateListener.php
+++ b/src/Sylius/Bundle/CoreBundle/Listener/CatalogPromotionUpdateListener.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sylius\Bundle\CoreBundle\Listener;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Sylius\Bundle\CoreBundle\Processor\CatalogPromotionClearerInterface;
 use Sylius\Bundle\CoreBundle\Processor\CatalogPromotionProcessorInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
@@ -27,14 +28,18 @@ final class CatalogPromotionUpdateListener
 
     private RepositoryInterface $catalogPromotionRepository;
 
+    private EntityManagerInterface $entityManager;
+
     public function __construct(
         CatalogPromotionClearerInterface $catalogPromotionClearer,
         CatalogPromotionProcessorInterface $catalogPromotionProcessor,
-        RepositoryInterface $catalogPromotionRepository
+        RepositoryInterface $catalogPromotionRepository,
+        EntityManagerInterface $entityManager
     ) {
         $this->catalogPromotionClearer = $catalogPromotionClearer;
         $this->catalogPromotionProcessor = $catalogPromotionProcessor;
         $this->catalogPromotionRepository = $catalogPromotionRepository;
+        $this->entityManager = $entityManager;
     }
 
     public function __invoke(CatalogPromotionUpdated $event): void
@@ -50,5 +55,7 @@ final class CatalogPromotionUpdateListener
         foreach ($this->catalogPromotionRepository->findAll() as $catalogPromotion) {
             $this->catalogPromotionProcessor->process($catalogPromotion);
         }
+
+        $this->entityManager->flush();
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Processor/CatalogPromotionClearer.php
+++ b/src/Sylius/Bundle/CoreBundle/Processor/CatalogPromotionClearer.php
@@ -20,14 +20,9 @@ final class CatalogPromotionClearer implements CatalogPromotionClearerInterface
 {
     private ChannelPricingRepositoryInterface $channelPricingRepository;
 
-    private EntityManagerInterface $entityManager;
-
-    public function __construct(
-        ChannelPricingRepositoryInterface $channelPricingRepository,
-        EntityManagerInterface $entityManager
-    ) {
+    public function __construct(ChannelPricingRepositoryInterface $channelPricingRepository)
+    {
         $this->channelPricingRepository = $channelPricingRepository;
-        $this->entityManager = $entityManager;
     }
 
     public function clear(): void
@@ -41,7 +36,5 @@ final class CatalogPromotionClearer implements CatalogPromotionClearerInterface
             $channelPricing->setPrice($channelPricing->getOriginalPrice());
             $channelPricing->clearAppliedPromotions();
         }
-
-        $this->entityManager->flush();
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Processor/CatalogPromotionProcessor.php
+++ b/src/Sylius/Bundle/CoreBundle/Processor/CatalogPromotionProcessor.php
@@ -25,16 +25,12 @@ final class CatalogPromotionProcessor implements CatalogPromotionProcessorInterf
 
     private CatalogPromotionApplicatorInterface $catalogPromotionApplicator;
 
-    private EntityManagerInterface $entityManager;
-
     public function __construct(
         CatalogPromotionVariantsProviderInterface $catalogPromotionVariantsProvider,
-        CatalogPromotionApplicatorInterface $catalogPromotionApplicator,
-        EntityManagerInterface $entityManager
+        CatalogPromotionApplicatorInterface $catalogPromotionApplicator
     ) {
         $this->catalogPromotionVariantsProvider = $catalogPromotionVariantsProvider;
         $this->catalogPromotionApplicator = $catalogPromotionApplicator;
-        $this->entityManager = $entityManager;
     }
 
     public function process(CatalogPromotionInterface $catalogPromotion): void
@@ -48,7 +44,5 @@ final class CatalogPromotionProcessor implements CatalogPromotionProcessorInterf
         foreach ($variants as $variant) {
             $this->catalogPromotionApplicator->applyCatalogPromotion($variant, $catalogPromotion);
         }
-
-        $this->entityManager->flush();
     }
 }

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services.xml
@@ -274,7 +274,6 @@
         >
             <argument type="service" id="Sylius\Component\Core\Provider\CatalogPromotionVariantsProviderInterface" />
             <argument type="service" id="Sylius\Bundle\CoreBundle\Applicator\CatalogPromotionApplicatorInterface" />
-            <argument type="service" id="sylius.manager.product" />
         </service>
 
         <service
@@ -282,7 +281,6 @@
             class="Sylius\Bundle\CoreBundle\Processor\CatalogPromotionClearer"
         >
             <argument type="service" id="sylius.repository.channel_pricing" />
-            <argument type="service" id="sylius.manager.channel_pricing" />
         </service>
     </services>
 </container>

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -101,6 +101,7 @@
             <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\CatalogPromotionClearerInterface" />
             <argument type="service" id="Sylius\Bundle\CoreBundle\Processor\CatalogPromotionProcessorInterface" />
             <argument type="service" id="sylius.repository.catalog_promotion" />
+            <argument type="service" id="doctrine.orm.entity_manager" />
             <tag name="messenger.message_handler" bus="sylius.event_bus" />
         </service>
     </services>

--- a/src/Sylius/Bundle/CoreBundle/spec/Listener/CatalogPromotionUpdateListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Listener/CatalogPromotionUpdateListenerSpec.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace spec\Sylius\Bundle\CoreBundle\Listener;
 
+use Doctrine\ORM\EntityManagerInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Sylius\Bundle\CoreBundle\Processor\CatalogPromotionClearerInterface;
@@ -26,14 +27,21 @@ final class CatalogPromotionUpdateListenerSpec extends ObjectBehavior
     function let(
         CatalogPromotionClearerInterface $catalogPromotionClearer,
         CatalogPromotionProcessorInterface $catalogPromotionProcessor,
-        RepositoryInterface $catalogPromotionRepository
+        RepositoryInterface $catalogPromotionRepository,
+        EntityManagerInterface $entityManager
     ): void {
-        $this->beConstructedWith($catalogPromotionClearer, $catalogPromotionProcessor, $catalogPromotionRepository);
+        $this->beConstructedWith(
+            $catalogPromotionClearer,
+            $catalogPromotionProcessor,
+            $catalogPromotionRepository,
+            $entityManager
+        );
     }
 
     function it_processes_catalog_promotion_that_has_just_been_updated(
         CatalogPromotionClearerInterface $catalogPromotionClearer,
         CatalogPromotionProcessorInterface $catalogPromotionProcessor,
+        EntityManagerInterface $entityManager,
         RepositoryInterface $catalogPromotionRepository,
         CatalogPromotionInterface $firstCatalogPromotion,
         CatalogPromotionInterface $secondCatalogPromotion
@@ -46,6 +54,8 @@ final class CatalogPromotionUpdateListenerSpec extends ObjectBehavior
 
         $catalogPromotionProcessor->process($firstCatalogPromotion)->shouldBeCalled();
         $catalogPromotionProcessor->process($secondCatalogPromotion)->shouldBeCalled();
+
+        $entityManager->flush()->shouldBeCalled();
 
         $this->__invoke(new CatalogPromotionUpdated('WINTER_MUGS_SALE'));
     }

--- a/src/Sylius/Bundle/CoreBundle/spec/Processor/CatalogPromotionClearerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Processor/CatalogPromotionClearerSpec.php
@@ -22,10 +22,9 @@ use Sylius\Component\Core\Repository\ChannelPricingRepositoryInterface;
 final class CatalogPromotionClearerSpec extends ObjectBehavior
 {
     function let(
-        ChannelPricingRepositoryInterface $channelPricingRepository,
-        EntityManagerInterface $entityManager
+        ChannelPricingRepositoryInterface $channelPricingRepository
     ): void {
-        $this->beConstructedWith($channelPricingRepository, $entityManager);
+        $this->beConstructedWith($channelPricingRepository);
     }
 
     function it_implements_catalog_promotion_clearer_interface(): void
@@ -35,7 +34,6 @@ final class CatalogPromotionClearerSpec extends ObjectBehavior
 
     function it_clears_channel_pricings_with_catalog_promotions_applied(
         ChannelPricingRepositoryInterface $channelPricingRepository,
-        EntityManagerInterface $entityManager,
         ChannelPricingInterface $firstChannelPricing,
         ChannelPricingInterface $secondChannelPricing
     ): void {
@@ -52,8 +50,6 @@ final class CatalogPromotionClearerSpec extends ObjectBehavior
         $secondChannelPricing->getAppliedPromotions()->willReturn([]);
         $secondChannelPricing->getOriginalPrice()->shouldNotBeCalled();
         $secondChannelPricing->clearAppliedPromotions()->shouldNotBeCalled();
-
-        $entityManager->flush()->shouldBeCalled();
 
         $this->clear();
     }

--- a/src/Sylius/Bundle/CoreBundle/spec/Processor/CatalogPromotionProcessorSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/Processor/CatalogPromotionProcessorSpec.php
@@ -15,6 +15,7 @@ namespace spec\Sylius\Bundle\CoreBundle\Processor;
 
 use Doctrine\ORM\EntityManagerInterface;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Sylius\Bundle\CoreBundle\Applicator\CatalogPromotionApplicatorInterface;
 use Sylius\Bundle\CoreBundle\Processor\CatalogPromotionProcessorInterface;
 use Sylius\Component\Core\Model\CatalogPromotionInterface;
@@ -25,13 +26,11 @@ final class CatalogPromotionProcessorSpec extends ObjectBehavior
 {
     function let(
         CatalogPromotionVariantsProviderInterface $catalogPromotionVariantsProvider,
-        CatalogPromotionApplicatorInterface $productCatalogPromotionApplicator,
-        EntityManagerInterface $entityManager
+        CatalogPromotionApplicatorInterface $productCatalogPromotionApplicator
     ): void {
         $this->beConstructedWith(
             $catalogPromotionVariantsProvider,
-            $productCatalogPromotionApplicator,
-            $entityManager
+            $productCatalogPromotionApplicator
         );
     }
 
@@ -43,7 +42,6 @@ final class CatalogPromotionProcessorSpec extends ObjectBehavior
     function it_applies_catalog_promotion_on_eligible_variants(
         CatalogPromotionVariantsProviderInterface $catalogPromotionVariantsProvider,
         CatalogPromotionApplicatorInterface $productCatalogPromotionApplicator,
-        EntityManagerInterface $entityManager,
         CatalogPromotionInterface $catalogPromotion,
         ProductVariantInterface $firstVariant,
         ProductVariantInterface $secondVariant
@@ -56,19 +54,17 @@ final class CatalogPromotionProcessorSpec extends ObjectBehavior
         $productCatalogPromotionApplicator->applyCatalogPromotion($firstVariant, $catalogPromotion)->shouldBeCalled();
         $productCatalogPromotionApplicator->applyCatalogPromotion($secondVariant, $catalogPromotion)->shouldBeCalled();
 
-        $entityManager->flush()->shouldBeCalled();
-
         $this->process($catalogPromotion);
     }
 
     function it_does_nothing_if_there_are_no_eligible_variants(
         CatalogPromotionVariantsProviderInterface $catalogPromotionVariantsProvider,
-        EntityManagerInterface $entityManager,
+        CatalogPromotionApplicatorInterface $productCatalogPromotionApplicator,
         CatalogPromotionInterface $catalogPromotion
     ): void {
         $catalogPromotionVariantsProvider->provideEligibleVariants($catalogPromotion)->willReturn([]);
 
-        $entityManager->flush()->shouldNotBeCalled();
+        $productCatalogPromotionApplicator->applyCatalogPromotion(Argument::any())->shouldNotBeCalled();
 
         $this->process($catalogPromotion);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

The previous implementation was causing unexpected doctrine event cascades that resulted in multiple applied promotions in some cases 💃 Calling flush only once should fix this problem once for ever 🚀 