### PR TITLE
[UI][CatalogPromotion] Reapplying catalog promotion on variant once its data changes

### DIFF
--- a/features/promotion/applying_catalog_promotions/reapplying_catalog_promotions_on_variant_once_its_data_changes.feature
+++ b/features/promotion/applying_catalog_promotions/reapplying_catalog_promotions_on_variant_once_its_data_changes.feature
@@ -12,13 +12,13 @@ Feature: Reapplying catalog promotions on variant once its data changes
         And there is another catalog promotion "Christmas sale" available in "Web-US" channel that reduces price by "50%" and applies on "PHP T-Shirt" variant
         And I am logged in as an administrator
 
-    @api
+    @api @ui
     Scenario: Changing the price of the variant
         When I change the price of the "PHP T-Shirt" product variant to "$50.00" in "Web-US" channel
         Then the visitor should still see "$35.00" as the price of the "T-Shirt" product in the "Web-US" channel
         And the visitor should still see "$100.00" as the original price of the "T-Shirt" product in the "Web-US" channel
 
-    @api
+    @api @ui
     Scenario: Changing the original price of the variant
         When I change the original price of the "PHP T-Shirt" product variant to "$50.00" in "Web-US" channel
         Then the visitor should see "$17.50" as the price of the "T-Shirt" product in the "Web-US" channel

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsPricesContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductVariantsPricesContext.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Behat\Context\Ui\Admin;
+
+use Behat\Behat\Context\Context;
+use Sylius\Behat\Page\Admin\ProductVariant\UpdatePageInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Webmozart\Assert\Assert;
+
+final class ManagingProductVariantsPricesContext implements Context
+{
+    private UpdatePageInterface $updatePage;
+
+    public function __construct(UpdatePageInterface $updatePage)
+    {
+        $this->updatePage = $updatePage;
+    }
+
+    /**
+     * @When /^I change the price of the ("[^"]+" product variant) to "(?:€|£|\$)([^"]+)" in ("[^"]+" channel)$/
+     */
+    public function iChangeThePriceOfTheProductVariantInChannel(
+        ProductVariantInterface $variant,
+        int $price,
+        ChannelInterface $channel
+    ): void {
+        $this->updatePage->open(['productId' => $variant->getProduct()->getId(), 'id' => $variant->getId()]);
+        $this->updatePage->specifyPrice($price, $channel);
+        $this->updatePage->saveChanges();
+    }
+
+    /**
+     * @When /^I change the original price of the ("[^"]+" product variant) to "(?:€|£|\$)([^"]+)" in ("[^"]+" channel)$/
+     */
+    public function iChangeTheOriginalPriceOfTheProductVariantInChannel(
+        ProductVariantInterface $variant,
+        int $originalPrice,
+        ChannelInterface $channel
+    ): void {
+        $this->updatePage->open(['productId' => $variant->getProduct()->getId(), 'id' => $variant->getId()]);
+        $this->updatePage->specifyOriginalPrice($originalPrice, $channel);
+        $this->updatePage->saveChanges();
+    }
+}

--- a/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
+++ b/src/Sylius/Behat/Context/Ui/Admin/ManagingProductsContext.php
@@ -45,7 +45,7 @@ final class ManagingProductsContext implements Context
 
     private CreateConfigurableProductPageInterface $createConfigurableProductPage;
 
-    private \Sylius\Behat\Page\Admin\Product\IndexPageInterface $indexPage;
+    private IndexPageInterface $indexPage;
 
     private UpdateSimpleProductPageInterface $updateSimpleProductPage;
 

--- a/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
+++ b/src/Sylius/Behat/Context/Ui/Shop/ProductContext.php
@@ -31,7 +31,7 @@ final class ProductContext implements Context
 {
     private ShowPageInterface $showPage;
 
-    private \Sylius\Behat\Page\Shop\Product\IndexPageInterface $indexPage;
+    private IndexPageInterface $indexPage;
 
     private ProductReviewIndexPageInterface $productReviewsIndexPage;
 
@@ -439,7 +439,6 @@ final class ProductContext implements Context
         $this->channelContextSetter->setChannel($channel);
 
         $localeCode = $channel->getDefaultLocale()->getCode();
-
         $this->showPage->open(['slug' => $product->getTranslation($localeCode)->getSlug(), '_locale' => $localeCode]);
 
         if ($priceType === 'original price') {

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/UpdatePage.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/UpdatePage.php
@@ -28,9 +28,26 @@ class UpdatePage extends BaseUpdatePage implements UpdatePageInterface
         return $this->getElement('code');
     }
 
-    public function specifyPrice(int $price): void
+    public function specifyPrice(int $price, ?ChannelInterface $channel = null): void
     {
-        $this->getDocument()->fillField('Price', $price);
+        if ($channel === null) {
+            $this->getDocument()->fillField('Price', $price);
+
+            return;
+        }
+
+        $this->getElement('price', ['%channelCode%' => $channel->getCode()])->setValue($price);
+    }
+
+    public function specifyOriginalPrice(int $originalPrice, ?ChannelInterface $channel = null): void
+    {
+        if ($channel === null) {
+            $this->getDocument()->fillField('Original price', $originalPrice);
+
+            return;
+        }
+
+        $this->getElement('original_price', ['%channelCode%' => $channel->getCode()])->setValue($originalPrice);
     }
 
     public function disableTracking(): void

--- a/src/Sylius/Behat/Page/Admin/ProductVariant/UpdatePageInterface.php
+++ b/src/Sylius/Behat/Page/Admin/ProductVariant/UpdatePageInterface.php
@@ -49,7 +49,9 @@ interface UpdatePageInterface extends BaseUpdatePageInterface
 
     public function specifyCurrentStock(int $amount): void;
 
-    public function specifyPrice(int $price): void;
+    public function specifyPrice(int $price, ?ChannelInterface $channelName = null): void;
+
+    public function specifyOriginalPrice(int $originalPrice, ?ChannelInterface $channel = null): void;
 
     public function disable(): void;
 

--- a/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
+++ b/src/Sylius/Behat/Resources/config/services/contexts/ui.xml
@@ -214,6 +214,10 @@
             <argument type="service" id="sylius.behat.notification_checker" />
         </service>
 
+        <service id="Sylius\Behat\Context\Ui\Admin\ManagingProductVariantsPricesContext">
+            <argument type="service" id="sylius.behat.page.admin.product_variant.update" />
+        </service>
+
         <service id="sylius.behat.context.ui.admin.browsing_product_variants" class="Sylius\Behat\Context\Ui\Admin\BrowsingProductVariantsContext">
             <argument type="service" id="sylius.behat.page.admin.product_variant.index" />
             <argument type="service" id="sylius.product_variant_resolver.default" />

--- a/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_catalog_promotions.yml
+++ b/src/Sylius/Behat/Resources/config/suites/ui/promotion/applying_catalog_promotions.yml
@@ -23,6 +23,7 @@ default:
                 - Sylius\Behat\Context\Transform\CatalogPromotionContext
 
                 - Sylius\Behat\Context\Ui\Admin\ManagingCatalogPromotionsContext
+                - Sylius\Behat\Context\Ui\Admin\ManagingProductVariantsPricesContext
                 - sylius.behat.context.ui.shop.product
 
             filters:

--- a/src/Sylius/Bundle/CoreBundle/EventListener/ProductVariantEventListener.php
+++ b/src/Sylius/Bundle/CoreBundle/EventListener/ProductVariantEventListener.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\Bundle\CoreBundle\EventListener;
+
+use Sylius\Component\Core\Event\ProductVariantUpdated;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Webmozart\Assert\Assert;
+
+final class ProductVariantEventListener
+{
+    private MessageBusInterface $eventBus;
+
+    public function __construct(MessageBusInterface $eventBus)
+    {
+        $this->eventBus = $eventBus;
+    }
+
+    public function postUpdate(GenericEvent $event): void
+    {
+        $variant = $event->getSubject();
+        Assert::isInstanceOf($variant, ProductVariantInterface::class);
+
+        $this->eventBus->dispatch(new ProductVariantUpdated($variant->getCode()));
+    }
+}

--- a/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
+++ b/src/Sylius/Bundle/CoreBundle/Resources/config/services/listeners.xml
@@ -105,6 +105,11 @@
             <tag name="messenger.message_handler" bus="sylius.event_bus" />
         </service>
 
+        <service id="Sylius\Bundle\CoreBundle\EventListener\ProductVariantEventListener">
+            <argument type="service" id="sylius.event_bus" />
+            <tag name="kernel.event_listener" event="sylius.product_variant.post_update" method="postUpdate" />
+        </service>
+
         <service id="Sylius\Bundle\CoreBundle\Listener\ProductVariantUpdateListener">
             <argument type="service" id="sylius.repository.product_variant" />
             <argument type="service" id="sylius.repository.catalog_promotion" />

--- a/src/Sylius/Bundle/CoreBundle/spec/EventListener/ProductVariantEventListenerSpec.php
+++ b/src/Sylius/Bundle/CoreBundle/spec/EventListener/ProductVariantEventListenerSpec.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace spec\Sylius\Bundle\CoreBundle\EventListener;
+
+use PhpSpec\ObjectBehavior;
+use Sylius\Component\Core\Event\ProductVariantUpdated;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class ProductVariantEventListenerSpec extends ObjectBehavior
+{
+    function let(MessageBusInterface $eventBus): void
+    {
+        $this->beConstructedWith($eventBus);
+    }
+
+    function it_dispatches_product_variant_updated_after_updating_product_variant(
+        MessageBusInterface $eventBus,
+        GenericEvent $event,
+        ProductVariantInterface $variant
+    ): void {
+        $event->getSubject()->willReturn($variant);
+
+        $variant->getCode()->willReturn('MUG');
+
+        $message = new ProductVariantUpdated('MUG');
+        $eventBus->dispatch($message)->willReturn(new Envelope($message))->shouldBeCalled();
+
+        $this->postUpdate($event);
+    }
+
+    function it_throws_exception_if_event_object_is_not_a_product_variant(GenericEvent $event): void
+    {
+        $event->getSubject()->willReturn('badObject')->shouldBeCalled();
+
+        $this
+            ->shouldThrow(\InvalidArgumentException::class)
+            ->during('postUpdate', [$event])
+        ;
+    }
+}


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | based on https://github.com/Sylius/Sylius/pull/13128
| License         | MIT

<!--
 - Bug fixes must be submitted against the 1.9 or 1.10 branch (the lowest possible)
 - Features and deprecations must be submitted against the master branch
 - Make sure that the correct base branch is set

 To be sure you are not breaking any Backward Compatibilities, check the documentation:
 https://docs.sylius.com/en/latest/book/organization/backward-compatibility-promise.html
-->
