### PR TITLE
[Bug] fix bug when applying few actions on single promotion

### DIFF
--- a/src/Sylius/Component/Core/Model/ChannelPricing.php
+++ b/src/Sylius/Component/Core/Model/ChannelPricing.php
@@ -92,6 +92,10 @@ class ChannelPricing implements ChannelPricingInterface
             return;
         }
 
+        if (array_key_exists(key($promotion), $this->appliedPromotions)) {
+            return;
+        }
+
         $this->appliedPromotions = array_merge_recursive($this->appliedPromotions, $promotion);
     }
 


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | 
| Related tickets | 
| License         | MIT

Once we created 2 or more actions on catalog promotions we couldnt display it as we got 500 error.

This way we avoid creating arrays on configuration keys.

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
